### PR TITLE
Add structured error codes with ErrorCode enum

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -18,6 +18,7 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './daemon/ipc-protocol.js';
+import { IpcError } from './util/errors.js';
 import { timeAgo } from './util/time.js';
 import {
   loadRawConfig,
@@ -71,7 +72,7 @@ function sendOneMessage(
 
     socket.on('close', () => {
       if (!resolved) {
-        reject(new Error('Socket closed before receiving a response'));
+        reject(new IpcError('Socket closed before receiving a response'));
       }
     });
   });
@@ -448,7 +449,7 @@ program
       } else {
         await new Promise<void>((resolve, reject) => {
           const s = net.createConnection(sock);
-          const timer = setTimeout(() => { s.destroy(); reject(new Error('timeout')); }, 2000);
+          const timer = setTimeout(() => { s.destroy(); reject(new IpcError('timeout')); }, 2000);
           s.on('connect', () => { clearTimeout(timer); s.end(); resolve(); });
           s.on('error', (err) => { clearTimeout(timer); reject(err); });
         });

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -3,6 +3,7 @@ import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { UserDecision, AllowlistOption, ScopeOption } from './types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { AssistantError, ErrorCode } from '../util/errors.js';
 
 const log = getLogger('permission-prompter');
 
@@ -76,7 +77,7 @@ export class PermissionPrompter {
   dispose(): void {
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);
-      pending.reject(new Error('Prompter disposed'));
+      pending.reject(new AssistantError('Prompter disposed', ErrorCode.INTERNAL_ERROR));
     }
     this.pending.clear();
   }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -7,16 +7,7 @@ import type {
   ToolDefinition,
   ContentBlock,
 } from "../types.js";
-
-export class ProviderError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown,
-  ) {
-    super(message);
-    this.name = "ProviderError";
-  }
-}
+import { ProviderError } from "../../util/errors.js";
 
 export class AnthropicProvider implements Provider {
   public readonly name = "anthropic";
@@ -81,12 +72,13 @@ export class AnthropicProvider implements Provider {
       if (error instanceof Anthropic.APIError) {
         throw new ProviderError(
           `Anthropic API error (${error.status}): ${error.message}`,
-          error,
+          'anthropic',
+          error.status,
         );
       }
       throw new ProviderError(
         `Anthropic request failed: ${error instanceof Error ? error.message : String(error)}`,
-        error,
+        'anthropic',
       );
     }
   }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "./types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { RetryProvider } from "./retry.js";
+import { ConfigError } from "../util/errors.js";
 
 const providers = new Map<string, Provider>();
 
