### PR TITLE
Auto-migrate plaintext API keys and add keys CLI commands

### DIFF
--- a/assistant/src/__tests__/key-migration.test.ts
+++ b/assistant/src/__tests__/key-migration.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-migration-test-${randomBytes(4).toString('hex')}`);
+const STORE_PATH = join(TEST_DIR, 'keys.enc');
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+  },
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+}));
+
+import { _setStorePath } from '../security/encrypted-store.js';
+import { _setBackend } from '../security/secure-keys.js';
+import { loadConfig, invalidateConfigCache } from '../config/loader.js';
+import { getSecureKey } from '../security/secure-keys.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('key migration', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _setBackend('encrypted');
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    _setBackend(undefined);
+    invalidateConfigCache();
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  test('migrates plaintext apiKeys from config.json to secure storage', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'anthropic',
+      apiKeys: {
+        anthropic: 'sk-ant-test-key-123',
+        openai: 'sk-openai-test-456',
+      },
+    }));
+
+    const config = loadConfig();
+
+    // Keys should be in the loaded config (from secure storage)
+    expect(config.apiKeys.anthropic).toBe('sk-ant-test-key-123');
+    expect(config.apiKeys.openai).toBe('sk-openai-test-456');
+
+    // Keys should be in secure storage
+    expect(getSecureKey('anthropic')).toBe('sk-ant-test-key-123');
+    expect(getSecureKey('openai')).toBe('sk-openai-test-456');
+
+    // Keys should be removed from config.json
+    const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(rawJson.apiKeys).toBeUndefined();
+    // Other config should still be there
+    expect(rawJson.provider).toBe('anthropic');
+  });
+
+  test('does not migrate when no apiKeys in config.json', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5-20250929',
+    }));
+
+    const config = loadConfig();
+    expect(config.provider).toBe('anthropic');
+
+    // Config file should be unchanged
+    const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(rawJson.provider).toBe('anthropic');
+    expect(rawJson.model).toBe('claude-sonnet-4-5-20250929');
+  });
+
+  test('does not migrate empty apiKeys object', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'anthropic',
+      apiKeys: {},
+    }));
+
+    loadConfig();
+
+    // Config file should still have the empty apiKeys
+    const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(rawJson.apiKeys).toEqual({});
+  });
+
+  test('preserves other config fields during migration', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'openai',
+      model: 'gpt-4',
+      maxTokens: 4096,
+      apiKeys: { anthropic: 'sk-ant-test' },
+      timeouts: { shellDefaultTimeoutSec: 30 },
+    }));
+
+    loadConfig();
+
+    const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(rawJson.provider).toBe('openai');
+    expect(rawJson.model).toBe('gpt-4');
+    expect(rawJson.maxTokens).toBe(4096);
+    expect(rawJson.timeouts.shellDefaultTimeoutSec).toBe(30);
+    expect(rawJson.apiKeys).toBeUndefined();
+  });
+
+  test('migration only happens once (idempotent)', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'anthropic',
+      apiKeys: { anthropic: 'sk-ant-test-key' },
+    }));
+
+    // First load — triggers migration
+    loadConfig();
+    expect(getSecureKey('anthropic')).toBe('sk-ant-test-key');
+
+    // Verify config.json no longer has apiKeys
+    const rawAfter = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(rawAfter.apiKeys).toBeUndefined();
+
+    // Second load — should not error or duplicate
+    invalidateConfigCache();
+    const config2 = loadConfig();
+    expect(config2.apiKeys.anthropic).toBe('sk-ant-test-key');
+  });
+
+  test('skips non-string values in apiKeys during migration', () => {
+    const configPath = join(TEST_DIR, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      provider: 'anthropic',
+      apiKeys: {
+        anthropic: 'sk-ant-valid',
+        broken: 123,
+        empty: '',
+      },
+    }));
+
+    loadConfig();
+
+    // Only the valid key should be migrated
+    expect(getSecureKey('anthropic')).toBe('sk-ant-valid');
+    expect(getSecureKey('broken')).toBeUndefined();
+    expect(getSecureKey('empty')).toBeUndefined();
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -56,6 +56,36 @@ export function loadConfig(): AssistantConfig {
       delete fileConfig.apiKeys;
     }
 
+    // Auto-migrate plaintext apiKeys from config.json to secure storage
+    if (fileConfig.apiKeys && typeof fileConfig.apiKeys === 'object') {
+      const plaintextKeys = Object.entries(fileConfig.apiKeys).filter(
+        ([, v]) => typeof v === 'string' && v.length > 0,
+      );
+      if (plaintextKeys.length > 0) {
+        let migrated = 0;
+        for (const [provider, value] of plaintextKeys) {
+          if (setSecureKey(provider, value as string)) {
+            migrated++;
+          } else {
+            log.warn(`Failed to migrate API key for "${provider}" to secure storage`);
+          }
+        }
+        if (migrated > 0) {
+          // Rewrite config.json without apiKeys
+          try {
+            const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+            delete rawJson.apiKeys;
+            writeFileSync(configPath, JSON.stringify(rawJson, null, 2) + '\n');
+            log.info(`Migrated ${migrated} API key(s) from config.json to secure storage`);
+          } catch (err) {
+            log.warn({ err }, 'Failed to remove migrated keys from config.json');
+          }
+        }
+        // Clear from fileConfig so they don't end up in the config object from file
+        delete fileConfig.apiKeys;
+      }
+    }
+
     const config: AssistantConfig = {
       ...DEFAULT_CONFIG,
       ...fileConfig,

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -31,6 +31,7 @@ import {
   removeRule,
   clearAllRules,
 } from './permissions/trust-store.js';
+import { getSecureKey, setSecureKey, deleteSecureKey } from './security/secure-keys.js';
 import { getRecentInvocations } from './memory/tool-usage-store.js';
 import {
   getConversation,
@@ -279,6 +280,51 @@ config
       console.log('No configuration set');
     } else {
       console.log(JSON.stringify(raw, null, 2));
+    }
+  });
+
+// --- Keys commands ---
+const keys = program.command('keys').description('Manage API keys in secure storage');
+
+keys
+  .command('list')
+  .description('List all stored API key names')
+  .action(() => {
+    const stored: string[] = [];
+    for (const provider of ['anthropic', 'openai', 'gemini', 'ollama']) {
+      const value = getSecureKey(provider);
+      if (value) stored.push(provider);
+    }
+    if (stored.length === 0) {
+      console.log('No API keys stored');
+    } else {
+      for (const name of stored) {
+        console.log(`  ${name}`);
+      }
+    }
+  });
+
+keys
+  .command('set <provider> <key>')
+  .description('Store an API key (e.g. vellum keys set anthropic sk-ant-...)')
+  .action((provider: string, key: string) => {
+    if (setSecureKey(provider, key)) {
+      console.log(`Stored API key for "${provider}"`);
+    } else {
+      console.error(`Failed to store API key for "${provider}"`);
+      process.exit(1);
+    }
+  });
+
+keys
+  .command('delete <provider>')
+  .description('Delete a stored API key')
+  .action((provider: string) => {
+    if (deleteSecureKey(provider)) {
+      console.log(`Deleted API key for "${provider}"`);
+    } else {
+      console.error(`No API key found for "${provider}"`);
+      process.exit(1);
     }
   });
 


### PR DESCRIPTION
## Summary
- **Auto-migration**: On first `loadConfig()`, detects plaintext API keys in `config.json`, migrates them to secure storage (keychain or encrypted file), and rewrites the JSON without `apiKeys`
- **CLI commands**: Added `vellum keys list|set|delete` subcommands for managing stored API keys directly
- 6 new tests covering migration behavior (idempotency, field preservation, edge cases)

## Auto-migration behavior
1. Parses `config.json` as usual
2. If `apiKeys` contains string values, migrates each to secure storage via `setSecureKey()`
3. On success, rewrites `config.json` without the `apiKeys` field (preserves all other config)
4. Migration is idempotent — only runs when plaintext keys exist in the file
5. Skips non-string and empty values gracefully

## CLI commands
- `vellum keys list` — shows names of all stored API keys (iterates known providers)
- `vellum keys set <provider> <key>` — stores a key in secure storage
- `vellum keys delete <provider>` — removes a key from secure storage

## Test plan
- [x] 6 migration tests pass (basic migration, no-op, empty, preserve fields, idempotent, skip invalid)
- [x] 14 secure-keys tests still pass
- [x] 31 encrypted-store tests still pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
