### PR TITLE
Fix KnowledgeCron build error

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
@@ -153,7 +153,7 @@ final class KnowledgeCron {
         ]
 
         do {
-            let (_, input) = try await client.sendToolUseRequest(
+            let result = try await client.sendToolUseRequest(
                 model: model,
                 maxTokens: 1024,
                 system: systemPrompt,
@@ -165,7 +165,7 @@ final class KnowledgeCron {
                 timeout: 30
             )
 
-            guard let rawInsights = input["insights"] as? [[String: Any]] else {
+            guard let rawInsights = result.input["insights"] as? [[String: Any]] else {
                 log.warning("Cron: failed to parse insights from response")
                 lastRunTimestamp = Date().timeIntervalSince1970
                 return


### PR DESCRIPTION
The purpose of this PR is to fix a build error in KnowledgeCron where `sendToolUseRequest` was incorrectly destructured as a tuple instead of an `InferenceResult` struct.

## Changes Made
- Replace tuple destructuring `let (_, input) = ...` with `let result = ...`
- Update `input["insights"]` reference to `result.input["insights"]`

## Testing
- Verified `swift build` succeeds

---
*This PR was created with Claude Code*