### PR TITLE
Fix code block extraction matching inline backticks

### DIFF
--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -14,7 +14,7 @@ export function copyToClipboard(text: string): void {
 }
 
 export function extractLastCodeBlock(text: string): string | null {
-  const re = /```[^\n]*\n([\s\S]*?)```/g;
+  const re = /```[^\n]*\n([\s\S]*?)\n```/g;
   let last: RegExpExecArray | null = null;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {


### PR DESCRIPTION
## Summary
- Fix `extractLastCodeBlock` regex to anchor the closing fence to the start of a line
- Previously, triple backticks inside code content (e.g. `const s = "` `` ` `` `"`) would be mistaken for the closing fence, truncating the copied snippet

Addresses review feedback from #105.

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass
- [ ] Manual: ask assistant for code containing backtick strings, `/copy-code` copies the full block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
