### PR TITLE
feat: config and daemon security hardening

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -10,6 +10,7 @@
         "drizzle-orm": "^0.38.4",
         "minimatch": "^10.1.2",
         "pino": "^9.6.0",
+        "pino-pretty": "^13.1.3",
         "tree-sitter-bash": "^0.25.1",
         "uuid": "^11.1.0",
         "web-tree-sitter": "^0.26.5",
@@ -19,7 +20,6 @@
         "@types/uuid": "^10.0.0",
         "drizzle-kit": "^0.30.4",
         "eslint": "^10.0.0",
-        "pino-pretty": "^13.0.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.54.0",
       },
@@ -340,7 +340,7 @@
 
     "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
-    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
@@ -432,7 +432,7 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -18,6 +18,7 @@
     "drizzle-orm": "^0.38.4",
     "minimatch": "^10.1.2",
     "pino": "^9.6.0",
+    "pino-pretty": "^13.1.3",
     "tree-sitter-bash": "^0.25.1",
     "uuid": "^11.1.0",
     "web-tree-sitter": "^0.26.5"
@@ -27,7 +28,6 @@
     "@types/uuid": "^10.0.0",
     "drizzle-kit": "^0.30.4",
     "eslint": "^10.0.0",
-    "pino-pretty": "^13.0.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.54.0"
   }

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1,8 +1,11 @@
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { getDataDir, ensureDataDir } from '../util/platform.js';
 import { ConfigError } from '../util/errors.js';
+import { getLogger } from '../util/logger.js';
 import { DEFAULT_CONFIG } from './defaults.js';
+
+const log = getLogger('config');
 import type { AssistantConfig } from './types.js';
 
 let cached: AssistantConfig | null = null;
