### PR TITLE
[#162] Fix suggestion window retention, OCR threading, and enabled state persistence

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -23,10 +23,12 @@ final class AmbientAgent: ObservableObject {
     var isEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: "ambientAgentEnabled") }
         set {
-            UserDefaults.standard.set(newValue, forKey: "ambientAgentEnabled")
             if newValue {
                 start()
+                // Only persist enabled if start() actually succeeded
+                UserDefaults.standard.set(watchTask != nil, forKey: "ambientAgentEnabled")
             } else {
+                UserDefaults.standard.set(false, forKey: "ambientAgentEnabled")
                 stop()
             }
         }
@@ -42,6 +44,7 @@ final class AmbientAgent: ObservableObject {
     private let knowledgeStore = KnowledgeStore()
     private var analyzer: AmbientAnalyzer?
     private var watchTask: Task<Void, Never>?
+    private var activeSuggestionWindow: AmbientSuggestionWindow?
     private var previousOCRText: String = ""
 
     weak var appDelegate: AppDelegate?
@@ -186,13 +189,16 @@ final class AmbientAgent: ObservableObject {
         let window = AmbientSuggestionWindow(
             suggestion: suggestion,
             onAccept: { [weak self] in
+                self?.activeSuggestionWindow = nil
                 self?.lastSuggestion = nil
                 appDelegate.startSession(task: suggestion)
             },
             onDismiss: { [weak self] in
+                self?.activeSuggestionWindow = nil
                 self?.lastSuggestion = nil
             }
         )
+        activeSuggestionWindow = window
         window.show()
     }
 

--- a/clients/macos/vellum-assistant/Ambient/ScreenOCR.swift
+++ b/clients/macos/vellum-assistant/Ambient/ScreenOCR.swift
@@ -4,43 +4,45 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ScreenOCR")
 
-final class ScreenOCR {
+final class ScreenOCR: Sendable {
     func recognizeText(from jpegData: Data) async -> String {
         await withCheckedContinuation { continuation in
-            guard let cgImage = cgImage(from: jpegData) else {
-                log.warning("Failed to create CGImage from JPEG data")
-                continuation.resume(returning: "")
-                return
-            }
-
-            let request = VNRecognizeTextRequest { request, error in
-                if let error = error {
-                    log.warning("OCR error: \(error.localizedDescription)")
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let cgImage = self.cgImage(from: jpegData) else {
+                    log.warning("Failed to create CGImage from JPEG data")
                     continuation.resume(returning: "")
                     return
                 }
 
-                guard let observations = request.results as? [VNRecognizedTextObservation] else {
-                    continuation.resume(returning: "")
-                    return
+                let request = VNRecognizeTextRequest { request, error in
+                    if let error = error {
+                        log.warning("OCR error: \(error.localizedDescription)")
+                        continuation.resume(returning: "")
+                        return
+                    }
+
+                    guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                        continuation.resume(returning: "")
+                        return
+                    }
+
+                    let text = observations.compactMap { observation in
+                        observation.topCandidates(1).first?.string
+                    }.joined(separator: "\n")
+
+                    continuation.resume(returning: text)
                 }
 
-                let text = observations.compactMap { observation in
-                    observation.topCandidates(1).first?.string
-                }.joined(separator: "\n")
+                request.recognitionLevel = .accurate
+                request.usesLanguageCorrection = true
 
-                continuation.resume(returning: text)
-            }
-
-            request.recognitionLevel = .accurate
-            request.usesLanguageCorrection = true
-
-            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-            do {
-                try handler.perform([request])
-            } catch {
-                log.warning("VNImageRequestHandler failed: \(error.localizedDescription)")
-                continuation.resume(returning: "")
+                let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+                do {
+                    try handler.perform([request])
+                } catch {
+                    log.warning("VNImageRequestHandler failed: \(error.localizedDescription)")
+                    continuation.resume(returning: "")
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -178,9 +178,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let provider = AnthropicProvider(apiKey: apiKey)
-        let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
-        let maxSteps = storedMaxSteps > 0 ? Int(storedMaxSteps) : 50
-        let session = ComputerUseSession(task: task, provider: provider, maxSteps: maxSteps)
+        let session = ComputerUseSession(task: task, provider: provider)
         currentSession = session
 
         let overlay = SessionOverlayWindow(session: session)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -178,7 +178,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let provider = AnthropicProvider(apiKey: apiKey)
-        let session = ComputerUseSession(task: task, provider: provider)
+        let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
+        let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
+        let session = ComputerUseSession(task: task, provider: provider, maxSteps: maxSteps)
         currentSession = session
 
         let overlay = SessionOverlayWindow(session: session)

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
-    @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
+    @State private var maxSteps: Double = 50
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
-    @State private var maxSteps: Double = 50
+    @State private var maxSteps: Double = {
+        let val = UserDefaults.standard.double(forKey: "maxStepsPerSession")
+        return val == 0 ? 50 : val
+    }()
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
     @State private var ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
@@ -60,6 +63,9 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
                 Slider(value: $maxSteps, in: 10...100, step: 10)
+                    .onChange(of: maxSteps) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: "maxStepsPerSession")
+                    }
             }
 
             Section("Ambient Agent") {


### PR DESCRIPTION
The purpose of this PR is to address review feedback from PR #162 (ambient screen-watching agent).

## Changes Made
- **Retain `AmbientSuggestionWindow` instance** (P1): Store the window in `activeSuggestionWindow` property to prevent premature deallocation — Accept/Dismiss buttons were non-functional because the local variable was immediately dropped
- **Move OCR to background queue** (P2): Wrap `VNImageRequestHandler.perform` in `DispatchQueue.global(qos: .userInitiated)` to avoid blocking the main thread during each capture cycle
- **Only persist enabled state on success** (P2): Defer writing `ambientAgentEnabled` to UserDefaults until after `start()` succeeds, preventing a stale enabled flag when no API key exists

## Testing
- Manual review of all three feedback items against the codebase

---
*This PR was created with Claude Code*