### PR TITLE
Fix keychain downgrade fallback, saveConfig key loss, and delete misclassification (#196 feedback)

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -229,7 +229,9 @@ export function saveConfig(config: AssistantConfig): void {
   // Route apiKeys to secure storage, write config without them
   for (const [provider, value] of Object.entries(config.apiKeys)) {
     if (typeof value === 'string' && value.length > 0) {
-      setSecureKey(provider, value);
+      if (!setSecureKey(provider, value)) {
+        throw new ConfigError(`Failed to save API key for "${provider}" to secure storage`);
+      }
     }
   }
   // Delete secure keys for providers no longer in apiKeys or with empty values

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -14,6 +14,8 @@ const log = getLogger('secure-keys');
 
 type Backend = 'keychain' | 'encrypted' | null;
 let resolvedBackend: Backend | undefined;
+/** True when backend was downgraded from keychain to encrypted at runtime. */
+let downgradedFromKeychain = false;
 
 function getBackend(): Backend {
   if (resolvedBackend !== undefined) return resolvedBackend;
@@ -49,6 +51,7 @@ function withKeychainFallback<T>(
   if (result === false) {
     log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
     resolvedBackend = 'encrypted';
+    downgradedFromKeychain = true;
     return encryptedFn();
   }
   return result;
@@ -66,7 +69,15 @@ export function getSecureKey(account: string): string | undefined {
     // distinguish, so no fallback on read. The fallback triggers on write.
     return value;
   }
-  if (backend === 'encrypted') return encryptedStore.getKey(account);
+  if (backend === 'encrypted') {
+    const value = encryptedStore.getKey(account);
+    // After a runtime downgrade, keys may still exist in the keychain.
+    // Try keychain read as fallback so pre-downgrade keys remain accessible.
+    if (value === undefined && downgradedFromKeychain) {
+      return keychain.getKey(account);
+    }
+    return value;
+  }
   return undefined;
 }
 
@@ -87,11 +98,26 @@ export function setSecureKey(account: string, value: string): boolean {
  * Returns `true` on success, `false` if not found or on error.
  */
 export function deleteSecureKey(account: string): boolean {
-  return withKeychainFallback(
-    () => keychain.deleteKey(account),
-    () => encryptedStore.deleteKey(account),
-    false,
-  );
+  const backend = getBackend();
+  if (backend === 'encrypted') return encryptedStore.deleteKey(account);
+  if (backend !== 'keychain') return false;
+
+  // Check if the key exists before attempting deletion so we can
+  // distinguish "key not found" (not an error) from a real runtime failure.
+  const exists = keychain.getKey(account) !== undefined;
+  const result = keychain.deleteKey(account);
+  if (result) return true;
+
+  if (!exists) {
+    // Key didn't exist — not a runtime failure, no downgrade needed.
+    return false;
+  }
+
+  // Key existed but deletion failed — treat as runtime failure and downgrade.
+  log.warn('Keychain delete failed at runtime, falling back to encrypted file storage');
+  resolvedBackend = 'encrypted';
+  downgradedFromKeychain = true;
+  return encryptedStore.deleteKey(account);
 }
 
 /**
@@ -108,9 +134,11 @@ export function listSecureKeys(): string[] {
 /** @internal Test-only: reset the cached backend so it's re-evaluated. */
 export function _resetBackend(): void {
   resolvedBackend = undefined;
+  downgradedFromKeychain = false;
 }
 
 /** @internal Test-only: force a specific backend. Pass `undefined` to reset. */
 export function _setBackend(backend: Backend | undefined): void {
   resolvedBackend = backend;
+  downgradedFromKeychain = false;
 }


### PR DESCRIPTION
## Summary

Addresses three review findings from PR #196:

- **Bug 1 (keychain read fallback after downgrade):** After a runtime downgrade from keychain to encrypted backend, `getSecureKey` now falls back to keychain read when the encrypted store returns `undefined`, so pre-downgrade keys remain accessible.
- **Bug 2 (saveConfig setSecureKey failure check):** `saveConfig` now checks the return value of `setSecureKey` and throws `ConfigError` on failure, consistent with `saveRawConfig`. Previously, a failed secure storage write would silently lose the API key since it was also stripped from the config file.
- **Bug 3 (deleteSecureKey missing-key handling):** `deleteSecureKey` now checks if the key exists before attempting deletion. A `false` from `deleteKey` for a non-existent key no longer triggers backend downgrade — only actual runtime failures do.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Test keychain downgrade scenario: after set/delete failure downgrades backend, getSecureKey still retrieves keys stored in keychain
- [ ] Test saveConfig throws when setSecureKey fails
- [ ] Test deleteSecureKey with missing key does not trigger downgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
