### PR TITLE
Replace regex status extraction with explicit tool status metadata

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -12,7 +12,7 @@ export type AgentEvent =
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
-  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }
+  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }
   | { type: 'error'; error: Error }
   | { type: 'usage'; inputTokens: number; outputTokens: number; model: string };
 
@@ -28,14 +28,14 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean } }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }>,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -118,6 +118,7 @@ export class AgentLoop {
             content: result.content,
             isError: result.isError,
             diff: result.diff,
+            status: result.status,
           });
 
           resultBlocks.push({

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -292,11 +292,12 @@ export async function startCli(): Promise<void> {
         case 'tool_result':
           if (!toolStreaming) spinner.stop();
           if (toolStreaming) {
-            // We already streamed the raw output; show any trailing status
-            // markers (timeout, truncation, exit code) that the tool appended
-            // after the streamed data.
-            const statusMatch = msg.result.match(/(\n\[(?:Command timed out|Output truncated|Command exited)[^\]]*\])+$/);
-            process.stdout.write((statusMatch ? statusMatch[0] : '') + '\n');
+            // We already streamed the raw output; show explicit status metadata
+            // (timeout, truncation, exit code) if the tool provided it.
+            if (msg.status) {
+              process.stdout.write(`\n${msg.status}`);
+            }
+            process.stdout.write('\n');
           } else {
             process.stdout.write(`\n[Tool: ${msg.result.slice(0, 200)}]\n`);
           }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -98,6 +98,7 @@ export interface ToolResult {
   result: string;
   isError?: boolean;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
+  status?: string;
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -155,7 +155,7 @@ export class Session {
               onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
               break;
             case 'tool_result':
-              onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff });
+              onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status });
               break;
             case 'error':
               onEvent({ type: 'error', message: event.error.message });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -95,22 +95,31 @@ class ShellTool implements Tool {
           output += (output ? '\n' : '') + stderr;
         }
 
+        const statusParts: string[] = [];
+
         if (timedOut) {
-          output += `\n[Command timed out after ${timeoutSec}s]`;
+          const msg = `[Command timed out after ${timeoutSec}s]`;
+          output += `\n${msg}`;
+          statusParts.push(msg);
         }
 
         // Truncate if too long
         if (output.length > MAX_OUTPUT_LENGTH) {
-          output = output.slice(0, MAX_OUTPUT_LENGTH) + '\n[Output truncated at 50K characters]';
+          const msg = '[Output truncated at 50K characters]';
+          output = output.slice(0, MAX_OUTPUT_LENGTH) + `\n${msg}`;
+          statusParts.push(msg);
         }
 
         if (!output.trim()) {
           output = code === 0 ? '[Command completed with no output]' : `[Command exited with code ${code}]`;
+        } else if (code !== 0 && !timedOut) {
+          statusParts.push(`[Command exited with code ${code}]`);
         }
 
         resolve({
           content: output,
           isError: code !== 0 || timedOut,
+          status: statusParts.length > 0 ? statusParts.join('\n') : undefined,
         });
       });
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -20,6 +20,8 @@ export interface ToolExecutionResult {
   content: string;
   isError: boolean;
   diff?: DiffInfo;
+  /** Optional status message for display (e.g. timeout, truncation). */
+  status?: string;
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
Addresses feedback from #136:

- The CLI was regex-parsing `msg.result` to extract trailing status markers (timeout, truncation, exit code). This could collide with real command output that ends with matching text like `printf '[Output truncated at 50K characters]'`, causing duplicate/misleading output.
- Fix: add an explicit `status` field that flows through the entire pipeline:
  - `ToolExecutionResult.status` — set by the shell tool when timeout, truncation, or non-zero exit occurs
  - `AgentEvent.tool_result.status` — passed through by the agent loop
  - `IPC ToolResult.status` — sent over the wire to the CLI
  - CLI displays `msg.status` directly instead of regex-parsing the result string
- No collision with user output is possible since the status comes from structured metadata, not string parsing.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 212 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
