### PR TITLE
Add observation deduplication to reduce redundant knowledge entries

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -183,7 +183,7 @@ final class AmbientAgent: ObservableObject {
             log.debug("[\(cycle)] Decision: ignore — \(result.reasoning)")
 
         case .observe:
-            if let observation = result.observation {
+            if let observation = result.observation, result.confidence > 0.5 {
                 knowledgeStore.addEntry(
                     category: "observation",
                     observation: observation,

--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -38,6 +38,9 @@ final class AmbientAnalyzer {
         - NEVER suggest help for: sensitive/private content (banking, passwords, personal messages), creative flow states (writing, coding in focus), casual browsing.
         - Keep observations concise (one sentence).
         - Keep suggestions actionable and specific (describe what the computer-use agent should do).
+        - Do NOT observe the same activity repeatedly. If the user is still doing the same thing as a recent observation, choose "ignore" instead.
+        - Check the knowledge context below before observing — if a similar observation already exists, do not create a duplicate.
+        - Observations should capture NEW learnings about the user, not restate what is already known.
         """
 
         let userMessage = """

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
@@ -51,6 +51,16 @@ final class KnowledgeStore: ObservableObject {
     }
 
     func addEntry(category: String, observation: String, sourceApp: String, confidence: Double) {
+        // Dedup: skip if a recent entry has a very similar observation
+        let recentWindow = knowledge.entries.suffix(20)
+        let isDuplicate = recentWindow.contains { existing in
+            ScreenOCR.similarity(existing.observation, observation) > 0.7
+        }
+        if isDuplicate {
+            log.debug("Skipping duplicate observation: \(observation.prefix(80))")
+            return
+        }
+
         let entry = KnowledgeEntry(
             id: UUID(),
             timestamp: Date(),


### PR DESCRIPTION
The purpose of this PR is to add observation deduplication to the ambient agent's KnowledgeStore, reducing the near-duplicate knowledge entries that accumulate from repeated screen captures of the same activity.

## Changes Made
- Add Jaccard similarity check (>0.7) against the last 20 entries in KnowledgeStore.addEntry(), mirroring the existing pattern in InsightStore.addInsights()
- Add minimum confidence threshold (>0.5) for observations in AmbientAgent.runCycle() to filter low-quality entries
- Strengthen the AmbientAnalyzer system prompt with rules to avoid re-observing the same activity and check existing knowledge before creating duplicates

## Testing
- Verified build succeeds via xcodebuild
- Dedup can be verified at runtime with: log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level debug | grep "Skipping duplicate"

---
*This PR was created with Claude Code*