### PR TITLE
Harden shell tool against command injection edge cases

### DIFF
--- a/assistant/src/__tests__/parser.test.ts
+++ b/assistant/src/__tests__/parser.test.ts
@@ -397,25 +397,19 @@ describe('Shell Parser', () => {
       expect(result.hasOpaqueConstructs).toBe(true);
     });
 
-    test('variable expansion as command name ($CMD) — not detected due to command_name wrapping', async () => {
-      // tree-sitter-bash wraps $CMD in a command_name node, so the parser's
-      // check for simple_expansion as first child of command doesn't trigger
+    test('variable expansion as command name ($CMD) is opaque', async () => {
       const result = await parse('$CMD arg1 arg2');
-      expect(result.hasOpaqueConstructs).toBe(false);
-      // The program IS captured as $CMD though
-      expect(result.segments[0].program).toBe('$CMD');
+      expect(result.hasOpaqueConstructs).toBe(true);
     });
 
-    test('${var} expansion as command name — not detected due to command_name wrapping', async () => {
+    test('${var} expansion as command name is opaque', async () => {
       const result = await parse('${CMD} arg1');
-      expect(result.hasOpaqueConstructs).toBe(false);
-      expect(result.segments[0].program).toBe('${CMD}');
+      expect(result.hasOpaqueConstructs).toBe(true);
     });
 
-    test('command substitution as command name — not detected due to command_name wrapping', async () => {
+    test('command substitution as command name is opaque', async () => {
       const result = await parse('$(get_cmd) arg1');
-      expect(result.hasOpaqueConstructs).toBe(false);
-      expect(result.segments[0].program).toBe('$(get_cmd)');
+      expect(result.hasOpaqueConstructs).toBe(true);
     });
 
     test('safe command is NOT opaque', async () => {

--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -297,12 +297,28 @@ function detectOpaqueConstructs(node: TSNode, segments: CommandSegment[]): boole
     // Variable expansion used as command name
     if (n.type === 'command') {
       const firstChild = n.namedChild(0);
-      if (firstChild && (
-        firstChild.type === 'simple_expansion' ||
-        firstChild.type === 'expansion' ||
-        firstChild.type === 'command_substitution'
-      )) {
-        return true;
+      if (firstChild) {
+        // Direct expansion as command (e.g. in some grammars)
+        if (
+          firstChild.type === 'simple_expansion' ||
+          firstChild.type === 'expansion' ||
+          firstChild.type === 'command_substitution'
+        ) {
+          return true;
+        }
+        // tree-sitter-bash wraps the command name in a command_name node,
+        // so check inside it for variable/command substitution
+        if (firstChild.type === 'command_name') {
+          const inner = firstChild.namedChild(0);
+          if (inner && (
+            inner.type === 'simple_expansion' ||
+            inner.type === 'expansion' ||
+            inner.type === 'command_substitution' ||
+            inner.type === 'concatenation'
+          )) {
+            return true;
+          }
+        }
       }
     }
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -39,6 +39,12 @@ class ShellTool implements Tool {
       return { content: 'Error: command is required and must be a string', isError: true };
     }
 
+    // Reject commands containing null bytes — they cause truncation at the
+    // OS level while the parser sees the full string, enabling bypass.
+    if (command.includes('\0')) {
+      return { content: 'Error: command contains null bytes', isError: true };
+    }
+
     log.info({ command, cwd: context.workingDir }, 'Executing shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
@@ -46,7 +52,9 @@ class ShellTool implements Tool {
       let stderr = '';
       let timedOut = false;
 
-      const child = spawn('bash', ['-c', command], {
+      // The '--' separator prevents bash from interpreting the command
+      // string as additional flags if it starts with '-'.
+      const child = spawn('bash', ['-c', '--', command], {
         cwd: context.workingDir,
         env: { ...process.env },
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- Add `--` separator to `spawn('bash', ['-c', '--', command])` preventing bash from interpreting commands starting with `-` as flags
- Reject commands containing null bytes (`\0`) which cause truncation at the OS level while the parser sees the full string
- Fix opaque construct detection for variable/command substitution as command names (`$CMD`, `${CMD}`, `$(cmd)`) — tree-sitter-bash wraps these in a `command_name` node, so the check now looks inside that wrapper

## Test plan
- [x] `bun tsc --noEmit` passes
- [x] All 212 tests pass (`bun test`)
- [x] Updated parser tests: variable expansion as command name now correctly detected as opaque

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
