### PR TITLE
fix: remove hard-coded max_tokens from Anthropic provider

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -27,15 +27,14 @@ export class AnthropicProvider implements Provider {
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
     try {
-      const params: Anthropic.MessageCreateParams = {
+      const params = {
         model: this.model,
-        max_tokens: 8192,
         messages: messages.map((m) => ({
           role: m.role,
           content: m.content.map((block) => this.toAnthropicBlock(block)),
         })),
         ...config,
-      };
+      } as Anthropic.MessageCreateParams;
 
       if (systemPrompt) {
         params.system = systemPrompt;


### PR DESCRIPTION
## Summary

- Remove the hard-coded `max_tokens: 8192` from `AnthropicProvider.sendMessage()` request params
- The `max_tokens` value is already provided dynamically at runtime via the `config` spread from `AgentLoop` (which passes `this.config.maxTokens`, defaulting to 4096)
- The hard-coded value was always being overridden by the spread and served no purpose
- Use a type assertion (`as Anthropic.MessageCreateParams`) since the Anthropic SDK requires `max_tokens` in its type definition, but the value is provided through the config object spread at runtime

## Test plan

- [x] `bunx tsc --noEmit` passes with no type errors
- [ ] Verify agent loop still works end-to-end (max_tokens provided via AgentLoop config)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
