### PR TITLE
Select Xcode 16.2 in macOS build workflow

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
       - name: Import code-signing certificate
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"


### PR DESCRIPTION
The macos-14 runner defaults to Xcode 15.4 which can't read the project (objectVersion 77 requires Xcode 16+). Adds an `xcode-select` step to use 16.2.

---
*This PR was created with Claude Code*