### PR TITLE
Verify bwrap namespace creation, not just binary existence

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -87,13 +87,21 @@ function getProfilePath(workingDir: string): string {
   return path;
 }
 
-/** Cache bwrap availability check so we only shell out once. */
+/** Cache bwrap usability check so we only shell out once. */
 let bwrapAvailable: boolean | null = null;
 
+/**
+ * Check whether bwrap is installed AND functional (can create namespaces).
+ *
+ * Just testing `bwrap --version` is not enough — the binary may exist but
+ * namespace creation can be blocked by the kernel (e.g. inside containers
+ * or when user namespaces are disabled). We run a minimal sandbox that
+ * executes `true` to verify end-to-end functionality.
+ */
 function isBwrapAvailable(): boolean {
   if (bwrapAvailable !== null) return bwrapAvailable;
   try {
-    execSync('bwrap --version', { stdio: 'ignore' });
+    execSync('bwrap --ro-bind / / true', { stdio: 'ignore', timeout: 5000 });
     bwrapAvailable = true;
   } catch {
     bwrapAvailable = false;
@@ -177,7 +185,7 @@ export function wrapCommand(
 
   if (isLinux()) {
     if (!isBwrapAvailable()) {
-      log.warn('Sandbox is enabled but bwrap is not installed. Running unsandboxed. Install bubblewrap: apt install bubblewrap');
+      log.warn('Sandbox is enabled but bwrap is not available or cannot create namespaces. Running unsandboxed. Install bubblewrap: apt install bubblewrap');
       return {
         command: 'bash',
         args: ['-c', '--', command],


### PR DESCRIPTION
## Summary
- **Bug fix**: `isBwrapAvailable()` was only checking `bwrap --version` which verifies the binary exists, but not that bwrap can actually create namespaces. On Linux hosts where user namespaces are disabled (common in containers/hardened kernels), bwrap would be detected as available but fail at runtime, causing shell commands to error instead of falling back to unsandboxed execution.
- Replace with `bwrap --ro-bind / / true` — a minimal functional test that exercises namespace creation with a 5s timeout.
- Updated warning message to mention both "not available" and "cannot create namespaces".

Addresses review feedback from #155.

## Test plan
- [x] Full test suite passes (224 tests)
- [x] TypeScript compiles cleanly
- [x] On macOS (no bwrap): `isBwrapAvailable()` correctly returns false and falls back to unsandboxed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
