### PR TITLE
Address PR review feedback: overlay resizing (#240) and confidence threshold (#243)

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -34,7 +34,7 @@ final class AmbientAnalyzer {
         DECISION GUIDE:
         - "ignore" — Most screen content is routine. Use this for normal browsing, reading, coding, etc.
         - "observe" — Record a neutral fact about the user's preferences, tools, or workflow. Use this for things that are informational, NOT things that look like problems.
-        - "suggest" — Offer to help when you see something that looks like a PROBLEM, not a preference. Ask yourself: "Is this something the user would want fixed, cleaned up, or improved?" If yes, suggest — don't just observe it.
+        - "suggest" — Offer to help when you see something that looks like a PROBLEM, not a preference, and you are highly confident (>0.8) it's actionable. Ask yourself: "Is this something the user would want fixed, cleaned up, or improved?" If yes, suggest — don't just observe it.
 
         WHEN TO SUGGEST (not just observe):
         - Clutter or digital debt: overflowing inboxes, thousands of unread messages, disorganized files, excessive browser tabs

--- a/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/UI/SessionOverlayWindow.swift
@@ -1,9 +1,12 @@
 import AppKit
+import Combine
 import SwiftUI
 
+@MainActor
 final class SessionOverlayWindow {
     private var panel: NSPanel?
     private let session: ComputerUseSession
+    private var stateCancellable: AnyCancellable?
 
     init(session: ComputerUseSession) {
         self.session = session
@@ -29,12 +32,30 @@ final class SessionOverlayWindow {
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
-        // Size window to fit SwiftUI content
+        // Size window to fit SwiftUI content and resize on every state change
+        sizeAndPosition(panel)
+        stateCancellable = session.$state
+            .sink { [weak self, weak panel] _ in
+                guard let self, let panel else { return }
+                self.sizeAndPosition(panel)
+            }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        stateCancellable?.cancel()
+        stateCancellable = nil
+        panel?.close()
+        panel = nil
+    }
+
+    private func sizeAndPosition(_ panel: NSPanel) {
         if let fittingSize = panel.contentView?.fittingSize {
             panel.setContentSize(fittingSize)
         }
-
-        // Position bottom-right — less obtrusive during computer use
+        // Pin to bottom-right of screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
             let panelFrame = panel.frame
@@ -42,13 +63,5 @@ final class SessionOverlayWindow {
             let y = screenFrame.minY + 20
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
-
-        panel.orderFront(nil)
-        self.panel = panel
-    }
-
-    func close() {
-        panel?.close()
-        panel = nil
     }
 }


### PR DESCRIPTION
The purpose of this PR is to address review feedback from PRs #240 and #243.

## Changes Made
- **SessionOverlayWindow** (#240 feedback): Subscribe to `session.$state` via Combine so the panel resizes and repositions on every state transition, fixing clipping when the view grows taller (e.g. `.awaitingConfirmation`). Added `@MainActor` annotation since all work is UI.
- **AmbientAnalyzer** (#243 feedback): Reinstate the explicit `>0.8` confidence threshold in the "suggest" prompt guidance to match the runtime gate in `AmbientAgent`, preventing silently dropped low-confidence suggestions.

## Testing
- xcodebuild succeeds
- Manual verification that overlay resizes across state transitions

---
*This PR was created with Claude Code*