### PR TITLE
Validate timeout config values to prevent NaN timeouts

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -97,6 +97,16 @@ function validateConfig(config: AssistantConfig): void {
       }
     }
   }
+
+  for (const field of ['shellDefaultTimeoutSec', 'shellMaxTimeoutSec', 'permissionTimeoutSec'] as const) {
+    const val = config.timeouts[field];
+    if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) {
+      log.error(
+        `Invalid timeouts.${field} "${val}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.timeouts[field]}.`,
+      );
+      config.timeouts[field] = DEFAULT_CONFIG.timeouts[field];
+    }
+  }
 }
 
 export function saveConfig(config: AssistantConfig): void {


### PR DESCRIPTION
## Summary
Addresses feedback from #133:

- Timeout config values from `config.json` were merged without validation. Non-numeric values like `"abc"` produced `NaN` timeouts, causing `setTimeout` to fire immediately:
  - `shellMaxTimeoutSec = "abc"` → shell commands killed instantly
  - `permissionTimeoutSec = "abc"` → permission prompts auto-denied immediately
- Added validation for all three timeout fields (`shellDefaultTimeoutSec`, `shellMaxTimeoutSec`, `permissionTimeoutSec`) in `validateConfig`, following the existing `maxTokens` pattern: checks `typeof === 'number'`, `Number.isFinite()`, and `> 0`, falling back to defaults with a logged error on invalid values.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
