### PR TITLE
Allow HTTP on ingress for SSL cert provisioning

### DIFF
--- a/platform/terraform/k8s.tf
+++ b/platform/terraform/k8s.tf
@@ -180,7 +180,7 @@ resource "kubernetes_ingress_v1" "app" {
       "kubernetes.io/ingress.class"                 = "gce"
       "kubernetes.io/ingress.global-static-ip-name" = google_compute_global_address.ingress_ip.name
       "ingress.gcp.kubernetes.io/pre-shared-cert"   = google_compute_managed_ssl_certificate.default.name
-      "kubernetes.io/ingress.allow-http"            = "false"
+      "kubernetes.io/ingress.allow-http"            = "true"
     }
   }
 


### PR DESCRIPTION
## Summary
- Changed `kubernetes.io/ingress.allow-http` from `"false"` to `"true"` on the ingress
- Google-managed SSL certs require HTTP access to validate domain ownership (`FAILED_NOT_VISIBLE`)
- GCE auto-redirects HTTP to HTTPS once the cert is active

## Test plan
- [ ] Verify SSL cert status moves from `PROVISIONING` to `ACTIVE`
- [ ] Confirm `https://assistant.vellum.ai` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
