### PR TITLE
Fix stale sessions stuck on old model after /model change

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -134,7 +134,7 @@ export class DaemonServer {
     let session = this.sessions.get(conversationId);
     const sendToClient = (msg: ServerMessage) => this.send(socket, msg);
 
-    if (!session) {
+    if (!session || session.isStale()) {
       const config = getConfig();
       const provider = getProvider(config.provider);
       const workingDir = process.cwd();
@@ -296,11 +296,13 @@ export class DaemonServer {
       const config = getConfig();
       initializeProviders(config);
 
-      // Evict idle sessions so they're re-created with the new provider.
-      // Sessions that are actively processing keep running with the old model.
+      // Evict idle sessions immediately; mark busy ones as stale so they
+      // get recreated with the new provider once they finish processing.
       for (const [id, session] of this.sessions) {
         if (!session.isProcessing()) {
           this.sessions.delete(id);
+        } else {
+          session.markStale();
         }
       }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -19,6 +19,7 @@ export class Session {
   private messages: Message[] = [];
   private agentLoop: AgentLoop;
   private processing = false;
+  private stale = false;
   private abortController: AbortController | null = null;
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
@@ -70,6 +71,14 @@ export class Session {
 
   isProcessing(): boolean {
     return this.processing;
+  }
+
+  markStale(): void {
+    this.stale = true;
+  }
+
+  isStale(): boolean {
+    return this.stale;
   }
 
   abort(): void {


### PR DESCRIPTION
## Summary
- Adds `stale` flag to `Session` with `markStale()` / `isStale()` methods
- In `handleModelSet`, sessions that are actively processing are now marked stale instead of being silently skipped
- In `getOrCreateSession`, stale sessions are detected and recreated with the current provider

Fixes a bug where sessions processing during a `/model` change would permanently use the old model for all future messages, with no way to fix it short of restarting the daemon.

Addresses review feedback on #115:
- https://github.com/vellum-ai/vellum-assistant/pull/115#discussion_r2779909783
- https://github.com/vellum-ai/vellum-assistant/pull/115#discussion_r2779909840

## Test plan
- [x] `bun tsc --noEmit` passes
- [x] All 212 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
