### PR TITLE
security: sanitize env vars passed to shell subprocesses

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -11,6 +11,38 @@ const log = getLogger('shell-tool');
 
 const MAX_OUTPUT_LENGTH = 50_000;
 
+/**
+ * Environment variables that are safe to pass through to child processes.
+ * Everything else (API keys, tokens, credentials) is stripped to prevent
+ * accidental leakage via agent-spawned commands.
+ */
+const SAFE_ENV_VARS = [
+  'PATH',
+  'HOME',
+  'TERM',
+  'LANG',
+  'EDITOR',
+  'SHELL',
+  'USER',
+  'TMPDIR',
+  'LC_ALL',
+  'LC_CTYPE',
+  'XDG_RUNTIME_DIR',
+  'DISPLAY',
+  'COLORTERM',
+  'TERM_PROGRAM',
+] as const;
+
+function buildSanitizedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of SAFE_ENV_VARS) {
+    if (process.env[key] != null) {
+      env[key] = process.env[key]!;
+    }
+  }
+  return env;
+}
+
 class ShellTool implements Tool {
   name = 'shell';
   description = 'Execute a shell command on the local machine';
@@ -67,7 +99,7 @@ class ShellTool implements Tool {
       const wrapped = wrapCommand(command, context.workingDir, sandboxEnabled);
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
-        env: { ...process.env },
+        env: buildSanitizedEnv(),
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 


### PR DESCRIPTION
## Summary

- Replace `{ ...process.env }` with a whitelist of safe environment variables when spawning child processes in the shell tool
- Adds a `SAFE_ENV_VARS` constant listing only variables needed for normal shell operation (PATH, HOME, TERM, LANG, EDITOR, SHELL, USER, TMPDIR, LC_ALL, LC_CTYPE, XDG_RUNTIME_DIR, DISPLAY, COLORTERM, TERM_PROGRAM)
- Prevents accidental leakage of API keys, tokens, and credentials to agent-spawned commands

## Test plan

- [ ] Verify shell commands still work correctly (PATH, HOME, etc. are available)
- [ ] Verify that sensitive env vars (e.g. API keys) are NOT visible in child processes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
