### PR TITLE
[#120] Address PR review feedback: verifier history, app targeting, max steps

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -136,7 +136,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let provider = AnthropicProvider(apiKey: apiKey)
-        let session = ComputerUseSession(task: task, provider: provider)
+        let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
+        let maxSteps = storedMaxSteps > 0 ? Int(storedMaxSteps) : 50
+        let session = ComputerUseSession(task: task, provider: provider, maxSteps: maxSteps)
         currentSession = session
 
         let overlay = SessionOverlayWindow(session: session)

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -21,6 +21,9 @@ struct AXElement: Identifiable {
 
 final class AccessibilityTreeEnumerator {
     private var nextId = 1
+    /// PID of the last successfully enumerated target app, used to resolve the
+    /// correct app when our own window is frontmost.
+    private var lastTargetPid: pid_t?
 
     static let interactiveRoles: Set<String> = [
         "AXButton", "AXTextField", "AXTextArea", "AXCheckBox", "AXRadioButton",
@@ -88,40 +91,57 @@ final class AccessibilityTreeEnumerator {
         let interactive = flat.filter { Self.interactiveRoles.contains($0.role) }
         log.info("Enumerated \(appName, privacy: .public): \(flat.count) total, \(interactive.count) interactive, maxId=\(self.nextId - 1)")
 
+        lastTargetPid = pid
         return (elements: elements, windowTitle: windowTitle, appName: appName)
     }
 
     /// When our own app is focused, find the previously-active app's window instead.
+    /// Prefers `lastTargetPid` so the agent returns to the correct window rather than
+    /// an arbitrary app from the running-apps list.
     private func enumeratePreviousApp() -> (elements: [AXElement], windowTitle: String, appName: String)? {
         let runningApps = NSWorkspace.shared.runningApplications
             .filter { $0.activationPolicy == .regular && $0.bundleIdentifier != Bundle.main.bundleIdentifier && !$0.isTerminated }
 
+        // Try the last-known target app first for deterministic behavior
+        if let targetPid = lastTargetPid,
+           let targetApp = runningApps.first(where: { $0.processIdentifier == targetPid }),
+           let result = enumerateAppWindow(targetApp) {
+            return result
+        }
+
+        // Fallback: scan all running apps
         for app in runningApps {
-            let pid = app.processIdentifier
-            let appElement = AXUIElementCreateApplication(pid)
-
-            if !Self.enhancedAXEnabled.contains(pid) {
-                AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
-                Self.enhancedAXEnabled.insert(pid)
-            }
-
-            var windowValue: CFTypeRef?
-            let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
-            guard result == .success, let windowRef = windowValue else { continue }
-            let windowElement = windowRef as! AXUIElement
-
-            let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
-            let appName = app.localizedName ?? "Unknown"
-
-            nextId = 1
-            let elements = enumerateElement(element: windowElement, depth: 0, maxDepth: 25)
-
-            // Only return if we found something useful
-            if !elements.isEmpty {
-                return (elements: elements, windowTitle: windowTitle, appName: appName)
+            if let result = enumerateAppWindow(app) {
+                return result
             }
         }
         return nil
+    }
+
+    /// Enumerate the focused window of a given app, returning nil if unavailable.
+    private func enumerateAppWindow(_ app: NSRunningApplication) -> (elements: [AXElement], windowTitle: String, appName: String)? {
+        let pid = app.processIdentifier
+        let appElement = AXUIElementCreateApplication(pid)
+
+        if !Self.enhancedAXEnabled.contains(pid) {
+            AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+            Self.enhancedAXEnabled.insert(pid)
+        }
+
+        var windowValue: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue)
+        guard result == .success, let windowRef = windowValue else { return nil }
+        let windowElement = windowRef as! AXUIElement
+
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+        let appName = app.localizedName ?? "Unknown"
+
+        nextId = 1
+        let elements = enumerateElement(element: windowElement, depth: 0, maxDepth: 25)
+
+        guard !elements.isEmpty else { return nil }
+        lastTargetPid = pid
+        return (elements: elements, windowTitle: windowTitle, appName: appName)
     }
 
     private func enumerateElement(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {

--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -69,6 +69,12 @@ final class ActionVerifier {
         return .allowed
     }
 
+    /// Record an action that was confirmed by the user and will be executed.
+    /// This ensures confirmed actions count toward step limits and loop detection.
+    func recordConfirmedAction(_ action: AgentAction) {
+        actionHistory.append(action)
+    }
+
     func reset() {
         actionHistory.removeAll()
         blockedCount = 0

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -180,6 +180,7 @@ final class ComputerUseSession: ObservableObject {
                     logger.finishSession(result: "cancelled: user rejected confirmation")
                     return
                 }
+                verifier.recordConfirmedAction(action)
                 state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: action.displayDescription)
 
             case .blocked(let reason):

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
-    @State private var maxSteps: Double = 50
+    @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
 


### PR DESCRIPTION
The purpose of this PR is to address the 3 pieces of review feedback on PR #120 (native macOS menu bar client).

## Changes Made
- **Fix confirmed action tracking (P1):** Add `recordConfirmedAction` to `ActionVerifier` and call it from `Session` after user approval, so confirmed actions count toward step limits and loop detection
- **Fix previous app resolution (P1):** Track `lastTargetPid` in `AccessibilityTreeEnumerator` so `enumeratePreviousApp()` returns to the correct window instead of an arbitrary running app
- **Wire up max steps setting (P2):** Persist the Settings slider via `@AppStorage` and read it in `AppDelegate.startSession` so the configured limit actually takes effect

## Testing
- Verified xcodebuild compiles cleanly with all changes

---
*This PR was created with Claude Code*