### PR TITLE
Show colored diffs when the agent edits or writes files

### DIFF
--- a/assistant/src/__tests__/diff.test.ts
+++ b/assistant/src/__tests__/diff.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+import { formatDiff, formatNewFileDiff } from '../util/diff.js';
+
+// Strip ANSI codes for easier assertion
+const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('formatDiff', () => {
+  test('returns empty string for identical content', () => {
+    const result = formatDiff('hello\nworld\n', 'hello\nworld\n', 'test.ts');
+    expect(result).toBe('');
+  });
+
+  test('shows single line addition', () => {
+    const old = 'line1\nline2\nline3';
+    const updated = 'line1\nline2\nnew line\nline3';
+    const result = stripAnsi(formatDiff(old, updated, 'test.ts'));
+    expect(result).toContain('--- a/test.ts');
+    expect(result).toContain('+++ b/test.ts');
+    expect(result).toContain('+new line');
+    expect(result).not.toContain('-new line');
+  });
+
+  test('shows single line removal', () => {
+    const old = 'line1\nline2\nline3';
+    const updated = 'line1\nline3';
+    const result = stripAnsi(formatDiff(old, updated, 'test.ts'));
+    expect(result).toContain('-line2');
+    expect(result).not.toContain('+line2');
+  });
+
+  test('shows line replacement', () => {
+    const old = 'const x = 1;\nconst y = 2;\nconst z = 3;';
+    const updated = 'const x = 1;\nconst y = 42;\nconst z = 3;';
+    const result = stripAnsi(formatDiff(old, updated, 'file.ts'));
+    expect(result).toContain('-const y = 2;');
+    expect(result).toContain('+const y = 42;');
+  });
+
+  test('includes context lines', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
+    const old = lines.join('\n');
+    const newLines = [...lines];
+    newLines[5] = 'CHANGED';
+    const updated = newLines.join('\n');
+    const result = stripAnsi(formatDiff(old, updated, 'ctx.ts'));
+    // Should include context before and after the change
+    expect(result).toContain(' line4');
+    expect(result).toContain(' line5');
+    expect(result).toContain('-line6');
+    expect(result).toContain('+CHANGED');
+    expect(result).toContain(' line7');
+    expect(result).toContain(' line8');
+  });
+
+  test('handles multi-hunk diffs', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
+    const old = lines.join('\n');
+    const newLines = [...lines];
+    newLines[2] = 'CHANGED_A';
+    newLines[17] = 'CHANGED_B';
+    const updated = newLines.join('\n');
+    const result = stripAnsi(formatDiff(old, updated, 'multi.ts'));
+    expect(result).toContain('-line3');
+    expect(result).toContain('+CHANGED_A');
+    expect(result).toContain('-line18');
+    expect(result).toContain('+CHANGED_B');
+    // Should have two @@ hunk headers
+    const hunkHeaders = result.match(/@@/g);
+    expect(hunkHeaders!.length).toBeGreaterThanOrEqual(4); // 2 hunks, each with @@ ... @@
+  });
+
+  test('uses ANSI colors for added/removed lines', () => {
+    const old = 'old line';
+    const updated = 'new line';
+    const result = formatDiff(old, updated, 'test.ts');
+    // Red for removed
+    expect(result).toContain('\x1b[31m-old line\x1b[0m');
+    // Green for added
+    expect(result).toContain('\x1b[32m+new line\x1b[0m');
+  });
+
+  test('handles empty old content (new file)', () => {
+    const result = stripAnsi(formatDiff('', 'new content\nline 2', 'new.ts'));
+    expect(result).toContain('+new content');
+    expect(result).toContain('+line 2');
+  });
+
+  test('handles empty new content (file deleted)', () => {
+    const result = stripAnsi(formatDiff('old content\nline 2', '', 'del.ts'));
+    expect(result).toContain('-old content');
+    expect(result).toContain('-line 2');
+  });
+});
+
+describe('formatNewFileDiff', () => {
+  test('shows all lines as additions', () => {
+    const content = 'line1\nline2\nline3';
+    const result = stripAnsi(formatNewFileDiff(content, 'new.ts'));
+    expect(result).toContain('--- /dev/null');
+    expect(result).toContain('+++ b/new.ts');
+    expect(result).toContain('+line1');
+    expect(result).toContain('+line2');
+    expect(result).toContain('+line3');
+  });
+
+  test('truncates long files', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line${i + 1}`);
+    const content = lines.join('\n');
+    const result = stripAnsi(formatNewFileDiff(content, 'big.ts', 10));
+    expect(result).toContain('+line1');
+    expect(result).toContain('+line10');
+    expect(result).not.toContain('+line11');
+    expect(result).toContain('... 40 more lines');
+  });
+
+  test('does not truncate short files', () => {
+    const content = 'a\nb\nc';
+    const result = stripAnsi(formatNewFileDiff(content, 'small.ts'));
+    expect(result).not.toContain('more lines');
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -11,7 +11,7 @@ export type AgentEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
-  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean }
+  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }
   | { type: 'error'; error: Error };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
@@ -26,14 +26,14 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private toolExecutor: ((name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }>,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -106,6 +106,7 @@ export class AgentLoop {
             toolUseId: toolUse.id,
             content: result.content,
             isError: result.isError,
+            diff: result.diff,
           });
 
           resultBlocks.push({

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -8,6 +8,7 @@ import {
   type ServerMessage,
   type ConfirmationRequest,
 } from './daemon/ipc-protocol.js';
+import { formatDiff, formatNewFileDiff } from './util/diff.js';
 
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
@@ -190,6 +191,14 @@ export async function startCli(): Promise<void> {
           process.stdout.write(
             `[Result: ${msg.result.slice(0, 200)}]\n`,
           );
+          if (msg.diff) {
+            const diffOutput = msg.diff.oldContent
+              ? formatDiff(msg.diff.oldContent, msg.diff.newContent, msg.diff.filePath)
+              : formatNewFileDiff(msg.diff.newContent, msg.diff.filePath);
+            if (diffOutput) {
+              process.stdout.write(diffOutput);
+            }
+          }
           break;
 
         case 'confirmation_request':

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -63,6 +63,7 @@ export interface ToolResult {
   toolName: string;
   result: string;
   isError?: boolean;
+  diff?: { filePath: string; oldContent: string; newContent: string };
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -123,7 +123,7 @@ export class Session {
               onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input });
               break;
             case 'tool_result':
-              onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError });
+              onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff });
               break;
             case 'error':
               onEvent({ type: 'error', message: event.error.message });

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -76,7 +76,11 @@ class FileEditTool implements Tool {
         const updated = content.split(oldString).join(newString);
         const count = content.split(oldString).length - 1;
         writeFileSync(filePath, updated);
-        return { content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`, isError: false };
+        return {
+          content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`,
+          isError: false,
+          diff: { filePath, oldContent: content, newContent: updated },
+        };
       }
 
       // Single-match path: cascading exact → whitespace → fuzzy
@@ -104,7 +108,11 @@ class FileEditTool implements Tool {
         : match.method === 'whitespace'
           ? ' (matched with whitespace normalization)'
           : ` (fuzzy matched, similarity ${(match.similarity * 100).toFixed(0)}%)`;
-      return { content: `Successfully edited ${filePath}${methodNote}`, isError: false };
+      return {
+        content: `Successfully edited ${filePath}${methodNote}`,
+        isError: false,
+        diff: { filePath, oldContent: content, newContent: updated },
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `Error editing file: ${msg}`, isError: true };

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
@@ -52,8 +52,18 @@ class FileWriteTool implements Tool {
         mkdirSync(dir, { recursive: true });
       }
 
+      // Capture old content for diff (if file exists)
+      let oldContent: string | null = null;
+      if (existsSync(filePath)) {
+        try { oldContent = readFileSync(filePath, 'utf-8'); } catch { /* new file */ }
+      }
+
       writeFileSync(filePath, fileContent);
-      return { content: `Successfully wrote to ${filePath}`, isError: false };
+      return {
+        content: `Successfully wrote to ${filePath}`,
+        isError: false,
+        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent },
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `Error writing file: ${msg}`, isError: true };

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -7,9 +7,16 @@ export interface ToolContext {
   conversationId: string;
 }
 
+export interface DiffInfo {
+  filePath: string;
+  oldContent: string;
+  newContent: string;
+}
+
 export interface ToolExecutionResult {
   content: string;
   isError: boolean;
+  diff?: DiffInfo;
 }
 
 export interface Tool {

--- a/assistant/src/util/diff.ts
+++ b/assistant/src/util/diff.ts
@@ -1,0 +1,176 @@
+/**
+ * Minimal line-level diff utility with colored unified diff output.
+ * No external dependencies.
+ */
+
+interface DiffEntry {
+  type: 'same' | 'add' | 'remove';
+  line: string;
+}
+
+/**
+ * Compute a line-level diff using LCS (longest common subsequence).
+ * O(n*m) time and space — fine for typical source files.
+ */
+function computeLineDiff(oldLines: string[], newLines: string[]): DiffEntry[] {
+  const m = oldLines.length;
+  const n = newLines.length;
+
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack to build diff
+  const result: DiffEntry[] = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({ type: 'same', line: oldLines[i - 1] });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({ type: 'add', line: newLines[j - 1] });
+      j--;
+    } else {
+      result.unshift({ type: 'remove', line: oldLines[i - 1] });
+      i--;
+    }
+  }
+
+  return result;
+}
+
+interface Hunk {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  lines: DiffEntry[];
+}
+
+const CONTEXT_LINES = 3;
+
+/**
+ * Group diff entries into hunks with surrounding context lines.
+ */
+function buildHunks(entries: DiffEntry[]): Hunk[] {
+  // Find ranges of changed lines
+  const changeRanges: Array<{ start: number; end: number }> = [];
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].type !== 'same') {
+      if (changeRanges.length > 0 && i - changeRanges[changeRanges.length - 1].end <= CONTEXT_LINES * 2) {
+        // Merge with previous range if close enough
+        changeRanges[changeRanges.length - 1].end = i + 1;
+      } else {
+        changeRanges.push({ start: i, end: i + 1 });
+      }
+    }
+  }
+
+  // Build hunks with context
+  const hunks: Hunk[] = [];
+  for (const range of changeRanges) {
+    const contextStart = Math.max(0, range.start - CONTEXT_LINES);
+    const contextEnd = Math.min(entries.length, range.end + CONTEXT_LINES);
+    const hunkEntries = entries.slice(contextStart, contextEnd);
+
+    // Count old/new lines for hunk header
+    let oldLine = 1, newLine = 1;
+    for (let i = 0; i < contextStart; i++) {
+      if (entries[i].type === 'same' || entries[i].type === 'remove') oldLine++;
+      if (entries[i].type === 'same' || entries[i].type === 'add') newLine++;
+    }
+
+    let oldCount = 0, newCount = 0;
+    for (const entry of hunkEntries) {
+      if (entry.type === 'same' || entry.type === 'remove') oldCount++;
+      if (entry.type === 'same' || entry.type === 'add') newCount++;
+    }
+
+    hunks.push({
+      oldStart: oldLine,
+      oldCount,
+      newStart: newLine,
+      newCount,
+      lines: hunkEntries,
+    });
+  }
+
+  return hunks;
+}
+
+// ANSI color codes
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const CYAN = '\x1b[36m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+/**
+ * Format a colored unified diff from old and new file content.
+ * Returns an empty string if the contents are identical.
+ */
+export function formatDiff(oldContent: string, newContent: string, filePath: string): string {
+  if (oldContent === newContent) return '';
+
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  const entries = computeLineDiff(oldLines, newLines);
+  const hunks = buildHunks(entries);
+
+  if (hunks.length === 0) return '';
+
+  let output = `${DIM}--- a/${filePath}${RESET}\n`;
+  output += `${DIM}+++ b/${filePath}${RESET}\n`;
+
+  for (const hunk of hunks) {
+    output += `${CYAN}@@ -${hunk.oldStart},${hunk.oldCount} +${hunk.newStart},${hunk.newCount} @@${RESET}\n`;
+    for (const entry of hunk.lines) {
+      switch (entry.type) {
+        case 'same':
+          output += ` ${entry.line}\n`;
+          break;
+        case 'remove':
+          output += `${RED}-${entry.line}${RESET}\n`;
+          break;
+        case 'add':
+          output += `${GREEN}+${entry.line}${RESET}\n`;
+          break;
+      }
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Format a "new file" diff (everything is added).
+ * Truncates to maxLines to avoid flooding the terminal.
+ */
+export function formatNewFileDiff(content: string, filePath: string, maxLines = 20): string {
+  const lines = content.split('\n');
+  const truncated = lines.length > maxLines;
+  const displayLines = truncated ? lines.slice(0, maxLines) : lines;
+
+  let output = `${DIM}--- /dev/null${RESET}\n`;
+  output += `${DIM}+++ b/${filePath}${RESET}\n`;
+  output += `${CYAN}@@ -0,0 +1,${lines.length} @@${RESET}\n`;
+
+  for (const line of displayLines) {
+    output += `${GREEN}+${line}${RESET}\n`;
+  }
+
+  if (truncated) {
+    output += `${DIM}... ${lines.length - maxLines} more lines${RESET}\n`;
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Summary

- When `file_edit` or `file_write` tools succeed, the CLI now displays a **colored unified diff** below the result message
- Red (`-`) for removed lines, green (`+`) for added lines, with 3 lines of context
- New files show all lines as additions, truncated at 20 lines for large files
- No external dependencies — LCS-based diff algorithm implemented from scratch

## Changes

- **New**: `util/diff.ts` — line-level LCS diff, hunk grouping with context, ANSI-colored unified diff output
- **New**: `__tests__/diff.test.ts` — 12 tests for diff formatting
- `tools/types.ts`: Add `DiffInfo` interface and optional `diff` field on `ToolExecutionResult`
- `tools/filesystem/write.ts`: Capture old content before overwriting, include diff in result
- `tools/filesystem/edit.ts`: Include before/after file content as diff in result
- `agent/loop.ts`: Thread `diff` through `AgentEvent` and `toolExecutor` type
- `daemon/ipc-protocol.ts`: Add optional `diff` to `ToolResult` IPC message
- `daemon/session.ts`: Forward diff from agent event to IPC
- `cli.ts`: Render colored diff (or new-file diff) when present on tool_result

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass (12 new)
- [x] Single line addition/removal/replacement diffs render correctly
- [x] Multi-hunk diffs with context lines
- [x] ANSI colors (red/green) applied correctly
- [x] New file diff shows all additions with truncation
- [x] Identical content produces no diff output
- [ ] Manual: edit a file via agent → verify colored diff appears in CLI
- [ ] Manual: write a new file → verify green "new file" diff appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
