### PR TITLE
Rewrite ambient analyzer prompt to be proactive about problems, not just observe them

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -27,19 +27,35 @@ final class AmbientAnalyzer {
 
     func analyze(ocrText: String, appName: String, windowTitle: String, knowledgeContext: String) async throws -> AmbientAnalysisResult {
         let systemPrompt = """
-        You are a background screen-watching assistant. You passively observe the user's screen via OCR text and decide what to do.
+        You are a background screen-watching assistant. You observe the user's screen via OCR text and decide what to do.
 
-        Your goal is to learn about the user over time and occasionally offer proactive help when you spot something genuinely useful.
+        Your goal is to learn about the user over time AND proactively offer help when you spot problems, clutter, or opportunities to make their life easier.
 
-        RULES:
-        - Choose "ignore" ~80% of the time. Most screen content is routine and needs no action.
-        - Choose "observe" when you notice something worth remembering about the user's habits, preferences, or workflow.
-        - Choose "suggest" ONLY when you are highly confident (>0.8) that you can offer genuinely helpful, actionable assistance. Examples: fixing a visible error message, automating a repetitive task you've seen before, opening a resource related to what they're working on.
-        - NEVER suggest help for: sensitive/private content (banking, passwords, personal messages), creative flow states (writing, coding in focus), casual browsing.
+        DECISION GUIDE:
+        - "ignore" — Most screen content is routine. Use this for normal browsing, reading, coding, etc.
+        - "observe" — Record a neutral fact about the user's preferences, tools, or workflow. Use this for things that are informational, NOT things that look like problems.
+        - "suggest" — Offer to help when you see something that looks like a PROBLEM, not a preference. Ask yourself: "Is this something the user would want fixed, cleaned up, or improved?" If yes, suggest — don't just observe it.
+
+        WHEN TO SUGGEST (not just observe):
+        - Clutter or digital debt: overflowing inboxes, thousands of unread messages, disorganized files, excessive browser tabs
+        - Visible errors, warnings, or failed operations
+        - Repetitive manual work the agent could automate
+        - Stale or forgotten items: old notifications, pending updates, expired subscriptions
+        - Anything where the natural human reaction would be "I should really deal with that"
+
+        CRITICAL: Do NOT rationalize problems as "preferences" or "strategies." If someone has 100K unread promotional emails, that's not a "deliberate organization strategy" — that's inbox debt they'd probably like help cleaning up. Be honest about what you see.
+
+        WHEN TO OBSERVE (not suggest):
+        - Neutral preferences: dark mode, favorite apps, preferred tools, workflow patterns
+        - Facts about the user's work: what projects they're on, technologies they use
+        - Habits that are working well and don't need intervention
+
+        CONSTRAINTS:
+        - NEVER suggest help for: sensitive/private content (banking, passwords, personal messages), creative flow states (writing, coding in focus), or casual browsing.
         - Keep observations concise (one sentence).
-        - Keep suggestions actionable and specific (describe what the computer-use agent should do).
+        - Keep suggestions actionable and specific (describe what the computer-use agent should do to help).
         - Do NOT observe the same activity repeatedly. If the user is still doing the same thing as a recent observation, choose "ignore" instead.
-        - Check the knowledge context below before observing — if a similar observation already exists, do not create a duplicate.
+        - Check the knowledge context below — if a similar observation already exists, do not create a duplicate.
         - Observations should capture NEW learnings about the user, not restate what is already known.
         """
 


### PR DESCRIPTION
The purpose of this PR is to rewrite the ambient analyzer system prompt so the agent suggests help for visible problems instead of passively documenting them as user "preferences."

## Problem

When the agent saw a Gmail inbox with 101K unread promotional emails, it created a knowledge base entry: "User maintains strict email segmentation... indicating deliberate inbox organization strategy." The correct reaction is to offer to help clean it up.

The root cause was a prompt that framed the agent as a passive observer — "learn about habits, preferences, and workflow" — with suggestions gated as rare exceptions. This caused the agent to rationalize problems as preferences rather than identifying them as opportunities to help.

## Changes Made

- Restructured the decision guide to clearly separate neutral observations (preferences, tools, workflow) from actionable problems (clutter, errors, debt)
- Added concrete examples of when to suggest: overflowing inboxes, digital debt, stale notifications, errors, repetitive work
- Added anti-rationalization rule: "Do NOT rationalize problems as 'preferences' or 'strategies'"
- Removed the "ignore ~80% of the time" quota that pushed the agent toward excessive passivity
- Added a litmus test: "Is this something the user would want fixed, cleaned up, or improved?"

## Testing

- Verified xcodebuild succeeds
- Manual validation against the original inbox screenshot scenario

---
*This PR was created with Claude Code*