### PR TITLE
Fix NSNumber type coercion bug in tool call integer parsing

### DIFF
--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -154,18 +154,26 @@ final class AnthropicProvider: ActionInferenceProvider {
 
     // MARK: - Tool Call Parsing
 
+    /// Extract an integer from a JSON value that may be NSNumber (int or double).
+    private func intFromJSON(_ value: Any?) -> Int? {
+        if let n = value as? Int { return n }
+        if let n = value as? NSNumber { return n.intValue }
+        return nil
+    }
+
     private func parseToolCall(name: String, input: [String: Any], elements: [AXElement]?) throws -> AgentAction {
         let reasoning = input["reasoning"] as? String ?? ""
-        let elementId = input["element_id"] as? Int
-        let inputX = input["x"] as? Int
-        let inputY = input["y"] as? Int
+        let elementId = intFromJSON(input["element_id"])
+        let inputX = intFromJSON(input["x"])
+        let inputY = intFromJSON(input["y"])
 
         switch name {
         case "click", "double_click", "right_click":
             let actionType: ActionType = name == "click" ? .click : name == "double_click" ? .doubleClick : .rightClick
             let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             guard let finalX = x, let finalY = y else {
-                throw InferenceError.parseError("\(name) requires element_id or x,y coordinates")
+                let rawKeys = Array(input.keys).joined(separator: ", ")
+                throw InferenceError.parseError("\(name) requires element_id or x,y coordinates (got keys: \(rawKeys), element_id=\(input["element_id"] ?? "nil"), x=\(input["x"] ?? "nil"), y=\(input["y"] ?? "nil"))")
             }
             return AgentAction(
                 type: actionType,
@@ -189,9 +197,9 @@ final class AnthropicProvider: ActionInferenceProvider {
             return AgentAction(type: .key, reasoning: reasoning, key: key)
 
         case "drag":
-            let toElementId = input["to_element_id"] as? Int
-            let inputToX = input["to_x"] as? Int
-            let inputToY = input["to_y"] as? Int
+            let toElementId = intFromJSON(input["to_element_id"])
+            let inputToX = intFromJSON(input["to_x"])
+            let inputToY = intFromJSON(input["to_y"])
             let (fromX, fromY, fromResolvedId, fromDesc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             let (toX, toY, _, _) = resolvePosition(elementId: toElementId, inputX: inputToX, inputY: inputToY, elements: elements)
             guard let finalFromX = fromX, let finalFromY = fromY else {
@@ -215,7 +223,7 @@ final class AnthropicProvider: ActionInferenceProvider {
             guard let direction = input["direction"] as? String else {
                 throw InferenceError.parseError("scroll requires 'direction' field")
             }
-            let amount = input["amount"] as? Int ?? 3
+            let amount = intFromJSON(input["amount"]) ?? 3
             let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             return AgentAction(
                 type: .scroll,
@@ -229,7 +237,7 @@ final class AnthropicProvider: ActionInferenceProvider {
             )
 
         case "wait":
-            guard let durationMs = input["duration_ms"] as? Int else {
+            guard let durationMs = intFromJSON(input["duration_ms"]) else {
                 throw InferenceError.parseError("wait requires 'duration_ms' field")
             }
             return AgentAction(type: .wait, reasoning: reasoning, waitDuration: durationMs)


### PR DESCRIPTION
The purpose of this PR is to fix a silent type coercion bug where `as? Int` fails on `NSNumber`-wrapped doubles from `JSONSerialization`, causing click/drag/scroll tool calls to lose their coordinates.

## Changes Made
- Add `intFromJSON()` helper that falls back to `NSNumber.intValue` when `as? Int` fails
- Apply to all integer extractions in `parseToolCall`: `element_id`, `x`, `y`, `to_element_id`, `to_x`, `to_y`, `amount`, `duration_ms`
- Improve error diagnostics by including raw input keys and values in parse error messages

## Testing
- All 40 existing tests pass
- Manual build verified

## Notes
This was causing `Parse error: click requires element_id or x,y coordinates` during computer use sessions — Claude was returning valid coordinates but `JSONSerialization` stored them as `NSNumber(double:)`, which silently failed the `as? Int` cast.

---
*This PR was created with Claude Code*