### PR TITLE
fix: distinguish keychain not-found from runtime errors in getKey

### DIFF
--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -107,9 +107,16 @@ describe('keychain', () => {
       expect(call!.args).toContain('-w');
     });
 
-    test('getKey returns undefined when key not found', () => {
-      execFileResults.set('find-generic-password', new Error('item not found'));
-      expect(getKey('nonexistent')).toBeUndefined();
+    test('getKey returns null when key not found', () => {
+      const err = Object.assign(new Error('item not found'), { status: 44 });
+      execFileResults.set('find-generic-password', err);
+      expect(getKey('nonexistent')).toBeNull();
+    });
+
+    test('getKey throws on runtime errors', () => {
+      const err = Object.assign(new Error('keychain locked'), { status: 1 });
+      execFileResults.set('find-generic-password', err);
+      expect(() => getKey('test')).toThrow('keychain locked');
     });
 
     test('setKey calls security add-generic-password with -U flag', () => {
@@ -178,9 +185,16 @@ describe('keychain', () => {
       expect(call!.args).toContain('openai');
     });
 
-    test('getKey returns undefined when key not found', () => {
-      execFileResults.set('lookup', new Error('not found'));
-      expect(getKey('missing')).toBeUndefined();
+    test('getKey returns null when key not found', () => {
+      const err = Object.assign(new Error('not found'), { status: 1 });
+      execFileResults.set('lookup', err);
+      expect(getKey('missing')).toBeNull();
+    });
+
+    test('getKey throws on runtime errors', () => {
+      const err = Object.assign(new Error('D-Bus error'), { status: 5 });
+      execFileResults.set('lookup', err);
+      expect(() => getKey('test')).toThrow('D-Bus error');
     });
 
     test('getKey preserves internal whitespace', () => {
@@ -216,8 +230,8 @@ describe('keychain', () => {
       mockPlatform = 'win32';
     });
 
-    test('getKey returns undefined', () => {
-      expect(getKey('any')).toBeUndefined();
+    test('getKey returns null', () => {
+      expect(getKey('any')).toBeNull();
     });
 
     test('setKey returns false', () => {
@@ -233,10 +247,11 @@ describe('keychain', () => {
   // Error handling
   // -----------------------------------------------------------------------
   describe('error handling', () => {
-    test('getKey gracefully handles unexpected errors', () => {
+    test('getKey throws on unexpected runtime errors', () => {
       mockPlatform = 'darwin';
-      execFileResults.set('find-generic-password', new Error('unexpected'));
-      expect(getKey('key')).toBeUndefined();
+      const err = Object.assign(new Error('unexpected'), { status: 1 });
+      execFileResults.set('find-generic-password', err);
+      expect(() => getKey('key')).toThrow('unexpected');
     });
 
     test('setKey gracefully handles unexpected errors', () => {

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -21,7 +21,10 @@ const keychainStore = new Map<string, string>();
 
 mock.module('../security/keychain.js', () => ({
   isKeychainAvailable: () => keychainAvailable,
-  getKey: (account: string) => keychainStore.get(account),
+  getKey: (account: string): string | null => {
+    if (keychainFailAtRuntime) throw new Error('Keychain runtime error');
+    return keychainStore.get(account) ?? null;
+  },
   setKey: (account: string, value: string) => {
     if (keychainFailAtRuntime) return false;
     keychainStore.set(account, value);
@@ -241,6 +244,30 @@ describe('secure-keys', () => {
       const result = deleteSecureKey('openai');
       expect(result).toBe(true);
       expect(getSecureKey('openai')).toBeUndefined();
+    });
+
+    test('deleteSecureKey triggers downgrade when key exists in keychain but keychain starts failing', () => {
+      // Step 1: Store a key while keychain is working
+      setSecureKey('anthropic', 'sk-ant-exists');
+      expect(keychainStore.get('anthropic')).toBe('sk-ant-exists');
+
+      // Step 2: Keychain starts failing at runtime
+      keychainFailAtRuntime = true;
+
+      // Step 3: Attempt to delete — should trigger fallback/downgrade
+      const result = deleteSecureKey('anthropic');
+      // deleteKey returns false because keychain is failing, and fallback
+      // encrypted store doesn't have the key, so the overall result is false.
+      // But the important thing is that the backend was downgraded.
+      expect(result).toBe(false);
+
+      // Step 4: Verify the backend has been downgraded to encrypted store.
+      // Subsequent operations should use encrypted store.
+      keychainFailAtRuntime = false;
+      setSecureKey('openai', 'sk-openai-new');
+      // Should be in encrypted store, not keychain
+      expect(keychainStore.has('openai')).toBe(false);
+      expect(getSecureKey('openai')).toBe('sk-openai-new');
     });
 
     test('backend permanently downgrades after keychain runtime failure', () => {

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -46,21 +46,17 @@ export function isKeychainAvailable(): boolean {
 
 /**
  * Retrieve a secret from the OS keychain.
- * Returns `undefined` if the key doesn't exist or the keychain is unavailable.
+ * Returns `null` if the key doesn't exist.
+ * Throws on runtime errors (keychain unavailable, locked, etc.).
  */
-export function getKey(account: string): string | undefined {
-  try {
-    if (isMacOS()) {
-      return macosGetKey(account);
-    }
-    if (isLinux()) {
-      return linuxGetKey(account);
-    }
-    return undefined;
-  } catch (err) {
-    log.debug({ err, account }, 'Failed to read from keychain');
-    return undefined;
+export function getKey(account: string): string | null {
+  if (isMacOS()) {
+    return macosGetKey(account);
   }
+  if (isLinux()) {
+    return linuxGetKey(account);
+  }
+  return null;
 }
 
 /**
@@ -105,7 +101,7 @@ export function deleteKey(account: string): boolean {
 // macOS Keychain via `security` CLI
 // ---------------------------------------------------------------------------
 
-function macosGetKey(account: string): string | undefined {
+function macosGetKey(account: string): string | null {
   try {
     const result = execFileSync('security', [
       'find-generic-password',
@@ -118,10 +114,14 @@ function macosGetKey(account: string): string | undefined {
       encoding: 'utf-8',
     });
     // Strip only the trailing newline added by the security CLI
-    return result.replace(/\n$/, '') || undefined;
-  } catch {
-    // Item not found (exit code 44) or other error
-    return undefined;
+    return result.replace(/\n$/, '') || null;
+  } catch (err: unknown) {
+    // Exit code 44 = item not found — return null.
+    // All other errors are runtime failures — re-throw.
+    if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 44) {
+      return null;
+    }
+    throw err;
   }
 }
 
@@ -167,7 +167,7 @@ function macosDeleteKey(account: string): boolean {
 // Linux via `secret-tool` (libsecret)
 // ---------------------------------------------------------------------------
 
-function linuxGetKey(account: string): string | undefined {
+function linuxGetKey(account: string): string | null {
   try {
     const result = execFileSync('secret-tool', [
       'lookup',
@@ -179,9 +179,13 @@ function linuxGetKey(account: string): string | undefined {
       encoding: 'utf-8',
     });
     // Strip only the trailing newline added by secret-tool
-    return result.replace(/\n$/, '') || undefined;
-  } catch {
-    return undefined;
+    return result.replace(/\n$/, '') || null;
+  } catch (err: unknown) {
+    // secret-tool exits with code 1 when the key is not found.
+    if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 1) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -45,9 +45,8 @@ function withKeychainFallback<T>(
   if (backend !== 'keychain') return fallbackValue;
 
   const result = keychainFn();
-  // keychain.getKey returns undefined on not-found (not an error),
   // keychain.setKey/deleteKey return false on failure.
-  // We only downgrade on set/delete failures (false), not on get misses (undefined).
+  // We downgrade on failures (false) to switch to encrypted backend.
   if (result === false) {
     log.warn('Keychain operation failed at runtime, falling back to encrypted file storage');
     resolvedBackend = 'encrypted';
@@ -64,17 +63,26 @@ function withKeychainFallback<T>(
 export function getSecureKey(account: string): string | undefined {
   const backend = getBackend();
   if (backend === 'keychain') {
-    const value = keychain.getKey(account);
-    // getKey returns undefined for both not-found and error — we can't
-    // distinguish, so no fallback on read. The fallback triggers on write.
-    return value;
+    try {
+      return keychain.getKey(account) ?? undefined;
+    } catch {
+      // Keychain runtime error on read — downgrade to encrypted store
+      log.warn('Keychain read failed at runtime, falling back to encrypted file storage');
+      resolvedBackend = 'encrypted';
+      downgradedFromKeychain = true;
+      return encryptedStore.getKey(account);
+    }
   }
   if (backend === 'encrypted') {
     const value = encryptedStore.getKey(account);
     // After a runtime downgrade, keys may still exist in the keychain.
     // Try keychain read as fallback so pre-downgrade keys remain accessible.
     if (value === undefined && downgradedFromKeychain) {
-      return keychain.getKey(account);
+      try {
+        return keychain.getKey(account) ?? undefined;
+      } catch {
+        return undefined;
+      }
     }
     return value;
   }
@@ -113,8 +121,14 @@ export function deleteSecureKey(account: string): boolean {
   // keychain.deleteKey returns false for both "not found" and "runtime error".
   // Check existence first so a missing key doesn't spuriously downgrade the
   // backend — saveConfig routinely deletes keys for unset providers.
-  if (keychain.getKey(account) === undefined) {
-    return false;
+  // getKey now returns null for "not found" and throws on runtime errors.
+  try {
+    if (keychain.getKey(account) === null) {
+      return false;
+    }
+  } catch {
+    // Keychain runtime error — fall through to withKeychainFallback which
+    // will handle the downgrade when deleteKey also fails.
   }
 
   return withKeychainFallback(


### PR DESCRIPTION
## Summary
- `keychain.getKey()` now returns `null` for "key not found" and throws on runtime errors (previously returned `undefined` for both cases)
- `deleteSecureKey` now properly falls through to `withKeychainFallback` when the keychain has runtime errors, instead of incorrectly treating the error as "key doesn't exist"
- `getSecureKey` also handles the new throwing behavior by catching runtime errors and triggering the encrypted store downgrade
- Added test covering the exact bug scenario: key exists in keychain, keychain starts failing, deleteSecureKey triggers downgrade

## Test plan
- [x] `bun test src/__tests__/keychain.test.ts` — 24 pass
- [x] `bun test src/__tests__/secure-keys.test.ts` — 19 pass (includes new test)
- [x] `bunx tsc --noEmit` — passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
