### PR TITLE
Fail closed when working directory has SBPL-unsafe characters

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { isMacOS, isLinux } from '../../util/platform.js';
+import { ToolError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('sandbox');
@@ -168,12 +169,11 @@ export function wrapCommand(
 
   if (isMacOS()) {
     if (!isSafeForSBPL(workingDir)) {
-      log.warn('Working directory contains characters unsafe for sandbox profile. Running unsandboxed.');
-      return {
-        command: 'bash',
-        args: ['-c', '--', command],
-        sandboxed: false,
-      };
+      throw new ToolError(
+        `Sandbox is enabled but the working directory contains characters unsafe for the sandbox profile (SBPL metacharacters). ` +
+        `Refusing to execute unsandboxed. Change to a directory without special characters in its path, or disable sandboxing.`,
+        'shell',
+      );
     }
     const profile = getProfilePath(workingDir);
     return {


### PR DESCRIPTION
## Summary
- **Security fix**: When sandbox is enabled on macOS but the working directory contains SBPL metacharacters (`"`, `(`, `)`, `\`, `;`), the code was silently falling back to unsandboxed execution. This made sandboxing trivially bypassable by running from a directory like `~/project (old)`.
- Now throws a `ToolError` instead of downgrading to unsandboxed, refusing to execute. The user must either change to a safe directory or disable sandboxing explicitly.

Addresses review feedback from #157.

## Test plan
- [x] Full test suite passes (224 tests)
- [x] TypeScript compiles cleanly
- [x] The error path is reached only when sandbox is enabled AND the macOS working directory contains SBPL metacharacters — a rare edge case that should fail loudly rather than silently bypass security

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
