### PR TITLE
Fix export command: init DB and remove prefix-match limit

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -35,6 +35,7 @@ import {
   getMessages,
   listConversations,
 } from './memory/conversation-store.js';
+import { initializeDb } from './memory/db.js';
 import { formatMarkdown, formatJson } from './export/formatter.js';
 
 function sendOneMessage(
@@ -179,6 +180,7 @@ sessions
   .option('-f, --format <format>', 'Output format: md or json', 'md')
   .option('-o, --output <file>', 'Write to file instead of stdout')
   .action(async (sessionId?: string, opts?: { format: string; output?: string }) => {
+    initializeDb();
     const format = opts?.format ?? 'md';
     if (format !== 'md' && format !== 'json') {
       console.error('Error: format must be "md" or "json"');
@@ -199,7 +201,7 @@ sessions
     // Support prefix matching for session IDs
     let conversation = getConversation(id);
     if (!conversation) {
-      const all = listConversations();
+      const all = listConversations(Number.MAX_SAFE_INTEGER);
       const match = all.find((c) => c.id.startsWith(id!));
       if (match) {
         conversation = match;


### PR DESCRIPTION
## Summary
- Call `initializeDb()` before querying conversations so `vellum sessions export` works in a fresh environment where the DB tables don't yet exist (previously crashed with "no such table: conversations")
- Use `Number.MAX_SAFE_INTEGER` limit for the prefix-match fallback search so users with >100 conversations can still match older session IDs

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/102

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
