### PR TITLE
Fix stale key resurrection, abort on write failure, and keychain runtime fallback (#189 feedback)

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -14,15 +14,23 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-// Track keychain availability and stored keys for mock
+// Track keychain availability, stored keys, and runtime failures for mock
 let keychainAvailable = false;
+let keychainFailAtRuntime = false;
 const keychainStore = new Map<string, string>();
 
 mock.module('../security/keychain.js', () => ({
   isKeychainAvailable: () => keychainAvailable,
   getKey: (account: string) => keychainStore.get(account),
-  setKey: (account: string, value: string) => { keychainStore.set(account, value); return true; },
-  deleteKey: (account: string) => keychainStore.delete(account),
+  setKey: (account: string, value: string) => {
+    if (keychainFailAtRuntime) return false;
+    keychainStore.set(account, value);
+    return true;
+  },
+  deleteKey: (account: string) => {
+    if (keychainFailAtRuntime) return false;
+    return keychainStore.delete(account);
+  },
 }));
 
 import {
@@ -46,6 +54,7 @@ describe('secure-keys', () => {
   beforeEach(() => {
     // Clean state
     keychainAvailable = false;
+    keychainFailAtRuntime = false;
     keychainStore.clear();
     _resetBackend();
 
@@ -191,6 +200,54 @@ describe('secure-keys', () => {
       setSecureKey('k2', 'v2');
       expect(keychainStore.has('k2')).toBe(false);
       expect(getSecureKey('k2')).toBe('v2');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keychain runtime failure fallback
+  // -----------------------------------------------------------------------
+  describe('keychain runtime fallback', () => {
+    beforeEach(() => {
+      keychainAvailable = true;
+      _resetBackend();
+    });
+
+    test('setSecureKey falls back to encrypted store when keychain fails at runtime', () => {
+      keychainFailAtRuntime = true;
+      const result = setSecureKey('anthropic', 'sk-test-fallback');
+      expect(result).toBe(true);
+      // Should have stored in encrypted store
+      expect(keychainStore.has('anthropic')).toBe(false);
+      expect(existsSync(STORE_PATH)).toBe(true);
+      // Subsequent gets should also use encrypted store now
+      expect(getSecureKey('anthropic')).toBe('sk-test-fallback');
+    });
+
+    test('deleteSecureKey falls back to encrypted store when keychain fails at runtime', () => {
+      // First store successfully in encrypted store via fallback
+      keychainFailAtRuntime = true;
+      setSecureKey('openai', 'sk-openai-test');
+      // Delete should also use encrypted store
+      const result = deleteSecureKey('openai');
+      expect(result).toBe(true);
+      expect(getSecureKey('openai')).toBeUndefined();
+    });
+
+    test('backend permanently downgrades after keychain runtime failure', () => {
+      // Start with working keychain
+      setSecureKey('anthropic', 'key1');
+      expect(keychainStore.get('anthropic')).toBe('key1');
+
+      // Keychain starts failing
+      keychainFailAtRuntime = true;
+      setSecureKey('openai', 'key2');
+
+      // Backend should now be encrypted — even if keychain "recovers"
+      keychainFailAtRuntime = false;
+      setSecureKey('gemini', 'key3');
+      // gemini should be in encrypted store, not keychain
+      expect(keychainStore.has('gemini')).toBe(false);
+      expect(getSecureKey('gemini')).toBe('key3');
     });
   });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -222,6 +222,13 @@ export function saveConfig(config: AssistantConfig): void {
       setSecureKey(provider, value);
     }
   }
+  // Delete secure keys for providers no longer in apiKeys or with empty values
+  for (const provider of VALID_PROVIDERS) {
+    const value = config.apiKeys[provider];
+    if (!value || (typeof value === 'string' && value.length === 0)) {
+      deleteSecureKey(provider);
+    }
+  }
   const { apiKeys: _, ...rest } = config;
   writeFileSync(configPath, JSON.stringify(rest, null, 2) + '\n');
 
@@ -281,7 +288,9 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   if (apiKeys && typeof apiKeys === 'object' && !Array.isArray(apiKeys)) {
     for (const [provider, value] of Object.entries(apiKeys as Record<string, unknown>)) {
       if (typeof value === 'string' && value.length > 0) {
-        setSecureKey(provider, value);
+        if (!setSecureKey(provider, value)) {
+          throw new ConfigError(`Failed to save API key for "${provider}" to secure storage. Key not removed from config to prevent data loss.`);
+        }
       } else if (value === undefined || value === null || value === '') {
         deleteSecureKey(provider);
       }

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -29,12 +29,43 @@ function getBackend(): Backend {
 }
 
 /**
+ * Try a keychain operation; on failure, permanently downgrade to encrypted
+ * backend and retry. This handles systems where the keychain CLI exists
+ * but is unusable at runtime (headless/locked sessions).
+ */
+function withKeychainFallback<T>(
+  keychainFn: () => T,
+  encryptedFn: () => T,
+  fallbackValue: T,
+): T {
+  const backend = getBackend();
+  if (backend === 'encrypted') return encryptedFn();
+  if (backend !== 'keychain') return fallbackValue;
+
+  const result = keychainFn();
+  // keychain.getKey returns undefined on not-found (not an error),
+  // keychain.setKey/deleteKey return false on failure.
+  // We only downgrade on set/delete failures (false), not on get misses (undefined).
+  if (result === false) {
+    log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
+    resolvedBackend = 'encrypted';
+    return encryptedFn();
+  }
+  return result;
+}
+
+/**
  * Retrieve a secret from secure storage.
  * Returns `undefined` if the key doesn't exist or on error.
  */
 export function getSecureKey(account: string): string | undefined {
   const backend = getBackend();
-  if (backend === 'keychain') return keychain.getKey(account);
+  if (backend === 'keychain') {
+    const value = keychain.getKey(account);
+    // getKey returns undefined for both not-found and error — we can't
+    // distinguish, so no fallback on read. The fallback triggers on write.
+    return value;
+  }
   if (backend === 'encrypted') return encryptedStore.getKey(account);
   return undefined;
 }
@@ -44,10 +75,11 @@ export function getSecureKey(account: string): string | undefined {
  * Returns `true` on success, `false` on failure.
  */
 export function setSecureKey(account: string, value: string): boolean {
-  const backend = getBackend();
-  if (backend === 'keychain') return keychain.setKey(account, value);
-  if (backend === 'encrypted') return encryptedStore.setKey(account, value);
-  return false;
+  return withKeychainFallback(
+    () => keychain.setKey(account, value),
+    () => encryptedStore.setKey(account, value),
+    false,
+  );
 }
 
 /**
@@ -55,10 +87,11 @@ export function setSecureKey(account: string, value: string): boolean {
  * Returns `true` on success, `false` if not found or on error.
  */
 export function deleteSecureKey(account: string): boolean {
-  const backend = getBackend();
-  if (backend === 'keychain') return keychain.deleteKey(account);
-  if (backend === 'encrypted') return encryptedStore.deleteKey(account);
-  return false;
+  return withKeychainFallback(
+    () => keychain.deleteKey(account),
+    () => encryptedStore.deleteKey(account),
+    false,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- **saveConfig deletes stale keys**: Iterates `VALID_PROVIDERS` and calls `deleteSecureKey()` for providers absent from or empty in `config.apiKeys`, preventing deleted keys from resurrecting on next `loadConfig()`
- **saveRawConfig aborts on write failure**: Throws `ConfigError` when `setSecureKey()` returns `false`, preventing silent credential loss when secure storage is detectable but not writable
- **Keychain runtime fallback**: `setSecureKey`/`deleteSecureKey` now fall back to encrypted-at-rest storage when keychain operations fail at runtime (e.g., locked/headless sessions), permanently downgrading the backend for the process lifetime
- 3 new tests for keychain runtime fallback behavior

## Test plan
- [x] All 17 secure-keys tests pass (14 existing + 3 new)
- [x] All 6 key-migration tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
