### PR TITLE
Fix partial migration data loss in API key migration (#191 feedback)

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -62,27 +62,37 @@ export function loadConfig(): AssistantConfig {
         ([, v]) => typeof v === 'string' && v.length > 0,
       );
       if (plaintextKeys.length > 0) {
-        let migrated = 0;
+        const migratedProviders: string[] = [];
         for (const [provider, value] of plaintextKeys) {
           if (setSecureKey(provider, value as string)) {
-            migrated++;
+            migratedProviders.push(provider);
           } else {
             log.warn(`Failed to migrate API key for "${provider}" to secure storage`);
           }
         }
-        if (migrated > 0) {
-          // Rewrite config.json without apiKeys
+        if (migratedProviders.length > 0) {
+          // Rewrite config.json without successfully migrated apiKeys
           try {
             const rawJson = JSON.parse(readFileSync(configPath, 'utf-8'));
-            delete rawJson.apiKeys;
+            for (const p of migratedProviders) {
+              delete rawJson.apiKeys[p];
+            }
+            if (Object.keys(rawJson.apiKeys).length === 0) {
+              delete rawJson.apiKeys;
+            }
             writeFileSync(configPath, JSON.stringify(rawJson, null, 2) + '\n');
-            log.info(`Migrated ${migrated} API key(s) from config.json to secure storage`);
+            log.info(`Migrated ${migratedProviders.length} API key(s) from config.json to secure storage`);
           } catch (err) {
             log.warn({ err }, 'Failed to remove migrated keys from config.json');
           }
         }
-        // Clear from fileConfig so they don't end up in the config object from file
-        delete fileConfig.apiKeys;
+        // Clear only migrated keys from fileConfig so failed keys still flow into config
+        for (const p of migratedProviders) {
+          delete fileConfig.apiKeys![p];
+        }
+        if (Object.keys(fileConfig.apiKeys!).length === 0) {
+          delete fileConfig.apiKeys;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #191: when some API keys successfully migrate to secure storage but others fail (`setSecureKey` returns `false`), the code was deleting the **entire** `apiKeys` object from both `config.json` and in-memory config, causing permanent loss of keys that failed to migrate.

### Changes
- Track which specific providers were successfully migrated (`migratedProviders[]`)
- When rewriting `config.json`, only delete successfully migrated keys instead of the entire `apiKeys` object
- Only delete the whole `apiKeys` object from `config.json` if it becomes empty after removing migrated keys
- Only clear migrated keys from `fileConfig.apiKeys` so failed keys still flow into the runtime config

### Files modified
- `assistant/src/config/loader.ts` (lines 64-95)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
