### PR TITLE
perf: efficient undo query in conversation-store

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,4 +1,4 @@
-import { eq, desc, asc } from 'drizzle-orm';
+import { eq, desc, asc, and, gte, count } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, messages } from './schema.js';
@@ -108,37 +108,35 @@ export function updateConversationUsage(
  */
 export function deleteLastExchange(conversationId: string): number {
   const db = getDb();
-  const allMessages = db
-    .select()
+
+  // Find the last user message without loading all messages
+  const lastUserMsg = db
+    .select({ createdAt: messages.createdAt })
     .from(messages)
-    .where(eq(messages.conversationId, conversationId))
-    .orderBy(asc(messages.createdAt))
-    .all();
+    .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'user')))
+    .orderBy(desc(messages.createdAt))
+    .limit(1)
+    .get();
 
-  if (allMessages.length === 0) return 0;
+  if (!lastUserMsg) return 0;
 
-  // Find the last user message
-  let lastUserIdx = -1;
-  for (let i = allMessages.length - 1; i >= 0; i--) {
-    if (allMessages[i].role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-  if (lastUserIdx === -1) return 0;
+  const condition = and(
+    eq(messages.conversationId, conversationId),
+    gte(messages.createdAt, lastUserMsg.createdAt),
+  );
 
-  // Delete from lastUserIdx onward, atomically with the updatedAt bump
-  const toDelete = allMessages.slice(lastUserIdx);
+  // Count messages to delete, then delete them atomically
+  const [{ deleted }] = db.select({ deleted: count() }).from(messages).where(condition).all();
+  if (deleted === 0) return 0;
+
   db.transaction((tx) => {
-    for (const m of toDelete) {
-      tx.delete(messages).where(eq(messages.id, m.id)).run();
-    }
+    tx.delete(messages).where(condition).run();
     tx.update(conversations)
       .set({ updatedAt: Date.now() })
       .where(eq(conversations.id, conversationId))
       .run();
   });
 
-  return toDelete.length;
+  return deleted;
 }
 


### PR DESCRIPTION
## Summary

`deleteLastExchange()` previously loaded ALL messages for a conversation into memory just to find the last user message and delete it plus subsequent messages. This replaces the approach with efficient SQL queries:

1. Find the last user message with `ORDER BY created_at DESC LIMIT 1` (fetches only 1 row)
2. Count messages at or after that timestamp (for the return value)
3. Bulk delete with a single `DELETE WHERE created_at >= ?` instead of individual deletes in a loop

This eliminates O(n) memory usage and replaces n individual DELETE statements with a single bulk DELETE.

## Files modified

- `assistant/src/memory/conversation-store.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
