### PR TITLE
Fix keychain data loss, process arg leak, and whitespace stripping (#182 feedback)

### DIFF
--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -112,21 +112,34 @@ describe('keychain', () => {
       expect(getKey('nonexistent')).toBeUndefined();
     });
 
-    test('setKey calls security add-generic-password', () => {
+    test('setKey calls security add-generic-password with -U flag', () => {
       const result = setKey('anthropic', 'sk-ant-key123');
       expect(result).toBe(true);
       const addCall = execFileCalls.find((c) => c.args.includes('add-generic-password'));
       expect(addCall).toBeDefined();
+      expect(addCall!.args).toContain('-U');
       expect(addCall!.args).toContain('-w');
-      expect(addCall!.args).toContain('sk-ant-key123');
     });
 
-    test('setKey deletes before adding (update pattern)', () => {
+    test('setKey passes secret via stdin, not in args', () => {
+      setKey('anthropic', 'sk-ant-key123');
+      const addCall = execFileCalls.find((c) => c.args.includes('add-generic-password'));
+      expect(addCall).toBeDefined();
+      // Secret should be in opts.input, not in the args array
+      expect(addCall!.opts.input).toBe('sk-ant-key123');
+      expect(addCall!.args).not.toContain('sk-ant-key123');
+    });
+
+    test('setKey does not delete before adding (relies on -U flag)', () => {
       setKey('anthropic', 'new-value');
-      // Should have a delete call before the add call
-      const deleteIdx = execFileCalls.findIndex((c) => c.args.includes('delete-generic-password'));
-      const addIdx = execFileCalls.findIndex((c) => c.args.includes('add-generic-password'));
-      expect(deleteIdx).toBeLessThan(addIdx);
+      const deleteCall = execFileCalls.find((c) => c.args.includes('delete-generic-password'));
+      expect(deleteCall).toBeUndefined();
+    });
+
+    test('getKey preserves internal whitespace', () => {
+      execFileResults.set('find-generic-password', ' value with spaces \n');
+      const result = getKey('test');
+      expect(result).toBe(' value with spaces ');
     });
 
     test('deleteKey calls security delete-generic-password', () => {
@@ -167,6 +180,12 @@ describe('keychain', () => {
     test('getKey returns undefined when key not found', () => {
       execFileResults.set('lookup', new Error('not found'));
       expect(getKey('missing')).toBeUndefined();
+    });
+
+    test('getKey preserves internal whitespace', () => {
+      execFileResults.set('lookup', ' value with spaces \n');
+      const result = getKey('test');
+      expect(result).toBe(' value with spaces ');
     });
 
     test('setKey calls secret-tool store with input', () => {

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -117,7 +117,8 @@ function macosGetKey(account: string): string | undefined {
       timeout: 5000,
       encoding: 'utf-8',
     });
-    return result.trim() || undefined;
+    // Strip only the trailing newline added by the security CLI
+    return result.replace(/\n$/, '') || undefined;
   } catch {
     // Item not found (exit code 44) or other error
     return undefined;
@@ -125,17 +126,17 @@ function macosGetKey(account: string): string | undefined {
 }
 
 function macosSetKey(account: string, value: string): boolean {
-  // Delete first to avoid "already exists" errors on update
-  macosDeleteKey(account);
+  // -U flag handles update-if-exists, no need to delete first
   try {
     execFileSync('security', [
       'add-generic-password',
       '-s', SERVICE_NAME,
       '-a', account,
-      '-w', value,
+      '-w', // read password from stdin (avoids exposing in process args)
       '-U', // update if exists
     ], {
-      stdio: ['ignore', 'ignore', 'ignore'],
+      input: value,
+      stdio: ['pipe', 'ignore', 'ignore'],
       timeout: 5000,
     });
     return true;
@@ -175,7 +176,8 @@ function linuxGetKey(account: string): string | undefined {
       timeout: 5000,
       encoding: 'utf-8',
     });
-    return result.trim() || undefined;
+    // Strip only the trailing newline added by secret-tool
+    return result.replace(/\n$/, '') || undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Three fixes from PR #182 feedback:

1. **Remove redundant delete before add (BUG)** — `macosSetKey` was calling `macosDeleteKey` before `add-generic-password`, causing data loss if the add fails. The `-U` flag already handles update-if-exists, making the delete redundant and dangerous.

2. **Pass secret via stdin instead of command-line args (P2)** — `-w value` puts the raw secret in the process argument list, visible via `ps`. Now passes the value via stdin (`input` option) so it never appears in process arguments.

3. **Strip only trailing newline, not all whitespace (P2)** — `result.trim()` was stripping significant leading/trailing whitespace from credentials. Now uses `result.replace(/\n$/, '')` to only remove the transport newline added by the CLI tools.

## Test plan

- [x] Updated: setKey passes secret via stdin, not in args
- [x] Updated: setKey does not delete before adding (relies on -U flag)
- [x] New: macOS getKey preserves internal whitespace
- [x] New: Linux getKey preserves internal whitespace
- [x] All 22 keychain tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
