### PR TITLE
feat: add CLI management commands

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -26,7 +26,11 @@ export function loadConfig(): AssistantConfig {
     }
   }
 
-  const config: AssistantConfig = { ...DEFAULT_CONFIG, ...fileConfig };
+  const config: AssistantConfig = {
+    ...DEFAULT_CONFIG,
+    ...fileConfig,
+    apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
+  };
 
   // Environment variables override config file
   if (process.env.ANTHROPIC_API_KEY) {

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -53,3 +53,50 @@ export function saveConfig(config: AssistantConfig): void {
 export function getConfig(): AssistantConfig {
   return loadConfig();
 }
+
+/**
+ * Load the raw config from disk (without env var overrides).
+ * Used by CLI config commands to read/write the file directly.
+ */
+export function loadRawConfig(): Record<string, unknown> {
+  ensureDataDir();
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) return {};
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf-8'));
+  } catch (err) {
+    throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
+  }
+}
+
+export function saveRawConfig(config: Record<string, unknown>): void {
+  ensureDataDir();
+  const configPath = getConfigPath();
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  cached = null; // invalidate cache
+}
+
+export function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const keys = path.split('.');
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+export function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const keys = path.split('.');
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (current[key] === undefined || current[key] === null || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]] = value;
+}

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,3 +1,4 @@
+import Anthropic from '@anthropic-ai/sdk';
 import type { Message } from '../providers/types.js';
 import type { ServerMessage } from './ipc-protocol.js';
 import { AgentLoop } from '../agent/loop.js';
