### PR TITLE
Fix stale line handlers on error during confirmation prompts

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -339,7 +339,11 @@ export async function startCli(): Promise<void> {
         spinner.stop();
         generating = false;
         pendingSessionPick = false;
-        pendingConfirmation = false;
+        if (pendingConfirmation) {
+          pendingConfirmation = false;
+          rl.removeAllListeners('line');
+          rl.on('line', handleLine);
+        }
         process.stdout.write(`\n[Error: ${msg.message}]\n`);
         prompt();
         break;


### PR DESCRIPTION
## Summary
- When a server error arrives while a confirmation/selection prompt is pending, the error handler now properly removes stale `rl.once('line')` handlers before re-registering `handleLine`
- Previously, the error handler set `pendingConfirmation = false` without cleaning up stale listeners, causing the next user input to fire both the stale `once` handler (sending a spurious `confirmation_response`) and `handleLine` simultaneously
- Mirrors the cleanup pattern already used in the `reconnect()` function

## Test plan
- [ ] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Simulate a server error during a confirmation prompt and verify next input is handled normally without spurious confirmation responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
