### PR TITLE
Fix retry for network errors wrapped in ProviderError

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -79,6 +79,8 @@ export class AnthropicProvider implements Provider {
       throw new ProviderError(
         `Anthropic request failed: ${error instanceof Error ? error.message : String(error)}`,
         'anthropic',
+        undefined,
+        { cause: error },
       );
     }
   }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -13,11 +13,18 @@ function isRetryableError(error: unknown): boolean {
     if (error.statusCode === 429 || error.statusCode >= 500) return true;
   }
 
-  // Check for network errors
+  // Check for network errors (direct or wrapped in cause chain)
   if (error instanceof Error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EPIPE') {
       return true;
+    }
+
+    if (error.cause instanceof Error) {
+      const causeCode = (error.cause as NodeJS.ErrnoException).code;
+      if (causeCode === 'ECONNRESET' || causeCode === 'ECONNREFUSED' || causeCode === 'ETIMEDOUT' || causeCode === 'EPIPE') {
+        return true;
+      }
     }
   }
 

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -31,8 +31,9 @@ export class AssistantError extends Error {
   constructor(
     message: string,
     public readonly code: ErrorCode,
+    options?: { cause?: unknown },
   ) {
-    super(message);
+    super(message, options);
     this.name = 'AssistantError';
   }
 }
@@ -42,8 +43,9 @@ export class ProviderError extends AssistantError {
     message: string,
     public readonly provider: string,
     public readonly statusCode?: number,
+    options?: { cause?: unknown },
   ) {
-    super(message, ErrorCode.PROVIDER_ERROR);
+    super(message, ErrorCode.PROVIDER_ERROR, options);
     this.name = 'ProviderError';
   }
 }


### PR DESCRIPTION
## Summary
- Add optional `cause` parameter to `AssistantError` and `ProviderError` using the standard `Error` cause option
- Pass the original error as `cause` when wrapping non-APIError exceptions in `AnthropicProvider`
- Inspect the `error.cause` chain in `isRetryableError` for network error codes (`ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`)

## Test plan
- [ ] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Confirm that a `ProviderError` wrapping an `ECONNRESET` error is correctly identified as retryable
- [ ] Confirm that direct network errors (not wrapped) are still retried
- [ ] Confirm that non-retryable errors are still thrown immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
