### PR TITLE
Throw on missing WASM checksum instead of silently passing

### DIFF
--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -59,7 +59,12 @@ function verifyWasmChecksum(filePath: string, label: string): void {
   const data = readFileSync(filePath);
   const hash = createHash('sha256').update(data).digest('hex');
   const expected = EXPECTED_CHECKSUMS[label];
-  if (expected && hash !== expected) {
+  if (!expected) {
+    throw new Error(
+      `No expected checksum registered for ${label}`,
+    );
+  }
+  if (hash !== expected) {
     throw new Error(
       `WASM integrity check failed for ${label}: expected ${expected}, got ${hash}`,
     );


### PR DESCRIPTION
## Summary
- `verifyWasmChecksum` now throws when no expected checksum is registered for a label, instead of silently skipping verification
- Prevents unregistered WASM binaries from loading unchecked (e.g. typo in label, missing entry for new dependency)

## Context
Devin flagged this on #119: the guard `if (expected && hash !== expected)` silently passes when `expected` is `undefined`, completely bypassing integrity verification. This undermines the security goal of checksum verification.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `bun test` passes (212 tests)
- [ ] Verify that calling `verifyWasmChecksum(path, 'unknown.wasm')` throws `No expected checksum registered for unknown.wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
