### PR TITLE
Change voice input key from Option to Fn

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -14,6 +14,8 @@ final class VoiceInputManager {
     private var isRecording = false
     private var globalMonitor: Any?
     private var localMonitor: Any?
+    private var fnHoldTask: Task<Void, Never>?
+    private static let holdDelay: UInt64 = 300_000_000 // 300ms in nanoseconds
 
     private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
@@ -58,9 +60,19 @@ final class VoiceInputManager {
         let hasOtherModifiers = !event.modifierFlags.intersection(otherModifiers).isEmpty
 
         if fnPressed && !hasOtherModifiers && !isRecording {
-            beginRecording()
-        } else if !fnPressed && isRecording {
-            stopRecording()
+            // Start a delayed hold — cancelled if Fn is released quickly (e.g. Fn+arrow combo)
+            fnHoldTask?.cancel()
+            fnHoldTask = Task {
+                try? await Task.sleep(nanoseconds: Self.holdDelay)
+                guard !Task.isCancelled else { return }
+                beginRecording()
+            }
+        } else if !fnPressed {
+            fnHoldTask?.cancel()
+            fnHoldTask = nil
+            if isRecording {
+                stopRecording()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -21,7 +21,7 @@ final class VoiceInputManager {
     private let audioEngine = AVAudioEngine()
 
     func start() {
-        setupOptionKeyMonitors()
+        setupFnKeyMonitors()
     }
 
     func stop() {
@@ -36,9 +36,9 @@ final class VoiceInputManager {
         stopRecording()
     }
 
-    // MARK: - Option Key Detection
+    // MARK: - Fn Key Detection
 
-    private func setupOptionKeyMonitors() {
+    private func setupFnKeyMonitors() {
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             Task { @MainActor in
                 self?.handleFlagsChanged(event)
@@ -53,13 +53,13 @@ final class VoiceInputManager {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let optionPressed = event.modifierFlags.contains(.option)
-        let otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control]
+        let fnPressed = event.modifierFlags.contains(.function)
+        let otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control, .option]
         let hasOtherModifiers = !event.modifierFlags.intersection(otherModifiers).isEmpty
 
-        if optionPressed && !hasOtherModifiers && !isRecording {
+        if fnPressed && !hasOtherModifiers && !isRecording {
             beginRecording()
-        } else if !optionPressed && isRecording {
+        } else if !fnPressed && isRecording {
             stopRecording()
         }
     }
@@ -81,7 +81,7 @@ final class VoiceInputManager {
         let authStatus = SFSpeechRecognizer.authorizationStatus()
         if authStatus == .notDetermined {
             SFSpeechRecognizer.requestAuthorization { _ in }
-            log.info("Requested speech recognition authorization — hold Option again after approving")
+            log.info("Requested speech recognition authorization — hold Fn again after approving")
             return
         }
         guard authStatus == .authorized else {


### PR DESCRIPTION
The purpose of this PR is to switch the voice input push-to-talk key from Option to Fn, since Option conflicts with common text navigation shortcuts.

## Changes Made
- Replace Option key (`.option`) with Fn key (`.function`) as the voice input trigger in `VoiceInputManager.swift`
- Add 300ms hold delay before starting recording so quick Fn+key combos (Fn+arrows for Home/End/PageUp/PageDown, Fn+Delete for forward delete) don't accidentally trigger voice input
- Add `.option` to the "other modifiers" guard so Option+Fn doesn't trigger recording

## Testing
- Manual testing needed: hold Fn for 300ms+ to start recording, quick Fn+arrow combos should not trigger recording

## Notes
- Users need to set **System Settings > Keyboard > "Press fn key to" → "Do Nothing"** to prevent macOS from intercepting the Fn key for emoji picker/dictation

---
*This PR was created with Claude Code*