### PR TITLE
Fix config loader re-entrancy to return in-flight config

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -11,9 +11,6 @@ const log = getLogger('config');
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 
 let cached: AssistantConfig | null = null;
-// Guard against concurrent loadConfig() calls: once one caller starts loading,
-// subsequent callers wait on the same result instead of loading independently.
-let loading = false;
 
 function getConfigPath(): string {
   return join(getDataDir(), 'config.json');
@@ -21,13 +18,6 @@ function getConfigPath(): string {
 
 export function loadConfig(): AssistantConfig {
   if (cached) return cached;
-
-  // loadConfig is synchronous (readFileSync) so this guard mainly protects
-  // against re-entrant calls (e.g. validateConfig logging triggers a reload).
-  if (loading) {
-    return { ...DEFAULT_CONFIG };
-  }
-  loading = true;
 
   try {
     ensureDataDir();
@@ -65,6 +55,12 @@ export function loadConfig(): AssistantConfig {
       timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
     };
 
+    // Set cached before validation so re-entrant calls (e.g. validateConfig
+    // logging triggers loadConfig) return the in-flight config instead of
+    // bare defaults. Validation mutates the same object, so callers see
+    // corrected values.
+    cached = config;
+
     validateConfig(config);
 
     // Environment variables override config file (after validation so apiKeys is a valid object)
@@ -78,10 +74,11 @@ export function loadConfig(): AssistantConfig {
       config.apiKeys.gemini = process.env.GEMINI_API_KEY;
     }
 
-    cached = config;
     return config;
-  } finally {
-    loading = false;
+  } catch (err) {
+    // Loading failed — clear cached so the next call retries
+    cached = null;
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- When `loadConfig()` was re-entered (e.g. `validateConfig` logging triggers a reload), it returned `{ ...DEFAULT_CONFIG }` — a shallow copy with incorrect provider/model/timeouts and shared nested `apiKeys`/`timeouts` references that could leak mutations into global defaults
- Fix by setting `cached` to the config object **before** calling `validateConfig`, so re-entrant calls hit the early `if (cached) return cached` check and get the same in-flight config reference
- Removed the now-unnecessary `loading` guard variable — `cached` handles re-entrancy naturally
- Added error handling: if loading fails, `cached` is cleared so the next call retries from scratch

Addresses feedback on #141.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 212 tests pass
- [ ] Verify config loads correctly with valid config file
- [ ] Verify re-entrant `loadConfig()` calls return the same config object, not defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
