### PR TITLE
Add /copy and /copy-code clipboard commands

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -10,6 +10,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
 import { Spinner } from './util/spinner.js';
+import { copyToClipboard, extractLastCodeBlock } from './util/clipboard.js';
 
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
@@ -17,6 +18,7 @@ export async function startCli(): Promise<void> {
   const parser = createMessageParser();
   let sessionId = '';
   let generating = false;
+  let lastResponse = '';
   const spinner = new Spinner();
 
   function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
@@ -187,6 +189,7 @@ export async function startCli(): Promise<void> {
 
         case 'assistant_text_delta':
           spinner.stop();
+          lastResponse += msg.text;
           process.stdout.write(msg.text);
           break;
 
@@ -250,11 +253,43 @@ export async function startCli(): Promise<void> {
 
   rl.on('line', (line) => {
     const content = line.trim();
-    if (content) {
-      generating = true;
-      send({ type: 'user_message', sessionId, content });
-      spinner.start('Thinking...');
+    if (!content) return;
+
+    if (content === '/copy') {
+      if (!lastResponse) {
+        process.stdout.write('No response to copy.\n');
+      } else {
+        try {
+          copyToClipboard(lastResponse);
+          process.stdout.write('Copied to clipboard.\n');
+        } catch (err) {
+          process.stdout.write(`Clipboard error: ${(err as Error).message}\n`);
+        }
+      }
+      prompt();
+      return;
     }
+
+    if (content === '/copy-code') {
+      const code = extractLastCodeBlock(lastResponse);
+      if (!code) {
+        process.stdout.write('No code block found.\n');
+      } else {
+        try {
+          copyToClipboard(code);
+          process.stdout.write('Copied code block to clipboard.\n');
+        } catch (err) {
+          process.stdout.write(`Clipboard error: ${(err as Error).message}\n`);
+        }
+      }
+      prompt();
+      return;
+    }
+
+    lastResponse = '';
+    generating = true;
+    send({ type: 'user_message', sessionId, content });
+    spinner.start('Thinking...');
   });
 
   rl.on('close', () => {

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -1,0 +1,25 @@
+import { execSync } from 'node:child_process';
+import { isMacOS, isLinux } from './platform.js';
+
+export function copyToClipboard(text: string): void {
+  let cmd: string;
+  if (isMacOS()) {
+    cmd = 'pbcopy';
+  } else if (isLinux()) {
+    cmd = 'xclip -selection clipboard';
+  } else {
+    throw new Error('Clipboard not supported on this platform');
+  }
+  execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
+}
+
+export function extractLastCodeBlock(text: string): string | null {
+  const re = /```[^\n]*\n([\s\S]*?)```/g;
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    last = m;
+  }
+  if (!last) return null;
+  return last[1].trimEnd();
+}


### PR DESCRIPTION
## Summary
- Add `/copy` slash command to copy the full last assistant response to the system clipboard
- Add `/copy-code` slash command to extract and copy the last fenced code block from the response
- Platform-aware clipboard: `pbcopy` on macOS, `xclip` on Linux, with graceful error handling

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 existing tests pass
- [ ] Manual: run `vellum`, ask a question, type `/copy`, verify clipboard contents
- [ ] Manual: ask for a code snippet, type `/copy-code`, verify only the code block is copied
- [ ] Manual: type `/copy` with no prior response, verify "No response to copy." message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