@@ -8,6 +9,7 @@ import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import type { UserDecision } from '../permissions/types.js';
+import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session');
@@ -94,6 +96,8 @@ export class Session {
     this.processing = true;
 
     try {
+      const isFirstMessage = this.messages.length === 0;
+
       // Add user message
       const userMessage = createUserMessage(content);
       this.messages.push(userMessage);
@@ -104,12 +108,14 @@ export class Session {
       );
 
       // Run agent loop
+      let firstAssistantText = '';
       const updatedHistory = await this.agentLoop.run(
         this.messages,
         (event) => {
           switch (event.type) {
             case 'text_delta':
               onEvent({ type: 'assistant_text_delta', text: event.text });
+              if (isFirstMessage) firstAssistantText += event.text;
               break;
             case 'tool_use':
               onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input });
@@ -134,12 +140,42 @@ export class Session {
 
       this.messages = updatedHistory;
       onEvent({ type: 'message_complete' });
+
+      // Auto-generate conversation title after first exchange
+      if (isFirstMessage) {
+        this.generateTitle(content, firstAssistantText).catch((err) => {
+          log.warn({ err }, 'Failed to generate conversation title');
+        });
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err }, 'Session processing error');
       onEvent({ type: 'error', message });
     } finally {
       this.processing = false;
+    }
+  }
+
+  private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {
+    const config = getConfig();
+    const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return;
+
+    const client = new Anthropic({ apiKey });
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 30,
+      messages: [{
+        role: 'user',
+        content: `Generate a short title (3-6 words, no quotes) for this conversation:\n\nUser: ${userMessage.slice(0, 200)}\nAssistant: ${assistantResponse.slice(0, 200)}`,
+      }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    if (textBlock && textBlock.type === 'text') {
+      const title = textBlock.text.trim().replace(/^["']|["']$/g, '');
+      conversationStore.updateConversationTitle(this.conversationId, title);
+      log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');
     }
   }
 }

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -8,8 +8,10 @@ import {
   stopDaemon,
   getDaemonStatus,
 } from './daemon/lifecycle.js';
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { startCli } from './cli.js';
-import { getSocketPath } from './util/platform.js';
+import { getSocketPath, getDataDir, getDbPath } from './util/platform.js';
 import {
   serialize,
   createMessageParser,
@@ -338,6 +340,80 @@ program
         r.riskLevel.padEnd(riskW) +
         dur,
       );
+    }
+  });
+
+// --- Doctor command ---
+program
+  .command('doctor')
+  .description('Run diagnostic checks')
+  .action(async () => {
+    const pass = (label: string) => console.log(`  \u2713 ${label}`);
+    const fail = (label: string, detail?: string) =>
+      console.log(`  \u2717 ${label}${detail ? ` — ${detail}` : ''}`);
+
+    console.log('Vellum Doctor\n');
+
+    // 1. Bun installed
+    try {
+      execSync('bun --version', { stdio: 'pipe' });
+      pass('Bun is installed');
+    } catch {
+      fail('Bun is installed', 'bun not found in PATH');
+    }
+
+    // 2. API key configured
+    const raw = loadRawConfig();
+    const envKey = process.env.ANTHROPIC_API_KEY;
+    const configKey = (raw.apiKeys as Record<string, string> | undefined)?.anthropic;
+    if (envKey || configKey) {
+      pass('API key configured');
+    } else {
+      fail('API key configured', 'set ANTHROPIC_API_KEY or run: vellum config set apiKeys.anthropic <key>');
+    }
+
+    // 3. Daemon reachable
+    try {
+      const sock = getSocketPath();
+      if (!existsSync(sock)) {
+        fail('Daemon reachable', 'socket not found (is the daemon running?)');
+      } else {
+        await new Promise<void>((resolve, reject) => {
+          const s = net.createConnection(sock);
+          s.on('connect', () => { s.end(); resolve(); });
+          s.on('error', reject);
+          setTimeout(() => { s.destroy(); reject(new Error('timeout')); }, 2000);
+        });
+        pass('Daemon reachable');
+      }
+    } catch {
+      fail('Daemon reachable', 'could not connect to daemon socket');
+    }
+
+    // 4. DB exists and readable
+    const dbPath = getDbPath();
+    if (existsSync(dbPath)) {
+      try {
+        const { Database } = await import('bun:sqlite');
+        const db = new Database(dbPath, { readonly: true });
+        db.query('SELECT 1').get();
+        db.close();
+        pass('Database exists and readable');
+      } catch {
+        fail('Database exists and readable', 'file exists but cannot be read');
+      }
+    } else {
+      fail('Database exists and readable', `not found at ${dbPath}`);
+    }
+
+    // 5. ~/.vellum/ directory structure
+    const dataDir = getDataDir();
+    const requiredDirs = [dataDir, `${dataDir}/data`, `${dataDir}/logs`];
+    const missing = requiredDirs.filter((d) => !existsSync(d));
+    if (missing.length === 0) {
+      pass('Directory structure exists');
+    } else {
+      fail('Directory structure exists', `missing: ${missing.join(', ')}`);
     }
   });
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -380,9 +380,9 @@ program
       } else {
         await new Promise<void>((resolve, reject) => {
           const s = net.createConnection(sock);
-          s.on('connect', () => { s.end(); resolve(); });
-          s.on('error', reject);
-          setTimeout(() => { s.destroy(); reject(new Error('timeout')); }, 2000);
+          const timer = setTimeout(() => { s.destroy(); reject(new Error('timeout')); }, 2000);
+          s.on('connect', () => { clearTimeout(timer); s.end(); resolve(); });
+          s.on('error', (err) => { clearTimeout(timer); reject(err); });
         });
         pass('Daemon reachable');
       }

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -27,6 +27,7 @@ import {
   removeRule,
   clearAllRules,
 } from './permissions/trust-store.js';
