### PR TITLE
Move static IP and managed SSL cert into k8s.tf

### DIFF
--- a/platform/terraform/k8s.tf
+++ b/platform/terraform/k8s.tf
@@ -152,6 +152,24 @@ resource "kubernetes_service" "app" {
   }
 }
 
+# Static IP for Ingress
+resource "google_compute_global_address" "ingress_ip" {
+  name = "vellum-assistant-ip"
+
+  depends_on = [google_project_service.compute]
+}
+
+# Managed SSL Certificate
+resource "google_compute_managed_ssl_certificate" "default" {
+  name = "vellum-assistant-cert"
+
+  depends_on = [google_project_service.compute]
+
+  managed {
+    domains = [var.domain]
+  }
+}
+
 # Ingress with Google-managed SSL
 resource "kubernetes_ingress_v1" "app" {
   metadata {

--- a/platform/terraform/main.tf
+++ b/platform/terraform/main.tf
@@ -125,21 +125,3 @@ resource "google_artifact_registry_repository" "gcr" {
 
   depends_on = [google_project_service.artifactregistry]
 }
-
-# Static IP for Ingress
-resource "google_compute_global_address" "ingress_ip" {
-  name = "vellum-assistant-ip"
-
-  depends_on = [google_project_service.compute]
-}
-
-# Managed SSL Certificate
-resource "google_compute_managed_ssl_certificate" "default" {
-  name = "vellum-assistant-cert"
-
-  depends_on = [google_project_service.compute]
-
-  managed {
-    domains = [var.domain]
-  }
-}


### PR DESCRIPTION
## Summary
- Moved `google_compute_global_address.ingress_ip` and `google_compute_managed_ssl_certificate.default` from `main.tf` into `k8s.tf`
- Consolidates all K8s networking resources (service, static IP, managed cert, ingress) in one file
- No functional changes — `terraform plan` should show zero diff

## Test plan
- [ ] Run `terraform plan` to confirm no infrastructure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
