### PR TITLE
Fix handleModelSet bugs: provider re-init, env key leak, session safety

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -2,8 +2,8 @@ import * as net from 'node:net';
 import { unlinkSync, existsSync, chmodSync } from 'node:fs';
 import { getSocketPath } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
-import { getProvider } from '../providers/registry.js';
-import { getConfig, saveConfig } from '../config/loader.js';
+import { getProvider, initializeProviders } from '../providers/registry.js';
+import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
@@ -290,12 +290,22 @@ export class DaemonServer {
 
   private handleModelSet(model: string, socket: net.Socket): void {
     try {
-      const config = getConfig();
-      config.model = model;
-      saveConfig(config);
+      // Use raw config to avoid persisting env-var API keys to disk
+      const raw = loadRawConfig();
+      raw.model = model;
+      saveRawConfig(raw);
 
-      // Invalidate cached sessions so new messages use the new model
-      this.sessions.clear();
+      // Re-initialize provider with the new model so LLM calls use it
+      const config = getConfig();
+      initializeProviders(config);
+
+      // Evict idle sessions so they're re-created with the new provider.
+      // Sessions that are actively processing keep running with the old model.
+      for (const [id, session] of this.sessions) {
+        if (!session.isProcessing()) {
+          this.sessions.delete(id);
+        }
+      }
 
       this.send(socket, {
         type: 'model_info',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -68,6 +68,10 @@ export class Session {
     this.prompter.updateSender(sendToClient);
   }
 
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
   abort(): void {
     if (this.processing) {
       log.info({ conversationId: this.conversationId }, 'Aborting in-flight processing');


### PR DESCRIPTION
## Summary
- Fixes `handleModelSet` using `loadRawConfig`/`saveRawConfig` instead of `getConfig`/`saveConfig` to avoid persisting environment variable API keys to disk (security fix)
- Re-initializes provider via `initializeProviders` after model change so the new model is actually used for LLM calls
- Only evicts idle sessions instead of `this.sessions.clear()`, preserving active sessions for other connected clients

Addresses feedback from #111:
- https://github.com/vellum-ai/vellum-assistant/pull/111#discussion_r2779869081
- https://github.com/vellum-ai/vellum-assistant/pull/111#discussion_r2779869125
- https://github.com/vellum-ai/vellum-assistant/pull/111#discussion_r2779869194

Note: The compact-related feedback items (abort signal, failed summarization guard) are not addressed here as `/compact` is being removed in a separate task.

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `bun test` — all 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
