### PR TITLE
Secret scanner false-positive allowlist

### DIFF
--- a/assistant/src/__tests__/secret-allowlist.test.ts
+++ b/assistant/src/__tests__/secret-allowlist.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock the data dir to a temp directory so tests don't touch ~/.vellum/
+let testDir: string;
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+}));
+
+import { isAllowlisted, resetAllowlist, loadAllowlist } from '../security/secret-allowlist.js';
+import { scanText } from '../security/secret-scanner.js';
+
+describe('secret-allowlist', () => {
+  beforeEach(() => {
+    testDir = join(tmpdir(), `vellum-allowlist-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    resetAllowlist();
+  });
+
+  afterEach(() => {
+    resetAllowlist();
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // No file — should not error, everything still detected
+  // -----------------------------------------------------------------------
+  test('works when no allowlist file exists', () => {
+    expect(isAllowlisted('AKIAIOSFODNN7REALKEY')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Exact values
+  // -----------------------------------------------------------------------
+  test('suppresses exact values', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['my-test-api-key-12345'] }),
+    );
+    expect(isAllowlisted('my-test-api-key-12345')).toBe(true);
+    expect(isAllowlisted('my-test-api-key-99999')).toBe(false);
+  });
+
+  test('exact values are case-sensitive', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['MyTestKey'] }),
+    );
+    expect(isAllowlisted('MyTestKey')).toBe(true);
+    expect(isAllowlisted('mytestkey')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Prefix matching
+  // -----------------------------------------------------------------------
+  test('suppresses values matching a prefix', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ prefixes: ['my-internal-'] }),
+    );
+    expect(isAllowlisted('my-internal-key-abc123')).toBe(true);
+    expect(isAllowlisted('other-key-abc123')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Regex patterns
+  // -----------------------------------------------------------------------
+  test('suppresses values matching a regex pattern', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ patterns: ['^ci-test-[a-z0-9]+$'] }),
+    );
+    expect(isAllowlisted('ci-test-abc123')).toBe(true);
+    expect(isAllowlisted('ci-prod-abc123')).toBe(false);
+  });
+
+  test('invalid regex is skipped without crashing', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ patterns: ['[invalid', '^valid$'] }),
+    );
+    loadAllowlist();
+    // The valid pattern should still work
+    expect(isAllowlisted('valid')).toBe(true);
+    // Invalid regex is skipped, not thrown
+    expect(isAllowlisted('other')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Combined rules
+  // -----------------------------------------------------------------------
+  test('combines values, prefixes, and patterns', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({
+        values: ['exact-match-value'],
+        prefixes: ['test-prefix-'],
+        patterns: ['^regex-[0-9]+$'],
+      }),
+    );
+    expect(isAllowlisted('exact-match-value')).toBe(true);
+    expect(isAllowlisted('test-prefix-anything')).toBe(true);
+    expect(isAllowlisted('regex-12345')).toBe(true);
+    expect(isAllowlisted('none-of-the-above')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Malformed file
+  // -----------------------------------------------------------------------
+  test('handles malformed JSON gracefully', () => {
+    writeFileSync(join(testDir, 'secret-allowlist.json'), 'not json{{{');
+    loadAllowlist();
+    // Should not throw, just log warning
+    expect(isAllowlisted('anything')).toBe(false);
+  });
+
+  test('handles non-array fields gracefully', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: 'not-an-array', prefixes: 42 }),
+    );
+    loadAllowlist();
+    expect(isAllowlisted('not-an-array')).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Integration with scanText
+  // -----------------------------------------------------------------------
+  test('allowlisted values are suppressed by scanText', () => {
+    const awsKey = 'AKIAIOSFODNN7REALKEY';
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: [awsKey] }),
+    );
+    resetAllowlist();
+
+    const matches = scanText(`Found key: ${awsKey}`);
+    const aws = matches.filter((m) => m.type === 'AWS Access Key');
+    expect(aws).toHaveLength(0);
+  });
+
+  test('non-allowlisted values are still detected by scanText', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['AKIAIOSFODNN7OTHERKE'] }),
+    );
+    resetAllowlist();
+
+    const matches = scanText('Found key: AKIAIOSFODNN7REALKEY');
+    const aws = matches.filter((m) => m.type === 'AWS Access Key');
+    expect(aws).toHaveLength(1);
+  });
+
+  test('prefix allowlist suppresses pattern matches', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ prefixes: ['ghp_AAAA'] }),
+    );
+    resetAllowlist();
+
+    const token = `ghp_AAAA${'B'.repeat(32)}`;
+    const matches = scanText(`token=${token}`);
+    const gh = matches.filter((m) => m.type === 'GitHub Token');
+    expect(gh).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // resetAllowlist
+  // -----------------------------------------------------------------------
+  test('resetAllowlist clears cached state', () => {
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['test-value'] }),
+    );
+    loadAllowlist();
+    expect(isAllowlisted('test-value')).toBe(true);
+
+    // Reset and remove file — should no longer be allowlisted
+    resetAllowlist();
+    rmSync(join(testDir, 'secret-allowlist.json'));
+    expect(isAllowlisted('test-value')).toBe(false);
+  });
+});

--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -1,0 +1,109 @@
+/**
+ * User-defined allowlist for suppressing secret scanner false positives.
+ *
+ * Reads `~/.vellum/secret-allowlist.json` (if present) and provides
+ * `isAllowlisted(value)` to check whether a matched value should be
+ * suppressed.
+ *
+ * File format:
+ * {
+ *   "values": ["exact-value-to-skip", ...],
+ *   "prefixes": ["sk-test-", ...],
+ *   "patterns": ["^test_.*$", ...]
+ * }
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { getDataDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('secret-allowlist');
+
+export interface AllowlistConfig {
+  /** Exact values to suppress (case-sensitive). */
+  values?: string[];
+  /** Prefix strings — any matched value starting with one of these is suppressed. */
+  prefixes?: string[];
+  /** Regex patterns (strings) — any matched value matching one of these is suppressed. */
+  patterns?: string[];
+}
+
+// Cached state
+let loaded = false;
+let allowedValues: Set<string> = new Set();
+let allowedPrefixes: string[] = [];
+let allowedRegexes: RegExp[] = [];
+
+/**
+ * Load the allowlist from disk. Called lazily on first `isAllowlisted` call.
+ * Safe to call multiple times — subsequent calls are no-ops unless `resetAllowlist` is called.
+ */
+export function loadAllowlist(): void {
+  if (loaded) return;
+  loaded = true;
+
+  const filePath = join(getDataDir(), 'secret-allowlist.json');
+  if (!existsSync(filePath)) return;
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const config: AllowlistConfig = JSON.parse(raw);
+
+    if (config.values && Array.isArray(config.values)) {
+      allowedValues = new Set(config.values.filter((v) => typeof v === 'string'));
+    }
+
+    if (config.prefixes && Array.isArray(config.prefixes)) {
+      allowedPrefixes = config.prefixes.filter((p) => typeof p === 'string' && p.length > 0);
+    }
+
+    if (config.patterns && Array.isArray(config.patterns)) {
+      for (const p of config.patterns) {
+        if (typeof p !== 'string') continue;
+        try {
+          allowedRegexes.push(new RegExp(p));
+        } catch {
+          log.warn({ pattern: p }, 'Invalid regex in secret-allowlist.json, skipping');
+        }
+      }
+    }
+
+    const total = allowedValues.size + allowedPrefixes.length + allowedRegexes.length;
+    if (total > 0) {
+      log.debug({ values: allowedValues.size, prefixes: allowedPrefixes.length, patterns: allowedRegexes.length }, 'Loaded secret allowlist');
+    }
+  } catch (err) {
+    log.warn({ err }, 'Failed to load secret-allowlist.json');
+  }
+}
+
+/**
+ * Check if a matched secret value is on the user's allowlist.
+ */
+export function isAllowlisted(value: string): boolean {
+  loadAllowlist();
+
+  if (allowedValues.has(value)) return true;
+
+  for (const prefix of allowedPrefixes) {
+    if (value.startsWith(prefix)) return true;
+  }
+
+  for (const re of allowedRegexes) {
+    re.lastIndex = 0;
+    if (re.test(value)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Reset cached state. Used in tests.
+ */
+export function resetAllowlist(): void {
+  loaded = false;
+  allowedValues = new Set();
+  allowedPrefixes = [];
+  allowedRegexes = [];
+}

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -4,6 +4,8 @@
  * from gitleaks and detect-secrets.
  */
 
+import { isAllowlisted } from './secret-allowlist.js';
+
 export interface SecretMatch {
   /** Human-readable type label, e.g. "AWS Access Key" */
   type: string;
@@ -394,8 +396,9 @@ function scanEntropy(
     const key = `${startIndex}:${endIndex}`;
     if (existingRanges.has(key)) continue;
 
-    // Skip placeholders
+    // Skip placeholders and allowlisted values
     if (isPlaceholder(value)) continue;
+    if (isAllowlisted(value)) continue;
 
     const entropy = shannonEntropy(value);
     if (entropy < config.hexThreshold) continue;
@@ -428,6 +431,7 @@ function scanEntropy(
     if (existingRanges.has(key)) continue;
 
     if (isPlaceholder(value)) continue;
+    if (isAllowlisted(value)) continue;
 
     const entropy = shannonEntropy(value);
     if (entropy < config.base64Threshold) continue;
@@ -474,6 +478,7 @@ export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): 
       const endIndex = startIndex + value.length;
 
       if (isPlaceholder(value)) continue;
+      if (isAllowlisted(value)) continue;
 
       // Extra validation for AWS Secret Keys to avoid hex-string false positives
       if (pattern.type === 'AWS Secret Key' && !isLikelyAwsSecret(value)) continue;


### PR DESCRIPTION
## Summary

Adds a user-defined allowlist at `~/.vellum/secret-allowlist.json` to suppress known false positives from the secret scanner. Supports three rule types:

- **`values`** — exact string matches (case-sensitive), e.g. `["my-test-key-12345"]`
- **`prefixes`** — prefix-based matches, e.g. `["my-internal-"]`
- **`patterns`** — regex patterns as strings, e.g. `["^ci-test-[a-z0-9]+$"]`

Example `secret-allowlist.json`:
```json
{
  "values": ["AKIAIOSFODNN7TESTKEY"],
  "prefixes": ["my-internal-", "ci-test-"],
  "patterns": ["^staging-[a-z0-9]+$"]
}
```

### Implementation

- New module `assistant/src/security/secret-allowlist.ts` — loads and caches the allowlist lazily on first use
- Integrated into `secret-scanner.ts` at all three detection paths (pattern-based, hex entropy, base64 entropy), checked right after the existing `isPlaceholder` gate
- Gracefully handles missing file, malformed JSON, invalid regex patterns (logs warnings, skips invalid entries)
- `resetAllowlist()` exported for test teardown

## Test plan

- [x] 13 new tests covering: no file, exact values, case sensitivity, prefix matching, regex patterns, invalid regex, combined rules, malformed JSON, non-array fields, integration with scanText, reset behavior
- [x] All 95 existing secret-scanner tests still pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
