### PR TITLE
fix: add 64KB buffer limit to IPC message parser

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -209,6 +209,9 @@ export type ServerMessage =
 
 // === Serialization ===
 
+/** Maximum size of a single line in the IPC buffer (64KB). */
+export const MAX_LINE_SIZE = 64 * 1024;
+
 export function serialize(msg: ClientMessage | ServerMessage): string {
   return JSON.stringify(msg) + '\n';
 }
@@ -232,6 +235,12 @@ export function createMessageParser() {
             // Skip malformed messages
           }
         }
+      }
+      if (buffer.length > MAX_LINE_SIZE) {
+        buffer = '';
+        throw new Error(
+          `IPC message exceeds maximum line size of ${MAX_LINE_SIZE} bytes. Message discarded.`,
+        );
       }
       return messages;
     },

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -189,7 +189,15 @@ export class DaemonServer {
     });
 
     socket.on('data', (data) => {
-      const messages = parser.feed(data.toString());
+      let messages;
+      try {
+        messages = parser.feed(data.toString());
+      } catch (err) {
+        log.error({ err }, 'IPC parse error, dropping client');
+        socket.write(serialize({ type: 'error', message: (err as Error).message }));
+        socket.destroy();
+        return;
+      }
       for (const msg of messages) {
         this.handleMessage(msg as ClientMessage, socket);
       }


### PR DESCRIPTION
## Summary
- Adds a `MAX_LINE_SIZE` constant (64KB) to `ipc-protocol.ts` to prevent unbounded buffer growth in the IPC message parser.
- When the partial-line buffer exceeds 64KB without a complete newline-delimited message, the parser resets the buffer and throws a descriptive error.
- The server (`server.ts`) catches the error, logs it, sends an error message back to the client, and destroys the socket — preventing a malicious or buggy client from crashing the daemon via memory exhaustion.

## Test plan
- [ ] Verify normal IPC messages (well under 64KB) continue to parse correctly.
- [ ] Simulate sending >64KB of data without a newline; confirm the server logs an error, sends an error message, and disconnects the client.
- [ ] Verify the daemon remains stable after a client triggers the buffer limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
