### PR TITLE
Fix P2 review feedback: fractional int rejection and Fn hold cancellation

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -68,6 +68,10 @@ final class VoiceInputManager {
                 guard !Task.isCancelled else { return }
                 beginRecording()
             }
+        } else if fnPressed && hasOtherModifiers {
+            // Another modifier pressed while Fn held — cancel pending voice activation
+            fnHoldTask?.cancel()
+            fnHoldTask = nil
         } else if !fnPressed {
             fnHoldTask?.cancel()
             fnHoldTask = nil

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -182,9 +182,14 @@ final class AnthropicProvider: ActionInferenceProvider {
     // MARK: - Tool Call Parsing
 
     /// Extract an integer from a JSON value that may be NSNumber (int or double).
+    /// Rejects fractional values to avoid silently truncating coordinates/IDs.
     private func intFromJSON(_ value: Any?) -> Int? {
         if let n = value as? Int { return n }
-        if let n = value as? NSNumber { return n.intValue }
+        if let n = value as? NSNumber {
+            let d = n.doubleValue
+            guard d == d.rounded(.towardZero) && !d.isNaN && !d.isInfinite else { return nil }
+            return n.intValue
+        }
         return nil
     }
 


### PR DESCRIPTION
## Summary
- **AnthropicProvider.intFromJSON** (#198 feedback): Reject fractional doubles (e.g. `412.8`, `7.5`) instead of silently truncating via `NSNumber.intValue`. Prevents mis-targeted clicks/drags from truncated coordinates.
- **VoiceInputManager.handleFlagsChanged** (#223 feedback): Cancel pending `fnHoldTask` when another modifier is pressed while Fn is held (e.g. Fn→Option within 300ms). Previously the hold timer would fire despite the `hasOtherModifiers` guard.

Three other P2 items (PRs #199, #180, #179) were already resolved on main.

## Test plan
- [ ] Verify `intFromJSON` returns `nil` for fractional values like `7.5` and accepts whole-number doubles like `7.0`
- [ ] Verify Fn+Option within 300ms does not trigger voice recording
- [ ] Verify Fn hold alone still triggers voice recording after 300ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)