### PR TITLE
Add slash commands for quick CLI actions

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -289,6 +289,44 @@ export async function startCli(): Promise<void> {
           }
           break;
 
+        case 'model_info':
+          process.stdout.write(`\n  Model: ${msg.model} (${msg.provider})\n\n`);
+          prompt();
+          break;
+
+        case 'history_response':
+          process.stdout.write('\n');
+          if (msg.messages.length === 0) {
+            process.stdout.write('  No messages in this session.\n');
+          } else {
+            for (const m of msg.messages) {
+              const label = m.role === 'user' ? 'you' : 'assistant';
+              const preview = m.text.length > 120 ? m.text.slice(0, 117) + '...' : m.text;
+              process.stdout.write(`  ${label}> ${preview.replace(/\n/g, ' ')}\n`);
+            }
+          }
+          process.stdout.write('\n');
+          prompt();
+          break;
+
+        case 'undo_complete':
+          if (msg.removedCount === 0) {
+            process.stdout.write('\n  Nothing to undo.\n\n');
+          } else {
+            lastResponse = '';
+            process.stdout.write(`\n  Removed last exchange (${msg.removedCount} messages).\n\n`);
+          }
+          prompt();
+          break;
+
+        case 'compact_complete':
+          spinner.stop();
+          generating = false;
+          lastResponse = '';
+          process.stdout.write(`\n\n  Compacted: ${msg.originalCount} messages -> ${msg.compactedCount}\n\n`);
+          prompt();
+          break;
+
         case 'pong':
           break;
       }
@@ -333,6 +371,64 @@ export async function startCli(): Promise<void> {
           process.stdout.write(`Clipboard error: ${(err as Error).message}\n`);
         }
       }
+      prompt();
+      return;
+    }
+
+    if (content === '/new') {
+      send({ type: 'session_create' });
+      return;
+    }
+
+    if (content === '/clear') {
+      lastResponse = '';
+      process.stdout.write('\x1B[2J\x1B[H');
+      process.stdout.write('  Screen cleared.\n\n');
+      prompt();
+      return;
+    }
+
+    if (content === '/model' || content.startsWith('/model ')) {
+      const modelArg = content.slice('/model'.length).trim();
+      if (modelArg) {
+        send({ type: 'model_set', model: modelArg });
+      } else {
+        send({ type: 'model_get' });
+      }
+      return;
+    }
+
+    if (content === '/history') {
+      send({ type: 'history_request', sessionId });
+      return;
+    }
+
+    if (content === '/undo') {
+      send({ type: 'undo', sessionId });
+      return;
+    }
+
+    if (content === '/compact') {
+      process.stdout.write('Compacting conversation...\n');
+      generating = true;
+      send({ type: 'compact', sessionId });
+      spinner.start('Summarizing...');
+      return;
+    }
+
+    if (content === '/help') {
+      process.stdout.write('\n  Available commands:\n');
+      process.stdout.write('  /new              Start a new session\n');
+      process.stdout.write('  /sessions         Switch between sessions\n');
+      process.stdout.write('  /clear            Clear the screen\n');
+      process.stdout.write('  /model [name]     Show or change the model\n');
+      process.stdout.write('  /history          Show conversation history\n');
+      process.stdout.write('  /undo             Remove last message exchange\n');
+      process.stdout.write('  /compact          Summarize conversation to save context\n');
+      process.stdout.write('  /copy             Copy last response to clipboard\n');
+      process.stdout.write('  /copy-code        Copy last code block to clipboard\n');
+      process.stdout.write('  /help             Show this help\n');
+      process.stdout.write('\n');
       prompt();
       return;
     }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -36,6 +36,30 @@ export interface CancelRequest {
   type: 'cancel';
 }
 
