### PR TITLE
Add native macOS menu bar client

### DIFF
--- a/clients/macos/.gitignore
+++ b/clients/macos/.gitignore
@@ -1,0 +1,7 @@
+.build/
+build/
+.swiftpm/
+*.xcuserdata
+xcuserdata/
+DerivedData/
+.DS_Store

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A native macOS menu bar app that controls your Mac via accessibility APIs and CGEvent input injection, powered by Claude via the Anthropic Messages API with tool use. It lives as a sparkles icon in the menu bar — users type a task (or will soon use voice), and the agent executes it step-by-step.
+
+## Build & Test
+
+The project has **dual build systems**: an Xcode project (generated via XcodeGen from `project.yml`) and a SwiftPM `Package.swift`. The Xcode build is the primary one for the app bundle:
+
+```bash
+# Build (release, via xcodebuild)
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme vellum-assistant -configuration Release -derivedDataPath build build
+
+# Build (debug, via SPM — faster iteration, but no bundle ID at runtime)
+swift build
+
+# Run tests
+swift test
+
+# Watch logs from a running instance
+log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level debug
+```
+
+## Architecture
+
+**Session loop** (`Session.swift`) — the core orchestration cycle runs per-task:
+1. **PERCEIVE** — enumerate the AX tree of the focused window (`AccessibilityTree.swift`); fall back to screenshot (`ScreenCapture.swift`) if no tree available
+2. **INFER** — send AX tree (or screenshot) + task + action history to Claude via Anthropic Messages API with forced tool use (`AnthropicProvider.swift`); model returns exactly one tool call per turn
+3. **VERIFY** — safety checks: sensitive data, destructive keys, loop detection, step limits, system menu bar exclusion (`ActionVerifier.swift`)
+4. **EXECUTE** — inject mouse/keyboard events via CGEvent (`ActionExecutor.swift`)
+5. **LOG** — record each turn to JSON (`SessionLogger.swift`)
+
+**App lifecycle** (`AppDelegate.swift`) — sets up NSStatusItem with NSPopover for task input, global hotkey (Cmd+Shift+G via HotKey package), and global Escape monitor. `VellumAssistantApp.swift` is the `@main` entry point using `@NSApplicationDelegateAdaptor`.
+
+**Inference** — `ActionInferenceProvider` protocol with `AnthropicProvider` implementation. Uses 8 tools: `click`, `double_click`, `right_click`, `type_text`, `key`, `scroll`, `wait`, `done`. Element targeting uses `[ID]` numbers from the AX tree resolved to screen coordinates via `resolvePosition`.
+
+**Text input** uses clipboard-paste (Cmd+V) rather than keystroke simulation, with clipboard save/restore.
+
+## Key Constraints
+
+- **LSUIElement app** — no dock icon; uses `.accessory` activation policy. Must temporarily switch to `.regular` when showing Settings window (see `TaskInputView.swift`).
+- **`Bundle.main.bundleIdentifier` is nil** when built via SwiftPM (no app bundle). The `os.Logger` subsystem uses a hardcoded fallback `"com.vellum.vellum-assistant"`.
+- **Two plists**: `Info.plist` (for SPM) and `Info-generated.plist` (for Xcode/XcodeGen). When adding new plist keys (e.g., usage descriptions), update both.
+- **Adding new .swift files**: When adding source files, they are automatically picked up by SwiftPM but must be **manually added to `vellum-assistant.xcodeproj/project.pbxproj`** (add to both PBXFileReference and PBXSourcesBuildPhase). Look at how `ChromeAccessibilityHelper.swift` was added as a pattern.
+- **Chrome special handling** — `ChromeAccessibilityHelper` detects when Chrome's AX tree lacks web content and auto-restarts Chrome with `--force-renderer-accessibility`.
+- **Popover close delay** — 300ms delay before session starts to let the popover close and target app regain focus.
+
+## Permissions
+
+The app requires macOS Accessibility and Screen Recording permissions (System Settings > Privacy & Security). `PermissionManager` and `ActionExecutor.checkAccessibilityPermission` handle checking/prompting.
+
+## Session Logs
+
+Written to `~/Library/Application Support/vellum-assistant/logs/session-*.json`.

--- a/clients/macos/Package.resolved
+++ b/clients/macos/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "hotkey",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soffes/HotKey",
+      "state" : {
+        "revision" : "a3cf605d7a96f6ff50e04fcb6dea6e2613cfcbe4",
+        "version" : "0.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "vellum-assistant",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(
+            name: "vellum-assistant",
+            targets: ["vellum-assistant"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/soffes/HotKey", from: "0.2.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "vellum-assistant",
+            dependencies: ["HotKey"],
+            path: "vellum-assistant",
+            exclude: ["Resources/Info.plist"],
+            resources: [
+                .process("Resources/Assets.xcassets")
+            ],
+            linkerSettings: [
+                .linkedFramework("ApplicationServices"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("ScreenCaptureKit"),
+                .linkedFramework("AppKit"),
+                .linkedFramework("Security"),
+                .linkedFramework("Speech"),
+            ]
+        ),
+        .testTarget(
+            name: "vellum-assistantTests",
+            dependencies: ["vellum-assistant"],
+            path: "vellum-assistantTests"
+        )
+    ]
+)

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -1,0 +1,110 @@
+# vellum-assistant
+
+A native macOS menu bar app that controls your Mac via accessibility APIs and CGEvent input injection, powered by Claude Haiku 4.5 for action inference via the Anthropic Messages API with tool use.
+
+## Requirements
+
+- macOS 14.0 (Sonoma) or later
+- Xcode 15+ (for building)
+- Anthropic API key
+
+## Build
+
+```bash
+# Resolve dependencies
+swift package resolve
+
+# Build
+swift build
+
+# Run tests
+swift test
+
+# Build for release
+swift build -c release
+```
+
+## Permissions
+
+The app requires two macOS permissions:
+- **Accessibility** — For reading UI element trees and injecting mouse/keyboard events
+- **Screen Recording** — For capturing screenshots (vision fallback when AX tree is sparse)
+
+Grant these in System Settings → Privacy & Security.
+
+## Usage
+
+1. Launch the app — it appears as a ✨ sparkles icon in your menu bar
+2. Open Settings (click icon → gear) and enter your Anthropic API key
+3. Click the menu bar icon or press `⌘⇧G` to open the task input
+4. Type a task (e.g., "Fill in the name field with John Smith") and press Go
+5. Watch the overlay as vellum-assistant works through the task
+6. Press Escape at any time to cancel
+
+## Architecture
+
+```
+App/                  Entry point, AppDelegate, menu bar setup, permissions
+ComputerUse/          Core perception + action pipeline
+  AccessibilityTree   AX element enumeration & formatting
+  ActionExecutor      CGEvent mouse/keyboard injection
+  ActionVerifier      Safety checks (sensitive data, loops, limits)
+  ScreenCapture       ScreenCaptureKit screenshot fallback
+  Session             Main orchestration loop
+Inference/            AI action selection
+  AnthropicProvider   Claude Haiku API integration
+  ToolDefinitions     Tool schemas for function calling
+UI/                   SwiftUI views + overlay window
+Logging/              Session recording to JSON
+```
+
+## Safety
+
+- Credit cards, SSNs, and passwords are blocked at the verifier level
+- Destructive key combos (Cmd+Q, Cmd+W, Cmd+Delete) require explicit user confirmation
+- Form submission (Enter after typing) requires confirmation
+- Loop detection aborts stuck agents (3 identical consecutive actions)
+- Step limit enforced (default 50, configurable)
+- System menu bar (top 25px) is off-limits
+- Escape key or Stop button instantly cancels
+
+## Project Structure
+
+```
+vellum-assistant/
+├── Package.swift                          SPM manifest
+├── vellum-assistant/
+│   ├── App/
+│   │   ├── VellumAssistantApp.swift       @main entry point
+│   │   ├── AppDelegate.swift              Menu bar + hotkey + session lifecycle
+│   │   ├── APIKeyManager.swift            Keychain storage
+│   │   └── PermissionManager.swift        AX + Screen Recording checks
+│   ├── ComputerUse/
+│   │   ├── ActionTypes.swift              AgentAction, ActionRecord
+│   │   ├── AccessibilityTree.swift        AX tree enumeration
+│   │   ├── ScreenCapture.swift            Screenshot capture
+│   │   ├── ActionExecutor.swift           CGEvent input injection
+│   │   ├── ActionVerifier.swift           Safety verification
+│   │   └── Session.swift                  Main orchestration loop
+│   ├── Inference/
+│   │   ├── ActionInferenceProvider.swift   Protocol
+│   │   ├── AnthropicProvider.swift        Claude Haiku API
+│   │   └── ToolDefinitions.swift          Tool schemas
+│   ├── UI/
+│   │   ├── TaskInputView.swift            Popover input
+│   │   ├── SessionOverlayWindow.swift     Floating NSPanel
+│   │   ├── SessionOverlayView.swift       Session status UI
+│   │   ├── ConfirmationView.swift         Action confirmation
+│   │   ├── SettingsView.swift             API key + preferences
+│   │   └── MenuBarController.swift        Reserved
+│   ├── Logging/
+│   │   ├── SessionLogger.swift            JSON session logs
+│   │   └── LogViewer.swift                Log browser UI
+│   └── Resources/
+│       ├── Info.plist
+│       └── Assets.xcassets
+└── vellum-assistantTests/
+    ├── ActionVerifierTests.swift
+    ├── AccessibilityTreeTests.swift
+    └── ToolDefinitionsTests.swift
+```

