### PR TITLE
Add usage and cost tracking

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -12,7 +12,8 @@ export type AgentEvent =
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }
-  | { type: 'error'; error: Error };
+  | { type: 'error'; error: Error }
+  | { type: 'usage'; inputTokens: number; outputTokens: number; model: string };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 4096,
@@ -68,6 +69,13 @@ export class AgentLoop {
             signal,
           },
         );
+
+        onEvent({
+          type: 'usage',
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          model: response.model,
+        });
 
         const assistantMessage: Message = {
           role: 'assistant',

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -20,6 +20,7 @@ export async function startCli(): Promise<void> {
   let sessionId = '';
   let generating = false;
   let lastResponse = '';
+  let lastUsage: { inputTokens: number; outputTokens: number; totalInputTokens: number; totalOutputTokens: number; estimatedCost: number; model: string } | null = null;
   let pendingSessionPick = false;
   const spinner = new Spinner();
 
@@ -233,12 +234,27 @@ export async function startCli(): Promise<void> {
           process.stdout.write(msg.text);
           break;
 
-        case 'message_complete':
+        case 'usage_update':
+          lastUsage = msg;
+          break;
+
+        case 'message_complete': {
           spinner.stop();
           generating = false;
-          process.stdout.write('\n\n');
+          if (lastUsage) {
+            const cost = lastUsage.estimatedCost > 0
+              ? ` ~$${lastUsage.estimatedCost.toFixed(4)}`
+              : '';
+            process.stdout.write(
+              `\n\n\x1B[2m[${lastUsage.inputTokens.toLocaleString()} in / ${lastUsage.outputTokens.toLocaleString()} out${cost}]\x1B[0m\n\n`,
+            );
+            lastUsage = null;
+          } else {
+            process.stdout.write('\n\n');
+          }
           prompt();
           break;
+        }
 
         case 'generation_cancelled':
           spinner.stop();
@@ -319,6 +335,20 @@ export async function startCli(): Promise<void> {
           }
           prompt();
           break;
+
+        case 'usage_response': {
+          process.stdout.write('\n');
+          process.stdout.write(`  Model:          ${msg.model}\n`);
+          process.stdout.write(`  Input tokens:   ${msg.totalInputTokens.toLocaleString()}\n`);
+          process.stdout.write(`  Output tokens:  ${msg.totalOutputTokens.toLocaleString()}\n`);
+          const costStr = msg.estimatedCost > 0
+            ? `$${msg.estimatedCost.toFixed(4)}`
+            : 'N/A (unknown model pricing)';
+          process.stdout.write(`  Estimated cost: ${costStr}\n`);
+          process.stdout.write('\n');
+          prompt();
+          break;
+        }
 
         case 'pong':
           break;
@@ -401,6 +431,11 @@ export async function startCli(): Promise<void> {
       return;
     }
 
+    if (content === '/usage') {
+      send({ type: 'usage_request', sessionId });
+      return;
+    }
+
     if (content === '/help') {
       process.stdout.write('\n  Available commands:\n');
       process.stdout.write('  /new              Start a new session\n');
@@ -409,6 +444,7 @@ export async function startCli(): Promise<void> {
       process.stdout.write('  /model [name]     Show or change the model\n');
       process.stdout.write('  /history          Show conversation history\n');
       process.stdout.write('  /undo             Remove last message exchange\n');
+      process.stdout.write('  /usage            Show token usage and cost\n');
       process.stdout.write('  /copy             Copy last response to clipboard\n');
       process.stdout.write('  /copy-code        Copy last code block to clipboard\n');
       process.stdout.write('  /help             Show this help\n');

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -55,6 +55,11 @@ export interface UndoRequest {
   sessionId: string;
 }
 
+export interface UsageRequest {
+  type: 'usage_request';
+  sessionId: string;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -66,7 +71,8 @@ export type ClientMessage =
   | ModelGetRequest
   | ModelSetRequest
   | HistoryRequest
-  | UndoRequest;
+  | UndoRequest
+  | UsageRequest;
 
 // === Server → Client messages ===
 
@@ -143,6 +149,24 @@ export interface UndoComplete {
   removedCount: number;
 }
 
+export interface UsageUpdate {
+  type: 'usage_update';
+  inputTokens: number;
+  outputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedCost: number;
+  model: string;
+}
+
+export interface UsageResponse {
+  type: 'usage_response';
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedCost: number;
+  model: string;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
@@ -156,7 +180,9 @@ export type ServerMessage =
   | GenerationCancelled
   | ModelInfo
   | HistoryResponse
-  | UndoComplete;
+  | UndoComplete
+  | UsageUpdate
+  | UsageResponse;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -7,6 +7,7 @@ import { getProvider, initializeProviders } from '../providers/registry.js';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
+import { estimateCost } from '../util/pricing.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
 import {
@@ -280,6 +281,9 @@ export class DaemonServer {
       case 'undo':
         this.handleUndo(msg.sessionId, socket);
         break;
+      case 'usage_request':
+        this.handleUsageRequest(msg.sessionId, socket);
+        break;
       case 'ping':
         this.send(socket, { type: 'pong' });
         break;
@@ -426,6 +430,26 @@ export class DaemonServer {
     }
     const removedCount = session.undo();
     this.send(socket, { type: 'undo_complete', removedCount });
+  }
+
+  private handleUsageRequest(sessionId: string, socket: net.Socket): void {
+    const conversation = conversationStore.getConversation(sessionId);
+    if (!conversation) {
+      this.send(socket, { type: 'error', message: 'No active session' });
+      return;
+    }
+    const config = getConfig();
+    this.send(socket, {
+      type: 'usage_response',
+      totalInputTokens: conversation.totalInputTokens,
+      totalOutputTokens: conversation.totalOutputTokens,
+      estimatedCost: estimateCost(
+        conversation.totalInputTokens,
+        conversation.totalOutputTokens,
+        config.model,
+      ),
+      model: config.model,
+    });
   }
 
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -10,6 +10,7 @@ import { ToolExecutor } from '../tools/executor.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
+import { estimateCost } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('session');
@@ -24,6 +25,8 @@ export class Session {
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
   private workingDir: string;
+  private totalInputTokens = 0;
+  private totalOutputTokens = 0;
 
   constructor(
     conversationId: string,
@@ -62,6 +65,13 @@ export class Session {
       role: m.role as 'user' | 'assistant',
       content: JSON.parse(m.content),
     }));
+
+    const conv = conversationStore.getConversation(this.conversationId);
+    if (conv) {
+      this.totalInputTokens = conv.totalInputTokens;
+      this.totalOutputTokens = conv.totalOutputTokens;
+    }
+
     log.info({ conversationId: this.conversationId, count: this.messages.length }, 'Loaded messages from DB');
   }
 
@@ -124,6 +134,9 @@ export class Session {
 
       // Run agent loop
       let firstAssistantText = '';
+      let exchangeInputTokens = 0;
+      let exchangeOutputTokens = 0;
+      let model = '';
       const updatedHistory = await this.agentLoop.run(
         this.messages,
         (event) => {
@@ -149,12 +162,37 @@ export class Session {
                 JSON.stringify(event.message.content),
               );
               break;
+            case 'usage':
+              exchangeInputTokens += event.inputTokens;
+              exchangeOutputTokens += event.outputTokens;
+              model = event.model;
+              break;
           }
         },
         this.abortController.signal,
       );
 
       this.messages = updatedHistory;
+
+      // Update cumulative token usage
+      if (exchangeInputTokens > 0 || exchangeOutputTokens > 0) {
+        this.totalInputTokens += exchangeInputTokens;
+        this.totalOutputTokens += exchangeOutputTokens;
+        conversationStore.updateConversationUsage(
+          this.conversationId,
+          this.totalInputTokens,
+          this.totalOutputTokens,
+        );
+        onEvent({
+          type: 'usage_update',
+          inputTokens: exchangeInputTokens,
+          outputTokens: exchangeOutputTokens,
+          totalInputTokens: this.totalInputTokens,
+          totalOutputTokens: this.totalOutputTokens,
+          estimatedCost: estimateCost(this.totalInputTokens, this.totalOutputTokens, model),
+          model,
+        });
+      }
 
       if (this.abortController?.signal.aborted) {
         onEvent({ type: 'generation_cancelled' });

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -11,6 +11,8 @@ export function createConversation(title?: string) {
     title: title ?? null,
     createdAt: now,
     updatedAt: now,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
   };
   db.insert(conversations).values(conversation).run();
   return conversation;
@@ -79,6 +81,18 @@ export function updateConversationTitle(id: string, title: string): void {
   const db = getDb();
   db.update(conversations)
     .set({ title, updatedAt: Date.now() })
+    .where(eq(conversations.id, id))
+    .run();
+}
+
+export function updateConversationUsage(
+  id: string,
+  totalInputTokens: number,
+  totalOutputTokens: number,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ totalInputTokens, totalOutputTokens, updatedAt: Date.now() })
     .where(eq(conversations.id, id))
     .run();
 }

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -50,4 +50,8 @@ export function initializeDb(): void {
       created_at INTEGER NOT NULL
     )
   `);
+
+  // Migrations — ALTER TABLE ADD COLUMN throws if column already exists
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -5,6 +5,8 @@ export const conversations = sqliteTable('conversations', {
   title: text('title'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
+  totalInputTokens: integer('total_input_tokens').notNull().default(0),
+  totalOutputTokens: integer('total_output_tokens').notNull().default(0),
 });
 
 export const messages = sqliteTable('messages', {

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -1,0 +1,26 @@
+interface ModelPricing {
+  inputPer1M: number;  // USD per 1M input tokens
+  outputPer1M: number; // USD per 1M output tokens
+}
+
+const PRICING: Record<string, ModelPricing> = {
+  'claude-opus-4-5-20250929':   { inputPer1M: 15, outputPer1M: 75 },
+  'claude-sonnet-4-5-20250929': { inputPer1M: 3, outputPer1M: 15 },
+  'claude-haiku-4-5-20251001':  { inputPer1M: 0.80, outputPer1M: 4 },
+};
+
+/**
+ * Estimate cost in USD for the given token counts and model.
+ * Returns 0 if the model is not in the pricing table.
+ */
+export function estimateCost(
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+): number {
+  const pricing = PRICING[model]
+    ?? Object.entries(PRICING).find(([key]) => model.startsWith(key))?.[1];
+  if (!pricing) return 0;
+  return (inputTokens / 1_000_000) * pricing.inputPer1M
+       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+}


### PR DESCRIPTION
## Summary
- Track input/output tokens per message exchange and cumulatively per session
- Show inline per-turn usage after each response: `[1,234 in / 567 out ~$0.0042]`
- New `/usage` command shows cumulative session totals (model, tokens, estimated cost)
- Persist cumulative token counts to the conversations table for durability across restarts

## Architecture
Token usage flows through the full pipeline:

```
Provider (already returns usage) → AgentLoop (new 'usage' event) → Session (accumulates, persists) → IPC (usage_update) → CLI (inline display)
```

**Files changed:**
- `util/pricing.ts` — new file: model pricing table and `estimateCost()` function
- `agent/loop.ts` — emit `usage` event after each LLM call
- `memory/schema.ts` + `db.ts` — add `total_input_tokens`/`total_output_tokens` columns
- `memory/conversation-store.ts` — add `updateConversationUsage()` function
- `daemon/ipc-protocol.ts` — add `UsageUpdate`, `UsageRequest`, `UsageResponse` messages
- `daemon/session.ts` — accumulate per-exchange tokens, persist totals, emit `usage_update`
- `daemon/server.ts` — handle `usage_request`
- `cli.ts` — handle `usage_update`/`usage_response`, add `/usage` command

## Design decisions
- **Accumulation in Session, not AgentLoop** — keeps the loop as a simple event emitter
- **Cumulative totals on conversations table** — no separate usage_events table needed
- **Undo doesn't decrement tokens** — tokens were consumed and billed regardless
- **Cost is best-effort** — unknown models return $0 gracefully

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `bun test` passes (212 tests)
- [ ] Send a message → verify `[X in / Y out ~$Z]` appears after response
- [ ] Run `/usage` → verify cumulative totals displayed
- [ ] Restart daemon, run `/usage` → totals persist from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
