### PR TITLE
Add tool result streaming for real-time shell output

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -11,6 +11,7 @@ export type AgentEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
   | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }
   | { type: 'error'; error: Error }
   | { type: 'usage'; inputTokens: number; outputTokens: number; model: string };
@@ -27,14 +28,14 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private toolExecutor: ((name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -107,7 +108,9 @@ export class AgentLoop {
             input: toolUse.input,
           });
 
-          const result = await this.toolExecutor(toolUse.name, toolUse.input);
+          const result = await this.toolExecutor(toolUse.name, toolUse.input, (chunk) => {
+            onEvent({ type: 'tool_output_chunk', toolUseId: toolUse.id, chunk });
+          });
 
           onEvent({
             type: 'tool_result',

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -22,6 +22,7 @@ export async function startCli(): Promise<void> {
   let lastResponse = '';
   let lastUsage: { inputTokens: number; outputTokens: number; totalInputTokens: number; totalOutputTokens: number; estimatedCost: number; model: string } | null = null;
   let pendingSessionPick = false;
+  let toolStreaming = false;
   const spinner = new Spinner();
 
   function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
@@ -276,12 +277,27 @@ export async function startCli(): Promise<void> {
           break;
 
         case 'tool_use_start':
+          toolStreaming = false;
           spinner.start(formatToolProgress(msg.toolName, msg.input));
           break;
 
+        case 'tool_output_chunk':
+          if (!toolStreaming) {
+            spinner.stop();
+            toolStreaming = true;
+          }
+          process.stdout.write(msg.chunk);
+          break;
+
         case 'tool_result':
-          spinner.stop();
-          process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
+          if (!toolStreaming) spinner.stop();
+          if (toolStreaming) {
+            // We already streamed the output; just add a newline separator
+            process.stdout.write('\n');
+          } else {
+            process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
+          }
+          toolStreaming = false;
           if (msg.diff) {
             const diffOutput = msg.diff.isNewFile
               ? formatNewFileDiff(msg.diff.newContent, msg.diff.filePath)

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -87,6 +87,11 @@ export interface ToolUseStart {
   input: Record<string, unknown>;
 }
 
+export interface ToolOutputChunk {
+  type: 'tool_output_chunk';
+  chunk: string;
+}
+
 export interface ToolResult {
   type: 'tool_result';
   toolName: string;
@@ -171,6 +176,7 @@ export interface UsageResponse {
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
+  | ToolOutputChunk
   | ToolResult
   | ConfirmationRequest
   | MessageComplete

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -43,11 +43,12 @@ export class Session {
     this.executor = new ToolExecutor(this.prompter);
 
     const toolDefs = getAllToolDefinitions();
-    const toolExecutor = async (name: string, input: Record<string, unknown>) => {
+    const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
       return this.executor.execute(name, input, {
         workingDir: this.workingDir,
         sessionId: this.conversationId,
         conversationId: this.conversationId,
+        onOutput,
       });
     };
 
@@ -149,6 +150,9 @@ export class Session {
               break;
             case 'tool_use':
               onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input });
+              break;
+            case 'tool_output_chunk':
+              onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
               break;
             case 'tool_result':
               onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -66,11 +66,15 @@ class ShellTool implements Tool {
       }, TIMEOUT_MS);
 
       child.stdout.on('data', (data: Buffer) => {
-        stdout += data.toString();
+        const chunk = data.toString();
+        stdout += chunk;
+        context.onOutput?.(chunk);
       });
 
       child.stderr.on('data', (data: Buffer) => {
-        stderr += data.toString();
+        const chunk = data.toString();
+        stderr += chunk;
+        context.onOutput?.(chunk);
       });
 
       child.on('close', (code) => {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -5,6 +5,8 @@ export interface ToolContext {
   workingDir: string;
   sessionId: string;
   conversationId: string;
+  /** Optional callback for streaming incremental output to the client. */
+  onOutput?: (chunk: string) => void;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Stream shell command stdout/stderr to the CLI client in real-time instead of buffering until completion
- Users now see build output, test results, and other long-running command output as it happens
- Previously, long-running commands showed only a spinner for minutes with no feedback

## How it works
The streaming pipeline threads an `onOutput` callback through the full stack:

1. **`ToolContext.onOutput`** (tools/types.ts) — optional callback for incremental output
2. **Shell tool** (tools/terminal/shell.ts) — calls `onOutput` on each stdout/stderr data event
3. **Agent loop** (agent/loop.ts) — wraps `onOutput` to emit `tool_output_chunk` events
4. **Session** (daemon/session.ts) — forwards chunks as `tool_output_chunk` IPC messages
5. **IPC protocol** (daemon/ipc-protocol.ts) — new `ToolOutputChunk` message type
6. **CLI client** (cli.ts) — stops spinner on first chunk, writes output directly to stdout

Non-shell tools are unaffected — they don't call `onOutput` and continue to show the truncated result summary as before.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass
- [x] Backward compatible — `onOutput` is optional, existing tools unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
