### PR TITLE
Fix preview diff edge cases for file write/edit

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -9,6 +9,7 @@ import { PermissionPrompter } from '../permissions/prompter.js';
 import { recordToolInvocation } from '../memory/tool-usage-store.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
+import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 
 const log = getLogger('tool-executor');
 
@@ -162,7 +163,7 @@ function computePreviewDiff(
     if (toolName === 'file_write') {
       const rawPath = input.path as string;
       const content = input.content as string;
-      if (!rawPath || !content) return undefined;
+      if (!rawPath || typeof content !== 'string') return undefined;
       const filePath = resolve(workingDir, rawPath);
       const isNewFile = !existsSync(filePath);
       const oldContent = isNewFile ? '' : readFileSync(filePath, 'utf-8');
@@ -183,9 +184,13 @@ function computePreviewDiff(
         if (!content.includes(oldString)) return undefined;
         updated = content.split(oldString).join(newString);
       } else {
-        const idx = content.indexOf(oldString);
-        if (idx === -1) return undefined;
-        updated = content.slice(0, idx) + newString + content.slice(idx + oldString.length);
+        const matches = findAllMatches(content, oldString);
+        if (matches.length !== 1) return undefined;
+        const match = matches[0];
+        const adjustedNewString = match.method !== 'exact'
+          ? adjustIndentation(oldString, match.matched, newString)
+          : newString;
+        updated = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
       }
       return { filePath, oldContent: content, newContent: updated, isNewFile: false };
     }


### PR DESCRIPTION
## Summary
Addresses feedback from #126:

- **Empty-string file_write preview**: The `!content` guard treated `content: ""` as falsy, skipping the diff preview for file truncation — exactly the case where a preview is most valuable. Changed to `typeof content !== 'string'`.
- **Multi-match file_edit preview**: The preview used simple `indexOf` to find the first match, but the actual tool uses `findAllMatches` and errors when multiple matches exist. The preview now uses the same `findAllMatches` logic: returns no preview when there are 0 or multiple matches, and correctly handles whitespace-normalized and fuzzy matches with proper indentation adjustment.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
