### PR TITLE
Integrate secret scanner into tool executor

### DIFF
--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -1,0 +1,283 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { SecretDetectionEvent, ToolExecutionResult } from '../tools/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — MUST be declared before importing executor
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600, permissionTimeoutSec: 300 },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: true, action: 'warn' as 'redact' | 'warn' | 'block', entropyThreshold: 4.0 },
+};
+
+let fakeToolResult: ToolExecutionResult = { content: 'ok', isError: false };
+const recordedInvocations: unknown[] = [];
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../permissions/checker.js', () => ({
+  classifyRisk: () => 'low',
+  check: () => ({ decision: 'allow' }),
+  generateAllowlistOptions: () => [],
+  generateScopeOptions: () => [],
+}));
+
+mock.module('../memory/tool-usage-store.js', () => ({
+  recordToolInvocation: (inv: unknown) => { recordedInvocations.push(inv); },
+}));
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => {
+    if (name === 'unknown_tool') return undefined;
+    return {
+      name,
+      description: 'test tool',
+      category: 'test',
+      defaultRiskLevel: 'low',
+      getDefinition: () => ({}),
+      execute: async () => fakeToolResult,
+    };
+  },
+}));
+
+mock.module('../tools/filesystem/fuzzy-match.js', () => ({
+  findAllMatches: () => [],
+  adjustIndentation: () => '',
+}));
+mock.module('../tools/filesystem/path-guard.js', () => ({
+  validateFilePath: () => ({ ok: false }),
+}));
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: () => ({ command: '', sandboxed: false }),
+}));
+mock.module('../permissions/trust-store.js', () => ({
+  addRule: () => {},
+}));
+
+// Now import the module under test — mocks are already in place
+import { ToolExecutor } from '../tools/executor.js';
+import { PermissionPrompter } from '../permissions/prompter.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides?: Partial<{ onSecretDetected: (e: SecretDetectionEvent) => void }>) {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+    ...overrides,
+  };
+}
+
+function makeMockPrompter() {
+  return {
+    prompt: async () => ({ decision: 'allow' as const }),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+describe('Secret scanner executor integration', () => {
+  let executor: ToolExecutor;
+
+  beforeEach(() => {
+    executor = new ToolExecutor(makeMockPrompter());
+    recordedInvocations.length = 0;
+    mockConfig.secretDetection = { enabled: true, action: 'warn', entropyThreshold: 4.0 };
+  });
+
+  // -----------------------------------------------------------------------
+  // warn mode
+  // -----------------------------------------------------------------------
+  test('warn mode: passes through content unchanged and fires callback', async () => {
+    mockConfig.secretDetection.action = 'warn';
+    const secret = 'AKIAIOSFODNN7REALKEY'; // 20-char AWS key
+    fakeToolResult = { content: `Found key: ${secret}`, isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    // Content should be unchanged in warn mode
+    expect(result.content).toContain(secret);
+    expect(result.isError).toBe(false);
+
+    // Callback should have fired
+    expect(events).toHaveLength(1);
+    expect(events[0].toolName).toBe('file_read');
+    expect(events[0].action).toBe('warn');
+    expect(events[0].matches.length).toBeGreaterThan(0);
+    expect(events[0].matches[0].type).toBe('AWS Access Key');
+  });
+
+  // -----------------------------------------------------------------------
+  // redact mode
+  // -----------------------------------------------------------------------
+  test('redact mode: replaces secrets with [REDACTED:type] markers', async () => {
+    mockConfig.secretDetection.action = 'redact';
+    const secret = 'AKIAIOSFODNN7REALKEY';
+    fakeToolResult = { content: `Found key: ${secret}`, isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    expect(result.content).not.toContain(secret);
+    expect(result.content).toContain('[REDACTED:AWS Access Key]');
+    expect(result.isError).toBe(false);
+    expect(events).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // block mode
+  // -----------------------------------------------------------------------
+  test('block mode: returns error and does not pass through content', async () => {
+    mockConfig.secretDetection.action = 'block';
+    const secret = 'AKIAIOSFODNN7REALKEY';
+    fakeToolResult = { content: `Found key: ${secret}`, isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('blocked');
+    expect(result.content).toContain('AWS Access Key');
+    // Callback should still fire so the client gets notified
+    expect(events).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // disabled
+  // -----------------------------------------------------------------------
+  test('disabled: does not scan or fire callback', async () => {
+    mockConfig.secretDetection.enabled = false;
+    fakeToolResult = { content: 'Found key: AKIAIOSFODNN7REALKEY', isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    expect(result.content).toContain('AKIAIOSFODNN7REALKEY');
+    expect(events).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // error results are not scanned
+  // -----------------------------------------------------------------------
+  test('does not scan error results', async () => {
+    mockConfig.secretDetection.action = 'redact';
+    fakeToolResult = { content: 'Error: AKIAIOSFODNN7REALKEY', isError: true };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    // Error results should pass through without scanning
+    expect(result.content).toContain('AKIAIOSFODNN7REALKEY');
+    expect(events).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // diff content is scanned
+  // -----------------------------------------------------------------------
+  test('redact mode: scans and redacts diff content', async () => {
+    mockConfig.secretDetection.action = 'redact';
+    const secret = 'AKIAIOSFODNN7REALKEY';
+    fakeToolResult = {
+      content: 'File written',
+      isError: false,
+      diff: {
+        filePath: '/tmp/test.txt',
+        oldContent: '',
+        newContent: `API_KEY=${secret}`,
+        isNewFile: true,
+      },
+    };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_write', {}, ctx);
+
+    expect(result.diff).toBeDefined();
+    expect(result.diff!.newContent).not.toContain(secret);
+    expect(result.diff!.newContent).toContain('[REDACTED:AWS Access Key]');
+    expect(events).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // no secrets: no callback fired
+  // -----------------------------------------------------------------------
+  test('no secrets: does not fire callback', async () => {
+    fakeToolResult = { content: 'Hello, world!', isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    expect(result.content).toBe('Hello, world!');
+    expect(events).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // no callback: does not throw
+  // -----------------------------------------------------------------------
+  test('works without onSecretDetected callback', async () => {
+    mockConfig.secretDetection.action = 'warn';
+    fakeToolResult = { content: 'Found key: AKIAIOSFODNN7REALKEY', isError: false };
+
+    const ctx = makeContext(); // no onSecretDetected
+
+    const result = await executor.execute('file_read', {}, ctx);
+
+    // Should not throw, content unchanged in warn mode
+    expect(result.content).toContain('AKIAIOSFODNN7REALKEY');
+  });
+
+  // -----------------------------------------------------------------------
+  // multiple secrets
+  // -----------------------------------------------------------------------
+  test('detects multiple secrets in one output', async () => {
+    mockConfig.secretDetection.action = 'warn';
+    const aws = 'AKIAIOSFODNN7REALKEY';
+    const ghToken = 'ghp_ABCDEFghijklMN0123456789abcdefghijkl';
+    fakeToolResult = { content: `AWS: ${aws}\nGitHub: ${ghToken}`, isError: false };
+
+    const events: SecretDetectionEvent[] = [];
+    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+
+    await executor.execute('file_read', {}, ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].matches.length).toBe(2);
+    const types = events[0].matches.map((m) => m.type);
+    expect(types).toContain('AWS Access Key');
+    expect(types).toContain('GitHub Token');
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -352,6 +352,20 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         prompt();
         break;
 
+      case 'secret_detected': {
+        const wasSpinning = spinner.isSpinning;
+        spinner.stop();
+        const types = msg.matches.map((m) => m.type).join(', ');
+        const actionLabel = msg.action === 'redact' ? 'redacted' : msg.action === 'block' ? 'blocked' : 'detected';
+        process.stdout.write(`\n  ⚠ Secret ${actionLabel} in ${msg.toolName} output: ${types}\n`);
+        for (const match of msg.matches) {
+          process.stdout.write(`    • ${match.type}: ${match.redactedValue}\n`);
+        }
+        process.stdout.write('\n');
+        if (wasSpinning) spinner.start('Thinking...');
+        break;
+      }
+
       case 'session_list_response':
         if (pendingSessionPick) {
           renderSessionPicker(msg.sessions);

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -19,6 +19,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     maxRequestsPerMinute: 0,
     maxTokensPerSession: 0,
   },
+  secretDetection: {
+    enabled: true,
+    action: 'warn',
+    entropyThreshold: 4.0,
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -23,7 +23,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit } };
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, secretDetection: { ...DEFAULT_CONFIG.secretDetection } };
   loading = true;
 
   try {
@@ -62,6 +62,7 @@ export function loadConfig(): AssistantConfig {
       timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
       sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
       rateLimit: { ...DEFAULT_CONFIG.rateLimit, ...(fileConfig as Record<string, unknown>).rateLimit as Partial<AssistantConfig['rateLimit']> },
+      secretDetection: { ...DEFAULT_CONFIG.secretDetection, ...(fileConfig as Record<string, unknown>).secretDetection as Partial<AssistantConfig['secretDetection']> },
     };
 
     // Set cached before validation so re-entrant calls (e.g. validateConfig
@@ -143,6 +144,22 @@ function validateConfig(config: AssistantConfig): void {
       );
       config.rateLimit[field] = DEFAULT_CONFIG.rateLimit[field];
     }
+  }
+
+  if (typeof config.secretDetection.enabled !== 'boolean') {
+    log.warn(`Invalid secretDetection.enabled "${config.secretDetection.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.secretDetection.enabled}.`);
+    config.secretDetection.enabled = DEFAULT_CONFIG.secretDetection.enabled;
+  }
+
+  const validActions = ['redact', 'warn', 'block'] as const;
+  if (!validActions.includes(config.secretDetection.action as (typeof validActions)[number])) {
+    log.warn(`Invalid secretDetection.action "${config.secretDetection.action}". Must be one of: ${validActions.join(', ')}. Falling back to "${DEFAULT_CONFIG.secretDetection.action}".`);
+    config.secretDetection.action = DEFAULT_CONFIG.secretDetection.action;
+  }
+
+  if (typeof config.secretDetection.entropyThreshold !== 'number' || !Number.isFinite(config.secretDetection.entropyThreshold) || config.secretDetection.entropyThreshold <= 0) {
+    log.warn(`Invalid secretDetection.entropyThreshold "${config.secretDetection.entropyThreshold}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.secretDetection.entropyThreshold}.`);
+    config.secretDetection.entropyThreshold = DEFAULT_CONFIG.secretDetection.entropyThreshold;
   }
 }
 

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -19,6 +19,15 @@ export interface RateLimitConfig {
   maxTokensPerSession: number;
 }
 
+export interface SecretDetectionConfig {
+  /** Whether secret detection is enabled. Default: true. */
+  enabled: boolean;
+  /** What to do when a secret is detected: redact, warn, or block. Default: 'warn'. */
+  action: 'redact' | 'warn' | 'block';
+  /** Shannon entropy threshold for entropy-based detection. Default: 4.0. */
+  entropyThreshold: number;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
@@ -29,4 +38,5 @@ export interface AssistantConfig {
   timeouts: TimeoutConfig;
   sandbox: SandboxConfig;
   rateLimit: RateLimitConfig;
+  secretDetection: SecretDetectionConfig;
 }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -181,6 +181,13 @@ export interface UsageResponse {
   model: string;
 }
 
+export interface SecretDetected {
+  type: 'secret_detected';
+  toolName: string;
+  matches: Array<{ type: string; redactedValue: string }>;
+  action: 'redact' | 'warn' | 'block';
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | ToolUseStart
@@ -197,7 +204,8 @@ export type ServerMessage =
   | HistoryResponse
   | UndoComplete
   | UsageUpdate
-  | UsageResponse;
+  | UsageResponse
+  | SecretDetected;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -24,6 +24,7 @@ export class Session {
   private abortController: AbortController | null = null;
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
+  private sendToClient: (msg: ServerMessage) => void;
   private workingDir: string;
   private sandboxOverride?: boolean;
   private totalInputTokens = 0;
@@ -40,6 +41,7 @@ export class Session {
   ) {
     this.conversationId = conversationId;
     this.workingDir = workingDir;
+    this.sendToClient = sendToClient;
     this.prompter = new PermissionPrompter(sendToClient);
     this.executor = new ToolExecutor(this.prompter);
 
@@ -51,6 +53,14 @@ export class Session {
         conversationId: this.conversationId,
         onOutput,
         sandboxOverride: this.sandboxOverride,
+        onSecretDetected: (event) => {
+          this.sendToClient({
+            type: 'secret_detected',
+            toolName: event.toolName,
+            matches: event.matches,
+            action: event.action,
+          });
+        },
       });
     };
 
@@ -81,6 +91,7 @@ export class Session {
   }
 
   updateClient(sendToClient: (msg: ServerMessage) => void): void {
+    this.sendToClient = sendToClient;
     this.prompter.updateSender(sendToClient);
   }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -12,6 +12,7 @@ import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
 import { wrapCommand } from './terminal/sandbox.js';
 import { getConfig } from '../config/loader.js';
+import { scanText, redactSecrets } from '../security/secret-scanner.js';
 
 const log = getLogger('tool-executor');
 
@@ -124,6 +125,51 @@ export class ToolExecutor {
 
       // Execute the tool
       const execResult = await tool.execute(input, context);
+
+      // Secret detection on tool output
+      const sdConfig = getConfig().secretDetection;
+      if (sdConfig.enabled && !execResult.isError) {
+        const entropyConfig = { enabled: true, base64Threshold: sdConfig.entropyThreshold };
+        const contentMatches = scanText(execResult.content, entropyConfig);
+        const diffMatches = execResult.diff
+          ? scanText(execResult.diff.newContent, entropyConfig)
+          : [];
+        const allMatches = [...contentMatches, ...diffMatches];
+
+        if (allMatches.length > 0) {
+          const matchSummary = allMatches.map((m) => ({
+            type: m.type,
+            redactedValue: m.redactedValue,
+          }));
+
+          log.warn(
+            { toolName: name, matchCount: allMatches.length, types: [...new Set(allMatches.map((m) => m.type))] },
+            'Secrets detected in tool output',
+          );
+
+          context.onSecretDetected?.({
+            toolName: name,
+            matches: matchSummary,
+            action: sdConfig.action,
+          });
+
+          if (sdConfig.action === 'redact') {
+            execResult.content = redactSecrets(execResult.content, entropyConfig);
+            if (execResult.diff) {
+              execResult.diff = {
+                ...execResult.diff,
+                newContent: redactSecrets(execResult.diff.newContent, entropyConfig),
+              };
+            }
+          } else if (sdConfig.action === 'block') {
+            const types = [...new Set(allMatches.map((m) => m.type))].join(', ');
+            return {
+              content: `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "warn" to allow output.`,
+              isError: true,
+            };
+          }
+        }
+      }
 
       const durationMs = Date.now() - startTime;
       recordToolInvocation({

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,6 +1,12 @@
 import type { RiskLevel } from '../permissions/types.js';
 import type { ToolDefinition } from '../providers/types.js';
 
+export interface SecretDetectionEvent {
+  toolName: string;
+  matches: Array<{ type: string; redactedValue: string }>;
+  action: 'redact' | 'warn' | 'block';
+}
+
 export interface ToolContext {
   workingDir: string;
   sessionId: string;
@@ -9,6 +15,8 @@ export interface ToolContext {
   onOutput?: (chunk: string) => void;
   /** Per-session sandbox override. When set, takes precedence over the global config. */
   sandboxOverride?: boolean;
+  /** Optional callback when secrets are detected in tool output. */
+  onSecretDetected?: (event: SecretDetectionEvent) => void;
 }
 
 export interface DiffInfo {

--- a/assistant/src/util/spinner.ts
+++ b/assistant/src/util/spinner.ts
@@ -15,6 +15,10 @@ export class Spinner {
   private timer: ReturnType<typeof setInterval> | null = null;
   private active = false;
 
+  get isSpinning(): boolean {
+    return this.active;
+  }
+
   start(message: string): void {
     if (!process.stderr.isTTY) return;
     this.stop();


### PR DESCRIPTION
## Summary
- Wires the secret scanner into `executor.ts` at the tool result return point (after `tool.execute()`, before return) to scan all tool outputs for leaked secrets
- Adds `SecretDetectionConfig` to the config system with three modes: **warn** (default — notify client but pass output through), **redact** (replace secrets with `[REDACTED:type]` markers in content and diffs), and **block** (return error instead of tool output)
- Adds `SecretDetected` IPC message type and CLI handler that displays inline warnings with match details
- Also scans `result.diff.newContent` for file write/edit tools
- Adds `entropyThreshold` config to control sensitivity of entropy-based detection
- 9 integration tests covering all three modes, disabled state, error result passthrough, diff scanning, multiple secrets, and missing callback safety

## Files changed
- `config/types.ts` — new `SecretDetectionConfig` interface
- `config/defaults.ts` — defaults (enabled: true, action: warn, entropyThreshold: 4.0)
- `config/loader.ts` — config spreading + validation for the new section
- `daemon/ipc-protocol.ts` — new `SecretDetected` server message type
- `tools/types.ts` — new `SecretDetectionEvent` interface, `onSecretDetected` callback on `ToolContext`
- `tools/executor.ts` — secret scanning logic after tool execution
- `daemon/session.ts` — wires `onSecretDetected` callback to send IPC message
- `cli.ts` — handles `secret_detected` messages with inline warnings
- `util/spinner.ts` — adds `isSpinning` getter for CLI handler
- `__tests__/secret-scanner-executor.test.ts` — 9 new tests

## Test plan
- [x] All 9 new executor integration tests pass
- [x] All 75 existing secret scanner tests still pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual test: run a shell command that outputs an AWS key, verify warning appears


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
