### PR TITLE
Add Ctrl+C cancellation of in-flight generation

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -45,22 +45,27 @@ export class AgentLoop {
   async run(
     messages: Message[],
     onEvent: (event: AgentEvent) => void,
+    signal?: AbortSignal,
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
 
     while (true) {
+      if (signal?.aborted) break;
 
       try {
         const response = await this.provider.sendMessage(
           history,
           this.tools.length > 0 ? this.tools : undefined,
           this.systemPrompt,
-          { max_tokens: this.config.maxTokens },
-          (event) => {
-            if (event.type === 'text_delta') {
-              onEvent({ type: 'text_delta', text: event.text });
-            }
+          {
+            config: { max_tokens: this.config.maxTokens },
+            onEvent: (event) => {
+              if (event.type === 'text_delta') {
+                onEvent({ type: 'text_delta', text: event.text });
+              }
+            },
+            signal,
           },
         );
 
@@ -86,6 +91,7 @@ export class AgentLoop {
         // Execute tools and collect results
         const resultBlocks: ContentBlock[] = [];
         for (const toolUse of toolUseBlocks) {
+          if (signal?.aborted) break;
           onEvent({
             type: 'tool_use',
             id: toolUse.id,

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -14,6 +14,7 @@ export async function startCli(): Promise<void> {
   const socket = net.createConnection(socketPath);
   const parser = createMessageParser();
   let sessionId = '';
+  let generating = false;
 
   const rl = readline.createInterface({
     input: process.stdin,
@@ -161,7 +162,14 @@ export async function startCli(): Promise<void> {
           break;
 
         case 'message_complete':
+          generating = false;
           process.stdout.write('\n\n');
+          prompt();
+          break;
+
+        case 'generation_cancelled':
+          generating = false;
+          process.stdout.write('\n[Cancelled]\n\n');
           prompt();
           break;
 
@@ -180,6 +188,7 @@ export async function startCli(): Promise<void> {
           break;
 
         case 'error':
+          generating = false;
           process.stdout.write(`\n[Error: ${msg.message}]\n`);
           prompt();
           break;
@@ -200,6 +209,7 @@ export async function startCli(): Promise<void> {
   rl.on('line', (line) => {
     const content = line.trim();
     if (content) {
+      generating = true;
       send({ type: 'user_message', sessionId, content });
     }
   });
@@ -209,9 +219,13 @@ export async function startCli(): Promise<void> {
     process.exit(0);
   });
 
-  // Ctrl+C also detaches (don't kill daemon)
+  // Ctrl+C: cancel generation if in progress, otherwise detach
   process.on('SIGINT', () => {
-    rl.close();
+    if (generating) {
+      send({ type: 'cancel' });
+    } else {
+      rl.close();
+    }
   });
 
   socket.on('close', () => {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -32,13 +32,18 @@ export interface PingMessage {
   type: 'ping';
 }
 
+export interface CancelRequest {
+  type: 'cancel';
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
   | SessionListRequest
   | SessionCreateRequest
   | SessionSwitchRequest
-  | PingMessage;
+  | PingMessage
+  | CancelRequest;
 
 // === Server → Client messages ===
 
@@ -94,6 +99,10 @@ export interface PongMessage {
   type: 'pong';
 }
 
+export interface GenerationCancelled {
+  type: 'generation_cancelled';
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
@@ -103,7 +112,8 @@ export type ServerMessage =
   | SessionInfo
   | SessionListResponse
   | ErrorMessage
-  | PongMessage;
+  | PongMessage
+  | GenerationCancelled;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -185,6 +185,16 @@ export class DaemonServer {
       case 'session_switch':
         this.handleSessionSwitch(msg.sessionId, socket);
         break;
+      case 'cancel': {
+        const cancelSessionId = this.socketToSession.get(socket);
+        if (cancelSessionId) {
+          const session = this.sessions.get(cancelSessionId);
+          if (session) {
+            session.abort();
+          }
+        }
+        break;
+      }
       case 'ping':
         this.send(socket, { type: 'pong' });
         break;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -19,6 +19,7 @@ export class Session {
   private messages: Message[] = [];
   private agentLoop: AgentLoop;
   private processing = false;
+  private abortController: AbortController | null = null;
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
   private workingDir: string;
@@ -70,8 +71,8 @@ export class Session {
   abort(): void {
     if (this.processing) {
       log.info({ conversationId: this.conversationId }, 'Aborting in-flight processing');
+      this.abortController?.abort();
       this.prompter.dispose();
-      this.processing = false;
     }
   }
 
@@ -94,6 +95,7 @@ export class Session {
     }
 
     this.processing = true;
+    this.abortController = new AbortController();
 
     try {
       const isFirstMessage = this.messages.length === 0;
@@ -136,10 +138,16 @@ export class Session {
               break;
           }
         },
+        this.abortController.signal,
       );
 
       this.messages = updatedHistory;
-      onEvent({ type: 'message_complete' });
+
+      if (this.abortController?.signal.aborted) {
+        onEvent({ type: 'generation_cancelled' });
+      } else {
+        onEvent({ type: 'message_complete' });
+      }
 
       // Auto-generate conversation title after first exchange
       if (isFirstMessage) {
@@ -148,10 +156,17 @@ export class Session {
         });
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error({ err }, 'Session processing error');
-      onEvent({ type: 'error', message });
+      // AbortError is expected when user cancels — don't treat as an error
+      if (this.abortController?.signal.aborted) {
+        log.info({ conversationId: this.conversationId }, 'Generation cancelled by user');
+        onEvent({ type: 'generation_cancelled' });
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error({ err }, 'Session processing error');
+        onEvent({ type: 'error', message });
+      }
     } finally {
+      this.abortController = null;
       this.processing = false;
     }
   }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
   Provider,
-  ProviderEvent,
   ProviderResponse,
+  SendMessageOptions,
   Message,
   ToolDefinition,
   ContentBlock,
@@ -32,9 +32,9 @@ export class AnthropicProvider implements Provider {
     messages: Message[],
     tools?: ToolDefinition[],
     systemPrompt?: string,
-    config?: object,
-    onEvent?: (event: ProviderEvent) => void,
+    options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
+    const { config, onEvent, signal } = options ?? {};
     try {
       const params: Anthropic.MessageCreateParams = {
         model: this.model,
@@ -58,7 +58,7 @@ export class AnthropicProvider implements Provider {
         }));
       }
 
-      const stream = this.client.messages.stream(params);
+      const stream = this.client.messages.stream(params, { signal });
 
       stream.on("text", (text) => {
         onEvent?.({ type: "text_delta", text });

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,4 +1,4 @@
-import type { Provider, ProviderResponse, ProviderEvent, Message, ToolDefinition } from './types.js';
+import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('retry');
@@ -55,14 +55,13 @@ export class RetryProvider implements Provider {
     messages: Message[],
     tools?: ToolDefinition[],
     systemPrompt?: string,
-    config?: object,
-    onEvent?: (event: ProviderEvent) => void,
+    options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        return await this.inner.sendMessage(messages, tools, systemPrompt, config, onEvent);
+        return await this.inner.sendMessage(messages, tools, systemPrompt, options);
       } catch (error) {
         lastError = error;
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -56,13 +56,18 @@ export interface ProviderResponse {
 export type ProviderEvent =
   | { type: 'text_delta'; text: string };
 
+export interface SendMessageOptions {
+  config?: object;
+  onEvent?: (event: ProviderEvent) => void;
+  signal?: AbortSignal;
+}
+
 export interface Provider {
   name: string;
   sendMessage(
     messages: Message[],
     tools?: ToolDefinition[],
     systemPrompt?: string,
-    config?: object,
-    onEvent?: (event: ProviderEvent) => void,
+    options?: SendMessageOptions,
   ): Promise<ProviderResponse>;
 }


### PR DESCRIPTION
## Summary

- Pressing **Ctrl+C** during generation now **cancels** the current response and returns to the prompt, instead of killing the CLI process
- Adds `CancelRequest` (client→server) and `GenerationCancelled` (server→client) IPC message types
- Threads `AbortSignal` through the full stack: `Session` → `AgentLoop` → `Provider` → Anthropic SDK stream
- Refactors `Provider.sendMessage` to use an options object (`SendMessageOptions`) for `config`, `onEvent`, and `signal`
- CLI tracks `generating` state: Ctrl+C sends cancel when active, detaches (closes readline) when idle

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 175 tests pass
- [ ] Manual: start daemon + CLI, send a message, press Ctrl+C mid-generation → should see `[Cancelled]` and return to prompt
- [ ] Manual: at idle prompt, press Ctrl+C → should detach from daemon as before
- [ ] Manual: verify daemon stays alive after cancel (send another message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
