### PR TITLE
Iterative min during compaction to avoid stack overflow (#177 feedback)

### DIFF
--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -212,6 +212,22 @@ describe('RateLimitProvider', () => {
       }
     });
 
+    test('handles large timestamp arrays without stack overflow', async () => {
+      const highLimit = 200_000;
+      const config: RateLimitConfig = { maxRequestsPerMinute: highLimit, maxTokensPerSession: 0 };
+      const shared: number[] = [];
+      const provider = new RateLimitProvider(makeProvider(), config, shared);
+
+      // Fill with timestamps that are all within the window
+      const now = Date.now();
+      for (let i = 0; i < highLimit; i++) {
+        shared.push(now - Math.floor(Math.random() * 59_000));
+      }
+
+      // This should throw RateLimitError, not RangeError
+      await expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
+    });
+
     test('shared array reference survives pruning', async () => {
       const config: RateLimitConfig = { maxRequestsPerMinute: 100, maxTokensPerSession: 0 };
       const shared: number[] = [];

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -47,18 +47,21 @@ export class RateLimitProvider implements Provider {
     const now = Date.now();
     const windowStart = now - 60_000;
     // Prune expired timestamps in-place to preserve the shared array
-    // reference. Single-pass compaction: copy valid entries to the front
-    // and truncate, handling out-of-order entries correctly in O(n).
+    // reference. Single-pass compaction: copy valid entries to the front,
+    // track the oldest surviving entry, and truncate — all in O(n).
     let write = 0;
+    let oldestInWindow = Infinity;
     for (let read = 0; read < this.requestTimestamps.length; read++) {
       if (this.requestTimestamps[read] > windowStart) {
+        if (this.requestTimestamps[read] < oldestInWindow) {
+          oldestInWindow = this.requestTimestamps[read];
+        }
         this.requestTimestamps[write++] = this.requestTimestamps[read];
       }
     }
     this.requestTimestamps.length = write;
 
     if (this.requestTimestamps.length >= limit) {
-      const oldestInWindow = Math.min(...this.requestTimestamps);
       const waitSec = Math.ceil((oldestInWindow + 60_000 - now) / 1000);
       throw new RateLimitError(
         `Rate limit exceeded: ${limit} requests/minute. Try again in ${waitSec}s.`,


### PR DESCRIPTION
## Summary

- Replace `Math.min(...this.requestTimestamps)` with an iterative minimum tracked during the compaction loop
- `Math.min(...array)` can throw `RangeError: Maximum call stack size exceeded` when the array exceeds the engine's argument limit (~65k-130k elements)
- Now the oldest timestamp is computed in O(n) during the same pass that prunes expired entries, with no extra iteration
- Addresses PR #177 feedback (P2)

## Test plan

- [x] New test: verifies 200k timestamps don't cause stack overflow
- [x] All 17 ratelimit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
