### PR TITLE
Fix code block regex to match empty code blocks

### DIFF
--- a/assistant/src/__tests__/clipboard.test.ts
+++ b/assistant/src/__tests__/clipboard.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test';
+import { extractLastCodeBlock } from '../util/clipboard.js';
+
+describe('extractLastCodeBlock', () => {
+  test('extracts a simple code block', () => {
+    const text = '```\nhello world\n```';
+    expect(extractLastCodeBlock(text)).toBe('hello world');
+  });
+
+  test('extracts code block with language tag', () => {
+    const text = '```typescript\nconst x = 1;\n```';
+    expect(extractLastCodeBlock(text)).toBe('const x = 1;');
+  });
+
+  test('returns the last code block when multiple exist', () => {
+    const text = '```\nfirst\n```\nsome text\n```\nsecond\n```';
+    expect(extractLastCodeBlock(text)).toBe('second');
+  });
+
+  test('handles empty code blocks', () => {
+    const text = '```\n```';
+    expect(extractLastCodeBlock(text)).toBe('');
+  });
+
+  test('handles empty code blocks with language tag', () => {
+    const text = '```python\n```';
+    expect(extractLastCodeBlock(text)).toBe('');
+  });
+
+  test('does not match inline backticks as closing fence', () => {
+    const text = '```\nconst s = "```"\n```';
+    expect(extractLastCodeBlock(text)).toBe('const s = "```"');
+  });
+
+  test('handles multi-line code blocks', () => {
+    const text = '```js\nfunction foo() {\n  return 42;\n}\n```';
+    expect(extractLastCodeBlock(text)).toBe('function foo() {\n  return 42;\n}');
+  });
+
+  test('returns null when no code blocks exist', () => {
+    expect(extractLastCodeBlock('no code here')).toBeNull();
+    expect(extractLastCodeBlock('`inline code`')).toBeNull();
+  });
+
+  test('extracts last block when separated by text', () => {
+    const text = '```\nfirst\n```\nSome explanation\n```\nsecond\n```';
+    expect(extractLastCodeBlock(text)).toBe('second');
+  });
+
+  test('handles non-empty block followed by empty block with text between', () => {
+    const text = '```\nreal code\n```\nSome text\n```\n```';
+    expect(extractLastCodeBlock(text)).toBe('');
+  });
+});

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -14,7 +14,7 @@ export function copyToClipboard(text: string): void {
 }
 
 export function extractLastCodeBlock(text: string): string | null {
-  const re = /```[^\n]*\n([\s\S]*?)\n```/g;
+  const re = /```[^\n]*\n((?:[\s\S]*?\n)?)```/g;
   let last: RegExpExecArray | null = null;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {


### PR DESCRIPTION
## Summary
- Addresses review feedback from #107 (Devin + Codex both flagged the issue)
- The regex from #107 required `\n` before the closing fence, which broke empty code blocks like ` ```python\n``` `
- Uses an optional group `((?:[\s\S]*?\n)?)` so empty blocks match while keeping the start-of-line anchor for closing fences
- Adds `extractLastCodeBlock` test suite (10 tests) covering: empty blocks, language tags, inline backticks, multi-line, multi-block, and null cases

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass (10 new clipboard tests)
- [x] Empty code blocks now correctly return `""` instead of `null`
- [x] Inline backtick fix from #107 preserved (backticks inside code content don't match as closing fence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
