### PR TITLE
Add conversation export as markdown or JSON

### DIFF
--- a/assistant/src/export/formatter.ts
+++ b/assistant/src/export/formatter.ts
@@ -1,0 +1,96 @@
+/**
+ * Conversation export formatters for markdown and JSON.
+ */
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  content?: string;
+  tool_use_id?: string;
+  is_error?: boolean;
+}
+
+interface ExportMessage {
+  role: string;
+  content: ContentBlock[];
+  createdAt: number;
+}
+
+interface ExportConversation {
+  id: string;
+  title: string | null;
+  createdAt: number;
+  updatedAt: number;
+  messages: ExportMessage[];
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function extractText(blocks: ContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'text':
+        if (block.text) parts.push(block.text);
+        break;
+      case 'tool_use':
+        parts.push(`[Tool: ${block.name}] ${JSON.stringify(block.input ?? {})}`);
+        break;
+      case 'tool_result':
+        if (block.is_error) {
+          parts.push(`[Error: ${block.content ?? ''}]`);
+        } else {
+          parts.push(`[Result: ${(block.content ?? '').slice(0, 500)}]`);
+        }
+        break;
+    }
+  }
+  return parts.join('\n');
+}
+
+export function formatMarkdown(conversation: ExportConversation): string {
+  const title = conversation.title ?? 'Untitled';
+  const lines: string[] = [];
+
+  lines.push(`# ${title}`);
+  lines.push('');
+  lines.push(`*Session ID: ${conversation.id}*`);
+  lines.push(`*Created: ${formatTimestamp(conversation.createdAt)}*`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of conversation.messages) {
+    const role = msg.role === 'user' ? 'You' : 'Assistant';
+    const time = formatTimestamp(msg.createdAt);
+    lines.push(`## ${role} (${time})`);
+    lines.push('');
+    lines.push(extractText(msg.content));
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push(`*Exported at ${formatTimestamp(Date.now())}*`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function formatJson(conversation: ExportConversation): string {
+  return JSON.stringify({
+    id: conversation.id,
+    title: conversation.title,
+    createdAt: new Date(conversation.createdAt).toISOString(),
+    updatedAt: new Date(conversation.updatedAt).toISOString(),
+    exportedAt: new Date().toISOString(),
+    messages: conversation.messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+      timestamp: new Date(msg.createdAt).toISOString(),
+    })),
+  }, null, 2);
+}

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -30,6 +30,12 @@ import {
   clearAllRules,
 } from './permissions/trust-store.js';
 import { getRecentInvocations } from './memory/tool-usage-store.js';
+import {
+  getConversation,
+  getMessages,
+  listConversations,
+} from './memory/conversation-store.js';
+import { formatMarkdown, formatJson } from './export/formatter.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -164,6 +170,65 @@ sessions
       console.log(`Created session: ${response.title} (${response.sessionId})`);
     } else if (response.type === 'error') {
       console.error(`Error: ${response.message}`);
+    }
+  });
+
+sessions
+  .command('export [sessionId]')
+  .description('Export a conversation as markdown or JSON')
+  .option('-f, --format <format>', 'Output format: md or json', 'md')
+  .option('-o, --output <file>', 'Write to file instead of stdout')
+  .action(async (sessionId?: string, opts?: { format: string; output?: string }) => {
+    const format = opts?.format ?? 'md';
+    if (format !== 'md' && format !== 'json') {
+      console.error('Error: format must be "md" or "json"');
+      process.exit(1);
+    }
+
+    // If no session ID given, pick the most recent one
+    let id = sessionId;
+    if (!id) {
+      const all = listConversations(1);
+      if (all.length === 0) {
+        console.error('No sessions found');
+        process.exit(1);
+      }
+      id = all[0].id;
+    }
+
+    // Support prefix matching for session IDs
+    let conversation = getConversation(id);
+    if (!conversation) {
+      const all = listConversations();
+      const match = all.find((c) => c.id.startsWith(id!));
+      if (match) {
+        conversation = match;
+      } else {
+        console.error(`Session not found: ${id}`);
+        process.exit(1);
+      }
+    }
+
+    const msgs = getMessages(conversation.id);
+    const exportData = {
+      ...conversation,
+      messages: msgs.map((m) => ({
+        role: m.role,
+        content: JSON.parse(m.content),
+        createdAt: m.createdAt,
+      })),
+    };
+
+    const output = format === 'json'
+      ? formatJson(exportData)
+      : formatMarkdown(exportData);
+
+    if (opts?.output) {
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(opts.output, output);
+      console.error(`Exported to ${opts.output}`);
+    } else {
+      process.stdout.write(output);
     }
   });
 


### PR DESCRIPTION
## Summary

Adds a new CLI command to export conversation sessions for sharing and archiving:

```
vellum sessions export [sessionId] [--format md|json] [--output file]
```

- **Markdown format** (default): Human-readable export with headers, timestamps, and tool use blocks rendered inline
- **JSON format**: Preserves raw Anthropic content blocks for programmatic use, includes ISO timestamps
- **Session ID prefix matching**: `vellum sessions export abc` matches `abc123-def-...`
- **Default to latest**: Omitting the session ID exports the most recent session
- **File output**: `--output report.md` writes to file, otherwise prints to stdout for piping
- **No daemon required**: Reads directly from the SQLite database

New files:
- `assistant/src/export/formatter.ts` — Markdown and JSON formatters (~96 lines)

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
