### PR TITLE
fix: prevent spurious keychain downgrade when deleting missing key

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -223,6 +223,16 @@ describe('secure-keys', () => {
       expect(getSecureKey('anthropic')).toBe('sk-test-fallback');
     });
 
+    test('deleteSecureKey for nonexistent key does not downgrade backend', () => {
+      // Deleting a key that doesn't exist should NOT trigger a downgrade
+      const result = deleteSecureKey('nonexistent');
+      expect(result).toBe(false);
+      // Backend should still be keychain — verify by storing a new key
+      setSecureKey('anthropic', 'sk-still-keychain');
+      expect(keychainStore.get('anthropic')).toBe('sk-still-keychain');
+      expect(existsSync(STORE_PATH)).toBe(false);
+    });
+
     test('deleteSecureKey falls back to encrypted store when keychain fails at runtime', () => {
       // First store successfully in encrypted store via fallback
       keychainFailAtRuntime = true;

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -110,10 +110,13 @@ export function deleteSecureKey(account: string): boolean {
   }
   if (backend !== 'keychain') return false;
 
-  // Use the same fallback pattern as setSecureKey: if deleteKey returns
-  // false, downgrade. keychain.deleteKey returns false for both "not found"
-  // and "runtime error", but downgrading on "not found" is harmless — the
-  // encrypted store also returns false for a missing key.
+  // keychain.deleteKey returns false for both "not found" and "runtime error".
+  // Check existence first so a missing key doesn't spuriously downgrade the
+  // backend — saveConfig routinely deletes keys for unset providers.
+  if (keychain.getKey(account) === undefined) {
+    return false;
+  }
+
   return withKeychainFallback(
     () => keychain.deleteKey(account),
     () => encryptedStore.deleteKey(account),


### PR DESCRIPTION
## Summary
- Fixes issue from PR #264 feedback where `deleteSecureKey` for a non-existent key would permanently downgrade the backend from OS keychain to encrypted file store
- `keychain.deleteKey()` returns `false` for both "not found" and "runtime error", and `withKeychainFallback` treats any `false` as a failure triggering permanent downgrade
- Normal operations like `saveConfig` iterate `API_KEY_PROVIDERS` and call `deleteSecureKey` for unset providers, causing the spurious downgrade
- Fix: check key existence via `keychain.getKey()` before attempting delete; if the key doesn't exist, return `false` immediately without entering the fallback path
- Added test verifying that deleting a non-existent key from keychain backend does not trigger downgrade

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 18 secure-keys tests pass (including new test)
- [x] New test: "deleteSecureKey for nonexistent key does not downgrade backend"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
