### PR TITLE
feat: add file size validation before read/write operations

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { getTool } from './registry.js';
 import type { ToolContext, ToolExecutionResult } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
@@ -10,6 +10,7 @@ import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
+import { MAX_FILE_SIZE_BYTES } from './filesystem/size-guard.js';
 import { wrapCommand } from './terminal/sandbox.js';
 import { getConfig } from '../config/loader.js';
 import { scanText, redactSecrets } from '../security/secret-scanner.js';
@@ -236,6 +237,10 @@ function computePreviewDiff(
       if (!pathCheck.ok) return undefined;
       const filePath = pathCheck.resolved;
       const isNewFile = !existsSync(filePath);
+      if (!isNewFile) {
+        const stat = statSync(filePath);
+        if (stat.size > MAX_FILE_SIZE_BYTES) return undefined;
+      }
       const oldContent = isNewFile ? '' : readFileSync(filePath, 'utf-8');
       return { filePath, oldContent, newContent: content, isNewFile };
     }
@@ -249,6 +254,8 @@ function computePreviewDiff(
       if (!pathCheck.ok) return undefined;
       const filePath = pathCheck.resolved;
       if (!existsSync(filePath)) return undefined;
+      const stat = statSync(filePath);
+      if (stat.size > MAX_FILE_SIZE_BYTES) return undefined;
       const content = readFileSync(filePath, 'utf-8');
       const replaceAll = input.replace_all === true;
       let updated: string;

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,10 +1,11 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, statSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { findAllMatches, adjustIndentation } from './fuzzy-match.js';
 import { validateFilePath } from './path-guard.js';
+import { checkFileSizeOnDisk } from './size-guard.js';
 
 class FileEditTool implements Tool {
   name = 'file_edit';
@@ -71,6 +72,11 @@ class FileEditTool implements Tool {
       return { content: `Error: ${pathCheck.error}`, isError: true };
     }
     const filePath = pathCheck.resolved;
+
+    const sizeError = checkFileSizeOnDisk(filePath);
+    if (sizeError) {
+      return { content: `Error: ${sizeError}`, isError: true };
+    }
 
     try {
       const content = readFileSync(filePath, 'utf-8');

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -4,6 +4,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { validateFilePath } from './path-guard.js';
+import { checkFileSizeOnDisk } from './size-guard.js';
 
 class FileReadTool implements Tool {
   name = 'file_read';
@@ -55,6 +56,11 @@ class FileReadTool implements Tool {
     const stat = statSync(filePath);
     if (stat.isDirectory()) {
       return { content: `Error: ${filePath} is a directory, not a file`, isError: true };
+    }
+
+    const sizeError = checkFileSizeOnDisk(filePath);
+    if (sizeError) {
+      return { content: `Error: ${sizeError}`, isError: true };
     }
 
     try {

--- a/assistant/src/tools/filesystem/size-guard.ts
+++ b/assistant/src/tools/filesystem/size-guard.ts
@@ -1,0 +1,41 @@
+import { statSync } from 'node:fs';
+
+/** Default maximum file size: 100 MB */
+export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Check whether a file on disk exceeds the size limit.
+ * Returns an error string if the file is too large, or undefined if OK.
+ */
+export function checkFileSizeOnDisk(
+  filePath: string,
+  limit: number = MAX_FILE_SIZE_BYTES,
+): string | undefined {
+  const stat = statSync(filePath);
+  if (stat.size > limit) {
+    return `File size (${formatBytes(stat.size)}) exceeds the ${formatBytes(limit)} limit: ${filePath}`;
+  }
+  return undefined;
+}
+
+/**
+ * Check whether content to be written exceeds the size limit.
+ * Returns an error string if the content is too large, or undefined if OK.
+ */
+export function checkContentSize(
+  content: string,
+  filePath: string,
+  limit: number = MAX_FILE_SIZE_BYTES,
+): string | undefined {
+  const size = Buffer.byteLength(content, 'utf-8');
+  if (size > limit) {
+    return `Content size (${formatBytes(size)}) exceeds the ${formatBytes(limit)} limit for: ${filePath}`;
+  }
+  return undefined;
+}

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -5,6 +5,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { validateFilePath } from './path-guard.js';
+import { checkContentSize } from './size-guard.js';
 
 class FileWriteTool implements Tool {
   name = 'file_write';
@@ -49,6 +50,11 @@ class FileWriteTool implements Tool {
       return { content: `Error: ${pathCheck.error}`, isError: true };
     }
     const filePath = pathCheck.resolved;
+
+    const sizeError = checkContentSize(fileContent, filePath);
+    if (sizeError) {
+      return { content: `Error: ${sizeError}`, isError: true };
+    }
 
     try {
       // Create parent directories if needed


### PR DESCRIPTION
## Summary
- Adds a configurable 100MB file size limit (`MAX_FILE_SIZE_BYTES`) that rejects file operations before reading/writing oversized files
- `file_read` and `file_edit` tools check on-disk file size via `statSync` before calling `readFileSync`
- `file_write` tool checks the byte length of content to be written before proceeding
- `computePreviewDiff` in `executor.ts` also skips oversized files gracefully
- Errors are returned as tool results (not thrown), so the agent sees a clear message and can adjust

## Files changed
- `assistant/src/tools/filesystem/size-guard.ts` (new) -- shared constants and helpers
- `assistant/src/tools/filesystem/read.ts` -- size check before read
- `assistant/src/tools/filesystem/write.ts` -- content size check before write  
- `assistant/src/tools/filesystem/edit.ts` -- size check before read
- `assistant/src/tools/executor.ts` -- size guard in preview diff computation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
