### PR TITLE
Fix spinner not stopping on Ctrl+C and add TTY guard

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -264,6 +264,7 @@ export async function startCli(): Promise<void> {
 
   // Ctrl+C: cancel generation if in progress, otherwise detach
   process.on('SIGINT', () => {
+    spinner.stop();
     if (generating) {
       send({ type: 'cancel' });
     } else {

--- a/assistant/src/util/spinner.ts
+++ b/assistant/src/util/spinner.ts
@@ -1,6 +1,7 @@
 /**
  * Terminal spinner with elapsed time display.
  * Renders to stderr so it doesn't interfere with stdout content.
+ * Silently no-ops when stderr is not a TTY (e.g. redirected to file).
  */
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -15,6 +16,7 @@ export class Spinner {
   private active = false;
 
   start(message: string): void {
+    if (!process.stderr.isTTY) return;
     this.stop();
     this.message = message;
     this.startTime = Date.now();


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #101 (progress indicators):

- **Stop spinner on SIGINT** (`cli.ts`): The SIGINT handler sent a cancel message but didn't stop the spinner, so it kept animating until the server responded with `generation_cancelled`. Now `spinner.stop()` is called immediately on Ctrl+C for instant visual feedback.

- **TTY guard** (`spinner.ts`): The spinner always wrote ANSI control sequences every 80ms, even when stderr was redirected to a file or pipe. In non-interactive contexts (CI, `2> logs.txt`), this would bloat logs with raw escape bytes. Now the spinner silently no-ops when `!process.stderr.isTTY`.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
