### PR TITLE
Add periodic knowledge cron for LLM-powered insight analysis

### DIFF
--- a/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
+++ b/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		F18D712D0E89F3DAD30D747C /* ActionPreviewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B2FD36E44863204BB546D0 /* ActionPreviewWindow.swift */; };
 		F29831F8092D9BBB259BAF7C /* TaskInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ABA40D80D70550AA640AF8 /* TaskInputView.swift */; };
 		FDB24168B7548DA9112747EB /* VoiceInputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6554B9F2EF61617575B63118 /* VoiceInputManager.swift */; };
+		AA09B2C3D4E5F607ABCDE009 /* InsightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09B2C3D4E5F607ABCDE009 /* InsightStore.swift */; };
+		AA10B2C3D4E5F607ABCDE010 /* KnowledgeCron.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC10B2C3D4E5F607ABCDE010 /* KnowledgeCron.swift */; };
+		AA11B2C3D4E5F607ABCDE011 /* InsightNotificationWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC11B2C3D4E5F607ABCDE011 /* InsightNotificationWindow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +102,9 @@
 		E8B923D05524A1E51EBB318E /* VoiceTranscriptionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptionWindow.swift; sourceTree = "<group>"; };
 		E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayWindow.swift; sourceTree = "<group>"; };
 		FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLogger.swift; sourceTree = "<group>"; };
+		CC09B2C3D4E5F607ABCDE009 /* InsightStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightStore.swift; sourceTree = "<group>"; };
+		CC10B2C3D4E5F607ABCDE010 /* KnowledgeCron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeCron.swift; sourceTree = "<group>"; };
+		CC11B2C3D4E5F607ABCDE011 /* InsightNotificationWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightNotificationWindow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +125,7 @@
 				87B2FD36E44863204BB546D0 /* ActionPreviewWindow.swift */,
 				BC313FB9D43F0FD9389049EF /* AmbientSuggestionWindow.swift */,
 				C0760D7F261720758A5FAC3E /* ConfirmationView.swift */,
+				CC11B2C3D4E5F607ABCDE011 /* InsightNotificationWindow.swift */,
 				09137E88F2AB02DF31D32BD0 /* MenuBarController.swift */,
 				4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */,
 				E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */,
@@ -157,6 +164,8 @@
 			children = (
 				4A3D1A1DE8CD5DA3C9E222C4 /* AmbientAgent.swift */,
 				D6D30A82CDD870C48EFE78D1 /* AmbientAnalyzer.swift */,
+				CC09B2C3D4E5F607ABCDE009 /* InsightStore.swift */,
+				CC10B2C3D4E5F607ABCDE010 /* KnowledgeCron.swift */,
 				BEE6E192E05E051AF75167BC /* KnowledgeStore.swift */,
 				C372E6C0EBAC12EE67226107 /* ScreenOCR.swift */,
 			);
@@ -371,6 +380,9 @@
 				C12CF51CE1378D77F77732CB /* AppDelegate.swift in Sources */,
 				1D3F4B2FE6DF331921F9F662 /* ChromeAccessibilityHelper.swift in Sources */,
 				A2B8C0BC3677B95F736E9DF4 /* ConfirmationView.swift in Sources */,
