### PR TITLE
Linear-time pruning and correct waitSec under clock skew (#173 feedback)

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -186,6 +186,32 @@ describe('RateLimitProvider', () => {
       expect(shared.length).toBe(3);
     });
 
+    test('waitSec uses actual oldest timestamp under clock skew', async () => {
+      const config: RateLimitConfig = { maxRequestsPerMinute: 2, maxTokensPerSession: 0 };
+      const shared: number[] = [];
+      const provider = new RateLimitProvider(makeProvider(), config, shared);
+
+      // Simulate out-of-order timestamps: newer one first, older one second
+      const now = Date.now();
+      shared.push(now);               // newest
+      shared.push(now - 30_000);      // 30s ago (oldest in window)
+
+      // Next request should be rate-limited with ~30s wait (not 60s)
+      try {
+        await provider.sendMessage(messages);
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimitError);
+        const msg = (err as RateLimitError).message;
+        // Wait time should be ~30s, not 60s
+        const waitMatch = msg.match(/(\d+)s/);
+        expect(waitMatch).toBeTruthy();
+        const waitSec = parseInt(waitMatch![1], 10);
+        expect(waitSec).toBeLessThanOrEqual(31);
+        expect(waitSec).toBeGreaterThanOrEqual(29);
+      }
+    });
+
     test('shared array reference survives pruning', async () => {
       const config: RateLimitConfig = { maxRequestsPerMinute: 100, maxTokensPerSession: 0 };
       const shared: number[] = [];

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -47,17 +47,18 @@ export class RateLimitProvider implements Provider {
     const now = Date.now();
     const windowStart = now - 60_000;
     // Prune expired timestamps in-place to preserve the shared array
-    // reference. We walk backward so each splice doesn't shift later
-    // indices, and we handle out-of-order entries (e.g. clock rollback)
-    // correctly — unlike a sorted-prefix approach.
-    for (let i = this.requestTimestamps.length - 1; i >= 0; i--) {
-      if (this.requestTimestamps[i] <= windowStart) {
-        this.requestTimestamps.splice(i, 1);
+    // reference. Single-pass compaction: copy valid entries to the front
+    // and truncate, handling out-of-order entries correctly in O(n).
+    let write = 0;
+    for (let read = 0; read < this.requestTimestamps.length; read++) {
+      if (this.requestTimestamps[read] > windowStart) {
+        this.requestTimestamps[write++] = this.requestTimestamps[read];
       }
     }
+    this.requestTimestamps.length = write;
 
     if (this.requestTimestamps.length >= limit) {
-      const oldestInWindow = this.requestTimestamps[0];
+      const oldestInWindow = Math.min(...this.requestTimestamps);
       const waitSec = Math.ceil((oldestInWindow + 60_000 - now) / 1000);
       throw new RateLimitError(
         `Rate limit exceeded: ${limit} requests/minute. Try again in ${waitSec}s.`,


### PR DESCRIPTION
## Summary

Addresses two feedback items from PR #173:

1. **Linear-time pruning** — The backward `splice(i, 1)` loop was O(n^2) because each splice shifts remaining elements. Replaced with a single-pass compaction: copy valid entries to the front of the array and truncate with `.length = write`. Still preserves the shared array reference.

2. **Correct `waitSec` under clock skew** — The error message used `timestamps[0]` as the oldest in-window entry, but after out-of-order pruning the array isn't sorted. Now uses `Math.min(...timestamps)` to find the actual oldest entry, giving accurate "Try again in Xs" messages.

## Test plan

- [x] New test verifying waitSec is ~30s (not 60s) when timestamps are out of order
- [x] All 16 rate limit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
