### PR TITLE
Add narrative onboarding flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -94,6 +94,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ambientItem.target = self
         menu.addItem(ambientItem)
 
+        let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")
+        onboardingItem.target = self
+        menu.addItem(onboardingItem)
+
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: button)
@@ -170,6 +174,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             systemSymbolName: iconName,
             accessibilityDescription: "vellum-assistant"
         )
+    }
+
+    @objc private func replayOnboarding() {
+        guard onboardingWindow == nil else { return }
+        popover.performClose(nil)
+
+        let onboarding = OnboardingWindow()
+        onboarding.onComplete = { [weak self] state in
+            UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
+            UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+
+            onboarding.close()
+            self?.onboardingWindow = nil
+            NSApp.setActivationPolicy(.accessory)
+        }
+        onboarding.show()
+        onboardingWindow = onboarding
     }
 
     // MARK: - Onboarding

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -14,15 +14,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     let ambientAgent = AmbientAgent()
 
+    private var onboardingWindow: OnboardingWindow?
     private var windowObserver: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        #if DEBUG
+        let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
+        #else
+        let skipOnboarding = false
+        #endif
+
+        if !skipOnboarding && !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
+            showOnboarding()
+            return
+        }
+
         setupMenuBar()
         setupHotKey()
         setupEscapeMonitor()
         setupVoiceInput()
         setupAmbientAgent()
+        setupWindowObserver()
+    }
 
+    private func setupWindowObserver() {
         // Watch for Settings window closing to revert to accessory activation policy
         windowObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification, object: nil, queue: .main
@@ -155,6 +170,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             systemSymbolName: iconName,
             accessibilityDescription: "vellum-assistant"
         )
+    }
+
+    // MARK: - Onboarding
+
+    private func showOnboarding() {
+        let onboarding = OnboardingWindow()
+        onboarding.onComplete = { [weak self] state in
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+            UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
+            UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+
+            onboarding.close()
+            self?.onboardingWindow = nil
+
+            self?.setupMenuBar()
+            self?.setupHotKey()
+            self?.setupEscapeMonitor()
+            self?.setupVoiceInput()
+            self?.setupAmbientAgent()
+            self?.setupWindowObserver()
+
+            NSApp.setActivationPolicy(.accessory)
+        }
+        onboarding.show()
+        onboardingWindow = onboarding
     }
 
     // MARK: - Popover

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -15,8 +15,16 @@ final class VoiceInputManager {
     private var isRecording = false
     private var globalMonitor: Any?
     private var localMonitor: Any?
-    private var fnHoldTask: Task<Void, Never>?
+    private var holdTask: Task<Void, Never>?
     private static let holdDelay: UInt64 = 300_000_000 // 300ms in nanoseconds
+
+    private var activationFlag: NSEvent.ModifierFlags {
+        let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
+        switch stored {
+        case "ctrl": return .control
+        default: return .function // fn and globe are the same physical key
+        }
+    }
 
     private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
@@ -56,25 +64,27 @@ final class VoiceInputManager {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let fnPressed = event.modifierFlags.contains(.function)
-        let otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control, .option]
+        let flag = activationFlag
+        let keyPressed = event.modifierFlags.contains(flag)
+        var otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control, .option, .function]
+        otherModifiers.remove(flag)
         let hasOtherModifiers = !event.modifierFlags.intersection(otherModifiers).isEmpty
 
