### PR TITLE
Fix stale session pick handler on error

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -338,9 +338,9 @@ export async function startCli(): Promise<void> {
       case 'error':
         spinner.stop();
         generating = false;
-        pendingSessionPick = false;
-        if (pendingConfirmation) {
+        if (pendingConfirmation || pendingSessionPick) {
           pendingConfirmation = false;
+          pendingSessionPick = false;
           rl.removeAllListeners('line');
           rl.on('line', handleLine);
         }


### PR DESCRIPTION
## Summary
- Extend the stale `rl.once('line')` cleanup in the error handler to also cover `pendingSessionPick`
- Previously only `pendingConfirmation` triggered listener cleanup, so a server error during a session picker prompt left the stale `once` handler from `renderSessionPicker` active
- This caused the next user input to fire both the stale session picker handler and `handleLine` simultaneously

## Test plan
- [x] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Simulate a server error during session picker and verify next input is handled normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
