### PR TITLE
perf: fix quadratic string concatenation in shell.ts

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -59,8 +59,8 @@ class ShellTool implements Tool {
     log.info({ command, cwd: context.workingDir, timeoutSec }, 'Executing shell command');
 
     return new Promise<ToolExecutionResult>((resolve) => {
-      let stdout = '';
-      let stderr = '';
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
       const sandboxEnabled = context.sandboxOverride ?? config.sandbox.enabled;
@@ -77,19 +77,20 @@ class ShellTool implements Tool {
       }, timeoutMs);
 
       child.stdout.on('data', (data: Buffer) => {
-        const chunk = data.toString();
-        stdout += chunk;
-        context.onOutput?.(chunk);
+        stdoutChunks.push(data);
+        context.onOutput?.(data.toString());
       });
 
       child.stderr.on('data', (data: Buffer) => {
-        const chunk = data.toString();
-        stderr += chunk;
-        context.onOutput?.(chunk);
+        stderrChunks.push(data);
+        context.onOutput?.(data.toString());
       });
 
       child.on('close', (code) => {
         clearTimeout(timer);
+
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
 
         let output = stdout;
         if (stderr) {


### PR DESCRIPTION
## Summary

Replace `stdout += chunk` / `stderr += chunk` in the shell tool's data event handlers with `Buffer[]` arrays joined via `Buffer.concat()` after the process closes.

The previous approach reallocated and copied the entire accumulated string on every `data` event, resulting in O(n^2) time complexity for large command outputs (up to 50KB). Collecting raw `Buffer` chunks in an array and concatenating once at the end is O(n).

## Changes

- `assistant/src/tools/terminal/shell.ts`: Replaced `let stdout = ''` / `let stderr = ''` with `const stdoutChunks: Buffer[]` / `const stderrChunks: Buffer[]`, pushed raw buffers in `data` handlers, and used `Buffer.concat(...).toString()` in the `close` handler.

## Test plan

- [x] `bunx tsc --noEmit` passes
- Behavioral semantics are unchanged: streaming `onOutput` callbacks still receive string chunks, final output assembly produces the same result.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