--- a/clients/macos/context.md
+++ b/clients/macos/context.md
@@ -1,0 +1,48 @@
+## Current Objective
+Add voice input (hold Option key to speak task) and right-click quit to the macOS computer use menu bar app.
+
+## Progress Summary
+- App successfully controls Chrome via AX tree + Claude Sonnet 4.5 tool use — filled out Google Forms on first try
+- Fixed os.Logger subsystem (`"com.vellum.vellum-assistant"` matching bundle ID), added comprehensive logging to Session and AccessibilityTree
+- Added ChromeAccessibilityHelper: auto-restarts Chrome with `--force-renderer-accessibility` when web content missing from AX tree
+- Aligned screen sizing with graphos: `CGDisplayBounds(CGMainDisplayID())` for logical display points
+- Fixed self-window race condition with 300ms popover-close delay
+- 8 custom tools (click, double_click, right_click, type_text, key, scroll, wait, done) with element_id targeting
+
+## Active Work
+Both features implemented:
+1. **Voice input**: Hold Option key → start recording (mic.fill icon), release → transcribe via SFSpeechRecognizer → submit as task. VoiceInputManager.swift uses global+local flagsChanged monitors. Only triggers on Option alone (not Cmd+Option etc). First use prompts for speech recognition + microphone permissions.
+2. **Right-click quit**: Right-clicking the menu bar status item shows context menu with "Quit". Uses button.sendAction(on: [.leftMouseUp, .rightMouseUp]) with NSMenu.popUp.
+
+## Technical Context
+- **Stack/Dependencies**: Swift/SwiftUI macOS 14+ app, Anthropic Messages API (Sonnet 4.5), CGEvent injection, ApplicationServices AX API, ScreenCaptureKit, HotKey package (soffes/HotKey)
+- **Architecture**: Menu bar app (LSUIElement) with NSStatusItem → NSPopover for task input. Session: PERCEIVE (AX tree) → INFER (Claude) → VERIFY → EXECUTE (CGEvent) → LOG
+- **Build**: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme vellum-assistant -configuration Release -derivedDataPath build build`
+- **Bundle ID**: `com.vellum.vellum-assistant`
+- **Log stream**: `log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level debug`
+- **Constraints**: `Bundle.main.bundleIdentifier` returns nil at runtime (SwiftPM executable context), so logger uses fallback string. App uses `.accessory` activation policy (no dock icon).
+
+## Next Steps
+1. Test end-to-end voice → transcription → session flow
+2. Consider adding visual feedback beyond mic icon (e.g., popover showing "Listening..." or waveform)
+3. Consider on-device vs server-side speech recognition toggle in Settings
+
+## Important Files
+```
+vellum-assistant/App/AppDelegate.swift - Menu bar setup, hotkey, session launching — modify for right-click menu and voice input
+vellum-assistant/App/VellumAssistantApp.swift - @main entry point, Settings scene
+vellum-assistant/UI/TaskInputView.swift - Text input popover UI
+vellum-assistant/ComputerUse/Session.swift - Main session loop with Chrome auto-fix, logging
+vellum-assistant/ComputerUse/AccessibilityTree.swift - AX tree enumeration with logging
+vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift - Auto-restart Chrome with accessibility flag
+vellum-assistant/ComputerUse/ScreenCapture.swift - CGDisplayBounds-based screen size
+vellum-assistant/Inference/AnthropicProvider.swift - API calls, system prompt, tool call parsing
+vellum-assistant/Inference/ToolDefinitions.swift - 8 tool schemas
+vellum-assistant/Resources/Info-generated.plist - Xcode-generated plist (needs mic/speech entitlements)
+vellum-assistant.xcodeproj/project.pbxproj - Must manually add new .swift files here
+```
+
+## Open Questions/Blockers
+- Voice input is an alternative alongside the popover (hold Option anywhere to speak, or click/Cmd+Shift+G for text input)
+- `Bundle.main.bundleIdentifier` is nil — new files must be added to pbxproj manually (see ChromeAccessibilityHelper pattern)
+- Session logs: `~/Library/Application Support/vellum-assistant/logs/session-*.json`

--- a/clients/macos/project.yml
+++ b/clients/macos/project.yml
@@ -1,0 +1,51 @@
+name: vellum-assistant
+options:
+  bundleIdPrefix: com.vellum
+  deploymentTarget:
+    macOS: "14.0"
+
+packages:
+  HotKey:
+    url: https://github.com/soffes/HotKey
+    from: "0.2.1"
+
+targets:
+  vellum-assistant:
+    type: application
+    platform: macOS
+    sources:
+      - path: vellum-assistant
+        excludes:
+          - Resources/Info.plist
+    info:
+      path: vellum-assistant/Resources/Info-generated.plist
+      properties:
+        LSUIElement: true
+        NSScreenRecordingUsageDescription: "vellum-assistant needs Screen Recording access to see what's on your screen during computer use tasks."
+        NSMicrophoneUsageDescription: "vellum-assistant needs microphone access to transcribe voice commands."
+        NSSpeechRecognitionUsageDescription: "vellum-assistant uses speech recognition to convert voice commands into tasks."
+        LSApplicationCategoryType: public.app-category.productivity
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.vellum.vellum-assistant
+        PRODUCT_NAME: vellum-assistant
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        SWIFT_VERSION: "5.9"
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_IDENTITY: "-"
+        DEVELOPMENT_TEAM: 7A7LUB87GP
+    dependencies:
+      - package: HotKey
+
+  vellum-assistantTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: vellum-assistantTests
+    dependencies:
+      - target: vellum-assistant
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.vellum.vellum-assistant-tests

--- a/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
+++ b/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
@@ -1,0 +1,594 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0654885DAD8FFD16D639D50F /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09137E88F2AB02DF31D32BD0 /* MenuBarController.swift */; };
+		0BAED176454C59993573CA0A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24486EB2442797096CD3CC38 /* SettingsView.swift */; };
+		1602CEC331C383C46984277A /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB2E3A6215CE30550FE5E61 /* AnthropicProvider.swift */; };
+		1DEE9818AE627F372EADF74A /* ActionVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */; };
+		24539EB93D0273F1439687A8 /* VellumAssistantApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7288C576664B021EF155B9C /* VellumAssistantApp.swift */; };
+		D2E3F4A5B6C70890ABCDE013 /* VoiceInputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F4A5B6C7D80901ABCDE014 /* VoiceInputManager.swift */; };
+		29E492439AEE36E5F9B7ED8F /* ToolDefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D9802001C0CCEFD3078EB8 /* ToolDefinitionsTests.swift */; };
+		3CBEF918BC31B5CDA67AB307 /* ToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */; };
+		43B58A748C33955C52226B4B /* AccessibilityTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */; };
+		A1B2C3D4E5F60789ABCDE012 /* ChromeAccessibilityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7089ABCDE01 /* ChromeAccessibilityHelper.swift */; };
+		4D469EED4BFBA43F6B759AAC /* SessionLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */; };
+		5099794339FDE050C79700BB /* LogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C691BD0FDCE6190A60F45F5C /* LogViewer.swift */; };
+		535ADB8BECF9E185F1BD3E19 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF062AE5C6B78D85CEDC7C3B /* Session.swift */; };
+		658A24BC47071CE83C3645B1 /* AccessibilityTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33DCEFE581D93580243939 /* AccessibilityTreeTests.swift */; };
+		6A077380F3286DD96EFD3522 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A751A31DD82FE6622EA4CD /* PermissionManager.swift */; };
+		6AD6CEEFD8DA3B5E15FB28C6 /* ActionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93BDB5AED0253CF3298634F3 /* ActionTypes.swift */; };
+		6CB40FE359E8E66B2112DD8F /* ActionVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7699446B63C8A3B7CAC33CC /* ActionVerifierTests.swift */; };
+		7F1E97ABA962B7ECB1511DAE /* ActionInferenceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */; };
+		8A677CC74636049BC83014BC /* ScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */; };
+		A2215F8493C316D8E139D1E6 /* ActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */; };
+		A22ACF7097DF1475D184958A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */; };
+		A2B8C0BC3677B95F736E9DF4 /* ConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0760D7F261720758A5FAC3E /* ConfirmationView.swift */; };
+		B8E68D3E4BAE108BA4DFAD15 /* SessionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */; };
+		C12CF51CE1378D77F77732CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4932108265C798B9FDE108 /* AppDelegate.swift */; };
+		DC3B028DC386EFE1436E30FF /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = F6CB2EC7443D3897D22E6D3E /* HotKey */; };
+		E96230E4CB5C96C982458657 /* APIKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822B891B496900302404DF02 /* APIKeyManager.swift */; };
+		EE8D6587E18994C45CB48652 /* SessionOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */; };
+		F29831F8092D9BBB259BAF7C /* TaskInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ABA40D80D70550AA640AF8 /* TaskInputView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5CD66BFF4368D9E62A34AD60 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BE50E89180C185313A06D25E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9FF83BE615D71B14DBCD81CC;
+			remoteInfo = "vellum-assistant";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		08ABA40D80D70550AA640AF8 /* TaskInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInputView.swift; sourceTree = "<group>"; };
+		09137E88F2AB02DF31D32BD0 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionVerifier.swift; sourceTree = "<group>"; };
+		1CB8813503311E10F158679D /* vellum-assistant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "vellum-assistant.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		24486EB2442797096CD3CC38 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		244CA8647EA7EA0E89AF1577 /* Info-generated.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Info-generated.plist"; sourceTree = "<group>"; };
+		2FB2E3A6215CE30550FE5E61 /* AnthropicProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProvider.swift; sourceTree = "<group>"; };
+		3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDefinitions.swift; sourceTree = "<group>"; };
+		4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayView.swift; sourceTree = "<group>"; };
+		56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTree.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7089ABCDE01 /* ChromeAccessibilityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeAccessibilityHelper.swift; sourceTree = "<group>"; };
+		6679C7528847C8E31C861F34 /* vellum-assistantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "vellum-assistantTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		822B891B496900302404DF02 /* APIKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyManager.swift; sourceTree = "<group>"; };
+		83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionInferenceProvider.swift; sourceTree = "<group>"; };
+		8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapture.swift; sourceTree = "<group>"; };
+		93BDB5AED0253CF3298634F3 /* ActionTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionTypes.swift; sourceTree = "<group>"; };
+		A7288C576664B021EF155B9C /* VellumAssistantApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumAssistantApp.swift; sourceTree = "<group>"; };
+		E3F4A5B6C7D80901ABCDE014 /* VoiceInputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputManager.swift; sourceTree = "<group>"; };
+		A7699446B63C8A3B7CAC33CC /* ActionVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionVerifierTests.swift; sourceTree = "<group>"; };
+		A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BC4932108265C798B9FDE108 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		BD33DCEFE581D93580243939 /* AccessibilityTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTreeTests.swift; sourceTree = "<group>"; };
+		BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExecutor.swift; sourceTree = "<group>"; };
+		C0760D7F261720758A5FAC3E /* ConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationView.swift; sourceTree = "<group>"; };
+		C691BD0FDCE6190A60F45F5C /* LogViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewer.swift; sourceTree = "<group>"; };
+		DF062AE5C6B78D85CEDC7C3B /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		E0D9802001C0CCEFD3078EB8 /* ToolDefinitionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDefinitionsTests.swift; sourceTree = "<group>"; };
+		E4A751A31DD82FE6622EA4CD /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
+		E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayWindow.swift; sourceTree = "<group>"; };
+		FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLogger.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B774C51CBD21B070C8CDE30C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC3B028DC386EFE1436E30FF /* HotKey in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		240BE551C8B6D79A8D0A192D /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				C0760D7F261720758A5FAC3E /* ConfirmationView.swift */,
+				09137E88F2AB02DF31D32BD0 /* MenuBarController.swift */,
+				4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */,
+				E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */,
+				24486EB2442797096CD3CC38 /* SettingsView.swift */,
+				08ABA40D80D70550AA640AF8 /* TaskInputView.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+		25DD8E1203E655B696FA8DB4 /* vellum-assistant */ = {
+			isa = PBXGroup;
+			children = (
+				552A2C545E2BF56B3E87BD60 /* App */,
+				77446C593F1B020A68C4E343 /* ComputerUse */,
+				803423BF8679AFBCCA292F91 /* Inference */,
+				380E7F936BBAF30C41F1796A /* Logging */,
+				4AF1F140E0C5F77CB8669CAC /* Resources */,
+				240BE551C8B6D79A8D0A192D /* UI */,
+			);
+			path = "vellum-assistant";
+			sourceTree = "<group>";
+		};
+		380E7F936BBAF30C41F1796A /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				C691BD0FDCE6190A60F45F5C /* LogViewer.swift */,
+				FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		4AF1F140E0C5F77CB8669CAC /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */,
+				244CA8647EA7EA0E89AF1577 /* Info-generated.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		552A2C545E2BF56B3E87BD60 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				822B891B496900302404DF02 /* APIKeyManager.swift */,
+				BC4932108265C798B9FDE108 /* AppDelegate.swift */,
+				E4A751A31DD82FE6622EA4CD /* PermissionManager.swift */,
+				A7288C576664B021EF155B9C /* VellumAssistantApp.swift */,
+				E3F4A5B6C7D80901ABCDE014 /* VoiceInputManager.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		6795C8638FF2B8939D24D72C = {
+			isa = PBXGroup;
+			children = (
+				25DD8E1203E655B696FA8DB4 /* vellum-assistant */,
+				833A49EB3959BFC35C57D434 /* vellum-assistantTests */,
+				C05A937512C71620246E7F6C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		77446C593F1B020A68C4E343 /* ComputerUse */ = {
+			isa = PBXGroup;
+			children = (
+				56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */,
+				BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */,
+				93BDB5AED0253CF3298634F3 /* ActionTypes.swift */,
+				12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */,
+				F1A2B3C4D5E6F7089ABCDE01 /* ChromeAccessibilityHelper.swift */,
+				8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */,
+				DF062AE5C6B78D85CEDC7C3B /* Session.swift */,
+			);
+			path = ComputerUse;
+			sourceTree = "<group>";
+		};
+		803423BF8679AFBCCA292F91 /* Inference */ = {
+			isa = PBXGroup;
+			children = (
+				83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */,
+				2FB2E3A6215CE30550FE5E61 /* AnthropicProvider.swift */,
+				3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */,
+			);
+			path = Inference;
+			sourceTree = "<group>";
+		};
+		833A49EB3959BFC35C57D434 /* vellum-assistantTests */ = {
+			isa = PBXGroup;
+			children = (
+				BD33DCEFE581D93580243939 /* AccessibilityTreeTests.swift */,
+				A7699446B63C8A3B7CAC33CC /* ActionVerifierTests.swift */,
+				E0D9802001C0CCEFD3078EB8 /* ToolDefinitionsTests.swift */,
+			);
+			path = "vellum-assistantTests";
+			sourceTree = "<group>";
+		};
+		C05A937512C71620246E7F6C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1CB8813503311E10F158679D /* vellum-assistant.app */,
+				6679C7528847C8E31C861F34 /* vellum-assistantTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9FF83BE615D71B14DBCD81CC /* vellum-assistant */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B2620C1F6E37478C146F9125 /* Build configuration list for PBXNativeTarget "vellum-assistant" */;
+			buildPhases = (
+				B3367575373617913ADB095D /* Sources */,
+				024317FC269C3FF9C48AEA03 /* Resources */,
+				B774C51CBD21B070C8CDE30C /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "vellum-assistant";
+			packageProductDependencies = (
+				F6CB2EC7443D3897D22E6D3E /* HotKey */,
+			);
+			productName = "vellum-assistant";
+			productReference = 1CB8813503311E10F158679D /* vellum-assistant.app */;
+			productType = "com.apple.product-type.application";
+		};
+		AD220DEA8208F3392A1B4621 /* vellum-assistantTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B1CC03C37918614F827636E /* Build configuration list for PBXNativeTarget "vellum-assistantTests" */;
+			buildPhases = (
+				13F7CD1EF943A02E087E41B2 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5DFBA98A8FE5F9C49CE86FEF /* PBXTargetDependency */,
+			);
+			name = "vellum-assistantTests";
+			packageProductDependencies = (
+			);
+			productName = "vellum-assistantTests";
+			productReference = 6679C7528847C8E31C861F34 /* vellum-assistantTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BE50E89180C185313A06D25E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					9FF83BE615D71B14DBCD81CC = {
+						DevelopmentTeam = 7A7LUB87GP;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 1A5A5233548E6B28FCC62872 /* Build configuration list for PBXProject "vellum-assistant" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 6795C8638FF2B8939D24D72C;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				94BCE7829D5C3A2915BA999F /* XCRemoteSwiftPackageReference "HotKey" */,
+			);
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9FF83BE615D71B14DBCD81CC /* vellum-assistant */,
+				AD220DEA8208F3392A1B4621 /* vellum-assistantTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		024317FC269C3FF9C48AEA03 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A22ACF7097DF1475D184958A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13F7CD1EF943A02E087E41B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				658A24BC47071CE83C3645B1 /* AccessibilityTreeTests.swift in Sources */,
+				6CB40FE359E8E66B2112DD8F /* ActionVerifierTests.swift in Sources */,
+				29E492439AEE36E5F9B7ED8F /* ToolDefinitionsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B3367575373617913ADB095D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E96230E4CB5C96C982458657 /* APIKeyManager.swift in Sources */,
+				43B58A748C33955C52226B4B /* AccessibilityTree.swift in Sources */,
+				A2215F8493C316D8E139D1E6 /* ActionExecutor.swift in Sources */,
+				A1B2C3D4E5F60789ABCDE012 /* ChromeAccessibilityHelper.swift in Sources */,
+				7F1E97ABA962B7ECB1511DAE /* ActionInferenceProvider.swift in Sources */,
+				6AD6CEEFD8DA3B5E15FB28C6 /* ActionTypes.swift in Sources */,
+				1DEE9818AE627F372EADF74A /* ActionVerifier.swift in Sources */,
+				1602CEC331C383C46984277A /* AnthropicProvider.swift in Sources */,
+				C12CF51CE1378D77F77732CB /* AppDelegate.swift in Sources */,
+				A2B8C0BC3677B95F736E9DF4 /* ConfirmationView.swift in Sources */,
+				5099794339FDE050C79700BB /* LogViewer.swift in Sources */,
+				0654885DAD8FFD16D639D50F /* MenuBarController.swift in Sources */,
+				6A077380F3286DD96EFD3522 /* PermissionManager.swift in Sources */,
+				8A677CC74636049BC83014BC /* ScreenCapture.swift in Sources */,
+				535ADB8BECF9E185F1BD3E19 /* Session.swift in Sources */,
+				4D469EED4BFBA43F6B759AAC /* SessionLogger.swift in Sources */,
+				B8E68D3E4BAE108BA4DFAD15 /* SessionOverlayView.swift in Sources */,
+				EE8D6587E18994C45CB48652 /* SessionOverlayWindow.swift in Sources */,
+				0BAED176454C59993573CA0A /* SettingsView.swift in Sources */,
+				F29831F8092D9BBB259BAF7C /* TaskInputView.swift in Sources */,
+				3CBEF918BC31B5CDA67AB307 /* ToolDefinitions.swift in Sources */,
+				D2E3F4A5B6C70890ABCDE013 /* VoiceInputManager.swift in Sources */,
+				24539EB93D0273F1439687A8 /* VellumAssistantApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5DFBA98A8FE5F9C49CE86FEF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9FF83BE615D71B14DBCD81CC /* vellum-assistant */;
+			targetProxy = 5CD66BFF4368D9E62A34AD60 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		57FAB8E9E3B2A69D14D3C380 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9F32996A87F9DD9688540BC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vellum.vellum-assistant-tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/vellum-assistant.app/Contents/MacOS/vellum-assistant";
+			};
+			name = Release;
+		};
+		A2D7A9E6E16AF469775E918D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7A7LUB87GP;
+				INFOPLIST_FILE = "vellum-assistant/Resources/Info-generated.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vellum.vellum-assistant";
+				PRODUCT_NAME = "vellum-assistant";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.9;
+			};
+			name = Debug;
+		};
+		ADC23910F1D0C7FE8C417E86 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vellum.vellum-assistant-tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/vellum-assistant.app/Contents/MacOS/vellum-assistant";
+			};
+			name = Debug;
+		};
+		C1CC177E70FFF5BAE135B483 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7A7LUB87GP;
+				INFOPLIST_FILE = "vellum-assistant/Resources/Info-generated.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vellum.vellum-assistant";
+				PRODUCT_NAME = "vellum-assistant";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.9;
+			};
+			name = Release;
+		};
+		D353CEA2889A84482962B755 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A5A5233548E6B28FCC62872 /* Build configuration list for PBXProject "vellum-assistant" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57FAB8E9E3B2A69D14D3C380 /* Debug */,
+				D353CEA2889A84482962B755 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		5B1CC03C37918614F827636E /* Build configuration list for PBXNativeTarget "vellum-assistantTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ADC23910F1D0C7FE8C417E86 /* Debug */,
+				9F32996A87F9DD9688540BC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B2620C1F6E37478C146F9125 /* Build configuration list for PBXNativeTarget "vellum-assistant" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A2D7A9E6E16AF469775E918D /* Debug */,
+				C1CC177E70FFF5BAE135B483 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		94BCE7829D5C3A2915BA999F /* XCRemoteSwiftPackageReference "HotKey" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/soffes/HotKey";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F6CB2EC7443D3897D22E6D3E /* HotKey */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 94BCE7829D5C3A2915BA999F /* XCRemoteSwiftPackageReference "HotKey" */;
+			productName = HotKey;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = BE50E89180C185313A06D25E /* Project object */;
+}

--- a/clients/macos/vellum-assistant.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/clients/macos/vellum-assistant.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/clients/macos/vellum-assistant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/clients/macos/vellum-assistant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "01f286328852d165d87f8fbee99b01f9c2c936f57ac234f76396f74f9d2496dd",
+  "pins" : [
+    {
+      "identity" : "hotkey",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soffes/HotKey",
+      "state" : {
+        "revision" : "a3cf605d7a96f6ff50e04fcb6dea6e2613cfcbe4",
+        "version" : "0.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Security
+
+enum APIKeyManager {
+    private static let service = "com.vellum-assistant.anthropic-api-key"
+    private static let account = "anthropic-api-key"
+
+    static func getKey() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func setKey(_ key: String) {
+        deleteKey()
+
+        guard let data = key.data(using: .utf8) else { return }
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    static func deleteKey() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1,0 +1,161 @@
+import AppKit
+import SwiftUI
+import HotKey
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem!
+    private var popover: NSPopover!
+    private var hotKey: HotKey?
+    private var escapeMonitor: Any?
+    private var overlayWindow: SessionOverlayWindow?
+    var currentSession: ComputerUseSession?
+    private var voiceInput: VoiceInputManager?
+
+    private var windowObserver: Any?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        setupMenuBar()
+        setupHotKey()
+        setupEscapeMonitor()
+        setupVoiceInput()
+
+        // Watch for Settings window closing to revert to accessory activation policy
+        windowObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: nil, queue: .main
+        ) { [weak self] notification in
+            guard let window = notification.object as? NSWindow,
+                  window.title.contains("Settings") || window.title.contains("vellum") else { return }
+            // Revert to accessory (no dock icon) after settings closes
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
+                if !hasVisibleWindows {
+                    NSApp.setActivationPolicy(.accessory)
+                }
+            }
+        }
+    }
+
+    // MARK: - Menu Bar
+
+    private func setupMenuBar() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: "vellum-assistant")
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            button.action = #selector(statusBarButtonClicked(_:))
+            button.target = self
+        }
+
+        let contentView = TaskInputView(onSubmit: { [weak self] task in
+            self?.startSession(task: task)
+        })
+
+        popover = NSPopover()
+        popover.contentSize = NSSize(width: 320, height: 200)
+        popover.behavior = .transient
+        popover.contentViewController = NSHostingController(rootView: contentView)
+    }
+
+    @objc private func statusBarButtonClicked(_ sender: NSStatusBarButton) {
+        guard let event = NSApp.currentEvent else { return }
+        if event.type == .rightMouseUp {
+            showContextMenu()
+        } else {
+            togglePopover()
+        }
+    }
+
+    private func showContextMenu() {
+        guard let button = statusItem.button else { return }
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: button)
+    }
+
+    // MARK: - Hotkey
+
+    private func setupHotKey() {
+        hotKey = HotKey(key: .g, modifiers: [.command, .shift])
+        hotKey?.keyDownHandler = { [weak self] in
+            self?.togglePopover()
+        }
+    }
+
+    private func setupEscapeMonitor() {
+        escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { // Escape
+                Task { @MainActor in
+                    self?.currentSession?.cancel()
+                }
+            }
+        }
+    }
+
+    // MARK: - Voice Input
+
+    private func setupVoiceInput() {
+        voiceInput = VoiceInputManager()
+        voiceInput?.onTranscription = { [weak self] text in
+            self?.startSession(task: text)
+        }
+        voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
+            self?.statusItem.button?.image = NSImage(
+                systemSymbolName: isRecording ? "mic.fill" : "sparkles",
+                accessibilityDescription: "vellum-assistant"
+            )
+        }
+        voiceInput?.start()
+    }
+
+    // MARK: - Popover
+
+    private func togglePopover() {
+        guard let button = statusItem.button else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    // MARK: - Session
+
+    func startSession(task: String) {
+        guard currentSession == nil else { return }
+        popover.performClose(nil)
+
+        guard let apiKey = APIKeyManager.getKey() else {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            return
+        }
+
+        guard ActionExecutor.checkAccessibilityPermission(prompt: true) else {
+            return
+        }
+
+        let provider = AnthropicProvider(apiKey: apiKey)
+        let session = ComputerUseSession(task: task, provider: provider)
+        currentSession = session
+
+        let overlay = SessionOverlayWindow(session: session)
+        overlay.show()
+        overlayWindow = overlay
+
+        Task { @MainActor in
+            await session.run()
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            overlay.close()
+            self.overlayWindow = nil
+            self.currentSession = nil
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let monitor = escapeMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        voiceInput?.stop()
+    }
+}

--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -1,0 +1,25 @@
+import ApplicationServices
+import ScreenCaptureKit
+
+enum PermissionStatus {
+    case granted
+    case denied
+    case unknown
+}
+
+enum PermissionManager {
+    static func accessibilityStatus(prompt: Bool = false) -> PermissionStatus {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): prompt] as CFDictionary
+        let trusted = AXIsProcessTrustedWithOptions(options)
+        return trusted ? .granted : .denied
+    }
+
+    static func screenRecordingStatus() async -> PermissionStatus {
+        do {
+            _ = try await SCShareableContent.current
+            return .granted
+        } catch {
+            return .denied
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant/App/VellumAssistantApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct VellumAssistantApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        Settings {
+            SettingsView()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1,0 +1,156 @@
+import Foundation
+import AppKit
+import Speech
+import AVFoundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "VoiceInput")
+
+@MainActor
+final class VoiceInputManager {
+    var onTranscription: ((String) -> Void)?
+    var onRecordingStateChanged: ((Bool) -> Void)?
+
+    private var isRecording = false
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+
+    private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let audioEngine = AVAudioEngine()
+
+    func start() {
+        setupOptionKeyMonitors()
+    }
+
+    func stop() {
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+        stopRecording()
+    }
+
+    // MARK: - Option Key Detection
+
+    private func setupOptionKeyMonitors() {
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            Task { @MainActor in
+                self?.handleFlagsChanged(event)
+            }
+        }
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            Task { @MainActor in
+                self?.handleFlagsChanged(event)
+            }
+            return event
+        }
+    }
+
+    private func handleFlagsChanged(_ event: NSEvent) {
+        let optionPressed = event.modifierFlags.contains(.option)
+        let otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control]
+        let hasOtherModifiers = !event.modifierFlags.intersection(otherModifiers).isEmpty
+
+        if optionPressed && !hasOtherModifiers && !isRecording {
+            beginRecording()
+        } else if !optionPressed && isRecording {
+            stopRecording()
+        }
+    }
+
+    // MARK: - Recording
+
+    private func beginRecording() {
+        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
+            log.error("Speech recognizer not available")
+            return
+        }
+
+        // Don't start if a previous recognition task is still processing
+        if recognitionTask != nil {
+            log.warning("Previous recognition task still active, skipping")
+            return
+        }
+
+        let authStatus = SFSpeechRecognizer.authorizationStatus()
+        if authStatus == .notDetermined {
+            SFSpeechRecognizer.requestAuthorization { _ in }
+            log.info("Requested speech recognition authorization — hold Option again after approving")
+            return
+        }
+        guard authStatus == .authorized else {
+            log.error("Speech recognition not authorized (status: \(authStatus.rawValue))")
+            return
+        }
+
+        isRecording = true
+        onRecordingStateChanged?(true)
+        log.info("Voice recording started")
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = false
+        recognitionRequest = request
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        guard recordingFormat.channelCount > 0 else {
+            log.error("No audio input channels available")
+            isRecording = false
+            onRecordingStateChanged?(false)
+            return
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
+            Task { @MainActor in
+                guard let self = self else { return }
+
+                if let result = result, result.isFinal {
+                    let text = result.bestTranscription.formattedString
+                    log.info("Transcription: \(text, privacy: .public)")
+                    if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        self.onTranscription?(text)
+                    }
+                    self.recognitionTask = nil
+                } else if let error = error {
+                    log.error("Recognition error: \(error.localizedDescription)")
+                    self.recognitionTask = nil
+                }
+            }
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+        } catch {
+            log.error("Audio engine failed to start: \(error.localizedDescription)")
+            isRecording = false
+            onRecordingStateChanged?(false)
+            recognitionRequest = nil
+            recognitionTask = nil
+        }
+    }
+
+    private func stopRecording() {
+        guard isRecording else { return }
+
+        isRecording = false
+        onRecordingStateChanged?(false)
+        log.info("Voice recording stopped")
+
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -1,0 +1,366 @@
+import ApplicationServices
+import AppKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AXTree")
+
+struct AXElement: Identifiable {
+    let id: Int
+    let role: String
+    let title: String?
+    let value: String?
+    let frame: CGRect
+    let isEnabled: Bool
+    let isFocused: Bool
+    let children: [AXElement]
+    let roleDescription: String?
+    let identifier: String?
+    let url: String?
+    let placeholderValue: String?
+}
+
+final class AccessibilityTreeEnumerator {
+    private var nextId = 1
+
+    static let interactiveRoles: Set<String> = [
+        "AXButton", "AXTextField", "AXTextArea", "AXCheckBox", "AXRadioButton",
+        "AXPopUpButton", "AXComboBox", "AXSlider", "AXLink", "AXMenuItem",
+        "AXMenuButton", "AXIncrementor", "AXDisclosureTriangle", "AXTab",
+        "AXTabGroup", "AXSegmentedControl"
+    ]
+
+    private static let containerRoles: Set<String> = [
+        "AXGroup", "AXScrollArea", "AXSplitGroup", "AXTabGroup", "AXToolbar",
+        "AXTable", "AXOutline", "AXList", "AXBrowser", "AXWebArea", "AXRow",
+        "AXCell", "AXSheet", "AXDrawer",
+        // Web content containers (Chrome, Safari, Electron)
+        "AXSection", "AXForm", "AXLandmarkMain", "AXLandmarkNavigation",
+        "AXLandmarkBanner", "AXLandmarkContentInfo", "AXLandmarkSearch",
+        "AXArticle", "AXDocument", "AXApplication"
+    ]
+
+    /// Set of app PIDs where we've already enabled enhanced AX.
+    private static var enhancedAXEnabled: Set<pid_t> = []
+
+    /// Clear the cache so we re-set AXEnhancedUserInterface (e.g., after restarting Chrome).
+    static func clearEnhancedAXCache() {
+        enhancedAXEnabled.removeAll()
+    }
+
+    func enumerateCurrentWindow() -> (elements: [AXElement], windowTitle: String, appName: String)? {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            log.warning("No frontmost application found")
+            return nil
+        }
+
+        let myBundleId = Bundle.main.bundleIdentifier
+        log.debug("Frontmost app: \(frontApp.localizedName ?? "?", privacy: .public) (\(frontApp.bundleIdentifier ?? "no-bundle-id", privacy: .public)) — my bundle: \(myBundleId ?? "nil", privacy: .public)")
+
+        // Skip our own app — we want the window behind the overlay
+        if let myId = myBundleId, frontApp.bundleIdentifier == myId {
+            log.info("Skipping own app, looking for previous app")
+            return enumeratePreviousApp()
+        }
+
+        let pid = frontApp.processIdentifier
+        let appName = frontApp.localizedName ?? "Unknown"
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // Tell apps (especially Chrome, Electron) to expose full web content AX tree.
+        // This is what real assistive technologies do.
+        if !Self.enhancedAXEnabled.contains(pid) {
+            let result = AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+            log.info("Set AXEnhancedUserInterface on \(appName, privacy: .public) (pid \(pid)): \(result == .success ? "success" : "failed (\(result.rawValue))")")
+            Self.enhancedAXEnabled.insert(pid)
+        }
+
+        var windowValue: CFTypeRef?
+        let windowResult = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+        guard windowResult == .success, let windowRef = windowValue else { return nil }
+        let windowElement = windowRef as! AXUIElement
+
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+
+        nextId = 1
+        let elements = enumerateElement(element: windowElement, depth: 0, maxDepth: 25)
+
+        let flat = AccessibilityTreeEnumerator.flattenElements(elements)
+        let interactive = flat.filter { Self.interactiveRoles.contains($0.role) }
+        log.info("Enumerated \(appName, privacy: .public): \(flat.count) total, \(interactive.count) interactive, maxId=\(self.nextId - 1)")
+
+        return (elements: elements, windowTitle: windowTitle, appName: appName)
+    }
+
+    /// When our own app is focused, find the previously-active app's window instead.
+    private func enumeratePreviousApp() -> (elements: [AXElement], windowTitle: String, appName: String)? {
+        let runningApps = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular && $0.bundleIdentifier != Bundle.main.bundleIdentifier && !$0.isTerminated }
+
+        for app in runningApps {
+            let pid = app.processIdentifier
+            let appElement = AXUIElementCreateApplication(pid)
+
+            if !Self.enhancedAXEnabled.contains(pid) {
+                AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+                Self.enhancedAXEnabled.insert(pid)
+            }
+
+            var windowValue: CFTypeRef?
+            let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+            guard result == .success, let windowRef = windowValue else { continue }
+            let windowElement = windowRef as! AXUIElement
+
+            let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+            let appName = app.localizedName ?? "Unknown"
+
+            nextId = 1
+            let elements = enumerateElement(element: windowElement, depth: 0, maxDepth: 25)
+
+            // Only return if we found something useful
+            if !elements.isEmpty {
+                return (elements: elements, windowTitle: windowTitle, appName: appName)
+            }
+        }
+        return nil
+    }
+
+    private func enumerateElement(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
+        guard depth < maxDepth else { return [] }
+
+        let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
+        let title = getStringAttribute(element, kAXTitleAttribute as CFString)
+            ?? getStringAttribute(element, kAXDescriptionAttribute as CFString)
+        let value = getValueAttribute(element)
+        let roleDescription = getStringAttribute(element, kAXRoleDescriptionAttribute as CFString)
+        let identifier = getStringAttribute(element, kAXIdentifierAttribute as CFString)
+        let placeholderValue = getStringAttribute(element, kAXPlaceholderValueAttribute as CFString)
+        let isEnabled = getBoolAttribute(element, kAXEnabledAttribute as CFString) ?? true
+        let isFocused = getBoolAttribute(element, kAXFocusedAttribute as CFString) ?? false
+        let frame = getFrameAttribute(element)
+        let url = getStringAttribute(element, "AXURL" as CFString)
+
+        let isInteractive = Self.interactiveRoles.contains(role)
+        let isContainer = Self.containerRoles.contains(role)
+        let hasTextContent = (title != nil && !title!.isEmpty) || (value != nil && !value!.isEmpty)
+        let isStaticText = role == "AXStaticText" || role == "AXHeading"
+
+        // Enumerate children
+        var childElements: [AXElement] = []
+        var childrenRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                childElements.append(contentsOf: enumerateElement(element: child, depth: depth + 1, maxDepth: maxDepth))
+            }
+        }
+
+        if isInteractive {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: [], // Flatten interactive elements
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        if isStaticText && hasTextContent {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: [],
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        if isContainer && !childElements.isEmpty {
+            let id = nextId
+            nextId += 1
+            return [AXElement(
+                id: id,
+                role: role,
+                title: title,
+                value: value,
+                frame: frame,
+                isEnabled: isEnabled,
+                isFocused: isFocused,
+                children: childElements,
+                roleDescription: roleDescription,
+                identifier: identifier,
+                url: url,
+                placeholderValue: placeholderValue
+            )]
+        }
+
+        // Skip this element but keep children
+        return childElements
+    }
+
+    // MARK: - AX Attribute Helpers
+
+    private func getStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private func getBoolAttribute(_ element: AXUIElement, _ attribute: CFString) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return (value as? NSNumber)?.boolValue
+    }
+
+    private func getValueAttribute(_ element: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? NSNumber { return num.stringValue }
+        return nil
+    }
+
+    private func getFrameAttribute(_ element: AXUIElement) -> CGRect {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success
+        else { return .zero }
+
+        var point = CGPoint.zero
+        var size = CGSize.zero
+
+        if let posRef = positionValue {
+            AXValueGetValue(posRef as! AXValue, .cgPoint, &point)
+        }
+        if let sizeRef = sizeValue {
+            AXValueGetValue(sizeRef as! AXValue, .cgSize, &size)
+        }
+
+        return CGRect(origin: point, size: size)
+    }
+
+    // MARK: - Formatting
+
+    static func formatAXTree(elements: [AXElement], windowTitle: String, appName: String) -> String {
+        var lines: [String] = []
+        lines.append("Window: \"\(windowTitle)\" (\(appName))")
+
+        var interactive: [String] = []
+        var staticTexts: [String] = []
+        collectFormatted(elements: elements, interactive: &interactive, staticTexts: &staticTexts)
+
+        if !interactive.isEmpty {
+            lines.append("Interactive elements:")
+            for line in interactive {
+                lines.append("  \(line)")
+            }
+        }
+
+        if !staticTexts.isEmpty {
+            lines.append("")
+            lines.append("Visible text:")
+            for text in staticTexts.prefix(30) {
+                lines.append("  \(text)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func collectFormatted(elements: [AXElement], interactive: inout [String], staticTexts: inout [String]) {
+        for element in elements {
+            let isInteractiveRole = interactiveRoles.contains(element.role)
+            let isText = element.role == "AXStaticText" || element.role == "AXHeading"
+
+            if isInteractiveRole {
+                let cleanedRole = cleanRole(element.role)
+                let centerX = Int(element.frame.midX)
+                let centerY = Int(element.frame.midY)
+                var line = "[\(element.id)] \(cleanedRole)"
+                if let title = element.title, !title.isEmpty {
+                    line += " \"\(title)\""
+                }
+                line += " at (\(centerX), \(centerY))"
+                if element.isFocused { line += " FOCUSED" }
+                if !element.isEnabled { line += " disabled" }
+                if let value = element.value, !value.isEmpty {
+                    let truncated = value.count > 50 ? String(value.prefix(50)) + "..." : value
+                    line += " value: \"\(truncated)\""
+                } else if let placeholder = element.placeholderValue, !placeholder.isEmpty {
+                    line += " placeholder: \"\(placeholder)\""
+                }
+                if let url = element.url, !url.isEmpty {
+                    line += " → \(url)"
+                }
+                interactive.append(line)
+            } else if isText {
+                if let title = element.title, !title.isEmpty {
+                    staticTexts.append(title)
+                } else if let value = element.value, !value.isEmpty {
+                    staticTexts.append(value)
+                }
+            }
+
+            collectFormatted(elements: element.children, interactive: &interactive, staticTexts: &staticTexts)
+        }
+    }
+
+    private static func cleanRole(_ role: String) -> String {
+        var cleaned = role
+        if cleaned.hasPrefix("AX") {
+            cleaned = String(cleaned.dropFirst(2))
+        }
+        // Split camelCase
+        var result = ""
+        for char in cleaned {
+            if char.isUppercase && !result.isEmpty {
+                result += " "
+            }
+            result += String(char).lowercased()
+        }
+        return result
+    }
+
+    static func shouldFallbackToVision(elements: [AXElement]) -> Bool {
+        var interactiveCount = 0
+        countInteractive(elements: elements, count: &interactiveCount)
+        return interactiveCount < 3
+    }
+
+    private static func countInteractive(elements: [AXElement], count: inout Int) {
+        for element in elements {
+            if interactiveRoles.contains(element.role) {
+                count += 1
+            }
+            countInteractive(elements: element.children, count: &count)
+        }
+    }
+
+    static func flattenElements(_ elements: [AXElement]) -> [AXElement] {
+        var result: [AXElement] = []
+        for element in elements {
+            result.append(element)
+            result.append(contentsOf: flattenElements(element.children))
+        }
+        return result
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -1,0 +1,237 @@
+import CoreGraphics
+import AppKit
+import ApplicationServices
+
+enum ExecutorError: LocalizedError {
+    case eventCreationFailed
+    case missingCoordinates
+    case missingText
+    case missingKey
+    case unknownKey(String)
+    case accessibilityNotGranted
+
+    var errorDescription: String? {
+        switch self {
+        case .eventCreationFailed: return "Failed to create CGEvent"
+        case .missingCoordinates: return "Action requires x,y coordinates"
+        case .missingText: return "Type action requires text"
+        case .missingKey: return "Key action requires key name"
+        case .unknownKey(let key): return "Unknown key: \(key)"
+        case .accessibilityNotGranted: return "Accessibility permission not granted"
+        }
+    }
+}
+
+final class ActionExecutor {
+    private let eventSource: CGEventSource?
+
+    init() {
+        eventSource = CGEventSource(stateID: .hidSystemState)
+    }
+
+    static func checkAccessibilityPermission(prompt: Bool = false) -> Bool {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): prompt] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    // MARK: - Mouse Actions
+
+    func click(at point: CGPoint) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    func doubleClick(at point: CGPoint) throws {
+        try click(at: point)
+        usleep(100_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.setIntegerValueField(.mouseEventClickState, value: 2)
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.setIntegerValueField(.mouseEventClickState, value: 2)
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    func rightClick(at point: CGPoint) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseDown, mouseCursorPosition: point, mouseButton: .right) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseUp, mouseCursorPosition: point, mouseButton: .right) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        mouseUp.post(tap: .cghidEventTap)
+    }
+
+    private func mouseMove(to point: CGPoint) throws {
+        guard let moveEvent = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        moveEvent.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Keyboard Actions
+
+    func typeText(_ text: String) throws {
+        let pasteboard = NSPasteboard.general
+        let previousContents = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        try keyCombo(keyCode: 9, modifiers: .maskCommand) // Cmd+V
+        usleep(100_000)
+
+        // Restore clipboard after delay
+        let saved = previousContents
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            if let saved = saved {
+                pb.setString(saved, forType: .string)
+            }
+        }
+    }
+
+    func pressKey(_ keyString: String) throws {
+        let parts = keyString.lowercased().split(separator: "+").map(String.init)
+        var modifiers: CGEventFlags = []
+        var keyName = ""
+
+        for part in parts {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            switch trimmed {
+            case "cmd", "command":
+                modifiers.insert(.maskCommand)
+            case "shift":
+                modifiers.insert(.maskShift)
+            case "option", "alt":
+                modifiers.insert(.maskAlternate)
+            case "ctrl", "control":
+                modifiers.insert(.maskControl)
+            default:
+                keyName = trimmed
+            }
+        }
+
+        guard let keyCode = Self.keyCodeMap[keyName] else {
+            throw ExecutorError.unknownKey(keyName)
+        }
+
+        try keyCombo(keyCode: keyCode, modifiers: modifiers)
+    }
+
+    func keyCombo(keyCode: CGKeyCode, modifiers: CGEventFlags) throws {
+        guard let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        keyDown.flags = modifiers
+        keyDown.post(tap: .cghidEventTap)
+        usleep(50_000)
+
+        guard let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        keyUp.flags = modifiers
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Scroll
+
+    func scroll(at point: CGPoint, direction: String, amount: Int) throws {
+        try mouseMove(to: point)
+        usleep(30_000)
+
+        let multiplier = amount * 5
+        var dy: Int32 = 0
+        var dx: Int32 = 0
+
+        switch direction.lowercased() {
+        case "up": dy = Int32(multiplier)
+        case "down": dy = -Int32(multiplier)
+        case "left": dx = Int32(multiplier)
+        case "right": dx = -Int32(multiplier)
+        default: break
+        }
+
+        guard let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) else {
+            throw ExecutorError.eventCreationFailed
+        }
+        scrollEvent.post(tap: .cgSessionEventTap)
+    }
+
+    // MARK: - Dispatch
+
+    func execute(_ action: AgentAction) async throws {
+        switch action.type {
+        case .click:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try click(at: CGPoint(x: x, y: y))
+        case .doubleClick:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try doubleClick(at: CGPoint(x: x, y: y))
+        case .rightClick:
+            guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
+            try rightClick(at: CGPoint(x: x, y: y))
+        case .type:
+            guard let text = action.text else { throw ExecutorError.missingText }
+            try typeText(text)
+        case .key:
+            guard let key = action.key else { throw ExecutorError.missingKey }
+            try pressKey(key)
+        case .scroll:
+            let x = action.x ?? 0
+            let y = action.y ?? 0
+            let direction = action.scrollDirection ?? "down"
+            let amount = action.scrollAmount ?? 3
+            try scroll(at: CGPoint(x: x, y: y), direction: direction, amount: amount)
+        case .wait:
+            let ms = action.waitDuration ?? 500
+            try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
+        case .done:
+            break
+        }
+    }
+
+    // MARK: - Key Code Map
+
+    static let keyCodeMap: [String: CGKeyCode] = [
+        "a": 0, "b": 11, "c": 8, "d": 2, "e": 14, "f": 3, "g": 5, "h": 4,
+        "i": 34, "j": 38, "k": 40, "l": 37, "m": 46, "n": 45, "o": 31, "p": 35,
+        "q": 12, "r": 15, "s": 1, "t": 17, "u": 32, "v": 9, "w": 13, "x": 7,
+        "y": 16, "z": 6,
+        "0": 29, "1": 18, "2": 19, "3": 20, "4": 21, "5": 23, "6": 22, "7": 26,
+        "8": 28, "9": 25,
+        "enter": 36, "return": 36, "tab": 48, "space": 49, "escape": 53, "esc": 53,
+        "backspace": 51, "delete": 51, "forwarddelete": 117,
+        "up": 126, "down": 125, "left": 123, "right": 124,
+        "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
+        "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+        "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+        "-": 27, "=": 24, "[": 33, "]": 30, "\\": 42, ";": 41, "'": 39,
+        ",": 43, ".": 47, "/": 44, "`": 50,
+    ]
+}

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -1,0 +1,118 @@
+import Foundation
+import CoreGraphics
+
+enum ActionType: String, Codable {
+    case click
+    case doubleClick = "double_click"
+    case rightClick = "right_click"
+    case type
+    case key
+    case scroll
+    case wait
+    case done
+}
+
+struct AgentAction: Codable {
+    let type: ActionType
+    var x: CGFloat?
+    var y: CGFloat?
+    var text: String?
+    var key: String?
+    var scrollDirection: String?
+    var scrollAmount: Int?
+    var summary: String?
+    var waitDuration: Int?
+    var reasoning: String
+    var resolvedFromElementId: Int?
+    var elementDescription: String?
+
+    init(
+        type: ActionType,
+        reasoning: String,
+        x: CGFloat? = nil,
+        y: CGFloat? = nil,
+        text: String? = nil,
+        key: String? = nil,
+        scrollDirection: String? = nil,
+        scrollAmount: Int? = nil,
+        summary: String? = nil,
+        waitDuration: Int? = nil,
+        resolvedFromElementId: Int? = nil,
+        elementDescription: String? = nil
+    ) {
+        self.type = type
+        self.reasoning = reasoning
+        self.x = x
+        self.y = y
+        self.text = text
+        self.key = key
+        self.scrollDirection = scrollDirection
+        self.scrollAmount = scrollAmount
+        self.summary = summary
+        self.waitDuration = waitDuration
+        self.resolvedFromElementId = resolvedFromElementId
+        self.elementDescription = elementDescription
+    }
+
+    var displayDescription: String {
+        switch type {
+        case .click:
+            if let id = resolvedFromElementId, let desc = elementDescription {
+                return "Click [\(id)] \(desc)"
+            }
+            if let x = x, let y = y {
+                return "Click at (\(Int(x)), \(Int(y)))"
+            }
+            return "Click"
+        case .doubleClick:
+            if let id = resolvedFromElementId, let desc = elementDescription {
+                return "Double-click [\(id)] \(desc)"
+            }
+            if let x = x, let y = y {
+                return "Double-click at (\(Int(x)), \(Int(y)))"
+            }
+            return "Double-click"
+        case .rightClick:
+            if let id = resolvedFromElementId, let desc = elementDescription {
+                return "Right-click [\(id)] \(desc)"
+            }
+            if let x = x, let y = y {
+                return "Right-click at (\(Int(x)), \(Int(y)))"
+            }
+            return "Right-click"
+        case .type:
+            if let text = text {
+                let preview = text.count > 40 ? String(text.prefix(40)) + "..." : text
+                return "Type \"\(preview)\""
+            }
+            return "Type"
+        case .key:
+            if let key = key {
+                return "Press \(key)"
+            }
+            return "Press key"
+        case .scroll:
+            let dir = scrollDirection ?? "down"
+            let amt = scrollAmount ?? 3
+            return "Scroll \(dir) \(amt)x"
+        case .wait:
+            if let ms = waitDuration {
+                return "Wait \(ms)ms"
+            }
+            return "Wait"
+        case .done:
+            if let summary = summary {
+                let preview = summary.count > 60 ? String(summary.prefix(60)) + "..." : summary
+                return "Done: \(preview)"
+            }
+            return "Done"
+        }
+    }
+}
+
+struct ActionRecord: Codable {
+    let step: Int
+    let action: AgentAction
+    let result: String?
+    let timestamp: Date
+}

