### PR TITLE
Retry loading allowlist when file missing or malformed

### DIFF
--- a/assistant/src/__tests__/secret-allowlist.test.ts
+++ b/assistant/src/__tests__/secret-allowlist.test.ts
@@ -176,6 +176,39 @@ describe('secret-allowlist', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Retry on missing/malformed file
+  // -----------------------------------------------------------------------
+  test('retries loading when file did not exist on first call', () => {
+    // First call — no file exists, should not cache as loaded
+    expect(isAllowlisted('test-key')).toBe(false);
+
+    // Now create the file
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['test-key'] }),
+    );
+
+    // Second call — should pick up the newly created file
+    expect(isAllowlisted('test-key')).toBe(true);
+  });
+
+  test('retries loading when file was malformed on first call', () => {
+    // First call with malformed JSON
+    writeFileSync(join(testDir, 'secret-allowlist.json'), 'not json{{{');
+    loadAllowlist();
+    expect(isAllowlisted('test-key')).toBe(false);
+
+    // Fix the file
+    writeFileSync(
+      join(testDir, 'secret-allowlist.json'),
+      JSON.stringify({ values: ['test-key'] }),
+    );
+
+    // Should retry and pick up the fixed file
+    expect(isAllowlisted('test-key')).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
   // resetAllowlist
   // -----------------------------------------------------------------------
   test('resetAllowlist clears cached state', () => {

--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -41,7 +41,6 @@ let allowedRegexes: RegExp[] = [];
  */
 export function loadAllowlist(): void {
   if (loaded) return;
-  loaded = true;
 
   const filePath = join(getDataDir(), 'secret-allowlist.json');
   if (!existsSync(filePath)) return;
@@ -68,6 +67,9 @@ export function loadAllowlist(): void {
         }
       }
     }
+
+    // Only mark as loaded after successful parse
+    loaded = true;
 
     const total = allowedValues.size + allowedPrefixes.length + allowedRegexes.length;
     if (total > 0) {


### PR DESCRIPTION
## Summary

- Move `loaded = true` to after successful parse in `loadAllowlist()`, so if the file doesn't exist or is malformed on first call, subsequent calls will retry
- Previously, `loaded` was set before file existence check, meaning a missing file on first scan would permanently prevent loading for the rest of the process lifetime
- Addresses PR #176 feedback (P2)

## Test plan

- [x] New test: retries loading when file did not exist on first call
- [x] New test: retries loading when file was malformed on first call
- [x] All 15 allowlist tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
