### PR TITLE
Fix /copy-code treating empty code blocks as not found

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -361,7 +361,7 @@ export async function startCli(): Promise<void> {
 
     if (content === '/copy-code') {
       const code = extractLastCodeBlock(lastResponse);
-      if (!code) {
+      if (code === null) {
         process.stdout.write('No code block found.\n');
       } else {
         try {


### PR DESCRIPTION
## Summary
- Addresses review feedback from #109 (Devin flagged the issue)
- `extractLastCodeBlock` now returns `""` for empty code blocks, but the CLI used `if (!code)` which treats `""` as falsy — showing "No code block found" instead of copying
- Fix: change to `if (code === null)` to only catch the truly-not-found case

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass
- [x] Empty code blocks (`""`) will now be copied instead of showing error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
