### PR TITLE
Encrypted-at-rest key storage fallback

### DIFF
--- a/assistant/src/__tests__/encrypted-store.test.ts
+++ b/assistant/src/__tests__/encrypted-store.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mock only the logger (not platform — we use _setStorePath instead)
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  getKey,
+  setKey,
+  deleteKey,
+  listKeys,
+  _setStorePath,
+} from '../security/encrypted-store.js';
+
+// ---------------------------------------------------------------------------
+// Use a temp directory so tests don't touch the real ~/.vellum
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-enc-test-${randomBytes(4).toString('hex')}`);
+const STORE_PATH = join(TEST_DIR, 'keys.enc');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('encrypted-store', () => {
+  beforeEach(() => {
+    // Ensure clean temp directory and point store at it
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic CRUD
+  // -----------------------------------------------------------------------
+  describe('basic operations', () => {
+    test('setKey creates the store file and returns true', () => {
+      const result = setKey('anthropic', 'sk-ant-key123');
+      expect(result).toBe(true);
+      expect(existsSync(STORE_PATH)).toBe(true);
+    });
+
+    test('getKey retrieves a previously stored value', () => {
+      setKey('anthropic', 'sk-ant-key123');
+      const result = getKey('anthropic');
+      expect(result).toBe('sk-ant-key123');
+    });
+
+    test('getKey returns undefined for nonexistent key', () => {
+      expect(getKey('nonexistent')).toBeUndefined();
+    });
+
+    test('getKey returns undefined when store file does not exist', () => {
+      expect(getKey('anything')).toBeUndefined();
+    });
+
+    test('setKey overwrites existing value', () => {
+      setKey('anthropic', 'old-value');
+      setKey('anthropic', 'new-value');
+      expect(getKey('anthropic')).toBe('new-value');
+    });
+
+    test('deleteKey removes an entry and returns true', () => {
+      setKey('anthropic', 'sk-ant-key123');
+      const result = deleteKey('anthropic');
+      expect(result).toBe(true);
+      expect(getKey('anthropic')).toBeUndefined();
+    });
+
+    test('deleteKey returns false for nonexistent key', () => {
+      setKey('anthropic', 'value');
+      expect(deleteKey('nonexistent')).toBe(false);
+    });
+
+    test('deleteKey returns false when store does not exist', () => {
+      expect(deleteKey('anything')).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple keys
+  // -----------------------------------------------------------------------
+  describe('multiple keys', () => {
+    test('stores and retrieves multiple independent keys', () => {
+      setKey('anthropic', 'sk-ant-123');
+      setKey('openai', 'sk-openai-456');
+      setKey('gemini', 'gem-key-789');
+
+      expect(getKey('anthropic')).toBe('sk-ant-123');
+      expect(getKey('openai')).toBe('sk-openai-456');
+      expect(getKey('gemini')).toBe('gem-key-789');
+    });
+
+    test('deleting one key does not affect others', () => {
+      setKey('anthropic', 'val-1');
+      setKey('openai', 'val-2');
+      deleteKey('anthropic');
+
+      expect(getKey('anthropic')).toBeUndefined();
+      expect(getKey('openai')).toBe('val-2');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // listKeys
+  // -----------------------------------------------------------------------
+  describe('listKeys', () => {
+    test('returns empty array when store does not exist', () => {
+      expect(listKeys()).toEqual([]);
+    });
+
+    test('returns all stored account names', () => {
+      setKey('anthropic', 'val-1');
+      setKey('openai', 'val-2');
+      const keys = listKeys();
+      expect(keys).toContain('anthropic');
+      expect(keys).toContain('openai');
+      expect(keys.length).toBe(2);
+    });
+
+    test('reflects deletions', () => {
+      setKey('anthropic', 'val-1');
+      setKey('openai', 'val-2');
+      deleteKey('anthropic');
+      expect(listKeys()).toEqual(['openai']);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Store format
+  // -----------------------------------------------------------------------
+  describe('store format', () => {
+    test('store file is valid JSON with version, salt, and entries', () => {
+      setKey('test', 'value');
+      const raw = readFileSync(STORE_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(1);
+      expect(typeof parsed.salt).toBe('string');
+      expect(parsed.salt.length).toBe(64); // 32 bytes = 64 hex chars
+      expect(typeof parsed.entries).toBe('object');
+      expect(parsed.entries.test).toBeDefined();
+    });
+
+    test('each entry has iv, tag, and data fields', () => {
+      setKey('test', 'value');
+      const raw = readFileSync(STORE_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      const entry = parsed.entries.test;
+      expect(typeof entry.iv).toBe('string');
+      expect(entry.iv.length).toBe(32); // 16 bytes = 32 hex chars
+      expect(typeof entry.tag).toBe('string');
+      expect(entry.tag.length).toBe(32); // 16 bytes = 32 hex chars
+      expect(typeof entry.data).toBe('string');
+      expect(entry.data.length).toBeGreaterThan(0);
+    });
+
+    test('ciphertext does not contain the plaintext value', () => {
+      const secret = 'super-secret-api-key-12345';
+      setKey('test', secret);
+      const raw = readFileSync(STORE_PATH, 'utf-8');
+      expect(raw).not.toContain(secret);
+    });
+
+    test('different values produce different ciphertexts (unique IVs)', () => {
+      setKey('key1', 'same-value');
+      const raw1 = readFileSync(STORE_PATH, 'utf-8');
+      const entry1 = JSON.parse(raw1).entries.key1;
+
+      // Delete and re-set to get a new IV
+      deleteKey('key1');
+      setKey('key1', 'same-value');
+      const raw2 = readFileSync(STORE_PATH, 'utf-8');
+      const entry2 = JSON.parse(raw2).entries.key1;
+
+      // IVs should differ (random), so ciphertext should differ too
+      expect(entry1.iv).not.toBe(entry2.iv);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+  describe('error handling', () => {
+    test('getKey returns undefined for corrupted store file', () => {
+      writeFileSync(STORE_PATH, 'not valid json');
+      expect(getKey('test')).toBeUndefined();
+    });
+
+    test('getKey returns undefined for invalid store version', () => {
+      writeFileSync(STORE_PATH, JSON.stringify({
+        version: 99,
+        salt: 'abc',
+        entries: {},
+      }));
+      expect(getKey('test')).toBeUndefined();
+    });
+
+    test('getKey returns undefined when entry has tampered ciphertext', () => {
+      setKey('test', 'secret');
+      const raw = readFileSync(STORE_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      // Flip a byte in the ciphertext
+      const data = parsed.entries.test.data;
+      const flipped = data[0] === '0' ? '1' + data.slice(1) : '0' + data.slice(1);
+      parsed.entries.test.data = flipped;
+      writeFileSync(STORE_PATH, JSON.stringify(parsed));
+      // GCM auth should fail
+      expect(getKey('test')).toBeUndefined();
+    });
+
+    test('getKey returns undefined when auth tag is tampered', () => {
+      setKey('test', 'secret');
+      const raw = readFileSync(STORE_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      // Flip a byte in the auth tag
+      const tag = parsed.entries.test.tag;
+      const flipped = tag[0] === '0' ? '1' + tag.slice(1) : '0' + tag.slice(1);
+      parsed.entries.test.tag = flipped;
+      writeFileSync(STORE_PATH, JSON.stringify(parsed));
+      expect(getKey('test')).toBeUndefined();
+    });
+
+    test('setKey creates directory if missing', () => {
+      // Point to a path in a non-existent subdirectory
+      const nestedPath = join(TEST_DIR, 'sub', 'dir', 'keys.enc');
+      _setStorePath(nestedPath);
+      const result = setKey('test', 'value');
+      expect(result).toBe(true);
+      expect(getKey('test')).toBe('value');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+  describe('edge cases', () => {
+    test('handles empty string value', () => {
+      setKey('empty', '');
+      expect(getKey('empty')).toBe('');
+    });
+
+    test('handles very long values', () => {
+      const longValue = 'x'.repeat(10_000);
+      setKey('long', longValue);
+      expect(getKey('long')).toBe(longValue);
+    });
+
+    test('handles special characters in value', () => {
+      const special = '🔑 key=val&foo "bar" \n\t\\';
+      setKey('special', special);
+      expect(getKey('special')).toBe(special);
+    });
+
+    test('handles special characters in account name', () => {
+      setKey('my/nested.key', 'value');
+      expect(getKey('my/nested.key')).toBe('value');
+    });
+
+    test('salt is preserved across set operations', () => {
+      setKey('key1', 'val1');
+      const raw1 = readFileSync(STORE_PATH, 'utf-8');
+      const salt1 = JSON.parse(raw1).salt;
+
+      setKey('key2', 'val2');
+      const raw2 = readFileSync(STORE_PATH, 'utf-8');
+      const salt2 = JSON.parse(raw2).salt;
+
+      expect(salt1).toBe(salt2);
+    });
+  });
+});

--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -1,0 +1,230 @@
+/**
+ * Encrypted-at-rest key storage — fallback for systems without OS keychain.
+ *
+ * Uses AES-256-GCM with a key derived from machine-specific entropy:
+ *   - hostname, username, platform, arch, homedir
+ *   - PBKDF2 with 100k iterations + a persisted random salt
+ *
+ * Secrets are stored in `~/.vellum/keys.enc` as a JSON blob encrypted
+ * with the derived key. Each entry has its own IV for authenticated encryption.
+ *
+ * Provides the same get/set/delete interface as `keychain.ts`.
+ */
+
+import {
+  randomBytes,
+  pbkdf2Sync,
+  createCipheriv,
+  createDecipheriv,
+} from 'node:crypto';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { hostname, userInfo } from 'node:os';
+import { getDataDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('encrypted-store');
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32; // bytes (256 bits)
+const IV_LENGTH = 16; // bytes (128 bits)
+const AUTH_TAG_LENGTH = 16; // bytes
+const PBKDF2_ITERATIONS = 100_000;
+const SALT_LENGTH = 32; // bytes
+
+/** On-disk format for the encrypted store. */
+interface StoreFile {
+  /** Version for future format changes. */
+  version: 1;
+  /** Hex-encoded salt for PBKDF2 key derivation. */
+  salt: string;
+  /** Individual encrypted entries keyed by account name. */
+  entries: Record<string, EncryptedEntry>;
+}
+
+/** A single encrypted value. */
+interface EncryptedEntry {
+  /** Hex-encoded IV. */
+  iv: string;
+  /** Hex-encoded auth tag. */
+  tag: string;
+  /** Hex-encoded ciphertext. */
+  data: string;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+let storePathOverride: string | null = null;
+
+function getStorePath(): string {
+  return storePathOverride ?? join(getDataDir(), 'keys.enc');
+}
+
+/** @internal Test-only: override the store file path. Pass `null` to reset. */
+export function _setStorePath(path: string | null): void {
+  storePathOverride = path;
+}
+
+// ---------------------------------------------------------------------------
+// Machine entropy for key derivation
+// ---------------------------------------------------------------------------
+
+function getMachineEntropy(): string {
+  const parts: string[] = [];
+  try { parts.push(hostname()); } catch { parts.push('unknown-host'); }
+  try { parts.push(userInfo().username); } catch { parts.push('unknown-user'); }
+  parts.push(process.platform);
+  parts.push(process.arch);
+  try { parts.push(userInfo().homedir); } catch { parts.push('/tmp'); }
+  return parts.join(':');
+}
+
+function deriveKey(salt: Buffer): Buffer {
+  const entropy = getMachineEntropy();
+  return pbkdf2Sync(entropy, salt, PBKDF2_ITERATIONS, KEY_LENGTH, 'sha512');
+}
+
+// ---------------------------------------------------------------------------
+// Store I/O
+// ---------------------------------------------------------------------------
+
+function readStore(): StoreFile | null {
+  const path = getStorePath();
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== 1 || typeof parsed.salt !== 'string' || typeof parsed.entries !== 'object') {
+      log.warn('Encrypted store has invalid format, ignoring');
+      return null;
+    }
+    return parsed as StoreFile;
+  } catch (err) {
+    log.warn({ err }, 'Failed to read encrypted store');
+    return null;
+  }
+}
+
+function writeStore(store: StoreFile): void {
+  const path = getStorePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+function getOrCreateStore(): StoreFile {
+  const existing = readStore();
+  if (existing) return existing;
+  const salt = randomBytes(SALT_LENGTH);
+  const store: StoreFile = {
+    version: 1,
+    salt: salt.toString('hex'),
+    entries: {},
+  };
+  writeStore(store);
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt / Decrypt
+// ---------------------------------------------------------------------------
+
+function encrypt(plaintext: string, key: Buffer): EncryptedEntry {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    iv: iv.toString('hex'),
+    tag: tag.toString('hex'),
+    data: encrypted.toString('hex'),
+  };
+}
+
+function decrypt(entry: EncryptedEntry, key: Buffer): string {
+  const iv = Buffer.from(entry.iv, 'hex');
+  const tag = Buffer.from(entry.tag, 'hex');
+  const data = Buffer.from(entry.data, 'hex');
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return decrypted.toString('utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Public API — matches keychain.ts interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieve a secret from the encrypted store.
+ * Returns `undefined` if the key doesn't exist or decryption fails.
+ */
+export function getKey(account: string): string | undefined {
+  try {
+    const store = readStore();
+    if (!store) return undefined;
+
+    const entry = store.entries[account];
+    if (!entry) return undefined;
+
+    const salt = Buffer.from(store.salt, 'hex');
+    const key = deriveKey(salt);
+    return decrypt(entry, key);
+  } catch (err) {
+    log.debug({ err, account }, 'Failed to read from encrypted store');
+    return undefined;
+  }
+}
+
+/**
+ * Store a secret in the encrypted store.
+ * Returns true on success, false on failure.
+ */
+export function setKey(account: string, value: string): boolean {
+  try {
+    const store = getOrCreateStore();
+    const salt = Buffer.from(store.salt, 'hex');
+    const key = deriveKey(salt);
+    store.entries[account] = encrypt(value, key);
+    writeStore(store);
+    return true;
+  } catch (err) {
+    log.warn({ err, account }, 'Failed to write to encrypted store');
+    return false;
+  }
+}
+
+/**
+ * Delete a secret from the encrypted store.
+ * Returns true on success, false if not found or on failure.
+ */
+export function deleteKey(account: string): boolean {
+  try {
+    const store = readStore();
+    if (!store || !(account in store.entries)) return false;
+
+    delete store.entries[account];
+    writeStore(store);
+    return true;
+  } catch (err) {
+    log.debug({ err, account }, 'Failed to delete from encrypted store');
+    return false;
+  }
+}
+
+/**
+ * List all account names in the encrypted store.
+ */
+export function listKeys(): string[] {
+  try {
+    const store = readStore();
+    if (!store) return [];
+    return Object.keys(store.entries);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

- Add `security/encrypted-store.ts` — AES-256-GCM encrypted key storage for systems without OS keychain access
- Key derived from machine-specific entropy (hostname, username, platform, arch, homedir) via PBKDF2 with 100k iterations and a persisted random salt
- Secrets stored in `~/.vellum/keys.enc` with per-entry unique IVs for authenticated encryption
- Same `getKey()`, `setKey()`, `deleteKey()` interface as `keychain.ts`, plus `listKeys()`
- Store file written with mode 0600 (owner-only permissions)
- 27 tests covering CRUD, multiple keys, store format validation, tamper detection, error handling, and edge cases

## Test plan

- [x] All 27 encrypted-store tests pass (`bun test encrypted-store`)
- [x] TypeScript compiles cleanly
- [x] All existing tests unaffected (pre-existing trust-store failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
