### PR TITLE
Hot reload config and trust rules on file change

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -109,6 +109,10 @@ export function getConfig(): AssistantConfig {
   return loadConfig();
 }
 
+export function invalidateConfigCache(): void {
+  cached = null;
+}
+
 /**
  * Load the raw config from disk (without env var overrides).
  * Used by CLI config commands to read/write the file directly.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,10 +1,12 @@
 import * as net from 'node:net';
-import { unlinkSync, existsSync, chmodSync } from 'node:fs';
-import { getSocketPath } from '../util/platform.js';
+import { unlinkSync, existsSync, chmodSync, watch, type FSWatcher } from 'node:fs';
+import { join } from 'node:path';
+import { getSocketPath, getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
-import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
+import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
+import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
 import {
@@ -21,6 +23,7 @@ export class DaemonServer {
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
   private socketPath: string;
+  private watchers: FSWatcher[] = [];
 
   constructor() {
     this.socketPath = getSocketPath();
@@ -31,6 +34,8 @@ export class DaemonServer {
     if (existsSync(this.socketPath)) {
       unlinkSync(this.socketPath);
     }
+
+    this.startFileWatchers();
 
     return new Promise((resolve, reject) => {
       this.server = net.createServer((socket) => {
@@ -60,6 +65,7 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
+    this.stopFileWatchers();
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {
@@ -73,6 +79,61 @@ export class DaemonServer {
         resolve();
       }
     });
+  }
+
+  private startFileWatchers(): void {
+    const dataDir = getDataDir();
+    const configPath = join(dataDir, 'config.json');
+    const trustPath = join(dataDir, 'trust.json');
+
+    const watchFile = (filePath: string, label: string, onChange: () => void) => {
+      if (!existsSync(filePath)) return;
+      try {
+        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+        const watcher = watch(filePath, () => {
+          // Debounce: editors often write files in multiple steps
+          if (debounceTimer) clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => {
+            log.info({ file: label }, 'File changed, reloading');
+            onChange();
+          }, 200);
+        });
+        this.watchers.push(watcher);
+        log.info({ file: label }, 'Watching for changes');
+      } catch (err) {
+        log.warn({ err, file: label }, 'Failed to watch file');
+      }
+    };
+
+    watchFile(configPath, 'config.json', () => {
+      invalidateConfigCache();
+      try {
+        const config = getConfig();
+        initializeProviders(config);
+      } catch (err) {
+        log.error({ err }, 'Failed to reload config');
+        return;
+      }
+      // Evict idle sessions; mark busy ones as stale
+      for (const [id, session] of this.sessions) {
+        if (!session.isProcessing()) {
+          this.sessions.delete(id);
+        } else {
+          session.markStale();
+        }
+      }
+    });
+
+    watchFile(trustPath, 'trust.json', () => {
+      clearTrustCache();
+    });
+  }
+
+  private stopFileWatchers(): void {
+    for (const watcher of this.watchers) {
+      watcher.close();
+    }
+    this.watchers = [];
   }
 
   private handleConnection(socket: net.Socket): void {


### PR DESCRIPTION
## Summary
- Watch `~/.vellum/config.json` and `~/.vellum/trust.json` for changes while the daemon is running
- **Config changes**: invalidate config cache, re-initialize providers, evict idle sessions / mark busy ones stale (same pattern as `/model` command)
- **Trust rule changes**: clear the trust rule cache so permission checks immediately use the latest rules
- Uses `fs.watch()` with 200ms debounce to handle editors that write files in multiple steps
- Watchers are started on `server.start()` and cleaned up on `server.stop()`
- Added `invalidateConfigCache()` export to `config/loader.ts`

## Test plan
- [x] `bun tsc --noEmit` passes
- [x] All 212 tests pass (`bun test`)
- [x] Manual verification: editing config.json while daemon runs triggers reload log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
