### PR TITLE
Fix global rate limiting and sandbox override race (#160, #161 feedback)

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -28,6 +28,8 @@ export class DaemonServer {
   // with the same conversation ID concurrently. The first caller creates the
   // session; subsequent callers await the same promise.
   private sessionCreating = new Map<string, Promise<Session>>();
+  // Shared across all sessions so maxRequestsPerMinute is enforced globally.
+  private sharedRequestTimestamps: number[] = [];
   private socketPath: string;
   private watchers: FSWatcher[] = [];
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -243,6 +245,7 @@ export class DaemonServer {
       if (pending) {
         session = await pending;
         session.updateClient(sendToClient);
+        session.setSandboxOverride(this.socketSandboxOverride.get(socket));
         return session;
       }
 
@@ -251,7 +254,7 @@ export class DaemonServer {
         let provider = getProvider(config.provider);
         const { rateLimit } = config;
         if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
-          provider = new RateLimitProvider(provider, rateLimit);
+          provider = new RateLimitProvider(provider, rateLimit, this.sharedRequestTimestamps);
         }
         const workingDir = process.cwd();
 

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -8,14 +8,16 @@ const log = getLogger('rate-limit');
 export class RateLimitProvider implements Provider {
   public readonly name: string;
 
-  private requestTimestamps: number[] = [];
+  private requestTimestamps: number[];
   private sessionTokens = 0;
 
   constructor(
     private readonly inner: Provider,
     private readonly config: RateLimitConfig,
+    sharedRequestTimestamps?: number[],
   ) {
     this.name = inner.name;
+    this.requestTimestamps = sharedRequestTimestamps ?? [];
   }
 
   async sendMessage(


### PR DESCRIPTION
## Summary

- **Global request rate limiting**: `RateLimitProvider` was instantiated per-session, so `maxRequestsPerMinute` could be bypassed by spreading calls across multiple sessions. Request timestamps are now shared globally via a common array reference, while per-session token budgets (`maxTokensPerSession`) remain correctly scoped per-session.
- **Sandbox override in pending-session path**: `getOrCreateSession` has three code paths (new, existing, pending). The pending path (concurrent session creation guard) was missing a `setSandboxOverride` call, causing the second client to silently inherit the first client's sandbox preference — the exact class of bug PR #161 aimed to fix.

## Test plan

- [x] All 224 existing tests pass
- [x] TypeScript compilation passes with no errors
- [ ] Manual: start daemon, connect two clients to different sessions, verify rate limit is enforced globally
- [ ] Manual: trigger concurrent session creation race and verify sandbox override is applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