+				AA09B2C3D4E5F607ABCDE009 /* InsightStore.swift in Sources */,
+				AA11B2C3D4E5F607ABCDE011 /* InsightNotificationWindow.swift in Sources */,
+				AA10B2C3D4E5F607ABCDE010 /* KnowledgeCron.swift in Sources */,
 				E079EDED2AA9AE71CBE2C2DA /* KnowledgeStore.swift in Sources */,
 				5099794339FDE050C79700BB /* LogViewer.swift in Sources */,
 				0654885DAD8FFD16D639D50F /* MenuBarController.swift in Sources */,

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -45,7 +45,9 @@ final class AmbientAgent: ObservableObject {
     let knowledgeStore = KnowledgeStore()
     private var analyzer: AmbientAnalyzer?
     private var watchTask: Task<Void, Never>?
+    private(set) var knowledgeCron: KnowledgeCron?
     private var activeSuggestionWindow: AmbientSuggestionWindow?
+    private var insightNotificationWindow: InsightNotificationWindow?
     private var previousOCRText: String = ""
     private var knowledgeCancellable: AnyCancellable?
     private var suggestionWindow: AmbientSuggestionWindow?
@@ -53,6 +55,7 @@ final class AmbientAgent: ObservableObject {
     weak var appDelegate: AppDelegate?
 
     var knowledge: KnowledgeStore { knowledgeStore }
+    var insightStore: InsightStore? { knowledgeCron?.insightStore }
 
     init() {
         knowledgeCancellable = knowledgeStore.objectWillChange.sink { [weak self] _ in
@@ -71,6 +74,13 @@ final class AmbientAgent: ObservableObject {
         state = .watching
         log.info("Ambient agent started (interval: \(self.captureIntervalSeconds)s)")
 
+        let cron = KnowledgeCron(knowledgeStore: knowledgeStore)
+        cron.onInsight = { [weak self] insight in
+            self?.showInsightNotification(insight)
+        }
+        cron.start(apiKey: apiKey)
+        knowledgeCron = cron
+
         watchTask = Task { @MainActor [weak self] in
             await self?.watchLoop()
         }
@@ -79,6 +89,8 @@ final class AmbientAgent: ObservableObject {
     func stop() {
         watchTask?.cancel()
         watchTask = nil
+        knowledgeCron?.stop()
+        knowledgeCron = nil
         analyzer = nil
         state = .disabled
         log.info("Ambient agent stopped")
@@ -212,6 +224,21 @@ final class AmbientAgent: ObservableObject {
         activeSuggestionWindow = window
         window.show()
         suggestionWindow = window
+    }
+
+    private func showInsightNotification(_ insight: KnowledgeInsight) {
+        let window = InsightNotificationWindow(
+            insight: insight,
+            onDismiss: { [weak self] in
+                self?.insightNotificationWindow = nil
+            },
+            onViewAll: { [weak self] in
+                self?.insightNotificationWindow = nil
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            }
+        )
+        insightNotificationWindow = window
+        window.show()
     }
 
     private func currentWindowTitle() -> String? {

--- a/clients/macos/vellum-assistant/Ambient/InsightStore.swift
+++ b/clients/macos/vellum-assistant/Ambient/InsightStore.swift
@@ -1,0 +1,106 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "InsightStore")
+
+enum InsightCategory: String, Codable {
+    case pattern
+    case automation
+    case insight
+}
+
+struct KnowledgeInsight: Codable, Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let category: InsightCategory
+    let title: String
+    let description: String
+    let confidence: Double
+    var dismissed: Bool
+}
+
+struct InsightsFile: Codable {
+    let version: Int
+    var insights: [KnowledgeInsight]
+}
+
+final class InsightStore: ObservableObject {
+    private let maxInsights = 50
+    @Published private var file: InsightsFile
+    private let fileURL: URL
+
+    init() {
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
+        self.fileURL = dir.appendingPathComponent("insights.json")
+
+        if let data = try? Data(contentsOf: fileURL),
+           let loaded = try? JSONDecoder.iso8601Decoder.decode(InsightsFile.self, from: data) {
+            self.file = loaded
+            log.info("Loaded \(loaded.insights.count) insights")
+        } else {
+            self.file = InsightsFile(version: 1, insights: [])
+        }
+    }
+
+    var insights: [KnowledgeInsight] { file.insights }
+
+    var insightCount: Int { file.insights.count }
+
+    func addInsights(_ newInsights: [KnowledgeInsight]) {
+        for insight in newInsights {
+            // Dedup: skip if an existing insight has a very similar title
+            let isDuplicate = file.insights.contains { existing in
+                ScreenOCR.similarity(existing.title, insight.title) > 0.7
+            }
+            guard !isDuplicate else {
+                log.debug("Skipping duplicate insight: \(insight.title.prefix(60))")
+                continue
+            }
+            file.insights.append(insight)
+        }
+
+        // FIFO pruning
+        if file.insights.count > maxInsights {
+            file.insights.removeFirst(file.insights.count - maxInsights)
+        }
+
+        save()
+    }
+
+    func dismissInsight(id: UUID) {
+        guard let idx = file.insights.firstIndex(where: { $0.id == id }) else { return }
+        file.insights[idx].dismissed = true
+        save()
+    }
+
+    func clearAll() {
+        file.insights.removeAll()
+        save()
+        log.info("Cleared all insights")
+    }
+
+    private func save() {
+        do {
+            let dir = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(file)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            log.error("Failed to save insights: \(error.localizedDescription)")
+        }
+    }
+}
+
+private extension JSONDecoder {
+    static let iso8601Decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
@@ -1,0 +1,211 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "KnowledgeCron")
+
+@MainActor
+final class KnowledgeCron {
+    let insightStore = InsightStore()
+    private let knowledgeStore: KnowledgeStore
+    private var client: AnthropicClient?
+    private var cronTask: Task<Void, Never>?
+    private let model = "claude-haiku-4-5-20251001"
+    private let minimumEntries = 5
+
+    var onInsight: ((KnowledgeInsight) -> Void)?
+
+    private var intervalHours: Double {
+        let val = UserDefaults.standard.double(forKey: "knowledgeCronIntervalHours")
+        return val > 0 ? val : 4.0
+    }
+
+    private var lastRunTimestamp: TimeInterval {
+        get { UserDefaults.standard.double(forKey: "knowledgeCronLastRun") }
+        set { UserDefaults.standard.set(newValue, forKey: "knowledgeCronLastRun") }
+    }
+
+    init(knowledgeStore: KnowledgeStore) {
+        self.knowledgeStore = knowledgeStore
+    }
+
+    func start(apiKey: String) {
+        guard cronTask == nil else { return }
+        client = AnthropicClient(apiKey: apiKey)
+        log.info("Knowledge cron started (interval: \(self.intervalHours)h)")
+
+        cronTask = Task { @MainActor [weak self] in
+            // Initial 5-minute delay
+            try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
+            guard !Task.isCancelled else { return }
+
+            while !Task.isCancelled {
+                await self?.checkAndRun()
+
+                // Sleep for 15 minutes, then re-check (handles laptop sleep correctly)
+                try? await Task.sleep(nanoseconds: 15 * 60 * 1_000_000_000)
+            }
+        }
+    }
+
+    func stop() {
+        cronTask?.cancel()
+        cronTask = nil
+        client = nil
+        log.info("Knowledge cron stopped")
+    }
+
+    private func checkAndRun() async {
+        let now = Date().timeIntervalSince1970
+        let intervalSeconds = intervalHours * 3600
+        let elapsed = now - lastRunTimestamp
+
+        guard elapsed >= intervalSeconds else {
+            log.debug("Cron: \(String(format: "%.0f", (intervalSeconds - elapsed) / 60)) minutes until next run")
+            return
+        }
+
+        guard knowledgeStore.entryCount >= minimumEntries else {
+            log.debug("Cron: only \(self.knowledgeStore.entryCount) entries, need \(self.minimumEntries)")
+            return
+        }
+
+        await runAnalysis()
+    }
+
+    private func runAnalysis() async {
+        guard let client = client else { return }
+
+        let lastRunDate = Date(timeIntervalSince1970: lastRunTimestamp)
+        let recentEntries = lastRunTimestamp > 0
+            ? knowledgeStore.entriesSince(lastRunDate)
+            : knowledgeStore.entries
+
+        guard !recentEntries.isEmpty else {
+            log.debug("Cron: no entries since last run")
+            lastRunTimestamp = Date().timeIntervalSince1970
+            return
+        }
+
+        log.info("Cron: analyzing \(recentEntries.count) entries")
+
+        let entriesText = recentEntries.map { entry in
+            "[\(entry.category)] \(entry.observation) (app: \(entry.sourceApp), confidence: \(String(format: "%.1f", entry.confidence)), time: \(ISO8601DateFormatter().string(from: entry.timestamp)))"
+        }.joined(separator: "\n")
+
+        let systemPrompt = """
+        You are analyzing a batch of observations about a user's computer behavior collected over time. \
+        Your goal is to find patterns, recurring behaviors, and opportunities for automation or workflow improvements.
+
+        Look for:
+        - Recurring patterns (same apps, same workflows, same times)
+        - Automation opportunities (repetitive tasks that could be scripted)
+        - Workflow insights (bottlenecks, context-switching patterns, focus periods)
+
+        Be specific and actionable. Only report findings you are genuinely confident about.
+        """
+
+        let userMessage = """
+        RECENT OBSERVATIONS:
+        \(entriesText)
+
+        BACKGROUND CONTEXT:
+        \(knowledgeStore.formattedContext())
+
+        Analyze these observations and report any interesting patterns, automation opportunities, or insights.
+        """
+
+        let toolDefinition: [String: Any] = [
+            "name": "report_insights",
+            "description": "Report patterns, automation opportunities, or workflow insights discovered from analyzing user behavior observations.",
+            "input_schema": [
+                "type": "object",
+                "required": ["insights"],
+                "properties": [
+                    "insights": [
+                        "type": "array",
+                        "description": "List of insights discovered from the observations. May be empty if nothing notable was found.",
+                        "items": [
+                            "type": "object",
+                            "required": ["category", "title", "description", "confidence"],
+                            "properties": [
+                                "category": [
+                                    "type": "string",
+                                    "enum": ["pattern", "automation", "insight"],
+                                    "description": "Type of finding: pattern (recurring behavior), automation (task that could be automated), insight (workflow observation)"
+                                ],
+                                "title": [
+                                    "type": "string",
+                                    "description": "Short title summarizing the finding (under 80 chars)"
+                                ],
+                                "description": [
+                                    "type": "string",
+                                    "description": "Detailed description of the finding and any recommendations"
+                                ],
+                                "confidence": [
+                                    "type": "number",
+                                    "description": "How confident you are in this finding (0.0 to 1.0)"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        do {
+            let (_, input) = try await client.sendToolUseRequest(
+                model: model,
+                maxTokens: 1024,
+                system: systemPrompt,
+                tools: [toolDefinition],
+                toolChoice: ["type": "any"],
+                messages: [
+                    ["role": "user", "content": userMessage]
+                ],
+                timeout: 30
+            )
+
+            guard let rawInsights = input["insights"] as? [[String: Any]] else {
+                log.warning("Cron: failed to parse insights from response")
+                lastRunTimestamp = Date().timeIntervalSince1970
+                return
+            }
+
+            let insights = rawInsights.compactMap { raw -> KnowledgeInsight? in
+                guard let categoryStr = raw["category"] as? String,
+                      let category = InsightCategory(rawValue: categoryStr),
+                      let title = raw["title"] as? String,
+                      let description = raw["description"] as? String,
+                      let confidence = raw["confidence"] as? Double else {
+                    return nil
+                }
+                return KnowledgeInsight(
+                    id: UUID(),
+                    timestamp: Date(),
+                    category: category,
+                    title: title,
+                    description: description,
+                    confidence: confidence,
+                    dismissed: false
+                )
+            }
+
+            if !insights.isEmpty {
+                insightStore.addInsights(insights)
+                log.info("Cron: added \(insights.count) insights")
+
+                // Fire callback for the highest-confidence insight
+                if let best = insights.max(by: { $0.confidence < $1.confidence }) {
+                    onInsight?(best)
+                }
+            } else {
+                log.info("Cron: no insights found in this run")
+            }
+
+        } catch {
+            log.warning("Cron: analysis failed: \(error.localizedDescription)")
+        }
+
+        lastRunTimestamp = Date().timeIntervalSince1970
+    }
+}

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
@@ -40,6 +40,12 @@ final class KnowledgeStore: ObservableObject {
 
     var entries: [KnowledgeEntry] { knowledge.entries }
 
+    var entryCount: Int { knowledge.entries.count }
+
+    func entriesSince(_ date: Date) -> [KnowledgeEntry] {
+        knowledge.entries.filter { $0.timestamp >= date }
+    }
+
     var recentEntries: [KnowledgeEntry] {
         Array(knowledge.entries.suffix(10))
     }

--- a/clients/macos/vellum-assistant/UI/InsightNotificationWindow.swift
+++ b/clients/macos/vellum-assistant/UI/InsightNotificationWindow.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SwiftUI
+
+final class InsightNotificationWindow {
+    private var panel: NSPanel?
+    private let insight: KnowledgeInsight
+    private let onDismiss: () -> Void
+    private let onViewAll: () -> Void
+
+    init(insight: KnowledgeInsight, onDismiss: @escaping () -> Void, onViewAll: @escaping () -> Void) {
+        self.insight = insight
+        self.onDismiss = onDismiss
+        self.onViewAll = onViewAll
+    }
+
+    func show() {
+        let view = InsightNotificationView(
+            insight: insight,
+            onDismiss: { [weak self] in
+                self?.close()
+                self?.onDismiss()
+            },
+            onViewAll: { [weak self] in
+                self?.close()
+                self?.onViewAll()
+            }
+        )
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 340, height: 160),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Position top-right, below where session overlay would appear
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - 340 - 20
+            let y = screenFrame.maxY - 160 - 200
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+
+        // Auto-dismiss after 60 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 60) { [weak self] in
+            if self?.panel != nil {
+                self?.close()
+                self?.onDismiss()
+            }
+        }
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}
+
+private struct InsightNotificationView: View {
+    let insight: KnowledgeInsight
+    let onDismiss: () -> Void
+    let onViewAll: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundStyle(.orange)
+                Text("Knowledge Insight")
+                    .font(.headline)
+                Spacer()
+                categoryBadge
+            }
+
+            Text(insight.title)
+                .font(.body)
+                .fontWeight(.bold)
+                .lineLimit(2)
+
+            Text(insight.description)
+                .font(.callout)
+                .lineLimit(3)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button("Dismiss") {
+                    onDismiss()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
+
+                Button("View All") {
+                    onViewAll()
+                }
+                .keyboardShortcut(.return, modifiers: [])
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 340)
+    }
+
+    private var categoryBadge: some View {
+        Text(insight.category.rawValue.capitalized)
+            .font(.caption)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(categoryColor.opacity(0.2))
+            .foregroundStyle(categoryColor)
+            .clipShape(Capsule())
+    }
+
+    private var categoryColor: Color {
+        switch insight.category {
+        case .pattern: return .blue
+        case .automation: return .green
+        case .insight: return .orange
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -90,6 +90,10 @@ struct SettingsView: View {
                         }
 
                     KnowledgeSection(store: ambientAgent.knowledgeStore)
+
+                    if let insightStore = ambientAgent.insightStore {
+                        InsightsSection(store: insightStore)
+                    }
                 }
             }
 
@@ -173,6 +177,116 @@ private struct KnowledgeSection: View {
         }
         .sheet(isPresented: $showingEntries) {
             KnowledgeEntriesView(store: store)
+        }
+    }
+}
+
+// MARK: - Insights Section
+
+private struct InsightsSection: View {
+    @ObservedObject var store: InsightStore
+    @State private var showingInsights = false
+
+    var body: some View {
+        HStack {
+            Text("Insights found")
+            Spacer()
+            Text("\(store.insightCount)")
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+
+        HStack {
+            Button("View Insights") {
+                showingInsights = true
+            }
+            .disabled(store.insights.isEmpty)
+
+            Spacer()
+
+            Button("Clear All") {
+                store.clearAll()
+            }
+            .tint(.red)
+            .disabled(store.insights.isEmpty)
+        }
+        .sheet(isPresented: $showingInsights) {
+            InsightsListView(store: store)
+        }
+    }
+}
+
+private struct InsightsListView: View {
+    @ObservedObject var store: InsightStore
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Knowledge Insights (\(store.insightCount))")
+                    .font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+            .padding()
+
+            Divider()
+
+            if store.insights.isEmpty {
+                Spacer()
+                Text("No insights yet")
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                List {
+                    ForEach(store.insights.reversed()) { insight in
+                        HStack(alignment: .top, spacing: 8) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 6) {
+                                    Text(insight.title)
+                                        .fontWeight(.bold)
+                                    Text(insight.category.rawValue.capitalized)
+                                        .font(.caption2)
+                                        .padding(.horizontal, 4)
+                                        .padding(.vertical, 1)
+                                        .background(categoryColor(insight.category).opacity(0.2))
+                                        .foregroundStyle(categoryColor(insight.category))
+                                        .clipShape(Capsule())
+                                }
+                                Text(insight.description)
+                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 4) {
+                                    Text(insight.timestamp, style: .relative)
+                                    Text("ago")
+                                    Text("\u{00b7}")
+                                    Text("\(Int(insight.confidence * 100))%")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                            }
+                            Spacer()
+                            Button {
+                                store.dismissInsight(id: insight.id)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundStyle(.red)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                        .padding(.vertical, 2)
+                        .opacity(insight.dismissed ? 0.5 : 1.0)
+                    }
+                }
+            }
+        }
+        .frame(width: 550, height: 450)
+    }
+
+    private func categoryColor(_ category: InsightCategory) -> Color {
+        switch category {
+        case .pattern: return .blue
+        case .automation: return .green
+        case .insight: return .orange
         }
     }
 }


### PR DESCRIPTION
The purpose of this PR is to add a periodic background cron job that analyzes accumulated knowledge entries using Claude Haiku and surfaces discovered patterns as native notifications.

## Changes Made
- **InsightStore.swift** — New persistence layer for insights (`insights.json`, max 50, FIFO pruning, title-similarity dedup via ScreenOCR)
- **KnowledgeCron.swift** — Background cron loop (4h default interval, configurable) that batches knowledge entries, sends them to Claude Haiku via a `report_insights` tool, and stores results. Handles laptop sleep correctly with a 15-minute wake-check pattern
- **InsightNotificationWindow.swift** — Floating HUD notification (lightbulb icon, category badge, 60s auto-dismiss) mirroring the existing AmbientSuggestionWindow pattern
- **KnowledgeStore.swift** — Added `entriesSince(_:)` and `entryCount` for the cron to query recent entries
- **AmbientAgent.swift** — Wired KnowledgeCron lifecycle into start/stop, added insight notification callback
- **SettingsView.swift** — Added InsightsSection with count display, "View Insights" sheet (reverse-chronological list with category badges, confidence, dismiss), and "Clear All"
- **project.pbxproj** — Registered all 3 new Swift files for Xcode build

## Testing
- `swift build` compiles successfully with zero errors
- Manual testing: enable ambient agent in Settings, verify "Insights found: 0" appears below knowledge entries

---
*This PR was created with Claude Code*