### PR TITLE
Fix stale session race condition during model change

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -195,7 +195,7 @@ export class DaemonServer {
     let session = this.sessions.get(conversationId);
     const sendToClient = (msg: ServerMessage) => this.send(socket, msg);
 
-    if (!session || session.isStale()) {
+    if (!session || (session.isStale() && !session.isProcessing())) {
       const config = getConfig();
       const provider = getProvider(config.provider);
       const workingDir = process.cwd();


### PR DESCRIPTION
## Summary
- Fixes a race condition where replacing a stale-but-still-processing session orphans the old session, causing concurrent DB writes, resource leaks, and broken abort
- Changes `getOrCreateSession` to only replace stale sessions once they finish processing: `if (!session || (session.isStale() && !session.isProcessing()))`

## Context
Both Devin and Codex review bots flagged this issue on #117. When `/model` is called while a session is processing, the session gets marked stale. If `getOrCreateSession` is called before processing completes (e.g., new message, reconnect, session switch), the old session is orphaned — still making API calls and writing to the DB — while a new session starts operating on the same conversation.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `bun test` passes (212 tests)
- [ ] Manual: call `/model` during active generation, then send another message — verify no concurrent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
