### PR TITLE
Add streaming voice transcription feedback and open_app tool

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     private var voiceInput: VoiceInputManager?
+    private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     let ambientAgent = AmbientAgent()
 
     private var windowObserver: Any?
@@ -112,7 +113,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupVoiceInput() {
         voiceInput = VoiceInputManager()
         voiceInput?.onTranscription = { [weak self] text in
+            self?.voiceTranscriptionWindow?.close()
+            self?.voiceTranscriptionWindow = nil
             self?.startSession(task: text)
+        }
+        voiceInput?.onPartialTranscription = { [weak self] text in
+            self?.voiceTranscriptionWindow?.updateText(text)
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
             if isRecording {
@@ -120,7 +126,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     systemSymbolName: "mic.fill",
                     accessibilityDescription: "vellum-assistant"
                 )
+                let window = VoiceTranscriptionWindow()
+                window.show()
+                self?.voiceTranscriptionWindow = window
             } else {
+                self?.voiceTranscriptionWindow?.close()
+                self?.voiceTranscriptionWindow = nil
                 self?.updateMenuBarIcon()
             }
         }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -9,6 +9,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 @MainActor
 final class VoiceInputManager {
     var onTranscription: ((String) -> Void)?
+    var onPartialTranscription: ((String) -> Void)?
     var onRecordingStateChanged: ((Bool) -> Void)?
 
     private var isRecording = false
@@ -94,7 +95,7 @@ final class VoiceInputManager {
         log.info("Voice recording started")
 
         let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = false
+        request.shouldReportPartialResults = true
         recognitionRequest = request
 
         let inputNode = audioEngine.inputNode
@@ -115,13 +116,17 @@ final class VoiceInputManager {
             Task { @MainActor in
                 guard let self = self else { return }
 
-                if let result = result, result.isFinal {
+                if let result = result {
                     let text = result.bestTranscription.formattedString
-                    log.info("Transcription: \(text, privacy: .public)")
-                    if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        self.onTranscription?(text)
+                    if result.isFinal {
+                        log.info("Transcription: \(text, privacy: .public)")
+                        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            self.onTranscription?(text)
+                        }
+                        self.recognitionTask = nil
+                    } else {
+                        self.onPartialTranscription?(text)
                     }
-                    self.recognitionTask = nil
                 } else if let error = error {
                     log.error("Recognition error: \(error.localizedDescription)")
                     self.recognitionTask = nil

--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -9,6 +9,7 @@ enum ExecutorError: LocalizedError {
     case missingKey
     case unknownKey(String)
     case accessibilityNotGranted
+    case appNotFound(String)
 
     var errorDescription: String? {
         switch self {
@@ -18,6 +19,7 @@ enum ExecutorError: LocalizedError {
         case .missingKey: return "Key action requires key name"
         case .unknownKey(let key): return "Unknown key: \(key)"
         case .accessibilityNotGranted: return "Accessibility permission not granted"
+        case .appNotFound(let name): return "Application not found: \(name)"
         }
     }
 }
@@ -216,6 +218,9 @@ final class ActionExecutor: ActionExecuting {
             guard let fromX = action.x, let fromY = action.y else { throw ExecutorError.missingCoordinates }
             guard let endX = action.toX, let endY = action.toY else { throw ExecutorError.missingCoordinates }
             try drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: endX, y: endY))
+        case .openApp:
+            guard let appName = action.appName else { throw ExecutorError.appNotFound("(no name)") }
+            try await openApp(name: appName)
         case .wait:
             let ms = action.waitDuration ?? 500
             try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
@@ -255,6 +260,71 @@ final class ActionExecutor: ActionExecuting {
             throw ExecutorError.eventCreationFailed
         }
         mouseUp.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Open App
+
+    private static let appAliases: [String: String] = [
+        "chrome": "Google Chrome",
+        "vs code": "Visual Studio Code",
+        "vscode": "Visual Studio Code",
+        "edge": "Microsoft Edge",
+        "word": "Microsoft Word",
+        "excel": "Microsoft Excel",
+        "powerpoint": "Microsoft PowerPoint",
+        "outlook": "Microsoft Outlook",
+        "teams": "Microsoft Teams",
+        "iterm": "iTerm",
+    ]
+
+    func openApp(name: String) async throws {
+        let workspace = NSWorkspace.shared
+
+        // 1. Check running apps for exact or case-insensitive match
+        let nameLower = name.lowercased()
+        if let runningApp = workspace.runningApplications.first(where: {
+            $0.localizedName?.lowercased() == nameLower
+        }) {
+            runningApp.activate()
+            try await Task.sleep(nanoseconds: 300_000_000) // 300ms for app to come forward
+            return
+        }
+
+        // 2. Resolve aliases
+        let resolvedName = Self.appAliases[nameLower] ?? name
+
+        // 3. Search common application directories
+        let searchDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            NSString("~/Applications").expandingTildeInPath,
+        ]
+
+        for dir in searchDirs {
+            let appPath = "\(dir)/\(resolvedName).app"
+            let appURL = URL(fileURLWithPath: appPath)
+            if FileManager.default.fileExists(atPath: appPath) {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = true
+                try await workspace.openApplication(at: appURL, configuration: config)
+                return
+            }
+        }
+
+        // 4. Try case-insensitive filesystem search in /Applications
+        if let found = try? FileManager.default.contentsOfDirectory(atPath: "/Applications")
+            .first(where: {
+                $0.lowercased() == "\(resolvedName.lowercased()).app"
+            }) {
+            let appURL = URL(fileURLWithPath: "/Applications/\(found)")
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            try await workspace.openApplication(at: appURL, configuration: config)
+            return
+        }
+
+        throw ExecutorError.appNotFound(name)
     }
 
     // MARK: - Key Code Map

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -11,6 +11,7 @@ enum ActionType: String, Codable {
     case wait
     case done
     case drag
+    case openApp = "open_app"
 }
 
 struct AgentAction: Codable {
@@ -25,6 +26,7 @@ struct AgentAction: Codable {
     var toY: CGFloat?
     var summary: String?
     var waitDuration: Int?
+    var appName: String?
     var reasoning: String
     var resolvedFromElementId: Int?
     var elementDescription: String?
@@ -42,6 +44,7 @@ struct AgentAction: Codable {
         scrollAmount: Int? = nil,
         summary: String? = nil,
         waitDuration: Int? = nil,
+        appName: String? = nil,
         resolvedFromElementId: Int? = nil,
         elementDescription: String? = nil
     ) {
@@ -57,6 +60,7 @@ struct AgentAction: Codable {
         self.scrollAmount = scrollAmount
         self.summary = summary
         self.waitDuration = waitDuration
+        self.appName = appName
         self.resolvedFromElementId = resolvedFromElementId
         self.elementDescription = elementDescription
     }
@@ -112,6 +116,11 @@ struct AgentAction: Codable {
                 return "Drag from (\(Int(x)),\(Int(y))) to (\(Int(tx)),\(Int(ty)))"
             }
             return "Drag"
+        case .openApp:
+            if let name = appName {
+                return "Open app: \(name)"
+            }
+            return "Open app"
         case .done:
             if let summary = summary {
                 let preview = summary.count > 60 ? String(summary.prefix(60)) + "..." : summary

--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -91,7 +91,7 @@ final class ActionVerifier {
     // MARK: - Comparison
 
     private func actionsAreIdentical(_ a: AgentAction, _ b: AgentAction) -> Bool {
-        a.type == b.type && a.x == b.x && a.y == b.y && a.text == b.text && a.key == b.key
+        a.type == b.type && a.x == b.x && a.y == b.y && a.text == b.text && a.key == b.key && a.appName == b.appName
     }
 
     // MARK: - Sensitive Data Detection

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -154,18 +154,26 @@ final class AnthropicProvider: ActionInferenceProvider {
 
     // MARK: - Tool Call Parsing
 
+    /// Extract an integer from a JSON value that may be NSNumber (int or double).
+    private func intFromJSON(_ value: Any?) -> Int? {
+        if let n = value as? Int { return n }
+        if let n = value as? NSNumber { return n.intValue }
+        return nil
+    }
+
     private func parseToolCall(name: String, input: [String: Any], elements: [AXElement]?) throws -> AgentAction {
         let reasoning = input["reasoning"] as? String ?? ""
-        let elementId = input["element_id"] as? Int
-        let inputX = input["x"] as? Int
-        let inputY = input["y"] as? Int
+        let elementId = intFromJSON(input["element_id"])
+        let inputX = intFromJSON(input["x"])
+        let inputY = intFromJSON(input["y"])
 
         switch name {
         case "click", "double_click", "right_click":
             let actionType: ActionType = name == "click" ? .click : name == "double_click" ? .doubleClick : .rightClick
             let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             guard let finalX = x, let finalY = y else {
-                throw InferenceError.parseError("\(name) requires element_id or x,y coordinates")
+                let rawKeys = Array(input.keys).joined(separator: ", ")
+                throw InferenceError.parseError("\(name) requires element_id or x,y coordinates (got keys: \(rawKeys), element_id=\(input["element_id"] ?? "nil"), x=\(input["x"] ?? "nil"), y=\(input["y"] ?? "nil"))")
             }
             return AgentAction(
                 type: actionType,
@@ -189,9 +197,9 @@ final class AnthropicProvider: ActionInferenceProvider {
             return AgentAction(type: .key, reasoning: reasoning, key: key)
 
         case "drag":
-            let toElementId = input["to_element_id"] as? Int
-            let inputToX = input["to_x"] as? Int
-            let inputToY = input["to_y"] as? Int
+            let toElementId = intFromJSON(input["to_element_id"])
+            let inputToX = intFromJSON(input["to_x"])
+            let inputToY = intFromJSON(input["to_y"])
             let (fromX, fromY, fromResolvedId, fromDesc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             let (toX, toY, _, _) = resolvePosition(elementId: toElementId, inputX: inputToX, inputY: inputToY, elements: elements)
             guard let finalFromX = fromX, let finalFromY = fromY else {
@@ -215,7 +223,7 @@ final class AnthropicProvider: ActionInferenceProvider {
             guard let direction = input["direction"] as? String else {
                 throw InferenceError.parseError("scroll requires 'direction' field")
             }
-            let amount = input["amount"] as? Int ?? 3
+            let amount = intFromJSON(input["amount"]) ?? 3
             let (x, y, resolvedId, desc) = resolvePosition(elementId: elementId, inputX: inputX, inputY: inputY, elements: elements)
             return AgentAction(
                 type: .scroll,
@@ -229,7 +237,7 @@ final class AnthropicProvider: ActionInferenceProvider {
             )
 
         case "wait":
-            guard let durationMs = input["duration_ms"] as? Int else {
+            guard let durationMs = intFromJSON(input["duration_ms"]) else {
                 throw InferenceError.parseError("wait requires 'duration_ms' field")
             }
             return AgentAction(type: .wait, reasoning: reasoning, waitDuration: durationMs)

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -47,7 +47,7 @@ final class AnthropicProvider: ActionInferenceProvider {
 
         You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements — this is much more reliable than pixel coordinates.
 
-        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, done.
+        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, open_app, done.
         You MUST only call one of these tools each turn. Do NOT attempt to call any other tool.
 
         RULES:
@@ -64,6 +64,18 @@ final class AnthropicProvider: ActionInferenceProvider {
         - You may receive a "CHANGES SINCE LAST ACTION" section that summarizes what changed in the UI. Use this to confirm your action worked or to adapt.
         - You may see "OTHER VISIBLE WINDOWS" showing elements from other apps. Use this for cross-app tasks (e.g., "copy from Safari, paste into Notes").
         - For drag operations (moving files, resizing, sliders), use the drag tool with source and destination element_ids or coordinates.
+
+        MULTI-STEP WORKFLOWS:
+        - When a task involves multiple apps (e.g., "send a message in Slack"), use open_app to switch apps — it is much more reliable than cmd+tab.
+        - After switching apps with open_app, wait one turn for the UI to update before interacting with the new app's elements.
+        - Break cross-app tasks into phases: (1) open_app to switch, (2) wait for UI, (3) interact with the app.
+
+        APP-SPECIFIC TIPS:
+        - Slack: Use cmd+k to quickly jump to a channel or DM by name.
+        - Safari / Chrome: Use cmd+l to focus the address bar.
+        - VS Code: Use cmd+shift+p to open the command palette.
+        - Finder: Use cmd+shift+g for "Go to Folder".
+        - Messages: Click the search bar or use cmd+n for a new message.
         """
     }
 
@@ -241,6 +253,12 @@ final class AnthropicProvider: ActionInferenceProvider {
                 throw InferenceError.parseError("wait requires 'duration_ms' field")
             }
             return AgentAction(type: .wait, reasoning: reasoning, waitDuration: durationMs)
+
+        case "open_app":
+            guard let appName = input["app_name"] as? String else {
+                throw InferenceError.parseError("open_app requires 'app_name' field")
+            }
+            return AgentAction(type: .openApp, reasoning: reasoning, appName: appName)
 
         case "done":
             let summary = input["summary"] as? String ?? "Task completed"

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -208,6 +208,24 @@ enum ToolDefinitions {
             ] as [String: Any]
         ],
         [
+            "name": "open_app",
+            "description": "Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps — more reliable and explicit.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "app_name": [
+                        "type": "string",
+                        "description": "The name of the application to open (e.g. \"Slack\", \"Safari\", \"Google Chrome\", \"VS Code\")"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of why you need to open or switch to this app"
+                    ]
+                ],
+                "required": ["app_name", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
             "name": "done",
             "description": "Task is complete",
             "input_schema": [

--- a/clients/macos/vellum-assistant/UI/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/UI/VoiceTranscriptionWindow.swift
@@ -1,0 +1,72 @@
+import AppKit
+import SwiftUI
+
+final class VoiceTranscriptionViewModel: ObservableObject {
+    @Published var transcriptionText: String = ""
+}
+
+struct VoiceTranscriptionView: View {
+    @ObservedObject var viewModel: VoiceTranscriptionViewModel
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mic.fill")
+                .foregroundColor(.red)
+                .font(.system(size: 18))
+
+            Text(viewModel.transcriptionText.isEmpty ? "Listening..." : viewModel.transcriptionText)
+                .foregroundColor(viewModel.transcriptionText.isEmpty ? .secondary : .primary)
+                .font(.system(size: 14))
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(width: 320)
+    }
+}
+
+@MainActor
+final class VoiceTranscriptionWindow {
+    private var panel: NSPanel?
+    private let viewModel = VoiceTranscriptionViewModel()
+
+    func show() {
+        let hostingController = NSHostingController(rootView: VoiceTranscriptionView(viewModel: viewModel))
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 56),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.9
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Position center-bottom of screen (above dock)
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.midX - 160
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func updateText(_ text: String) {
+        viewModel.transcriptionText = text
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -519,6 +519,33 @@ final class SessionTests: XCTestCase {
 
     // MARK: - Task Property
 
+    // MARK: - Open App
+
+    @MainActor
+    func testOpenApp_executesSuccessfully() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .openApp, reasoning: "Open Slack to send message", appName: "Slack"),
+            AgentAction(type: .done, reasoning: "done", summary: "Opened Slack")
+        ])
+        let executor = MockActionExecutor()
+        let session = makeSession(provider: provider, executor: executor)
+
+        await session.run()
+
+        if case .completed(let summary, let steps) = session.state {
+            XCTAssertEqual(steps, 2)
+            XCTAssertEqual(summary, "Opened Slack")
+        } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+
+        XCTAssertEqual(executor.executedActions.count, 1)
+        XCTAssertEqual(executor.executedActions[0].type, .openApp)
+        XCTAssertEqual(executor.executedActions[0].appName, "Slack")
+    }
+
+    // MARK: - Task Property
+
     @MainActor
     func testTaskProperty_matchesInput() async {
         let provider = MockInferenceProvider(actions: [

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ToolDefinitionsTests: XCTestCase {
 
     func testToolCount() {
-        XCTAssertEqual(ToolDefinitions.tools.count, 9, "Should have 9 tools defined")
+        XCTAssertEqual(ToolDefinitions.tools.count, 10, "Should have 10 tools defined")
     }
 
     func testToolNames() {
@@ -17,6 +17,7 @@ final class ToolDefinitionsTests: XCTestCase {
         XCTAssertTrue(names.contains("scroll"))
         XCTAssertTrue(names.contains("wait"))
         XCTAssertTrue(names.contains("drag"))
+        XCTAssertTrue(names.contains("open_app"))
         XCTAssertTrue(names.contains("done"))
     }
 


### PR DESCRIPTION
The purpose of this PR is to add live voice transcription feedback and a new `open_app` tool for reliable cross-app task execution.

## Changes Made
- **Streaming voice transcription**: VoiceInputManager now reports partial results, displayed in a floating HUD window at the bottom of the screen while the user holds Option
- **`open_app` tool**: New agent tool that switches to or launches apps by name, with alias resolution (e.g. "Chrome" → "Google Chrome"), running app activation, and filesystem search fallback
- **System prompt improvements**: Added multi-step workflow guidance and app-specific tips (Slack cmd+k, Safari cmd+l, VS Code cmd+shift+p, etc.)
- **Loop detection fix**: `actionsAreIdentical` now compares `appName` field

## Testing
- All 41 existing + new tests pass (`swift test`)
- Added `testOpenApp_executesSuccessfully` session test
- Updated ToolDefinitionsTests for new tool count (9 → 10) and `open_app` name check

---
*This PR was created with Claude Code*