### PR TITLE
Add progress indicators with spinner and elapsed time

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -9,6 +9,7 @@ import {
   type ConfirmationRequest,
 } from './daemon/ipc-protocol.js';
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
+import { Spinner } from './util/spinner.js';
 
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
@@ -16,6 +17,22 @@ export async function startCli(): Promise<void> {
   const parser = createMessageParser();
   let sessionId = '';
   let generating = false;
+  const spinner = new Spinner();
+
+  function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
+    switch (toolName) {
+      case 'shell':
+        return `Running \`${String(input.command ?? '').slice(0, 60)}\`...`;
+      case 'file_read':
+        return `Reading ${input.path ?? ''}...`;
+      case 'file_write':
+        return `Writing ${input.path ?? ''}...`;
+      case 'file_edit':
+        return `Editing ${input.path ?? ''}...`;
+      default:
+        return `Running ${toolName}...`;
+    }
+  }
 
   const rl = readline.createInterface({
     input: process.stdin,
@@ -169,29 +186,31 @@ export async function startCli(): Promise<void> {
           break;
 
         case 'assistant_text_delta':
+          spinner.stop();
           process.stdout.write(msg.text);
           break;
 
         case 'message_complete':
+          spinner.stop();
           generating = false;
           process.stdout.write('\n\n');
           prompt();
           break;
 
         case 'generation_cancelled':
+          spinner.stop();
           generating = false;
           process.stdout.write('\n[Cancelled]\n\n');
           prompt();
           break;
 
         case 'tool_use_start':
-          process.stdout.write(`\n[Tool: ${msg.toolName}]\n`);
+          spinner.start(formatToolProgress(msg.toolName, msg.input));
           break;
 
         case 'tool_result':
-          process.stdout.write(
-            `[Result: ${msg.result.slice(0, 200)}]\n`,
-          );
+          spinner.stop();
+          process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
           if (msg.diff) {
             const diffOutput = msg.diff.isNewFile
               ? formatNewFileDiff(msg.diff.newContent, msg.diff.filePath)
@@ -200,13 +219,17 @@ export async function startCli(): Promise<void> {
               process.stdout.write(diffOutput);
             }
           }
+          // Agent will call the LLM again after tool results
+          spinner.start('Thinking...');
           break;
 
         case 'confirmation_request':
+          spinner.stop();
           renderConfirmationPrompt(msg);
           break;
 
         case 'error':
+          spinner.stop();
           generating = false;
           process.stdout.write(`\n[Error: ${msg.message}]\n`);
           prompt();
@@ -230,6 +253,7 @@ export async function startCli(): Promise<void> {
     if (content) {
       generating = true;
       send({ type: 'user_message', sessionId, content });
+      spinner.start('Thinking...');
     }
   });
 

--- a/assistant/src/util/spinner.ts
+++ b/assistant/src/util/spinner.ts
@@ -1,0 +1,45 @@
+/**
+ * Terminal spinner with elapsed time display.
+ * Renders to stderr so it doesn't interfere with stdout content.
+ */
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+export class Spinner {
+  private message = '';
+  private startTime = 0;
+  private frameIndex = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private active = false;
+
+  start(message: string): void {
+    this.stop();
+    this.message = message;
+    this.startTime = Date.now();
+    this.frameIndex = 0;
+    this.active = true;
+    this.render();
+    this.timer = setInterval(() => this.render(), 80);
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    this.active = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    // Clear the spinner line
+    process.stderr.write('\r\x1b[K');
+  }
+
+  private render(): void {
+    const frame = FRAMES[this.frameIndex % FRAMES.length];
+    this.frameIndex++;
+    const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+    const timeStr = elapsed > 0 ? ` (${elapsed}s)` : '';
+    process.stderr.write(`\r\x1b[K${DIM}${frame} ${this.message}${timeStr}${RESET}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds progress indicators to the CLI so users can see what the agent is doing:

- **Thinking spinner**: Shows `⠋ Thinking... (3s)` while waiting for the LLM response, with an animated braille spinner and elapsed time counter
- **Tool-specific messages**: Context-aware progress for each tool type:
  - `⠹ Running \`npm test\`... (2s)` for shell commands
  - `⠸ Reading src/index.ts...` for file reads
  - `⠼ Writing config.json... (1s)` for file writes
  - `⠴ Editing main.ts...` for file edits
  - `⠦ Running tool_name...` for other tools
- **Automatic lifecycle**: Spinner starts on user message send, clears on first text output, restarts for tool execution, and stops on completion/cancellation/error/permission prompt
- **stderr rendering**: Spinner writes to stderr to avoid interfering with stdout content piping

New file: `assistant/src/util/spinner.ts` (~45 lines, zero dependencies)

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