--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -1,0 +1,114 @@
+import Foundation
+import CoreGraphics
+
+enum VerifyResult {
+    case allowed
+    case needsConfirmation(String)
+    case blocked(String)
+}
+
+final class ActionVerifier {
+    private var actionHistory: [AgentAction] = []
+    private let maxSteps: Int
+    private(set) var blockedCount: Int = 0
+
+    init(maxSteps: Int = 50) {
+        self.maxSteps = maxSteps
+    }
+
+    func verify(_ action: AgentAction) -> VerifyResult {
+        // 1. Step limit
+        if actionHistory.count >= maxSteps {
+            return .blocked("Maximum step limit (\(maxSteps)) reached")
+        }
+
+        // 2. Loop detection — same action 3 times consecutively
+        if actionHistory.count >= 2 {
+            let last2 = Array(actionHistory.suffix(2))
+            if last2.allSatisfy({ actionsAreIdentical($0, action) }) {
+                return .blocked("Agent appears stuck — same action repeated 3 times consecutively")
+            }
+        }
+
+        // 3. Sensitive text detection
+        if let text = action.text {
+            if looksLikeCreditCard(text) {
+                return .blocked("Blocked: text appears to contain a credit card number")
+            }
+            if looksLikeSSN(text) {
+                return .blocked("Blocked: text appears to contain a Social Security Number")
+            }
+            if looksLikePassword(text) {
+                return .blocked("Blocked: text appears to contain a password")
+            }
+        }
+
+        // 4. Destructive key combos
+        if action.type == .key, let key = action.key?.lowercased() {
+            let destructiveKeys = ["cmd+q", "command+q", "cmd+w", "command+w",
+                                   "cmd+delete", "command+delete", "cmd+backspace", "command+backspace"]
+            if destructiveKeys.contains(key) {
+                return .needsConfirmation("Key combo '\(key)' could close a window or delete content")
+            }
+        }
+
+        // 5. Form submission (Enter after typing)
+        if action.type == .key, let key = action.key?.lowercased(),
+           (key == "enter" || key == "return"),
+           let lastAction = actionHistory.last, lastAction.type == .type {
+            return .needsConfirmation("Pressing Enter may submit a form")
+        }
+
+        // 6. Forbidden screen region (system menu bar)
+        if let y = action.y, y < 25, action.type == .click || action.type == .doubleClick || action.type == .rightClick {
+            return .blocked("Action targets the system menu bar (y < 25)")
+        }
+
+        // All checks passed
+        actionHistory.append(action)
+        return .allowed
+    }
+
+    func reset() {
+        actionHistory.removeAll()
+        blockedCount = 0
+    }
+
+    var currentStepCount: Int { actionHistory.count }
+
+    var consecutiveBlockCount: Int { blockedCount }
+
+    func recordBlock() { blockedCount += 1 }
+
+    func resetBlockCount() { blockedCount = 0 }
+
+    // MARK: - Comparison
+
+    private func actionsAreIdentical(_ a: AgentAction, _ b: AgentAction) -> Bool {
+        a.type == b.type && a.x == b.x && a.y == b.y && a.text == b.text && a.key == b.key
+    }
+
+    // MARK: - Sensitive Data Detection
+
+    private func looksLikeCreditCard(_ text: String) -> Bool {
+        let stripped = text.replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+        guard stripped.count >= 13 && stripped.count <= 19 else { return false }
+        return stripped.allSatisfy(\.isNumber)
+    }
+
+    private func looksLikeSSN(_ text: String) -> Bool {
+        let pattern = #"^\d{3}-?\d{2}-?\d{4}$"#
+        return text.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private func looksLikePassword(_ text: String) -> Bool {
+        guard text.count >= 8 && text.count <= 64 else { return false }
+        let hasUpper = text.contains(where: \.isUppercase)
+        let hasLower = text.contains(where: \.isLowercase)
+        let hasDigit = text.contains(where: \.isNumber)
+        let symbols = CharacterSet.alphanumerics.inverted
+        let hasSymbol = text.unicodeScalars.contains(where: { symbols.contains($0) })
+        return hasUpper && hasLower && hasDigit && hasSymbol
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -1,0 +1,95 @@
+import AppKit
+import ApplicationServices
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChromeA11y")
+
+/// Ensures Chrome exposes its full web content accessibility tree.
+/// Chrome requires `--force-renderer-accessibility` to expose form inputs, links, etc.
+/// Without it, only toolbar elements and some static text are visible via AX APIs.
+final class ChromeAccessibilityHelper {
+
+    /// Known Chrome-family bundle identifiers.
+    static let chromeBundleIds: Set<String> = [
+        "com.google.Chrome",
+        "com.google.Chrome.canary",
+        "com.brave.Browser",
+        "com.microsoft.edgemac",
+        "com.vivaldi.Vivaldi",
+    ]
+
+    /// Returns true if the given app is a Chromium-based browser.
+    static func isChromium(_ app: NSRunningApplication) -> Bool {
+        guard let bundleId = app.bundleIdentifier else { return false }
+        return chromeBundleIds.contains(bundleId)
+    }
+
+    /// Check whether Chrome's AX tree includes web content (not just toolbar).
+    /// A shallow tree (few interactive elements, none below the toolbar y-band) means
+    /// Chrome isn't exposing renderer accessibility.
+    static func hasWebContent(elements: [AXElement]) -> Bool {
+        let flat = AccessibilityTreeEnumerator.flattenElements(elements)
+        let interactive = flat.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }
+
+        // Chrome toolbar sits at roughly y < 150. If ALL interactive elements are in
+        // that band, we're only seeing the toolbar, not web content.
+        let webInteractive = interactive.filter { $0.frame.midY > 200 }
+
+        // Also check for web-specific roles that only appear with renderer accessibility
+        let hasWebRoles = flat.contains { el in
+            let role = el.role
+            return role == "AXWebArea" || role == "AXForm" || role == "AXLandmarkMain"
+                || role == "AXSection" || role == "AXArticle"
+        }
+
+        let result = !webInteractive.isEmpty || hasWebRoles
+        log.info("hasWebContent: \(result) — \(interactive.count) interactive, \(webInteractive.count) below toolbar, hasWebRoles=\(hasWebRoles)")
+        return result
+    }
+
+    /// Restart Chrome with `--force-renderer-accessibility` so the full AX tree is available.
+    /// Chrome's built-in session restore will reopen all tabs.
+    /// Returns true if Chrome was successfully restarted.
+    @MainActor
+    static func restartChromeWithAccessibility(app: NSRunningApplication) async -> Bool {
+        guard let bundleId = app.bundleIdentifier,
+              let bundleURL = app.bundleURL else {
+            log.error("Cannot restart: missing bundle info")
+            return false
+        }
+
+        log.info("Restarting \(bundleId, privacy: .public) with --force-renderer-accessibility")
+
+        // Gracefully terminate — Chrome will save session state
+        app.terminate()
+
+        // Wait for Chrome to fully quit (up to 5 seconds)
+        for _ in 0..<50 {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            if app.isTerminated { break }
+        }
+
+        if !app.isTerminated {
+            log.warning("Chrome didn't quit gracefully, force-terminating")
+            app.forceTerminate()
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+
+        // Relaunch with accessibility flag
+        do {
+            let config = NSWorkspace.OpenConfiguration()
+            config.arguments = ["--force-renderer-accessibility"]
+            config.activates = true
+
+            _ = try await NSWorkspace.shared.openApplication(at: bundleURL, configuration: config)
+            log.info("Chrome relaunched with accessibility flag")
+
+            // Wait for Chrome to start and restore tabs
+            try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
+            return true
+        } catch {
+            log.error("Failed to relaunch Chrome: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
@@ -1,0 +1,64 @@
+import ScreenCaptureKit
+import AppKit
+import CoreGraphics
+
+enum CaptureError: LocalizedError {
+    case noDisplay
+    case conversionFailed
+    case permissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .noDisplay: return "No display found"
+        case .conversionFailed: return "Failed to convert screenshot to JPEG"
+        case .permissionDenied: return "Screen Recording permission denied"
+        }
+    }
+}
+
+final class ScreenCapture {
+    func captureScreen(maxWidth: Int = 1920, maxHeight: Int = 1080) async throws -> Data {
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.current
+        } catch {
+            throw CaptureError.permissionDenied
+        }
+
+        guard let display = content.displays.first else {
+            throw CaptureError.noDisplay
+        }
+
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let config = SCStreamConfiguration()
+
+        let displayWidth = CGFloat(display.width)
+        let displayHeight = CGFloat(display.height)
+        let scaleX = CGFloat(maxWidth) / displayWidth
+        let scaleY = CGFloat(maxHeight) / displayHeight
+        let scale = min(scaleX, scaleY, 1.0) // Don't upscale
+
+        config.width = Int(displayWidth * scale)
+        config.height = Int(displayHeight * scale)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.showsCursor = true
+
+        let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+
+        let nsImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+        guard let tiffData = nsImage.tiffRepresentation,
+              let bitmapRep = NSBitmapImageRep(data: tiffData),
+              let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.8]) else {
+            throw CaptureError.conversionFailed
+        }
+
+        return jpegData
+    }
+
+    /// Returns the main display size in logical points (same coordinate space as AX tree and CGEvent).
+    /// Uses CGDisplayBounds like graphos for consistency.
+    func screenSize() -> CGSize {
+        let bounds = CGDisplayBounds(CGMainDisplayID())
+        return bounds.size
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -1,0 +1,249 @@
+import Foundation
+import CoreGraphics
+import AppKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "Session")
+
+enum SessionState: Equatable {
+    case idle
+    case running(step: Int, maxSteps: Int, lastAction: String)
+    case paused(step: Int, maxSteps: Int)
+    case awaitingConfirmation(reason: String)
+    case completed(summary: String, steps: Int)
+    case failed(reason: String)
+    case cancelled
+}
+
+@MainActor
+final class ComputerUseSession: ObservableObject {
+    @Published var state: SessionState = .idle
+
+    let task: String
+    private let provider: ActionInferenceProvider
+    private let maxSteps: Int
+    private let stepDelayMs: UInt64
+
+    private var actionHistory: [ActionRecord] = []
+    private var isCancelled = false
+    private var isPaused = false
+    private var confirmationContinuation: CheckedContinuation<Bool, Never>?
+
+    private let enumerator = AccessibilityTreeEnumerator()
+    private let screenCapture = ScreenCapture()
+    private let executor = ActionExecutor()
+    private let verifier: ActionVerifier
+    private let logger: SessionLogger
+    private var didChromeAccessibilityCheck = false
+
+    init(task: String, provider: ActionInferenceProvider, maxSteps: Int = 50, stepDelayMs: UInt64 = 500) {
+        self.task = task
+        self.provider = provider
+        self.maxSteps = maxSteps
+        self.stepDelayMs = stepDelayMs
+        self.verifier = ActionVerifier(maxSteps: maxSteps)
+        self.logger = SessionLogger(task: task)
+    }
+
+    func run() async {
+        actionHistory.removeAll()
+        verifier.reset()
+        isCancelled = false
+        isPaused = false
+        state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...")
+
+        log.info("Session starting — task: \(self.task, privacy: .public)")
+        log.info("Screen size: \(Int(self.screenCapture.screenSize().width))×\(Int(self.screenCapture.screenSize().height))")
+
+        // Brief delay to let the popover close and the target app regain focus
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        while !isCancelled {
+            // Wait while paused
+            while isPaused && !isCancelled {
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            }
+            if isCancelled { break }
+
+            let stepNumber = actionHistory.count + 1
+
+            // 1. PERCEIVE — always prefer accessibility tree
+            var axTreeText: String?
+            var elements: [AXElement]?
+            var screenshot: Data?
+            var usedVision = false
+
+            if let result = enumerator.enumerateCurrentWindow() {
+                // On first step with Chrome: check if web content is visible.
+                // If not, restart Chrome with --force-renderer-accessibility and re-enumerate.
+                if !didChromeAccessibilityCheck,
+                   let frontApp = NSWorkspace.shared.frontmostApplication,
+                   ChromeAccessibilityHelper.isChromium(frontApp),
+                   !ChromeAccessibilityHelper.hasWebContent(elements: result.elements) {
+                    didChromeAccessibilityCheck = true
+                    log.warning("Chrome detected but AX tree has no web content — restarting with accessibility")
+                    state = .running(step: 0, maxSteps: maxSteps, lastAction: "Enabling Chrome accessibility...")
+                    let restarted = await ChromeAccessibilityHelper.restartChromeWithAccessibility(app: frontApp)
+                    if restarted {
+                        // Clear the enhanced-AX cache so we re-set it on the new process
+                        AccessibilityTreeEnumerator.clearEnhancedAXCache()
+                        log.info("Chrome restarted — re-enumerating")
+                        continue // re-run the PERCEIVE step
+                    } else {
+                        log.error("Chrome restart failed — continuing with limited AX tree")
+                    }
+                }
+                didChromeAccessibilityCheck = true
+
+                // Always use the AX tree when we have a focused window
+                axTreeText = AccessibilityTreeEnumerator.formatAXTree(
+                    elements: result.elements,
+                    windowTitle: result.windowTitle,
+                    appName: result.appName
+                )
+                elements = result.elements
+                let flat = AccessibilityTreeEnumerator.flattenElements(result.elements)
+                let interactiveCount = flat.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }.count
+                log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
+                log.debug("[\(stepNumber)] AX tree text:\n\(axTreeText ?? "(empty)")")
+
+                // Also capture a screenshot so the model can see content beyond the AX tree
+                // (e.g., a PDF in another window, images, or other visual context)
+                do {
+                    screenshot = try await screenCapture.captureScreen()
+                    log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
+                } catch {
+                    log.warning("[\(stepNumber)] Screenshot capture failed alongside AX tree: \(error.localizedDescription)")
+                    // Non-fatal — we still have the AX tree
+                }
+            } else {
+                // No focused window — try screenshot as last resort
+                log.warning("[\(stepNumber)] No AX tree available — falling back to screenshot")
+                do {
+                    screenshot = try await screenCapture.captureScreen()
+                    usedVision = true
+                    log.info("[\(stepNumber)] Screenshot captured (\(screenshot?.count ?? 0) bytes)")
+                } catch {
+                    log.error("[\(stepNumber)] Screen capture failed: \(error.localizedDescription)")
+                    state = .failed(reason: "No focused window and screen capture failed")
+                    logger.finishSession(result: "failed: no window")
+                    return
+                }
+            }
+
+            // 2. INFER
+            let action: AgentAction
+            do {
+                action = try await provider.infer(
+                    axTree: axTreeText,
+                    screenshot: screenshot,
+                    screenSize: screenCapture.screenSize(),
+                    task: task,
+                    history: actionHistory,
+                    elements: elements.flatMap { AccessibilityTreeEnumerator.flattenElements($0) }
+                )
+            } catch {
+                log.error("[\(stepNumber)] Inference error: \(error.localizedDescription)")
+                state = .failed(reason: "Inference failed: \(error.localizedDescription)")
+                logger.finishSession(result: "failed: inference error")
+                return
+            }
+
+            log.info("[\(stepNumber)] Model action: \(action.displayDescription) — reasoning: \(action.reasoning)")
+            logger.logTurn(step: stepNumber, axTree: axTreeText, screenshot: screenshot, action: action, usedVision: usedVision)
+
+            // 3. CHECK COMPLETION
+            if action.type == .done {
+                let summary = action.summary ?? "Task completed"
+                let record = ActionRecord(step: stepNumber, action: action, result: "executed", timestamp: Date())
+                actionHistory.append(record)
+                state = .completed(summary: summary, steps: stepNumber)
+                logger.finishSession(result: "completed: \(summary)")
+                return
+            }
+
+            // 4. VERIFY
+            let verifyResult = verifier.verify(action)
+            switch verifyResult {
+            case .allowed:
+                verifier.resetBlockCount()
+
+            case .needsConfirmation(let reason):
+                state = .awaitingConfirmation(reason: reason)
+                let approved = await withCheckedContinuation { continuation in
+                    confirmationContinuation = continuation
+                }
+                confirmationContinuation = nil
+
+                if !approved {
+                    state = .cancelled
+                    logger.finishSession(result: "cancelled: user rejected confirmation")
+                    return
+                }
+                state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: action.displayDescription)
+
+            case .blocked(let reason):
+                log.warning("[\(stepNumber)] BLOCKED: \(reason)")
+                let record = ActionRecord(step: stepNumber, action: action, result: "BLOCKED: \(reason)", timestamp: Date())
+                actionHistory.append(record)
+                verifier.recordBlock()
+                if verifier.consecutiveBlockCount >= 3 {
+                    state = .failed(reason: "Session stopped: 3 consecutive actions blocked")
+                    logger.finishSession(result: "failed: too many blocks")
+                    return
+                }
+                continue
+            }
+
+            // 5. EXECUTE
+            do {
+                try await executor.execute(action)
+            } catch {
+                let record = ActionRecord(step: stepNumber, action: action, result: "ERROR: \(error.localizedDescription)", timestamp: Date())
+                actionHistory.append(record)
+                state = .failed(reason: "Execution failed: \(error.localizedDescription)")
+                logger.finishSession(result: "failed: execution error")
+                return
+            }
+
+            let record = ActionRecord(step: stepNumber, action: action, result: "executed", timestamp: Date())
+            actionHistory.append(record)
+
+            // 6. UPDATE UI
+            state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: action.displayDescription)
+
+            // 7. WAIT
+            try? await Task.sleep(nanoseconds: stepDelayMs * 1_000_000)
+        }
+
+        // Cancelled
+        state = .cancelled
+        logger.finishSession(result: "cancelled")
+    }
+
+    // MARK: - Control
+
+    func pause() {
+        isPaused = true
+        let step = actionHistory.count
+        state = .paused(step: step, maxSteps: maxSteps)
+    }
+
+    func resume() {
+        isPaused = false
+    }
+
+    func cancel() {
+        isCancelled = true
+        confirmationContinuation?.resume(returning: false)
+        confirmationContinuation = nil
+    }
+
+    func approveConfirmation() {
+        confirmationContinuation?.resume(returning: true)
+    }
+
+    func rejectConfirmation() {
+        confirmationContinuation?.resume(returning: false)
+    }
+}

