### PR TITLE
Fix file watcher robustness: dir watching, cleanup, suppression

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -24,6 +24,8 @@ export class DaemonServer {
   private socketToSession = new Map<net.Socket, string>();
   private socketPath: string;
   private watchers: FSWatcher[] = [];
+  private debounceTimers: ReturnType<typeof setTimeout>[] = [];
+  private suppressConfigReload = false;
 
   constructor() {
     this.socketPath = getSocketPath();
@@ -83,53 +85,63 @@ export class DaemonServer {
 
   private startFileWatchers(): void {
     const dataDir = getDataDir();
-    const configPath = join(dataDir, 'config.json');
-    const trustPath = join(dataDir, 'trust.json');
 
-    const watchFile = (filePath: string, label: string, onChange: () => void) => {
-      if (!existsSync(filePath)) return;
-      try {
-        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-        const watcher = watch(filePath, () => {
-          // Debounce: editors often write files in multiple steps
-          if (debounceTimer) clearTimeout(debounceTimer);
-          debounceTimer = setTimeout(() => {
-            log.info({ file: label }, 'File changed, reloading');
-            onChange();
-          }, 200);
-        });
-        this.watchers.push(watcher);
-        log.info({ file: label }, 'Watching for changes');
-      } catch (err) {
-        log.warn({ err, file: label }, 'Failed to watch file');
-      }
+    // Watch the data directory instead of individual files so we detect:
+    // - Files that don't exist yet at startup (new config/trust creation)
+    // - Atomic rename writes (trust-store uses renameSync)
+    const handlers: Record<string, () => void> = {
+      'config.json': () => {
+        if (this.suppressConfigReload) return;
+        invalidateConfigCache();
+        try {
+          const config = getConfig();
+          initializeProviders(config);
+        } catch (err) {
+          log.error({ err }, 'Failed to reload config');
+          return;
+        }
+        // Evict idle sessions; mark busy ones as stale
+        for (const [id, session] of this.sessions) {
+          if (!session.isProcessing()) {
+            this.sessions.delete(id);
+          } else {
+            session.markStale();
+          }
+        }
+      },
+      'trust.json': () => {
+        clearTrustCache();
+      },
     };
 
-    watchFile(configPath, 'config.json', () => {
-      invalidateConfigCache();
-      try {
-        const config = getConfig();
-        initializeProviders(config);
-      } catch (err) {
-        log.error({ err }, 'Failed to reload config');
-        return;
-      }
-      // Evict idle sessions; mark busy ones as stale
-      for (const [id, session] of this.sessions) {
-        if (!session.isProcessing()) {
-          this.sessions.delete(id);
-        } else {
-          session.markStale();
-        }
-      }
-    });
+    const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-    watchFile(trustPath, 'trust.json', () => {
-      clearTrustCache();
-    });
+    try {
+      const watcher = watch(dataDir, (_eventType, filename) => {
+        if (!filename || !handlers[filename]) return;
+        // Debounce: editors often write files in multiple steps
+        const existing = debounceTimers.get(filename);
+        if (existing) clearTimeout(existing);
+        const timer = setTimeout(() => {
+          debounceTimers.delete(filename);
+          log.info({ file: filename }, 'File changed, reloading');
+          handlers[filename]();
+        }, 200);
+        debounceTimers.set(filename, timer);
+        this.debounceTimers.push(timer);
+      });
+      this.watchers.push(watcher);
+      log.info({ dir: dataDir }, 'Watching data directory for config/trust changes');
+    } catch (err) {
+      log.warn({ err }, 'Failed to watch data directory');
+    }
   }
 
   private stopFileWatchers(): void {
+    for (const timer of this.debounceTimers) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers = [];
     for (const watcher of this.watchers) {
       watcher.close();
     }
@@ -351,7 +363,13 @@ export class DaemonServer {
       // Use raw config to avoid persisting env-var API keys to disk
       const raw = loadRawConfig();
       raw.model = model;
+
+      // Suppress the file watcher callback — handleModelSet already does
+      // the full reload sequence; a redundant watcher-triggered reload
+      // would incorrectly evict sessions created after this method returns.
+      this.suppressConfigReload = true;
       saveRawConfig(raw);
+      setTimeout(() => { this.suppressConfigReload = false; }, 300);
 
       // Re-initialize provider with the new model so LLM calls use it
       const config = getConfig();


### PR DESCRIPTION
## Summary
- Watch the data directory instead of individual files — handles files that don't exist at startup and atomic rename writes
- Cancel pending debounce timers on server stop to prevent use-after-teardown
- Suppress redundant config reload when `handleModelSet` writes config.json (it already does the full reload)

## Context
Addresses all 5 review comments on #121 from Devin and Codex:

1. **P1** (both bots): `watchFile` skipped when file doesn't exist at startup — new users who haven't created config.json/trust.json yet would never get hot reload
2. **P2** (Codex): Atomic rename writes (`renameSync` in trust-store) break per-file `fs.watch()` on many platforms
3. **P2** (Devin): Debounce timers fire after `stopFileWatchers()`, causing use-after-teardown
4. **P2** (Devin): `handleModelSet` → `saveRawConfig` triggers the file watcher, causing a redundant reload that evicts sessions created in the 200ms debounce window

The directory-watching approach solves #1 and #2 together. Debounce timer tracking solves #3. The `suppressConfigReload` flag solves #4.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `bun test` passes (212 tests)
- [ ] Manual: start daemon without config.json, then `vellum config set model ...` — verify hot reload triggers
- [ ] Manual: call `/model` — verify no duplicate reload in daemon logs
- [ ] Manual: stop daemon shortly after config change — verify no errors from stale timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
