### PR TITLE
Fix abort handling bugs in agent loop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -117,6 +117,9 @@ export class AgentLoop {
           });
         }
 
+        // If cancelled mid-execution, discard incomplete results
+        if (signal?.aborted) break;
+
         // Track tool-use turns and inject progress reminder every N turns
         toolUseTurns++;
         if (toolUseTurns % PROGRESS_CHECK_INTERVAL === 0) {
@@ -129,6 +132,8 @@ export class AgentLoop {
         // Add tool results as a user message and continue the loop
         history.push({ role: 'user', content: resultBlocks });
       } catch (error) {
+        // Abort errors are expected when user cancels — don't emit as errors
+        if (signal?.aborted) break;
         const err = error instanceof Error ? error : new Error(String(error));
         log.error({ err }, 'Agent loop error');
         onEvent({ type: 'error', error: err });


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #93 (abort/cancel feature):

- **Discard incomplete tool results on abort**: When cancellation occurs between tool executions in the for-loop, the `resultBlocks` array is incomplete. Previously these partial results were pushed to conversation history, corrupting the session. Now we check `signal.aborted` after the loop and break before pushing.

- **Suppress error events on abort**: When the abort signal fires during streaming, the Anthropic SDK throws an error that was being forwarded to the CLI as `[Error: ...]` before the session also sent `[Cancelled]`, causing duplicate messages. Now the catch block checks `signal.aborted` first and silently breaks instead of emitting an error event.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
