### PR TITLE
Fix shared rate limit array detachment on prune (#165 feedback)

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -152,6 +152,43 @@ describe('RateLimitProvider', () => {
     });
   });
 
+  describe('shared request timestamps', () => {
+    test('multiple providers sharing timestamps enforce a global rate limit', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 2, maxTokensPerSession: 0 };
+      const shared: number[] = [];
+      const provider1 = new RateLimitProvider(makeProvider(), config, shared);
+      const provider2 = new RateLimitProvider(makeProvider(), config, shared);
+
+      // Each provider sends one request — together they hit the limit of 2
+      await provider1.sendMessage(messages);
+      await provider2.sendMessage(messages);
+
+      // A third request from either provider should be rate-limited
+      await expect(provider1.sendMessage(messages)).rejects.toThrow(RateLimitError);
+      await expect(provider2.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+
+    test('shared array reference survives pruning', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 100, maxTokensPerSession: 0 };
+      const shared: number[] = [];
+      const provider1 = new RateLimitProvider(makeProvider(), config, shared);
+      const provider2 = new RateLimitProvider(makeProvider(), config, shared);
+
+      // Provider 1 sends a request, adding a timestamp to the shared array
+      await provider1.sendMessage(messages);
+      expect(shared.length).toBe(1);
+
+      // Provider 2 sends a request — enforceRequestRate prunes expired
+      // entries, but the shared reference must still be the same array
+      await provider2.sendMessage(messages);
+      expect(shared.length).toBe(2);
+
+      // Both providers still share the same underlying array
+      await provider1.sendMessage(messages);
+      expect(shared.length).toBe(3);
+    });
+  });
+
   describe('race condition prevention', () => {
     test('concurrent calls are rate-limited because timestamp is recorded before await', async () => {
       const config: RateLimitConfig = { maxRequestsPerMinute: 1, maxTokensPerSession: 0 };

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -46,7 +46,15 @@ export class RateLimitProvider implements Provider {
 
     const now = Date.now();
     const windowStart = now - 60_000;
-    this.requestTimestamps = this.requestTimestamps.filter((t) => t > windowStart);
+    // Prune expired timestamps in-place to preserve the shared array
+    // reference. Using .filter() would create a new array, breaking the
+    // cross-session sharing established by DaemonServer.
+    const cutoff = this.requestTimestamps.findIndex((t) => t > windowStart);
+    if (cutoff > 0) {
+      this.requestTimestamps.splice(0, cutoff);
+    } else if (cutoff === -1) {
+      this.requestTimestamps.length = 0;
+    }
 
     if (this.requestTimestamps.length >= limit) {
       const oldestInWindow = this.requestTimestamps[0];


### PR DESCRIPTION
## Summary

- `enforceRequestRate()` used `Array.filter()` which creates a new array and reassigns `this.requestTimestamps`, breaking the shared reference to `DaemonServer.sharedRequestTimestamps`
- After the first prune, each session's `RateLimitProvider` had its own private array, defeating the global rate limiting introduced in PR #165
- Fixed by mutating the shared array in-place with `splice(0, cutoff)` / `length = 0` instead of reassigning
- Added 2 tests: cross-session rate enforcement and shared reference survival after pruning

## Test plan

- [x] All 284 tests pass (2 new)
- [x] TypeScript compilation passes
- [x] New test verifies two providers sharing timestamps enforce a single global limit
- [x] New test verifies shared array reference survives the prune operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
