### PR TITLE
Add --no-sandbox CLI flag and permission prompt indicator

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -19,7 +19,11 @@ const HEARTBEAT_TIMEOUT_MS = 10_000;
 const RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 
-export async function startCli(): Promise<void> {
+export interface CliOptions {
+  noSandbox?: boolean;
+}
+
+export async function startCli(options: CliOptions = {}): Promise<void> {
   const socketPath = getSocketPath();
   let socket: net.Socket;
   let parser = createMessageParser();
@@ -85,7 +89,7 @@ export async function startCli(): Promise<void> {
     const preview = formatCommandPreview(req);
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${req.toolName}: ${preview}\n`);
-    process.stdout.write(`\u2502 Risk: ${req.riskLevel}\n`);
+    process.stdout.write(`\u2502 Risk: ${req.riskLevel}${req.sandboxed ? '  [sandboxed]' : ''}\n`);
     if (req.diff) {
       const diffOutput = req.diff.isNewFile
         ? formatNewFileDiff(req.diff.newContent, req.diff.filePath)
@@ -645,4 +649,9 @@ export async function startCli(): Promise<void> {
 
   // Initial connection
   await connect();
+
+  // Send sandbox override if --no-sandbox was passed
+  if (options.noSandbox) {
+    send({ type: 'sandbox_set', enabled: false });
+  }
 }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -60,6 +60,11 @@ export interface UsageRequest {
   sessionId: string;
 }
 
+export interface SandboxSetRequest {
+  type: 'sandbox_set';
+  enabled: boolean;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -72,7 +77,8 @@ export type ClientMessage =
   | ModelSetRequest
   | HistoryRequest
   | UndoRequest
-  | UsageRequest;
+  | UsageRequest
+  | SandboxSetRequest;
 
 // === Server → Client messages ===
 
@@ -110,6 +116,7 @@ export interface ConfirmationRequest {
   allowlistOptions: Array<{ label: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
+  sandboxed?: boolean;
 }
 
 export interface MessageComplete {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -327,6 +327,9 @@ export class DaemonServer {
       case 'usage_request':
         this.handleUsageRequest(msg.sessionId, socket);
         break;
+      case 'sandbox_set':
+        this.handleSandboxSet(msg.enabled);
+        break;
       case 'ping':
         this.send(socket, { type: 'pong' });
         break;
@@ -449,6 +452,14 @@ export class DaemonServer {
       const message = err instanceof Error ? err.message : String(err);
       this.send(socket, { type: 'error', message: `Failed to set model: ${message}` });
     }
+  }
+
+  private handleSandboxSet(enabled: boolean): void {
+    // Runtime-only override: modify the in-memory config without persisting
+    // to disk. Takes effect immediately for all subsequent shell executions.
+    const config = getConfig();
+    config.sandbox.enabled = enabled;
+    log.info({ enabled }, 'Sandbox override applied (runtime only)');
   }
 
   private handleHistoryRequest(sessionId: string, socket: net.Socket): void {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -84,9 +84,10 @@ program
   .name('vellum')
   .description('Local AI assistant')
   .version('0.1.0')
-  .action(async () => {
+  .option('--no-sandbox', 'Disable sandbox for this session (runtime override, not persisted)')
+  .action(async (opts: { sandbox?: boolean }) => {
     await ensureDaemonRunning();
-    await startCli();
+    await startCli({ noSandbox: opts.sandbox === false });
   });
 
 const daemon = program.command('daemon').description('Manage the daemon process');

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -32,6 +32,7 @@ export class PermissionPrompter {
     allowlistOptions: AllowlistOption[],
     scopeOptions: ScopeOption[],
     diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean },
+    sandboxed?: boolean,
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -54,6 +55,7 @@ export class PermissionPrompter {
         allowlistOptions: allowlistOptions.map((o) => ({ label: o.label, pattern: o.pattern })),
         scopeOptions: scopeOptions.map((o) => ({ label: o.label, scope: o.scope })),
         diff,
+        sandboxed,
       });
     });
   }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -10,6 +10,8 @@ import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
+import { wrapCommand } from './terminal/sandbox.js';
+import { getConfig } from '../config/loader.js';
 
 const log = getLogger('tool-executor');
 
@@ -63,6 +65,13 @@ export class ToolExecutor {
         // Compute preview diff for file tools so the user sees what will change
         const previewDiff = computePreviewDiff(name, input, context.workingDir);
 
+        // Check if this shell command will run sandboxed
+        let sandboxed: boolean | undefined;
+        if (name === 'shell' && typeof input.command === 'string') {
+          const wrapped = wrapCommand(input.command, context.workingDir, getConfig().sandbox.enabled);
+          sandboxed = wrapped.sandboxed;
+        }
+
         const response = await this.prompter.prompt(
           name,
           input,
@@ -70,6 +79,7 @@ export class ToolExecutor {
           allowlistOptions,
           scopeOptions,
           previewDiff,
+          sandboxed,
         );
 
         decision = response.decision;


### PR DESCRIPTION
## Summary
- Add `--no-sandbox` flag to the root `vellum` command for one-off sandbox overrides (runtime only, not persisted to config)
- Add `sandbox_set` IPC message type so the CLI can tell the daemon to disable sandboxing for the session
- Show `[sandboxed]` indicator in the permission confirmation prompt when a shell command will run in the sandbox
- Thread `sandboxed` flag through executor → prompter → IPC → CLI render

## Test plan
- [ ] `vellum --no-sandbox` sends `sandbox_set` message to daemon on connect
- [ ] Permission prompt shows `[sandboxed]` when sandbox is enabled and command is on macOS
- [ ] Permission prompt does not show `[sandboxed]` when sandbox is disabled
- [ ] `--no-sandbox` does not persist the override to `~/.vellum/config.json`
- [ ] Type-check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
