### PR TITLE
Fix deny rules security bypass and CLI shortcut ordering

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -59,7 +59,20 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2514 > `);
 
     rl.once('line', (answer) => {
-      const choice = answer.trim().toLowerCase();
+      const trimmed = answer.trim();
+      const choice = trimmed.toLowerCase();
+
+      // Uppercase 'A' → allowlist pattern selection (check before lowercase 'a')
+      if (trimmed === 'A' || choice === 'allowlist') {
+        renderPatternSelection(req, 'always_allow');
+        return;
+      }
+
+      // Uppercase 'D' → denylist pattern selection (check before lowercase 'd')
+      if (trimmed === 'D' || choice === 'denylist') {
+        renderPatternSelection(req, 'always_deny');
+        return;
+      }
 
       if (choice === 'a') {
         send({
@@ -76,18 +89,6 @@ export async function startCli(): Promise<void> {
           requestId: req.requestId,
           decision: 'deny',
         });
-        return;
-      }
-
-      // 'A' or 'allowlist' → enter pattern selection
-      if (answer.trim() === 'A' || choice === 'allowlist') {
-        renderPatternSelection(req, 'always_allow');
-        return;
-      }
-
-      // 'D' or 'denylist' → enter deny pattern selection
-      if (answer.trim() === 'D' || choice === 'denylist') {
-        renderPatternSelection(req, 'always_deny');
         return;
       }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -81,8 +81,10 @@ export class ToolExecutor {
           return { content: 'Permission denied by user', isError: true };
         }
 
-        if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
-          addRule(name, response.selectedPattern, response.selectedScope, 'deny');
+        if (response.decision === 'always_deny') {
+          if (response.selectedPattern && response.selectedScope) {
+            addRule(name, response.selectedPattern, response.selectedScope, 'deny');
+          }
           const durationMs = Date.now() - startTime;
           recordToolInvocation({
             conversationId: context.conversationId,


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #94 (deny rules feature):

- **Security fix in `executor.ts`**: When `always_deny` was received without `selectedPattern`/`selectedScope` (both optional in the IPC protocol), the guard condition failed and execution fell through to run the tool — a security bypass where a user-denied tool gets executed anyway. Now `always_deny` always blocks execution, and only persists the rule when pattern/scope are provided.

- **CLI shortcut fix in `cli.ts`**: The `[A] Allowlist` and `[D] Denylist` shortcuts were unreachable because input was lowercased to `choice` before checking, so uppercase `A`/`D` matched the allow-once/deny-once handlers first. Reordered checks so case-sensitive uppercase shortcuts are evaluated before lowercase ones.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
