### PR TITLE
Add VoiceTranscriptionWindow to Xcode project and fix voice recognition error handling (#209 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -127,7 +127,9 @@ final class VoiceInputManager {
                     } else {
                         self.onPartialTranscription?(text)
                     }
-                } else if let error = error {
+                }
+
+                if let error = error {
                     log.error("Recognition error: \(error.localizedDescription)")
                     self.recognitionTask = nil
                 }


### PR DESCRIPTION
The purpose of this PR is to address review feedback from PR #209 by adding the missing Xcode project reference and fixing a voice recognition error-handling bug.

## Changes Made
- **Add `VoiceTranscriptionWindow.swift` to Xcode project** (`project.pbxproj`): Added PBXFileReference, PBXBuildFile, UI group entry, and PBXSourcesBuildPhase entry so the Xcode build no longer fails with an unresolved symbol
- **Fix recognition error handling** (`VoiceInputManager.swift`): Changed `else if let error` to a separate `if let error` block so errors are handled even when a partial result is also delivered, preventing `recognitionTask` from getting stuck and blocking subsequent recordings

## Testing
- SwiftPM build system picks up both changes automatically
- Xcode project file validated structurally (correct sections updated following existing patterns)

---
*This PR was created with Claude Code*