### PR TITLE
Record tool invocation before block-mode early return (#171 feedback)

### DIFF
--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -167,6 +167,12 @@ describe('Secret scanner executor integration', () => {
     expect(result.content).toContain('AWS Access Key');
     // Callback should still fire so the client gets notified
     expect(events).toHaveLength(1);
+    // Invocation should be recorded for audit trail
+    expect(recordedInvocations).toHaveLength(1);
+    const inv = recordedInvocations[0] as Record<string, unknown>;
+    expect(inv.toolName).toBe('file_read');
+    expect(inv.conversationId).toBe('test-conversation');
+    expect((inv.result as string)).toContain('blocked');
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -163,8 +163,19 @@ export class ToolExecutor {
             }
           } else if (sdConfig.action === 'block') {
             const types = [...new Set(allMatches.map((m) => m.type))].join(', ');
+            const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "warn" to allow output.`;
+            const durationMs = Date.now() - startTime;
+            recordToolInvocation({
+              conversationId: context.conversationId,
+              toolName: name,
+              input: JSON.stringify(input),
+              result: blockedContent.slice(0, 1000),
+              decision,
+              riskLevel,
+              durationMs,
+            });
             return {
-              content: `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "warn" to allow output.`,
+              content: blockedContent,
               isError: true,
             };
           }


### PR DESCRIPTION
## Summary

- **Fix missing audit record for blocked tool outputs** — When `secretDetection.action` is `block` and secrets are detected, the early return skipped `recordToolInvocation`, making blocked executions invisible in the tool usage store. Now records the blocked outcome before returning, consistent with all other exit paths (deny, always_deny, error, normal completion).

## Test plan

- [x] Updated block mode test to verify `recordedInvocations` is populated
- [x] All 9 executor integration tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
