### PR TITLE
Synthesize cancelled tool_results on abort to maintain API contract

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -117,8 +117,28 @@ export class AgentLoop {
           });
         }
 
-        // If cancelled mid-execution, discard incomplete results
-        if (signal?.aborted) break;
+        // If cancelled mid-execution, synthesize cancelled results for
+        // any tool_use blocks that weren't executed, so the API contract
+        // (every tool_use must have a matching tool_result) is maintained.
+        if (signal?.aborted) {
+          const completedIds = new Set(
+            resultBlocks
+              .filter((b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result')
+              .map((b) => b.tool_use_id),
+          );
+          for (const toolUse of toolUseBlocks) {
+            if (!completedIds.has(toolUse.id)) {
+              resultBlocks.push({
+                type: 'tool_result',
+                tool_use_id: toolUse.id,
+                content: 'Cancelled by user',
+                is_error: true,
+              });
+            }
+          }
+          history.push({ role: 'user', content: resultBlocks });
+          break;
+        }
 
         // Track tool-use turns and inject progress reminder every N turns
         toolUseTurns++;


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #96 (abort handling):

When abort occurs during tool execution, the assistant message containing `tool_use` blocks has already been pushed to history and persisted to the database. The previous fix simply discarded incomplete `resultBlocks` by breaking out of the loop, but this left orphaned `tool_use` blocks with no matching `tool_result` message. The Anthropic API requires every `tool_use` to have a corresponding `tool_result` — without it, the next user message would trigger an API validation error.

Now instead of discarding results on abort, the loop synthesizes `"Cancelled by user"` `tool_result` blocks (with `is_error: true`) for any `tool_use` blocks that weren't executed, then pushes the complete results to history. This maintains the API invariant and allows the conversation to continue cleanly after cancellation.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
