### PR TITLE
perf: add SQLite indexes for query performance

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -58,6 +58,11 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_estimated_cost REAL NOT NULL DEFAULT 0`); } catch { /* already exists */ }
 
   migrateToolInvocationsFk(database);
+
+  // Indexes for query performance on large datasets
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tool_invocations_conversation_id ON tool_invocations(conversation_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at)`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add explicit `CREATE INDEX IF NOT EXISTS` statements for three columns that are frequently queried:
  - `idx_messages_conversation_id` on `messages(conversation_id)`
  - `idx_tool_invocations_conversation_id` on `tool_invocations(conversation_id)`
  - `idx_conversations_updated_at` on `conversations(updated_at)`
- Uses `IF NOT EXISTS` so it's idempotent and safe to run on existing databases.
- Placed after table creation and migrations in `initializeDb()`.

## Why
These columns are used in WHERE/JOIN clauses when loading conversations, listing by recency, and fetching related messages/tool invocations. Without indexes, SQLite performs full table scans which degrade with large datasets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
