### PR TITLE
Add deny rules to the permissions system

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -268,10 +268,51 @@ describe('Permission Checker', () => {
       expect(result.matchedRule).toBeDefined();
     });
 
-    test('high risk ignores trust rules', async () => {
+    test('high risk ignores allow rules', async () => {
       addRule('shell', 'sudo *', 'everywhere');
       const result = await check('shell', { command: 'sudo rm -rf /' }, '/tmp');
       expect(result.decision).toBe('prompt');
+    });
+
+    // Deny rule tests
+    test('deny rule blocks medium-risk command', async () => {
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      const result = await check('shell', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toContain('deny rule');
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.decision).toBe('deny');
+    });
+
+    test('deny rule overrides allow rule', async () => {
+      addRule('shell', 'rm *', '/tmp', 'allow');
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      const result = await check('shell', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
+
+    test('deny rule blocks low-risk command', async () => {
+      addRule('shell', 'ls', '/tmp', 'deny');
+      const result = await check('shell', { command: 'ls' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
+
+    test('deny rule blocks high-risk command without prompting', async () => {
+      addRule('shell', 'sudo *', 'everywhere', 'deny');
+      const result = await check('shell', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
+
+    test('deny rule for file tools', async () => {
+      addRule('file_write', 'file_write:/etc/*', 'everywhere', 'deny');
+      const result = await check('file_write', { path: '/etc/passwd' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
+
+    test('non-matching deny rule does not block', async () => {
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      const result = await check('shell', { command: 'ls' }, '/tmp');
+      expect(result.decision).toBe('allow');
     });
   });
 

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -37,7 +37,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { addRule, removeRule, findMatchingRule, getAllRules, clearCache } from '../permissions/trust-store.js';
+import { addRule, removeRule, findMatchingRule, findDenyRule, getAllRules, clearCache } from '../permissions/trust-store.js';
 
 describe('Trust Store', () => {
   beforeEach(() => {
@@ -260,6 +260,68 @@ describe('Trust Store', () => {
       expect(data).toHaveProperty('version', 1);
       expect(data).toHaveProperty('rules');
       expect(Array.isArray(data.rules)).toBe(true);
+    });
+  });
+
+  // ── deny rules ─────────────────────────────────────────────────
+
+  describe('deny rules', () => {
+    test('addRule with deny decision creates a deny rule', () => {
+      const rule = addRule('shell', 'rm -rf *', '/tmp', 'deny');
+      expect(rule.decision).toBe('deny');
+      expect(rule.tool).toBe('shell');
+      expect(rule.pattern).toBe('rm -rf *');
+    });
+
+    test('deny rule persists to disk', () => {
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      clearCache();
+      const rules = getAllRules();
+      expect(rules).toHaveLength(1);
+      expect(rules[0].decision).toBe('deny');
+    });
+
+    test('findDenyRule finds deny rules', () => {
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      const match = findDenyRule('shell', 'rm file.txt', '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.decision).toBe('deny');
+    });
+
+    test('findDenyRule ignores allow rules', () => {
+      addRule('shell', 'rm *', '/tmp', 'allow');
+      const match = findDenyRule('shell', 'rm file.txt', '/tmp');
+      expect(match).toBeNull();
+    });
+
+    test('findMatchingRule ignores deny rules', () => {
+      addRule('shell', 'rm *', '/tmp', 'deny');
+      const match = findMatchingRule('shell', 'rm file.txt', '/tmp');
+      expect(match).toBeNull();
+    });
+
+    test('deny and allow rules coexist', () => {
+      addRule('shell', 'git *', '/tmp', 'allow');
+      addRule('shell', 'git push --force *', '/tmp', 'deny');
+      expect(findMatchingRule('shell', 'git status', '/tmp')).not.toBeNull();
+      expect(findDenyRule('shell', 'git push --force origin', '/tmp')).not.toBeNull();
+    });
+
+    test('deny rule with scope matching', () => {
+      addRule('shell', 'rm *', '/home/user/project', 'deny');
+      expect(findDenyRule('shell', 'rm file.txt', '/home/user/project/sub')).not.toBeNull();
+      expect(findDenyRule('shell', 'rm file.txt', '/home/other')).toBeNull();
+    });
+
+    test('deny rule with everywhere scope', () => {
+      addRule('shell', 'rm -rf *', 'everywhere', 'deny');
+      expect(findDenyRule('shell', 'rm -rf /', '/any/path')).not.toBeNull();
+    });
+
+    test('removeRule works for deny rules', () => {
+      const rule = addRule('shell', 'rm *', '/tmp', 'deny');
+      expect(removeRule(rule.id)).toBe(true);
+      expect(findDenyRule('shell', 'rm file.txt', '/tmp')).toBeNull();
     });
   });
 });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -53,6 +53,7 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2502 [d] Deny once\n`);
     if (req.allowlistOptions.length > 0) {
       process.stdout.write(`\u2502 [A] Allowlist...\n`);
+      process.stdout.write(`\u2502 [D] Denylist...\n`);
     }
     process.stdout.write(`\u2514 > `);
 
@@ -79,7 +80,13 @@ export async function startCli(): Promise<void> {
 
       // 'A' or 'allowlist' → enter pattern selection
       if (answer.trim() === 'A' || choice === 'allowlist') {
-        renderPatternSelection(req);
+        renderPatternSelection(req, 'always_allow');
+        return;
+      }
+
+      // 'D' or 'denylist' → enter deny pattern selection
+      if (answer.trim() === 'D' || choice === 'denylist') {
+        renderPatternSelection(req, 'always_deny');
         return;
       }
 
@@ -92,9 +99,10 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  function renderPatternSelection(req: ConfirmationRequest): void {
+  function renderPatternSelection(req: ConfirmationRequest, decision: 'always_allow' | 'always_deny'): void {
+    const label = decision === 'always_allow' ? 'Allowlist' : 'Denylist';
     process.stdout.write('\n');
-    process.stdout.write(`\u250C Allowlist: choose command pattern\n`);
+    process.stdout.write(`\u250C ${label}: choose command pattern\n`);
     for (let i = 0; i < req.allowlistOptions.length; i++) {
       process.stdout.write(`\u2502 [${i + 1}] ${req.allowlistOptions[i].label}\n`);
     }
@@ -104,7 +112,7 @@ export async function startCli(): Promise<void> {
       const idx = parseInt(answer.trim(), 10) - 1;
       if (idx >= 0 && idx < req.allowlistOptions.length) {
         const selectedPattern = req.allowlistOptions[idx].pattern;
-        renderScopeSelection(req, selectedPattern);
+        renderScopeSelection(req, selectedPattern, decision);
       } else {
         // Invalid selection → deny
         send({
@@ -116,9 +124,10 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  function renderScopeSelection(req: ConfirmationRequest, selectedPattern: string): void {
+  function renderScopeSelection(req: ConfirmationRequest, selectedPattern: string, decision: 'always_allow' | 'always_deny'): void {
+    const label = decision === 'always_allow' ? 'Allowlist' : 'Denylist';
     process.stdout.write('\n');
-    process.stdout.write(`\u250C Allowlist: choose scope\n`);
+    process.stdout.write(`\u250C ${label}: choose scope\n`);
     for (let i = 0; i < req.scopeOptions.length; i++) {
       process.stdout.write(`\u2502 [${i + 1}] ${req.scopeOptions[i].label}\n`);
     }
@@ -130,7 +139,7 @@ export async function startCli(): Promise<void> {
         send({
           type: 'confirmation_response',
           requestId: req.requestId,
-          decision: 'always_allow',
+          decision,
           selectedPattern,
           selectedScope: req.scopeOptions[idx].scope,
         });

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -9,7 +9,7 @@ export interface UserMessage {
 export interface ConfirmationResponse {
   type: 'confirmation_response';
   requestId: string;
-  decision: 'allow' | 'always_allow' | 'deny';
+  decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
   selectedPattern?: string;
   selectedScope?: string;
 }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,5 +1,5 @@
 import { RiskLevel, type PermissionCheckResult, type AllowlistOption, type ScopeOption } from './types.js';
-import { findMatchingRule } from './trust-store.js';
+import { findMatchingRule, findDenyRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -125,7 +125,18 @@ export async function check(
 ): Promise<PermissionCheckResult> {
   const risk = await classifyRisk(toolName, input);
 
-  // High risk → always prompt, trust rules ignored
+  // Build command string for rule matching
+  const commandStr = toolName === 'shell'
+    ? (input.command as string) ?? ''
+    : `${toolName}:${(input.path as string) ?? (input.file_path as string) ?? ''}`;
+
+  // Deny rules take precedence at ALL risk levels
+  const denyRule = findDenyRule(toolName, commandStr, workingDir);
+  if (denyRule) {
+    return { decision: 'deny', reason: `Blocked by deny rule: ${denyRule.pattern}`, matchedRule: denyRule };
+  }
+
+  // High risk → always prompt, allow rules ignored
   if (risk === RiskLevel.High) {
     return { decision: 'prompt', reason: `High risk: always requires approval` };
   }
@@ -135,11 +146,7 @@ export async function check(
     return { decision: 'allow', reason: 'Low risk: auto-allowed' };
   }
 
-  // Medium risk → check trust rules
-  const commandStr = toolName === 'shell'
-    ? (input.command as string) ?? ''
-    : `${toolName}:${(input.path as string) ?? (input.file_path as string) ?? ''}`;
-
+  // Medium risk → check allow rules
   const matchedRule = findMatchingRule(toolName, commandStr, workingDir);
   if (matchedRule) {
     return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -59,14 +59,14 @@ function getRules(): TrustRule[] {
   return cachedRules;
 }
 
-export function addRule(tool: string, pattern: string, scope: string): TrustRule {
+export function addRule(tool: string, pattern: string, scope: string, decision: 'allow' | 'deny' = 'allow'): TrustRule {
   const rules = getRules();
   const rule: TrustRule = {
     id: uuid(),
     tool,
     pattern,
     scope,
-    decision: 'allow',
+    decision,
     createdAt: Date.now(),
   };
   rules.push(rule);
@@ -87,16 +87,25 @@ export function removeRule(id: string): boolean {
   return true;
 }
 
-export function findMatchingRule(tool: string, command: string, scope: string): TrustRule | null {
+function findRuleByDecision(tool: string, command: string, scope: string, decision: 'allow' | 'deny'): TrustRule | null {
   const rules = getRules();
   for (const rule of rules) {
     if (rule.tool !== tool) continue;
+    if (rule.decision !== decision) continue;
     if (!minimatch(command, rule.pattern)) continue;
     // Scope check: rule scope must be a prefix of the working dir, or 'everywhere'
     if (rule.scope !== 'everywhere' && !scope.startsWith(rule.scope.replace(/\*$/, ''))) continue;
     return rule;
   }
   return null;
+}
+
+export function findMatchingRule(tool: string, command: string, scope: string): TrustRule | null {
+  return findRuleByDecision(tool, command, scope, 'allow');
+}
+
+export function findDenyRule(tool: string, command: string, scope: string): TrustRule | null {
+  return findRuleByDecision(tool, command, scope, 'deny');
 }
 
 export function getAllRules(): TrustRule[] {

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -9,11 +9,11 @@ export interface TrustRule {
   tool: string;
   pattern: string;
   scope: string;
-  decision: 'allow';
+  decision: 'allow' | 'deny';
   createdAt: number;
 }
 
-export type UserDecision = 'allow' | 'always_allow' | 'deny';
+export type UserDecision = 'allow' | 'always_allow' | 'deny' | 'always_deny';
 
 export interface PermissionCheckResult {
   decision: 'allow' | 'deny' | 'prompt';

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -37,6 +37,21 @@ export class ToolExecutor {
       riskLevel = risk;
       const result = await check(name, input, context.workingDir);
 
+      if (result.decision === 'deny') {
+        decision = 'denied';
+        const durationMs = Date.now() - startTime;
+        recordToolInvocation({
+          conversationId: context.conversationId,
+          toolName: name,
+          input: JSON.stringify(input),
+          result: `denied: ${result.reason}`,
+          decision: 'denied',
+          riskLevel,
+          durationMs,
+        });
+        return { content: result.reason, isError: true };
+      }
+
       if (result.decision === 'prompt') {
         // Need user approval
         const allowlistOptions = generateAllowlistOptions(name, input);
@@ -64,6 +79,21 @@ export class ToolExecutor {
             durationMs,
           });
           return { content: 'Permission denied by user', isError: true };
+        }
+
+        if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
+          addRule(name, response.selectedPattern, response.selectedScope, 'deny');
+          const durationMs = Date.now() - startTime;
+          recordToolInvocation({
+            conversationId: context.conversationId,
+            toolName: name,
+            input: JSON.stringify(input),
+            result: 'denied (permanent)',
+            decision: 'denied',
+            riskLevel,
+            durationMs,
+          });
+          return { content: 'Permission denied by user (rule saved)', isError: true };
         }
 
         if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {


### PR DESCRIPTION
## Summary

- Adds **deny rules** that permanently block matching commands, providing defense-in-depth alongside the existing allow rules
- Deny rules take **precedence over everything**: allow rules, low-risk auto-allow, and high-risk prompts
- Users create deny rules via a new `[D] Denylist...` option in the CLI confirmation prompt, selecting a pattern and scope just like allowlist rules
- Backward compatible: existing `trust.json` files with only allow rules work unchanged

## Changes

- `types.ts`: Widen `TrustRule.decision` to `'allow' | 'deny'`, add `'always_deny'` to `UserDecision`
- `trust-store.ts`: Add `decision` parameter to `addRule()`, add `findDenyRule()` function
- `checker.ts`: Check deny rules first in `check()` before risk classification
- `ipc-protocol.ts`: Add `'always_deny'` to `ConfirmationResponse.decision`
- `executor.ts`: Handle `'deny'` from checker (auto-block) and `'always_deny'` from user (persist + block)
- `cli.ts`: Add `[D] Denylist...` option, reuse pattern/scope selection flow

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 190 tests pass (15 new)
- [x] Deny rule blocks medium-risk commands
- [x] Deny rule overrides allow rules for the same pattern
- [x] Deny rule blocks low-risk (auto-allow) commands
- [x] Deny rule blocks high-risk commands without prompting
- [x] Deny rule scope matching (prefix, everywhere)
- [x] findMatchingRule ignores deny rules / findDenyRule ignores allow rules
- [x] Deny rules persist to disk and survive cache clear
- [ ] Manual: trigger confirmation prompt → select [D] → pick pattern → pick scope → verify rule saved in trust.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
