### PR TITLE
Clear suppress timer before overwrite in handleModelSet

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -373,6 +373,8 @@ export class DaemonServer {
         this.suppressConfigReload = false;
         throw err;
       }
+      const existingSuppressTimer = this.debounceTimers.get('__suppress_reset__');
+      if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
       const resetTimer = setTimeout(() => { this.suppressConfigReload = false; }, 300);
       this.debounceTimers.set('__suppress_reset__', resetTimer);
 


### PR DESCRIPTION
## Summary
Addresses feedback from #127:

- Clear the existing `__suppress_reset__` timer before creating a new one in `handleModelSet`. Without this, rapid successive model changes would leave orphaned timers that fire early, resetting `suppressConfigReload` to `false` prematurely and causing the file watcher to trigger redundant config reloads that evict sessions.

This matches the pattern already used in the file watcher debounce code (lines 121-122).

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