+import { getRecentInvocations } from './memory/tool-usage-store.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -283,6 +284,60 @@ trust
       console.log(`Cleared ${rules.length} trust rules`);
     } else {
       console.log('Cancelled');
+    }
+  });
+
+// --- Audit command ---
+program
+  .command('audit')
+  .description('Show recent tool invocations')
+  .option('-l, --limit <n>', 'Number of entries to show', '20')
+  .action((opts: { limit: string }) => {
+    const limit = parseInt(opts.limit, 10) || 20;
+    const rows = getRecentInvocations(limit);
+    if (rows.length === 0) {
+      console.log('No tool invocations recorded');
+      return;
+    }
+    const tsW = 20;
+    const toolW = 14;
+    const inputW = 30;
+    const decW = 8;
+    const riskW = 8;
+    const durW = 8;
+    console.log(
+      'Timestamp'.padEnd(tsW) +
+      'Tool'.padEnd(toolW) +
+      'Input'.padEnd(inputW) +
+      'Decision'.padEnd(decW) +
+      'Risk'.padEnd(riskW) +
+      'Duration',
+    );
+    console.log('-'.repeat(tsW + toolW + inputW + decW + riskW + durW));
+    for (const r of rows) {
+      const ts = new Date(r.createdAt).toISOString().slice(0, 19).replace('T', ' ');
+      // Summarize input: take first meaningful chunk
+      let inputSummary = '';
+      try {
+        const parsed = JSON.parse(r.input);
+        if (parsed.command) inputSummary = parsed.command;
+        else if (parsed.path) inputSummary = parsed.path;
+        else inputSummary = r.input;
+      } catch {
+        inputSummary = r.input;
+      }
+      if (inputSummary.length > inputW - 2) {
+        inputSummary = inputSummary.slice(0, inputW - 4) + '..';
+      }
+      const dur = r.durationMs < 1000 ? `${r.durationMs}ms` : `${(r.durationMs / 1000).toFixed(1)}s`;
+      console.log(
+        ts.padEnd(tsW) +
+        r.toolName.padEnd(toolW) +
+        inputSummary.padEnd(inputW) +
+        r.decision.padEnd(decW) +
+        r.riskLevel.padEnd(riskW) +
+        dur,
+      );
     }
   });
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -22,6 +22,11 @@ import {
   getNestedValue,
   setNestedValue,
 } from './config/loader.js';
+import {
+  getAllRules,
+  removeRule,
+  clearAllRules,
+} from './permissions/trust-store.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -201,6 +206,83 @@ config
       console.log('No configuration set');
     } else {
       console.log(JSON.stringify(raw, null, 2));
+    }
+  });
+
+// --- Trust commands ---
+const trust = program.command('trust').description('Manage trust rules');
+
+trust
+  .command('list')
+  .description('List all trust rules')
+  .action(() => {
+    const rules = getAllRules();
+    if (rules.length === 0) {
+      console.log('No trust rules');
+      return;
+    }
+    // Table header
+    const idW = 8;
+    const toolW = 12;
+    const patternW = 30;
+    const scopeW = 20;
+    console.log(
+      'ID'.padEnd(idW) +
+      'Tool'.padEnd(toolW) +
+      'Pattern'.padEnd(patternW) +
+      'Scope'.padEnd(scopeW) +
+      'Created',
+    );
+    console.log('-'.repeat(idW + toolW + patternW + scopeW + 20));
+    for (const r of rules) {
+      const id = r.id.slice(0, 8);
+      const created = new Date(r.createdAt).toISOString().slice(0, 10);
+      console.log(
+        id.padEnd(idW) +
+        r.tool.padEnd(toolW) +
+        r.pattern.slice(0, patternW - 2).padEnd(patternW) +
+        r.scope.slice(0, scopeW - 2).padEnd(scopeW) +
+        created,
+      );
+    }
+  });
+
+trust
+  .command('remove <id>')
+  .description('Remove a trust rule by ID (or prefix)')
+  .action((id: string) => {
+    // Support prefix matching
+    const rules = getAllRules();
+    const match = rules.find((r) => r.id.startsWith(id));
+    if (!match) {
+      console.error(`No rule found matching "${id}"`);
+      process.exit(1);
+    }
+    removeRule(match.id);
+    console.log(`Removed rule ${match.id.slice(0, 8)} (${match.tool}: ${match.pattern})`);
+  });
+
+trust
+  .command('clear')
+  .description('Remove all trust rules')
+  .action(async () => {
+    const rules = getAllRules();
+    if (rules.length === 0) {
+      console.log('No trust rules to clear');
+      return;
+    }
+    // Confirmation prompt
+    const readline = await import('node:readline');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(`Remove all ${rules.length} trust rules? (y/N) `, resolve);
+    });
+    rl.close();
+    if (answer.toLowerCase() === 'y') {
+      clearAllRules();
+      console.log(`Cleared ${rules.length} trust rules`);
+    } else {
+      console.log('Cancelled');
     }
   });
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -16,6 +16,12 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './daemon/ipc-protocol.js';
+import {
+  loadRawConfig,
+  saveRawConfig,
+  getNestedValue,
+  setNestedValue,
+} from './config/loader.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -150,6 +156,51 @@ sessions
       console.log(`Created session: ${response.title} (${response.sessionId})`);
     } else if (response.type === 'error') {
       console.error(`Error: ${response.message}`);
+    }
+  });
+
+// --- Config commands ---
+const config = program.command('config').description('Manage configuration');
+
+config
+  .command('set <key> <value>')
+  .description('Set a config value (supports dotted paths like apiKeys.anthropic)')
+  .action((key: string, value: string) => {
+    const raw = loadRawConfig();
+    // Try to parse as JSON for booleans/numbers, fall back to string
+    let parsed: unknown = value;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      // keep as string
+    }
+    setNestedValue(raw, key, parsed);
+    saveRawConfig(raw);
+    console.log(`Set ${key} = ${JSON.stringify(parsed)}`);
+  });
+
+config
+  .command('get <key>')
+  .description('Get a config value (supports dotted paths)')
+  .action((key: string) => {
+    const raw = loadRawConfig();
+    const value = getNestedValue(raw, key);
+    if (value === undefined) {
+      console.log(`(not set)`);
+    } else {
+      console.log(typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value));
+    }
+  });
+
+config
+  .command('list')
+  .description('List all config values')
+  .action(() => {
+    const raw = loadRawConfig();
+    if (Object.keys(raw).length === 0) {
+      console.log('No configuration set');
+    } else {
+      console.log(JSON.stringify(raw, null, 2));
     }
   });
 

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -1,4 +1,5 @@
 import { v4 as uuid } from 'uuid';
