### PR TITLE
Fix session picker input leaking to chat handler

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -200,6 +200,7 @@ export async function startCli(): Promise<void> {
       if (idx >= 0 && idx < sessions.length) {
         if (sessions[idx].id === sessionId) {
           // Already on this session
+          pendingSessionPick = false;
           process.stdout.write(
             `\n  Session: ${sessions[idx].title}\n  Type your message. Ctrl+D to detach.\n\n`,
           );
@@ -219,6 +220,7 @@ export async function startCli(): Promise<void> {
     for (const msg of messages) {
       switch (msg.type) {
         case 'session_info':
+          pendingSessionPick = false;
           sessionId = msg.sessionId;
           process.stdout.write(
             `\n  Session: ${msg.title}\n  Type your message. Ctrl+D to detach.\n\n`,
@@ -299,6 +301,7 @@ export async function startCli(): Promise<void> {
   rl.on('line', (line) => {
     const content = line.trim();
     if (!content) return;
+    if (pendingSessionPick) return;
 
     if (content === '/copy') {
       if (!lastResponse) {


### PR DESCRIPTION
## Summary
- Add `pendingSessionPick` guard in the permanent `rl.on('line')` handler so picker input isn't also sent as a chat message
- Reset `pendingSessionPick` on `session_info` (after switch/create) and when selecting the current session

Addresses review feedback from #106 (both Devin and Codex flagged the same bug).

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 202 tests pass
- [ ] Manual: `/sessions`, pick a session, verify no "1" message sent to LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
