### PR TITLE
feat: core provider and agent loop improvements

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -57,6 +57,11 @@ export class AgentLoop {
           this.tools.length > 0 ? this.tools : undefined,
           this.systemPrompt,
           { max_tokens: this.config.maxTokens },
+          (event) => {
+            if (event.type === 'text_delta') {
+              onEvent({ type: 'text_delta', text: event.text });
+            }
+          },
         );
 
         const assistantMessage: Message = {
@@ -64,13 +69,6 @@ export class AgentLoop {
           content: response.content,
         };
         history.push(assistantMessage);
-
-        // Emit text content
-        for (const block of response.content) {
-          if (block.type === 'text') {
-            onEvent({ type: 'text_delta', text: block.text });
-          }
-        }
 
         onEvent({ type: 'message_complete', message: assistantMessage });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -5,7 +5,6 @@ const log = getLogger('agent-loop');
 
 export interface AgentLoopConfig {
   maxTokens: number;
-  maxTurns: number;
 }
 
 export type AgentEvent =
@@ -17,8 +16,10 @@ export type AgentEvent =
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 4096,
-  maxTurns: 10,
 };
+
+const PROGRESS_CHECK_INTERVAL = 5;
+const PROGRESS_CHECK_REMINDER = 'You have been using tools for several turns. Check whether you are making meaningful progress toward the user\'s goal. If you are stuck in a loop or not making progress, summarize what you have tried and ask the user for guidance instead of continuing.';
 
 export class AgentLoop {
   private provider: Provider;
@@ -46,10 +47,9 @@ export class AgentLoop {
     onEvent: (event: AgentEvent) => void,
   ): Promise<Message[]> {
     const history = [...messages];
-    let turns = 0;
+    let toolUseTurns = 0;
 
-    while (turns < this.config.maxTurns) {
-      turns++;
+    while (true) {
 
       try {
         const response = await this.provider.sendMessage(
@@ -109,6 +109,15 @@ export class AgentLoop {
             tool_use_id: toolUse.id,
             content: result.content,
             is_error: result.isError,
+          });
+        }
+
+        // Track tool-use turns and inject progress reminder every N turns
+        toolUseTurns++;
+        if (toolUseTurns % PROGRESS_CHECK_INTERVAL === 0) {
+          resultBlocks.push({
+            type: 'text',
+            text: `[System: ${PROGRESS_CHECK_REMINDER}]`,
           });
         }
 

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -3,7 +3,7 @@ import type { AssistantConfig } from './types.js';
 
 export const DEFAULT_CONFIG: AssistantConfig = {
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929',
+  model: 'claude-sonnet-4-5-20250929', // alias: claude-sonnet-4-5
   apiKeys: {},
   maxTokens: 4096,
   dataDir: getDataDir(),

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
   Provider,
+  ProviderEvent,
   ProviderResponse,
   Message,
   ToolDefinition,
@@ -32,6 +33,7 @@ export class AnthropicProvider implements Provider {
     tools?: ToolDefinition[],
     systemPrompt?: string,
     config?: object,
+    onEvent?: (event: ProviderEvent) => void,
   ): Promise<ProviderResponse> {
     try {
       const params: Anthropic.MessageCreateParams = {
@@ -56,7 +58,13 @@ export class AnthropicProvider implements Provider {
         }));
       }
 
-      const response = await this.client.messages.create(params);
+      const stream = this.client.messages.stream(params);
+
+      stream.on("text", (text) => {
+        onEvent?.({ type: "text_delta", text });
+      });
+
+      const response = await stream.finalMessage();
 
       return {
         content: response.content.map((block) =>

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -22,9 +22,9 @@ export class AnthropicProvider implements Provider {
   private client: Anthropic;
   private model: string;
 
-  constructor(apiKey: string, model?: string) {
+  constructor(apiKey: string, model: string) {
     this.client = new Anthropic({ apiKey });
-    this.model = model ?? "claude-sonnet-4-20250514";
+    this.model = model;
   }
 
   async sendMessage(

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,5 +1,6 @@
 import type { Provider } from "./types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
+import { RetryProvider } from "./retry.js";
 
 const providers = new Map<string, Provider>();
 
@@ -29,9 +30,8 @@ export interface ProvidersConfig {
 
 export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
-    const provider = new AnthropicProvider(
-      config.apiKeys.anthropic,
-      config.model,
+    const provider = new RetryProvider(
+      new AnthropicProvider(config.apiKeys.anthropic, config.model),
     );
     registerProvider("anthropic", provider);
   }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,0 +1,82 @@
+import type { Provider, ProviderResponse, ProviderEvent, Message, ToolDefinition } from './types.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('retry');
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function isRetryableError(error: unknown): boolean {
+  if (error && typeof error === 'object') {
+    // Check cause for API status codes (e.g. Anthropic.APIError)
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause && typeof cause === 'object' && 'status' in cause) {
+      const status = (cause as { status: number }).status;
+      if (status === 429 || status >= 500) return true;
+    }
+  }
+
+  // Check for network errors
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EPIPE') {
+      return true;
+    }
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause instanceof Error) {
+      const causeCode = (cause as NodeJS.ErrnoException).code;
+      if (causeCode === 'ECONNRESET' || causeCode === 'ECONNREFUSED' || causeCode === 'ETIMEDOUT' || causeCode === 'EPIPE') {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function getRetryDelay(attempt: number): number {
+  const exponential = BASE_DELAY_MS * Math.pow(2, attempt);
+  const jitter = Math.random() * BASE_DELAY_MS;
+  return exponential + jitter;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RetryProvider implements Provider {
+  public readonly name: string;
+
+  constructor(private readonly inner: Provider) {
+    this.name = inner.name;
+  }
+
+  async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    config?: object,
+    onEvent?: (event: ProviderEvent) => void,
+  ): Promise<ProviderResponse> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await this.inner.sendMessage(messages, tools, systemPrompt, config, onEvent);
+      } catch (error) {
+        lastError = error;
+
+        if (attempt < MAX_RETRIES && isRetryableError(error)) {
+          const delay = getRetryDelay(attempt);
+          log.warn({ attempt: attempt + 1, delay }, 'Retrying after transient error');
+          await sleep(delay);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw lastError;
+  }
+}

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -53,6 +53,9 @@ export interface ProviderResponse {
   stopReason: string;
 }
 
+export type ProviderEvent =
+  | { type: 'text_delta'; text: string };
+
 export interface Provider {
   name: string;
   sendMessage(
@@ -60,5 +63,6 @@ export interface Provider {
     tools?: ToolDefinition[],
     systemPrompt?: string,
     config?: object,
+    onEvent?: (event: ProviderEvent) => void,
   ): Promise<ProviderResponse>;
 }


### PR DESCRIPTION
## Summary

- **Update Anthropic models**: Remove deprecated `claude-sonnet-4-20250514` hardcoded fallback. Model is now always supplied from config (default: `claude-sonnet-4-5-20250929`). Supports Opus 4.6, Sonnet 4.5, and Haiku 4.5.
- **Remove 10-turn tool use limit**: Replace hard `maxTurns: 10` cap with an unbounded loop. Every 5 tool-use turns, a system reminder is injected asking the agent to check progress and wrap up if stuck.
- **Streaming responses**: Switch from `messages.create()` to `messages.stream()` so text deltas arrive token-by-token via the existing event plumbing.
- **Retry with exponential backoff**: Add `RetryProvider` wrapper with max 3 retries for rate limits (429), server errors (500+), and network errors. Uses exponential backoff with jitter. Applied at the registry layer so all providers benefit.

## Test plan

- [ ] Verify model is configurable via `~/.vellum/config.json` (`"model": "claude-haiku-4-5-20251001"` etc.)
- [ ] Confirm streaming text arrives incrementally in the CLI (not all at once)
- [ ] Test agent completes multi-step tool-use tasks beyond 10 turns
- [ ] Verify progress check reminder appears after 5 consecutive tool-use turns
- [ ] Simulate 429/500 errors and confirm retry with backoff (check logs)
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
