### PR TITLE
fix: use rowid instead of timestamp for undo delete cursor

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,4 +1,4 @@
-import { eq, desc, asc, and, gte, count } from 'drizzle-orm';
+import { eq, desc, asc, and, count, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, messages } from './schema.js';
@@ -104,14 +104,16 @@ export function updateConversationUsage(
 
 /**
  * Delete the last user message and any subsequent assistant messages.
+ * Uses rowid comparison instead of timestamps to avoid deleting messages
+ * that share the same millisecond timestamp.
  * Returns the number of messages deleted.
  */
 export function deleteLastExchange(conversationId: string): number {
   const db = getDb();
 
-  // Find the last user message without loading all messages
+  // Find the last user message's id
   const lastUserMsg = db
-    .select({ createdAt: messages.createdAt })
+    .select({ id: messages.id })
     .from(messages)
     .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'user')))
     .orderBy(desc(messages.createdAt))
@@ -120,9 +122,13 @@ export function deleteLastExchange(conversationId: string): number {
 
   if (!lastUserMsg) return 0;
 
+  // Use rowid to identify the last user message and everything after it.
+  // rowid is monotonically increasing for inserts, so this is safe even if
+  // multiple messages share the same millisecond timestamp.
+  const rowidSubquery = sql`(SELECT rowid FROM messages WHERE id = ${lastUserMsg.id})`;
   const condition = and(
     eq(messages.conversationId, conversationId),
-    gte(messages.createdAt, lastUserMsg.createdAt),
+    sql`rowid >= ${rowidSubquery}`,
   );
 
   // Count messages to delete, then delete them atomically


### PR DESCRIPTION
## Summary

`deleteLastExchange` previously used `created_at >= lastUserMsg.createdAt` to identify messages to delete during `/undo`. Since `created_at` is millisecond `Date.now()`, multiple messages can share the same timestamp, causing `/undo` to accidentally delete earlier messages.

This switches to using SQLite's internal `rowid` as the cursor: find the last user message by `id`, then delete all messages with `rowid >= (SELECT rowid FROM messages WHERE id = ?)` within the conversation. Since `rowid` is monotonically increasing for inserts, this correctly bounds the deletion to the last exchange.

## Changes

- `assistant/src/memory/conversation-store.ts`: Changed `deleteLastExchange` to select by `messages.id` instead of `messages.createdAt`, and use a `rowid >=` subquery instead of `gte(createdAt)` for the deletion condition.
- Replaced unused `gte` import with `sql` from drizzle-orm.

## Test plan

- [x] `bunx tsc --noEmit` passes
- Verified that the rowid-based approach correctly handles the edge case where two messages share the same millisecond timestamp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
