### PR TITLE
OS keychain abstraction layer

### DIFF
--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports
+// ---------------------------------------------------------------------------
+
+let mockPlatform = 'darwin';
+let execFileCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+let execFileResults: Map<string, string | Error> = new Map();
+
+mock.module('../util/platform.js', () => ({
+  isMacOS: () => mockPlatform === 'darwin',
+  isLinux: () => mockPlatform === 'linux',
+  isWindows: () => mockPlatform === 'win32',
+  getDataDir: () => '/tmp/vellum-test',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('node:child_process', () => ({
+  execFileSync: (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    execFileCalls.push({ cmd, args: [...args], opts: { ...opts } });
+
+    // Build a key from the command for result lookup
+    const key = `${cmd} ${args.join(' ')}`;
+    for (const [pattern, result] of execFileResults) {
+      if (key.includes(pattern)) {
+        if (result instanceof Error) throw result;
+        return result;
+      }
+    }
+    // Default: return empty string (success)
+    return '';
+  },
+}));
+
+import {
+  isKeychainAvailable,
+  getKey,
+  setKey,
+  deleteKey,
+} from '../security/keychain.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('keychain', () => {
+  beforeEach(() => {
+    execFileCalls = [];
+    execFileResults = new Map();
+    mockPlatform = 'darwin';
+  });
+
+  // -----------------------------------------------------------------------
+  // isKeychainAvailable
+  // -----------------------------------------------------------------------
+  describe('isKeychainAvailable', () => {
+    test('returns true on macOS when security CLI works', () => {
+      mockPlatform = 'darwin';
+      expect(isKeychainAvailable()).toBe(true);
+      expect(execFileCalls[0].cmd).toBe('security');
+      expect(execFileCalls[0].args).toContain('list-keychains');
+    });
+
+    test('returns true on Linux when secret-tool exists', () => {
+      mockPlatform = 'linux';
+      expect(isKeychainAvailable()).toBe(true);
+      expect(execFileCalls[0].cmd).toBe('which');
+      expect(execFileCalls[0].args).toContain('secret-tool');
+    });
+
+    test('returns false on unsupported platform', () => {
+      mockPlatform = 'win32';
+      expect(isKeychainAvailable()).toBe(false);
+    });
+
+    test('returns false when CLI command fails', () => {
+      mockPlatform = 'darwin';
+      execFileResults.set('list-keychains', new Error('not found'));
+      expect(isKeychainAvailable()).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // macOS getKey / setKey / deleteKey
+  // -----------------------------------------------------------------------
+  describe('macOS', () => {
+    beforeEach(() => {
+      mockPlatform = 'darwin';
+    });
+
+    test('getKey calls security find-generic-password', () => {
+      execFileResults.set('find-generic-password', 'my-secret-value\n');
+      const result = getKey('anthropic');
+      expect(result).toBe('my-secret-value');
+      const call = execFileCalls.find((c) => c.args.includes('find-generic-password'));
+      expect(call).toBeDefined();
+      expect(call!.args).toContain('-s');
+      expect(call!.args).toContain('vellum-assistant');
+      expect(call!.args).toContain('-a');
+      expect(call!.args).toContain('anthropic');
+      expect(call!.args).toContain('-w');
+    });
+
+    test('getKey returns undefined when key not found', () => {
+      execFileResults.set('find-generic-password', new Error('item not found'));
+      expect(getKey('nonexistent')).toBeUndefined();
+    });
+
+    test('setKey calls security add-generic-password', () => {
+      const result = setKey('anthropic', 'sk-ant-key123');
+      expect(result).toBe(true);
+      const addCall = execFileCalls.find((c) => c.args.includes('add-generic-password'));
+      expect(addCall).toBeDefined();
+      expect(addCall!.args).toContain('-w');
+      expect(addCall!.args).toContain('sk-ant-key123');
+    });
+
+    test('setKey deletes before adding (update pattern)', () => {
+      setKey('anthropic', 'new-value');
+      // Should have a delete call before the add call
+      const deleteIdx = execFileCalls.findIndex((c) => c.args.includes('delete-generic-password'));
+      const addIdx = execFileCalls.findIndex((c) => c.args.includes('add-generic-password'));
+      expect(deleteIdx).toBeLessThan(addIdx);
+    });
+
+    test('deleteKey calls security delete-generic-password', () => {
+      const result = deleteKey('anthropic');
+      expect(result).toBe(true);
+      const call = execFileCalls.find((c) => c.args.includes('delete-generic-password'));
+      expect(call).toBeDefined();
+      expect(call!.args).toContain('vellum-assistant');
+      expect(call!.args).toContain('anthropic');
+    });
+
+    test('deleteKey returns false on error', () => {
+      execFileResults.set('delete-generic-password', new Error('item not found'));
+      expect(deleteKey('nonexistent')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Linux getKey / setKey / deleteKey
+  // -----------------------------------------------------------------------
+  describe('Linux', () => {
+    beforeEach(() => {
+      mockPlatform = 'linux';
+    });
+
+    test('getKey calls secret-tool lookup', () => {
+      execFileResults.set('lookup', 'linux-secret-value\n');
+      const result = getKey('openai');
+      expect(result).toBe('linux-secret-value');
+      const call = execFileCalls.find((c) => c.cmd === 'secret-tool' && c.args.includes('lookup'));
+      expect(call).toBeDefined();
+      expect(call!.args).toContain('service');
+      expect(call!.args).toContain('vellum-assistant');
+      expect(call!.args).toContain('account');
+      expect(call!.args).toContain('openai');
+    });
+
+    test('getKey returns undefined when key not found', () => {
+      execFileResults.set('lookup', new Error('not found'));
+      expect(getKey('missing')).toBeUndefined();
+    });
+
+    test('setKey calls secret-tool store with input', () => {
+      const result = setKey('gemini', 'gemini-key-123');
+      expect(result).toBe(true);
+      const call = execFileCalls.find((c) => c.cmd === 'secret-tool' && c.args.includes('store'));
+      expect(call).toBeDefined();
+      expect(call!.args).toContain('--label');
+      expect(call!.opts.input).toBe('gemini-key-123');
+    });
+
+    test('deleteKey calls secret-tool clear', () => {
+      const result = deleteKey('gemini');
+      expect(result).toBe(true);
+      const call = execFileCalls.find((c) => c.cmd === 'secret-tool' && c.args.includes('clear'));
+      expect(call).toBeDefined();
+      expect(call!.args).toContain('vellum-assistant');
+      expect(call!.args).toContain('gemini');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unsupported platform
+  // -----------------------------------------------------------------------
+  describe('unsupported platform', () => {
+    beforeEach(() => {
+      mockPlatform = 'win32';
+    });
+
+    test('getKey returns undefined', () => {
+      expect(getKey('any')).toBeUndefined();
+    });
+
+    test('setKey returns false', () => {
+      expect(setKey('any', 'value')).toBe(false);
+    });
+
+    test('deleteKey returns false', () => {
+      expect(deleteKey('any')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+  describe('error handling', () => {
+    test('getKey gracefully handles unexpected errors', () => {
+      mockPlatform = 'darwin';
+      execFileResults.set('find-generic-password', new Error('unexpected'));
+      expect(getKey('key')).toBeUndefined();
+    });
+
+    test('setKey gracefully handles unexpected errors', () => {
+      mockPlatform = 'darwin';
+      execFileResults.set('add-generic-password', new Error('unexpected'));
+      expect(setKey('key', 'val')).toBe(false);
+    });
+  });
+});

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -1,0 +1,216 @@
+/**
+ * OS keychain abstraction — platform-agnostic secure credential storage.
+ *
+ * - macOS: uses the `security` CLI to interact with Keychain
+ * - Linux: uses `secret-tool` (libsecret) for GNOME/KDE keyrings
+ *
+ * All operations are synchronous to match the config loader's sync API.
+ * Callers should check `isKeychainAvailable()` before use and fall back
+ * to encrypted-at-rest storage when the keychain is not accessible.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { isMacOS, isLinux } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('keychain');
+
+const SERVICE_NAME = 'vellum-assistant';
+
+/** Check if the OS keychain is available on this system. */
+export function isKeychainAvailable(): boolean {
+  try {
+    if (isMacOS()) {
+      // Verify `security` CLI exists and can list keychains
+      execFileSync('security', ['list-keychains'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 5000,
+      });
+      return true;
+    }
+
+    if (isLinux()) {
+      // Verify `secret-tool` exists
+      execFileSync('which', ['secret-tool'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 5000,
+      });
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Retrieve a secret from the OS keychain.
+ * Returns `undefined` if the key doesn't exist or the keychain is unavailable.
+ */
+export function getKey(account: string): string | undefined {
+  try {
+    if (isMacOS()) {
+      return macosGetKey(account);
+    }
+    if (isLinux()) {
+      return linuxGetKey(account);
+    }
+    return undefined;
+  } catch (err) {
+    log.debug({ err, account }, 'Failed to read from keychain');
+    return undefined;
+  }
+}
+
+/**
+ * Store a secret in the OS keychain.
+ * Returns true on success, false on failure.
+ */
+export function setKey(account: string, value: string): boolean {
+  try {
+    if (isMacOS()) {
+      return macosSetKey(account, value);
+    }
+    if (isLinux()) {
+      return linuxSetKey(account, value);
+    }
+    return false;
+  } catch (err) {
+    log.warn({ err, account }, 'Failed to write to keychain');
+    return false;
+  }
+}
+
+/**
+ * Delete a secret from the OS keychain.
+ * Returns true on success, false if not found or on failure.
+ */
+export function deleteKey(account: string): boolean {
+  try {
+    if (isMacOS()) {
+      return macosDeleteKey(account);
+    }
+    if (isLinux()) {
+      return linuxDeleteKey(account);
+    }
+    return false;
+  } catch (err) {
+    log.debug({ err, account }, 'Failed to delete from keychain');
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// macOS Keychain via `security` CLI
+// ---------------------------------------------------------------------------
+
+function macosGetKey(account: string): string | undefined {
+  try {
+    const result = execFileSync('security', [
+      'find-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+      '-w', // output password only
+    ], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+      encoding: 'utf-8',
+    });
+    return result.trim() || undefined;
+  } catch {
+    // Item not found (exit code 44) or other error
+    return undefined;
+  }
+}
+
+function macosSetKey(account: string, value: string): boolean {
+  // Delete first to avoid "already exists" errors on update
+  macosDeleteKey(account);
+  try {
+    execFileSync('security', [
+      'add-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+      '-w', value,
+      '-U', // update if exists
+    ], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function macosDeleteKey(account: string): boolean {
+  try {
+    execFileSync('security', [
+      'delete-generic-password',
+      '-s', SERVICE_NAME,
+      '-a', account,
+    ], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Linux via `secret-tool` (libsecret)
+// ---------------------------------------------------------------------------
+
+function linuxGetKey(account: string): string | undefined {
+  try {
+    const result = execFileSync('secret-tool', [
+      'lookup',
+      'service', SERVICE_NAME,
+      'account', account,
+    ], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+      encoding: 'utf-8',
+    });
+    return result.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function linuxSetKey(account: string, value: string): boolean {
+  try {
+    execFileSync('secret-tool', [
+      'store',
+      '--label', `${SERVICE_NAME}: ${account}`,
+      'service', SERVICE_NAME,
+      'account', account,
+    ], {
+      input: value,
+      stdio: ['pipe', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function linuxDeleteKey(account: string): boolean {
+  try {
+    execFileSync('secret-tool', [
+      'clear',
+      'service', SERVICE_NAME,
+      'account', account,
+    ], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Add platform-agnostic OS keychain module (`security/keychain.ts`) for secure credential storage
- macOS support via `security` CLI (Keychain), Linux support via `secret-tool` (libsecret)
- Provides `isKeychainAvailable()`, `getKey()`, `setKey()`, `deleteKey()` with 5s timeouts and graceful fallback
- 19 tests covering macOS, Linux, unsupported platforms, and error handling

## Test plan

- [x] All 19 keychain tests pass (`bun test keychain`)
- [x] TypeScript compiles cleanly
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
