### PR TITLE
Add adaptive delay, drag tool, multi-window awareness, AX tree diffing

### DIFF
--- a/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
+++ b/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3CBEF918BC31B5CDA67AB307 /* ToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */; };
 		43B58A748C33955C52226B4B /* AccessibilityTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */; };
 		A1B2C3D4E5F60789ABCDE012 /* ChromeAccessibilityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7089ABCDE01 /* ChromeAccessibilityHelper.swift */; };
+		AA08B2C3D4E5F607ABCDE008 /* AXTreeDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB08B2C3D4E5F607ABCDE008 /* AXTreeDiff.swift */; };
 		4D469EED4BFBA43F6B759AAC /* SessionLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */; };
 		5099794339FDE050C79700BB /* LogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C691BD0FDCE6190A60F45F5C /* LogViewer.swift */; };
 		535ADB8BECF9E185F1BD3E19 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF062AE5C6B78D85CEDC7C3B /* Session.swift */; };
@@ -67,6 +68,7 @@
 		4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayView.swift; sourceTree = "<group>"; };
 		56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTree.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7089ABCDE01 /* ChromeAccessibilityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeAccessibilityHelper.swift; sourceTree = "<group>"; };
+		BB08B2C3D4E5F607ABCDE008 /* AXTreeDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTreeDiff.swift; sourceTree = "<group>"; };
 		6679C7528847C8E31C861F34 /* vellum-assistantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "vellum-assistantTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		822B891B496900302404DF02 /* APIKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyManager.swift; sourceTree = "<group>"; };
 		83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionInferenceProvider.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */,
+				BB08B2C3D4E5F607ABCDE008 /* AXTreeDiff.swift */,
 				BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */,
 				93BDB5AED0253CF3298634F3 /* ActionTypes.swift */,
 				12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */,
