### PR TITLE
Add file write/edit previews in confirmation prompts

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -71,6 +71,17 @@ export async function startCli(): Promise<void> {
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${req.toolName}: ${preview}\n`);
     process.stdout.write(`\u2502 Risk: ${req.riskLevel}\n`);
+    if (req.diff) {
+      const diffOutput = req.diff.isNewFile
+        ? formatNewFileDiff(req.diff.newContent, req.diff.filePath)
+        : formatDiff(req.diff.oldContent, req.diff.newContent, req.diff.filePath);
+      if (diffOutput) {
+        process.stdout.write(`\u2502\n`);
+        for (const line of diffOutput.split('\n')) {
+          if (line) process.stdout.write(`\u2502 ${line}\n`);
+        }
+      }
+    }
     process.stdout.write(`\u2502\n`);
     process.stdout.write(`\u2502 [a] Allow once\n`);
     process.stdout.write(`\u2502 [d] Deny once\n`);

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -103,6 +103,7 @@ export interface ConfirmationRequest {
   riskLevel: string;
   allowlistOptions: Array<{ label: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
+  diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
 }
 
 export interface MessageComplete {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -31,6 +31,7 @@ export class PermissionPrompter {
     riskLevel: string,
     allowlistOptions: AllowlistOption[],
     scopeOptions: ScopeOption[],
+    diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean },
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -51,6 +52,7 @@ export class PermissionPrompter {
         riskLevel,
         allowlistOptions: allowlistOptions.map((o) => ({ label: o.label, pattern: o.pattern })),
         scopeOptions: scopeOptions.map((o) => ({ label: o.label, scope: o.scope })),
+        diff,
       });
     });
   }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,3 +1,5 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { getTool } from './registry.js';
 import type { ToolContext, ToolExecutionResult } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
@@ -57,12 +59,16 @@ export class ToolExecutor {
         const allowlistOptions = generateAllowlistOptions(name, input);
         const scopeOptions = generateScopeOptions(context.workingDir);
 
+        // Compute preview diff for file tools so the user sees what will change
+        const previewDiff = computePreviewDiff(name, input, context.workingDir);
+
         const response = await this.prompter.prompt(
           name,
           input,
           riskLevel,
           allowlistOptions,
           scopeOptions,
+          previewDiff,
         );
 
         decision = response.decision;
@@ -141,4 +147,50 @@ export class ToolExecutor {
       return { content: `Tool error: ${msg}`, isError: true };
     }
   }
+}
+
+/**
+ * Compute a preview diff for file tools so the confirmation prompt can show
+ * what will change. Returns undefined for non-file tools or on any error.
+ */
+function computePreviewDiff(
+  toolName: string,
+  input: Record<string, unknown>,
+  workingDir: string,
+): { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } | undefined {
+  try {
+    if (toolName === 'file_write') {
+      const rawPath = input.path as string;
+      const content = input.content as string;
+      if (!rawPath || !content) return undefined;
+      const filePath = resolve(workingDir, rawPath);
+      const isNewFile = !existsSync(filePath);
+      const oldContent = isNewFile ? '' : readFileSync(filePath, 'utf-8');
+      return { filePath, oldContent, newContent: content, isNewFile };
+    }
+
+    if (toolName === 'file_edit') {
+      const rawPath = input.path as string;
+      const oldString = input.old_string as string;
+      const newString = input.new_string as string;
+      if (!rawPath || typeof oldString !== 'string' || typeof newString !== 'string') return undefined;
+      const filePath = resolve(workingDir, rawPath);
+      if (!existsSync(filePath)) return undefined;
+      const content = readFileSync(filePath, 'utf-8');
+      const replaceAll = input.replace_all === true;
+      let updated: string;
+      if (replaceAll) {
+        if (!content.includes(oldString)) return undefined;
+        updated = content.split(oldString).join(newString);
+      } else {
+        const idx = content.indexOf(oldString);
+        if (idx === -1) return undefined;
+        updated = content.slice(0, idx) + newString + content.slice(idx + oldString.length);
+      }
+      return { filePath, oldContent: content, newContent: updated, isNewFile: false };
+    }
+  } catch {
+    // Preview is best-effort — don't block the prompt on errors
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Show a colored diff preview in the confirmation prompt before file_write and file_edit operations execute
- Users can now see exactly what will change before approving, especially for overwrites

## How it works
When a file tool triggers a permission prompt (risk level Medium, no matching trust rule):

1. **ToolExecutor** computes a preview diff before calling the prompter:
   - `file_write`: reads existing file (if any) and diffs against proposed content
   - `file_edit`: simulates string replacement in-memory and diffs original vs result
2. The diff is attached to the `ConfirmationRequest` IPC message
3. The CLI renders the colored unified diff inside the confirmation box using existing `formatDiff()`/`formatNewFileDiff()` utilities

Preview is **only shown when prompted** — trust rules that auto-allow skip it (the user opted into auto-approve).

## Files changed
- `daemon/ipc-protocol.ts` — added optional `diff` field to `ConfirmationRequest`
- `permissions/prompter.ts` — pass diff through `prompt()` method
- `tools/executor.ts` — `computePreviewDiff()` helper computes diffs for file tools before prompting
- `cli.ts` — render diff in `renderConfirmationPrompt()`

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `bun test` passes (212 tests)
- [ ] Have agent write a new file → confirm prompt shows new file preview
- [ ] Have agent overwrite a file → confirm prompt shows unified diff of changes
- [ ] Have agent edit a file → confirm prompt shows the edit diff
- [ ] Deny the write → file is NOT modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