-        if fnPressed && !hasOtherModifiers && !isRecording {
-            // Start a delayed hold — cancelled if Fn is released quickly (e.g. Fn+arrow combo)
-            fnHoldTask?.cancel()
-            fnHoldTask = Task {
+        if keyPressed && !hasOtherModifiers && !isRecording {
+            // Start a delayed hold — cancelled if key is released quickly (e.g. Fn+arrow combo)
+            holdTask?.cancel()
+            holdTask = Task {
                 try? await Task.sleep(nanoseconds: Self.holdDelay)
                 guard !Task.isCancelled else { return }
                 beginRecording()
             }
-        } else if fnPressed && hasOtherModifiers {
-            // Another modifier pressed while Fn held — cancel pending voice activation
-            fnHoldTask?.cancel()
-            fnHoldTask = nil
-        } else if !fnPressed {
-            fnHoldTask?.cancel()
-            fnHoldTask = nil
+        } else if keyPressed && hasOtherModifiers {
+            // Another modifier pressed while activation key held — cancel pending voice activation
+            holdTask?.cancel()
+            holdTask = nil
+        } else if !keyPressed {
+            holdTask?.cancel()
+            holdTask = nil
             if isRecording {
                 stopRecording()
             }

--- a/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
@@ -19,10 +19,10 @@ struct AliveStepView: View {
     @State private var particlesLaunched = false
 
     private let abilities = [
-        ("Control your Mac", "cursorarrow.click.2"),
-        ("Listen to you", "mic.fill"),
-        ("See your screen", "eye.fill"),
-        ("Learn & adapt", "brain.head.profile"),
+        ("Hands-free", "cursorarrow.click.2"),
+        ("Voice input", "mic.fill"),
+        ("Screen-aware", "eye.fill"),
+        ("Adaptive", "brain.head.profile"),
     ]
 
     var body: some View {
@@ -40,32 +40,50 @@ struct AliveStepView: View {
             }
             .frame(width: 120, height: 120)
 
-            Text("I'm fully alive.")
+            Text("\(state.assistantName.isEmpty ? "I'm" : state.assistantName + " is") ready.")
                 .font(.system(.title, design: .serif))
                 .foregroundColor(.white)
 
-            // Ability tags
-            HStack(spacing: 10) {
-                ForEach(Array(abilities.enumerated()), id: \.offset) { index, ability in
-                    abilityTag(ability.0, icon: ability.1)
-                        .opacity(showAbilities ? 1 : 0)
-                        .offset(y: showAbilities ? 0 : 10)
-                        .animation(
-                            .easeOut(duration: 0.4).delay(Double(index) * 0.2),
-                            value: showAbilities
-                        )
+            // Ability tags — 2×2 grid
+            VStack(spacing: 10) {
+                ForEach([0, 2], id: \.self) { row in
+                    HStack(spacing: 10) {
+                        ForEach(row..<min(row + 2, abilities.count), id: \.self) { index in
+                            abilityTag(abilities[index].0, icon: abilities[index].1)
+                                .opacity(showAbilities ? 1 : 0)
+                                .offset(y: showAbilities ? 0 : 10)
+                                .animation(
+                                    .easeOut(duration: 0.4).delay(Double(index) * 0.15),
+                                    value: showAbilities
+                                )
+                        }
+                    }
                 }
             }
 
-            VStack(spacing: 12) {
+            VStack(spacing: 16) {
                 OnboardingButton(title: "Start using Vellum", style: .primary) {
                     onComplete()
                 }
-                OnboardingButton(title: "Open Settings first", style: .ghost) {
+                .font(.system(size: 17, weight: .semibold))
+
+                Button {
                     onOpenSettings()
+                } label: {
+                    Text("Open Settings first")
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundColor(.white.opacity(0.45))
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    NSCursor.pointingHand.set()
+                    if !hovering { NSCursor.arrow.set() }
                 }
             }
             .opacity(showButtons ? 1 : 0)
+
+            Spacer()
+                .frame(height: 24)
         }
         .onAppear {
             state.orbMood = .celebrating

--- a/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct SparkleParticle: Identifiable {
+    let id = UUID()
+    var x: CGFloat
+    var y: CGFloat
+    var opacity: Double
+    var scale: CGFloat
+}
+
+struct AliveStepView: View {
+    @Bindable var state: OnboardingState
+    var onComplete: () -> Void
+    var onOpenSettings: () -> Void
+
+    @State private var showAbilities = false
+    @State private var showButtons = false
+    @State private var particles: [SparkleParticle] = []
+    @State private var particlesLaunched = false
+
+    private let abilities = [
+        ("Control your Mac", "cursorarrow.click.2"),
+        ("Listen to you", "mic.fill"),
+        ("See your screen", "eye.fill"),
+        ("Learn & adapt", "brain.head.profile"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 28) {
+            ZStack {
+                // Sparkle particles
+                ForEach(particles) { particle in
+                    Circle()
+                        .fill(Color(hex: 0xD4A843))
+                        .frame(width: 4, height: 4)
+                        .scaleEffect(particle.scale)
+                        .opacity(particle.opacity)
+                        .offset(x: particle.x, y: particle.y)
+                }
+            }
+            .frame(width: 120, height: 120)
+
+            Text("I'm fully alive.")
+                .font(.system(.title, design: .serif))
+                .foregroundColor(.white)
+
+            // Ability tags
+            HStack(spacing: 10) {
+                ForEach(Array(abilities.enumerated()), id: \.offset) { index, ability in
+                    abilityTag(ability.0, icon: ability.1)
+                        .opacity(showAbilities ? 1 : 0)
+                        .offset(y: showAbilities ? 0 : 10)
+                        .animation(
+                            .easeOut(duration: 0.4).delay(Double(index) * 0.2),
+                            value: showAbilities
+                        )
+                }
+            }
+
+            VStack(spacing: 12) {
+                OnboardingButton(title: "Start using Vellum", style: .primary) {
+                    onComplete()
+                }
+                OnboardingButton(title: "Open Settings first", style: .ghost) {
+                    onOpenSettings()
+                }
+            }
+            .opacity(showButtons ? 1 : 0)
+        }
+        .onAppear {
+            state.orbMood = .celebrating
+            launchSparkles()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                showAbilities = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showButtons = true
+                }
+            }
+        }
+    }
+
+    private func abilityTag(_ title: String, icon: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+        }
+        .foregroundColor(.white.opacity(0.8))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            Capsule()
+                .fill(Color.white.opacity(0.06))
+                .overlay(
+                    Capsule()
+                        .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                )
+        )
+    }
+
+    private func launchSparkles() {
+        guard !particlesLaunched else { return }
+        particlesLaunched = true
+
+        for _ in 0..<12 {
+            let angle = Double.random(in: 0...(2 * .pi))
+            let distance = CGFloat.random(in: 30...60)
+            let particle = SparkleParticle(
+                x: 0,
+                y: 0,
+                opacity: 0.8,
+                scale: CGFloat.random(in: 0.5...1.5)
+            )
+            particles.append(particle)
+
+            let index = particles.count - 1
+            withAnimation(.easeOut(duration: 1.0)) {
+                particles[index].x = cos(angle) * distance
+                particles[index].y = sin(angle) * distance
+                particles[index].opacity = 0
+                particles[index].scale = 0.2
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            particles.removeAll()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        AliveStepView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 5
+                s.assistantName = "Alex"
+                return s
+            }(),
+            onComplete: {},
+            onOpenSettings: {}
+        )
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct FnKeyStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showButtons = false
+    @State private var highlightedKey: ActivationKey?
+    @State private var wrongKeyHint: String?
+    @State private var eventMonitor: Any?
+
+    private let keyOptions: [(key: ActivationKey, label: String)] = [
+        (.fn, "fn"),
+        (.globe, "\u{1F310}"),
+        (.ctrl, "ctrl"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ReactionBubble(
+                text: "Great, \(state.assistantName)! Let's set up how you'll summon me."
+            )
+
+            Text("Press or pick your activation key")
+                .font(.system(size: 15))
+                .foregroundColor(.white.opacity(0.6))
+                .opacity(showButtons ? 1 : 0)
+
+            HStack(spacing: 12) {
+                ForEach(keyOptions, id: \.key) { option in
+                    keyButton(option.key, label: option.label)
+                }
+            }
+            .opacity(showButtons ? 1 : 0)
+
+            if let hint = wrongKeyHint {
+                Text(hint)
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.5))
+                    .transition(.opacity)
+            }
+
+            if highlightedKey != nil || state.chosenKey != .fn {
+                OnboardingButton(title: "Continue", style: .primary) {
+                    state.advance()
+                }
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.3), value: wrongKeyHint)
+        .animation(.easeOut(duration: 0.3), value: highlightedKey)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showButtons = true
+                }
+            }
+            startKeyMonitor()
+        }
+        .onDisappear {
+            stopKeyMonitor()
+        }
+    }
+
+    private func keyButton(_ key: ActivationKey, label: String) -> some View {
+        Button {
+            selectKey(key)
+        } label: {
+            Text(label)
+                .font(.system(size: 16, weight: .medium, design: .monospaced))
+                .foregroundColor(highlightedKey == key ? Color(hex: 0x0E0E11) : .white.opacity(0.85))
+                .frame(width: 64, height: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(highlightedKey == key ? Color(hex: 0xD4A843) : Color.white.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(highlightedKey == key ? Color.clear : Color.white.opacity(0.15), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func selectKey(_ key: ActivationKey) {
+        highlightedKey = key
+        state.chosenKey = key
+        wrongKeyHint = nil
+    }
+
+    private func startKeyMonitor() {
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if flags.contains(.function) {
+                // fn / globe key (same physical key on modern Macs)
+                selectKey(.fn)
+            } else if flags.contains(.control) {
+                selectKey(.ctrl)
+            } else if flags.contains(.command) {
+                withAnimation {
+                    wrongKeyHint = "That's Cmd \u{2014} try fn or ctrl"
+                }
+                clearHintAfterDelay()
+            } else if flags.contains(.option) {
+                withAnimation {
+                    wrongKeyHint = "Close! That's Option \u{2014} try fn or ctrl"
+                }
+                clearHintAfterDelay()
+            }
+            return event
+        }
+    }
+
+    private func stopKeyMonitor() {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+    }
+
+    private func clearHintAfterDelay() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            withAnimation {
+                wrongKeyHint = nil
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        FnKeyStepView(state: {
+            let s = OnboardingState()
+            s.assistantName = "Alex"
+            s.currentStep = 2
+            return s
+        }())
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/MicPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/MicPermissionStepView.swift
@@ -1,0 +1,127 @@
+import AVFoundation
+import SwiftUI
+
+struct MicPermissionStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showCard = false
+    @State private var permissionGranted = false
+    @State private var pollTimer: Timer?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ReactionBubble(
+                text: "Now let's give me ears so I can hear you."
+            )
+
+            // Permission card
+            VStack(spacing: 16) {
+                Text("\u{1F399}")
+                    .font(.system(size: 32))
+
+                Text("Microphone Access")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(.white)
+
+                Text("I need mic access so you can talk to me with your voice.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 280)
+
+                if permissionGranted {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Granted!")
+                            .foregroundColor(.green)
+                            .font(.system(size: 15, weight: .medium))
+                    }
+                    .transition(.scale.combined(with: .opacity))
+                } else {
+                    OnboardingButton(title: "Enable Microphone", style: .primary) {
+                        requestMicPermission()
+                    }
+                }
+            }
+            .padding(24)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color(hex: 0xD4A843).opacity(0.3), lineWidth: 1)
+                    )
+            )
+            .opacity(showCard ? 1 : 0)
+            .offset(y: showCard ? 0 : 12)
+        }
+        .animation(.easeOut(duration: 0.5), value: permissionGranted)
+        .onAppear {
+            state.orbMood = .listening
+            if state.skipPermissionChecks {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    grantPermission()
+                }
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showCard = true
+                }
+            }
+        }
+        .onDisappear {
+            pollTimer?.invalidate()
+        }
+    }
+
+    private func requestMicPermission() {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async {
+                if granted {
+                    grantPermission()
+                }
+            }
+        }
+        startPolling()
+    }
+
+    private func startPolling() {
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            let status = AVCaptureDevice.authorizationStatus(for: .audio)
+            if status == .authorized {
+                DispatchQueue.main.async {
+                    grantPermission()
+                }
+            }
+        }
+    }
+
+    private func grantPermission() {
+        pollTimer?.invalidate()
+        permissionGranted = true
+        state.micGranted = true
+        state.orbMood = .celebrating
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            state.orbMood = .breathing
+            state.advance()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        VStack {
+            SoulOrbView(mood: .listening)
+                .padding(.bottom, 20)
+            MicPermissionStepView(state: {
+                let s = OnboardingState()
+                s.currentStep = 3
+                return s
+            }())
+        }
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/NamingStepView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct NamingStepView: View {
+    @Bindable var state: OnboardingState
+
+    @FocusState private var nameFieldFocused: Bool
+    @State private var showInput = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ReactionBubble(text: "Hey! Nice to meet you.")
+
+            Text("What should I call you?")
+                .font(.system(size: 15))
+                .foregroundColor(.white.opacity(0.6))
+                .opacity(showInput ? 1 : 0)
+
+            TextField("Your name", text: $state.assistantName)
+                .textFieldStyle(.plain)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .background(
+                    Capsule()
+                        .fill(Color.white.opacity(0.06))
+                        .overlay(
+                            Capsule()
+                                .stroke(Color.white.opacity(0.15), lineWidth: 1)
+                        )
+                )
+                .frame(maxWidth: 280)
+                .focused($nameFieldFocused)
+                .opacity(showInput ? 1 : 0)
+                .onSubmit {
+                    confirmName()
+                }
+
+            OnboardingButton(
+                title: "That's me",
+                style: .primary,
+                disabled: state.assistantName.trimmingCharacters(in: .whitespaces).isEmpty
+            ) {
+                confirmName()
+            }
+            .opacity(showInput ? 1 : 0)
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showInput = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    nameFieldFocused = true
+                }
+            }
+        }
+    }
+
+    private func confirmName() {
+        guard !state.assistantName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        state.advance()
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        NamingStepView(state: {
+            let s = OnboardingState()
+            s.currentStep = 1
+            return s
+        }())
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingBackground.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingBackground.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct OnboardingBackground: View {
+    @State private var offset1: CGFloat = 0
+    @State private var offset2: CGFloat = 0
+    @State private var offset3: CGFloat = 0
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x0E0E11)
+
+            // Ambient gradient orb 1 — top-left, warm
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [
+                            Color(hex: 0xD4A843).opacity(0.08),
+                            Color.clear,
+                        ]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: 200
+                    )
+                )
+                .frame(width: 400, height: 400)
+                .offset(x: -120 + offset1 * 10, y: -100 + offset1 * 6)
+
+            // Ambient gradient orb 2 — bottom-right, cool
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [
+                            Color(hex: 0x4A3A8A).opacity(0.06),
+                            Color.clear,
+                        ]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: 180
+                    )
+                )
+                .frame(width: 360, height: 360)
+                .offset(x: 140 + offset2 * 8, y: 120 + offset2 * -5)
+
+            // Ambient gradient orb 3 — center, subtle gold
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [
+                            Color(hex: 0xD4A843).opacity(0.04),
+                            Color.clear,
+                        ]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: 150
+                    )
+                )
+                .frame(width: 300, height: 300)
+                .offset(x: 30 + offset3 * -6, y: -20 + offset3 * 8)
+        }
+        .ignoresSafeArea()
+        .onAppear {
+            withAnimation(.easeInOut(duration: 8).repeatForever(autoreverses: true)) {
+                offset1 = 1
+            }
+            withAnimation(.easeInOut(duration: 10).repeatForever(autoreverses: true)) {
+                offset2 = 1
+            }
+            withAnimation(.easeInOut(duration: 12).repeatForever(autoreverses: true)) {
+                offset3 = 1
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingBackground()
+        .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingButton.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+enum OnboardingButtonStyle {
+    case primary
+    case ghost
+}
+
+struct OnboardingButton: View {
+    let title: String
+    var style: OnboardingButtonStyle = .primary
+    var disabled: Bool = false
+    var fadeIn: Bool = false
+    var fadeDelay: TimeInterval = 0
+    let action: () -> Void
+
+    @State private var visible = false
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(foregroundColor)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 10)
+                .background(background)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(borderColor, lineWidth: style == .ghost ? 1 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(opacity)
+        .scaleEffect(isHovered && !disabled ? 1.03 : 1.0)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+        .onAppear {
+            if fadeIn {
+                DispatchQueue.main.asyncAfter(deadline: .now() + fadeDelay) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        visible = true
+                    }
+                }
+            } else {
+                visible = true
+            }
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .primary:
+            return disabled ? Color.white.opacity(0.4) : Color(hex: 0x0E0E11)
+        case .ghost:
+            return disabled ? Color.white.opacity(0.3) : Color.white.opacity(0.85)
+        }
+    }
+
+    private var background: some ShapeStyle {
+        switch style {
+        case .primary:
+            return AnyShapeStyle(disabled ? Color(hex: 0xD4A843).opacity(0.3) : Color(hex: 0xD4A843))
+        case .ghost:
+            return AnyShapeStyle(Color.clear)
+        }
+    }
+
+    private var borderColor: Color {
+        style == .ghost ? Color.white.opacity(disabled ? 0.1 : 0.25) : .clear
+    }
+
+    private var opacity: Double {
+        fadeIn ? (visible ? 1 : 0) : (disabled ? 0.6 : 1)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        VStack(spacing: 16) {
+            OnboardingButton(title: "Say hello", style: .primary) {}
+            OnboardingButton(title: "Skip", style: .ghost) {}
+            OnboardingButton(title: "Disabled", style: .primary, disabled: true) {}
+        }
+    }
+    .frame(width: 400, height: 200)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingFlowView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct OnboardingFlowView: View {
+    @Bindable var state: OnboardingState
+    var onComplete: () -> Void
+    var onOpenSettings: () -> Void
+
+    var body: some View {
+        ZStack {
+            OnboardingBackground()
+
+            VStack(spacing: 0) {
+                // Orb area — always visible at top
+                SoulOrbView(mood: state.orbMood)
+                    .padding(.top, 60)
+                    .padding(.bottom, 32)
+
+                // Step content — bottom area
+                Group {
+                    switch state.currentStep {
+                    case 0:
+                        WakeUpStepView(state: state)
+                    case 1:
+                        NamingStepView(state: state)
+                    case 2:
+                        FnKeyStepView(state: state)
+                    case 3:
+                        MicPermissionStepView(state: state)
+                    case 4:
+                        ScreenPermissionStepView(state: state)
+                    case 5:
+                        AliveStepView(
+                            state: state,
+                            onComplete: onComplete,
+                            onOpenSettings: onOpenSettings
+                        )
+                    default:
+                        EmptyView()
+                    }
+                }
+                .transition(
+                    .opacity.combined(with: .scale(scale: 0.97))
+                )
+                .id(state.currentStep)
+                .frame(maxHeight: .infinity)
+            }
+        }
+        .frame(width: 600, height: 500)
+        .animation(.easeOut(duration: 0.8), value: state.currentStep)
+    }
+}
+
+#Preview {
+    OnboardingFlowView(
+        state: OnboardingState(),
+        onComplete: {},
+        onOpenSettings: {}
+    )
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+enum OrbMood {
+    case breathing
+    case listening
+    case celebrating
+}
+
+enum ActivationKey: String {
+    case fn
+    case globe
+    case ctrl
+}
+
+@Observable
+@MainActor
+final class OnboardingState {
+    var currentStep: Int = 0
+    var assistantName: String = ""
+    var chosenKey: ActivationKey = .fn
+    var orbMood: OrbMood = .breathing
+    var micGranted: Bool = false
+    var screenGranted: Bool = false
+    var skipPermissionChecks: Bool = false
+
+    func advance() {
+        withAnimation(.easeOut(duration: 0.8)) {
+            currentStep += 1
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingWindow.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OnboardingWindow {
+    private var window: NSWindow?
+    let state = OnboardingState()
+    var onComplete: ((OnboardingState) -> Void)?
+
+    func show() {
+        #if DEBUG
+        if CommandLine.arguments.contains("--skip-permission-checks") {
+            state.skipPermissionChecks = true
+        }
+        #endif
+
+        let flowView = OnboardingFlowView(
+            state: state,
+            onComplete: { [weak self] in
+                guard let self else { return }
+                self.onComplete?(self.state)
+            },
+            onOpenSettings: { [weak self] in
+                guard let self else { return }
+                self.onComplete?(self.state)
+                // Settings will be opened by AppDelegate after onComplete
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                }
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: flowView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 500),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = NSColor(red: 14/255, green: 14/255, blue: 17/255, alpha: 1)
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        // Make the app a regular app so the window gets focus
+        NSApp.setActivationPolicy(.regular)
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/ReactionBubble.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/ReactionBubble.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ReactionBubble: View {
+    let text: String
+    var delay: TimeInterval = 0.4
+
+    @State private var visible = false
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 15))
+            .foregroundColor(.white.opacity(0.9))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white.opacity(0.08))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                    )
+            )
+            .opacity(visible ? 1 : 0)
+            .offset(y: visible ? 0 : 8)
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        visible = true
+                    }
+                }
+            }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        ReactionBubble(text: "Nice to meet you!")
+    }
+    .frame(width: 400, height: 200)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
@@ -1,0 +1,128 @@
+import ScreenCaptureKit
+import SwiftUI
+
+struct ScreenPermissionStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showCard = false
+    @State private var permissionGranted = false
+    @State private var pollTimer: Timer?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ReactionBubble(
+                text: "Almost there! Now let's give me eyes."
+            )
+
+            // Permission card
+            VStack(spacing: 16) {
+                Text("\u{1F441}")
+                    .font(.system(size: 32))
+
+                Text("Screen Recording")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(.white)
+
+                Text("I need to see your screen so I can help you navigate and complete tasks.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 280)
+
+                if permissionGranted {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Granted!")
+                            .foregroundColor(.green)
+                            .font(.system(size: 15, weight: .medium))
+                    }
+                    .transition(.scale.combined(with: .opacity))
+                } else {
+                    OnboardingButton(title: "Enable Screen Recording", style: .primary) {
+                        requestScreenPermission()
+                    }
+                }
+            }
+            .padding(24)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color(hex: 0xD4A843).opacity(0.3), lineWidth: 1)
+                    )
+            )
+            .opacity(showCard ? 1 : 0)
+            .offset(y: showCard ? 0 : 12)
+        }
+        .animation(.easeOut(duration: 0.5), value: permissionGranted)
+        .onAppear {
+            if state.skipPermissionChecks {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    grantPermission()
+                }
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showCard = true
+                }
+            }
+        }
+        .onDisappear {
+            pollTimer?.invalidate()
+        }
+    }
+
+    private func requestScreenPermission() {
+        // Calling SCShareableContent.current triggers the system permission dialog
+        Task {
+            do {
+                _ = try await SCShareableContent.current
+                grantPermission()
+            } catch {
+                // Permission denied or dialog shown — start polling
+                startPolling()
+            }
+        }
+    }
+
+    private func startPolling() {
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+            Task { @MainActor in
+                let status = await PermissionManager.screenRecordingStatus()
+                if status == .granted {
+                    grantPermission()
+                }
+            }
+        }
+    }
+
+    private func grantPermission() {
+        pollTimer?.invalidate()
+        permissionGranted = true
+        state.screenGranted = true
+        state.orbMood = .celebrating
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            state.orbMood = .breathing
+            state.advance()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        VStack {
+            SoulOrbView(mood: .breathing)
+                .padding(.bottom, 20)
+            ScreenPermissionStepView(state: {
+                let s = OnboardingState()
+                s.currentStep = 4
+                return s
+            }())
+        }
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/SoulOrbView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/SoulOrbView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct SoulOrbView: View {
+    var mood: OrbMood
+    var size: CGFloat = 56
+
+    @State private var scale: CGFloat = 1.0
+    @State private var ringScale: CGFloat = 1.0
+    @State private var ringOpacity: Double = 0.0
+    @State private var celebrateRings: [CGFloat] = [1.0, 1.0, 1.0]
+    @State private var celebrateOpacities: [Double] = [0.6, 0.5, 0.4]
+
+    var body: some View {
+        ZStack {
+            // Celebrate ring bursts
+            if mood == .celebrating {
+                ForEach(0..<3, id: \.self) { i in
+                    Circle()
+                        .stroke(Color(hex: 0xD4A843).opacity(celebrateOpacities[i]), lineWidth: 2)
+                        .frame(width: size, height: size)
+                        .scaleEffect(celebrateRings[i])
+                }
+            }
+
+            // Listening pulse ring
+            if mood == .listening {
+                Circle()
+                    .stroke(Color(hex: 0xD4A843).opacity(ringOpacity), lineWidth: 1.5)
+                    .frame(width: size, height: size)
+                    .scaleEffect(ringScale)
+            }
+
+            // Core orb
+            Circle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [
+                            Color(hex: 0xD4A843),
+                            Color(hex: 0xB8922E),
+                            Color(hex: 0x8B6914),
+                        ]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: size / 2
+                    )
+                )
+                .frame(width: size, height: size)
+                .shadow(color: Color(hex: 0xD4A843).opacity(0.4), radius: 12)
+                .scaleEffect(scale)
+        }
+        .onChange(of: mood, initial: true) { _, newMood in
+            applyAnimation(for: newMood)
+        }
+    }
+
+    private func applyAnimation(for mood: OrbMood) {
+        switch mood {
+        case .breathing:
+            withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
+                scale = 1.05
+            }
+        case .listening:
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                scale = 1.1
+            }
+            withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                ringScale = 1.8
+                ringOpacity = 0.0
+            }
+            // Reset ring for repeating pulse
+            ringScale = 1.0
+            ringOpacity = 0.5
+            withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                ringScale = 1.8
+                ringOpacity = 0.0
+            }
+        case .celebrating:
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                scale = 1.15
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                    scale = 1.0
+                }
+            }
+            // Ring bursts
+            for i in 0..<3 {
+                let delay = Double(i) * 0.15
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    celebrateRings[i] = 1.0
+                    celebrateOpacities[i] = 0.6 - Double(i) * 0.1
+                    withAnimation(.easeOut(duration: 0.8)) {
+                        celebrateRings[i] = 2.5 + CGFloat(i) * 0.3
+                        celebrateOpacities[i] = 0.0
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension Color {
+    init(hex: UInt, alpha: Double = 1.0) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: alpha
+        )
+    }
+}
+
+#Preview("Breathing") {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        SoulOrbView(mood: .breathing)
+    }
+    .frame(width: 200, height: 200)
+}
+
+#Preview("Listening") {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        SoulOrbView(mood: .listening)
+    }
+    .frame(width: 200, height: 200)
+}
+
+#Preview("Celebrating") {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        SoulOrbView(mood: .celebrating)
+    }
+    .frame(width: 200, height: 200)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/TypewriterText.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/TypewriterText.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct TypewriterText: View {
+    let fullText: String
+    var speed: TimeInterval = 0.05
+    var font: Font = .system(.largeTitle, design: .serif)
+    var onComplete: (() -> Void)? = nil
+
+    @State private var displayedText = ""
+    @State private var timer: Timer?
+    @State private var charIndex = 0
+
+    var body: some View {
+        Text(displayedText)
+            .font(font)
+            .foregroundColor(.white)
+            .onAppear {
+                startTyping()
+            }
+            .onDisappear {
+                timer?.invalidate()
+            }
+    }
+
+    private func startTyping() {
+        displayedText = ""
+        charIndex = 0
+        let characters = Array(fullText)
+        timer = Timer.scheduledTimer(withTimeInterval: speed, repeats: true) { t in
+            if charIndex < characters.count {
+                displayedText.append(characters[charIndex])
+                charIndex += 1
+            } else {
+                t.invalidate()
+                onComplete?()
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(hex: 0x0E0E11)
+        TypewriterText(fullText: "Hello, world.")
+    }
+    .frame(width: 400, height: 200)
+}

--- a/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct WakeUpStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showSubtext = false
+    @State private var showButton = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            TypewriterText(
+                fullText: "Hello, world.",
+                speed: 0.06,
+                font: .system(.largeTitle, design: .serif)
+            ) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        showSubtext = true
+                    }
+                }
+            }
+
+            Text("I've been waiting for you.")
+                .font(.system(size: 15))
+                .foregroundColor(.white.opacity(0.5))
+                .opacity(showSubtext ? 1 : 0)
+                .offset(y: showSubtext ? 0 : 8)
+                .onChange(of: showSubtext) { _, visible in
+                    if visible {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                            withAnimation(.easeOut(duration: 0.5)) {
+                                showButton = true
+                            }
+                        }
+                    }
+                }
+
+            OnboardingButton(
+                title: "Say hello",
+                style: .primary
+            ) {
+                state.advance()
+            }
+            .opacity(showButton ? 1 : 0)
+            .offset(y: showButton ? 0 : 8)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        OnboardingBackground()
+        WakeUpStepView(state: OnboardingState())
+    }
+    .frame(width: 600, height: 500)
+}