@@ -11,7 +12,7 @@ export function registerProvider(name: string, provider: Provider): void {
 export function getProvider(name: string): Provider {
   const provider = providers.get(name);
   if (!provider) {
-    throw new Error(
+    throw new ConfigError(
       `Provider "${name}" not found. Available: ${listProviders().join(", ")}`,
     );
   }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,4 +1,5 @@
 import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
+import { ProviderError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('retry');
@@ -7,13 +8,9 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 
 function isRetryableError(error: unknown): boolean {
-  if (error && typeof error === 'object') {
-    // Check cause for API status codes (e.g. Anthropic.APIError)
-    const cause = (error as { cause?: unknown }).cause;
-    if (cause && typeof cause === 'object' && 'status' in cause) {
-      const status = (cause as { status: number }).status;
-      if (status === 429 || status >= 500) return true;
-    }
+  // Check ProviderError.statusCode for retryable HTTP status codes
+  if (error instanceof ProviderError && error.statusCode !== undefined) {
+    if (error.statusCode === 429 || error.statusCode >= 500) return true;
   }
 
   // Check for network errors
@@ -21,13 +18,6 @@ function isRetryableError(error: unknown): boolean {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EPIPE') {
       return true;
-    }
-    const cause = (error as { cause?: unknown }).cause;
-    if (cause instanceof Error) {
-      const causeCode = (cause as NodeJS.ErrnoException).code;
-      if (causeCode === 'ECONNRESET' || causeCode === 'ECONNREFUSED' || causeCode === 'ETIMEDOUT' || causeCode === 'EPIPE') {
-        return true;
-      }
     }
   }
 

--- a/assistant/src/tools/terminal/parser.ts
+++ b/assistant/src/tools/terminal/parser.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { getLogger } from '../../util/logger.js';
+import { IntegrityError } from '../../util/errors.js';
 import { Parser, Language, type Node as TSNode } from 'web-tree-sitter';
 
 const log = getLogger('shell-parser');
@@ -60,12 +61,12 @@ function verifyWasmChecksum(filePath: string, label: string): void {
   const hash = createHash('sha256').update(data).digest('hex');
   const expected = EXPECTED_CHECKSUMS[label];
   if (!expected) {
-    throw new Error(
+    throw new IntegrityError(
       `No expected checksum registered for ${label}`,
     );
   }
   if (hash !== expected) {
-    throw new Error(
+    throw new IntegrityError(
       `WASM integrity check failed for ${label}: expected ${expected}, got ${hash}`,
     );
   }

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { isMacOS, isLinux } from './platform.js';
+import { PlatformError } from './errors.js';
 
 export function copyToClipboard(text: string): void {
   let cmd: string;
@@ -8,7 +9,7 @@ export function copyToClipboard(text: string): void {
   } else if (isLinux()) {
     cmd = 'xclip -selection clipboard';
   } else {
-    throw new Error('Clipboard not supported on this platform');
+    throw new PlatformError('Clipboard not supported on this platform');
   }
   execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
 }

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -1,7 +1,36 @@
+export enum ErrorCode {
+  // Provider errors
+  PROVIDER_ERROR = 'PROVIDER_ERROR',
+
+  // Tool errors
+  TOOL_ERROR = 'TOOL_ERROR',
+
+  // Permission errors
+  PERMISSION_DENIED = 'PERMISSION_DENIED',
+
+  // Config errors
+  CONFIG_ERROR = 'CONFIG_ERROR',
+
+  // Daemon errors
+  DAEMON_ERROR = 'DAEMON_ERROR',
+
+  // IPC/socket errors
+  IPC_ERROR = 'IPC_ERROR',
+
+  // Platform-specific errors (clipboard, unsupported OS features)
+  PLATFORM_ERROR = 'PLATFORM_ERROR',
+
+  // WASM integrity check failures
+  INTEGRITY_ERROR = 'INTEGRITY_ERROR',
+
+  // Internal/unexpected errors
+  INTERNAL_ERROR = 'INTERNAL_ERROR',
+}
+
 export class AssistantError extends Error {
   constructor(
     message: string,
-    public readonly code: string,
+    public readonly code: ErrorCode,
   ) {
     super(message);
     this.name = 'AssistantError';
@@ -14,7 +43,7 @@ export class ProviderError extends AssistantError {
     public readonly provider: string,
     public readonly statusCode?: number,
   ) {
-    super(message, 'PROVIDER_ERROR');
+    super(message, ErrorCode.PROVIDER_ERROR);
     this.name = 'ProviderError';
   }
 }
@@ -24,7 +53,7 @@ export class ToolError extends AssistantError {
     message: string,
     public readonly toolName: string,
   ) {
-    super(message, 'TOOL_ERROR');
+    super(message, ErrorCode.TOOL_ERROR);
     this.name = 'ToolError';
   }
 }
@@ -34,21 +63,42 @@ export class PermissionDeniedError extends AssistantError {
     message: string,
     public readonly toolName: string,
   ) {
-    super(message, 'PERMISSION_DENIED');
+    super(message, ErrorCode.PERMISSION_DENIED);
     this.name = 'PermissionDeniedError';
   }
 }
 
 export class ConfigError extends AssistantError {
   constructor(message: string) {
-    super(message, 'CONFIG_ERROR');
+    super(message, ErrorCode.CONFIG_ERROR);
     this.name = 'ConfigError';
   }
 }
 
 export class DaemonError extends AssistantError {
   constructor(message: string) {
-    super(message, 'DAEMON_ERROR');
+    super(message, ErrorCode.DAEMON_ERROR);
     this.name = 'DaemonError';
+  }
+}
+
+export class IpcError extends AssistantError {
+  constructor(message: string) {
+    super(message, ErrorCode.IPC_ERROR);
+    this.name = 'IpcError';
+  }
+}
+
+export class PlatformError extends AssistantError {
+  constructor(message: string) {
+    super(message, ErrorCode.PLATFORM_ERROR);
+    this.name = 'PlatformError';
+  }
+}
+
+export class IntegrityError extends AssistantError {
+  constructor(message: string) {
+    super(message, ErrorCode.INTEGRITY_ERROR);
+    this.name = 'IntegrityError';
   }
 }


### PR DESCRIPTION
## Summary
- Added `ErrorCode` enum with 9 codes: `PROVIDER_ERROR`, `TOOL_ERROR`, `PERMISSION_DENIED`, `CONFIG_ERROR`, `DAEMON_ERROR`, `IPC_ERROR`, `PLATFORM_ERROR`, `INTEGRITY_ERROR`, `INTERNAL_ERROR`
- Typed `AssistantError.code` as `ErrorCode` instead of `string` for compile-time safety
- Added 3 new error classes: `IpcError` (socket failures), `PlatformError` (unsupported features), `IntegrityError` (WASM checksum failures)
- Removed duplicate `ProviderError` from `anthropic/client.ts` — now uses the single definition from `util/errors.ts` with proper `provider` and `statusCode` fields
- Simplified `retry.ts` — checks `ProviderError.statusCode` directly instead of digging into `.cause` chain
- Replaced all plain `Error()` throws with appropriate typed error classes across 6 files

## Test plan
- [ ] Verify all 212 tests pass
- [ ] Verify API errors surface correct provider name and status code
- [ ] Verify WASM integrity check failures show IntegrityError
- [ ] Verify clipboard errors on unsupported platforms show PlatformError

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
