### PR TITLE
perf: lazy tool registration for deferred module loading

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -1,4 +1,5 @@
-import type { Tool } from './types.js';
+import { RiskLevel } from '../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 
@@ -6,12 +7,68 @@ const log = getLogger('tool-registry');
 
 const tools = new Map<string, Tool>();
 
+export interface LazyToolDescriptor {
+  name: string;
+  description: string;
+  category: string;
+  defaultRiskLevel: RiskLevel;
+  definition: ToolDefinition;
+  loader: () => Promise<Tool>;
+}
+
+/**
+ * A tool wrapper that exposes metadata eagerly but defers module loading
+ * and execute() initialization until the tool is first invoked.
+ */
+class LazyTool implements Tool {
+  name: string;
+  description: string;
+  category: string;
+  defaultRiskLevel: RiskLevel;
+  private definition: ToolDefinition;
+  private loader: () => Promise<Tool>;
+  private resolvedTool: Tool | null = null;
+  private loadPromise: Promise<Tool> | null = null;
+
+  constructor(descriptor: LazyToolDescriptor) {
+    this.name = descriptor.name;
+    this.description = descriptor.description;
+    this.category = descriptor.category;
+    this.defaultRiskLevel = descriptor.defaultRiskLevel;
+    this.definition = descriptor.definition;
+    this.loader = descriptor.loader;
+  }
+
+  getDefinition(): ToolDefinition {
+    return this.definition;
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    if (!this.resolvedTool) {
+      if (!this.loadPromise) {
+        this.loadPromise = this.loader().then((tool) => {
+          this.resolvedTool = tool;
+          log.info({ name: this.name }, 'Lazy tool loaded');
+          return tool;
+        });
+      }
+      await this.loadPromise;
+    }
+    return this.resolvedTool!.execute(input, context);
+  }
+}
+
 export function registerTool(tool: Tool): void {
   if (tools.has(tool.name)) {
     log.warn({ name: tool.name }, 'Tool already registered, overwriting');
   }
   tools.set(tool.name, tool);
   log.info({ name: tool.name, category: tool.category }, 'Tool registered');
+}
+
+export function registerLazyTool(descriptor: LazyToolDescriptor): void {
+  const lazy = new LazyTool(descriptor);
+  registerTool(lazy);
 }
 
 export function getTool(name: string): Tool | undefined {
@@ -27,11 +84,45 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  // Import tool modules to trigger registration side effects
-  await import('./terminal/shell.js');
+  // Import tool modules to trigger registration side effects.
+  // Filesystem and network tools are cheap to load — import eagerly.
   await import('./filesystem/read.js');
   await import('./filesystem/write.js');
   await import('./filesystem/edit.js');
   await import('./network/web-search.js');
+
+  // The shell tool loads web-tree-sitter WASM for command parsing, which is
+  // expensive.  Register it lazily so the WASM is only loaded on first use.
+  registerLazyTool({
+    name: 'shell',
+    description: 'Execute a shell command on the local machine',
+    category: 'terminal',
+    defaultRiskLevel: RiskLevel.Medium,
+    definition: {
+      name: 'shell',
+      description: 'Execute a shell command on the local machine',
+      input_schema: {
+        type: 'object',
+        properties: {
+          command: {
+            type: 'string',
+            description: 'The shell command to execute',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description: 'Optional timeout in seconds. Defaults to the configured default (120s). Cannot exceed the configured maximum.',
+          },
+        },
+        required: ['command'],
+      },
+    },
+    loader: async () => {
+      // Dynamically import the shell module.  Its side-effect registerTool()
+      // call replaces the lazy wrapper in the map with the real tool.
+      const mod = await import('./terminal/shell.js');
+      return mod.shellTool;
+    },
+  });
+
   log.info({ count: tools.size }, 'Tools initialized');
 }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -168,4 +168,5 @@ class ShellTool implements Tool {
   }
 }
 
-registerTool(new ShellTool());
+export const shellTool: Tool = new ShellTool();
+registerTool(shellTool);


### PR DESCRIPTION
## Summary
- Add `LazyTool` wrapper class and `registerLazyTool()` to the tool registry that exposes tool metadata eagerly but defers module import and `execute()` initialization until first invocation
- Register the shell tool lazily since it pulls in `web-tree-sitter` WASM, `child_process`, and sandbox dependencies — these are now only loaded when the shell tool is first used
- Other tools (filesystem, web-search) remain eagerly loaded since they are lightweight

## Files changed
- `assistant/src/tools/registry.ts` — Added `LazyTool` class, `LazyToolDescriptor` interface, `registerLazyTool()` function; changed `initializeTools()` to register shell tool lazily with inline metadata
- `assistant/src/tools/terminal/shell.ts` — Export `shellTool` instance so the lazy loader can access it after dynamic import
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
