### PR TITLE
fix: add SSH_AUTH_SOCK and GPG vars to shell env allowlist

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -31,6 +31,10 @@ const SAFE_ENV_VARS = [
   'DISPLAY',
   'COLORTERM',
   'TERM_PROGRAM',
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'GPG_TTY',
+  'GNUPGHOME',
 ] as const;
 
 function buildSanitizedEnv(): Record<string, string> {


### PR DESCRIPTION
Addresses review feedback on #279. The env var allowlist was missing SSH_AUTH_SOCK, breaking SSH agent forwarding for git operations.

Added:
- `SSH_AUTH_SOCK` — required for SSH agent forwarding (git fetch/push over SSH)
- `SSH_AGENT_PID` — commonly needed alongside SSH_AUTH_SOCK
- `GPG_TTY` — required for GPG signing of git commits
- `GNUPGHOME` — custom GPG home directory
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
