### PR TITLE
Fix rate limiter race condition and per-session token tracking

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -151,4 +151,50 @@ describe('RateLimitProvider', () => {
       expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
     });
   });
+
+  describe('race condition prevention', () => {
+    test('concurrent calls are rate-limited because timestamp is recorded before await', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 1, maxTokensPerSession: 0 };
+      // Slow provider that yields to the event loop
+      const inner: Provider = {
+        name: 'slow',
+        sendMessage: async () => {
+          await new Promise((r) => setTimeout(r, 10));
+          return {
+            content: [{ type: 'text' as const, text: '' }],
+            model: 'test',
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: 'end_turn',
+          };
+        },
+      };
+      const provider = new RateLimitProvider(inner, config);
+
+      // Fire two concurrent requests — second should fail
+      const results = await Promise.allSettled([
+        provider.sendMessage(messages),
+        provider.sendMessage(messages),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter((r) => r.status === 'rejected');
+      expect(fulfilled.length).toBe(1);
+      expect(rejected.length).toBe(1);
+    });
+
+    test('failed inner calls still count toward request rate', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 1, maxTokensPerSession: 0 };
+      const inner: Provider = {
+        name: 'failing',
+        sendMessage: async () => { throw new Error('provider error'); },
+      };
+      const provider = new RateLimitProvider(inner, config);
+
+      // First call fails at the provider level
+      await expect(provider.sendMessage(messages)).rejects.toThrow('provider error');
+
+      // Second call should be rate-limited (timestamp was recorded before the failed await)
+      await expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+  });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -23,7 +23,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox } };
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit } };
   loading = true;
 
   try {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,6 +3,7 @@ import { unlinkSync, existsSync, chmodSync, watch, type FSWatcher } from 'node:f
 import { getSocketPath, getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
+import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
@@ -247,7 +248,11 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        const provider = getProvider(config.provider);
+        let provider = getProvider(config.provider);
+        const { rateLimit } = config;
+        if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
+          provider = new RateLimitProvider(provider, rateLimit);
+        }
         const workingDir = process.cwd();
 
         const newSession = new Session(

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -27,9 +27,12 @@ export class RateLimitProvider implements Provider {
     this.enforceRequestRate();
     this.enforceTokenBudget();
 
+    // Record the request timestamp before the await to prevent concurrent
+    // calls from bypassing the rate limit during the async gap.
+    this.recordRequest();
+
     const response = await this.inner.sendMessage(messages, tools, systemPrompt, options);
 
-    this.recordRequest();
     this.recordTokens(response.usage.inputTokens + response.usage.outputTokens);
 
     return response;

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,8 +1,6 @@
 import type { Provider } from "./types.js";
-import type { RateLimitConfig } from "../config/types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { RetryProvider } from "./retry.js";
-import { RateLimitProvider } from "./ratelimit.js";
 import { ConfigError } from "../util/errors.js";
 
 const providers = new Map<string, Provider>();
@@ -29,17 +27,13 @@ export interface ProvidersConfig {
   apiKeys: Record<string, string>;
   provider: string;
   model: string;
-  rateLimit: RateLimitConfig;
 }
 
 export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
-    let provider: Provider = new RetryProvider(
+    const provider: Provider = new RetryProvider(
       new AnthropicProvider(config.apiKeys.anthropic, config.model),
     );
-    if (config.rateLimit.maxRequestsPerMinute > 0 || config.rateLimit.maxTokensPerSession > 0) {
-      provider = new RateLimitProvider(provider, config.rateLimit);
-    }
     registerProvider("anthropic", provider);
   }
 }


### PR DESCRIPTION
## Summary
- **Race condition fix**: Move `recordRequest()` before the `await` so concurrent calls see each other's in-flight requests and can't bypass the rate limit during the async gap. Failed provider calls now also count toward the request rate.
- **Per-session token tracking**: Wrap with `RateLimitProvider` at session creation instead of at provider initialization, so each session gets its own instance with independent `sessionTokens` counters. Previously all sessions shared a single global counter.
- **Config re-entrancy guard**: Add `rateLimit` shallow copy to the re-entrancy guard in `loadConfig()` to match the pattern for `apiKeys`, `timeouts`, and `sandbox`, preventing potential `DEFAULT_CONFIG.rateLimit` mutation.

Addresses review feedback from #158.

## Test plan
- [x] Existing rate limit tests pass (12 tests)
- [x] New test: concurrent calls are correctly rate-limited
- [x] New test: failed inner provider calls still count toward request rate
- [x] Full test suite passes (224 tests)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
