### PR TITLE
Test all namespace types in bwrap availability check (#163 feedback)

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -97,12 +97,13 @@ let bwrapAvailable: boolean | null = null;
  * Just testing `bwrap --version` is not enough — the binary may exist but
  * namespace creation can be blocked by the kernel (e.g. inside containers
  * or when user namespaces are disabled). We run a minimal sandbox that
- * executes `true` to verify end-to-end functionality.
+ * exercises all namespace types used by buildBwrapArgs() (mount, network,
+ * PID) to verify end-to-end functionality.
  */
 function isBwrapAvailable(): boolean {
   if (bwrapAvailable !== null) return bwrapAvailable;
   try {
-    execSync('bwrap --ro-bind / / true', { stdio: 'ignore', timeout: 5000 });
+    execSync('bwrap --ro-bind / / --unshare-net --unshare-pid true', { stdio: 'ignore', timeout: 5000 });
     bwrapAvailable = true;
   } catch {
     bwrapAvailable = false;


### PR DESCRIPTION
## Summary

- The bwrap availability check only tested mount namespace creation (`--ro-bind / / true`), but `buildBwrapArgs()` also uses `--unshare-net` and `--unshare-pid`
- On systems where mount namespaces work but network/PID namespace creation is blocked (e.g. containers with restrictive seccomp profiles), the check would pass but actual sandboxed commands would fail at runtime
- Now exercises all three namespace types (`--ro-bind / / --unshare-net --unshare-pid true`) to match the actual sandbox configuration

## Test plan

- [x] All 282 tests pass
- [x] TypeScript compilation passes
- [ ] Verify on a system with restricted namespace support that the check correctly falls back to unsandboxed execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
