### PR TITLE
Add /sessions command for interactive session switching

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
 import { Spinner } from './util/spinner.js';
 import { copyToClipboard, extractLastCodeBlock } from './util/clipboard.js';
+import { timeAgo } from './util/time.js';
 
 export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
@@ -19,6 +20,8 @@ export async function startCli(): Promise<void> {
   let sessionId = '';
   let generating = false;
   let lastResponse = '';
+  let pendingSessionPick = false;
+  let pendingSessionList: Array<{ id: string; title: string; updatedAt: number }> = [];
   const spinner = new Spinner();
 
   function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
@@ -175,6 +178,42 @@ export async function startCli(): Promise<void> {
     });
   }
 
+  function renderSessionPicker(sessions: Array<{ id: string; title: string; updatedAt: number }>): void {
+    process.stdout.write('\n  Recent sessions:\n');
+    for (let i = 0; i < sessions.length; i++) {
+      const s = sessions[i];
+      const ago = timeAgo(s.updatedAt);
+      const title = s.title.length > 50 ? s.title.slice(0, 47) + '...' : s.title;
+      const padding = ' '.repeat(Math.max(1, 55 - title.length));
+      process.stdout.write(`  [${i + 1}] ${title}${padding}${ago}\n`);
+    }
+    process.stdout.write('  [n] New session\n\n');
+    process.stdout.write('  Pick a session> ');
+
+    rl.once('line', (answer) => {
+      const trimmed = answer.trim().toLowerCase();
+      if (trimmed === 'n') {
+        send({ type: 'session_create' });
+        return;
+      }
+      const idx = parseInt(trimmed, 10) - 1;
+      if (idx >= 0 && idx < sessions.length) {
+        if (sessions[idx].id === sessionId) {
+          // Already on this session
+          process.stdout.write(
+            `\n  Session: ${sessions[idx].title}\n  Type your message. Ctrl+D to detach.\n\n`,
+          );
+          prompt();
+        } else {
+          send({ type: 'session_switch', sessionId: sessions[idx].id });
+        }
+      } else {
+        process.stdout.write('  Invalid selection.\n');
+        renderSessionPicker(sessions);
+      }
+    });
+  }
+
   socket.on('data', (data) => {
     const messages = parser.feed(data.toString()) as ServerMessage[];
     for (const msg of messages) {
@@ -239,10 +278,16 @@ export async function startCli(): Promise<void> {
           break;
 
         case 'session_list_response':
-          for (const session of msg.sessions) {
-            process.stdout.write(`  ${session.id}  ${session.title}\n`);
+          if (pendingSessionPick) {
+            pendingSessionPick = false;
+            pendingSessionList = msg.sessions;
+            renderSessionPicker(msg.sessions);
+          } else {
+            for (const session of msg.sessions) {
+              process.stdout.write(`  ${session.id}  ${session.title}\n`);
+            }
+            prompt();
           }
-          prompt();
           break;
 
         case 'pong':
@@ -267,6 +312,12 @@ export async function startCli(): Promise<void> {
         }
       }
       prompt();
+      return;
+    }
+
+    if (content === '/sessions') {
+      pendingSessionPick = true;
+      send({ type: 'session_list' });
       return;
     }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -88,7 +88,7 @@ export interface SessionInfo {
 
 export interface SessionListResponse {
   type: 'session_list_response';
-  sessions: Array<{ id: string; title: string }>;
+  sessions: Array<{ id: string; title: string; updatedAt: number }>;
 }
 
 export interface ErrorMessage {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -226,6 +226,7 @@ export class DaemonServer {
       sessions: conversations.map((c) => ({
         id: c.id,
         title: c.title ?? 'Untitled',
+        updatedAt: c.updatedAt,
       })),
     });
   }

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -18,6 +18,7 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './daemon/ipc-protocol.js';
+import { timeAgo } from './util/time.js';
 import {
   loadRawConfig,
   saveRawConfig,
@@ -150,7 +151,7 @@ sessions
         console.log('No sessions');
       } else {
         for (const s of response.sessions) {
-          console.log(`  ${s.id}  ${s.title}`);
+          console.log(`  ${s.id}  ${s.title}  ${timeAgo(s.updatedAt)}`);
         }
       }
     } else if (response.type === 'error') {

--- a/assistant/src/util/time.ts
+++ b/assistant/src/util/time.ts
@@ -1,0 +1,16 @@
+export function timeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 14) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 8) return `${weeks}w ago`;
+  const date = new Date(timestamp);
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[date.getMonth()]} ${date.getDate()}`;
+}


### PR DESCRIPTION
## Summary
- Add `/sessions` slash command that shows a numbered list of recent sessions with relative timestamps
- Users can pick a session to switch to or create a new one, all inline in the chat
- Extend IPC protocol to include `updatedAt` in session list responses
- Show relative timestamps in `vellum sessions list` CLI command
- Add `timeAgo()` utility for human-readable relative time formatting

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 existing tests pass
- [ ] Manual: type `/sessions`, verify list appears with timestamps
- [ ] Manual: pick a session number, verify it switches correctly
- [ ] Manual: pick "n", verify new session is created
- [ ] Manual: pick current session, verify it re-prompts without switching
- [ ] Manual: `vellum sessions list` shows timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