@@ -19,6 +22,14 @@ export function loadConfig(): AssistantConfig {
 
   let fileConfig: Partial<AssistantConfig> = {};
   if (existsSync(configPath)) {
+    const mode = statSync(configPath).mode;
+    if (mode & 0o077) {
+      log.warn(
+        `Config file ${configPath} is readable by other users (mode ${(mode & 0o777).toString(8)}). ` +
+        `Run: chmod 600 ${configPath}`,
+      );
+    }
+
     try {
       fileConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
     } catch (err) {

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -45,7 +45,9 @@ export function loadConfig(): AssistantConfig {
     apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
   };
 
-  // Environment variables override config file
+  validateConfig(config);
+
+  // Environment variables override config file (after validation so apiKeys is a valid object)
   if (process.env.ANTHROPIC_API_KEY) {
     config.apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
   }
@@ -55,8 +57,6 @@ export function loadConfig(): AssistantConfig {
   if (process.env.GEMINI_API_KEY) {
     config.apiKeys.gemini = process.env.GEMINI_API_KEY;
   }
-
-  validateConfig(config);
 
   cached = config;
   return config;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -39,6 +39,14 @@ export function loadConfig(): AssistantConfig {
     }
   }
 
+  if (
+    fileConfig.apiKeys !== undefined &&
+    (typeof fileConfig.apiKeys !== 'object' || fileConfig.apiKeys === null || Array.isArray(fileConfig.apiKeys))
+  ) {
+    log.error('Invalid apiKeys in config file: must be an object with string values. Ignoring.');
+    delete fileConfig.apiKeys;
+  }
+
   const config: AssistantConfig = {
     ...DEFAULT_CONFIG,
     ...fileConfig,

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -4,9 +4,11 @@ import { getDataDir, ensureDataDir } from '../util/platform.js';
 import { ConfigError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { DEFAULT_CONFIG } from './defaults.js';
+import type { AssistantConfig } from './types.js';
 
 const log = getLogger('config');
-import type { AssistantConfig } from './types.js';
+
+const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 
 let cached: AssistantConfig | null = null;
 
@@ -54,8 +56,38 @@ export function loadConfig(): AssistantConfig {
     config.apiKeys.gemini = process.env.GEMINI_API_KEY;
   }
 
+  validateConfig(config);
+
   cached = config;
   return config;
+}
+
+function validateConfig(config: AssistantConfig): void {
+  if (!VALID_PROVIDERS.includes(config.provider as (typeof VALID_PROVIDERS)[number])) {
+    log.error(
+      `Invalid provider "${config.provider}". Valid providers: ${VALID_PROVIDERS.join(', ')}. Falling back to "${DEFAULT_CONFIG.provider}".`,
+    );
+    config.provider = DEFAULT_CONFIG.provider;
+  }
+
+  if (!Number.isInteger(config.maxTokens) || config.maxTokens <= 0) {
+    log.error(
+      `Invalid maxTokens "${config.maxTokens}". Must be a positive integer. Falling back to ${DEFAULT_CONFIG.maxTokens}.`,
+    );
+    config.maxTokens = DEFAULT_CONFIG.maxTokens;
+  }
+
+  if (typeof config.apiKeys !== 'object' || config.apiKeys === null || Array.isArray(config.apiKeys)) {
+    log.error('Invalid apiKeys: must be an object with string values. Falling back to empty object.');
+    config.apiKeys = {};
+  } else {
+    for (const [key, value] of Object.entries(config.apiKeys)) {
+      if (typeof value !== 'string') {
+        log.error(`Invalid apiKeys.${key}: value must be a string. Removing entry.`);
+        delete config.apiKeys[key];
+      }
+    }
+  }
 }
 
 export function saveConfig(config: AssistantConfig): void {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -39,7 +39,7 @@ export class DaemonServer {
 
       const oldUmask = process.umask(0o177);
 
-      this.server.on('error', (err) => {
+      this.server.once('error', (err) => {
         process.umask(oldUmask);
         log.error({ err }, 'Server error');
         reject(err);
@@ -47,6 +47,11 @@ export class DaemonServer {
 
       this.server.listen(this.socketPath, () => {
         process.umask(oldUmask);
+        // Replace the one-shot startup handler with a permanent one
+        this.server!.removeAllListeners('error');
+        this.server!.on('error', (err) => {
+          log.error({ err }, 'Server error');
+        });
         chmodSync(this.socketPath, 0o600);
         log.info({ socketPath: this.socketPath }, 'Daemon server listening');
         resolve();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -37,12 +37,14 @@ export class DaemonServer {
         this.handleConnection(socket);
       });
 
+      const oldUmask = process.umask(0o177);
+
       this.server.on('error', (err) => {
+        process.umask(oldUmask);
         log.error({ err }, 'Server error');
         reject(err);
       });
 
-      const oldUmask = process.umask(0o177);
       this.server.listen(this.socketPath, () => {
         process.umask(oldUmask);
         chmodSync(this.socketPath, 0o600);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -42,7 +42,9 @@ export class DaemonServer {
         reject(err);
       });
 
+      const oldUmask = process.umask(0o177);
       this.server.listen(this.socketPath, () => {
+        process.umask(oldUmask);
         chmodSync(this.socketPath, 0o600);
         log.info({ socketPath: this.socketPath }, 'Daemon server listening');
         resolve();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,5 +1,5 @@
 import * as net from 'node:net';
-import { unlinkSync, existsSync } from 'node:fs';
+import { unlinkSync, existsSync, chmodSync } from 'node:fs';
 import { getSocketPath } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider } from '../providers/registry.js';
@@ -43,6 +43,7 @@ export class DaemonServer {
       });
 
       this.server.listen(this.socketPath, () => {
+        chmodSync(this.socketPath, 0o600);
         log.info({ socketPath: this.socketPath }, 'Daemon server listening');
         resolve();
       });

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -1,4 +1,5 @@
 import pino from 'pino';
+import pinoPretty from 'pino-pretty';
 import { getLogPath, ensureDataDir } from './platform.js';
 
 let rootLogger: pino.Logger | null = null;
@@ -6,10 +7,18 @@ let rootLogger: pino.Logger | null = null;
 function getRootLogger(): pino.Logger {
   if (!rootLogger) {
     ensureDataDir();
-    rootLogger = pino(
-      { level: 'info' },
-      pino.destination({ dest: getLogPath(), sync: false, mkdir: true }),
-    );
+    const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
+
+    if (process.env.VELLUM_DEBUG === '1') {
+      const prettyStream = pinoPretty({ destination: 2 });
+      const multi = pino.multistream([
+        { stream: fileStream },
+        { stream: prettyStream },
+      ]);
+      rootLogger = pino({ level: 'debug' }, multi);
+    } else {
+      rootLogger = pino({ level: 'info' }, fileStream);
+    }
   }
   return rootLogger;
 }

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -12,8 +12,8 @@ function getRootLogger(): pino.Logger {
     if (process.env.VELLUM_DEBUG === '1') {
       const prettyStream = pinoPretty({ destination: 2 });
       const multi = pino.multistream([
-        { stream: fileStream },
-        { stream: prettyStream },
+        { stream: fileStream, level: 'info' as const },
+        { stream: prettyStream, level: 'debug' as const },
       ]);
       rootLogger = pino({ level: 'debug' }, multi);
     } else {


### PR DESCRIPTION
## Summary

- **Socket permissions**: Set Unix socket to `0600` after creation so only the owning user can connect to the daemon
- **Config file permissions**: Warn on load if `~/.vellum/config.json` is group/world-readable, suggesting `chmod 600`
- **Config validation**: Validate `provider`, `maxTokens`, and `apiKeys` after loading config — log clear errors and fall back to defaults instead of crashing
- **Debug mode**: When `VELLUM_DEBUG=1` is set, add a pino-pretty stderr transport via multistream alongside the existing file log

## Test plan

- [ ] Start daemon and verify `~/.vellum/vellum.sock` has mode `0600` (`ls -l ~/.vellum/vellum.sock`)
- [ ] Set config.json to `chmod 644` and confirm a warning is logged on startup
- [ ] Set invalid values in config.json (`"provider": "invalid"`, `"maxTokens": -1`, `"apiKeys": 123`) and verify error messages and fallback to defaults
- [ ] Run with `VELLUM_DEBUG=1 vellum daemon start` and verify logs appear on stderr with pretty formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
