### PR TITLE
Add diff size cutoff and explicit isNewFile flag

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -11,7 +11,7 @@ export type AgentEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
-  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }
+  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }
   | { type: 'error'; error: Error };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
@@ -26,14 +26,14 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private toolExecutor: ((name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string } }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -193,9 +193,9 @@ export async function startCli(): Promise<void> {
             `[Result: ${msg.result.slice(0, 200)}]\n`,
           );
           if (msg.diff) {
-            const diffOutput = msg.diff.oldContent
-              ? formatDiff(msg.diff.oldContent, msg.diff.newContent, msg.diff.filePath)
-              : formatNewFileDiff(msg.diff.newContent, msg.diff.filePath);
+            const diffOutput = msg.diff.isNewFile
+              ? formatNewFileDiff(msg.diff.newContent, msg.diff.filePath)
+              : formatDiff(msg.diff.oldContent, msg.diff.newContent, msg.diff.filePath);
             if (diffOutput) {
               process.stdout.write(diffOutput);
             }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -63,7 +63,7 @@ export interface ToolResult {
   toolName: string;
   result: string;
   isError?: boolean;
-  diff?: { filePath: string; oldContent: string; newContent: string };
+  diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -79,7 +79,7 @@ class FileEditTool implements Tool {
         return {
           content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`,
           isError: false,
-          diff: { filePath, oldContent: content, newContent: updated },
+          diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
         };
       }
 
@@ -111,7 +111,7 @@ class FileEditTool implements Tool {
       return {
         content: `Successfully edited ${filePath}${methodNote}`,
         isError: false,
-        diff: { filePath, oldContent: content, newContent: updated },
+        diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -54,15 +54,16 @@ class FileWriteTool implements Tool {
 
       // Capture old content for diff (if file exists)
       let oldContent: string | null = null;
-      if (existsSync(filePath)) {
-        try { oldContent = readFileSync(filePath, 'utf-8'); } catch { /* new file */ }
+      const isNewFile = !existsSync(filePath);
+      if (!isNewFile) {
+        try { oldContent = readFileSync(filePath, 'utf-8'); } catch { /* unreadable */ }
       }
 
       writeFileSync(filePath, fileContent);
       return {
         content: `Successfully wrote to ${filePath}`,
         isError: false,
-        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent },
+        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent, isNewFile },
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -11,6 +11,7 @@ export interface DiffInfo {
   filePath: string;
   oldContent: string;
   newContent: string;
+  isNewFile: boolean;
 }
 
 export interface ToolExecutionResult {

--- a/assistant/src/util/diff.ts
+++ b/assistant/src/util/diff.ts
@@ -56,6 +56,7 @@ interface Hunk {
 }
 
 const CONTEXT_LINES = 3;
+const MAX_DIFF_LINES = 1000;
 
 /**
  * Group diff entries into hunks with surrounding context lines.
@@ -122,6 +123,16 @@ export function formatDiff(oldContent: string, newContent: string, filePath: str
 
   const oldLines = oldContent.split('\n');
   const newLines = newContent.split('\n');
+
+  // Guard against quadratic blowup on large files
+  if (oldLines.length > MAX_DIFF_LINES || newLines.length > MAX_DIFF_LINES) {
+    const removed = oldLines.length;
+    const added = newLines.length;
+    let output = `${DIM}--- a/${filePath}${RESET}\n`;
+    output += `${DIM}+++ b/${filePath}${RESET}\n`;
+    output += `${DIM}[Diff too large to display: ${removed} lines → ${added} lines]${RESET}\n`;
+    return output;
+  }
 
   const entries = computeLineDiff(oldLines, newLines);
   const hunks = buildHunks(entries);


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #95 (diff display feature):

- **Size cutoff for diff computation** (`diff.ts`): The LCS algorithm builds a full `(m+1) x (n+1)` DP table, which is O(n*m) in time and space. For large files (multi-thousand lines), this could freeze or crash the CLI. Added a `MAX_DIFF_LINES = 1000` guard that falls back to a summary message instead of computing the full diff.

- **Explicit `isNewFile` flag** (7 files): The CLI was using `msg.diff.oldContent` truthiness to decide between `formatDiff` and `formatNewFileDiff`. Since `''` is falsy, overwriting an empty file was misclassified as a new file. Added an explicit `isNewFile: boolean` field to `DiffInfo`, threaded through `AgentEvent`, IPC `ToolResult`, and CLI rendering.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
