### PR TITLE
Fix stale sandbox override on session reconnect

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -264,10 +264,7 @@ export class DaemonServer {
           workingDir,
         );
         await newSession.loadFromDb();
-        const override = this.socketSandboxOverride.get(socket);
-        if (override !== undefined) {
-          newSession.setSandboxOverride(override);
-        }
+        newSession.setSandboxOverride(this.socketSandboxOverride.get(socket));
         this.sessions.set(conversationId, newSession);
         return newSession;
       })();
@@ -281,10 +278,7 @@ export class DaemonServer {
     } else {
       // Rebind to the new socket so IPC goes to the current client
       session.updateClient(sendToClient);
-      const override = this.socketSandboxOverride.get(socket);
-      if (override !== undefined) {
-        session.setSandboxOverride(override);
-      }
+      session.setSandboxOverride(this.socketSandboxOverride.get(socket));
     }
     return session;
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -84,7 +84,7 @@ export class Session {
     this.prompter.updateSender(sendToClient);
   }
 
-  setSandboxOverride(enabled: boolean): void {
+  setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
   }
 


### PR DESCRIPTION
## Summary
- **Security fix**: When a client with `--no-sandbox` disconnects and a new client reconnects to the same session *without* `--no-sandbox`, the session's `sandboxOverride = false` persisted from the previous client. Shell commands would silently run unsandboxed for the new client.
- Always call `setSandboxOverride` with the current socket's value (or `undefined` when absent), resetting the session to use the global sandbox config when no override is specified.
- Update `setSandboxOverride` to accept `boolean | undefined` so the override can be cleared.

Addresses review feedback from #159.

## Test plan
- [x] Full test suite passes (224 tests)
- [x] TypeScript compiles cleanly
- [x] Manual review: both code paths in `getOrCreateSession` (new session and existing session) now unconditionally set the sandbox override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
