### PR TITLE
Fix macOS security CLI -w flag consuming -U as password (#186 feedback)

### DIFF
--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -121,13 +121,14 @@ describe('keychain', () => {
       expect(addCall!.args).toContain('-w');
     });
 
-    test('setKey passes secret via stdin, not in args', () => {
+    test('setKey passes secret as -w argument', () => {
       setKey('anthropic', 'sk-ant-key123');
       const addCall = execFileCalls.find((c) => c.args.includes('add-generic-password'));
       expect(addCall).toBeDefined();
-      // Secret should be in opts.input, not in the args array
-      expect(addCall!.opts.input).toBe('sk-ant-key123');
-      expect(addCall!.args).not.toContain('sk-ant-key123');
+      // macOS security CLI requires password as the -w argument value
+      const wIndex = addCall!.args.indexOf('-w');
+      expect(wIndex).toBeGreaterThanOrEqual(0);
+      expect(addCall!.args[wIndex + 1]).toBe('sk-ant-key123');
     });
 
     test('setKey does not delete before adding (relies on -U flag)', () => {

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -126,17 +126,19 @@ function macosGetKey(account: string): string | undefined {
 }
 
 function macosSetKey(account: string, value: string): boolean {
-  // -U flag handles update-if-exists, no need to delete first
+  // -U flag handles update-if-exists, no need to delete first.
+  // macOS `security` requires the password as the argument to -w;
+  // it does NOT read from stdin. Using `-w` without a value causes
+  // the next flag to be consumed as the password.
   try {
     execFileSync('security', [
       'add-generic-password',
       '-s', SERVICE_NAME,
       '-a', account,
-      '-w', // read password from stdin (avoids exposing in process args)
+      '-w', value,
       '-U', // update if exists
     ], {
-      input: value,
-      stdio: ['pipe', 'ignore', 'ignore'],
+      stdio: ['ignore', 'ignore', 'ignore'],
       timeout: 5000,
     });
     return true;


### PR DESCRIPTION
## Summary
- **BUG FIX**: macOS `security add-generic-password -w` requires the password as its next positional argument — it does NOT read from stdin
- The previous code passed `-w` as a standalone flag expecting stdin input, which caused `-U` (the next argument) to be consumed as the password value
- This silently stored the literal string `-U` instead of the actual secret, and also disabled the update-if-exists behavior
- Fix: pass the value directly as `-w value` argument, matching the macOS `security` CLI API

## Root cause
The `security` man page shows: `-w password    Specify password to be added. Put at end of command to be prompted (recommended)`

The `-w` flag requires a value argument. Unlike `secret-tool` on Linux (which reads from stdin), macOS `security` only accepts passwords via the `-w <value>` argument syntax.

## Test plan
- [x] All 22 keychain tests pass
- [x] TypeScript type check passes
- [x] Manually verified on macOS: `echo "test" | security add-generic-password -s test -a test -w -U` stores `-U` as the password, confirming the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
