### PR TITLE
fix: distinguish Linux keychain not-found from runtime errors via stderr

### DIFF
--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -191,8 +191,11 @@ describe('keychain', () => {
       expect(getKey('missing')).toBeNull();
     });
 
-    test('getKey throws on runtime errors', () => {
-      const err = Object.assign(new Error('D-Bus error'), { status: 5 });
+    test('getKey throws on runtime errors (exit code 1 with stderr)', () => {
+      const err = Object.assign(new Error('D-Bus error'), {
+        status: 1,
+        stderr: 'Cannot autolaunch D-Bus without X11',
+      });
       execFileResults.set('lookup', err);
       expect(() => getKey('test')).toThrow('D-Bus error');
     });

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -174,15 +174,21 @@ function linuxGetKey(account: string): string | null {
       'service', SERVICE_NAME,
       'account', account,
     ], {
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 5000,
       encoding: 'utf-8',
     });
     // Strip only the trailing newline added by secret-tool
     return result.replace(/\n$/, '') || null;
   } catch (err: unknown) {
-    // secret-tool exits with code 1 when the key is not found.
+    // secret-tool exits with code 1 for BOTH "not found" and runtime errors
+    // (D-Bus failures, keyring locked, etc.). Distinguish by checking stderr:
+    // empty stderr → key not found; non-empty stderr → runtime error.
     if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 1) {
+      const stderr = String((err as { stderr?: unknown }).stderr ?? '').trim();
+      if (stderr.length > 0) {
+        throw err;
+      }
       return null;
     }
     throw err;


### PR DESCRIPTION
## Summary
- Addresses review feedback on #278
- On Linux, `secret-tool lookup` exits with code 1 for both "not found" and runtime errors (D-Bus failures, keyring locked, etc.)
- Now captures stderr (`stdio: ['ignore', 'pipe', 'pipe']`) to distinguish the two cases: empty stderr = not found (return `null`), non-empty stderr = genuine runtime failure (throw)
- Updated test to use `status: 1` with `stderr` content for the D-Bus error case, matching real `secret-tool` behavior

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 24 keychain tests pass
- [x] Existing "not found" test (status 1, no stderr) still returns null
- [x] D-Bus error test now uses status 1 with stderr and verifies it throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
