### PR TITLE
Fix base64 padding matching and word-boundary context keywords (#169 feedback)

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -549,7 +549,8 @@ describe('entropy-based detection', () => {
 
   test('detects high-entropy base64 token near secret keyword', () => {
     const b64Secret = 'aB3cD4eF5gH6iJ7kL8mN+pQ/rS0tU1vW2xY3zA=';
-    const input = `token: "${b64Secret}"`;
+    // Use "is" instead of ": " to avoid triggering the generic assignment pattern
+    const input = `The token is ${b64Secret}`;
     const matches = scanText(input);
     const entropyMatch = matches.find((m) => m.type === 'High-Entropy Base64 Token');
     expect(entropyMatch).toBeDefined();
@@ -746,5 +747,91 @@ describe('unquoted generic secret assignments', () => {
     const matches = scanText(input);
     const generic = matches.filter((m) => m.type === 'Generic Secret Assignment');
     expect(generic).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Base64 padding in entropy detection (#169 feedback)
+// ---------------------------------------------------------------------------
+describe('base64 padding handling', () => {
+  test('includes trailing = padding in the match', () => {
+    const b64 = 'aB3cD4eF5gH6iJ7kL8mN9pQrS0tU1vW2xY3zA=';
+    const input = `token: ${b64}`;
+    const matches = scanText(input);
+    const entropyMatch = matches.find((m) => m.type === 'High-Entropy Base64 Token');
+    expect(entropyMatch).toBeDefined();
+    // endIndex should include the '='
+    expect(input.slice(entropyMatch!.startIndex, entropyMatch!.endIndex)).toContain('=');
+  });
+
+  test('includes trailing == padding in the match', () => {
+    const b64 = 'aB3cD4eF5gH6iJ7kL8mN9pQrS0tU1vW2x==';
+    const input = `token: ${b64}`;
+    const matches = scanText(input);
+    const entropyMatch = matches.find((m) => m.type === 'High-Entropy Base64 Token');
+    expect(entropyMatch).toBeDefined();
+    expect(input.slice(entropyMatch!.startIndex, entropyMatch!.endIndex)).toContain('==');
+  });
+
+  test('redactSecrets fully redacts padded base64 tokens', () => {
+    const b64 = 'aB3cD4eF5gH6iJ7kL8mN9pQrS0tU1vW2xY3zA=';
+    const input = `token: "${b64}"`;
+    const result = redactSecrets(input);
+    // No trailing '=' should leak after redaction
+    expect(result).not.toMatch(/\[REDACTED:[^\]]+\]=/);
+    expect(result).toContain('[REDACTED:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Word-boundary context keyword matching (#169 feedback)
+// ---------------------------------------------------------------------------
+describe('word-boundary context keywords', () => {
+  test('does not match "key" inside "monkey"', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `monkey: ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy).toHaveLength(0);
+  });
+
+  test('does not match "key" inside "keyboard"', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `keyboard = ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy).toHaveLength(0);
+  });
+
+  test('does not match "token" inside "tokenizer"', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `tokenizer: ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy).toHaveLength(0);
+  });
+
+  test('still matches "key" as a standalone word', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `The key is ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy.length).toBeGreaterThan(0);
+  });
+
+  test('still matches "api_key" with underscores', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `The api_key is ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy.length).toBeGreaterThan(0);
+  });
+
+  test('still matches "api-key" with hyphens', () => {
+    const hexSecret = 'a3f8c1b2d9e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8';
+    const input = `The api-key is ${hexSecret}`;
+    const matches = scanText(input);
+    const entropy = matches.filter((m) => m.type.startsWith('High-Entropy'));
+    expect(entropy.length).toBeGreaterThan(0);
   });
 });

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -333,18 +333,24 @@ const SECRET_CONTEXT_KEYWORDS = [
 /** Match hex strings (20+ chars of [0-9a-fA-F]) */
 const HEX_TOKEN_RE = /\b([0-9a-fA-F]{20,})\b/g;
 
-/** Match base64 strings (20+ chars of [A-Za-z0-9+/=_-]) that aren't pure alphanumeric */
-const BASE64_TOKEN_RE = /\b([A-Za-z0-9+/\-_]{20,}={0,3})\b/g;
+/** Match base64 strings (20+ chars of [A-Za-z0-9+/_-]) with optional = padding.
+ *  Trailing \b would fail after '=' (non-word char), so we use a lookahead. */
+const BASE64_TOKEN_RE = /\b([A-Za-z0-9+/\-_]{20,}={0,3})(?=\W|$)/g;
 
 /**
  * Check whether a token appears near a secret-related keyword in the
  * surrounding text (up to 60 chars before the match).
  */
+/** Pre-compiled word-boundary regex for each context keyword. */
+const SECRET_CONTEXT_RES = SECRET_CONTEXT_KEYWORDS.map(
+  (kw) => new RegExp(`(?:^|[^a-z0-9])${kw.replace(/[-]/g, '\\$&')}(?:[^a-z0-9]|$)`, 'i'),
+);
+
 function hasSecretContext(text: string, matchStart: number): boolean {
   // Look at up to 60 chars before the token for context keywords
   const contextStart = Math.max(0, matchStart - 60);
-  const prefix = text.slice(contextStart, matchStart).toLowerCase();
-  return SECRET_CONTEXT_KEYWORDS.some((kw) => prefix.includes(kw));
+  const prefix = text.slice(contextStart, matchStart);
+  return SECRET_CONTEXT_RES.some((re) => re.test(prefix));
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses two feedback items from PR #169:

1. **Fix base64 padding not included in entropy matches** — The `BASE64_TOKEN_RE` regex ended with `\b`, but `=` is a non-word character, making the `={0,3}` quantifier dead code. Replaced trailing `\b` with `(?=\W|$)` so padded base64 tokens like `...zA=` are fully matched and redacted. Previously the trailing `=` would leak after the redaction marker.

2. **Word-boundary context keyword matching** — Context detection used substring `includes()`, so short keywords like `key` matched inside `monkey` or `keyboard`, causing false positives. Replaced with pre-compiled word-boundary regexes that require non-alphanumeric boundaries around each keyword.

## Test plan

- [x] 9 new tests covering both fixes (base64 padding inclusion, word-boundary matching)
- [x] Updated 1 existing test whose input now correctly deduplicates with generic assignment pattern
- [x] All 95 secret-scanner tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
