### PR TITLE
Add macOS sandbox profile for shell command isolation

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -12,6 +12,9 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
+  sandbox: {
+    enabled: false,
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -23,7 +23,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts } };
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox } };
   loading = true;
 
   try {
@@ -60,6 +60,7 @@ export function loadConfig(): AssistantConfig {
       ...fileConfig,
       apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
       timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
+      sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
     };
 
     // Set cached before validation so re-entrant calls (e.g. validateConfig
@@ -126,6 +127,11 @@ function validateConfig(config: AssistantConfig): void {
       );
       config.timeouts[field] = DEFAULT_CONFIG.timeouts[field];
     }
+  }
+
+  if (typeof config.sandbox.enabled !== 'boolean') {
+    log.warn(`Invalid sandbox.enabled "${config.sandbox.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.sandbox.enabled}.`);
+    config.sandbox.enabled = DEFAULT_CONFIG.sandbox.enabled;
   }
 }
 

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -7,6 +7,11 @@ export interface TimeoutConfig {
   permissionTimeoutSec: number;
 }
 
+export interface SandboxConfig {
+  /** Whether to run shell commands in a sandbox. Default: false. */
+  enabled: boolean;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
@@ -15,4 +20,5 @@ export interface AssistantConfig {
   maxTokens: number;
   dataDir: string;
   timeouts: TimeoutConfig;
+  sandbox: SandboxConfig;
 }

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -1,0 +1,116 @@
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { isMacOS } from '../../util/platform.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('sandbox');
+
+/**
+ * macOS sandbox-exec profile that restricts shell commands:
+ * - Denies all by default
+ * - Allows read access to most of the filesystem (needed for toolchains)
+ * - Allows write access only to the working directory and temp dirs
+ * - Blocks outbound network access
+ * - Blocks process debugging (ptrace)
+ *
+ * The WORKING_DIR placeholder is replaced at runtime with the actual
+ * working directory path.
+ */
+const SANDBOX_PROFILE = `
+(version 1)
+(deny default)
+
+;; Allow read access to the filesystem (tools, libraries, etc.)
+(allow file-read*)
+
+;; Allow write access to the working directory and its children
+(allow file-write*
+  (subpath "__WORKING_DIR__")
+  (subpath "/private/tmp")
+  (subpath "/tmp")
+  (subpath "/var/folders"))
+
+;; Allow process execution (needed to run commands)
+(allow process-exec*)
+(allow process-fork)
+
+;; Allow signal delivery between parent and child
+(allow signal (target others))
+
+;; Allow sysctl reads (needed by many tools)
+(allow sysctl-read)
+
+;; Allow mach lookups (IPC, needed for basic process operation)
+(allow mach-lookup)
+(allow mach-register)
+
+;; Allow IOKit (needed for some system calls)
+(allow iokit-open)
+
+;; Block network access
+(deny network*)
+
+;; Block process debugging
+(deny process-info-pidinfo (target others))
+`.trim();
+
+/**
+ * Get the path to the sandbox profile file, creating it if needed.
+ * The profile is written to ~/.vellum/sandbox-profile.sb.
+ */
+function getProfilePath(workingDir: string): string {
+  const dir = join(process.env.HOME ?? '/tmp', '.vellum');
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const path = join(dir, 'sandbox-profile.sb');
+
+  // Always rewrite with the current working directory
+  const profile = SANDBOX_PROFILE.replace(/__WORKING_DIR__/g, workingDir);
+  writeFileSync(path, profile + '\n');
+  return path;
+}
+
+export interface SandboxResult {
+  /** The command/args to use for spawning. */
+  command: string;
+  args: string[];
+  /** Whether sandboxing was applied. */
+  sandboxed: boolean;
+}
+
+/**
+ * Wrap a shell command for sandboxed execution.
+ *
+ * On macOS with sandbox enabled, wraps the command with sandbox-exec.
+ * On unsupported platforms, returns the command unchanged with a warning.
+ */
+export function wrapCommand(
+  command: string,
+  workingDir: string,
+  enabled: boolean,
+): SandboxResult {
+  if (!enabled) {
+    return {
+      command: 'bash',
+      args: ['-c', '--', command],
+      sandboxed: false,
+    };
+  }
+
+  if (!isMacOS()) {
+    log.warn('Sandbox is enabled but not supported on this platform. Running unsandboxed.');
+    return {
+      command: 'bash',
+      args: ['-c', '--', command],
+      sandboxed: false,
+    };
+  }
+
+  const profile = getProfilePath(workingDir);
+  return {
+    command: 'sandbox-exec',
+    args: ['-f', profile, 'bash', '-c', '--', command],
+    sandboxed: true,
+  };
+}

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -5,6 +5,7 @@ import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { wrapCommand } from './sandbox.js';
 
 const log = getLogger('shell-tool');
 
@@ -62,9 +63,8 @@ class ShellTool implements Tool {
       let stderr = '';
       let timedOut = false;
 
-      // The '--' separator prevents bash from interpreting the command
-      // string as additional flags if it starts with '-'.
-      const child = spawn('bash', ['-c', '--', command], {
+      const wrapped = wrapCommand(command, context.workingDir, config.sandbox.enabled);
+      const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env: { ...process.env },
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- Add `sandbox-exec` SBPL profile that restricts shell commands: deny-all default, filesystem reads allowed, writes scoped to working dir + temp dirs, network blocked, process debugging blocked
- Integrate `wrapCommand()` into the shell tool — commands are wrapped with `sandbox-exec -f <profile>` when `sandbox.enabled` is true in config
- Add `SandboxConfig` interface to config types with validation and merging in the config loader
- Disabled by default; non-macOS platforms fall back to unsandboxed execution with a warning

## Test plan
- [ ] Verify `sandbox.enabled: false` (default) runs commands normally without sandbox-exec
- [ ] Enable `sandbox.enabled: true` on macOS and verify commands are wrapped with sandbox-exec
- [ ] Verify sandboxed commands can read files but cannot write outside working dir
- [ ] Verify sandboxed commands cannot make network requests
- [ ] Verify non-macOS platforms log a warning and run unsandboxed
- [ ] Verify config validation rejects non-boolean `sandbox.enabled` with warning and fallback
- [ ] Type-check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
