### PR TITLE
Remove legacy cost fallback to prevent fabricated usage values

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -8,7 +8,6 @@ import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
-import { estimateCost } from '../util/pricing.js';
 import {
   serialize,
   createMessageParser,
@@ -443,17 +442,11 @@ export class DaemonServer {
       return;
     }
     const config = getConfig();
-    // Legacy fallback: pre-upgrade conversations have tokens but cost=0.
-    // Re-estimate using current model — not perfect if model changed, but
-    // better than reporting $0 for sessions with real usage.
-    const cost = conversation.totalEstimatedCost > 0
-      ? conversation.totalEstimatedCost
-      : estimateCost(conversation.totalInputTokens, conversation.totalOutputTokens, config.model);
     this.send(socket, {
       type: 'usage_response',
       totalInputTokens: conversation.totalInputTokens,
       totalOutputTokens: conversation.totalOutputTokens,
-      estimatedCost: cost,
+      estimatedCost: conversation.totalEstimatedCost,
       model: config.model,
     });
   }


### PR DESCRIPTION
## Summary
Addresses feedback from #131:

- The legacy cost fallback re-estimated cost for all conversations with `totalEstimatedCost === 0` using the current model. However, `0` is also the correct stored value when pricing is unavailable (unknown models via `estimateCost` returning 0).
- If a user changed `/model` to a priced model, `/usage` would retroactively fabricate a non-zero cost for old unknown-model turns using the new model's pricing — reporting an inaccurate value instead of "unknown."
- Fix: remove the fallback entirely. Report the stored `totalEstimatedCost` directly. Cost tracking (PR #125) works correctly going forward by accumulating per-exchange costs with the right model at the time of use. Legacy pre-upgrade conversations show $0, which is honest.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
