### PR TITLE
Add legacy cost fallback for pre-upgrade conversations

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -8,6 +8,7 @@ import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
+import { estimateCost } from '../util/pricing.js';
 import {
   serialize,
   createMessageParser,
@@ -442,11 +443,17 @@ export class DaemonServer {
       return;
     }
     const config = getConfig();
+    // Legacy fallback: pre-upgrade conversations have tokens but cost=0.
+    // Re-estimate using current model — not perfect if model changed, but
+    // better than reporting $0 for sessions with real usage.
+    const cost = conversation.totalEstimatedCost > 0
+      ? conversation.totalEstimatedCost
+      : estimateCost(conversation.totalInputTokens, conversation.totalOutputTokens, config.model);
     this.send(socket, {
       type: 'usage_response',
       totalInputTokens: conversation.totalInputTokens,
       totalOutputTokens: conversation.totalOutputTokens,
-      estimatedCost: conversation.totalEstimatedCost,
+      estimatedCost: cost,
       model: config.model,
     });
   }


### PR DESCRIPTION
## Summary
Addresses feedback from #128:

- Pre-existing conversations have non-zero `total_input_tokens`/`total_output_tokens` but `total_estimated_cost=0` because the column was added with `DEFAULT 0` and no backfill was performed.
- The `/usage` handler now falls back to estimating cost from token totals using the current model when the persisted cost is zero. Not perfect if the model changed mid-conversation, but far better than reporting `$0` for sessions with real usage.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
