### PR TITLE
Fix usage tracking: per-turn cost, stale state, model accuracy

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -270,6 +270,7 @@ export async function startCli(): Promise<void> {
         case 'generation_cancelled':
           spinner.stop();
           generating = false;
+          lastUsage = null;
           process.stdout.write('\n[Cancelled]\n\n');
           prompt();
           break;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,7 +6,6 @@ import { getProvider, initializeProviders } from '../providers/registry.js';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
-import { estimateCost } from '../util/pricing.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
 import {
@@ -445,11 +444,7 @@ export class DaemonServer {
       type: 'usage_response',
       totalInputTokens: conversation.totalInputTokens,
       totalOutputTokens: conversation.totalOutputTokens,
-      estimatedCost: estimateCost(
-        conversation.totalInputTokens,
-        conversation.totalOutputTokens,
-        config.model,
-      ),
+      estimatedCost: conversation.totalEstimatedCost,
       model: config.model,
     });
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -27,6 +27,7 @@ export class Session {
   private workingDir: string;
   private totalInputTokens = 0;
   private totalOutputTokens = 0;
+  private totalEstimatedCost = 0;
 
   constructor(
     conversationId: string,
@@ -70,6 +71,7 @@ export class Session {
     if (conv) {
       this.totalInputTokens = conv.totalInputTokens;
       this.totalOutputTokens = conv.totalOutputTokens;
+      this.totalEstimatedCost = conv.totalEstimatedCost;
     }
 
     log.info({ conversationId: this.conversationId, count: this.messages.length }, 'Loaded messages from DB');
@@ -178,10 +180,13 @@ export class Session {
       if (exchangeInputTokens > 0 || exchangeOutputTokens > 0) {
         this.totalInputTokens += exchangeInputTokens;
         this.totalOutputTokens += exchangeOutputTokens;
+        const exchangeCost = estimateCost(exchangeInputTokens, exchangeOutputTokens, model);
+        this.totalEstimatedCost += exchangeCost;
         conversationStore.updateConversationUsage(
           this.conversationId,
           this.totalInputTokens,
           this.totalOutputTokens,
+          this.totalEstimatedCost,
         );
         onEvent({
           type: 'usage_update',
@@ -189,7 +194,7 @@ export class Session {
           outputTokens: exchangeOutputTokens,
           totalInputTokens: this.totalInputTokens,
           totalOutputTokens: this.totalOutputTokens,
-          estimatedCost: estimateCost(this.totalInputTokens, this.totalOutputTokens, model),
+          estimatedCost: exchangeCost,
           model,
         });
       }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -13,6 +13,7 @@ export function createConversation(title?: string) {
     updatedAt: now,
     totalInputTokens: 0,
     totalOutputTokens: 0,
+    totalEstimatedCost: 0,
   };
   db.insert(conversations).values(conversation).run();
   return conversation;
@@ -89,10 +90,11 @@ export function updateConversationUsage(
   id: string,
   totalInputTokens: number,
   totalOutputTokens: number,
+  totalEstimatedCost: number,
 ): void {
   const db = getDb();
   db.update(conversations)
-    .set({ totalInputTokens, totalOutputTokens, updatedAt: Date.now() })
+    .set({ totalInputTokens, totalOutputTokens, totalEstimatedCost, updatedAt: Date.now() })
     .where(eq(conversations.id, id))
     .run();
 }

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -54,4 +54,5 @@ export function initializeDb(): void {
   // Migrations — ALTER TABLE ADD COLUMN throws if column already exists
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_estimated_cost REAL NOT NULL DEFAULT 0`); } catch { /* already exists */ }
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
 
 export const conversations = sqliteTable('conversations', {
   id: text('id').primaryKey(),
@@ -7,6 +7,7 @@ export const conversations = sqliteTable('conversations', {
   updatedAt: integer('updated_at').notNull(),
   totalInputTokens: integer('total_input_tokens').notNull().default(0),
   totalOutputTokens: integer('total_output_tokens').notNull().default(0),
+  totalEstimatedCost: real('total_estimated_cost').notNull().default(0),
 });
 
 export const messages = sqliteTable('messages', {


### PR DESCRIPTION
## Summary
- Clear `lastUsage` on `generation_cancelled` to prevent stale usage displaying on next response
- Compute `estimatedCost` in `usage_update` from per-turn exchange tokens instead of cumulative totals
- Persist `totalEstimatedCost` in the DB, accumulated from per-turn costs computed with the correct model at each turn
- `/usage` reads persisted cost instead of re-pricing all tokens with the current model

## Context
Addresses all 3 review comments from Devin and Codex on #125:

1. **Stale `lastUsage`** (Devin): After cancellation, `lastUsage` wasn't cleared, so the next `message_complete` could display wrong tokens from the cancelled exchange
2. **Per-turn cost mismatch** (Codex): `estimatedCost` was computed from cumulative token totals but displayed alongside per-turn counts — now uses exchange tokens
3. **Model-switch cost inaccuracy** (Codex): `/usage` re-priced all historical tokens with the current model. Now `totalEstimatedCost` accumulates per-turn costs at the model that produced each turn, persisted in the DB via a new `total_estimated_cost REAL` column

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `bun test` passes (212 tests)
- [ ] Manual: cancel a generation, verify next response shows correct (not stale) usage
- [ ] Manual: multi-turn conversation, verify inline cost matches per-turn tokens
- [ ] Manual: switch model mid-session, `/usage` shows correct cumulative cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
