### PR TITLE
Add path traversal protection for file tools

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,5 +1,4 @@
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { getTool } from './registry.js';
 import type { ToolContext, ToolExecutionResult } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
@@ -10,6 +9,7 @@ import { recordToolInvocation } from '../memory/tool-usage-store.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
+import { validateFilePath } from './filesystem/path-guard.js';
 
 const log = getLogger('tool-executor');
 
@@ -164,7 +164,9 @@ function computePreviewDiff(
       const rawPath = input.path as string;
       const content = input.content as string;
       if (!rawPath || typeof content !== 'string') return undefined;
-      const filePath = resolve(workingDir, rawPath);
+      const pathCheck = validateFilePath(rawPath, workingDir, { mustExist: false });
+      if (!pathCheck.ok) return undefined;
+      const filePath = pathCheck.resolved;
       const isNewFile = !existsSync(filePath);
       const oldContent = isNewFile ? '' : readFileSync(filePath, 'utf-8');
       return { filePath, oldContent, newContent: content, isNewFile };
@@ -175,7 +177,9 @@ function computePreviewDiff(
       const oldString = input.old_string as string;
       const newString = input.new_string as string;
       if (!rawPath || typeof oldString !== 'string' || typeof newString !== 'string' || oldString.length === 0) return undefined;
-      const filePath = resolve(workingDir, rawPath);
+      const pathCheck = validateFilePath(rawPath, workingDir);
+      if (!pathCheck.ok) return undefined;
+      const filePath = pathCheck.resolved;
       if (!existsSync(filePath)) return undefined;
       const content = readFileSync(filePath, 'utf-8');
       const replaceAll = input.replace_all === true;

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,10 +1,10 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { findAllMatches, adjustIndentation } from './fuzzy-match.js';
+import { validateFilePath } from './path-guard.js';
 
 class FileEditTool implements Tool {
   name = 'file_edit';
@@ -66,7 +66,11 @@ class FileEditTool implements Tool {
     }
 
     const replaceAll = input.replace_all === true;
-    const filePath = resolve(context.workingDir, rawPath);
+    const pathCheck = validateFilePath(rawPath, context.workingDir);
+    if (!pathCheck.ok) {
+      return { content: `Error: ${pathCheck.error}`, isError: true };
+    }
+    const filePath = pathCheck.resolved;
 
     try {
       const content = readFileSync(filePath, 'utf-8');

--- a/assistant/src/tools/filesystem/path-guard.ts
+++ b/assistant/src/tools/filesystem/path-guard.ts
@@ -1,0 +1,54 @@
+import { resolve, relative } from 'node:path';
+import { realpathSync } from 'node:fs';
+
+/**
+ * Resolve a user-supplied path against the working directory and verify
+ * that the result stays within the allowed boundary (workingDir by default).
+ *
+ * Returns the resolved absolute path on success, or an error message string.
+ *
+ * For existing paths, symlinks are resolved via realpathSync so a symlink
+ * pointing outside the boundary is caught. For new paths (file_write),
+ * the caller should pass `mustExist: false` to skip the realpath check —
+ * the lexical prefix check still catches `../` traversal.
+ */
+export function validateFilePath(
+  rawPath: string,
+  workingDir: string,
+  options?: { mustExist?: boolean },
+): { ok: true; resolved: string } | { ok: false; error: string } {
+  const mustExist = options?.mustExist ?? true;
+
+  // Resolve to absolute path (handles relative paths and ..)
+  const resolved = resolve(workingDir, rawPath);
+
+  // For existing files, resolve symlinks to catch symlink-based escapes
+  let realResolved = resolved;
+  if (mustExist) {
+    try {
+      realResolved = realpathSync(resolved);
+    } catch {
+      // File doesn't exist — will be caught by the tool's own existence check
+      realResolved = resolved;
+    }
+  }
+
+  // Resolve the working directory's real path too (in case it's a symlink)
+  let realWorkingDir: string;
+  try {
+    realWorkingDir = realpathSync(workingDir);
+  } catch {
+    realWorkingDir = workingDir;
+  }
+
+  // Check that the resolved path is within the working directory
+  const rel = relative(realWorkingDir, realResolved);
+  if (rel.startsWith('..') || resolve(realWorkingDir, rel) !== realResolved) {
+    return {
+      ok: false,
+      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realWorkingDir}"`,
+    };
+  }
+
+  return { ok: true, resolved };
+}

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -1,9 +1,9 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
+import { validateFilePath } from './path-guard.js';
 
 class FileReadTool implements Tool {
   name = 'file_read';
@@ -42,7 +42,11 @@ class FileReadTool implements Tool {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
 
-    const filePath = resolve(context.workingDir, rawPath);
+    const pathCheck = validateFilePath(rawPath, context.workingDir);
+    if (!pathCheck.ok) {
+      return { content: `Error: ${pathCheck.error}`, isError: true };
+    }
+    const filePath = pathCheck.resolved;
 
     if (!existsSync(filePath)) {
       return { content: `Error: File not found: ${filePath}`, isError: true };

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,9 +1,10 @@
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { dirname } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
+import { validateFilePath } from './path-guard.js';
 
 class FileWriteTool implements Tool {
   name = 'file_write';
@@ -43,7 +44,11 @@ class FileWriteTool implements Tool {
       return { content: 'Error: content is required and must be a string', isError: true };
     }
 
-    const filePath = resolve(context.workingDir, rawPath);
+    const pathCheck = validateFilePath(rawPath, context.workingDir, { mustExist: false });
+    if (!pathCheck.ok) {
+      return { content: `Error: ${pathCheck.error}`, isError: true };
+    }
+    const filePath = pathCheck.resolved;
 
     try {
       // Create parent directories if needed


### PR DESCRIPTION
## Summary
- Add `validateFilePath` utility in `tools/filesystem/path-guard.ts` that validates user-supplied paths stay within the working directory
- Resolves relative paths, `..` sequences, and symlinks to detect directory escape attempts
- Applied to all three file tools (file_read, file_write, file_edit) and the executor's preview diff computation
- Paths like `../../../etc/passwd` or symlinks pointing outside the working directory are blocked with a clear error message
- For `file_write`, uses `mustExist: false` since the target file may not exist yet (lexical prefix check still catches `../` traversal)

## Test plan
- [x] Verify type-checking passes (`bun run tsc --noEmit`)
- [ ] Verify `file_read` with `../../../etc/passwd` returns an error
- [ ] Verify `file_read` with a normal relative path works
- [ ] Verify `file_write` to a path outside working dir is blocked
- [ ] Verify `file_edit` on a file outside working dir is blocked
- [ ] Verify symlinks pointing outside working dir are blocked for existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
