### PR TITLE
Fix misleading 'rule saved' message when no deny rule is persisted

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -82,20 +82,21 @@ export class ToolExecutor {
         }
 
         if (response.decision === 'always_deny') {
-          if (response.selectedPattern && response.selectedScope) {
-            addRule(name, response.selectedPattern, response.selectedScope, 'deny');
+          const ruleSaved = !!(response.selectedPattern && response.selectedScope);
+          if (ruleSaved) {
+            addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
           }
           const durationMs = Date.now() - startTime;
           recordToolInvocation({
             conversationId: context.conversationId,
             toolName: name,
             input: JSON.stringify(input),
-            result: 'denied (permanent)',
+            result: ruleSaved ? 'denied (permanent)' : 'denied',
             decision: 'denied',
             riskLevel,
             durationMs,
           });
-          return { content: 'Permission denied by user (rule saved)', isError: true };
+          return { content: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user', isError: true };
         }
 
         if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #97 (deny rules fix):

When `always_deny` is received without `selectedPattern`/`selectedScope` (both optional in the IPC protocol), no persistent deny rule is saved — but the return message unconditionally said `"Permission denied by user (rule saved)"`. This gives the LLM and user incorrect feedback, making them believe a permanent deny rule exists when it doesn't.

Now the message accurately reflects what happened:
- With pattern/scope: `"Permission denied by user (rule saved)"`
- Without: `"Permission denied by user"`

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
