### PR TITLE
Add Linux sandbox support with bubblewrap (bwrap)

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { isMacOS } from '../../util/platform.js';
+import { isMacOS, isLinux } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('sandbox');
@@ -71,6 +72,48 @@ function getProfilePath(workingDir: string): string {
   return path;
 }
 
+/** Cache bwrap availability check so we only shell out once. */
+let bwrapAvailable: boolean | null = null;
+
+function isBwrapAvailable(): boolean {
+  if (bwrapAvailable !== null) return bwrapAvailable;
+  try {
+    execSync('bwrap --version', { stdio: 'ignore' });
+    bwrapAvailable = true;
+  } catch {
+    bwrapAvailable = false;
+  }
+  return bwrapAvailable;
+}
+
+/**
+ * Build bwrap arguments for Linux sandboxing.
+ *
+ * Strategy mirrors the macOS sandbox-exec profile:
+ * - Read-only bind-mount of the root filesystem (toolchains, libs, etc.)
+ * - Read-write bind-mount of the working directory
+ * - Read-write tmpfs for /tmp
+ * - /proc mounted for basic process operation
+ * - /dev bind-mounted for device access (needed by many tools)
+ * - Network access blocked (--unshare-net)
+ * - PID namespace isolated (--unshare-pid)
+ */
+function buildBwrapArgs(workingDir: string, command: string): string[] {
+  return [
+    // Filesystem: read-only root, writable working dir and temp
+    '--ro-bind', '/', '/',
+    '--bind', workingDir, workingDir,
+    '--bind', '/tmp', '/tmp',
+    '--dev', '/dev',
+    '--proc', '/proc',
+    // Isolation
+    '--unshare-net',
+    '--unshare-pid',
+    // Run bash inside the sandbox
+    'bash', '-c', '--', command,
+  ];
+}
+
 export interface SandboxResult {
   /** The command/args to use for spawning. */
   command: string;
@@ -82,8 +125,10 @@ export interface SandboxResult {
 /**
  * Wrap a shell command for sandboxed execution.
  *
- * On macOS with sandbox enabled, wraps the command with sandbox-exec.
- * On unsupported platforms, returns the command unchanged with a warning.
+ * On macOS, wraps with sandbox-exec using an SBPL profile.
+ * On Linux, wraps with bwrap (bubblewrap) if available.
+ * On unsupported platforms or when bwrap is missing, returns the
+ * command unchanged with a warning.
  */
 export function wrapCommand(
   command: string,
@@ -98,19 +143,35 @@ export function wrapCommand(
     };
   }
 
-  if (!isMacOS()) {
-    log.warn('Sandbox is enabled but not supported on this platform. Running unsandboxed.');
+  if (isMacOS()) {
+    const profile = getProfilePath(workingDir);
     return {
-      command: 'bash',
-      args: ['-c', '--', command],
-      sandboxed: false,
+      command: 'sandbox-exec',
+      args: ['-f', profile, 'bash', '-c', '--', command],
+      sandboxed: true,
     };
   }
 
-  const profile = getProfilePath(workingDir);
+  if (isLinux()) {
+    if (!isBwrapAvailable()) {
+      log.warn('Sandbox is enabled but bwrap is not installed. Running unsandboxed. Install bubblewrap: apt install bubblewrap');
+      return {
+        command: 'bash',
+        args: ['-c', '--', command],
+        sandboxed: false,
+      };
+    }
+    return {
+      command: 'bwrap',
+      args: buildBwrapArgs(workingDir, command),
+      sandboxed: true,
+    };
+  }
+
+  log.warn('Sandbox is enabled but not supported on this platform. Running unsandboxed.');
   return {
-    command: 'sandbox-exec',
-    args: ['-f', profile, 'bash', '-c', '--', command],
-    sandboxed: true,
+    command: 'bash',
+    args: ['-c', '--', command],
+    sandboxed: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add `bwrap` (bubblewrap) as the Linux sandbox backend, completing the cross-platform sandbox support
- Mirrors the macOS sandbox-exec security profile: read-only root filesystem, writable working dir + /tmp, network blocked, PID namespace isolated
- Cached `bwrap --version` check to avoid repeated shell-outs
- Platform detection auto-selects the right backend: `sandbox-exec` on macOS, `bwrap` on Linux
- Falls back to unsandboxed with a warning and install instructions (`apt install bubblewrap`) if bwrap is not available
- Unsupported platforms (e.g. Windows) get a generic warning and run unsandboxed

## Test plan
- [ ] On Linux with bwrap installed: verify sandboxed commands can read files but cannot write outside working dir
- [ ] On Linux with bwrap installed: verify sandboxed commands cannot make network requests
- [ ] On Linux without bwrap: verify warning is logged and command runs unsandboxed
- [ ] On macOS: verify existing sandbox-exec behavior is unchanged
- [ ] On unsupported platforms: verify generic warning and unsandboxed execution
- [ ] Type-check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
