### PR TITLE
Prevent corrupt store overwrite, enforce chmod, fix prototype pollution (#183 feedback)

### DIFF
--- a/assistant/src/__tests__/encrypted-store.test.ts
+++ b/assistant/src/__tests__/encrypted-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, statSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -251,6 +251,36 @@ describe('encrypted-store', () => {
       expect(result).toBe(true);
       expect(getKey('test')).toBe('value');
     });
+
+    test('setKey refuses to overwrite a corrupt store file', () => {
+      // Write a valid store first
+      setKey('existing', 'old-secret');
+      // Corrupt the store
+      writeFileSync(STORE_PATH, 'corrupted data');
+      // setKey should fail rather than overwrite with new salt
+      const result = setKey('new-key', 'new-value');
+      expect(result).toBe(false);
+    });
+
+    test('setKey refuses to overwrite a store with invalid version', () => {
+      writeFileSync(STORE_PATH, JSON.stringify({
+        version: 99,
+        salt: 'abc',
+        entries: {},
+      }));
+      const result = setKey('test', 'value');
+      expect(result).toBe(false);
+    });
+
+    test('writeStore enforces 0600 permissions on existing files', () => {
+      setKey('test', 'value');
+      // Loosen permissions
+      chmodSync(STORE_PATH, 0o644);
+      // Write again — should re-enforce 0600
+      setKey('test2', 'value2');
+      const mode = statSync(STORE_PATH).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -277,6 +307,14 @@ describe('encrypted-store', () => {
     test('handles special characters in account name', () => {
       setKey('my/nested.key', 'value');
       expect(getKey('my/nested.key')).toBe('value');
+    });
+
+    test('__proto__ account name works correctly', () => {
+      setKey('__proto__', 'proto-value');
+      expect(getKey('__proto__')).toBe('proto-value');
+      expect(listKeys()).toContain('__proto__');
+      deleteKey('__proto__');
+      expect(getKey('__proto__')).toBeUndefined();
     });
 
     test('salt is preserved across set operations', () => {

--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -17,7 +17,7 @@ import {
   createCipheriv,
   createDecipheriv,
 } from 'node:crypto';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { hostname, userInfo } from 'node:os';
 import { getDataDir } from '../util/platform.js';
@@ -90,21 +90,26 @@ function deriveKey(salt: Buffer): Buffer {
 // Store I/O
 // ---------------------------------------------------------------------------
 
+/**
+ * Read result: distinguishes "file missing" from "file corrupt/unreadable".
+ * - `null`: file does not exist (safe to create)
+ * - `StoreFile`: successfully parsed
+ * - throws: file exists but cannot be parsed (corrupt/invalid)
+ */
 function readStore(): StoreFile | null {
   const path = getStorePath();
   if (!existsSync(path)) return null;
-  try {
-    const raw = readFileSync(path, 'utf-8');
-    const parsed = JSON.parse(raw);
-    if (parsed.version !== 1 || typeof parsed.salt !== 'string' || typeof parsed.entries !== 'object') {
-      log.warn('Encrypted store has invalid format, ignoring');
-      return null;
-    }
-    return parsed as StoreFile;
-  } catch (err) {
-    log.warn({ err }, 'Failed to read encrypted store');
-    return null;
+
+  const raw = readFileSync(path, 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (parsed.version !== 1 || typeof parsed.salt !== 'string' || typeof parsed.entries !== 'object') {
+    throw new Error('Encrypted store has invalid format');
   }
+  // Use null-prototype object for entries to prevent prototype pollution
+  const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
+  Object.assign(safeEntries, parsed.entries);
+  parsed.entries = safeEntries;
+  return parsed as StoreFile;
 }
 
 function writeStore(store: StoreFile): void {
@@ -114,16 +119,22 @@ function writeStore(store: StoreFile): void {
     mkdirSync(dir, { recursive: true });
   }
   writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 });
+  // Enforce 0600 even if the file already existed with permissive bits
+  chmodSync(path, 0o600);
 }
 
 function getOrCreateStore(): StoreFile {
-  const existing = readStore();
-  if (existing) return existing;
+  const path = getStorePath();
+  if (existsSync(path)) {
+    // File exists — must be parseable, otherwise fail to prevent data loss
+    return readStore()!;
+  }
   const salt = randomBytes(SALT_LENGTH);
+  const entries: Record<string, EncryptedEntry> = Object.create(null);
   const store: StoreFile = {
     version: 1,
     salt: salt.toString('hex'),
-    entries: {},
+    entries,
   };
   writeStore(store);
   return store;
@@ -205,7 +216,7 @@ export function setKey(account: string, value: string): boolean {
 export function deleteKey(account: string): boolean {
   try {
     const store = readStore();
-    if (!store || !(account in store.entries)) return false;
+    if (!store || !Object.prototype.hasOwnProperty.call(store.entries, account)) return false;
 
     delete store.entries[account];
     writeStore(store);


### PR DESCRIPTION
## Summary

Three fixes from PR #183 feedback:

1. **P1: Prevent overwriting corrupt store** — `getOrCreateStore()` was reinitializing when an existing file was malformed, permanently orphaning all stored secrets. Now `readStore()` throws on corrupt files instead of returning `null`, and `getOrCreateStore()` only creates new stores when the file truly doesn't exist. Writes to a corrupt store fail gracefully with `false`.

2. **P2: Enforce 0600 permissions on every write** — `writeFileSync` `mode` only applies at creation time. Added `chmodSync(path, 0o600)` after every write to enforce owner-only permissions even on pre-existing files with permissive bits.

3. **BUG: Fix `__proto__` prototype pollution** — Using bracket notation on plain objects silently drops `__proto__` keys. Now uses `Object.create(null)` for entries objects and `Object.prototype.hasOwnProperty.call` for existence checks.

## Test plan

- [x] New: setKey refuses to overwrite a corrupt store file
- [x] New: setKey refuses to overwrite a store with invalid version
- [x] New: writeStore enforces 0600 permissions on existing files
- [x] New: `__proto__` account name works correctly (set, get, list, delete)
- [x] All 31 encrypted-store tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