+export interface ModelGetRequest {
+  type: 'model_get';
+}
+
+export interface ModelSetRequest {
+  type: 'model_set';
+  model: string;
+}
+
+export interface HistoryRequest {
+  type: 'history_request';
+  sessionId: string;
+}
+
+export interface UndoRequest {
+  type: 'undo';
+  sessionId: string;
+}
+
+export interface CompactRequest {
+  type: 'compact';
+  sessionId: string;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -43,7 +67,12 @@ export type ClientMessage =
   | SessionCreateRequest
   | SessionSwitchRequest
   | PingMessage
-  | CancelRequest;
+  | CancelRequest
+  | ModelGetRequest
+  | ModelSetRequest
+  | HistoryRequest
+  | UndoRequest
+  | CompactRequest;
 
 // === Server → Client messages ===
 
@@ -104,6 +133,28 @@ export interface GenerationCancelled {
   type: 'generation_cancelled';
 }
 
+export interface ModelInfo {
+  type: 'model_info';
+  model: string;
+  provider: string;
+}
+
+export interface HistoryResponse {
+  type: 'history_response';
+  messages: Array<{ role: string; text: string; timestamp: number }>;
+}
+
+export interface UndoComplete {
+  type: 'undo_complete';
+  removedCount: number;
+}
+
+export interface CompactComplete {
+  type: 'compact_complete';
+  originalCount: number;
+  compactedCount: number;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
@@ -114,7 +165,11 @@ export type ServerMessage =
   | SessionListResponse
   | ErrorMessage
   | PongMessage
-  | GenerationCancelled;
+  | GenerationCancelled
+  | ModelInfo
+  | HistoryResponse
+  | UndoComplete
+  | CompactComplete;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,7 +3,7 @@ import { unlinkSync, existsSync, chmodSync } from 'node:fs';
 import { getSocketPath } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider } from '../providers/registry.js';
-import { getConfig } from '../config/loader.js';
+import { getConfig, saveConfig } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
@@ -195,6 +195,21 @@ export class DaemonServer {
         }
         break;
       }
+      case 'model_get':
+        this.handleModelGet(socket);
+        break;
+      case 'model_set':
+        this.handleModelSet(msg.model, socket);
+        break;
+      case 'history_request':
+        this.handleHistoryRequest(msg.sessionId, socket);
+        break;
+      case 'undo':
+        this.handleUndo(msg.sessionId, socket);
+        break;
+      case 'compact':
+        this.handleCompact(msg.sessionId, socket);
+        break;
       case 'ping':
         this.send(socket, { type: 'pong' });
         break;
@@ -262,5 +277,87 @@ export class DaemonServer {
       sessionId: conversation.id,
       title: conversation.title ?? 'Untitled',
     });
+  }
+
+  private handleModelGet(socket: net.Socket): void {
+    const config = getConfig();
+    this.send(socket, {
+      type: 'model_info',
+      model: config.model,
+      provider: config.provider,
+    });
+  }
+
+  private handleModelSet(model: string, socket: net.Socket): void {
+    try {
+      const config = getConfig();
+      config.model = model;
+      saveConfig(config);
+
+      // Invalidate cached sessions so new messages use the new model
+      this.sessions.clear();
+
+      this.send(socket, {
+        type: 'model_info',
+        model: config.model,
+        provider: config.provider,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.send(socket, { type: 'error', message: `Failed to set model: ${message}` });
+    }
+  }
+
+  private handleHistoryRequest(sessionId: string, socket: net.Socket): void {
+    const dbMessages = conversationStore.getMessages(sessionId);
+    const historyMessages = dbMessages.map((m) => {
+      let text = '';
+      try {
+        const content = JSON.parse(m.content);
+        if (Array.isArray(content)) {
+          text = content
+            .filter((b: { type: string }) => b.type === 'text')
+            .map((b: { text: string }) => b.text)
+            .join('');
+        } else {
+          text = String(content);
+        }
+      } catch {
+        text = m.content;
+      }
+      return { role: m.role, text, timestamp: m.createdAt };
+    });
+    this.send(socket, { type: 'history_response', messages: historyMessages });
+  }
+
+  private handleUndo(sessionId: string, socket: net.Socket): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.send(socket, { type: 'error', message: 'No active session' });
+      return;
+    }
+    const removedCount = session.undo();
+    this.send(socket, { type: 'undo_complete', removedCount });
+  }
+
+  private async handleCompact(sessionId: string, socket: net.Socket): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.send(socket, { type: 'error', message: 'No active session' });
+      return;
+    }
+    try {
+      const result = await session.compact((event) => {
+        this.send(socket, event);
+      });
+      this.send(socket, {
+        type: 'compact_complete',
+        originalCount: result.originalCount,
+        compactedCount: result.compactedCount,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.send(socket, { type: 'error', message: `Compact failed: ${message}` });
+    }
   }
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -171,6 +171,92 @@ export class Session {
     }
   }
 
