### PR TITLE
Cache missing-file check to avoid repeated existsSync on hot path (#184 feedback)

### DIFF
--- a/assistant/src/__tests__/secret-allowlist.test.ts
+++ b/assistant/src/__tests__/secret-allowlist.test.ts
@@ -178,17 +178,19 @@ describe('secret-allowlist', () => {
   // -----------------------------------------------------------------------
   // Retry on missing/malformed file
   // -----------------------------------------------------------------------
-  test('retries loading when file did not exist on first call', () => {
-    // First call — no file exists, should not cache as loaded
+  test('caches missing file check to avoid repeated existsSync', () => {
+    // First call — no file exists, caches fileChecked = true
     expect(isAllowlisted('test-key')).toBe(false);
 
-    // Now create the file
+    // Create the file — but fileChecked is cached, so it won't be seen
     writeFileSync(
       join(testDir, 'secret-allowlist.json'),
       JSON.stringify({ values: ['test-key'] }),
     );
+    expect(isAllowlisted('test-key')).toBe(false);
 
-    // Second call — should pick up the newly created file
+    // After reset, the file should be found
+    resetAllowlist();
     expect(isAllowlisted('test-key')).toBe(true);
   });
 

--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -31,6 +31,7 @@ export interface AllowlistConfig {
 
 // Cached state
 let loaded = false;
+let fileChecked = false;
 let allowedValues: Set<string> = new Set();
 let allowedPrefixes: string[] = [];
 let allowedRegexes: RegExp[] = [];
@@ -40,10 +41,13 @@ let allowedRegexes: RegExp[] = [];
  * Safe to call multiple times — subsequent calls are no-ops unless `resetAllowlist` is called.
  */
 export function loadAllowlist(): void {
-  if (loaded) return;
+  if (loaded || fileChecked) return;
 
   const filePath = join(getDataDir(), 'secret-allowlist.json');
-  if (!existsSync(filePath)) return;
+  if (!existsSync(filePath)) {
+    fileChecked = true;
+    return;
+  }
 
   try {
     const raw = readFileSync(filePath, 'utf-8');
@@ -105,6 +109,7 @@ export function isAllowlisted(value: string): boolean {
  */
 export function resetAllowlist(): void {
   loaded = false;
+  fileChecked = false;
   allowedValues = new Set();
   allowedPrefixes = [];
   allowedRegexes = [];


### PR DESCRIPTION
## Summary
- When `secret-allowlist.json` doesn't exist (common case), `loadAllowlist()` was calling `existsSync()` on every `isAllowlisted()` invocation — a hot path called many times per `scanText()` call
- Added a separate `fileChecked` flag that caches the "file doesn't exist" result, preventing repeated filesystem syscalls
- Malformed files still retry on next call (only `loaded` is set on successful parse, not `fileChecked`)
- Both `loaded` and `fileChecked` are cleared by `resetAllowlist()`
- Updated test to verify the caching behavior

## Test plan
- [x] All 15 allowlist tests pass
- [x] TypeScript type check passes
- [x] Verify missing file is cached (no repeated existsSync)
- [x] Verify malformed file still retries
- [x] Verify resetAllowlist clears both flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
