### PR TITLE
fix: restore max_tokens default for Anthropic provider

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -27,14 +27,15 @@ export class AnthropicProvider implements Provider {
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
     try {
-      const params = {
+      const params: Anthropic.MessageCreateParams = {
         model: this.model,
+        max_tokens: 8192,
         messages: messages.map((m) => ({
           role: m.role,
           content: m.content.map((block) => this.toAnthropicBlock(block)),
         })),
         ...config,
-      } as Anthropic.MessageCreateParams;
+      };
 
       if (systemPrompt) {
         params.system = systemPrompt;


### PR DESCRIPTION
## Summary

- Restores `max_tokens: 8192` as a default in the Anthropic provider params, placed before the `...config` spread so callers can still override it. This fixes the runtime failure introduced by PR #274, since `max_tokens` is a required parameter for the Anthropic Messages API.
- Switches from `as Anthropic.MessageCreateParams` type assertion to a proper `: Anthropic.MessageCreateParams` type annotation so the compiler catches missing required fields at build time.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Verify that calls without explicit `max_tokens` in config succeed at runtime
- [ ] Verify that calls with explicit `max_tokens` in config use the caller's value (not 8192)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
