### PR TITLE
fix: enforce FK constraint on tool_invocations.conversation_id

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -10,6 +10,7 @@ export function getDb() {
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec('PRAGMA journal_mode=WAL');
+    sqlite.exec('PRAGMA foreign_keys = ON');
     db = drizzle(sqlite, { schema });
   }
   return db;
@@ -40,7 +41,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS tool_invocations (
       id TEXT PRIMARY KEY,
-      conversation_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
       tool_name TEXT NOT NULL,
       input TEXT NOT NULL,
       result TEXT NOT NULL,
@@ -55,4 +56,37 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_estimated_cost REAL NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+
+  migrateToolInvocationsFk(database);
+}
+
+/**
+ * Migrate existing tool_invocations table to add FK constraint with ON DELETE CASCADE.
+ * SQLite doesn't support ALTER TABLE ADD CONSTRAINT, so we rebuild the table.
+ * This is idempotent: it checks whether the FK already exists before migrating.
+ */
+function migrateToolInvocationsFk(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as any).$client as Database;
+  const row = raw.query(`SELECT sql FROM sqlite_master WHERE type='table' AND name='tool_invocations'`).get() as { sql: string } | null;
+  if (!row) return; // table doesn't exist yet (will be created above)
+
+  // If the DDL already contains REFERENCES, the FK is in place
+  if (row.sql.includes('REFERENCES')) return;
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE tool_invocations_new (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO tool_invocations_new SELECT * FROM tool_invocations;
+    DROP TABLE tool_invocations;
+    ALTER TABLE tool_invocations_new RENAME TO tool_invocations;
+  `);
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from #271: the Drizzle schema declared `.references()` on `toolInvocations.conversationId`, but the raw SQL `CREATE TABLE` lacked the `REFERENCES` clause, so SQLite never actually enforced referential integrity.

- Added `REFERENCES conversations(id) ON DELETE CASCADE` to the `tool_invocations` CREATE TABLE statement
- Added `PRAGMA foreign_keys = ON` on connection init (SQLite defaults to OFF)
- Added an idempotent migration (`migrateToolInvocationsFk`) that rebuilds the table for existing databases using the standard SQLite table-rebuild pattern (create new -> copy data -> drop old -> rename), since SQLite does not support `ALTER TABLE ADD CONSTRAINT`

## Test plan

- [ ] Fresh database: verify `tool_invocations` is created with FK constraint
- [ ] Existing database without FK: verify migration rebuilds the table with FK
- [ ] Already-migrated database: verify migration is a no-op (idempotent)
- [ ] Delete a conversation and verify its tool invocations are cascade-deleted
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
