### PR TITLE
better-secret

### DIFF
--- a/vel/src/commands/up.ts
+++ b/vel/src/commands/up.ts
@@ -87,7 +87,7 @@ export async function up(): Promise<void> {
         ...secrets,
         DATABASE_URL: process.env.DATABASE_URL || 'postgresql://vellum:password@localhost:5432/vellum',
         APP_URL: process.env.APP_URL || 'http://localhost:3000',
-        BETTER_AUTH_SECRET: 'secret',
+        BETTER_AUTH_SECRET: 'localsecretatleast32characterslong',
         BETTER_AUTH_URL: process.env.BETTER_AUTH_URL || 'http://localhost:3000',
         GS_PROJECT_ID: GS_PROJECT_ID,
         MINIO_ENDPOINT: process.env.MINIO_ENDPOINT || 'http://localhost:9000',


### PR DESCRIPTION
gets rid of:

<img width="1339" height="583" alt="Screenshot 2026-02-08 at 10 09 59 PM" src="https://github.com/user-attachments/assets/5ed2e571-a28d-49b1-894b-0c6735dee8cc" />

I didn't run into any auth issues switching it, but letting you know just in case