### PR DESCRIPTION
## Summary
- Implement 6-step onboarding where the assistant "wakes up" and gains senses (mic, screen) step by step
- Steps: Wake Up → Naming → Fn Key Selection → Mic Permission → Screen Recording → Fully Alive
- Shared components: animated gold orb (SoulOrbView), typewriter text, reaction bubbles, themed buttons, ambient background
- AppDelegate gates all setup behind `hasCompletedOnboarding` UserDefaults, stores user name and activation key on completion
- Debug flags: `--skip-onboarding` bypasses entirely, `--skip-permission-checks` auto-grants permissions for iterating without TCC re-prompts

## Test plan
- [ ] Build & run → onboarding window appears centered with dark background and gradient orbs
- [ ] Walk through all 6 steps verifying animations, transitions, and sequenced reveals
- [ ] Verify Fn key detection highlights the correct button on physical key press
- [ ] Test permission steps grant flow (or use `--skip-permission-checks` in scheme args)
- [ ] After completion → menu bar icon appears, onboarding doesn't show on next launch
- [ ] Reset with `defaults delete com.vellum.vellum-assistant hasCompletedOnboarding` and verify onboarding shows again
- [ ] Verify `#Preview` blocks render in Xcode Canvas for each view

🤖 Generated with [Claude Code](https://claude.com/claude-code)