### PR TITLE
refactor: consolidate session usage stats into UsageStats object

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -1,3 +1,11 @@
+// === Shared types ===
+
+export interface UsageStats {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+}
+
 // === Client → Server messages ===
 
 export interface UserMessage {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { Message } from '../providers/types.js';
-import type { ServerMessage } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats } from './ipc-protocol.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { createUserMessage } from '../agent/message-types.js';
@@ -27,9 +27,7 @@ export class Session {
   private sendToClient: (msg: ServerMessage) => void;
   private workingDir: string;
   private sandboxOverride?: boolean;
-  private totalInputTokens = 0;
-  private totalOutputTokens = 0;
-  private totalEstimatedCost = 0;
+  private usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
 
   constructor(
     conversationId: string,
@@ -82,9 +80,11 @@ export class Session {
 
     const conv = conversationStore.getConversation(this.conversationId);
     if (conv) {
-      this.totalInputTokens = conv.totalInputTokens;
-      this.totalOutputTokens = conv.totalOutputTokens;
-      this.totalEstimatedCost = conv.totalEstimatedCost;
+      this.usageStats = {
+        inputTokens: conv.totalInputTokens,
+        outputTokens: conv.totalOutputTokens,
+        estimatedCost: conv.totalEstimatedCost,
+      };
     }
 
     log.info({ conversationId: this.conversationId, count: this.messages.length }, 'Loaded messages from DB');
@@ -199,22 +199,24 @@ export class Session {
 
       // Update cumulative token usage
       if (exchangeInputTokens > 0 || exchangeOutputTokens > 0) {
-        this.totalInputTokens += exchangeInputTokens;
-        this.totalOutputTokens += exchangeOutputTokens;
         const exchangeCost = estimateCost(exchangeInputTokens, exchangeOutputTokens, model);
-        this.totalEstimatedCost += exchangeCost;
+        this.usageStats = {
+          inputTokens: this.usageStats.inputTokens + exchangeInputTokens,
+          outputTokens: this.usageStats.outputTokens + exchangeOutputTokens,
+          estimatedCost: this.usageStats.estimatedCost + exchangeCost,
+        };
         conversationStore.updateConversationUsage(
           this.conversationId,
-          this.totalInputTokens,
-          this.totalOutputTokens,
-          this.totalEstimatedCost,
+          this.usageStats.inputTokens,
+          this.usageStats.outputTokens,
+          this.usageStats.estimatedCost,
         );
         onEvent({
           type: 'usage_update',
           inputTokens: exchangeInputTokens,
           outputTokens: exchangeOutputTokens,
-          totalInputTokens: this.totalInputTokens,
-          totalOutputTokens: this.totalOutputTokens,
+          totalInputTokens: this.usageStats.inputTokens,
+          totalOutputTokens: this.usageStats.outputTokens,
           estimatedCost: exchangeCost,
           model,
         });


### PR DESCRIPTION
## Summary
- Replaced three separate `totalInputTokens`, `totalOutputTokens`, `totalEstimatedCost` fields in `Session` with a single `usageStats: UsageStats` object to prevent state drift between related fields.
- Exported the `UsageStats` interface from `ipc-protocol.ts` so other modules can reuse the type.
- IPC message shapes and DB schema are unchanged -- this is a pure internal refactor.

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [ ] Manual smoke test: start daemon, send messages, verify `/usage` still reports correct totals
- [ ] Verify session reload from DB correctly populates `usageStats`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
