### PR TITLE
Watch secret-allowlist.json for changes so daemon picks up new allowlists (#188 feedback)

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -7,6 +7,7 @@ import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
+import { resetAllowlist } from '../security/secret-allowlist.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
 import {
@@ -140,6 +141,9 @@ export class DaemonServer {
       },
       'trust.json': () => {
         clearTrustCache();
+      },
+      'secret-allowlist.json': () => {
+        resetAllowlist();
       },
     };
 

--- a/assistant/src/security/secret-allowlist.ts
+++ b/assistant/src/security/secret-allowlist.ts
@@ -105,7 +105,9 @@ export function isAllowlisted(value: string): boolean {
 }
 
 /**
- * Reset cached state. Used in tests.
+ * Reset cached state so the allowlist is reloaded on next check.
+ * Called by the daemon file watcher when secret-allowlist.json changes,
+ * and by tests.
  */
 export function resetAllowlist(): void {
   loaded = false;


### PR DESCRIPTION
## Summary
- Add `secret-allowlist.json` to the daemon's file watcher handlers in `server.ts`
- When the file changes (created, modified, deleted), `resetAllowlist()` is called, so the next secret scan reloads the allowlist from disk
- Fixes the issue where a daemon started without `secret-allowlist.json` would never pick up a file created later due to the `fileChecked` cache flag

## Test plan
- [x] Existing 15 allowlist tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Start daemon without allowlist file, create `~/.vellum/secret-allowlist.json`, verify it's picked up on next scan without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
