### PR TITLE
Fix reconnect robustness: stale handlers, null socket, timer leak

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -60,7 +60,7 @@ export async function startCli(): Promise<void> {
   }
 
   function send(msg: ClientMessage): void {
-    if (!socket.destroyed) {
+    if (socket && !socket.destroyed) {
       socket.write(serialize(msg));
     }
   }
@@ -414,6 +414,9 @@ export async function startCli(): Promise<void> {
     heartbeatTimer = setInterval(() => {
       if (socket.destroyed) return;
       send({ type: 'ping' });
+      if (heartbeatTimeout) {
+        clearTimeout(heartbeatTimeout);
+      }
       heartbeatTimeout = setTimeout(() => {
         // No pong received — daemon is unresponsive, trigger reconnect
         socket.destroy();
@@ -432,6 +435,11 @@ export async function startCli(): Promise<void> {
     toolStreaming = false;
     pendingSessionPick = false;
     lastUsage = null;
+
+    // Remove stale rl.once('line') handlers from confirmation/selection prompts
+    // and re-register the main line handler
+    rl.removeAllListeners('line');
+    rl.on('line', handleLine);
 
     for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
       process.stdout.write(`\n  Reconnecting to daemon (attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS})...\n`);
@@ -492,7 +500,7 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  rl.on('line', (line) => {
+  function handleLine(line: string): void {
     const content = line.trim();
     if (!content) return;
     if (pendingSessionPick) return;
@@ -594,7 +602,9 @@ export async function startCli(): Promise<void> {
     generating = true;
     send({ type: 'user_message', sessionId, content });
     spinner.start('Thinking...');
-  });
+  }
+
+  rl.on('line', handleLine);
 
   rl.on('close', () => {
     stopHeartbeat();

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -28,6 +28,7 @@ export async function startCli(): Promise<void> {
   let lastResponse = '';
   let lastUsage: { inputTokens: number; outputTokens: number; totalInputTokens: number; totalOutputTokens: number; estimatedCost: number; model: string } | null = null;
   let pendingSessionPick = false;
+  let pendingConfirmation = false;
   let toolStreaming = false;
   let reconnecting = false;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -59,10 +60,12 @@ export async function startCli(): Promise<void> {
     rl.prompt();
   }
 
-  function send(msg: ClientMessage): void {
+  function send(msg: ClientMessage): boolean {
     if (socket && !socket.destroyed) {
       socket.write(serialize(msg));
+      return true;
     }
+    return false;
   }
 
   function formatCommandPreview(req: ConfirmationRequest): string {
@@ -103,22 +106,26 @@ export async function startCli(): Promise<void> {
     }
     process.stdout.write(`\u2514 > `);
 
+    pendingConfirmation = true;
     rl.once('line', (answer) => {
       const trimmed = answer.trim();
       const choice = trimmed.toLowerCase();
 
       // Uppercase 'A' → allowlist pattern selection (check before lowercase 'a')
       if (trimmed === 'A' || choice === 'allowlist') {
+        // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_allow');
         return;
       }
 
       // Uppercase 'D' → denylist pattern selection (check before lowercase 'd')
       if (trimmed === 'D' || choice === 'denylist') {
+        // pendingConfirmation stays true through sub-prompts
         renderPatternSelection(req, 'always_deny');
         return;
       }
 
+      pendingConfirmation = false;
       if (choice === 'a') {
         send({
           type: 'confirmation_response',
@@ -159,9 +166,11 @@ export async function startCli(): Promise<void> {
       const idx = parseInt(answer.trim(), 10) - 1;
       if (idx >= 0 && idx < req.allowlistOptions.length) {
         const selectedPattern = req.allowlistOptions[idx].pattern;
+        // pendingConfirmation stays true through scope selection
         renderScopeSelection(req, selectedPattern, decision);
       } else {
         // Invalid selection → deny
+        pendingConfirmation = false;
         send({
           type: 'confirmation_response',
           requestId: req.requestId,
@@ -181,6 +190,7 @@ export async function startCli(): Promise<void> {
     process.stdout.write(`\u2514 > `);
 
     rl.once('line', (answer) => {
+      pendingConfirmation = false;
       const idx = parseInt(answer.trim(), 10) - 1;
       if (idx >= 0 && idx < req.scopeOptions.length) {
         send({
@@ -329,6 +339,7 @@ export async function startCli(): Promise<void> {
         spinner.stop();
         generating = false;
         pendingSessionPick = false;
+        pendingConfirmation = false;
         process.stdout.write(`\n[Error: ${msg.message}]\n`);
         prompt();
         break;
@@ -434,6 +445,7 @@ export async function startCli(): Promise<void> {
     generating = false;
     toolStreaming = false;
     pendingSessionPick = false;
+    pendingConfirmation = false;
     lastUsage = null;
 
     // Remove stale rl.once('line') handlers from confirmation/selection prompts
@@ -504,6 +516,7 @@ export async function startCli(): Promise<void> {
     const content = line.trim();
     if (!content) return;
     if (pendingSessionPick) return;
+    if (pendingConfirmation) return;
     if (reconnecting) return;
 
     if (content === '/copy') {
@@ -599,8 +612,12 @@ export async function startCli(): Promise<void> {
     }
 
     lastResponse = '';
+    if (!send({ type: 'user_message', sessionId, content })) {
+      process.stdout.write('[Not connected — message not sent]\n');
+      prompt();
+      return;
+    }
     generating = true;
-    send({ type: 'user_message', sessionId, content });
     spinner.start('Thinking...');
   }
 


### PR DESCRIPTION
## Summary
- **Clear stale `rl.once('line')` handlers on reconnect** — when the daemon drops during a confirmation/selection prompt, the pending `once('line')` handler would fire on the next user input after reconnect, sending a spurious `confirmation_response` with a stale `requestId`. Now `reconnect()` removes all line listeners and re-registers only the main handler.
- **Guard `send()` against null socket** — if input arrives before the initial connection completes, `send()` would throw accessing `socket.destroyed` on an uninitialized variable. Now checks `socket &&` first.
- **Clear previous heartbeat timeout before setting new one** — prevents timer leaks if timing constants are changed such that `HEARTBEAT_INTERVAL_MS <= HEARTBEAT_TIMEOUT_MS`.

Addresses feedback on #140.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 212 tests pass
- [ ] Kill daemon during confirmation prompt → CLI reconnects and returns to clean prompt without spurious messages
- [ ] Pipe input to CLI before connection completes → no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
