### PR TITLE
Show tool status markers when streaming output

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -292,8 +292,11 @@ export async function startCli(): Promise<void> {
         case 'tool_result':
           if (!toolStreaming) spinner.stop();
           if (toolStreaming) {
-            // We already streamed the output; just add a newline separator
-            process.stdout.write('\n');
+            // We already streamed the raw output; show any trailing status
+            // markers (timeout, truncation, exit code) that the tool appended
+            // after the streamed data.
+            const statusMatch = msg.result.match(/(\n\[(?:Command timed out|Output truncated|Command exited)[^\]]*\])+$/);
+            process.stdout.write((statusMatch ? statusMatch[0] : '') + '\n');
           } else {
             process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
           }


### PR DESCRIPTION
## Summary
Addresses feedback from #132:

- When tool output was streamed (`toolStreaming = true`), the CLI dropped `msg.result` entirely and only printed a newline separator. This hid status markers that the shell tool appends after the streamed data, like `[Command timed out after Xs]` or `[Output truncated at 50K characters]`.
- A timed-out command that emitted any output before timing out would look identical to a successful completion.
- Fix: extract trailing status markers (timeout, truncation, exit code) from `msg.result` using a regex and display them after the streamed output. Normal completions still get just a newline separator.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
