### PR TITLE
Add configurable tool timeouts with LLM-selectable shell timeout

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -7,6 +7,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   apiKeys: {},
   maxTokens: 4096,
   dataDir: getDataDir(),
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -51,6 +51,7 @@ export function loadConfig(): AssistantConfig {
     ...DEFAULT_CONFIG,
     ...fileConfig,
     apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
+    timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
   };
 
   validateConfig(config);

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -1,3 +1,12 @@
+export interface TimeoutConfig {
+  /** Maximum shell command timeout in seconds. LLM can request up to this. */
+  shellMaxTimeoutSec: number;
+  /** Default shell command timeout in seconds when LLM doesn't specify one. */
+  shellDefaultTimeoutSec: number;
+  /** Permission prompt timeout in seconds. */
+  permissionTimeoutSec: number;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
@@ -5,4 +14,5 @@ export interface AssistantConfig {
   systemPrompt?: string;
   maxTokens: number;
   dataDir: string;
+  timeouts: TimeoutConfig;
 }

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -1,11 +1,10 @@
 import { v4 as uuid } from 'uuid';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { UserDecision, AllowlistOption, ScopeOption } from './types.js';
+import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('permission-prompter');
-
-const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 interface PendingPrompt {
   resolve: (value: { decision: UserDecision; selectedPattern?: string; selectedScope?: string }) => void;
@@ -36,11 +35,12 @@ export class PermissionPrompter {
     const requestId = uuid();
 
     return new Promise((resolve, reject) => {
+      const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
         log.warn({ requestId, toolName }, 'Permission prompt timed out, defaulting to deny');
         resolve({ decision: 'deny' });
-      }, TIMEOUT_MS);
+      }, timeoutMs);
 
       this.pending.set(requestId, { resolve, reject, timer });
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -3,12 +3,12 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
+import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('shell-tool');
 
 const MAX_OUTPUT_LENGTH = 50_000;
-const TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 
 class ShellTool implements Tool {
   name = 'shell';
@@ -26,6 +26,10 @@ class ShellTool implements Tool {
           command: {
             type: 'string',
             description: 'The shell command to execute',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',
           },
         },
         required: ['command'],
@@ -45,7 +49,13 @@ class ShellTool implements Tool {
       return { content: 'Error: command contains null bytes', isError: true };
     }
 
-    log.info({ command, cwd: context.workingDir }, 'Executing shell command');
+    const config = getConfig();
+    const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
+    const requestedSec = typeof input.timeout_seconds === 'number' ? input.timeout_seconds : shellDefaultTimeoutSec;
+    const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
+    const timeoutMs = timeoutSec * 1000;
+
+    log.info({ command, cwd: context.workingDir, timeoutSec }, 'Executing shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
       let stdout = '';
@@ -63,7 +73,7 @@ class ShellTool implements Tool {
       const timer = setTimeout(() => {
         timedOut = true;
         child.kill('SIGKILL');
-      }, TIMEOUT_MS);
+      }, timeoutMs);
 
       child.stdout.on('data', (data: Buffer) => {
         const chunk = data.toString();
@@ -86,7 +96,7 @@ class ShellTool implements Tool {
         }
 
         if (timedOut) {
-          output += '\n[Command timed out after 2 minutes]';
+          output += `\n[Command timed out after ${timeoutSec}s]`;
         }
 
         // Truncate if too long


### PR DESCRIPTION
## Summary
- Replace all hardcoded timeouts with configurable values in `config.json` under a `timeouts` key
- Allow the LLM to specify a `timeout_seconds` parameter on shell tool calls for long-running commands
- Enforce hard limits so the LLM can't set arbitrarily long timeouts

## Configuration

New `timeouts` section in `~/.vellum/config.json`:

```json
{
  "timeouts": {
    "shellDefaultTimeoutSec": 120,
    "shellMaxTimeoutSec": 600,
    "permissionTimeoutSec": 300
  }
}
```

- **shellDefaultTimeoutSec** (default: 120) — used when LLM doesn't specify a timeout
- **shellMaxTimeoutSec** (default: 600) — hard cap on LLM-requested timeouts
- **permissionTimeoutSec** (default: 300) — how long to wait for user to respond to permission prompt

## How it works
- Shell tool accepts optional `timeout_seconds` parameter in its input schema
- Value is clamped to `[1, shellMaxTimeoutSec]`
- Permission prompter reads timeout from config at prompt time (hot-reloadable)
- All defaults match the previous hardcoded values (120s shell, 300s permission)

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass
- [x] Backward compatible — defaults match previous behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
