### PR TITLE
fix: address PR #260 feedback for web search tool

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -11,6 +11,9 @@ const log = getLogger('config');
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 
+// Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
+const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'brave'] as const;
+
 let cached: AssistantConfig | null = null;
 let loading = false;
 
@@ -117,7 +120,7 @@ export function loadConfig(): AssistantConfig {
 
     // Secure storage keys override plaintext config file
     try {
-      for (const provider of ['anthropic', 'openai', 'gemini', 'ollama', 'brave']) {
+      for (const provider of API_KEY_PROVIDERS) {
         const secureKey = getSecureKey(provider);
         if (secureKey) {
           config.apiKeys[provider] = secureKey;
@@ -238,7 +241,7 @@ export function saveConfig(config: AssistantConfig): void {
     }
   }
   // Delete secure keys for providers no longer in apiKeys or with empty values
-  for (const provider of VALID_PROVIDERS) {
+  for (const provider of API_KEY_PROVIDERS) {
     const value = config.apiKeys[provider];
     if (!value || (typeof value === 'string' && value.length === 0)) {
       deleteSecureKey(provider);
@@ -280,7 +283,7 @@ export function loadRawConfig(): Record<string, unknown> {
     const apiKeys = (raw.apiKeys && typeof raw.apiKeys === 'object' && !Array.isArray(raw.apiKeys))
       ? { ...raw.apiKeys as Record<string, unknown> }
       : {};
-    for (const provider of VALID_PROVIDERS) {
+    for (const provider of API_KEY_PROVIDERS) {
       const value = getSecureKey(provider);
       if (value) apiKeys[provider] = value;
     }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -55,6 +55,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'file_read') return RiskLevel.Low;
   if (toolName === 'file_write') return RiskLevel.Medium;
   if (toolName === 'file_edit') return RiskLevel.Medium;
+  if (toolName === 'web_search') return RiskLevel.Low;
 
   if (toolName === 'shell') {
     const command = (input.command as string) ?? '';


### PR DESCRIPTION
## Summary
- Adds `API_KEY_PROVIDERS` constant that includes `'brave'` alongside LLM providers, used for secure key operations (`saveConfig`, `loadRawConfig`, `loadConfig`). Keeps `VALID_PROVIDERS` for LLM provider validation only. Fixes stale Brave API key cleanup and config CLI visibility.
- Wires `web_search` into `classifyRisk` in `checker.ts` so it returns `RiskLevel.Low` instead of falling through to the default `Medium`, allowing autonomous execution without confirmation prompts.

## Test plan
- [x] Existing checker tests pass (79 tests)
- [x] Existing web-search tests pass
- [x] Full test suite passes (417/420 — 3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
