### PR TITLE
Reduce LLM request latency and add inference observability

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -85,7 +85,7 @@ final class AmbientAnalyzer {
             ]
         ]
 
-        let (_, input) = try await client.sendToolUseRequest(
+        let inferenceResult = try await client.sendToolUseRequest(
             model: model,
             maxTokens: 512,
             system: systemPrompt,
@@ -97,6 +97,7 @@ final class AmbientAnalyzer {
             timeout: 15
         )
 
+        let input = inferenceResult.input
         guard let decisionStr = input["decision"] as? String,
               let decision = AmbientDecision(rawValue: decisionStr),
               let confidence = input["confidence"] as? Double,

--- a/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
@@ -114,6 +114,13 @@ enum AXTreeDiff {
 
         guard !changes.isEmpty else { return nil }
 
+        // If more than half the elements changed on a non-trivial page, it likely navigated —
+        // the diff is noise, so drop it and let the model just read the current tree.
+        let totalElements = max(prevFlat.count, currFlat.count)
+        if totalElements >= 10 && changes.count > totalElements / 2 {
+            return nil
+        }
+
         return "CHANGES SINCE LAST ACTION:\n" + changes.joined(separator: "\n")
     }
 

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -131,6 +131,11 @@ struct AgentAction: Codable {
     }
 }
 
+struct TokenUsage: Codable {
+    let inputTokens: Int
+    let outputTokens: Int
+}
+
 struct ActionRecord: Codable {
     let step: Int
     let action: AgentAction

--- a/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
@@ -23,12 +23,12 @@ protocol ScreenCaptureProviding {
 
 extension ScreenCaptureProviding {
     func captureScreen() async throws -> Data {
-        try await captureScreen(maxWidth: 1920, maxHeight: 1080)
+        try await captureScreen(maxWidth: 1280, maxHeight: 720)
     }
 }
 
 final class ScreenCapture: ScreenCaptureProviding {
-    func captureScreen(maxWidth: Int = 1920, maxHeight: Int = 1080) async throws -> Data {
+    func captureScreen(maxWidth: Int = 1280, maxHeight: Int = 720) async throws -> Data {
         let content: SCShareableContent
         do {
             content = try await SCShareableContent.current
@@ -59,7 +59,7 @@ final class ScreenCapture: ScreenCaptureProviding {
         let nsImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
         guard let tiffData = nsImage.tiffRepresentation,
               let bitmapRep = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.8]) else {
+              let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.6]) else {
             throw CaptureError.conversionFailed
         }
 

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -188,8 +188,9 @@ final class ComputerUseSession: ObservableObject {
 
             // 2. INFER
             let action: AgentAction
+            let tokenUsage: TokenUsage?
             do {
-                action = try await provider.infer(
+                let result = try await provider.infer(
                     axTree: axTreeText,
                     previousAXTree: previousAXTreeText,
                     axDiff: axDiffText,
@@ -200,6 +201,8 @@ final class ComputerUseSession: ObservableObject {
                     history: actionHistory,
                     elements: elements.flatMap { AccessibilityTreeEnumerator.flattenElements($0) }
                 )
+                action = result.action
+                tokenUsage = result.usage
             } catch {
                 log.error("[\(stepNumber)] Inference error: \(error.localizedDescription)")
                 state = .failed(reason: "Inference failed: \(error.localizedDescription)")
@@ -208,7 +211,10 @@ final class ComputerUseSession: ObservableObject {
             }
 
             log.info("[\(stepNumber)] Model action: \(action.displayDescription) — reasoning: \(action.reasoning)")
-            logger.logTurn(step: stepNumber, axTree: axTreeText, screenshot: screenshot, action: action, usedVision: usedVision)
+            if let usage = tokenUsage {
+                log.info("[\(stepNumber)] Tokens — input: \(usage.inputTokens), output: \(usage.outputTokens)")
+            }
+            logger.logTurn(step: stepNumber, axTree: axTreeText, screenshot: screenshot, action: action, usedVision: usedVision, usage: tokenUsage)
 
             // 3. CHECK COMPLETION
             if action.type == .done {

--- a/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/ActionInferenceProvider.swift
@@ -12,5 +12,5 @@ protocol ActionInferenceProvider {
         task: String,
         history: [ActionRecord],
         elements: [AXElement]?
-    ) async throws -> AgentAction
+    ) async throws -> (action: AgentAction, usage: TokenUsage?)
 }

--- a/clients/macos/vellum-assistant/Inference/AnthropicClient.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicClient.swift
@@ -19,6 +19,13 @@ enum InferenceError: LocalizedError {
     }
 }
 
+struct InferenceResult {
+    let name: String
+    let input: [String: Any]
+    let inputTokens: Int?
+    let outputTokens: Int?
+}
+
 /// Shared HTTP client for the Anthropic Messages API.
 /// Handles auth headers, retry with exponential backoff for transient errors,
 /// response parsing, and tool_use block extraction.
@@ -52,7 +59,7 @@ final class AnthropicClient {
     ///   - toolChoice: Tool choice dictionary (e.g. `["type": "any"]`).
     ///   - messages: Array of message dictionaries.
     ///   - timeout: HTTP request timeout in seconds.
-    /// - Returns: A tuple of `(name, input)` from the first `tool_use` content block.
+    /// - Returns: An `InferenceResult` with tool name, input, and token usage from the response.
     /// - Throws: `InferenceError` on failure.
     func sendToolUseRequest(
         model: String,
@@ -62,7 +69,7 @@ final class AnthropicClient {
         toolChoice: [String: Any],
         messages: [[String: Any]],
         timeout: TimeInterval
-    ) async throws -> (name: String, input: [String: Any]) {
+    ) async throws -> InferenceResult {
         let body: [String: Any] = [
             "model": model,
             "max_tokens": maxTokens,
@@ -73,6 +80,7 @@ final class AnthropicClient {
         ]
 
         let jsonData = try JSONSerialization.data(withJSONObject: body)
+        log.info("Request body size: \(jsonData.count) bytes")
 
         var request = URLRequest(url: URL(string: baseURL)!)
         request.httpMethod = "POST"
@@ -136,7 +144,7 @@ final class AnthropicClient {
         return statusCode == 429 || (statusCode >= 500 && statusCode <= 599)
     }
 
-    private func parseToolUseResponse(data: Data) throws -> (name: String, input: [String: Any]) {
+    private func parseToolUseResponse(data: Data) throws -> InferenceResult {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let content = json["content"] as? [[String: Any]] else {
             throw InferenceError.parseError("Invalid response structure")
@@ -148,6 +156,10 @@ final class AnthropicClient {
             throw InferenceError.parseError("No tool_use block in response")
         }
 
-        return (name: toolName, input: input)
+        let usage = json["usage"] as? [String: Any]
+        let inputTokens = usage?["input_tokens"] as? Int
+        let outputTokens = usage?["output_tokens"] as? Int
+
+        return InferenceResult(name: toolName, input: input, inputTokens: inputTokens, outputTokens: outputTokens)
     }
 }

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -20,13 +20,13 @@ final class AnthropicProvider: ActionInferenceProvider {
         task: String,
         history: [ActionRecord],
         elements: [AXElement]?
-    ) async throws -> AgentAction {
+    ) async throws -> (action: AgentAction, usage: TokenUsage?) {
         let systemPrompt = buildSystemPrompt(screenSize: screenSize)
         let messages = buildMessages(axTree: axTree, previousAXTree: previousAXTree, axDiff: axDiff, secondaryWindows: secondaryWindows, screenshot: screenshot, task: task, history: history)
 
-        let (toolName, input) = try await client.sendToolUseRequest(
+        let result = try await client.sendToolUseRequest(
             model: model,
-            maxTokens: 1024,
+            maxTokens: 4096,
             system: systemPrompt,
             tools: ToolDefinitions.tools,
             toolChoice: ["type": "any"],
@@ -34,7 +34,14 @@ final class AnthropicProvider: ActionInferenceProvider {
             timeout: 30
         )
 
-        return try parseToolCall(name: toolName, input: input, elements: elements)
+        let action = try parseToolCall(name: result.name, input: result.input, elements: elements)
+        let usage: TokenUsage?
+        if let inputTokens = result.inputTokens, let outputTokens = result.outputTokens {
+            usage = TokenUsage(inputTokens: inputTokens, outputTokens: outputTokens)
+        } else {
+            usage = nil
+        }
+        return (action: action, usage: usage)
     }
 
     // MARK: - System Prompt
@@ -140,7 +147,15 @@ final class AnthropicProvider: ActionInferenceProvider {
         if !history.isEmpty {
             textParts.append("")
             textParts.append("ACTIONS TAKEN SO FAR:")
-            for record in history {
+            let maxHistoryEntries = 10
+            let windowedHistory: [ActionRecord]
+            if history.count > maxHistoryEntries {
+                textParts.append("  [... \(history.count - maxHistoryEntries) earlier actions omitted]")
+                windowedHistory = Array(history.suffix(maxHistoryEntries))
+            } else {
+                windowedHistory = history
+            }
+            for record in windowedHistory {
                 let result = record.result ?? "executed"
                 textParts.append("  \(record.step). \(record.action.displayDescription) → \(result)")
             }

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -1,85 +1,39 @@
 import Foundation
 
 enum ToolDefinitions {
+    private static func makeClickVariant(name: String, verb: String) -> [String: Any] {
+        [
+            "name": name,
+            "description": "\(verb) on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "element_id": [
+                        "type": "integer",
+                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
+                    ],
+                    "x": [
+                        "type": "integer",
+                        "description": "X coordinate on screen (fallback when no element_id)"
+                    ],
+                    "y": [
+                        "type": "integer",
+                        "description": "Y coordinate on screen (fallback when no element_id)"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what you see and why you are \(verb.lowercased())ing here"
+                    ]
+                ],
+                "required": ["reasoning"]
+            ] as [String: Any]
+        ]
+    }
+
     static let tools: [[String: Any]] = [
-        [
-            "name": "click",
-            "description": "Click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
-            "input_schema": [
-                "type": "object",
-                "properties": [
-                    "element_id": [
-                        "type": "integer",
-                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
-                    ],
-                    "x": [
-                        "type": "integer",
-                        "description": "X coordinate on screen (fallback when no element_id)"
-                    ],
-                    "y": [
-                        "type": "integer",
-                        "description": "Y coordinate on screen (fallback when no element_id)"
-                    ],
-                    "reasoning": [
-                        "type": "string",
-                        "description": "Explanation of what you see and why you are clicking here"
-                    ]
-                ],
-                "required": ["reasoning"]
-            ] as [String: Any]
-        ],
-        [
-            "name": "double_click",
-            "description": "Double-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
-            "input_schema": [
-                "type": "object",
-                "properties": [
-                    "element_id": [
-                        "type": "integer",
-                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
-                    ],
-                    "x": [
-                        "type": "integer",
-                        "description": "X coordinate on screen (fallback when no element_id)"
-                    ],
-                    "y": [
-                        "type": "integer",
-                        "description": "Y coordinate on screen (fallback when no element_id)"
-                    ],
-                    "reasoning": [
-                        "type": "string",
-                        "description": "Explanation of what you see and why you are double-clicking here"
-                    ]
-                ],
-                "required": ["reasoning"]
-            ] as [String: Any]
-        ],
-        [
-            "name": "right_click",
-            "description": "Right-click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback.",
-            "input_schema": [
-                "type": "object",
-                "properties": [
-                    "element_id": [
-                        "type": "integer",
-                        "description": "The [ID] number of the element from the accessibility tree (preferred)"
-                    ],
-                    "x": [
-                        "type": "integer",
-                        "description": "X coordinate on screen (fallback when no element_id)"
-                    ],
-                    "y": [
-                        "type": "integer",
-                        "description": "Y coordinate on screen (fallback when no element_id)"
-                    ],
-                    "reasoning": [
-                        "type": "string",
-                        "description": "Explanation of what you see and why you are right-clicking here"
-                    ]
-                ],
-                "required": ["reasoning"]
-            ] as [String: Any]
-        ],
+        makeClickVariant(name: "click", verb: "Click"),
+        makeClickVariant(name: "double_click", verb: "Double-click"),
+        makeClickVariant(name: "right_click", verb: "Right-click"),
         [
             "name": "type_text",
             "description": "Type text at the current cursor position. The target field must already be focused (click it first).",

--- a/clients/macos/vellum-assistant/Logging/SessionLogger.swift
+++ b/clients/macos/vellum-assistant/Logging/SessionLogger.swift
@@ -7,6 +7,9 @@ struct TurnLog: Codable {
     let hadScreenshot: Bool
     let usedVision: Bool
     let action: AgentAction
+    let requestBytes: Int?
+    let inputTokens: Int?
+    let outputTokens: Int?
 }
 
 struct SessionLog: Codable {
@@ -27,14 +30,17 @@ final class SessionLogger {
         self.startTime = Date()
     }
 
-    func logTurn(step: Int, axTree: String?, screenshot: Data?, action: AgentAction, usedVision: Bool) {
+    func logTurn(step: Int, axTree: String?, screenshot: Data?, action: AgentAction, usedVision: Bool, usage: TokenUsage? = nil) {
         let turn = TurnLog(
             step: step,
             timestamp: Date(),
             axTree: axTree,
             hadScreenshot: screenshot != nil,
             usedVision: usedVision,
-            action: action
+            action: action,
+            requestBytes: nil,
+            inputTokens: usage?.inputTokens,
+            outputTokens: usage?.outputTokens
         )
         turns.append(turn)
     }

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -25,7 +25,7 @@ final class MockInferenceProvider: ActionInferenceProvider {
         task: String,
         history: [ActionRecord],
         elements: [AXElement]?
-    ) async throws -> AgentAction {
+    ) async throws -> (action: AgentAction, usage: TokenUsage?) {
         if delayNanoseconds > 0 {
             try? await Task.sleep(nanoseconds: delayNanoseconds)
         }
@@ -38,9 +38,9 @@ final class MockInferenceProvider: ActionInferenceProvider {
         }
 
         guard index < actions.count else {
-            return AgentAction(type: .done, reasoning: "No more scripted actions", summary: "Auto-completed")
+            return (action: AgentAction(type: .done, reasoning: "No more scripted actions", summary: "Auto-completed"), usage: nil)
         }
-        return actions[index]
+        return (action: actions[index], usage: nil)
     }
 }
 


### PR DESCRIPTION
The purpose of this PR is to reduce per-turn API latency in the computer-use session loop and add observability into request/response sizes and token usage.

## Changes Made
- Lower screenshot resolution (1920x1080 → 1280x720) and JPEG quality (0.8 → 0.6) for ~40-50% smaller payloads
- Increase `max_tokens` from 1024 → 4096 for better model reasoning budget
- Window action history to last 10 entries to bound prompt growth over long sessions
- Extract and log token usage (input/output) and request body size from API responses
- Cap AX tree diff when >50% of elements changed (drops noisy diffs on page navigations)
- DRY up click/double_click/right_click tool definitions via shared helper

## Testing
- All 44 existing tests pass (`swift test`)
- Verified token counts and request sizes are stable across steps via live session logs
- ToolDefinitionsTests still asserts 10 tools with same names

---
*This PR was created with Claude Code*