### PR TITLE
Add audit log rotation with configurable retention period

### DIFF
--- a/assistant/src/__tests__/audit-log-rotation.test.ts
+++ b/assistant/src/__tests__/audit-log-rotation.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { Database } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Test setup — temp directory and mock modules
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-rotation-test-${randomBytes(4).toString('hex')}`);
+const DB_PATH = join(TEST_DIR, 'assistant.db');
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  getDbPath: () => DB_PATH,
+  ensureDataDir: () => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+  },
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+}));
+
+import { initializeDb } from '../memory/db.js';
+import {
+  recordToolInvocation,
+  getRecentInvocations,
+  rotateToolInvocations,
+} from '../memory/tool-usage-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function addInvocation(ageMs: number): void {
+  // Insert directly with a specific timestamp in the past
+  const db = new Database(DB_PATH);
+  const id = randomBytes(8).toString('hex');
+  const createdAt = Date.now() - ageMs;
+  db.prepare(
+    `INSERT INTO tool_invocations (id, conversation_id, tool_name, input, result, decision, risk_level, duration_ms, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, 'conv-1', 'shell', '{"command":"echo hi"}', 'hi', 'allow', 'Low', 100, createdAt);
+  db.close();
+}
+
+function clearTable(): void {
+  const db = new Database(DB_PATH);
+  db.run('DELETE FROM tool_invocations');
+  db.close();
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('audit log rotation', () => {
+  beforeAll(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    clearTable();
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  test('returns 0 when retentionDays is 0 (retain forever)', () => {
+    addInvocation(100 * ONE_DAY_MS); // 100 days old
+    const deleted = rotateToolInvocations(0);
+    expect(deleted).toBe(0);
+    expect(getRecentInvocations(100).length).toBe(1);
+  });
+
+  test('returns 0 when retentionDays is negative', () => {
+    addInvocation(100 * ONE_DAY_MS);
+    const deleted = rotateToolInvocations(-5);
+    expect(deleted).toBe(0);
+    expect(getRecentInvocations(100).length).toBe(1);
+  });
+
+  test('deletes records older than retentionDays', () => {
+    addInvocation(10 * ONE_DAY_MS); // 10 days old — should be deleted with 7-day retention
+    addInvocation(3 * ONE_DAY_MS);  // 3 days old — should be kept
+    addInvocation(1 * ONE_DAY_MS);  // 1 day old — should be kept
+
+    const deleted = rotateToolInvocations(7);
+    expect(deleted).toBe(1);
+    expect(getRecentInvocations(100).length).toBe(2);
+  });
+
+  test('keeps all records when none exceed retention', () => {
+    addInvocation(1 * ONE_DAY_MS);
+    addInvocation(2 * ONE_DAY_MS);
+    addInvocation(3 * ONE_DAY_MS);
+
+    const deleted = rotateToolInvocations(30);
+    expect(deleted).toBe(0);
+    expect(getRecentInvocations(100).length).toBe(3);
+  });
+
+  test('deletes all records when all exceed retention', () => {
+    addInvocation(60 * ONE_DAY_MS);
+    addInvocation(90 * ONE_DAY_MS);
+    addInvocation(120 * ONE_DAY_MS);
+
+    const deleted = rotateToolInvocations(30);
+    expect(deleted).toBe(3);
+    expect(getRecentInvocations(100).length).toBe(0);
+  });
+
+  test('returns 0 when table is empty', () => {
+    const deleted = rotateToolInvocations(7);
+    expect(deleted).toBe(0);
+  });
+
+  test('handles 1-day retention (deletes everything older than 24h)', () => {
+    addInvocation(2 * ONE_DAY_MS);  // 2 days old — delete
+    addInvocation(12 * 60 * 60 * 1000); // 12 hours old — keep
+
+    const deleted = rotateToolInvocations(1);
+    expect(deleted).toBe(1);
+    expect(getRecentInvocations(100).length).toBe(1);
+  });
+
+  test('works with recordToolInvocation (via ORM)', () => {
+    // Add one via the ORM
+    recordToolInvocation({
+      conversationId: 'conv-1',
+      toolName: 'shell',
+      input: '{"command":"ls"}',
+      result: 'output',
+      decision: 'allow',
+      riskLevel: 'Low',
+      durationMs: 50,
+    });
+
+    // This record was just created, so it should not be rotated
+    const deleted = rotateToolInvocations(1);
+    expect(deleted).toBe(0);
+    expect(getRecentInvocations(100).length).toBe(1);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -24,6 +24,9 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     action: 'warn',
     entropyThreshold: 4.0,
   },
+  auditLog: {
+    retentionDays: 0,
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -24,7 +24,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, secretDetection: { ...DEFAULT_CONFIG.secretDetection } };
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, secretDetection: { ...DEFAULT_CONFIG.secretDetection }, auditLog: { ...DEFAULT_CONFIG.auditLog } };
   loading = true;
 
   try {
@@ -94,6 +94,7 @@ export function loadConfig(): AssistantConfig {
       sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
       rateLimit: { ...DEFAULT_CONFIG.rateLimit, ...(fileConfig as Record<string, unknown>).rateLimit as Partial<AssistantConfig['rateLimit']> },
       secretDetection: { ...DEFAULT_CONFIG.secretDetection, ...(fileConfig as Record<string, unknown>).secretDetection as Partial<AssistantConfig['secretDetection']> },
+      auditLog: { ...DEFAULT_CONFIG.auditLog, ...(fileConfig as Record<string, unknown>).auditLog as Partial<AssistantConfig['auditLog']> },
     };
 
     // Set cached before validation so re-entrant calls (e.g. validateConfig
@@ -203,6 +204,11 @@ function validateConfig(config: AssistantConfig): void {
   if (typeof config.secretDetection.entropyThreshold !== 'number' || !Number.isFinite(config.secretDetection.entropyThreshold) || config.secretDetection.entropyThreshold <= 0) {
     log.warn(`Invalid secretDetection.entropyThreshold "${config.secretDetection.entropyThreshold}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.secretDetection.entropyThreshold}.`);
     config.secretDetection.entropyThreshold = DEFAULT_CONFIG.secretDetection.entropyThreshold;
+  }
+
+  if (typeof config.auditLog.retentionDays !== 'number' || !Number.isFinite(config.auditLog.retentionDays) || config.auditLog.retentionDays < 0 || !Number.isInteger(config.auditLog.retentionDays)) {
+    log.warn(`Invalid auditLog.retentionDays "${config.auditLog.retentionDays}". Must be a non-negative integer. Falling back to ${DEFAULT_CONFIG.auditLog.retentionDays}.`);
+    config.auditLog.retentionDays = DEFAULT_CONFIG.auditLog.retentionDays;
   }
 }
 

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -28,6 +28,11 @@ export interface SecretDetectionConfig {
   entropyThreshold: number;
 }
 
+export interface AuditLogConfig {
+  /** Number of days to retain tool invocation records. 0 = retain forever. Default: 0. */
+  retentionDays: number;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
@@ -39,4 +44,5 @@ export interface AssistantConfig {
   sandbox: SandboxConfig;
   rateLimit: RateLimitConfig;
   secretDetection: SecretDetectionConfig;
+  auditLog: AuditLogConfig;
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -7,6 +7,7 @@ import {
   ensureDataDir,
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
+import { rotateToolInvocations } from '../memory/tool-usage-store.js';
 import { initializeProviders } from '../providers/registry.js';
 import { initializeTools } from '../tools/registry.js';
 import { loadConfig } from '../config/loader.js';
@@ -166,6 +167,12 @@ export async function runDaemon(): Promise<void> {
   initializeDb();
 
   const config = loadConfig();
+
+  // Rotate old audit log entries if retention is configured
+  if (config.auditLog.retentionDays > 0) {
+    rotateToolInvocations(config.auditLog.retentionDays);
+  }
+
   initializeProviders(config);
   await initializeTools();
 

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -1,7 +1,8 @@
 import { v4 as uuid } from 'uuid';
-import { desc } from 'drizzle-orm';
+import { desc, lt, count } from 'drizzle-orm';
 import { getDb } from './db.js';
 import { toolInvocations } from './schema.js';
+import { getLogger } from '../util/logger.js';
 
 export interface ToolInvocationRecord {
   conversationId: string;
@@ -36,4 +37,26 @@ export function getRecentInvocations(limit: number) {
     .orderBy(desc(toolInvocations.createdAt))
     .limit(limit)
     .all();
+}
+
+const log = getLogger('audit-log');
+
+/**
+ * Delete tool invocation records older than the specified number of days.
+ * Returns the number of deleted records. Does nothing if retentionDays is 0.
+ */
+export function rotateToolInvocations(retentionDays: number): number {
+  if (retentionDays <= 0) return 0;
+
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  const db = getDb();
+
+  // Count before delete (Drizzle's .run() returns void on bun-sqlite)
+  const [countRow] = db.select({ value: count() }).from(toolInvocations).where(lt(toolInvocations.createdAt, cutoff)).all();
+  const toDelete = countRow?.value ?? 0;
+  if (toDelete === 0) return 0;
+
+  db.delete(toolInvocations).where(lt(toolInvocations.createdAt, cutoff)).run();
+  log.info(`Rotated ${toDelete} audit log entries older than ${retentionDays} day(s)`);
+  return toDelete;
 }


### PR DESCRIPTION
## Summary
- Add `rotateToolInvocations(retentionDays)` to delete tool invocation records older than the configured retention period
- Add `auditLog.retentionDays` config field (default 0 = retain forever) with validation
- Call rotation at daemon startup when retention is configured (> 0)
- 8 new tests covering edge cases: retain-forever, negative values, partial/full deletion, empty table, 1-day retention, ORM integration

## Test plan
- [x] All 8 audit-log-rotation tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify rotation works with real data by setting `auditLog.retentionDays` in config and restarting daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
