### PR TITLE
Remove the /compact command

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -320,14 +320,6 @@ export async function startCli(): Promise<void> {
           prompt();
           break;
 
-        case 'compact_complete':
-          spinner.stop();
-          generating = false;
-          lastResponse = '';
-          process.stdout.write(`\n\n  Compacted: ${msg.originalCount} messages -> ${msg.compactedCount}\n\n`);
-          prompt();
-          break;
-
         case 'pong':
           break;
       }
@@ -409,14 +401,6 @@ export async function startCli(): Promise<void> {
       return;
     }
 
-    if (content === '/compact') {
-      process.stdout.write('Compacting conversation...\n');
-      generating = true;
-      send({ type: 'compact', sessionId });
-      spinner.start('Summarizing...');
-      return;
-    }
-
     if (content === '/help') {
       process.stdout.write('\n  Available commands:\n');
       process.stdout.write('  /new              Start a new session\n');
@@ -425,7 +409,6 @@ export async function startCli(): Promise<void> {
       process.stdout.write('  /model [name]     Show or change the model\n');
       process.stdout.write('  /history          Show conversation history\n');
       process.stdout.write('  /undo             Remove last message exchange\n');
-      process.stdout.write('  /compact          Summarize conversation to save context\n');
       process.stdout.write('  /copy             Copy last response to clipboard\n');
       process.stdout.write('  /copy-code        Copy last code block to clipboard\n');
       process.stdout.write('  /help             Show this help\n');

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -55,11 +55,6 @@ export interface UndoRequest {
   sessionId: string;
 }
 
-export interface CompactRequest {
-  type: 'compact';
-  sessionId: string;
-}
-
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -71,8 +66,7 @@ export type ClientMessage =
   | ModelGetRequest
   | ModelSetRequest
   | HistoryRequest
-  | UndoRequest
-  | CompactRequest;
+  | UndoRequest;
 
 // === Server → Client messages ===
 
@@ -149,12 +143,6 @@ export interface UndoComplete {
   removedCount: number;
 }
 
-export interface CompactComplete {
-  type: 'compact_complete';
-  originalCount: number;
-  compactedCount: number;
-}
-
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
@@ -168,8 +156,7 @@ export type ServerMessage =
   | GenerationCancelled
   | ModelInfo
   | HistoryResponse
-  | UndoComplete
-  | CompactComplete;
+  | UndoComplete;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -207,9 +207,6 @@ export class DaemonServer {
       case 'undo':
         this.handleUndo(msg.sessionId, socket);
         break;
-      case 'compact':
-        this.handleCompact(msg.sessionId, socket);
-        break;
       case 'ping':
         this.send(socket, { type: 'pong' });
         break;
@@ -350,24 +347,4 @@ export class DaemonServer {
     this.send(socket, { type: 'undo_complete', removedCount });
   }
 
-  private async handleCompact(sessionId: string, socket: net.Socket): Promise<void> {
-    const session = this.sessions.get(sessionId);
-    if (!session) {
-      this.send(socket, { type: 'error', message: 'No active session' });
-      return;
-    }
-    try {
-      const result = await session.compact((event) => {
-        this.send(socket, event);
-      });
-      this.send(socket, {
-        type: 'compact_complete',
-        originalCount: result.originalCount,
-        compactedCount: result.compactedCount,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.send(socket, { type: 'error', message: `Compact failed: ${message}` });
-    }
-  }
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -205,62 +205,6 @@ export class Session {
     return removed;
   }
 
-  /**
-   * Compact the conversation by summarizing it with the LLM.
-   * Replaces all messages with a single assistant summary.
-   */
-  async compact(
-    onEvent: (msg: ServerMessage) => void,
-  ): Promise<{ originalCount: number; compactedCount: number }> {
-    if (this.processing) {
-      return { originalCount: 0, compactedCount: 0 };
-    }
-
-    const originalCount = this.messages.length;
-    if (originalCount === 0) {
-      return { originalCount: 0, compactedCount: 0 };
-    }
-
-    this.processing = true;
-    try {
-      // Build a text summary of the conversation
-      const summaryRequest: Message[] = [
-        ...this.messages,
-        {
-          role: 'user',
-          content: [{ type: 'text', text: 'Please provide a concise summary of our conversation so far. Include key decisions, code changes, and any important context. This will be used to continue the conversation with reduced context.' }],
-        },
-      ];
-
-      const summaryMessages = await this.agentLoop.run(
-        summaryRequest,
-        (event) => {
-          if (event.type === 'text_delta') {
-            onEvent({ type: 'assistant_text_delta', text: event.text });
-          }
-        },
-      );
-
-      // Extract the last assistant message as the summary
-      const lastAssistant = summaryMessages[summaryMessages.length - 1];
-      if (lastAssistant && lastAssistant.role === 'assistant') {
-        // Clear DB messages and replace with summary
-        conversationStore.deleteAllMessages(this.conversationId);
-        conversationStore.addMessage(
-          this.conversationId,
-          'assistant',
-          JSON.stringify(lastAssistant.content),
-        );
-
-        this.messages = [lastAssistant];
-      }
-
-      return { originalCount, compactedCount: this.messages.length };
-    } finally {
-      this.processing = false;
-    }
-  }
-
   private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {
     const config = getConfig();
     const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -122,21 +122,3 @@ export function deleteLastExchange(conversationId: string): number {
   return toDelete.length;
 }
 
-/**
- * Delete all messages in a conversation (for compaction — caller replaces with summary).
- * Returns the number of messages deleted.
- */
-export function deleteAllMessages(conversationId: string): number {
-  const db = getDb();
-  const allMessages = db
-    .select()
-    .from(messages)
-    .where(eq(messages.conversationId, conversationId))
-    .all();
-
-  for (const m of allMessages) {
-    db.delete(messages).where(eq(messages.id, m.id)).run();
-  }
-
-  return allMessages.length;
-}


### PR DESCRIPTION
## Summary
- Remove the `/compact` command from the CLI, IPC protocol, daemon server, and session logic
- Remove the `deleteAllMessages` DB helper from `conversation-store.ts` that was only used by compact
- This command will be superseded by the new memory/context window management system

## Test plan
- [x] `bun tsc --noEmit` passes — no type errors
- [x] All 212 tests pass (`bun test`)
- [x] Verified `deleteAllMessages` had no other callers before removing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
