### PR TITLE
Fix shutdown ordering: stop accepting before destroying

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -73,32 +73,38 @@ export class DaemonServer {
   async stop(): Promise<void> {
     this.stopFileWatchers();
 
-    // Abort all active sessions so in-flight agent loops wind down
-    for (const session of this.sessions.values()) {
-      session.abort();
-    }
-    this.sessions.clear();
-
-    // Destroy all connected client sockets
-    for (const socket of this.connectedSockets) {
-      socket.destroy();
-    }
-    this.connectedSockets.clear();
-    this.socketToSession.clear();
-
-    return new Promise((resolve) => {
+    // 1. Stop accepting new connections first. server.close() prevents new
+    //    connections from arriving, so the cleanup below won't race with
+    //    handleConnection() adding sockets that never get destroyed.
+    //    Its callback fires once all existing connections have ended.
+    const serverClosed = new Promise<void>((resolve) => {
       if (this.server) {
         this.server.close(() => {
           if (existsSync(this.socketPath)) {
             unlinkSync(this.socketPath);
           }
-          log.info('Daemon server stopped');
           resolve();
         });
       } else {
         resolve();
       }
     });
+
+    // 2. Now abort sessions and destroy sockets. This lets server.close()
+    //    finish promptly since all connections will be ended.
+    for (const session of this.sessions.values()) {
+      session.abort();
+    }
+    this.sessions.clear();
+
+    for (const socket of this.connectedSockets) {
+      socket.destroy();
+    }
+    this.connectedSockets.clear();
+    this.socketToSession.clear();
+
+    await serverClosed;
+    log.info('Daemon server stopped');
   }
 
   private startFileWatchers(): void {


### PR DESCRIPTION
## Summary
- Addresses review feedback on #138: `server.close()` was called after session abort and socket destruction, leaving a window where new connections could arrive and never be cleaned up, causing `server.close()` to hang indefinitely
- Now calls `server.close()` first (stops accepting), then aborts sessions and destroys sockets, then awaits the close callback
- This ensures graceful shutdown completes with exit code 0 instead of falling back to the 10s forced exit

## Test plan
- [ ] Verify `vellum daemon stop` exits cleanly (no 10s delay)
- [ ] Kill daemon with SIGTERM — should shut down promptly
- [ ] Connect a client, send SIGTERM to daemon — client should see disconnect, daemon exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
