### PR TITLE
Add re-entrancy guard to loadConfig before any log paths

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -11,6 +11,7 @@ const log = getLogger('config');
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 
 let cached: AssistantConfig | null = null;
+let loading = false;
 
 function getConfigPath(): string {
   return join(getDataDir(), 'config.json');
@@ -18,6 +19,12 @@ function getConfigPath(): string {
 
 export function loadConfig(): AssistantConfig {
   if (cached) return cached;
+
+  // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
+  // invalid apiKeys) can trigger loadConfig again. Return defaults to
+  // break the cycle instead of recursing to stack overflow.
+  if (loading) return DEFAULT_CONFIG;
+  loading = true;
 
   try {
     ensureDataDir();
@@ -74,10 +81,12 @@ export function loadConfig(): AssistantConfig {
       config.apiKeys.gemini = process.env.GEMINI_API_KEY;
     }
 
+    loading = false;
     return config;
   } catch (err) {
     // Loading failed — clear cached so the next call retries
     cached = null;
+    loading = false;
     throw err;
   }
 }
@@ -133,6 +142,7 @@ export function getConfig(): AssistantConfig {
 
 export function invalidateConfigCache(): void {
   cached = null;
+  loading = false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a `loading` boolean guard at the top of `loadConfig()` that returns `DEFAULT_CONFIG` for re-entrant calls
- Fixes potential stack overflow when log calls in early branches (file-mode warning at line 30, invalid apiKeys error at line 47) re-enter `loadConfig()` before `cached` is set
- Reset the guard on both success and failure paths, and in `invalidateConfigCache()`

## Test plan
- [ ] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Verify that a config file with invalid apiKeys doesn't cause infinite recursion
- [ ] Verify that a config file with overly permissive file permissions doesn't cause infinite recursion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
