### PR TITLE
Fix session overlay bottom cutoff

### DIFF
--- a/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
@@ -29,10 +29,16 @@ final class SessionOverlayWindow {
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
+        // Size window to fit SwiftUI content
+        if let fittingSize = panel.contentView?.fittingSize {
+            panel.setContentSize(fittingSize)
+        }
+
         // Position bottom-right — less obtrusive during computer use
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.maxX - 340 - 20
+            let panelFrame = panel.frame
+            let x = screenFrame.maxX - panelFrame.width - 20
             let y = screenFrame.minY + 20
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }


### PR DESCRIPTION
The purpose of this PR is to fix the session overlay panel being cut off at the bottom of the screen during computer use.

## Changes Made
- Size the NSPanel to fit its SwiftUI content using `contentView.fittingSize` before positioning, instead of relying on the hardcoded 160pt contentRect height
- Use actual panel frame dimensions for bottom-right positioning instead of hardcoded width

## Testing
- Manual testing: verify the overlay is fully visible and properly pinned to the bottom-right corner

---
*This PR was created with Claude Code*