### PR TITLE
Handle out-of-order timestamps in rate limit pruning (#168 feedback)

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -168,6 +168,24 @@ describe('RateLimitProvider', () => {
       await expect(provider2.sendMessage(messages)).rejects.toThrow(RateLimitError);
     });
 
+    test('out-of-order timestamps are pruned correctly (clock skew)', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 3, maxTokensPerSession: 0 };
+      const shared: number[] = [];
+      const provider = new RateLimitProvider(makeProvider(), config, shared);
+
+      // Simulate clock skew: insert an old timestamp between newer ones
+      const now = Date.now();
+      shared.push(now);                   // current
+      shared.push(now - 120_000);         // 2 minutes ago (expired)
+      shared.push(now);                   // current
+
+      // enforceRequestRate should prune the expired entry regardless of position
+      await provider.sendMessage(messages);
+
+      // 2 fresh timestamps from before + 1 from the new call = 3 (the expired one was removed)
+      expect(shared.length).toBe(3);
+    });
+
     test('shared array reference survives pruning', async () => {
       const config: RateLimitConfig = { maxRequestsPerMinute: 100, maxTokensPerSession: 0 };
       const shared: number[] = [];

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -47,13 +47,13 @@ export class RateLimitProvider implements Provider {
     const now = Date.now();
     const windowStart = now - 60_000;
     // Prune expired timestamps in-place to preserve the shared array
-    // reference. Using .filter() would create a new array, breaking the
-    // cross-session sharing established by DaemonServer.
-    const cutoff = this.requestTimestamps.findIndex((t) => t > windowStart);
-    if (cutoff > 0) {
-      this.requestTimestamps.splice(0, cutoff);
-    } else if (cutoff === -1) {
-      this.requestTimestamps.length = 0;
+    // reference. We walk backward so each splice doesn't shift later
+    // indices, and we handle out-of-order entries (e.g. clock rollback)
+    // correctly — unlike a sorted-prefix approach.
+    for (let i = this.requestTimestamps.length - 1; i >= 0; i--) {
+      if (this.requestTimestamps[i] <= windowStart) {
+        this.requestTimestamps.splice(i, 1);
+      }
     }
 
     if (this.requestTimestamps.length >= limit) {


### PR DESCRIPTION
## Summary

- **Fix order-dependent pruning regression** — The `findIndex` + prefix `splice` approach assumed timestamps were strictly time-ordered. Under clock skew (e.g., `Date.now()` rollback), expired entries appearing after the first in-window entry were never removed, overstating the count and causing premature rate limiting. Replaced with a backward iteration that removes expired entries in-place regardless of ordering, preserving the shared array reference.
- **New test for clock-skew scenario** — Verifies that an expired timestamp sandwiched between fresh timestamps is correctly pruned.

## Test plan

- [x] New clock-skew test covering out-of-order timestamps
- [x] All 15 rate limit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
