### PR TITLE
Standardize error logging with correct severity levels

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -51,7 +51,7 @@ export function loadConfig(): AssistantConfig {
       fileConfig.apiKeys !== undefined &&
       (typeof fileConfig.apiKeys !== 'object' || fileConfig.apiKeys === null || Array.isArray(fileConfig.apiKeys))
     ) {
-      log.error('Invalid apiKeys in config file: must be an object with string values. Ignoring.');
+      log.warn('Invalid apiKeys in config file: must be an object with string values. Ignoring.');
       delete fileConfig.apiKeys;
     }
 
@@ -93,26 +93,26 @@ export function loadConfig(): AssistantConfig {
 
 function validateConfig(config: AssistantConfig): void {
   if (!VALID_PROVIDERS.includes(config.provider as (typeof VALID_PROVIDERS)[number])) {
-    log.error(
+    log.warn(
       `Invalid provider "${config.provider}". Valid providers: ${VALID_PROVIDERS.join(', ')}. Falling back to "${DEFAULT_CONFIG.provider}".`,
     );
     config.provider = DEFAULT_CONFIG.provider;
   }
 
   if (!Number.isInteger(config.maxTokens) || config.maxTokens <= 0) {
-    log.error(
+    log.warn(
       `Invalid maxTokens "${config.maxTokens}". Must be a positive integer. Falling back to ${DEFAULT_CONFIG.maxTokens}.`,
     );
     config.maxTokens = DEFAULT_CONFIG.maxTokens;
   }
 
   if (typeof config.apiKeys !== 'object' || config.apiKeys === null || Array.isArray(config.apiKeys)) {
-    log.error('Invalid apiKeys: must be an object with string values. Falling back to empty object.');
+    log.warn('Invalid apiKeys: must be an object with string values. Falling back to empty object.');
     config.apiKeys = {};
   } else {
     for (const [key, value] of Object.entries(config.apiKeys)) {
       if (typeof value !== 'string') {
-        log.error(`Invalid apiKeys.${key}: value must be a string. Removing entry.`);
+        log.warn(`Invalid apiKeys.${key}: value must be a string. Removing entry.`);
         delete config.apiKeys[key];
       }
     }
@@ -121,7 +121,7 @@ function validateConfig(config: AssistantConfig): void {
   for (const field of ['shellDefaultTimeoutSec', 'shellMaxTimeoutSec', 'permissionTimeoutSec'] as const) {
     const val = config.timeouts[field];
     if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) {
-      log.error(
+      log.warn(
         `Invalid timeouts.${field} "${val}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.timeouts[field]}.`,
       );
       config.timeouts[field] = DEFAULT_CONFIG.timeouts[field];

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -148,8 +148,8 @@ export async function stopDaemon(): Promise<{ stopped: boolean }> {
   // Force kill
   try {
     process.kill(pid, 'SIGKILL');
-  } catch {
-    // Already dead
+  } catch (err) {
+    log.debug({ err, pid }, 'SIGKILL failed, process already exited');
   }
   cleanupPidFile();
   return { stopped: true };

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -465,7 +465,8 @@ export class DaemonServer {
         } else {
           text = String(content);
         }
-      } catch {
+      } catch (err) {
+        log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
         text = m.content;
       }
       return { role: m.role, text, timestamp: m.createdAt };


### PR DESCRIPTION
## Summary
- Change `log.error` → `log.warn` in config validation for all non-fatal issues that fall back to defaults (provider, maxTokens, apiKeys, timeouts)
- Add `log.debug` for two silent error swallows: JSON parse fallback in history handler, SIGKILL ESRCH in lifecycle
- Establishes consistent pattern: `log.error` = actual errors, `log.warn` = recoverable with fallback, `log.debug` = expected/benign failures

## Test plan
- [x] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Verify config with invalid values logs warnings (not errors) and falls back to defaults
- [ ] Verify `VELLUM_DEBUG=1` shows debug-level messages for history parse fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
