### PR TITLE
Fix debounce timer memory leak and suppress timer cleanup

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,6 +1,5 @@
 import * as net from 'node:net';
 import { unlinkSync, existsSync, chmodSync, watch, type FSWatcher } from 'node:fs';
-import { join } from 'node:path';
 import { getSocketPath, getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
@@ -25,7 +24,7 @@ export class DaemonServer {
   private socketToSession = new Map<net.Socket, string>();
   private socketPath: string;
   private watchers: FSWatcher[] = [];
-  private debounceTimers: ReturnType<typeof setTimeout>[] = [];
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private suppressConfigReload = false;
 
   constructor() {
@@ -115,21 +114,18 @@ export class DaemonServer {
       },
     };
 
-    const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
     try {
       const watcher = watch(dataDir, (_eventType, filename) => {
         if (!filename || !handlers[filename]) return;
         // Debounce: editors often write files in multiple steps
-        const existing = debounceTimers.get(filename);
+        const existing = this.debounceTimers.get(filename);
         if (existing) clearTimeout(existing);
         const timer = setTimeout(() => {
-          debounceTimers.delete(filename);
+          this.debounceTimers.delete(filename);
           log.info({ file: filename }, 'File changed, reloading');
           handlers[filename]();
         }, 200);
-        debounceTimers.set(filename, timer);
-        this.debounceTimers.push(timer);
+        this.debounceTimers.set(filename, timer);
       });
       this.watchers.push(watcher);
       log.info({ dir: dataDir }, 'Watching data directory for config/trust changes');
@@ -139,10 +135,10 @@ export class DaemonServer {
   }
 
   private stopFileWatchers(): void {
-    for (const timer of this.debounceTimers) {
+    for (const timer of this.debounceTimers.values()) {
       clearTimeout(timer);
     }
-    this.debounceTimers = [];
+    this.debounceTimers.clear();
     for (const watcher of this.watchers) {
       watcher.close();
     }
@@ -372,8 +368,14 @@ export class DaemonServer {
       // the full reload sequence; a redundant watcher-triggered reload
       // would incorrectly evict sessions created after this method returns.
       this.suppressConfigReload = true;
-      saveRawConfig(raw);
-      setTimeout(() => { this.suppressConfigReload = false; }, 300);
+      try {
+        saveRawConfig(raw);
+      } catch (err) {
+        this.suppressConfigReload = false;
+        throw err;
+      }
+      const resetTimer = setTimeout(() => { this.suppressConfigReload = false; }, 300);
+      this.debounceTimers.set('__suppress_reset__', resetTimer);
 
       // Re-initialize provider with the new model so LLM calls use it
       const config = getConfig();


### PR DESCRIPTION
## Summary
- Replace `debounceTimers` array with a `Map<string, Timer>` instance field — the Map naturally deduplicates by filename, preventing unbounded growth from repeated file-change events
- Track the `suppressConfigReload` reset timer in the Map so it gets cancelled on server stop
- Reset `suppressConfigReload` immediately if `saveRawConfig` throws, preventing hot-reload from staying permanently disabled after a failed model update
- Remove unused `join` import

## Context
Addresses all 3 review comments from Devin and Codex on #124:

1. **Memory leak** (Devin): `this.debounceTimers.push(timer)` accumulated timer refs without cleanup — replaced array with Map instance field that naturally deduplicates
2. **Untracked timer** (Devin): The 300ms `suppressConfigReload` reset timer wasn't tracked for cancellation on server stop — now stored in the debounce Map
3. **Permanent suppression on failure** (Codex): If `saveRawConfig` threw, `suppressConfigReload` stayed `true` forever — now wrapped in try/catch that resets the flag on failure

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `bun test` passes (212 tests)
- [ ] Manual: verify config hot-reload still works after model set
- [ ] Manual: verify daemon stop doesn't leave stale timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
