### PR TITLE
fix: add foreign key on toolInvocations.conversationId

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -22,7 +22,9 @@ export const messages = sqliteTable('messages', {
 
 export const toolInvocations = sqliteTable('tool_invocations', {
   id: text('id').primaryKey(),
-  conversationId: text('conversation_id').notNull(),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id),
   toolName: text('tool_name').notNull(),
   input: text('input').notNull(),
   result: text('result').notNull(),


### PR DESCRIPTION
## Summary

The `toolInvocations` table was missing a foreign key constraint on its `conversationId` column, while the `messages` table already had one. This adds `.references(() => conversations.id)` to enforce referential integrity, ensuring every tool invocation row points to a valid conversation.

## Changes

- `assistant/src/memory/schema.ts`: Added FK reference on `toolInvocations.conversationId` → `conversations.id`, matching the existing pattern on `messages.conversationId`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
