### PR TITLE
Defer audit rotation to after daemon startup handshake (#192 feedback)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -168,11 +168,6 @@ export async function runDaemon(): Promise<void> {
 
   const config = loadConfig();
 
-  // Rotate old audit log entries if retention is configured
-  if (config.auditLog.retentionDays > 0) {
-    rotateToolInvocations(config.auditLog.retentionDays);
-  }
-
   initializeProviders(config);
   await initializeTools();
 
@@ -181,6 +176,17 @@ export async function runDaemon(): Promise<void> {
 
   writePid(process.pid);
   log.info({ pid: process.pid }, 'Daemon started');
+
+  // Rotate old audit log entries after startup handshake is complete.
+  // This runs after the socket is listening so it won't block the 5s
+  // readiness window in startDaemon().
+  if (config.auditLog.retentionDays > 0) {
+    try {
+      rotateToolInvocations(config.auditLog.retentionDays);
+    } catch (err) {
+      log.warn({ err }, 'Audit log rotation failed');
+    }
+  }
 
   // Graceful shutdown
   let shuttingDown = false;


### PR DESCRIPTION
Moves audit log rotation to run after the daemon startup handshake completes, preventing startup timeout when the tool_invocations table is large.

## Problem

`rotateToolInvocations()` ran synchronously in `runDaemon()` **before** `server.start()`. The `startDaemon()` client polls for the Unix socket with a fixed 5s timeout. When `auditLog.retentionDays` is enabled and the `tool_invocations` table is large, the rotation could take long enough to exceed the readiness window, causing a spurious startup failure report even though the daemon process was still alive.

## Fix

- Moved `rotateToolInvocations()` to run **after** `server.start()` and `writePid()`, so the socket is already listening and the startup handshake succeeds before rotation begins.
- Wrapped the rotation in a `try/catch` so a failure in rotation doesn't crash the running daemon.

## Files changed

- `assistant/src/daemon/lifecycle.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
