### PR TITLE
Fix session picker guard to stay active until pick resolves

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -21,7 +21,6 @@ export async function startCli(): Promise<void> {
   let generating = false;
   let lastResponse = '';
   let pendingSessionPick = false;
-  let pendingSessionList: Array<{ id: string; title: string; updatedAt: number }> = [];
   const spinner = new Spinner();
 
   function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
@@ -281,8 +280,6 @@ export async function startCli(): Promise<void> {
 
         case 'session_list_response':
           if (pendingSessionPick) {
-            pendingSessionPick = false;
-            pendingSessionList = msg.sessions;
             renderSessionPicker(msg.sessions);
           } else {
             for (const session of msg.sessions) {


### PR DESCRIPTION
## Summary
- Addresses review feedback from #108 (both Devin P0 and Codex P1 flagged the same bug)
- `pendingSessionPick` was reset to `false` in `session_list_response` *before* the user typed their selection, so the `rl.on('line')` guard at line 304 was already disabled when input arrived — the picker input (e.g. "1") still leaked as a chat message to the LLM
- Fix: remove the premature `pendingSessionPick = false` from `session_list_response`. The flag is now only reset when the pick is fully consumed: in `session_info` (after switch/create) or when selecting the current session
- Removes unused `pendingSessionList` variable

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass
- [ ] Manual: `/sessions`, pick a session, verify no "1" message sent to LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
