### PR TITLE
Fix cron deterministic failure infinite retry loop (#226 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
@@ -168,8 +168,9 @@ final class KnowledgeCron {
             )
 
             guard let rawInsights = result.input["insights"] as? [[String: Any]] else {
-                log.warning("Cron: failed to parse insights from response")
-                advanceOrRetry()
+                log.warning("Cron: failed to parse insights from response, advancing watermark (deterministic failure)")
+                consecutiveFailures = 0
+                lastRunTimestamp = Date().timeIntervalSince1970
                 return
             }
 


### PR DESCRIPTION
The purpose of this PR is to fix the KnowledgeCron infinite retry loop on deterministic analysis failures, addressing review feedback from PR #226.

## Changes Made
- **Advance watermark immediately on parse failures** (`KnowledgeCron.swift`): When `insights` cannot be parsed from the API response, the watermark now advances immediately instead of going through the `advanceOrRetry()` 3-retry path. Parse failures are deterministic — the same entries will always produce the same unparseable response — so retrying wastes API calls without ever succeeding.
- Transient API/network errors (the `catch` block) still use the existing retry-then-advance logic via `advanceOrRetry()`.

## Testing
- Code review of failure paths confirms correct behavior: deterministic failures skip ahead, transient failures retry

## Notes
- The PR #211 P1 (missing fallback xcconfig) was already resolved on main by hardcoding ad-hoc signing settings directly, so no xcconfig changes are needed.

---
*This PR was created with Claude Code*