+import { desc } from 'drizzle-orm';
 import { getDb } from './db.js';
 import { toolInvocations } from './schema.js';
 
@@ -25,4 +26,14 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
     durationMs: record.durationMs,
     createdAt: Date.now(),
   }).run();
+}
+
+export function getRecentInvocations(limit: number) {
+  const db = getDb();
+  return db
+    .select()
+    .from(toolInvocations)
+    .orderBy(desc(toolInvocations.createdAt))
+    .limit(limit)
+    .all();
 }

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -103,6 +103,12 @@ export function getAllRules(): TrustRule[] {
   return [...getRules()];
 }
 
+export function clearAllRules(): void {
+  cachedRules = [];
+  saveToDisk([]);
+  log.info('Cleared all trust rules');
+}
+
 export function clearCache(): void {
   cachedRules = null;
 }


### PR DESCRIPTION
## Summary

- **`vellum config set/get/list`** — Read and write `~/.vellum/config.json` with dotted-path support (e.g. `apiKeys.anthropic`), enabling model switching and API key management from the CLI.
- **`vellum trust list/remove/clear`** — Manage trust rules: list in a table, remove by ID prefix, clear all with confirmation prompt.
- **`vellum audit`** — Query the `tool_invocations` SQLite table and display recent tool uses in a table (timestamp, tool, input summary, decision, risk level, duration). Supports `--limit N`.
- **`vellum doctor`** — Diagnostic checklist verifying bun is installed, API key is configured, daemon is reachable, DB exists, and `~/.vellum/` directory structure is present.
- **Auto-generated conversation titles** — After the first assistant response, a background Haiku call generates a short title and saves it to the DB.

## Test plan

- [ ] Run `vellum config set model claude-haiku-4-5-20251001` then `vellum config get model` to verify round-trip
- [ ] Run `vellum config set apiKeys.anthropic sk-test` to verify dotted path support
- [ ] Run `vellum config list` to verify all values display
- [ ] Run `vellum trust list` with and without existing rules
- [ ] Run `vellum trust clear` and verify confirmation prompt works (y/N)
- [ ] Run `vellum audit` and `vellum audit --limit 5` against a DB with tool invocations
- [ ] Run `vellum doctor` and verify all checks pass/fail appropriately
- [ ] Start a new conversation and verify a title is auto-generated after the first exchange
- [ ] Run `npx tsc --noEmit` to confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
