### PR TITLE
Fix macOS build notarization auth

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -2,8 +2,6 @@ name: Build and Release macOS App
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 */4 * * *'
 
 concurrency:
   group: build-release
@@ -174,13 +172,18 @@ jobs:
           codesign --verify --verbose "$DMG_PATH"
           echo "DMG signature verified"
 
+      - name: Store API key for notarization
+        run: |
+          mkdir -p ~/private_keys
+          echo "${{ secrets.APPLE_API_KEY }}" > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+
       - name: Notarize DMG
         run: |
           echo "Submitting DMG for notarization..."
           NOTARIZE_OUTPUT=$(xcrun notarytool submit "$DMG_PATH" \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8 \
+            --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
+            --issuer "${{ secrets.APPLE_API_ISSUER }}" \
             --wait \
             --timeout 30m \
             2>&1) || NOTARIZE_FAILED=true
@@ -195,9 +198,9 @@ jobs:
             if [ -n "$SUBMISSION_ID" ]; then
               echo "Fetching notarization log for submission $SUBMISSION_ID..."
               xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "${{ secrets.APPLE_ID }}" \
-                --password "${{ secrets.APPLE_APP_PASSWORD }}" \
-                --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+                --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8 \
+                --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
+                --issuer "${{ secrets.APPLE_API_ISSUER }}" \
                 || echo "::warning::Could not fetch notarization log"
             fi
             exit 1
@@ -260,8 +263,9 @@ jobs:
 
           echo "Release created at https://github.com/$REPO/releases/tag/latest"
 
-      - name: Cleanup keychain
+      - name: Cleanup keychain and secrets
         if: always()
         run: |
           KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf ~/private_keys 2>/dev/null || true


### PR DESCRIPTION
The purpose of this PR is to fix the macOS build/release workflow by switching notarization from Apple ID + app-specific password to App Store Connect API key authentication.

## Changes Made
- Switch `notarytool` auth from `--apple-id`/`--password` to `--key`/`--key-id`/`--issuer` (API key)
- Add step to write API key `.p8` file for `notarytool`
- Disable scheduled builds (manual `workflow_dispatch` only) until new secrets are configured
- Clean up API key file in the `always()` cleanup step

## Testing
- Will verify via manual workflow dispatch after adding `APPLE_API_KEY`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER` secrets

## Notes
- Old `APPLE_ID` and `APPLE_APP_PASSWORD` secrets can be removed once confirmed working
- Re-enable the cron schedule after secrets are set up

---
*This PR was created with Claude Code*