### PR TITLE
Simplify onboarding voice key selection to fn and ctrl

### DIFF
--- a/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/FnKeyStepView.swift
@@ -10,8 +10,7 @@ struct FnKeyStepView: View {
     @State private var nameReaction: String = ""
 
     private let keyOptions: [(key: ActivationKey, label: String)] = [
-        (.fn, "fn"),
-        (.globe, "\u{1F310}"),
+        (.fn, "\u{1F310} fn"),
         (.ctrl, "ctrl"),
     ]
 

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
@@ -9,12 +9,11 @@ enum OrbMood {
 
 enum ActivationKey: String {
     case fn
-    case globe
     case ctrl
 
     var displayName: String {
         switch self {
-        case .fn, .globe: return "fn"
+        case .fn: return "fn"
         case .ctrl: return "ctrl"
         }
     }


### PR DESCRIPTION
The purpose of this PR is to simplify the onboarding voice input key selection from three options to two, since fn and globe are the same physical key on modern Macs.

## Changes Made
- Remove `.globe` case from `ActivationKey` enum
- Collapse key options to two buttons: 🌐 fn and ctrl

## Testing
- Build verified, manual onboarding flow test

---
*This PR was created with Claude Code*