### PR TITLE
Entropy-based secret detection

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect } from 'bun:test';
 import {
   scanText,
   redactSecrets,
+  shannonEntropy,
   _isPlaceholder,
   _redact,
+  _hasSecretContext,
   type SecretMatch,
 } from '../security/secret-scanner.js';
 
@@ -500,5 +502,146 @@ describe('false positive resistance', () => {
     const matches = scanText(pubKey);
     const privKeys = matches.filter((m) => m.type === 'Private Key');
     expect(privKeys).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shannon entropy
+// ---------------------------------------------------------------------------
+describe('shannonEntropy', () => {
+  test('returns 0 for empty string', () => {
+    expect(shannonEntropy('')).toBe(0);
+  });
+
+  test('returns 0 for single repeated character', () => {
+    expect(shannonEntropy('aaaaaa')).toBe(0);
+  });
+
+  test('returns 1.0 for two equally distributed characters', () => {
+    expect(shannonEntropy('ababab')).toBeCloseTo(1.0, 5);
+  });
+
+  test('returns high entropy for random-looking strings', () => {
+    // A high-entropy hex string
+    const entropy = shannonEntropy('a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4');
+    expect(entropy).toBeGreaterThan(3.0);
+  });
+
+  test('returns lower entropy for structured/repetitive content', () => {
+    const entropy = shannonEntropy('abcabcabcabcabcabc');
+    expect(entropy).toBeLessThan(2.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entropy-based secret detection
+// ---------------------------------------------------------------------------
+describe('entropy-based detection', () => {
+  test('detects high-entropy hex token near secret keyword', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `api_key = ${hexSecret}`;
+    const matches = scanText(input);
+    const entropyMatch = matches.find((m) => m.type === 'High-Entropy Hex Token');
+    expect(entropyMatch).toBeDefined();
+    expect(entropyMatch!.startIndex).toBe(input.indexOf(hexSecret));
+  });
+
+  test('detects high-entropy base64 token near secret keyword', () => {
+    const b64Secret = 'aB3cD4eF5gH6iJ7kL8mN+pQ/rS0tU1vW2xY3zA=';
+    const input = `token: "${b64Secret}"`;
+    const matches = scanText(input);
+    const entropyMatch = matches.find((m) => m.type === 'High-Entropy Base64 Token');
+    expect(entropyMatch).toBeDefined();
+  });
+
+  test('does not flag high-entropy hex without secret context', () => {
+    const hexString = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    // No secret keyword nearby — just "checksum"
+    const input = `checksum: ${hexString}`;
+    const matches = scanText(input);
+    const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches).toHaveLength(0);
+  });
+
+  test('does not flag low-entropy tokens even with context', () => {
+    // Repeated pattern = low entropy
+    const lowEntropy = 'abcabcabcabcabcabcabcabc';
+    const input = `secret = ${lowEntropy}`;
+    const matches = scanText(input);
+    const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches).toHaveLength(0);
+  });
+
+  test('does not flag tokens shorter than minLength', () => {
+    const shortToken = 'a3f8c1b2d9e4f5a6';
+    const input = `api_key = ${shortToken}`;
+    const matches = scanText(input);
+    const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches).toHaveLength(0);
+  });
+
+  test('can be disabled via config', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `api_key = ${hexSecret}`;
+    const matches = scanText(input, { enabled: false });
+    const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyMatches).toHaveLength(0);
+  });
+
+  test('respects custom threshold', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `api_key = ${hexSecret}`;
+
+    // With extremely high threshold, nothing matches
+    const matchesHigh = scanText(input, { hexThreshold: 10.0 });
+    const entropyHigh = matchesHigh.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyHigh).toHaveLength(0);
+
+    // With low threshold, it matches
+    const matchesLow = scanText(input, { hexThreshold: 1.0 });
+    const entropyLow = matchesLow.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropyLow.length).toBeGreaterThan(0);
+  });
+
+  test('does not double-count tokens already matched by patterns', () => {
+    // An AWS access key should only appear once (pattern match), not again as entropy
+    const input = `api_key = AKIAIOSFODNN7REALKEY`;
+    const matches = scanText(input);
+    const awsMatches = matches.filter((m) => m.type === 'AWS Access Key');
+    const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(awsMatches).toHaveLength(1);
+    // Should not have an entropy match for the same range
+    expect(entropyMatches).toHaveLength(0);
+  });
+
+  test('recognizes various secret context keywords', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const keywords = ['secret', 'password', 'bearer', 'credentials', 'access_key', 'private_key'];
+    for (const kw of keywords) {
+      const input = `${kw} = ${hexSecret}`;
+      const matches = scanText(input);
+      const entropyMatches = matches.filter((m) => m.type.startsWith('High-Entropy'));
+      expect(entropyMatches.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasSecretContext helper
+// ---------------------------------------------------------------------------
+describe('hasSecretContext', () => {
+  test('detects keyword in prefix', () => {
+    const text = 'api_key = abc123';
+    expect(_hasSecretContext(text, 10)).toBe(true);
+  });
+
+  test('returns false without keyword', () => {
+    const text = 'username = abc123';
+    expect(_hasSecretContext(text, 11)).toBe(false);
+  });
+
+  test('detects keyword case-insensitively', () => {
+    const text = 'API_KEY = abc123';
+    expect(_hasSecretContext(text, 10)).toBe(true);
   });
 });

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -271,6 +271,170 @@ function isLikelyAwsSecret(value: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Entropy-based detection
+// ---------------------------------------------------------------------------
+
+export interface EntropyConfig {
+  /** Enable entropy-based scanning. Default: true */
+  enabled: boolean;
+  /** Minimum Shannon entropy (bits per char) for hex tokens. Default: 3.0 */
+  hexThreshold: number;
+  /** Minimum Shannon entropy (bits per char) for base64 tokens. Default: 4.0 */
+  base64Threshold: number;
+  /** Minimum token length to consider. Default: 20 */
+  minLength: number;
+}
+
+export const DEFAULT_ENTROPY_CONFIG: EntropyConfig = {
+  enabled: true,
+  hexThreshold: 3.0,
+  base64Threshold: 4.0,
+  minLength: 20,
+};
+
+/**
+ * Calculate Shannon entropy in bits per character.
+ * Higher entropy = more random = more likely to be a secret.
+ */
+export function shannonEntropy(s: string): number {
+  if (s.length === 0) return 0;
+  const freq = new Map<string, number>();
+  for (const ch of s) {
+    freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of freq.values()) {
+    const p = count / s.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+/** Keywords that, when adjacent to a high-entropy token, boost confidence. */
+const SECRET_CONTEXT_KEYWORDS = [
+  'key', 'token', 'secret', 'password', 'passwd', 'pwd',
+  'api_key', 'api-key', 'apikey',
+  'access_key', 'access-key', 'accesskey',
+  'auth_token', 'auth-token', 'authtoken',
+  'bearer', 'authorization',
+  'credential', 'credentials',
+  'private_key', 'private-key',
+  'client_secret', 'client-secret',
+  'signing_key', 'signing-key',
+  'encryption_key', 'encryption-key',
+];
+
+/** Match hex strings (20+ chars of [0-9a-fA-F]) */
+const HEX_TOKEN_RE = /\b([0-9a-fA-F]{20,})\b/g;
+
+/** Match base64 strings (20+ chars of [A-Za-z0-9+/=_-]) that aren't pure alphanumeric */
+const BASE64_TOKEN_RE = /\b([A-Za-z0-9+/\-_]{20,}={0,3})\b/g;
+
+/**
+ * Check whether a token appears near a secret-related keyword in the
+ * surrounding text (up to 60 chars before the match).
+ */
+function hasSecretContext(text: string, matchStart: number): boolean {
+  // Look at up to 60 chars before the token for context keywords
+  const contextStart = Math.max(0, matchStart - 60);
+  const prefix = text.slice(contextStart, matchStart).toLowerCase();
+  return SECRET_CONTEXT_KEYWORDS.some((kw) => prefix.includes(kw));
+}
+
+/**
+ * Check if a string is purely hex characters.
+ */
+function isHex(s: string): boolean {
+  return /^[0-9a-fA-F]+$/.test(s);
+}
+
+/**
+ * Check if a string looks like base64 (has mixed case or base64 special chars).
+ */
+function isBase64Like(s: string): boolean {
+  return /[A-Za-z]/.test(s) && /[0-9]/.test(s) && /[+/\-_=]/.test(s);
+}
+
+/**
+ * Scan for high-entropy tokens that may be secrets not matching known patterns.
+ * Returns matches only for tokens with entropy above the configured threshold
+ * AND that appear in a secret-related context (near keywords like "key", "token",
+ * "password", etc.).
+ */
+function scanEntropy(
+  text: string,
+  config: EntropyConfig,
+  existingRanges: Set<string>,
+): SecretMatch[] {
+  if (!config.enabled) return [];
+  const matches: SecretMatch[] = [];
+
+  // Scan hex tokens
+  HEX_TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HEX_TOKEN_RE.exec(text)) !== null) {
+    const value = m[1];
+    if (value.length < config.minLength) continue;
+    const startIndex = m.index;
+    const endIndex = startIndex + value.length;
+
+    // Skip if already covered by a pattern match
+    const key = `${startIndex}:${endIndex}`;
+    if (existingRanges.has(key)) continue;
+
+    // Skip placeholders
+    if (isPlaceholder(value)) continue;
+
+    const entropy = shannonEntropy(value);
+    if (entropy < config.hexThreshold) continue;
+
+    // Require secret-related context to reduce false positives
+    if (!hasSecretContext(text, startIndex)) continue;
+
+    existingRanges.add(key);
+    matches.push({
+      type: 'High-Entropy Hex Token',
+      startIndex,
+      endIndex,
+      redactedValue: redact(value),
+    });
+  }
+
+  // Scan base64 tokens
+  BASE64_TOKEN_RE.lastIndex = 0;
+  while ((m = BASE64_TOKEN_RE.exec(text)) !== null) {
+    const value = m[1];
+    if (value.length < config.minLength) continue;
+    // Must look like base64 (not pure alphanumeric) or pure hex
+    if (isHex(value)) continue; // Already handled above
+    if (!isBase64Like(value) && !/[A-Z]/.test(value)) continue;
+
+    const startIndex = m.index;
+    const endIndex = startIndex + value.length;
+
+    const key = `${startIndex}:${endIndex}`;
+    if (existingRanges.has(key)) continue;
+
+    if (isPlaceholder(value)) continue;
+
+    const entropy = shannonEntropy(value);
+    if (entropy < config.base64Threshold) continue;
+
+    if (!hasSecretContext(text, startIndex)) continue;
+
+    existingRanges.add(key);
+    matches.push({
+      type: 'High-Entropy Base64 Token',
+      startIndex,
+      endIndex,
+      redactedValue: redact(value),
+    });
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Scan function
 // ---------------------------------------------------------------------------
 
@@ -278,8 +442,11 @@ function isLikelyAwsSecret(value: string): boolean {
  * Scan text for leaked secrets. Returns an array of matches sorted by
  * position. Each match includes the secret type, position, and a redacted
  * preview of the matched value.
+ *
+ * @param entropyConfig — optional config for entropy-based scanning.
+ *   Pass `{ enabled: false }` to disable. Defaults to DEFAULT_ENTROPY_CONFIG.
  */
-export function scanText(text: string): SecretMatch[] {
+export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): SecretMatch[] {
   const matches: SecretMatch[] = [];
   // De-duplicate overlapping ranges (a match can fire on multiple patterns)
   const seen = new Set<string>();
@@ -312,6 +479,11 @@ export function scanText(text: string): SecretMatch[] {
     }
   }
 
+  // Entropy-based scanning for tokens that don't match known patterns
+  const eConfig = { ...DEFAULT_ENTROPY_CONFIG, ...entropyConfig };
+  const entropyMatches = scanEntropy(text, eConfig, seen);
+  matches.push(...entropyMatches);
+
   // Sort by position
   matches.sort((a, b) => a.startIndex - b.startIndex);
   return matches;
@@ -321,8 +493,8 @@ export function scanText(text: string): SecretMatch[] {
  * Replace detected secrets in text with redaction markers.
  * Returns the modified text.
  */
-export function redactSecrets(text: string): string {
-  const matches = scanText(text);
+export function redactSecrets(text: string, entropyConfig?: Partial<EntropyConfig>): string {
+  const matches = scanText(text, entropyConfig);
   if (matches.length === 0) return text;
 
   let result = '';
@@ -339,4 +511,9 @@ export function redactSecrets(text: string): string {
 }
 
 // Exported for testing only
-export { isPlaceholder as _isPlaceholder, redact as _redact, PATTERNS as _PATTERNS };
+export {
+  isPlaceholder as _isPlaceholder,
+  redact as _redact,
+  PATTERNS as _PATTERNS,
+  hasSecretContext as _hasSecretContext,
+};


### PR DESCRIPTION
## Summary

- Adds Shannon entropy analysis to `secret-scanner.ts` for catching secrets that don't match known patterns (custom API keys, internal tokens, non-standard formats)
- **Hex tokens**: Scans for 20+ char hex strings with entropy above 3.0 bits/char
- **Base64 tokens**: Scans for 20+ char base64-like strings with entropy above 4.0 bits/char  
- **Adjacency heuristics**: Only flags high-entropy tokens that appear near secret-related keywords (`key`, `token`, `secret`, `password`, `bearer`, `credentials`, `authorization`, `signing_key`, etc.) within 60 chars before the match — dramatically reduces false positives
- **Fully configurable**: `EntropyConfig` with `enabled`, `hexThreshold`, `base64Threshold`, `minLength` fields; pass `{ enabled: false }` to disable entirely
- **De-duplication**: Skips tokens already matched by pattern-based detection
- **API-compatible**: `scanText()` and `redactSecrets()` accept optional `Partial<EntropyConfig>` — existing callers are unaffected

## Test plan

- [x] 17 new tests covering entropy calculation, detection with/without context, threshold customization, disable toggle, de-duplication, and keyword recognition
- [x] All 301 tests pass (no regressions)
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