--- a/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreGraphics
+
+protocol ActionInferenceProvider {
+    func infer(
+        axTree: String?,
+        screenshot: Data?,
+        screenSize: CGSize,
+        task: String,
+        history: [ActionRecord],
+        elements: [AXElement]?
+    ) async throws -> AgentAction
+}

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -1,0 +1,265 @@
+import Foundation
+import CoreGraphics
+
+enum InferenceError: LocalizedError {
+    case networkError(String)
+    case apiError(statusCode: Int, body: String)
+    case parseError(String)
+    case noAPIKey
+
+    var errorDescription: String? {
+        switch self {
+        case .networkError(let msg): return "Network error: \(msg)"
+        case .apiError(let code, let body): return "API error (\(code)): \(body)"
+        case .parseError(let msg): return "Parse error: \(msg)"
+        case .noAPIKey: return "No API key configured"
+        }
+    }
+}
+
+final class AnthropicProvider: ActionInferenceProvider {
+    private let apiKey: String
+    private let model: String
+    private let baseURL = "https://api.anthropic.com/v1/messages"
+    private let apiVersion = "2023-06-01"
+
+    init(apiKey: String, model: String = "claude-sonnet-4-5-20250929") {
+        self.apiKey = apiKey
+        self.model = model
+    }
+
+    func infer(
+        axTree: String?,
+        screenshot: Data?,
+        screenSize: CGSize,
+        task: String,
+        history: [ActionRecord],
+        elements: [AXElement]?
+    ) async throws -> AgentAction {
+        let systemPrompt = buildSystemPrompt(screenSize: screenSize)
+        let messages = buildMessages(axTree: axTree, screenshot: screenshot, task: task, history: history)
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1024,
+            "system": systemPrompt,
+            "tools": ToolDefinitions.tools,
+            "tool_choice": ["type": "any"],
+            "messages": messages
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: body)
+
+        var request = URLRequest(url: URL(string: baseURL)!)
+        request.httpMethod = "POST"
+        request.httpBody = jsonData
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue(apiVersion, forHTTPHeaderField: "anthropic-version")
+        request.timeoutInterval = 30
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw InferenceError.networkError(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw InferenceError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw InferenceError.apiError(statusCode: httpResponse.statusCode, body: body)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]] else {
+            throw InferenceError.parseError("Invalid response structure")
+        }
+
+        // Find the tool_use block
+        guard let toolUse = content.first(where: { ($0["type"] as? String) == "tool_use" }),
+              let toolName = toolUse["name"] as? String,
+              let input = toolUse["input"] as? [String: Any] else {
+            throw InferenceError.parseError("No tool_use block in response")
+        }
+
+        return try parseToolCall(name: toolName, input: input, elements: elements)
+    }
+
+    // MARK: - System Prompt
+
+    private func buildSystemPrompt(screenSize: CGSize) -> String {
+        """
+        You are vellum-assistant's computer use agent. You control the user's Mac to accomplish tasks by interacting with UI elements one action at a time.
+
+        The screen is \(Int(screenSize.width))×\(Int(screenSize.height)) pixels.
+
+        You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements — this is much more reliable than pixel coordinates.
+
+        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, wait, done.
+        You MUST only call one of these tools each turn. Do NOT attempt to call any other tool.
+
+        RULES:
+        - Call exactly one tool per turn. After each action, you'll receive the updated screen state.
+        - ALWAYS use element_id to target elements from the accessibility tree. Only fall back to x,y coordinates if no tree is available.
+        - Use the wait tool when you need to pause for UI to update (e.g. after clicking a button that loads content).
+        - FORM FIELD WORKFLOW: To fill a text field, first click it (by element_id) to focus it, then call type_text. If a field already shows "FOCUSED", skip the click and type immediately.
+        - After typing, verify in the next turn that the text appeared correctly.
+        - If something unexpected happens, adapt your approach.
+        - If you're stuck (same state after 3+ actions), try a different approach or call done with an explanation.
+        - NEVER type passwords, credit card numbers, SSNs, or other sensitive data.
+        - Prefer keyboard shortcuts (cmd+c, cmd+v) over menu navigation when possible.
+        - When the task is complete, call the done tool with a summary.
+        """
+    }
+
+    // MARK: - Message Building
+
+    private func buildMessages(axTree: String?, screenshot: Data?, task: String, history: [ActionRecord]) -> [[String: Any]] {
+        var contentBlocks: [[String: Any]] = []
+
+        // Screenshot image block
+        if let screenshotData = screenshot {
+            contentBlocks.append([
+                "type": "image",
+                "source": [
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": screenshotData.base64EncodedString()
+                ]
+            ])
+        }
+
+        // Text block
+        var textParts: [String] = []
+        textParts.append("TASK: \(task)")
+        textParts.append("")
+
+        if let tree = axTree {
+            textParts.append("CURRENT SCREEN STATE (accessibility tree of the focused window):")
+            textParts.append(tree)
+            textParts.append("")
+            textParts.append("Use element_id with the [ID] numbers shown above to target elements.")
+            if screenshot != nil {
+                textParts.append("")
+                textParts.append("A screenshot of the FULL SCREEN is also attached above. Use it to see content outside the focused window (e.g., reference documents, PDFs, other apps visible behind the current window). The AX tree only covers the focused window, but the screenshot shows everything visible on screen.")
+            }
+        } else if screenshot != nil {
+            textParts.append("CURRENT SCREEN STATE:")
+            textParts.append("See the screenshot above. No accessibility tree available — estimate coordinates from the image.")
+        } else {
+            textParts.append("CURRENT SCREEN STATE:")
+            textParts.append("No screen data available.")
+        }
+
+        if !history.isEmpty {
+            textParts.append("")
+            textParts.append("ACTIONS TAKEN SO FAR:")
+            for record in history {
+                let result = record.result ?? "executed"
+                textParts.append("  \(record.step). \(record.action.displayDescription) → \(result)")
+            }
+        }
+
+        textParts.append("")
+        if history.isEmpty {
+            textParts.append("This is the first action. Examine the screen state and decide what to do first.")
+        } else {
+            textParts.append("Decide the next action to take.")
+        }
+
+        contentBlocks.append([
+            "type": "text",
+            "text": textParts.joined(separator: "\n")
+        ])
+
+        return [[
+            "role": "user",
+            "content": contentBlocks
+        ]]
+    }
+
+    // MARK: - Tool Call Parsing
+
+    private func parseToolCall(name: String, input: [String: Any], elements: [AXElement]?) throws -> AgentAction {
+        let reasoning = input["reasoning"] as? String ?? ""
+        let elementId = input["element_id"] as? Int
+        let inputX = input["x"] as? Int
+        let inputY = input["y"] as? Int
+
+        switch name {
+        case "click", "double_click", "right_click":
+            let actionType: ActionType = name == "click" ? .click : name == "double_click" ? .doubleClick : .rightClick
+            let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
+            guard let finalX = x, let finalY = y else {
+                throw InferenceError.parseError("\(name) requires element_id or x,y coordinates")
+            }
+            return AgentAction(
+                type: actionType,
+                reasoning: reasoning,
+                x: CGFloat(finalX),
+                y: CGFloat(finalY),
+                resolvedFromElementId: resolvedId,
+                elementDescription: desc
+            )
+
+        case "type_text":
+            guard let text = input["text"] as? String else {
+                throw InferenceError.parseError("type_text requires 'text' field")
+            }
+            return AgentAction(type: .type, reasoning: reasoning, text: text)
+
+        case "key":
+            guard let key = input["key"] as? String else {
+                throw InferenceError.parseError("key requires 'key' field")
+            }
+            return AgentAction(type: .key, reasoning: reasoning, key: key)
+
+        case "scroll":
+            guard let direction = input["direction"] as? String else {
+                throw InferenceError.parseError("scroll requires 'direction' field")
+            }
+            let amount = input["amount"] as? Int ?? 3
+            let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
+            return AgentAction(
+                type: .scroll,
+                reasoning: reasoning,
+                x: x.map(CGFloat.init) ?? 0,
+                y: y.map(CGFloat.init) ?? 0,
+                scrollDirection: direction,
+                scrollAmount: amount,
+                resolvedFromElementId: resolvedId,
+                elementDescription: desc
+            )
+
+        case "wait":
+            guard let durationMs = input["duration_ms"] as? Int else {
+                throw InferenceError.parseError("wait requires 'duration_ms' field")
+            }
+            return AgentAction(type: .wait, reasoning: reasoning, waitDuration: durationMs)
+
+        case "done":
+            let summary = input["summary"] as? String ?? "Task completed"
+            return AgentAction(type: .done, reasoning: reasoning, summary: summary)
+
+        default:
+            throw InferenceError.parseError("Unknown tool: \(name)")
+        }
+    }
+
+    private func resolvePosition(elementId: Int?, inputX: Int?, inputY: Int?, elements: [AXElement]?) -> (x: Int?, y: Int?, resolvedId: Int?, desc: String?) {
+        if let elementId = elementId, let elements = elements {
+            let flat = AccessibilityTreeEnumerator.flattenElements(elements)
+            if let element = flat.first(where: { $0.id == elementId }) {
+                let x = Int(element.frame.midX)
+                let y = Int(element.frame.midY)
+                let desc = element.title ?? element.roleDescription ?? element.role
+                return (x, y, elementId, desc)
+            }
+        }
+        return (inputX, inputY, nil, nil)
+    }
+}

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+enum ToolDefinitions {
+    static let tools: [[String: Any]] = [
+        [
+            "name": "click",
+            "description": "Click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "X coordinate on screen (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Y coordinate on screen (fallback when no element_id)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you see and why you are clicking here"
+                    ]
+                ],
+                "required": ["reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "double_click",
+            "description": "Double-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "X coordinate on screen (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Y coordinate on screen (fallback when no element_id)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you see and why you are double-clicking here"
+                    ]
+                ],
+                "required": ["reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "right_click",
+            "description": "Right-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "X coordinate on screen (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Y coordinate on screen (fallback when no element_id)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you see and why you are right-clicking here"
+                    ]
+                ],
+                "required": ["reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "type_text",
+            "description": "Type text at the current cursor position. The target field must already be focused (click it first).",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "text": [
+                        "type": "string",
+                        "description": "The text to type"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you are typing and why"
+                    ]
+                ],
+                "required": ["text", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "key",
+            "description": "Press a key or keyboard shortcut. Supported: enter, tab, escape, backspace, delete, up, down, left, right, space, cmd+a, cmd+c, cmd+v, cmd+z, cmd+tab, cmd+w, shift+tab, option+tab",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "key": [
+                        "type": "string",
+                        "description": "Key or shortcut to press (e.g. enter, tab, cmd+c, cmd+v)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of why you are pressing this key"
+                    ]
+                ],
+                "required": ["key", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "scroll",
+            "description": "Scroll within an element by its [ID], or at raw screen coordinates as fallback.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] number of the element to scroll within (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "X coordinate on screen (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Y coordinate on screen (fallback when no element_id)"
+                    ],
+                    "direction": [
+                        "type": "string",
+                        "enum": ["up", "down", "left", "right"],
+                        "description": "Scroll direction"
+                    ],
+                    "amount": [
+                        "type": "integer",
+                        "description": "Scroll amount (1-10)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of why you are scrolling"
+                    ]
+                ],
+                "required": ["direction", "amount", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "wait",
+            "description": "Wait for the UI to update",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "duration_ms": [
+                        "type": "integer",
+                        "description": "Milliseconds to wait"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you are waiting for"
+                    ]
+                ],
+                "required": ["duration_ms", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
+            "name": "done",
+            "description": "Task is complete",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "summary": [
+                        "type": "string",
+                        "description": "Human-readable summary of what was accomplished"
+                    ]
+                ],
+                "required": ["summary"]
+            ] as [String: Any]
+        ]
+    ]
+}

