### PR TITLE
Add rate limiting for API requests

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, mock } from 'bun:test';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { RateLimitProvider } from '../providers/ratelimit.js';
+import { RateLimitError } from '../util/errors.js';
+import type { Provider, ProviderResponse, Message } from '../providers/types.js';
+import type { RateLimitConfig } from '../config/types.js';
+
+function makeProvider(response?: Partial<ProviderResponse>): Provider {
+  return {
+    name: 'mock',
+    sendMessage: async () => ({
+      content: [{ type: 'text' as const, text: 'ok' }],
+      model: 'test-model',
+      usage: { inputTokens: 100, outputTokens: 50 },
+      stopReason: 'end_turn',
+      ...response,
+    }),
+  };
+}
+
+const messages: Message[] = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }];
+
+describe('RateLimitProvider', () => {
+  describe('request rate limiting', () => {
+    test('allows requests under the limit', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 5, maxTokensPerSession: 0 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      for (let i = 0; i < 5; i++) {
+        await provider.sendMessage(messages);
+      }
+    });
+
+    test('throws RateLimitError when exceeding request limit', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 2, maxTokensPerSession: 0 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      await provider.sendMessage(messages);
+      await provider.sendMessage(messages);
+
+      expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+
+    test('unlimited when maxRequestsPerMinute is 0', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 0 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      for (let i = 0; i < 100; i++) {
+        await provider.sendMessage(messages);
+      }
+    });
+  });
+
+  describe('session token limiting', () => {
+    test('allows requests under the token budget', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 1000 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      // Each call uses 150 tokens (100 input + 50 output)
+      for (let i = 0; i < 6; i++) {
+        await provider.sendMessage(messages);
+      }
+      // 6 * 150 = 900, still under 1000
+    });
+
+    test('throws RateLimitError when token budget exhausted', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 300 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      // 150 tokens per call
+      await provider.sendMessage(messages); // 150
+      await provider.sendMessage(messages); // 300
+
+      expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+
+    test('unlimited when maxTokensPerSession is 0', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 0 };
+      const provider = new RateLimitProvider(
+        makeProvider({ usage: { inputTokens: 10000, outputTokens: 10000 } }),
+        config,
+      );
+
+      for (let i = 0; i < 10; i++) {
+        await provider.sendMessage(messages);
+      }
+    });
+  });
+
+  describe('passthrough behavior', () => {
+    test('delegates to inner provider', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 0 };
+      const inner = makeProvider({ model: 'custom-model' });
+      const provider = new RateLimitProvider(inner, config);
+
+      const response = await provider.sendMessage(messages);
+      expect(response.model).toBe('custom-model');
+    });
+
+    test('preserves provider name', () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 0 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+      expect(provider.name).toBe('mock');
+    });
+
+    test('passes through all arguments to inner provider', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 0, maxTokensPerSession: 0 };
+      let receivedArgs: unknown[] = [];
+      const inner: Provider = {
+        name: 'spy',
+        sendMessage: async (...args) => {
+          receivedArgs = args;
+          return {
+            content: [{ type: 'text' as const, text: '' }],
+            model: 'test',
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: 'end_turn',
+          };
+        },
+      };
+      const provider = new RateLimitProvider(inner, config);
+
+      const tools = [{ name: 'test', description: 'test', input_schema: {} }];
+      const systemPrompt = 'hello';
+      const options = { config: { max_tokens: 100 } };
+
+      await provider.sendMessage(messages, tools, systemPrompt, options);
+
+      expect(receivedArgs[0]).toBe(messages);
+      expect(receivedArgs[1]).toBe(tools);
+      expect(receivedArgs[2]).toBe(systemPrompt);
+      expect(receivedArgs[3]).toBe(options);
+    });
+  });
+
+  describe('combined limits', () => {
+    test('enforces both limits simultaneously', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 10, maxTokensPerSession: 300 };
+      const provider = new RateLimitProvider(makeProvider(), config);
+
+      // Token limit should hit first (2 * 150 = 300)
+      await provider.sendMessage(messages);
+      await provider.sendMessage(messages);
+
+      expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -15,6 +15,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   sandbox: {
     enabled: false,
   },
+  rateLimit: {
+    maxRequestsPerMinute: 0,
+    maxTokensPerSession: 0,
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -61,6 +61,7 @@ export function loadConfig(): AssistantConfig {
       apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
       timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
       sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
+      rateLimit: { ...DEFAULT_CONFIG.rateLimit, ...(fileConfig as Record<string, unknown>).rateLimit as Partial<AssistantConfig['rateLimit']> },
     };
 
     // Set cached before validation so re-entrant calls (e.g. validateConfig
@@ -132,6 +133,16 @@ function validateConfig(config: AssistantConfig): void {
   if (typeof config.sandbox.enabled !== 'boolean') {
     log.warn(`Invalid sandbox.enabled "${config.sandbox.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.sandbox.enabled}.`);
     config.sandbox.enabled = DEFAULT_CONFIG.sandbox.enabled;
+  }
+
+  for (const field of ['maxRequestsPerMinute', 'maxTokensPerSession'] as const) {
+    const val = config.rateLimit[field];
+    if (typeof val !== 'number' || !Number.isFinite(val) || val < 0 || !Number.isInteger(val)) {
+      log.warn(
+        `Invalid rateLimit.${field} "${val}". Must be a non-negative integer. Falling back to ${DEFAULT_CONFIG.rateLimit[field]}.`,
+      );
+      config.rateLimit[field] = DEFAULT_CONFIG.rateLimit[field];
+    }
   }
 }
 

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -12,6 +12,13 @@ export interface SandboxConfig {
   enabled: boolean;
 }
 
+export interface RateLimitConfig {
+  /** Maximum API requests per minute. 0 = unlimited. */
+  maxRequestsPerMinute: number;
+  /** Maximum total tokens (input + output) per session. 0 = unlimited. */
+  maxTokensPerSession: number;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
@@ -21,4 +28,5 @@ export interface AssistantConfig {
   dataDir: string;
   timeouts: TimeoutConfig;
   sandbox: SandboxConfig;
+  rateLimit: RateLimitConfig;
 }

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -1,0 +1,76 @@
+import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
+import type { RateLimitConfig } from '../config/types.js';
+import { RateLimitError } from '../util/errors.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('rate-limit');
+
+export class RateLimitProvider implements Provider {
+  public readonly name: string;
+
+  private requestTimestamps: number[] = [];
+  private sessionTokens = 0;
+
+  constructor(
+    private readonly inner: Provider,
+    private readonly config: RateLimitConfig,
+  ) {
+    this.name = inner.name;
+  }
+
+  async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    this.enforceRequestRate();
+    this.enforceTokenBudget();
+
+    const response = await this.inner.sendMessage(messages, tools, systemPrompt, options);
+
+    this.recordRequest();
+    this.recordTokens(response.usage.inputTokens + response.usage.outputTokens);
+
+    return response;
+  }
+
+  private enforceRequestRate(): void {
+    const limit = this.config.maxRequestsPerMinute;
+    if (limit <= 0) return;
+
+    const now = Date.now();
+    const windowStart = now - 60_000;
+    this.requestTimestamps = this.requestTimestamps.filter((t) => t > windowStart);
+
+    if (this.requestTimestamps.length >= limit) {
+      const oldestInWindow = this.requestTimestamps[0];
+      const waitSec = Math.ceil((oldestInWindow + 60_000 - now) / 1000);
+      throw new RateLimitError(
+        `Rate limit exceeded: ${limit} requests/minute. Try again in ${waitSec}s.`,
+      );
+    }
+  }
+
+  private enforceTokenBudget(): void {
+    const limit = this.config.maxTokensPerSession;
+    if (limit <= 0) return;
+
+    if (this.sessionTokens >= limit) {
+      throw new RateLimitError(
+        `Session token budget exhausted: ${this.sessionTokens.toLocaleString()}/${limit.toLocaleString()} tokens used. Start a new session to continue.`,
+      );
+    }
+  }
+
+  private recordRequest(): void {
+    if (this.config.maxRequestsPerMinute <= 0) return;
+    this.requestTimestamps.push(Date.now());
+  }
+
+  private recordTokens(tokens: number): void {
+    if (this.config.maxTokensPerSession <= 0) return;
+    this.sessionTokens += tokens;
+    log.debug({ sessionTokens: this.sessionTokens, limit: this.config.maxTokensPerSession }, 'Token usage updated');
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,6 +1,8 @@
 import type { Provider } from "./types.js";
+import type { RateLimitConfig } from "../config/types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { RetryProvider } from "./retry.js";
+import { RateLimitProvider } from "./ratelimit.js";
 import { ConfigError } from "../util/errors.js";
 
 const providers = new Map<string, Provider>();
@@ -27,13 +29,17 @@ export interface ProvidersConfig {
   apiKeys: Record<string, string>;
   provider: string;
   model: string;
+  rateLimit: RateLimitConfig;
 }
 
 export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
-    const provider = new RetryProvider(
+    let provider: Provider = new RetryProvider(
       new AnthropicProvider(config.apiKeys.anthropic, config.model),
     );
+    if (config.rateLimit.maxRequestsPerMinute > 0 || config.rateLimit.maxTokensPerSession > 0) {
+      provider = new RateLimitProvider(provider, config.rateLimit);
+    }
     registerProvider("anthropic", provider);
   }
 }

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -23,6 +23,9 @@ export enum ErrorCode {
   // WASM integrity check failures
   INTEGRITY_ERROR = 'INTEGRITY_ERROR',
 
+  // Rate limit exceeded
+  RATE_LIMIT_ERROR = 'RATE_LIMIT_ERROR',
+
   // Internal/unexpected errors
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
@@ -102,5 +105,12 @@ export class IntegrityError extends AssistantError {
   constructor(message: string) {
     super(message, ErrorCode.INTEGRITY_ERROR);
     this.name = 'IntegrityError';
+  }
+}
+
+export class RateLimitError extends AssistantError {
+  constructor(message: string) {
+    super(message, ErrorCode.RATE_LIMIT_ERROR);
+    this.name = 'RateLimitError';
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `RateLimitProvider` decorator that wraps the provider chain to enforce configurable rate limits before API calls are made
- Two configurable limits: `maxRequestsPerMinute` (sliding window) and `maxTokensPerSession` (cumulative budget), both defaulting to 0 (unlimited)
- Configured via `rateLimit` section in `~/.vellum/config.json`; only activates when at least one limit is set above 0

## Test plan
- [x] 10 new unit tests covering request rate limiting, token budget limiting, passthrough behavior, and combined limits
- [x] All 222 tests pass (including existing tests)
- [x] TypeScript compiles cleanly with `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