@@ -336,6 +339,7 @@
 			files = (
 				E96230E4CB5C96C982458657 /* APIKeyManager.swift in Sources */,
 				43B58A748C33955C52226B4B /* AccessibilityTree.swift in Sources */,
+				AA08B2C3D4E5F607ABCDE008 /* AXTreeDiff.swift in Sources */,
 				CC06B2C3D4E5F607ABCDE006 /* ActionPreviewWindow.swift in Sources */,
 				A2215F8493C316D8E139D1E6 /* ActionExecutor.swift in Sources */,
 				A1B2C3D4E5F60789ABCDE012 /* ChromeAccessibilityHelper.swift in Sources */,

--- a/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Computes a compact diff between two formatted AX tree snapshots.
+/// Returns a human-readable summary of what changed (elements added, removed, value changes, focus changes).
+enum AXTreeDiff {
+
+    struct ElementSnapshot: Hashable {
+        let id: Int
+        let role: String
+        let title: String?
+        let value: String?
+        let isFocused: Bool
+        let isEnabled: Bool
+    }
+
+    /// Produce a compact diff summary between two AX tree element lists.
+    /// Returns nil if the trees are identical.
+    static func diff(previous: [AXElement], current: [AXElement]) -> String? {
+        let prevFlat = AccessibilityTreeEnumerator.flattenElements(previous)
+        let currFlat = AccessibilityTreeEnumerator.flattenElements(current)
+
+        let prevSnapshots = Dictionary(
+            prevFlat.map { (snapshot(of: $0).id, snapshot(of: $0)) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let currSnapshots = Dictionary(
+            currFlat.map { (snapshot(of: $0).id, snapshot(of: $0)) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var changes: [String] = []
+
+        // Find removed elements (in previous but not in current)
+        let removedIds = Set(prevSnapshots.keys).subtracting(currSnapshots.keys)
+        for id in removedIds.sorted() {
+            if let snap = prevSnapshots[id] {
+                let label = snap.title ?? snap.role
+                changes.append("- Removed: [\(id)] \(label)")
+            }
+        }
+
+        // Find added elements (in current but not in previous)
+        let addedIds = Set(currSnapshots.keys).subtracting(prevSnapshots.keys)
+        for id in addedIds.sorted() {
+            if let snap = currSnapshots[id] {
+                let label = snap.title ?? snap.role
+                changes.append("+ Added: [\(id)] \(label)")
+            }
+        }
+
+        // Find changed elements (same ID, different state)
+        let commonIds = Set(prevSnapshots.keys).intersection(currSnapshots.keys)
+        for id in commonIds.sorted() {
+            guard let prev = prevSnapshots[id], let curr = currSnapshots[id] else { continue }
+            if prev == curr { continue }
+
+            var elementChanges: [String] = []
+            let label = curr.title ?? curr.role
+
+            if prev.value != curr.value {
+                let oldVal = prev.value ?? "(empty)"
+                let newVal = curr.value ?? "(empty)"
+                let truncOld = oldVal.count > 30 ? String(oldVal.prefix(30)) + "..." : oldVal
+                let truncNew = newVal.count > 30 ? String(newVal.prefix(30)) + "..." : newVal
+                elementChanges.append("value: \"\(truncOld)\" → \"\(truncNew)\"")
+            }
+            if prev.isFocused != curr.isFocused {
+                elementChanges.append(curr.isFocused ? "gained focus" : "lost focus")
+            }
+            if prev.isEnabled != curr.isEnabled {
+                elementChanges.append(curr.isEnabled ? "enabled" : "disabled")
+            }
+            if prev.title != curr.title {
+                elementChanges.append("title: \"\(prev.title ?? "(none)")\" → \"\(curr.title ?? "(none)")\"")
+            }
+
+            if !elementChanges.isEmpty {
+                changes.append("~ Changed: [\(id)] \(label) — \(elementChanges.joined(separator: ", "))")
+            }
+        }
+
+        guard !changes.isEmpty else { return nil }
+
+        return "CHANGES SINCE LAST ACTION:\n" + changes.joined(separator: "\n")
+    }
+
+    private static func snapshot(of element: AXElement) -> ElementSnapshot {
+        ElementSnapshot(
+            id: element.id,
+            role: element.role,
+            title: element.title,
+            value: element.value,
+            isFocused: element.isFocused,
+            isEnabled: element.isEnabled
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AccessibilityTree.swift
@@ -19,8 +19,15 @@ struct AXElement: Identifiable {
     let placeholderValue: String?
 }
 
+struct WindowInfo {
+    let elements: [AXElement]
+    let windowTitle: String
+    let appName: String
+}
+
 protocol AccessibilityTreeProviding {
     func enumerateCurrentWindow() -> (elements: [AXElement], windowTitle: String, appName: String)?
+    func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int) -> [WindowInfo]
 }
 
 final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
@@ -188,6 +195,53 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
         guard !elements.isEmpty else { return nil }
         lastTargetPid = pid
         return (elements: elements, windowTitle: windowTitle, appName: appName)
+    }
+
+    /// Enumerate the focused windows of other visible apps (not the primary one).
+    /// Returns up to `maxWindows` secondary window trees, useful for cross-app tasks.
+    func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int = 2) -> [WindowInfo] {
+        let myBundleId = Bundle.main.bundleIdentifier
+        let runningApps = NSWorkspace.shared.runningApplications
+            .filter { app in
+                app.activationPolicy == .regular
+                    && !app.isTerminated
+                    && app.bundleIdentifier != myBundleId
+                    && (excludingPID == nil || app.processIdentifier != excludingPID)
+            }
+
+        var results: [WindowInfo] = []
+        for app in runningApps {
+            guard results.count < maxWindows else { break }
+            let pid = app.processIdentifier
+            let appElement = AXUIElementCreateApplication(pid)
+
+            if !Self.enhancedAXEnabled.contains(pid) {
+                AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+                Self.enhancedAXEnabled.insert(pid)
+            }
+
+            // Get all windows for this app
+            var windowsRef: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+                  let windows = windowsRef as? [AXUIElement],
+                  let firstWindow = windows.first else { continue }
+
+            // Check if the window is on-screen (has a reasonable size)
+            let frame = getFrameAttribute(firstWindow)
+            guard frame.width > 50 && frame.height > 50 else { continue }
+
+            let windowTitle = getStringAttribute(firstWindow, kAXTitleAttribute as CFString) ?? "Untitled"
+            let appName = app.localizedName ?? "Unknown"
+
+            nextId = 1
+            let elements = enumerateElement(element: firstWindow, depth: 0, maxDepth: 15) // shallower for secondary
+            guard !elements.isEmpty else { continue }
+
+            results.append(WindowInfo(elements: elements, windowTitle: windowTitle, appName: appName))
+            log.info("Secondary window: \(appName, privacy: .public) — \"\(windowTitle)\"")
+        }
+
+        return results
     }
 
     private func enumerateElement(element: AXUIElement, depth: Int, maxDepth: Int) -> [AXElement] {
@@ -404,6 +458,39 @@ final class AccessibilityTreeEnumerator: AccessibilityTreeProviding {
             result += String(char).lowercased()
         }
         return result
+    }
+
+    /// Format secondary windows into a compact text representation.
+    /// Uses a condensed format (interactive elements only) to minimize token cost.
+    static func formatSecondaryWindows(_ windows: [WindowInfo]) -> String? {
+        guard !windows.isEmpty else { return nil }
+
+        var lines: [String] = ["OTHER VISIBLE WINDOWS:"]
+        for window in windows {
+            lines.append("")
+            lines.append("  Window: \"\(window.windowTitle)\" (\(window.appName))")
+
+            var interactive: [String] = []
+            var staticTexts: [String] = []
+            collectFormatted(elements: window.elements, interactive: &interactive, staticTexts: &staticTexts)
+
+            if !interactive.isEmpty {
+                for line in interactive.prefix(15) { // Cap per window to limit tokens
+                    lines.append("    \(line)")
+                }
+                if interactive.count > 15 {
+                    lines.append("    ... and \(interactive.count - 15) more elements")
+                }
+            }
+
+            if !staticTexts.isEmpty {
+                for text in staticTexts.prefix(10) {
+                    lines.append("    \(text)")
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
     }
 
     static func shouldFallbackToVision(elements: [AXElement]) -> Bool {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -37,6 +37,13 @@ final class ComputerUseSession: ObservableObject {
     private let initialDelayMs: UInt64
     private var didChromeAccessibilityCheck = false
     private var previousAXTreeText: String?
+    private var previousElements: [AXElement]?
+
+    /// Adaptive delay configuration
+    private let adaptiveDelayEnabled: Bool
+    private let minDelayMs: UInt64 = 100
+    private let maxDelayMs: UInt64 = 2000
+    private let pollIntervalMs: UInt64 = 50
 
     init(
         task: String,
@@ -46,7 +53,8 @@ final class ComputerUseSession: ObservableObject {
         executor: ActionExecuting = ActionExecutor(),
         maxSteps: Int = 50,
         stepDelayMs: UInt64 = 500,
-        initialDelayMs: UInt64 = 300
+        initialDelayMs: UInt64 = 300,
+        adaptiveDelay: Bool = true
     ) {
         self.task = task
         self.provider = provider
@@ -56,6 +64,7 @@ final class ComputerUseSession: ObservableObject {
         self.maxSteps = maxSteps
         self.stepDelayMs = stepDelayMs
         self.initialDelayMs = initialDelayMs
+        self.adaptiveDelayEnabled = adaptiveDelay
         self.verifier = ActionVerifier(maxSteps: maxSteps)
         self.logger = SessionLogger(task: task)
     }
@@ -66,6 +75,7 @@ final class ComputerUseSession: ObservableObject {
         isCancelled = false
         isPaused = false
         previousAXTreeText = nil
+        previousElements = nil
         state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...", reasoning: "")
 
         log.info("Session starting — task: \(self.task, privacy: .public)")
@@ -90,6 +100,9 @@ final class ComputerUseSession: ObservableObject {
             var elements: [AXElement]?
             var screenshot: Data?
             var usedVision = false
+            var axDiffText: String?
+            var secondaryWindowsText: String?
+            var primaryPID: pid_t?
 
             if let result = enumerator.enumerateCurrentWindow() {
                 // On first step with Chrome: check if web content is visible.
@@ -125,8 +138,31 @@ final class ComputerUseSession: ObservableObject {
                 log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
                 log.debug("[\(stepNumber)] AX tree text:\n\(axTreeText ?? "(empty)")")
 
+                // Compute AX tree diff if we have a previous snapshot
+                if let prevElements = previousElements {
+                    axDiffText = AXTreeDiff.diff(previous: prevElements, current: result.elements)
+                    if let diff = axDiffText {
+                        log.info("[\(stepNumber)] AX diff:\n\(diff)")
+                    } else {
+                        log.info("[\(stepNumber)] AX tree unchanged from previous step")
+                    }
+                }
+
+                // Track the primary app's PID for secondary window exclusion
+                primaryPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+
+                // Enumerate secondary windows for cross-app awareness
+                let secondaryWindows = enumerator.enumerateSecondaryWindows(
+                    excludingPID: primaryPID,
+                    maxWindows: 2
+                )
+                secondaryWindowsText = AccessibilityTreeEnumerator.formatSecondaryWindows(secondaryWindows)
+                if let secText = secondaryWindowsText {
+                    log.info("[\(stepNumber)] Secondary windows: \(secondaryWindows.count)")
+                    log.debug("[\(stepNumber)] Secondary windows text:\n\(secText)")
+                }
+
                 // Also capture a screenshot so the model can see content beyond the AX tree
-                // (e.g., a PDF in another window, images, or other visual context)
                 do {
                     screenshot = try await screenCapture.captureScreen()
                     log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
@@ -155,6 +191,8 @@ final class ComputerUseSession: ObservableObject {
                 action = try await provider.infer(
                     axTree: axTreeText,
                     previousAXTree: previousAXTreeText,
+                    axDiff: axDiffText,
+                    secondaryWindows: secondaryWindowsText,
                     screenshot: screenshot,
                     screenSize: screenCapture.screenSize(),
                     task: task,
@@ -234,14 +272,49 @@ final class ComputerUseSession: ObservableObject {
 
             // Save current AX tree for next step's context
             previousAXTreeText = axTreeText
+            previousElements = elements
 
-            // 7. WAIT
-            try? await Task.sleep(nanoseconds: stepDelayMs * 1_000_000)
+            // 7. WAIT — adaptive delay: poll for AX tree changes instead of fixed sleep
+            if adaptiveDelayEnabled && axTreeText != nil {
+                await waitForUISettle(previousTree: axTreeText)
+            } else {
+                try? await Task.sleep(nanoseconds: stepDelayMs * 1_000_000)
+            }
         }
 
         // Cancelled
         state = .cancelled
         logger.finishSession(result: "cancelled")
+    }
+
+    // MARK: - Adaptive Delay
+
+    /// Poll the AX tree until it changes or a max wait is reached.
+    /// Returns as soon as the tree differs from `previousTree`, ensuring minimum delay.
+    private func waitForUISettle(previousTree: String?) async {
+        // Always wait the minimum delay to let CGEvents propagate
+        try? await Task.sleep(nanoseconds: minDelayMs * 1_000_000)
+
+        var elapsed = minDelayMs
+        while elapsed < maxDelayMs && !isCancelled {
+            // Quick check if the AX tree has changed
+            if let result = enumerator.enumerateCurrentWindow() {
+                let currentTree = AccessibilityTreeEnumerator.formatAXTree(
+                    elements: result.elements,
+                    windowTitle: result.windowTitle,
+                    appName: result.appName
+                )
+                if currentTree != previousTree {
+                    log.debug("UI settled after \(elapsed)ms (tree changed)")
+                    return
+                }
+            }
+
+            try? await Task.sleep(nanoseconds: pollIntervalMs * 1_000_000)
+            elapsed += pollIntervalMs
+        }
+
+        log.debug("UI settle timeout after \(elapsed)ms")
     }
 
     // MARK: - Control

--- a/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
@@ -5,6 +5,8 @@ protocol ActionInferenceProvider {
     func infer(
         axTree: String?,
         previousAXTree: String?,
+        axDiff: String?,
+        secondaryWindows: String?,
         screenshot: Data?,
         screenSize: CGSize,
         task: String,

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -13,6 +13,8 @@ final class AnthropicProvider: ActionInferenceProvider {
     func infer(
         axTree: String?,
         previousAXTree: String?,
+        axDiff: String?,
+        secondaryWindows: String?,
         screenshot: Data?,
         screenSize: CGSize,
         task: String,
@@ -20,7 +22,7 @@ final class AnthropicProvider: ActionInferenceProvider {
         elements: [AXElement]?
     ) async throws -> AgentAction {
         let systemPrompt = buildSystemPrompt(screenSize: screenSize)
-        let messages = buildMessages(axTree: axTree, previousAXTree: previousAXTree, screenshot: screenshot, task: task, history: history)
+        let messages = buildMessages(axTree: axTree, previousAXTree: previousAXTree, axDiff: axDiff, secondaryWindows: secondaryWindows, screenshot: screenshot, task: task, history: history)
 
         let (toolName, input) = try await client.sendToolUseRequest(
             model: model,
@@ -59,13 +61,15 @@ final class AnthropicProvider: ActionInferenceProvider {
         - NEVER type passwords, credit card numbers, SSNs, or other sensitive data.
         - Prefer keyboard shortcuts (cmd+c, cmd+v) over menu navigation when possible.
         - When the task is complete, call the done tool with a summary.
-        - You may receive the previous screen state alongside the current one. Compare them to understand what changed after your last action.
+        - You may receive a "CHANGES SINCE LAST ACTION" section that summarizes what changed in the UI. Use this to confirm your action worked or to adapt.
+        - You may see "OTHER VISIBLE WINDOWS" showing elements from other apps. Use this for cross-app tasks (e.g., "copy from Safari, paste into Notes").
+        - For drag operations (moving files, resizing, sliders), use the drag tool with source and destination element_ids or coordinates.
         """
     }
 
     // MARK: - Message Building
 
-    private func buildMessages(axTree: String?, previousAXTree: String?, screenshot: Data?, task: String, history: [ActionRecord]) -> [[String: Any]] {
+    private func buildMessages(axTree: String?, previousAXTree: String?, axDiff: String?, secondaryWindows: String?, screenshot: Data?, task: String, history: [ActionRecord]) -> [[String: Any]] {
         var contentBlocks: [[String: Any]] = []
 
         // Screenshot image block
@@ -85,8 +89,12 @@ final class AnthropicProvider: ActionInferenceProvider {
         textParts.append("TASK: \(task)")
         textParts.append("")
 
-        // Include previous AX tree so the model can see what changed
-        if let prevTree = previousAXTree, !history.isEmpty {
+        // Include AX tree diff (compact summary of what changed)
+        if let diff = axDiff, !history.isEmpty {
+            textParts.append(diff)
+            textParts.append("")
+        } else if let prevTree = previousAXTree, !history.isEmpty {
+            // Fall back to full previous tree if diff unavailable
             textParts.append("SCREEN STATE BEFORE YOUR LAST ACTION:")
             textParts.append(prevTree)
             textParts.append("")
@@ -97,9 +105,17 @@ final class AnthropicProvider: ActionInferenceProvider {
             textParts.append(tree)
             textParts.append("")
             textParts.append("Use element_id with the [ID] numbers shown above to target elements.")
+            // Include secondary windows for cross-app awareness
+            if let secWindows = secondaryWindows {
+                textParts.append("")
+                textParts.append(secWindows)
+                textParts.append("")
+                textParts.append("Note: The element [ID]s above are from other windows — you can reference them for context but can only interact with the focused window's elements.")
+            }
+
             if screenshot != nil {
                 textParts.append("")
-                textParts.append("A screenshot of the FULL SCREEN is also attached above. Use it to see content outside the focused window (e.g., reference documents, PDFs, other apps visible behind the current window). The AX tree only covers the focused window, but the screenshot shows everything visible on screen.")
+                textParts.append("A screenshot of the FULL SCREEN is also attached above. Use it to see content outside the focused window (e.g., reference documents, PDFs, other apps visible behind the current window).")
             }
         } else if screenshot != nil {
             textParts.append("CURRENT SCREEN STATE:")

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -152,6 +152,44 @@ enum ToolDefinitions {
             ] as [String: Any]
         ],
         [
+            "name": "drag",
+            "description": "Drag from one element or position to another. Use for moving files, resizing windows, rearranging items, or adjusting sliders.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] of the source element to drag from (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "Source X coordinate (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Source Y coordinate (fallback when no element_id)"
+                    ],
+                    "to_element_id": [
+                        "type": "integer",
+                        "description": "The [ID] of the destination element to drag to (preferred)"
+                    ],
+                    "to_x": [
+                        "type": "integer",
+                        "description": "Destination X coordinate (fallback when no to_element_id)"
+                    ],
+                    "to_y": [
+                        "type": "integer",
+                        "description": "Destination Y coordinate (fallback when no to_element_id)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you are dragging and why"
+                    ]
+                ],
+                "required": ["reasoning"]
+            ] as [String: Any]
+        ],
+        [
             "name": "wait",
             "description": "Wait for the UI to update",
             "input_schema": [

--- a/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
+++ b/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
@@ -63,6 +63,93 @@ final class AccessibilityTreeTests: XCTestCase {
                         "Should not fallback with 3+ interactive elements")
     }
 
+    // MARK: - AX Tree Diff
+
+    func testDiff_identicalTrees_returnsNil() {
+        let elements = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        XCTAssertNil(AXTreeDiff.diff(previous: elements, current: elements))
+    }
+
+    func testDiff_addedElement() {
+        let prev = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let curr = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil),
+            AXElement(id: 2, role: "AXButton", title: "Cancel", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let diff = AXTreeDiff.diff(previous: prev, current: curr)
+        XCTAssertNotNil(diff)
+        XCTAssertTrue(diff!.contains("Added"))
+        XCTAssertTrue(diff!.contains("Cancel"))
+    }
+
+    func testDiff_removedElement() {
+        let prev = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil),
+            AXElement(id: 2, role: "AXButton", title: "Cancel", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let curr = [
+            AXElement(id: 1, role: "AXButton", title: "OK", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let diff = AXTreeDiff.diff(previous: prev, current: curr)
+        XCTAssertNotNil(diff)
+        XCTAssertTrue(diff!.contains("Removed"))
+        XCTAssertTrue(diff!.contains("Cancel"))
+    }
+
+    func testDiff_changedValue() {
+        let prev = [
+            AXElement(id: 1, role: "AXTextField", title: "Name", value: "John", frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let curr = [
+            AXElement(id: 1, role: "AXTextField", title: "Name", value: "Jane", frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let diff = AXTreeDiff.diff(previous: prev, current: curr)
+        XCTAssertNotNil(diff)
+        XCTAssertTrue(diff!.contains("Changed"))
+        XCTAssertTrue(diff!.contains("John"))
+        XCTAssertTrue(diff!.contains("Jane"))
+    }
+
+    func testDiff_focusChange() {
+        let prev = [
+            AXElement(id: 1, role: "AXTextField", title: "Name", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: false, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let curr = [
+            AXElement(id: 1, role: "AXTextField", title: "Name", value: nil, frame: .zero,
+                      isEnabled: true, isFocused: true, children: [],
+                      roleDescription: nil, identifier: nil, url: nil, placeholderValue: nil)
+        ]
+        let diff = AXTreeDiff.diff(previous: prev, current: curr)
+        XCTAssertNotNil(diff)
+        XCTAssertTrue(diff!.contains("gained focus"))
+    }
+
+    // MARK: - Flatten
+
     func testFlattenElements() {
         let child = AXElement(id: 2, role: "AXButton", title: "Child", value: nil, frame: .zero,
                               isEnabled: true, isFocused: false, children: [],

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -18,6 +18,8 @@ final class MockInferenceProvider: ActionInferenceProvider {
     func infer(
         axTree: String?,
         previousAXTree: String?,
+        axDiff: String?,
+        secondaryWindows: String?,
         screenshot: Data?,
         screenSize: CGSize,
         task: String,
@@ -51,6 +53,10 @@ final class MockAccessibilityTreeEnumerator: AccessibilityTreeProviding {
 
     func enumerateCurrentWindow() -> (elements: [AXElement], windowTitle: String, appName: String)? {
         return result
+    }
+
+    func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int) -> [WindowInfo] {
+        return []
     }
 }
 
@@ -149,7 +155,8 @@ private func makeDefaultEnumerator() -> MockAccessibilityTreeEnumerator {
         executor: executor ?? MockActionExecutor(),
         maxSteps: maxSteps,
         stepDelayMs: 0,
-        initialDelayMs: 0
+        initialDelayMs: 0,
+        adaptiveDelay: false
     )
 }
 

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ToolDefinitionsTests: XCTestCase {
 
     func testToolCount() {
-        XCTAssertEqual(ToolDefinitions.tools.count, 8, "Should have 8 tools defined")
+        XCTAssertEqual(ToolDefinitions.tools.count, 9, "Should have 9 tools defined")
     }
 
     func testToolNames() {
@@ -16,6 +16,7 @@ final class ToolDefinitionsTests: XCTestCase {
         XCTAssertTrue(names.contains("key"))
         XCTAssertTrue(names.contains("scroll"))
         XCTAssertTrue(names.contains("wait"))
+        XCTAssertTrue(names.contains("drag"))
         XCTAssertTrue(names.contains("done"))
     }
 


### PR DESCRIPTION
The purpose of this PR is to implement four P1 features that improve agent speed, perception capabilities, and tool coverage.

## Changes Made
- **Adaptive step delay** (`Session.swift`): Replace fixed 500ms post-action delay with AX tree polling (100ms–2s). Proceeds immediately when UI changes are detected; waits longer when no change occurs.
- **Drag tool definition** (`ToolDefinitions.swift`): Add tool schema so the model can call the existing drag executor. Supports `element_id` and `to_element_id` targeting plus coordinate fallbacks.
- **Multi-window awareness** (`AccessibilityTree.swift`): New `enumerateSecondaryWindows` method enumerates up to 2 other visible app windows. Formatted as "OTHER VISIBLE WINDOWS" section in model context for cross-app tasks.
- **AX tree diffing** (`AXTreeDiff.swift`): New file computing compact diffs (added/removed/changed elements, focus shifts, value changes). Sent as "CHANGES SINCE LAST ACTION" replacing the full previous tree to reduce token usage.
- Updated `ActionInferenceProvider` protocol and `AnthropicProvider` to pass `axDiff` and `secondaryWindows` context
- Updated `SessionTests` mock and test helpers for new protocol; added 5 AX diff unit tests

## Testing
- All 40 tests pass (`swift test`): 9 AccessibilityTree (5 new diff tests), 11 ActionVerifier, 16 Session, 4 ToolDefinitions
- Xcode project updated with new `AXTreeDiff.swift` file reference

---
*This PR was created with Claude Code*