### PR TITLE
Guard against empty old_string in fuzzy match and file edit

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -174,7 +174,7 @@ function computePreviewDiff(
       const rawPath = input.path as string;
       const oldString = input.old_string as string;
       const newString = input.new_string as string;
-      if (!rawPath || typeof oldString !== 'string' || typeof newString !== 'string') return undefined;
+      if (!rawPath || typeof oldString !== 'string' || typeof newString !== 'string' || oldString.length === 0) return undefined;
       const filePath = resolve(workingDir, rawPath);
       if (!existsSync(filePath)) return undefined;
       const content = readFileSync(filePath, 'utf-8');

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -57,6 +57,10 @@ class FileEditTool implements Tool {
       return { content: 'Error: new_string is required and must be a string', isError: true };
     }
 
+    if (oldString.length === 0) {
+      return { content: 'Error: old_string must not be empty', isError: true };
+    }
+
     if (oldString === newString) {
       return { content: 'Error: old_string and new_string must be different', isError: true };
     }

--- a/assistant/src/tools/filesystem/fuzzy-match.ts
+++ b/assistant/src/tools/filesystem/fuzzy-match.ts
@@ -125,6 +125,8 @@ function tryFuzzyMatch(contentLines: IndexedLine[], targetNorm: string[], thresh
 const FUZZY_THRESHOLD = 0.8;
 
 export function findMatch(content: string, target: string): MatchResult | null {
+  if (target.length === 0) return null;
+
   // 1. Exact match
   const exact = tryExactMatch(content, target);
   if (exact) return exact;
@@ -147,6 +149,8 @@ export function findMatch(content: string, target: string): MatchResult | null {
 }
 
 export function findAllMatches(content: string, target: string): MatchResult[] {
+  if (target.length === 0) return [];
+
   // 1. Exact matches
   const exactMatches = findAllExactMatches(content, target);
   if (exactMatches.length > 0) return exactMatches;


### PR DESCRIPTION
## Summary
Addresses feedback from #129:

- **Infinite loop on empty `old_string`**: `findAllMatches(content, "")` loops indefinitely because `indexOf("")` matches every position in the string. This can hang `computePreviewDiff` before the permission prompt is shown, and also hang the actual `file_edit` tool execution.
- Guards added at three levels:
  - `findMatch` / `findAllMatches` return early for empty targets
  - `file_edit` tool rejects empty `old_string` with a clear error
  - `computePreviewDiff` skips preview for empty `old_string`

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
