### PR TITLE
Fix symlink bypass in path validation for file_write

### DIFF
--- a/assistant/src/tools/filesystem/path-guard.ts
+++ b/assistant/src/tools/filesystem/path-guard.ts
@@ -1,4 +1,4 @@
-import { resolve, relative } from 'node:path';
+import { resolve, relative, dirname, basename, join } from 'node:path';
 import { realpathSync } from 'node:fs';
 
 /**
@@ -9,8 +9,8 @@ import { realpathSync } from 'node:fs';
  *
  * For existing paths, symlinks are resolved via realpathSync so a symlink
  * pointing outside the boundary is caught. For new paths (file_write),
- * the caller should pass `mustExist: false` to skip the realpath check —
- * the lexical prefix check still catches `../` traversal.
+ * the caller should pass `mustExist: false` — the nearest existing ancestor
+ * directory is resolved via realpathSync to catch symlinks in parent dirs.
  */
 export function validateFilePath(
   rawPath: string,
@@ -22,7 +22,10 @@ export function validateFilePath(
   // Resolve to absolute path (handles relative paths and ..)
   const resolved = resolve(workingDir, rawPath);
 
-  // For existing files, resolve symlinks to catch symlink-based escapes
+  // Resolve symlinks to catch symlink-based escapes.
+  // For mustExist=false (file_write), walk up to the nearest existing
+  // ancestor and resolve it, then re-append the trailing components.
+  // This prevents symlink directories from escaping the boundary.
   let realResolved = resolved;
   if (mustExist) {
     try {
@@ -30,6 +33,19 @@ export function validateFilePath(
     } catch {
       // File doesn't exist — will be caught by the tool's own existence check
       realResolved = resolved;
+    }
+  } else {
+    let current = resolved;
+    const trailing: string[] = [];
+    while (current !== dirname(current)) {
+      try {
+        const real = realpathSync(current);
+        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
+        break;
+      } catch {
+        trailing.unshift(basename(current));
+        current = dirname(current);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix security bypass where `mustExist=false` (used by `file_write`) skipped `realpathSync` entirely, allowing symlink directories within the working directory to escape the boundary
- Walk up the directory tree to the nearest existing ancestor, resolve it via `realpathSync`, then re-append trailing components — catches symlinks in parent dirs even when the target file doesn't exist
- Also fixes a related usability issue where `context.workingDir` being a symlink caused legitimate writes to be rejected

Addresses feedback from [PR #152](https://github.com/vellum-ai/vellum-assistant/pull/152) (Codex and Devin reviews).

## Test plan
- [ ] Symlink dir inside workdir pointing outside → `file_write` to `link/file.txt` is correctly rejected
- [ ] Normal `file_write` to a new file within workdir succeeds
- [ ] `file_write` when `workingDir` is itself a symlink works correctly
- [ ] Existing `mustExist=true` behavior for `file_read`/`file_edit` unchanged
- [ ] Type-check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
