### PR TITLE
feat: read --version from package.json

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
 import * as net from 'node:net';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json') as { version: string };
 import {
   ensureDaemonRunning,
   startDaemon,
@@ -84,7 +88,7 @@ const program = new Command();
 program
   .name('vellum')
   .description('Local AI assistant')
-  .version('0.1.0')
+  .version(version)
   .option('--no-sandbox', 'Disable sandbox for this session (runtime override, not persisted)')
   .action(async (opts: { sandbox?: boolean }) => {
     await ensureDaemonRunning();


### PR DESCRIPTION
## Summary
- Replace hardcoded version string in Commander `.version()` call with dynamic import from `package.json`
- Uses `createRequire` from `node:module` to load `package.json` at startup
- `vellum --version` and `vellum -V` now automatically reflect the version in `package.json`

## Changed files
- `assistant/src/index.ts` — import version from package.json, pass to `.version()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
