### PR TITLE
fix: resolve deleteSecureKey downgrade and cleanup bugs

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -99,25 +99,26 @@ export function setSecureKey(account: string, value: string): boolean {
  */
 export function deleteSecureKey(account: string): boolean {
   const backend = getBackend();
-  if (backend === 'encrypted') return encryptedStore.deleteKey(account);
+  if (backend === 'encrypted') {
+    const result = encryptedStore.deleteKey(account);
+    // After a runtime downgrade, keys may still exist in the keychain.
+    // Attempt best-effort cleanup so stale credentials don't linger.
+    if (downgradedFromKeychain) {
+      keychain.deleteKey(account); // best-effort, ignore result
+    }
+    return result;
+  }
   if (backend !== 'keychain') return false;
 
-  // Check if the key exists before attempting deletion so we can
-  // distinguish "key not found" (not an error) from a real runtime failure.
-  const exists = keychain.getKey(account) !== undefined;
-  const result = keychain.deleteKey(account);
-  if (result) return true;
-
-  if (!exists) {
-    // Key didn't exist — not a runtime failure, no downgrade needed.
-    return false;
-  }
-
-  // Key existed but deletion failed — treat as runtime failure and downgrade.
-  log.warn('Keychain delete failed at runtime, falling back to encrypted file storage');
-  resolvedBackend = 'encrypted';
-  downgradedFromKeychain = true;
-  return encryptedStore.deleteKey(account);
+  // Use the same fallback pattern as setSecureKey: if deleteKey returns
+  // false, downgrade. keychain.deleteKey returns false for both "not found"
+  // and "runtime error", but downgrading on "not found" is harmless — the
+  // encrypted store also returns false for a missing key.
+  return withKeychainFallback(
+    () => keychain.deleteKey(account),
+    () => encryptedStore.deleteKey(account),
+    false,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Fix ambiguous getKey result in deleteSecureKey**: `keychain.getKey()` returns `undefined` for both "key not found" and "keychain error". The previous code used this to infer key existence before attempting deletion, which caused it to skip downgrade when the keychain was completely broken. Now uses `withKeychainFallback` (same pattern as `setSecureKey`) which correctly triggers downgrade on any `deleteKey` failure.
- **Fix missing keychain cleanup after downgrade**: When the backend was downgraded from keychain to encrypted storage at runtime, `deleteSecureKey` only deleted from the encrypted store, leaving stale credentials in the (possibly partially working) keychain. Now attempts best-effort keychain deletion after downgrade.

Addresses review feedback from PR #254.

## Test plan
- [ ] Verify type-checking passes (`npx tsc --noEmit`)
- [ ] Test delete when keychain is working: should delete from keychain and return true
- [ ] Test delete when keychain is broken: should downgrade to encrypted backend and retry
- [ ] Test delete after runtime downgrade: should delete from encrypted store AND attempt keychain cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