--- a/clients/macos/vellum-assistant/Logging/LogViewer.swift
+++ b/clients/macos/vellum-assistant/Logging/LogViewer.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import Foundation
+
+struct LogViewer: View {
+    @State private var logFiles: [URL] = []
+    @State private var selectedLog: SessionLog?
+
+    var body: some View {
+        NavigationSplitView {
+            List(logFiles, id: \.absoluteString, selection: Binding(
+                get: { nil as URL? },
+                set: { url in
+                    if let url = url { loadLog(url) }
+                }
+            )) { url in
+                Text(url.lastPathComponent)
+                    .font(.caption.monospaced())
+            }
+            .navigationTitle("Session Logs")
+        } detail: {
+            if let log = selectedLog {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Task: \(log.task)")
+                            .font(.headline)
+                        Text("Result: \(log.result)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text("Steps: \(log.turns.count)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        Divider()
+
+                        ForEach(log.turns, id: \.step) { turn in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Step \(turn.step)")
+                                    .font(.caption.bold())
+                                Text(turn.action.displayDescription)
+                                    .font(.caption)
+                                if turn.usedVision {
+                                    Text("(vision fallback)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.orange)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding()
+                }
+            } else {
+                Text("Select a log file")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear { loadLogFiles() }
+    }
+
+    private func loadLogFiles() {
+        let fileManager = FileManager.default
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
+        let logDir = appSupport.appendingPathComponent("vellum-assistant/logs", isDirectory: true)
+
+        do {
+            let files = try fileManager.contentsOfDirectory(at: logDir, includingPropertiesForKeys: [.contentModificationDateKey])
+                .filter { $0.pathExtension == "json" }
+                .sorted { $0.lastPathComponent > $1.lastPathComponent }
+            logFiles = files
+        } catch {
+            logFiles = []
+        }
+    }
+
+    private func loadLog(_ url: URL) {
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            selectedLog = try decoder.decode(SessionLog.self, from: data)
+        } catch {
+            print("Failed to load log: \(error)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Logging/SessionLogger.swift
+++ b/clients/macos/vellum-assistant/Logging/SessionLogger.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct TurnLog: Codable {
+    let step: Int
+    let timestamp: Date
+    let axTree: String?
+    let hadScreenshot: Bool
+    let usedVision: Bool
+    let action: AgentAction
+}
+
+struct SessionLog: Codable {
+    let task: String
+    let startTime: Date
+    let endTime: Date
+    let result: String
+    let turns: [TurnLog]
+}
+
+final class SessionLogger {
+    let task: String
+    let startTime: Date
+    private var turns: [TurnLog] = []
+
+    init(task: String) {
+        self.task = task
+        self.startTime = Date()
+    }
+
+    func logTurn(step: Int, axTree: String?, screenshot: Data?, action: AgentAction, usedVision: Bool) {
+        let turn = TurnLog(
+            step: step,
+            timestamp: Date(),
+            axTree: axTree,
+            hadScreenshot: screenshot != nil,
+            usedVision: usedVision,
+            action: action
+        )
+        turns.append(turn)
+    }
+
+    func finishSession(result: String) {
+        let log = SessionLog(
+            task: task,
+            startTime: startTime,
+            endTime: Date(),
+            result: result,
+            turns: turns
+        )
+
+        let fileManager = FileManager.default
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
+        let logDir = appSupport.appendingPathComponent("vellum-assistant/logs", isDirectory: true)
+
+        do {
+            try fileManager.createDirectory(at: logDir, withIntermediateDirectories: true)
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            let timestamp = formatter.string(from: startTime)
+                .replacingOccurrences(of: ":", with: "-")
+            let fileName = "session-\(timestamp).json"
+            let fileURL = logDir.appendingPathComponent(fileName)
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(log)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save session log: \(error)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/clients/macos/vellum-assistant/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/macos/vellum-assistant/Resources/Assets.xcassets/Contents.json
+++ b/clients/macos/vellum-assistant/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/macos/vellum-assistant/Resources/Info-generated.plist
+++ b/clients/macos/vellum-assistant/Resources/Info-generated.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSScreenRecordingUsageDescription</key>
+	<string>vellum-assistant needs Screen Recording access to see what's on your screen during computer use tasks.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>vellum-assistant needs microphone access to transcribe voice commands.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+</dict>
+</plist>

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSScreenRecordingUsageDescription</key>
+    <string>vellum-assistant needs Screen Recording access to see what's on your screen during computer use tasks.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>vellum-assistant needs microphone access to transcribe voice commands.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.productivity</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/clients/macos/vellum-assistant/UI/ConfirmationView.swift
+++ b/clients/macos/vellum-assistant/UI/ConfirmationView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ConfirmationView: View {
+    let reason: String
+    let onAllow: () -> Void
+    let onBlock: () -> Void
+    let onStop: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.yellow)
+                Text("Action Requires Confirmation")
+                    .font(.headline)
+            }
+
+            Text(reason)
+                .font(.body)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Spacer()
+                Button("Stop Session") {
+                    onStop()
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+
+                Button("Block") {
+                    onBlock()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Allow") {
+                    onAllow()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}

--- a/clients/macos/vellum-assistant/UI/MenuBarController.swift
+++ b/clients/macos/vellum-assistant/UI/MenuBarController.swift
@@ -1,0 +1,4 @@
+import AppKit
+
+// MenuBarController is handled by AppDelegate directly via NSStatusItem.
+// This file is reserved for future menu bar customization if needed.

--- a/clients/macos/vellum-assistant/UI/SessionOverlayView.swift
+++ b/clients/macos/vellum-assistant/UI/SessionOverlayView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+struct SessionOverlayView: View {
+    @ObservedObject var session: ComputerUseSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header
+            HStack(spacing: 6) {
+                Image(systemName: "cursorarrow.click.2")
+                    .foregroundStyle(.blue)
+                Text("vellum-assistant is working...")
+                    .font(.headline)
+                    .lineLimit(1)
+            }
+
+            // Task text
+            Text(session.task)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            Divider()
+
+            // State-dependent content
+            stateContent
+
+            // Controls
+            controlButtons
+        }
+        .padding(14)
+        .frame(width: 340, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch session.state {
+        case .idle:
+            Text("Initializing...")
+                .foregroundStyle(.secondary)
+
+        case .running(let step, let maxSteps, let lastAction):
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Step \(step) of \(maxSteps)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(lastAction)
+                    .font(.caption)
+                    .lineLimit(2)
+            }
+
+        case .paused(let step, let maxSteps):
+            Text("Paused at step \(step)/\(maxSteps)")
+                .font(.caption)
+                .foregroundStyle(.orange)
+
+        case .awaitingConfirmation(let reason):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                    Text("Confirmation needed")
+                        .font(.caption.bold())
+                }
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    Button("Allow") {
+                        session.approveConfirmation()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.blue)
+                    .controlSize(.small)
+
+                    Button("Block") {
+                        session.rejectConfirmation()
+                    }
+                    .controlSize(.small)
+
+                    Button("Stop") {
+                        session.cancel()
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                    .controlSize(.small)
+                }
+            }
+
+        case .completed(let summary, let steps):
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Done in \(steps) steps")
+                        .font(.caption.bold())
+                    Text(summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+        case .failed(let reason):
+            HStack(spacing: 6) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+
+        case .cancelled:
+            Text("Cancelled")
+                .font(.caption.bold())
+                .foregroundStyle(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private var controlButtons: some View {
+        switch session.state {
+        case .running:
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Pause") {
+                    session.pause()
+                }
+                .controlSize(.small)
+
+                Button("Stop") {
+                    session.cancel()
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .controlSize(.small)
+            }
+
+        case .paused:
+            HStack {
+                Spacer()
+                Button("Resume") {
+                    session.resume()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
+                Button("Stop") {
+                    session.cancel()
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .controlSize(.small)
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+
+final class SessionOverlayWindow {
+    private var panel: NSPanel?
+    private let session: ComputerUseSession
+
+    init(session: ComputerUseSession) {
+        self.session = session
+    }
+
+    func show() {
+        let overlayView = SessionOverlayView(session: session)
+        let hostingController = NSHostingController(rootView: overlayView)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 340, height: 160),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.9
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Position top-right
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 340 - 20
+            let y = screenFrame.maxY - 160 - 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var apiKeyText = ""
+    @State private var hasKey = APIKeyManager.getKey() != nil
+    @State private var maxSteps: Double = 50
+    @State private var accessibilityGranted = false
+    @State private var screenRecordingGranted = false
+
+    // Re-check permissions every 2 seconds while the window is open
+    private let permissionTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Form {
+            Section("Anthropic API Key") {
+                if hasKey {
+                    HStack {
+                        Text("sk-ant-...configured")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Clear") {
+                            APIKeyManager.deleteKey()
+                            hasKey = false
+                            apiKeyText = ""
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    SecureField("Enter API key", text: $apiKeyText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your API key at console.anthropic.com")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Save") {
+                            let trimmed = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            APIKeyManager.setKey(trimmed)
+                            hasKey = true
+                            apiKeyText = ""
+                        }
+                        .disabled(apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+
+            Section("Computer Use") {
+                HStack {
+                    Text("Max steps per session")
+                    Spacer()
+                    Text("\(Int(maxSteps))")
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+                Slider(value: $maxSteps, in: 10...100, step: 10)
+            }
+
+            Section("Permissions") {
+                HStack {
+                    Image(systemName: accessibilityGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(accessibilityGranted ? .green : .red)
+                    Text("Accessibility")
+                    Spacer()
+                    if !accessibilityGranted {
+                        Button("Grant") {
+                            _ = PermissionManager.accessibilityStatus(prompt: true)
+                            checkPermissions()
+                        }
+                    }
+                }
+
+                HStack {
+                    Image(systemName: screenRecordingGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(screenRecordingGranted ? .green : .red)
+                    Text("Screen Recording")
+                    Spacer()
+                    if !screenRecordingGranted {
+                        Button("Check") {
+                            Task {
+                                let status = await PermissionManager.screenRecordingStatus()
+                                screenRecordingGranted = status == .granted
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 450, height: 350)
+        .onAppear {
+            checkPermissions()
+        }
+        .onReceive(permissionTimer) { _ in
+            checkPermissions()
+        }
+    }
+
+    private func checkPermissions() {
+        accessibilityGranted = PermissionManager.accessibilityStatus() == .granted
+        Task {
+            let status = await PermissionManager.screenRecordingStatus()
+            screenRecordingGranted = status == .granted
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/UI/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/UI/TaskInputView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import AppKit
+
+struct TaskInputView: View {
+    let onSubmit: (String) -> Void
+    @State private var taskText = ""
+    @FocusState private var isTextFieldFocused: Bool
+    @Environment(\.openSettings) private var openSettings
+
+    private var hasAPIKey: Bool {
+        APIKeyManager.getKey() != nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("vellum-assistant")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Button(action: {
+                    // LSUIElement apps need to become regular apps temporarily to take focus
+                    NSApp.setActivationPolicy(.regular)
+                    openSettings()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                }) {
+                    Image(systemName: "gear")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+
+            TextEditor(text: $taskText)
+                .font(.body)
+                .frame(minHeight: 60, maxHeight: 100)
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .background(Color(.textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .focused($isTextFieldFocused)
+
+            if !hasAPIKey {
+                Text("No API key configured. Open Settings to add one.")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Go") {
+                    submitTask()
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .disabled(taskText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !hasAPIKey)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 320)
+        .onAppear {
+            isTextFieldFocused = true
+        }
+    }
+
+    private func submitTask() {
+        let trimmed = taskText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        taskText = ""
+        onSubmit(trimmed)
+    }
+}

--- a/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
+++ b/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import vellum_assistant
+
+final class AccessibilityTreeTests: XCTestCase {
+
+    func testCleanRole() {
+        // Test via formatAXTree with a known element
+        let element = AXElement(
+            id: 1,
+            role: "AXButton",
+            title: "Submit",
+            value: nil,
+            frame: CGRect(x: 480, y: 580, width: 40, height: 20),
+            isEnabled: true,
+            isFocused: false,
+            children: [],
+            roleDescription: "button",
+            identifier: nil,
+            url: nil,
+            placeholderValue: nil
+        )
+
+        let formatted = AccessibilityTreeEnumerator.formatAXTree(
+            elements: [element],
+            windowTitle: "Test Window",
+            appName: "TestApp"
+        )
+
+        XCTAssertTrue(formatted.contains("Window: \"Test Window\" (TestApp)"))
+        XCTAssertTrue(formatted.contains("[1]"))
+        XCTAssertTrue(formatted.contains("Submit"))
+        XCTAssertTrue(formatted.contains("(500, 590)")) // midX, midY
+    }
+
+    func testShouldFallbackToVision_fewElements() {
+        let elements = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil),
+            AXElement(id: 2, role: "AXStaticText", title: "Hello", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+
+        XCTAssertTrue(AccessibilityTreeEnumerator.shouldFallbackToVision(elements: elements),
+                       "Should fallback when fewer than 3 interactive elements")
+    }
+
+    func testShouldNotFallbackToVision_enoughElements() {
+        let elements = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil),
+            AXElement(id: 2, role: "AXTextField", title: "Name", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil),
+            AXElement(id: 3, role: "AXButton", title: "Cancel", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+
+        XCTAssertFalse(AccessibilityTreeEnumerator.shouldFallbackToVision(elements: elements),
+                        "Should not fallback with 3+ interactive elements")
+    }
+
+    func testFlattenElements() {
+        let child = AXElement(id: 2, role: "AXButton", title: "Child", value: nil, frame: .zero,
+                              isEnabled: true, isFocused: false, children: [],
+                              roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        let parent = AXElement(id: 1, role: "AXGroup", title: "Parent", value: nil, frame: .zero,
+                               isEnabled: true, isFocused: false, children: [child],
+                               roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+
+        let flat = AccessibilityTreeEnumerator.flattenElements([parent])
+        XCTAssertEqual(flat.count, 2)
+        XCTAssertEqual(flat[0].id, 1)
+        XCTAssertEqual(flat[1].id, 2)
+    }
+}

--- a/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
+++ b/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import vellum_assistant
+
+final class ActionVerifierTests: XCTestCase {
+    var verifier: ActionVerifier!
+
+    override func setUp() {
+        verifier = ActionVerifier(maxSteps: 50)
+    }
+
+    // MARK: - Loop Detection
+
+    func testLoopDetection_threeIdenticalActions_blocked() {
+        let action = AgentAction(type: .click, reasoning: "test", x: 100, y: 200)
+
+        let result1 = verifier.verify(action)
+        XCTAssertEqual(isAllowed(result1), true, "First action should be allowed")
+
+        let result2 = verifier.verify(action)
+        XCTAssertEqual(isAllowed(result2), true, "Second identical action should be allowed")
+
+        let result3 = verifier.verify(action)
+        XCTAssertEqual(isBlocked(result3), true, "Third identical consecutive action should be blocked")
+    }
+
+    func testLoopDetection_differentActions_allowed() {
+        let action1 = AgentAction(type: .click, reasoning: "test", x: 100, y: 200)
+        let action2 = AgentAction(type: .click, reasoning: "test", x: 300, y: 400)
+
+        _ = verifier.verify(action1)
+        _ = verifier.verify(action2)
+        let result = verifier.verify(action1)
+        XCTAssertEqual(isAllowed(result), true, "Non-consecutive identical actions should be allowed")
+    }
+
+    // MARK: - Credit Card Detection
+
+    func testSensitiveData_creditCard_blocked() {
+        let action1 = AgentAction(type: .type, reasoning: "test", text: "4111111111111111")
+        XCTAssertEqual(isBlocked(verifier.verify(action1)), true, "Raw credit card should be blocked")
+
+        let verifier2 = ActionVerifier()
+        let action2 = AgentAction(type: .type, reasoning: "test", text: "4111 1111 1111 1111")
+        XCTAssertEqual(isBlocked(verifier2.verify(action2)), true, "Spaced credit card should be blocked")
+
+        let verifier3 = ActionVerifier()
+        let action3 = AgentAction(type: .type, reasoning: "test", text: "4111-1111-1111-1111")
+        XCTAssertEqual(isBlocked(verifier3.verify(action3)), true, "Dashed credit card should be blocked")
+    }
+
+    // MARK: - SSN Detection
+
+    func testSensitiveData_ssn_blocked() {
+        let action = AgentAction(type: .type, reasoning: "test", text: "123-45-6789")
+        XCTAssertEqual(isBlocked(verifier.verify(action)), true, "SSN should be blocked")
+
+        let verifier2 = ActionVerifier()
+        let action2 = AgentAction(type: .type, reasoning: "test", text: "123456789")
+        // 9 digits without dashes is also SSN
+        XCTAssertEqual(isBlocked(verifier2.verify(action2)), true, "SSN without dashes should be blocked")
+    }
+
+    // MARK: - Password Detection
+
+    func testSensitiveData_password_blocked() {
+        let action = AgentAction(type: .type, reasoning: "test", text: "P@ssw0rd!")
+        XCTAssertEqual(isBlocked(verifier.verify(action)), true, "Complex password should be blocked")
+    }
+
+    // MARK: - Normal Text Allowed
+
+    func testNormalText_allowed() {
+        let action1 = AgentAction(type: .type, reasoning: "test", text: "John Smith")
+        XCTAssertEqual(isAllowed(verifier.verify(action1)), true, "Normal name should be allowed")
+
+        let verifier2 = ActionVerifier()
+        let action2 = AgentAction(type: .type, reasoning: "test", text: "hello@example.com")
+        XCTAssertEqual(isAllowed(verifier2.verify(action2)), true, "Email should be allowed")
+    }
+
+    // MARK: - System Menu Bar
+
+    func testSystemMenuBar_blocked() {
+        let action = AgentAction(type: .click, reasoning: "test", x: 100, y: 10)
+        XCTAssertEqual(isBlocked(verifier.verify(action)), true, "Click in menu bar (y < 25) should be blocked")
+    }
+
+    func testBelowMenuBar_allowed() {
+        let action = AgentAction(type: .click, reasoning: "test", x: 100, y: 30)
+        XCTAssertEqual(isAllowed(verifier.verify(action)), true, "Click below menu bar should be allowed")
+    }
+
+    // MARK: - Step Limit
+
+    func testStepLimit_enforced() {
+        let smallVerifier = ActionVerifier(maxSteps: 3)
+
+        for i in 0..<3 {
+            let action = AgentAction(type: .click, reasoning: "step \(i)", x: CGFloat(100 + i * 50), y: 200)
+            _ = smallVerifier.verify(action)
+        }
+
+        let overLimit = AgentAction(type: .click, reasoning: "over limit", x: 500, y: 200)
+        XCTAssertEqual(isBlocked(smallVerifier.verify(overLimit)), true, "Should be blocked after step limit")
+    }
+
+    // MARK: - Destructive Keys
+
+    func testDestructiveKey_needsConfirmation() {
+        let action = AgentAction(type: .key, reasoning: "test", key: "cmd+q")
+        let result = verifier.verify(action)
+        XCTAssertEqual(isNeedsConfirmation(result), true, "Cmd+Q should need confirmation")
+    }
+
+    // MARK: - Form Submission
+
+    func testFormSubmission_enterAfterType_needsConfirmation() {
+        let typeAction = AgentAction(type: .type, reasoning: "typing", text: "test@email.com")
+        _ = verifier.verify(typeAction)
+
+        let enterAction = AgentAction(type: .key, reasoning: "submit", key: "enter")
+        let result = verifier.verify(enterAction)
+        XCTAssertEqual(isNeedsConfirmation(result), true, "Enter after type should need confirmation")
+    }
+
+    // MARK: - Helpers
+
+    private func isAllowed(_ result: VerifyResult) -> Bool {
+        if case .allowed = result { return true }
+        return false
+    }
+
+    private func isBlocked(_ result: VerifyResult) -> Bool {
+        if case .blocked = result { return true }
+        return false
+    }
+
+    private func isNeedsConfirmation(_ result: VerifyResult) -> Bool {
+        if case .needsConfirmation = result { return true }
+        return false
+    }
+}

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import vellum_assistant
+
+final class ToolDefinitionsTests: XCTestCase {
+
+    func testToolCount() {
+        XCTAssertEqual(ToolDefinitions.tools.count, 8, "Should have 8 tools defined")
+    }
+
+    func testToolNames() {
+        let names = ToolDefinitions.tools.compactMap { $0["name"] as? String }
+        XCTAssertTrue(names.contains("click"))
+        XCTAssertTrue(names.contains("double_click"))
+        XCTAssertTrue(names.contains("right_click"))
+        XCTAssertTrue(names.contains("type_text"))
+        XCTAssertTrue(names.contains("key"))
+        XCTAssertTrue(names.contains("scroll"))
+        XCTAssertTrue(names.contains("wait"))
+        XCTAssertTrue(names.contains("done"))
+    }
+
+    func testToolsHaveInputSchema() {
+        for tool in ToolDefinitions.tools {
+            let name = tool["name"] as? String ?? "unknown"
+            XCTAssertNotNil(tool["input_schema"], "Tool '\(name)' should have input_schema")
+        }
+    }
+
+    func testToolsSerialization() {
+        // Verify tools can be serialized to JSON (required for API calls)
+        do {
+            let data = try JSONSerialization.data(withJSONObject: ToolDefinitions.tools)
+            XCTAssertTrue(data.count > 0, "Should produce non-empty JSON")
+        } catch {
+            XCTFail("Tools should be JSON-serializable: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to add a native macOS menu bar client that controls your Mac via accessibility APIs and CGEvent input injection, powered by Claude via the Anthropic Messages API with tool use.

## Demo
https://www.loom.com/share/9c149012b78248b1ae2f762ed2ef06f0

## Changes Made
- Add `clients/macos/` with full Xcode project and SwiftPM dual build system
- Implement perceive-infer-verify-execute session loop (`Session.swift`) using AX tree enumeration and screenshot fallback
- Add Anthropic Messages API integration with 8 computer-use tools (click, type_text, key, scroll, etc.)
- Build SwiftUI menu bar UI with task input popover, session overlay, settings, and confirmation dialogs
- Add safety layer with action verification (destructive key guards, loop detection, system menu exclusion)
- Include Chrome accessibility helper for auto-enabling renderer accessibility
- Add unit tests for AccessibilityTree, ActionVerifier, and ToolDefinitions

## Testing
- Unit tests added for core logic (accessibility tree parsing, action verification, tool definitions)
- Manual testing of end-to-end session flow on macOS

---
*This PR was created with Claude Code*