+  getMessages(): Message[] {
+    return this.messages;
+  }
+
+  /**
+   * Remove the last user+assistant exchange from memory and DB.
+   * Returns the number of messages removed.
+   */
+  undo(): number {
+    if (this.processing) return 0;
+
+    // Find last user message in memory
+    let lastUserIdx = -1;
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      if (this.messages[i].role === 'user') {
+        lastUserIdx = i;
+        break;
+      }
+    }
+    if (lastUserIdx === -1) return 0;
+
+    const removed = this.messages.length - lastUserIdx;
+    this.messages = this.messages.slice(0, lastUserIdx);
+
+    // Also remove from DB
+    conversationStore.deleteLastExchange(this.conversationId);
+
+    return removed;
+  }
+
+  /**
+   * Compact the conversation by summarizing it with the LLM.
+   * Replaces all messages with a single assistant summary.
+   */
+  async compact(
+    onEvent: (msg: ServerMessage) => void,
+  ): Promise<{ originalCount: number; compactedCount: number }> {
+    if (this.processing) {
+      return { originalCount: 0, compactedCount: 0 };
+    }
+
+    const originalCount = this.messages.length;
+    if (originalCount === 0) {
+      return { originalCount: 0, compactedCount: 0 };
+    }
+
+    this.processing = true;
+    try {
+      // Build a text summary of the conversation
+      const summaryRequest: Message[] = [
+        ...this.messages,
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Please provide a concise summary of our conversation so far. Include key decisions, code changes, and any important context. This will be used to continue the conversation with reduced context.' }],
+        },
+      ];
+
+      const summaryMessages = await this.agentLoop.run(
+        summaryRequest,
+        (event) => {
+          if (event.type === 'text_delta') {
+            onEvent({ type: 'assistant_text_delta', text: event.text });
+          }
+        },
+      );
+
+      // Extract the last assistant message as the summary
+      const lastAssistant = summaryMessages[summaryMessages.length - 1];
+      if (lastAssistant && lastAssistant.role === 'assistant') {
+        // Clear DB messages and replace with summary
+        conversationStore.deleteAllMessages(this.conversationId);
+        conversationStore.addMessage(
+          this.conversationId,
+          'assistant',
+          JSON.stringify(lastAssistant.content),
+        );
+
+        this.messages = [lastAssistant];
+      }
+
+      return { originalCount, compactedCount: this.messages.length };
+    } finally {
+      this.processing = false;
+    }
+  }
+
   private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {
     const config = getConfig();
     const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -82,3 +82,61 @@ export function updateConversationTitle(id: string, title: string): void {
     .where(eq(conversations.id, id))
     .run();
 }
+
+/**
+ * Delete the last user message and any subsequent assistant messages.
+ * Returns the number of messages deleted.
+ */
+export function deleteLastExchange(conversationId: string): number {
+  const db = getDb();
+  const allMessages = db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(asc(messages.createdAt))
+    .all();
+
+  if (allMessages.length === 0) return 0;
+
+  // Find the last user message
+  let lastUserIdx = -1;
+  for (let i = allMessages.length - 1; i >= 0; i--) {
+    if (allMessages[i].role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  if (lastUserIdx === -1) return 0;
+
+  // Delete from lastUserIdx onward
+  const toDelete = allMessages.slice(lastUserIdx);
+  for (const m of toDelete) {
+    db.delete(messages).where(eq(messages.id, m.id)).run();
+  }
+
+  db.update(conversations)
+    .set({ updatedAt: Date.now() })
+    .where(eq(conversations.id, conversationId))
+    .run();
+
+  return toDelete.length;
+}
+
+/**
+ * Delete all messages in a conversation (for compaction — caller replaces with summary).
+ * Returns the number of messages deleted.
+ */
+export function deleteAllMessages(conversationId: string): number {
+  const db = getDb();
+  const allMessages = db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .all();
+
+  for (const m of allMessages) {
+    db.delete(messages).where(eq(messages.id, m.id)).run();
+  }
+
+  return allMessages.length;
+}


### PR DESCRIPTION
## Summary
- Adds 7 new slash commands for quick actions without leaving the chat
- New IPC message types for client-server communication
- New DB operations for undo and compact functionality

### Commands added:
| Command | Description | Implementation |
|---------|-------------|----------------|
| `/new` | Start a new session | Client-side, reuses `session_create` IPC |
| `/clear` | Clear terminal screen | Client-side only (ANSI escape) |
| `/model [name]` | Show/change model | New `model_get`/`model_set` IPC |
| `/history` | Show conversation history | New `history_request`/`history_response` IPC |
| `/undo` | Remove last exchange | New `undo`/`undo_complete` IPC + DB deletion |
| `/compact` | Summarize conversation | New `compact`/`compact_complete` IPC + LLM summary |
| `/help` | List all commands | Client-side only |

### Files changed:
- `cli.ts` — command parsing and response handling
- `ipc-protocol.ts` — 5 new client message types, 4 new server message types
- `server.ts` — 5 new handler methods
- `session.ts` — `getMessages()`, `undo()`, `compact()` methods
- `conversation-store.ts` — `deleteLastExchange()`, `deleteAllMessages()`

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass
- [ ] Manual: test each command in a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
