### PR TITLE
Return defensive copy from loadConfig re-entrancy guard

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -23,7 +23,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return DEFAULT_CONFIG;
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts } };
   loading = true;
 
   try {


### PR DESCRIPTION
## Summary
- The re-entrancy guard in `loadConfig()` was returning the shared `DEFAULT_CONFIG` singleton directly
- If a re-entrant caller mutated the returned object, it would permanently corrupt `DEFAULT_CONFIG` for all future config loads and fallback values
- Now returns a shallow copy with spread nested objects (`apiKeys`, `timeouts`)

## Test plan
- [x] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Verify re-entrant config loads don't corrupt DEFAULT_CONFIG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
