### PR TITLE
Redact widest overlapping match span (#172 feedback)

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -672,6 +672,26 @@ describe('overlapping match redaction', () => {
     // Should not contain the raw key
     expect(result).not.toContain('AKIAIOSFODNN7REALKEY');
   });
+
+  test('wider overlapping match extends redaction span (#172 feedback)', () => {
+    // A shorter match (e.g. AWS-like 40 chars) inside a longer generic assignment
+    // should not leak the suffix of the longer match
+    const input = `password = "AKIAIOSFODNN7REALKEY extra-tail-secret"`;
+    const result = redactSecrets(input);
+    // Nothing from the original secret value should leak
+    expect(result).not.toContain('extra-tail-secret');
+    expect(result).not.toContain('AKIAIOSFODNN7REALKEY');
+    expect(result).toContain('[REDACTED:');
+  });
+
+  test('wider match at same start position wins', () => {
+    // When two matches start at same offset, wider one should be used
+    const input = `token = "AKIAIOSFODNN7REALKEY-plus-extra-data"`;
+    const result = redactSecrets(input);
+    expect(result).not.toContain('AKIAIOSFODNN7REALKEY');
+    expect(result).not.toContain('plus-extra-data');
+    expect(result).toContain('[REDACTED:');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -501,8 +501,8 @@ export function scanText(text: string, entropyConfig?: Partial<EntropyConfig>): 
   const entropyMatches = scanEntropy(text, eConfig, seen);
   matches.push(...entropyMatches);
 
-  // Sort by position
-  matches.sort((a, b) => a.startIndex - b.startIndex);
+  // Sort by position; at same start, wider match first so redaction covers the full span
+  matches.sort((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
   return matches;
 }
 
@@ -518,7 +518,13 @@ export function redactSecrets(text: string, entropyConfig?: Partial<EntropyConfi
   let lastIndex = 0;
 
   for (const match of matches) {
-    if (match.startIndex < lastIndex) continue; // skip overlapping match
+    if (match.startIndex < lastIndex) {
+      // Overlapping match — extend the redacted span if this one reaches further
+      if (match.endIndex > lastIndex) {
+        lastIndex = match.endIndex;
+      }
+      continue;
+    }
     result += text.slice(lastIndex, match.startIndex);
     result += `[REDACTED:${match.type}]`;
     lastIndex = match.endIndex;


### PR DESCRIPTION
## Summary

- **Fix partial secret leakage with overlapping matches** — When a shorter match (e.g., AWS Secret Key at 40 chars) overlapped with a longer match (e.g., Generic Secret Assignment with extra tail content), the shorter match was redacted first and the longer one was skipped, leaking the suffix. Now:
  1. Matches are sorted by `startIndex` ascending, then `endIndex` descending, so the wider match at the same start position is preferred.
  2. When an overlapping match extends beyond the current `lastIndex`, `lastIndex` is extended to cover the full span rather than skipping.

## Test plan

- [x] 2 new tests: wider overlapping match extends redaction, wider match at same start wins
- [x] All 97 secret-scanner tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
