### PR TITLE
Integrate keychain/encrypted store into config loader

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mock logger and keychain
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Track keychain availability and stored keys for mock
+let keychainAvailable = false;
+const keychainStore = new Map<string, string>();
+
+mock.module('../security/keychain.js', () => ({
+  isKeychainAvailable: () => keychainAvailable,
+  getKey: (account: string) => keychainStore.get(account),
+  setKey: (account: string, value: string) => { keychainStore.set(account, value); return true; },
+  deleteKey: (account: string) => keychainStore.delete(account),
+}));
+
+import {
+  getSecureKey,
+  setSecureKey,
+  deleteSecureKey,
+  listSecureKeys,
+  _resetBackend,
+  _setBackend,
+} from '../security/secure-keys.js';
+import { _setStorePath } from '../security/encrypted-store.js';
+
+// ---------------------------------------------------------------------------
+// Use a temp directory for encrypted store tests
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-seckeys-test-${randomBytes(4).toString('hex')}`);
+const STORE_PATH = join(TEST_DIR, 'keys.enc');
+
+describe('secure-keys', () => {
+  beforeEach(() => {
+    // Clean state
+    keychainAvailable = false;
+    keychainStore.clear();
+    _resetBackend();
+
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    _resetBackend();
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Backend selection
+  // -----------------------------------------------------------------------
+  describe('backend selection', () => {
+    test('uses encrypted store when keychain is unavailable', () => {
+      keychainAvailable = false;
+      _resetBackend();
+      setSecureKey('anthropic', 'sk-test-123');
+      expect(getSecureKey('anthropic')).toBe('sk-test-123');
+      // Should be in encrypted store, not keychain
+      expect(keychainStore.has('anthropic')).toBe(false);
+      expect(existsSync(STORE_PATH)).toBe(true);
+    });
+
+    test('uses keychain when available', () => {
+      keychainAvailable = true;
+      _resetBackend();
+      setSecureKey('anthropic', 'sk-test-456');
+      expect(getSecureKey('anthropic')).toBe('sk-test-456');
+      // Should be in keychain, not encrypted store
+      expect(keychainStore.get('anthropic')).toBe('sk-test-456');
+      expect(existsSync(STORE_PATH)).toBe(false);
+    });
+
+    test('caches backend selection', () => {
+      keychainAvailable = false;
+      _resetBackend();
+      setSecureKey('test', 'val1');
+
+      // Change availability — should still use encrypted store
+      keychainAvailable = true;
+      setSecureKey('test2', 'val2');
+      expect(keychainStore.has('test2')).toBe(false);
+      expect(existsSync(STORE_PATH)).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD operations (via encrypted store backend)
+  // -----------------------------------------------------------------------
+  describe('CRUD with encrypted backend', () => {
+    test('set and get a key', () => {
+      setSecureKey('openai', 'sk-openai-789');
+      expect(getSecureKey('openai')).toBe('sk-openai-789');
+    });
+
+    test('get returns undefined for nonexistent key', () => {
+      expect(getSecureKey('nonexistent')).toBeUndefined();
+    });
+
+    test('delete removes a key', () => {
+      setSecureKey('gemini', 'gem-key');
+      expect(deleteSecureKey('gemini')).toBe(true);
+      expect(getSecureKey('gemini')).toBeUndefined();
+    });
+
+    test('delete returns false for nonexistent key', () => {
+      expect(deleteSecureKey('missing')).toBe(false);
+    });
+
+    test('listSecureKeys returns all keys', () => {
+      setSecureKey('anthropic', 'val1');
+      setSecureKey('openai', 'val2');
+      const keys = listSecureKeys();
+      expect(keys).toContain('anthropic');
+      expect(keys).toContain('openai');
+      expect(keys.length).toBe(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CRUD operations (via keychain backend)
+  // -----------------------------------------------------------------------
+  describe('CRUD with keychain backend', () => {
+    beforeEach(() => {
+      keychainAvailable = true;
+      _resetBackend();
+    });
+
+    test('set and get a key', () => {
+      setSecureKey('anthropic', 'sk-ant-123');
+      expect(getSecureKey('anthropic')).toBe('sk-ant-123');
+    });
+
+    test('delete removes a key', () => {
+      setSecureKey('anthropic', 'sk-ant-123');
+      deleteSecureKey('anthropic');
+      expect(getSecureKey('anthropic')).toBeUndefined();
+    });
+
+    test('listSecureKeys returns empty for keychain backend', () => {
+      setSecureKey('anthropic', 'val');
+      // Keychain doesn't support listing
+      expect(listSecureKeys()).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _setBackend
+  // -----------------------------------------------------------------------
+  describe('_setBackend', () => {
+    test('forces encrypted backend', () => {
+      _setBackend('encrypted');
+      setSecureKey('test', 'value');
+      expect(existsSync(STORE_PATH)).toBe(true);
+      expect(keychainStore.has('test')).toBe(false);
+    });
+
+    test('forces keychain backend', () => {
+      _setBackend('keychain');
+      setSecureKey('test', 'value');
+      expect(keychainStore.get('test')).toBe('value');
+    });
+
+    test('reset re-evaluates backend', () => {
+      _setBackend('keychain');
+      setSecureKey('k1', 'v1');
+      expect(keychainStore.get('k1')).toBe('v1');
+
+      _setBackend(undefined); // reset
+      keychainAvailable = false;
+      setSecureKey('k2', 'v2');
+      expect(keychainStore.has('k2')).toBe(false);
+      expect(getSecureKey('k2')).toBe('v2');
+    });
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -4,6 +4,7 @@ import { getDataDir, ensureDataDir } from '../util/platform.js';
 import { ConfigError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { DEFAULT_CONFIG } from './defaults.js';
+import { getSecureKey, setSecureKey, deleteSecureKey } from '../security/secure-keys.js';
 import type { AssistantConfig } from './types.js';
 
 const log = getLogger('config');
@@ -73,7 +74,19 @@ export function loadConfig(): AssistantConfig {
 
     validateConfig(config);
 
-    // Environment variables override config file (after validation so apiKeys is a valid object)
+    // Secure storage keys override plaintext config file
+    try {
+      for (const provider of ['anthropic', 'openai', 'gemini', 'ollama']) {
+        const secureKey = getSecureKey(provider);
+        if (secureKey) {
+          config.apiKeys[provider] = secureKey;
+        }
+      }
+    } catch (err) {
+      log.debug({ err }, 'Failed to load keys from secure storage');
+    }
+
+    // Environment variables override everything (after validation so apiKeys is a valid object)
     if (process.env.ANTHROPIC_API_KEY) {
       config.apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
     }
@@ -166,7 +179,16 @@ function validateConfig(config: AssistantConfig): void {
 export function saveConfig(config: AssistantConfig): void {
   ensureDataDir();
   const configPath = getConfigPath();
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+  // Route apiKeys to secure storage, write config without them
+  for (const [provider, value] of Object.entries(config.apiKeys)) {
+    if (typeof value === 'string' && value.length > 0) {
+      setSecureKey(provider, value);
+    }
+  }
+  const { apiKeys: _, ...rest } = config;
+  writeFileSync(configPath, JSON.stringify(rest, null, 2) + '\n');
+
   cached = config;
 }
 
@@ -180,24 +202,61 @@ export function invalidateConfigCache(): void {
 }
 
 /**
- * Load the raw config from disk (without env var overrides).
+ * Load the raw config from disk, merging API keys from secure storage.
  * Used by CLI config commands to read/write the file directly.
  */
 export function loadRawConfig(): Record<string, unknown> {
   ensureDataDir();
   const configPath = getConfigPath();
-  if (!existsSync(configPath)) return {};
-  try {
-    return JSON.parse(readFileSync(configPath, 'utf-8'));
-  } catch (err) {
-    throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
+  let raw: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
+    }
   }
+
+  // Merge secure keys into apiKeys so `config get apiKeys.*` works
+  try {
+    const apiKeys = (raw.apiKeys && typeof raw.apiKeys === 'object' && !Array.isArray(raw.apiKeys))
+      ? { ...raw.apiKeys as Record<string, unknown> }
+      : {};
+    for (const provider of VALID_PROVIDERS) {
+      const value = getSecureKey(provider);
+      if (value) apiKeys[provider] = value;
+    }
+    if (Object.keys(apiKeys).length > 0) {
+      raw.apiKeys = apiKeys;
+    }
+  } catch (err) {
+    log.debug({ err }, 'Failed to merge secure keys into raw config');
+  }
+
+  return raw;
 }
 
 export function saveRawConfig(config: Record<string, unknown>): void {
   ensureDataDir();
   const configPath = getConfigPath();
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+  // Route apiKeys to secure storage and strip from plaintext file
+  const apiKeys = config.apiKeys;
+  if (apiKeys && typeof apiKeys === 'object' && !Array.isArray(apiKeys)) {
+    for (const [provider, value] of Object.entries(apiKeys as Record<string, unknown>)) {
+      if (typeof value === 'string' && value.length > 0) {
+        setSecureKey(provider, value);
+      } else if (value === undefined || value === null || value === '') {
+        deleteSecureKey(provider);
+      }
+    }
+    // Remove apiKeys from plaintext config
+    const { apiKeys: _, ...rest } = config;
+    writeFileSync(configPath, JSON.stringify(rest, null, 2) + '\n');
+  } else {
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  }
+
   cached = null; // invalidate cache
 }
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -1,0 +1,83 @@
+/**
+ * Unified secure key storage — tries OS keychain first, falls back to
+ * encrypted-at-rest file storage.
+ *
+ * Provides the same get/set/delete/list interface used by both backends.
+ * Backend selection is cached after the first call for the process lifetime.
+ */
+
+import * as keychain from './keychain.js';
+import * as encryptedStore from './encrypted-store.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('secure-keys');
+
+type Backend = 'keychain' | 'encrypted' | null;
+let resolvedBackend: Backend | undefined;
+
+function getBackend(): Backend {
+  if (resolvedBackend !== undefined) return resolvedBackend;
+
+  if (keychain.isKeychainAvailable()) {
+    log.debug('Using OS keychain for secure key storage');
+    resolvedBackend = 'keychain';
+  } else {
+    log.debug('OS keychain unavailable, using encrypted file storage');
+    resolvedBackend = 'encrypted';
+  }
+  return resolvedBackend;
+}
+
+/**
+ * Retrieve a secret from secure storage.
+ * Returns `undefined` if the key doesn't exist or on error.
+ */
+export function getSecureKey(account: string): string | undefined {
+  const backend = getBackend();
+  if (backend === 'keychain') return keychain.getKey(account);
+  if (backend === 'encrypted') return encryptedStore.getKey(account);
+  return undefined;
+}
+
+/**
+ * Store a secret in secure storage.
+ * Returns `true` on success, `false` on failure.
+ */
+export function setSecureKey(account: string, value: string): boolean {
+  const backend = getBackend();
+  if (backend === 'keychain') return keychain.setKey(account, value);
+  if (backend === 'encrypted') return encryptedStore.setKey(account, value);
+  return false;
+}
+
+/**
+ * Delete a secret from secure storage.
+ * Returns `true` on success, `false` if not found or on error.
+ */
+export function deleteSecureKey(account: string): boolean {
+  const backend = getBackend();
+  if (backend === 'keychain') return keychain.deleteKey(account);
+  if (backend === 'encrypted') return encryptedStore.deleteKey(account);
+  return false;
+}
+
+/**
+ * List all account names in secure storage.
+ * Only supported by the encrypted backend; keychain returns empty array.
+ */
+export function listSecureKeys(): string[] {
+  const backend = getBackend();
+  if (backend === 'encrypted') return encryptedStore.listKeys();
+  // OS keychains don't provide a list API scoped to our service
+  return [];
+}
+
+/** @internal Test-only: reset the cached backend so it's re-evaluated. */
+export function _resetBackend(): void {
+  resolvedBackend = undefined;
+}
+
+/** @internal Test-only: force a specific backend. Pass `undefined` to reset. */
+export function _setBackend(backend: Backend | undefined): void {
+  resolvedBackend = backend;
+}


### PR DESCRIPTION
## Summary
- Added `secure-keys.ts` — unified abstraction that tries OS keychain first, falls back to encrypted-at-rest file storage, with cached backend selection
- Updated `loadConfig()` to merge API keys from secure storage (priority: env vars > secure storage > plaintext file > defaults)
- Updated `saveConfig()` and `saveRawConfig()` to route `apiKeys.*` writes to secure storage and strip them from plaintext `config.json`
- Updated `loadRawConfig()` to merge secure keys so `config get apiKeys.*` returns stored values
- 14 new tests covering backend selection, CRUD operations with both backends, and caching behavior

## Key design decisions
- **Priority order**: env vars > secure storage > plaintext file > defaults. Env vars always win for flexibility.
- **Automatic stripping**: When saving config, API keys are automatically routed to secure storage and removed from plaintext JSON. No more secrets in `config.json`.
- **Backend caching**: Backend (keychain vs encrypted) is determined once per process lifetime, avoiding repeated `isKeychainAvailable()` checks.
- **Known provider iteration**: Since OS keychains don't support listing keys by service, we iterate known provider names (anthropic, openai, gemini, ollama) when loading.

## Test plan
- [x] 14 secure-keys tests pass (backend selection, CRUD with encrypted/keychain, caching)
- [x] 31 encrypted-store tests still pass
- [x] TypeScript type check passes
- [x] Verify `config set apiKeys.anthropic` routes to secure storage
- [x] Verify `config get apiKeys.anthropic` reads from secure storage
- [x] Verify plaintext config.json does not contain API keys after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
