### PR TITLE
Reset session-pick guard on error to prevent CLI lockup (#110 feedback)

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -274,6 +274,7 @@ export async function startCli(): Promise<void> {
         case 'error':
           spinner.stop();
           generating = false;
+          pendingSessionPick = false;
           process.stdout.write(`\n[Error: ${msg.message}]\n`);
           prompt();
           break;


### PR DESCRIPTION
## Summary
- Fixes bug where CLI becomes permanently unresponsive after a failed session switch
- When the server responds with `error` instead of `session_info` (e.g. session deleted between listing and picking), `pendingSessionPick` was never reset to `false`
- The `rl.on('line')` guard at line 339 then silently drops all subsequent input, requiring a process restart
- Fix: reset `pendingSessionPick = false` in the `error` handler alongside `generating = false`
- Addresses review feedback from #110 (Devin P0 + Codex P1)

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass
- [ ] Manual: `/sessions`, pick a deleted/invalid session, verify error is shown and CLI remains responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
