### PR TITLE
Fix SBPL injection and race condition in sandbox profile

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -1,5 +1,6 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { isMacOS, isLinux } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
@@ -55,18 +56,32 @@ const SANDBOX_PROFILE = `
 (deny process-info-pidinfo (target others))
 `.trim();
 
+/** Characters that are meaningful in SBPL syntax and must not appear in paths. */
+const SBPL_UNSAFE = /["()\\;\n\r]/;
+
+/**
+ * Validate that a path is safe to embed in an SBPL profile string.
+ * Returns true if the path contains no SBPL metacharacters.
+ */
+function isSafeForSBPL(path: string): boolean {
+  return !SBPL_UNSAFE.test(path);
+}
+
 /**
  * Get the path to the sandbox profile file, creating it if needed.
- * The profile is written to ~/.vellum/sandbox-profile.sb.
+ *
+ * Each distinct working directory gets its own profile file (keyed by
+ * a hash of the path) to avoid race conditions when concurrent commands
+ * use different working directories.
  */
 function getProfilePath(workingDir: string): string {
   const dir = join(process.env.HOME ?? '/tmp', '.vellum');
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const path = join(dir, 'sandbox-profile.sb');
+  const hash = createHash('sha256').update(workingDir).digest('hex').slice(0, 12);
+  const path = join(dir, `sandbox-profile-${hash}.sb`);
 
-  // Always rewrite with the current working directory
   const profile = SANDBOX_PROFILE.replace(/__WORKING_DIR__/g, workingDir);
   writeFileSync(path, profile + '\n');
   return path;
@@ -144,6 +159,14 @@ export function wrapCommand(
   }
 
   if (isMacOS()) {
+    if (!isSafeForSBPL(workingDir)) {
+      log.warn('Working directory contains characters unsafe for sandbox profile. Running unsandboxed.');
+      return {
+        command: 'bash',
+        args: ['-c', '--', command],
+        sandboxed: false,
+      };
+    }
     const profile = getProfilePath(workingDir);
     return {
       command: 'sandbox-exec',


### PR DESCRIPTION
## Summary
- Fix SBPL injection vulnerability: reject working directory paths containing SBPL metacharacters (`"`, `(`, `)`, `\`, `;`, newlines) before embedding in the sandbox profile. Falls back to unsandboxed with a warning.
- Fix race condition: use per-directory profile files keyed by a SHA-256 hash of the working directory path (`sandbox-profile-<hash>.sb`). Concurrent commands with different working directories no longer overwrite each other's profile.

Addresses feedback from [PR #153](https://github.com/vellum-ai/vellum-assistant/pull/153) (Devin and Codex reviews).

## Test plan
- [ ] Path with SBPL metacharacters (e.g., `"`, `)`) triggers unsandboxed fallback with warning
- [ ] Normal working directory paths continue to work with sandboxing
- [ ] Different working directories produce different profile files
- [ ] Same working directory produces the same profile file (deterministic hash)
- [ ] Type-check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
