### PR TITLE
Fix --no-sandbox to be per-session and survive reconnects

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -468,6 +468,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       try {
         await ensureDaemonRunning();
         await connect();
+        if (options.noSandbox) {
+          send({ type: 'sandbox_set', enabled: false });
+        }
         reconnecting = false;
         return;
       } catch {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -22,6 +22,7 @@ export class DaemonServer {
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
   private connectedSockets = new Set<net.Socket>();
+  private socketSandboxOverride = new Map<net.Socket, boolean>();
   // Guards against duplicate session creation when multiple clients connect
   // with the same conversation ID concurrently. The first caller creates the
   // session; subsequent callers await the same promise.
@@ -102,6 +103,7 @@ export class DaemonServer {
     }
     this.connectedSockets.clear();
     this.socketToSession.clear();
+    this.socketSandboxOverride.clear();
 
     await serverClosed;
     log.info('Daemon server stopped');
@@ -188,6 +190,7 @@ export class DaemonServer {
 
     socket.on('close', () => {
       this.connectedSockets.delete(socket);
+      this.socketSandboxOverride.delete(socket);
       const sessionId = this.socketToSession.get(socket);
       if (sessionId) {
         const session = this.sessions.get(sessionId);
@@ -256,6 +259,10 @@ export class DaemonServer {
           workingDir,
         );
         await newSession.loadFromDb();
+        const override = this.socketSandboxOverride.get(socket);
+        if (override !== undefined) {
+          newSession.setSandboxOverride(override);
+        }
         this.sessions.set(conversationId, newSession);
         return newSession;
       })();
@@ -269,6 +276,10 @@ export class DaemonServer {
     } else {
       // Rebind to the new socket so IPC goes to the current client
       session.updateClient(sendToClient);
+      const override = this.socketSandboxOverride.get(socket);
+      if (override !== undefined) {
+        session.setSandboxOverride(override);
+      }
     }
     return session;
   }
@@ -328,7 +339,7 @@ export class DaemonServer {
         this.handleUsageRequest(msg.sessionId, socket);
         break;
       case 'sandbox_set':
-        this.handleSandboxSet(msg.enabled);
+        this.handleSandboxSet(msg.enabled, socket);
         break;
       case 'ping':
         this.send(socket, { type: 'pong' });
@@ -454,12 +465,18 @@ export class DaemonServer {
     }
   }
 
-  private handleSandboxSet(enabled: boolean): void {
-    // Runtime-only override: modify the in-memory config without persisting
-    // to disk. Takes effect immediately for all subsequent shell executions.
-    const config = getConfig();
-    config.sandbox.enabled = enabled;
-    log.info({ enabled }, 'Sandbox override applied (runtime only)');
+  private handleSandboxSet(enabled: boolean, socket: net.Socket): void {
+    // Per-socket override: store the sandbox preference for this client only.
+    // The override is applied to the session so it doesn't affect other clients.
+    this.socketSandboxOverride.set(socket, enabled);
+    const sessionId = this.socketToSession.get(socket);
+    if (sessionId) {
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        session.setSandboxOverride(enabled);
+      }
+    }
+    log.info({ enabled }, 'Sandbox override applied (per-session)');
   }
 
   private handleHistoryRequest(sessionId: string, socket: net.Socket): void {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -25,6 +25,7 @@ export class Session {
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
   private workingDir: string;
+  private sandboxOverride?: boolean;
   private totalInputTokens = 0;
   private totalOutputTokens = 0;
   private totalEstimatedCost = 0;
@@ -49,6 +50,7 @@ export class Session {
         sessionId: this.conversationId,
         conversationId: this.conversationId,
         onOutput,
+        sandboxOverride: this.sandboxOverride,
       });
     };
 
@@ -80,6 +82,10 @@ export class Session {
 
   updateClient(sendToClient: (msg: ServerMessage) => void): void {
     this.prompter.updateSender(sendToClient);
+  }
+
+  setSandboxOverride(enabled: boolean): void {
+    this.sandboxOverride = enabled;
   }
 
   isProcessing(): boolean {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -68,7 +68,8 @@ export class ToolExecutor {
         // Check if this shell command will run sandboxed
         let sandboxed: boolean | undefined;
         if (name === 'shell' && typeof input.command === 'string') {
-          const wrapped = wrapCommand(input.command, context.workingDir, getConfig().sandbox.enabled);
+          const sandboxEnabled = context.sandboxOverride ?? getConfig().sandbox.enabled;
+          const wrapped = wrapCommand(input.command, context.workingDir, sandboxEnabled);
           sandboxed = wrapped.sandboxed;
         }
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -63,7 +63,8 @@ class ShellTool implements Tool {
       let stderr = '';
       let timedOut = false;
 
-      const wrapped = wrapCommand(command, context.workingDir, config.sandbox.enabled);
+      const sandboxEnabled = context.sandboxOverride ?? config.sandbox.enabled;
+      const wrapped = wrapCommand(command, context.workingDir, sandboxEnabled);
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env: { ...process.env },

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -7,6 +7,8 @@ export interface ToolContext {
   conversationId: string;
   /** Optional callback for streaming incremental output to the client. */
   onOutput?: (chunk: string) => void;
+  /** Per-session sandbox override. When set, takes precedence over the global config. */
+  sandboxOverride?: boolean;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Sandbox override is now stored per-socket in the DaemonServer instead of mutating the global config singleton, so one client's `--no-sandbox` doesn't affect other connected clients
- Override is threaded through `Session` → `ToolContext` → `executor`/`shell` so both the permission prompt indicator and actual sandbox wrapping respect the per-session setting
- CLI re-sends `sandbox_set` after reconnecting to the daemon, so the override isn't silently lost on reconnect/daemon restart

Addresses review feedback on #154.

## Test plan
- [x] All 222 tests pass
- [x] TypeScript compiles cleanly with `tsc --noEmit`
- [ ] Manual: `vellum --no-sandbox` disables sandbox only for that client session
- [ ] Manual: A second concurrent client without `--no-sandbox` still has sandbox enabled
- [ ] Manual: After daemon restart, reconnected client re-applies `--no-sandbox` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
