### PR TITLE
Add graceful daemon shutdown with session cleanup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -176,8 +176,20 @@ export async function runDaemon(): Promise<void> {
   log.info({ pid: process.pid }, 'Daemon started');
 
   // Graceful shutdown
+  let shuttingDown = false;
   const shutdown = async () => {
+    if (shuttingDown) return; // Prevent re-entrant shutdown
+    shuttingDown = true;
     log.info('Shutting down daemon...');
+
+    // Force exit if graceful shutdown takes too long
+    const forceTimer = setTimeout(() => {
+      log.warn('Graceful shutdown timed out, forcing exit');
+      cleanupPidFile();
+      process.exit(1);
+    }, 10_000);
+    forceTimer.unref();
+
     await server.stop();
     cleanupPidFile();
     process.exit(0);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -21,6 +21,7 @@ export class DaemonServer {
   private server: net.Server | null = null;
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
+  private connectedSockets = new Set<net.Socket>();
   private socketPath: string;
   private watchers: FSWatcher[] = [];
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -67,6 +68,20 @@ export class DaemonServer {
 
   async stop(): Promise<void> {
     this.stopFileWatchers();
+
+    // Abort all active sessions so in-flight agent loops wind down
+    for (const session of this.sessions.values()) {
+      session.abort();
+    }
+    this.sessions.clear();
+
+    // Destroy all connected client sockets
+    for (const socket of this.connectedSockets) {
+      socket.destroy();
+    }
+    this.connectedSockets.clear();
+    this.socketToSession.clear();
+
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {
@@ -146,6 +161,7 @@ export class DaemonServer {
 
   private handleConnection(socket: net.Socket): void {
     log.info('Client connected');
+    this.connectedSockets.add(socket);
     const parser = createMessageParser();
 
     // Send initial session info
@@ -161,6 +177,7 @@ export class DaemonServer {
     });
 
     socket.on('close', () => {
+      this.connectedSockets.delete(socket);
       const sessionId = this.socketToSession.get(socket);
       if (sessionId) {
         const session = this.sessions.get(sessionId);


### PR DESCRIPTION
## Summary
Implements graceful daemon shutdown:

- **Session cleanup on shutdown**: `DaemonServer.stop()` now aborts all active sessions before closing. This triggers `AbortController.abort()` on each session, which causes the agent loop to wind down cleanly — synthesizing cancelled results for in-flight tool calls and disposing permission prompters (clearing pending timeouts and rejecting pending promises).
- **Socket cleanup**: Tracks all connected client sockets and destroys them during shutdown, preventing dangling connections.
- **Forced shutdown timeout**: If graceful shutdown takes longer than 10 seconds (e.g., a stuck LLM call), the daemon force-exits with code 1.
- **Re-entrancy guard**: Prevents multiple SIGTERM/SIGINT signals from triggering concurrent shutdown sequences.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
