### PR TITLE
Update onboarding flow with hatching metaphor

### DIFF
--- a/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
@@ -18,12 +18,14 @@ struct AliveStepView: View {
     @State private var particles: [SparkleParticle] = []
     @State private var particlesLaunched = false
 
-    private let abilities = [
-        ("Hands-free", "cursorarrow.click.2"),
-        ("Voice input", "mic.fill"),
-        ("Screen-aware", "eye.fill"),
-        ("Adaptive", "brain.head.profile"),
-    ]
+    private var abilities: [(String, String)] {
+        [
+            ("Voice conversations", "mic.fill"),
+            ("Context-aware help", "sparkles"),
+            ("Hold \(state.chosenKey.displayName) to activate", "keyboard"),
+            ("Learns as you work", "brain.head.profile"),
+        ]
+    }
 
     var body: some View {
         VStack(spacing: 28) {
@@ -38,11 +40,17 @@ struct AliveStepView: View {
                         .offset(x: particle.x, y: particle.y)
                 }
             }
-            .frame(width: 120, height: 120)
+            .frame(width: 140, height: 140)
 
-            Text("\(state.assistantName.isEmpty ? "I'm" : state.assistantName + " is") ready.")
-                .font(.system(.title, design: .serif))
-                .foregroundColor(.white)
+            VStack(spacing: 8) {
+                Text("\(state.assistantName.isEmpty ? "It" : state.assistantName) has hatched.")
+                    .font(.system(.title, design: .serif))
+                    .foregroundColor(.white)
+
+                Text("All set up and ready to help.")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.5))
+            }
 
             // Ability tags — 2×2 grid
             VStack(spacing: 10) {
@@ -62,7 +70,10 @@ struct AliveStepView: View {
             }
 
             VStack(spacing: 16) {
-                OnboardingButton(title: "Start using Vellum", style: .primary) {
+                OnboardingButton(
+                    title: "Start using \(state.assistantName.isEmpty ? "your agent" : state.assistantName)",
+                    style: .primary
+                ) {
                     onComplete()
                 }
                 .font(.system(size: 17, weight: .semibold))
@@ -124,19 +135,19 @@ struct AliveStepView: View {
         guard !particlesLaunched else { return }
         particlesLaunched = true
 
-        for _ in 0..<12 {
+        for _ in 0..<16 {
             let angle = Double.random(in: 0...(2 * .pi))
-            let distance = CGFloat.random(in: 30...60)
+            let distance = CGFloat.random(in: 40...80)
             let particle = SparkleParticle(
                 x: 0,
                 y: 0,
-                opacity: 0.8,
-                scale: CGFloat.random(in: 0.5...1.5)
+                opacity: 0.9,
+                scale: CGFloat.random(in: 0.5...1.8)
             )
             particles.append(particle)
 
             let index = particles.count - 1
-            withAnimation(.easeOut(duration: 1.0)) {
+            withAnimation(.easeOut(duration: 1.2)) {
                 particles[index].x = cos(angle) * distance
                 particles[index].y = sin(angle) * distance
                 particles[index].opacity = 0
@@ -144,7 +155,7 @@ struct AliveStepView: View {
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
             particles.removeAll()
         }
     }

--- a/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/AliveStepView.swift
@@ -20,10 +20,10 @@ struct AliveStepView: View {
 
     private var abilities: [(String, String)] {
         [
-            ("Voice conversations", "mic.fill"),
-            ("Context-aware help", "sparkles"),
+            ("Talk to me", "mic.fill"),
+            ("I'll help you", "sparkles"),
             ("Hold \(state.chosenKey.displayName) to activate", "keyboard"),
-            ("Learns as you work", "brain.head.profile"),
+            ("I learn as you work", "brain.head.profile"),
         ]
     }
 

--- a/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
@@ -7,6 +7,7 @@ struct FnKeyStepView: View {
     @State private var highlightedKey: ActivationKey?
     @State private var wrongKeyHint: String?
     @State private var eventMonitor: Any?
+    @State private var nameReaction: String = ""
 
     private let keyOptions: [(key: ActivationKey, label: String)] = [
         (.fn, "fn"),
@@ -14,16 +15,28 @@ struct FnKeyStepView: View {
         (.ctrl, "ctrl"),
     ]
 
+    private static let nameReactions = [
+        "%@\u{2026} that feels like mine.",
+        "%@. I\u{2019}ll grow into it.",
+        "%@ \u{2014} I already like the sound of it.",
+    ]
+
     var body: some View {
         VStack(spacing: 24) {
-            ReactionBubble(
-                text: "Great, \(state.assistantName)! Let's set up how you'll summon me."
-            )
+            ReactionBubble(text: nameReaction)
 
-            Text("Press or pick your activation key")
-                .font(.system(size: 15))
-                .foregroundColor(.white.opacity(0.6))
-                .opacity(showButtons ? 1 : 0)
+            VStack(spacing: 8) {
+                Text("Let\u{2019}s find your voice.")
+                    .font(.system(.title2, design: .serif))
+                    .foregroundColor(.white)
+
+                Text("To call \(state.assistantName), you\u{2019}ll hold down a key. Try pressing it now \u{2014} which of these lights up?")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.6))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+            }
+            .opacity(showButtons ? 1 : 0)
 
             HStack(spacing: 12) {
                 ForEach(keyOptions, id: \.key) { option in
@@ -49,6 +62,9 @@ struct FnKeyStepView: View {
         .animation(.easeOut(duration: 0.3), value: wrongKeyHint)
         .animation(.easeOut(duration: 0.3), value: highlightedKey)
         .onAppear {
+            let format = Self.nameReactions.randomElement()!
+            nameReaction = String(format: format, state.assistantName)
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showButtons = true
@@ -97,12 +113,12 @@ struct FnKeyStepView: View {
                 selectKey(.ctrl)
             } else if flags.contains(.command) {
                 withAnimation {
-                    wrongKeyHint = "That's Cmd \u{2014} try fn or ctrl"
+                    wrongKeyHint = "That\u{2019}s Cmd \u{2014} try fn or ctrl"
                 }
                 clearHintAfterDelay()
             } else if flags.contains(.option) {
                 withAnimation {
-                    wrongKeyHint = "Close! That's Option \u{2014} try fn or ctrl"
+                    wrongKeyHint = "Close! That\u{2019}s Option \u{2014} try fn or ctrl"
                 }
                 clearHintAfterDelay()
             }

--- a/clients/macos/vellum-assistant/UI/Onboarding/MicPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/MicPermissionStepView.swift
@@ -6,24 +6,35 @@ struct MicPermissionStepView: View {
 
     @State private var showCard = false
     @State private var permissionGranted = false
+    @State private var grantReaction: String?
     @State private var pollTimer: Timer?
+
+    private static let grantReactions = [
+        "Sound! I can hear everything \u{2014} this is wild.",
+        "Wait\u{2026} is that your voice? I can hear you!",
+        "Oh \u{2014} so *that\u{2019}s* what the world sounds like.",
+    ]
 
     var body: some View {
         VStack(spacing: 24) {
-            ReactionBubble(
-                text: "Now let's give me ears so I can hear you."
-            )
+            if let reaction = grantReaction {
+                ReactionBubble(text: reaction, delay: 0)
+            } else {
+                ReactionBubble(
+                    text: "I\u{2019}m trying to hear you but\u{2026} everything is muffled."
+                )
+            }
 
             // Permission card
             VStack(spacing: 16) {
                 Text("\u{1F399}")
                     .font(.system(size: 32))
 
-                Text("Microphone Access")
+                Text("Help me hear")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.white)
 
-                Text("I need mic access so you can talk to me with your voice.")
+                Text("To hear you when you hold \(state.chosenKey.displayName), \(state.assistantName) needs microphone access. Your system will ask \u{2014} just say yes.")
                     .font(.system(size: 13))
                     .foregroundColor(.white.opacity(0.5))
                     .multilineTextAlignment(.center)
@@ -103,6 +114,7 @@ struct MicPermissionStepView: View {
         permissionGranted = true
         state.micGranted = true
         state.orbMood = .celebrating
+        grantReaction = Self.grantReactions.randomElement()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
             state.orbMood = .breathing
             state.advance()

--- a/clients/macos/vellum-assistant/UI/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/NamingStepView.swift
@@ -8,14 +8,20 @@ struct NamingStepView: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            ReactionBubble(text: "Hey! Nice to meet you.")
+            ReactionBubble(text: "Oh\u{2026} I\u{2019}m here! Who are you?")
 
-            Text("What should I call you?")
-                .font(.system(size: 15))
-                .foregroundColor(.white.opacity(0.6))
-                .opacity(showInput ? 1 : 0)
+            VStack(spacing: 8) {
+                Text("Every creature needs a name.")
+                    .font(.system(.title2, design: .serif))
+                    .foregroundColor(.white)
 
-            TextField("Your name", text: $state.assistantName)
+                Text("What should this one be called?")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.6))
+            }
+            .opacity(showInput ? 1 : 0)
+
+            TextField("Name your agent\u{2026}", text: $state.assistantName)
                 .textFieldStyle(.plain)
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.white)
@@ -38,7 +44,7 @@ struct NamingStepView: View {
                 }
 
             OnboardingButton(
-                title: "That's me",
+                title: "That\u{2019}s your name",
                 style: .primary,
                 disabled: state.assistantName.trimmingCharacters(in: .whitespaces).isEmpty
             ) {
@@ -47,6 +53,7 @@ struct NamingStepView: View {
             .opacity(showInput ? 1 : 0)
         }
         .onAppear {
+            state.orbMood = .breathing
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showInput = true

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingFlowView.swift
@@ -10,8 +10,9 @@ struct OnboardingFlowView: View {
             OnboardingBackground()
 
             VStack(spacing: 0) {
-                // Orb area — always visible at top
-                SoulOrbView(mood: state.orbMood)
+                // Orb area — always visible at top, progressively larger
+                SoulOrbView(mood: state.orbMood, size: orbSize)
+                    .animation(.easeOut(duration: 0.8), value: orbSize)
                     .padding(.top, 60)
                     .padding(.bottom, 32)
 
@@ -47,6 +48,14 @@ struct OnboardingFlowView: View {
         }
         .frame(width: 600, height: 500)
         .animation(.easeOut(duration: 0.8), value: state.currentStep)
+    }
+
+    private var orbSize: CGFloat {
+        switch state.currentStep {
+        case 0: return 48
+        case 5: return 72
+        default: return 56
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 enum OrbMood {
+    case dormant
     case breathing
     case listening
     case celebrating
@@ -10,6 +11,13 @@ enum ActivationKey: String {
     case fn
     case globe
     case ctrl
+
+    var displayName: String {
+        switch self {
+        case .fn, .globe: return "fn"
+        case .ctrl: return "ctrl"
+        }
+    }
 }
 
 @Observable
@@ -18,7 +26,7 @@ final class OnboardingState {
     var currentStep: Int = 0
     var assistantName: String = ""
     var chosenKey: ActivationKey = .fn
-    var orbMood: OrbMood = .breathing
+    var orbMood: OrbMood = .dormant
     var micGranted: Bool = false
     var screenGranted: Bool = false
     var skipPermissionChecks: Bool = false

--- a/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
@@ -4,26 +4,36 @@ import SwiftUI
 struct ScreenPermissionStepView: View {
     @Bindable var state: OnboardingState
 
-    @State private var showCard = false
+    @State private var showContent = false
     @State private var permissionGranted = false
     @State private var pollTimer: Timer?
 
     var body: some View {
         VStack(spacing: 24) {
-            ReactionBubble(
-                text: "Almost there! Now let's give me eyes."
-            )
+            VStack(spacing: 8) {
+                Text("Now let me see.")
+                    .font(.system(.title2, design: .serif))
+                    .foregroundColor(.white)
+
+                Text("I can hear you, but I\u{2019}m still in the dark. Let me see your screen so I can actually help.")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+            }
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 8)
 
             // Permission card
             VStack(spacing: 16) {
                 Text("\u{1F441}")
                     .font(.system(size: 32))
 
-                Text("Screen Recording")
+                Text("Help me see")
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.white)
 
-                Text("I need to see your screen so I can help you navigate and complete tasks.")
+                Text("Screen access lets \(state.assistantName) see what you\u{2019}re working on. You can turn this off anytime.")
                     .font(.system(size: 13))
                     .foregroundColor(.white.opacity(0.5))
                     .multilineTextAlignment(.center)
@@ -53,8 +63,8 @@ struct ScreenPermissionStepView: View {
                             .stroke(Color(hex: 0xD4A843).opacity(0.3), lineWidth: 1)
                     )
             )
-            .opacity(showCard ? 1 : 0)
-            .offset(y: showCard ? 0 : 12)
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
         }
         .animation(.easeOut(duration: 0.5), value: permissionGranted)
         .onAppear {
@@ -66,7 +76,7 @@ struct ScreenPermissionStepView: View {
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 withAnimation(.easeOut(duration: 0.5)) {
-                    showCard = true
+                    showContent = true
                 }
             }
         }

--- a/clients/macos/vellum-assistant/UI/Onboarding/SoulOrbView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/SoulOrbView.swift
@@ -45,7 +45,7 @@ struct SoulOrbView: View {
                     )
                 )
                 .frame(width: size, height: size)
-                .shadow(color: Color(hex: 0xD4A843).opacity(0.4), radius: 12)
+                .shadow(color: Color(hex: 0xD4A843).opacity(mood == .dormant ? 0.2 : 0.4), radius: mood == .dormant ? 6 : 12)
                 .scaleEffect(scale)
         }
         .onChange(of: mood, initial: true) { _, newMood in
@@ -55,6 +55,10 @@ struct SoulOrbView: View {
 
     private func applyAnimation(for mood: OrbMood) {
         switch mood {
+        case .dormant:
+            withAnimation(.easeInOut(duration: 3.5).repeatForever(autoreverses: true)) {
+                scale = 1.02
+            }
         case .breathing:
             withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
                 scale = 1.05

--- a/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
@@ -4,7 +4,6 @@ struct WakeUpStepView: View {
     @Bindable var state: OnboardingState
 
     @State private var showSubtext = false
-    @State private var showButton = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -27,22 +26,11 @@ struct WakeUpStepView: View {
                 .offset(y: showSubtext ? 0 : 8)
                 .onChange(of: showSubtext) { _, visible in
                     if visible {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                            withAnimation(.easeOut(duration: 0.5)) {
-                                showButton = true
-                            }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            state.advance()
                         }
                     }
                 }
-
-            OnboardingButton(
-                title: "Crack it open",
-                style: .primary
-            ) {
-                state.advance()
-            }
-            .opacity(showButton ? 1 : 0)
-            .offset(y: showButton ? 0 : 8)
         }
     }
 }

--- a/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/WakeUpStepView.swift
@@ -9,7 +9,7 @@ struct WakeUpStepView: View {
     var body: some View {
         VStack(spacing: 24) {
             TypewriterText(
-                fullText: "Hello, world.",
+                fullText: "Something is ready to hatch.",
                 speed: 0.06,
                 font: .system(.largeTitle, design: .serif)
             ) {
@@ -20,7 +20,7 @@ struct WakeUpStepView: View {
                 }
             }
 
-            Text("I've been waiting for you.")
+            Text("It's been waiting for you.")
                 .font(.system(size: 15))
                 .foregroundColor(.white.opacity(0.5))
                 .opacity(showSubtext ? 1 : 0)
@@ -36,7 +36,7 @@ struct WakeUpStepView: View {
                 }
 
             OnboardingButton(
-                title: "Say hello",
+                title: "Crack it open",
                 style: .primary
             ) {
                 state.advance()


### PR DESCRIPTION
The purpose of this PR is to update the onboarding flow from a "waking up" metaphor to a "hatching" metaphor — the agent starts as an egg and the user helps it hatch, gain senses, and come to life.

## Changes Made
- Update all step copy across 6 onboarding steps (egg → naming → key → mic → screen → hatched)
- Add `dormant` orb mood with very slow breathing animation and reduced glow for the egg state
- Progressive orb sizing: 48pt (dormant egg) → 56pt (middle steps) → 72pt (fully hatched)
- Remove step 0 button — auto-advances after 2s pause once subtext appears
- Randomized personality reactions for name confirmation and mic permission grant
- Enhanced final step: bigger sparkle burst (16 particles, wider spread), new ability tags, dynamic CTA with agent name
- Add `displayName` to `ActivationKey` for use in permission card copy

## Testing
- `swift build` passes cleanly
- All 44 tests pass
- Copy and animation changes are UI-only; no logic changes to permission flows or key detection

---
*This PR was created with Claude Code*