### PR TITLE
fix: make IPC parser buffer limit opt-in to prevent client crashes

### DIFF
--- a/assistant/src/__tests__/ipc-protocol.test.ts
+++ b/assistant/src/__tests__/ipc-protocol.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'bun:test';
+import { createMessageParser, serialize, MAX_LINE_SIZE } from '../daemon/ipc-protocol.js';
+
+describe('IPC Protocol', () => {
+  describe('serialize', () => {
+    test('serializes a message to JSON with trailing newline', () => {
+      const result = serialize({ type: 'ping' });
+      expect(result).toBe('{"type":"ping"}\n');
+    });
+  });
+
+  describe('createMessageParser', () => {
+    test('parses a complete JSON message', () => {
+      const parser = createMessageParser();
+      const messages = parser.feed('{"type":"ping"}\n');
+      expect(messages).toEqual([{ type: 'ping' }]);
+    });
+
+    test('handles partial messages across multiple feeds', () => {
+      const parser = createMessageParser();
+      const m1 = parser.feed('{"type":');
+      expect(m1).toEqual([]);
+      const m2 = parser.feed('"ping"}\n');
+      expect(m2).toEqual([{ type: 'ping' }]);
+    });
+
+    test('parses multiple messages in one feed', () => {
+      const parser = createMessageParser();
+      const messages = parser.feed('{"type":"ping"}\n{"type":"pong"}\n');
+      expect(messages).toEqual([{ type: 'ping' }, { type: 'pong' }]);
+    });
+
+    test('skips malformed JSON lines', () => {
+      const parser = createMessageParser();
+      const messages = parser.feed('not-json\n{"type":"ping"}\n');
+      expect(messages).toEqual([{ type: 'ping' }]);
+    });
+
+    describe('without maxLineSize (client-side)', () => {
+      test('does NOT throw on large messages', () => {
+        const parser = createMessageParser();
+        const largePayload = 'x'.repeat(MAX_LINE_SIZE + 1000);
+        // Feed a large partial line (no newline) — should not throw
+        expect(() => parser.feed(largePayload)).not.toThrow();
+      });
+
+      test('successfully parses a large complete message', () => {
+        const parser = createMessageParser();
+        const bigText = 'a'.repeat(MAX_LINE_SIZE + 100);
+        const msg = { type: 'assistant_text_delta' as const, text: bigText };
+        const messages = parser.feed(serialize(msg));
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toEqual(msg);
+      });
+    });
+
+    describe('with maxLineSize (server-side)', () => {
+      test('throws when buffer exceeds maxLineSize', () => {
+        const parser = createMessageParser({ maxLineSize: 100 });
+        const largePayload = 'x'.repeat(150);
+        expect(() => parser.feed(largePayload)).toThrow(
+          /exceeds maximum line size of 100 bytes/,
+        );
+      });
+
+      test('clears buffer after throwing', () => {
+        const parser = createMessageParser({ maxLineSize: 100 });
+        const largePayload = 'x'.repeat(150);
+        expect(() => parser.feed(largePayload)).toThrow();
+        // After the throw, the buffer should be cleared and parsing should work again
+        const messages = parser.feed('{"type":"ping"}\n');
+        expect(messages).toEqual([{ type: 'ping' }]);
+      });
+
+      test('does not throw when buffer is within limit', () => {
+        const parser = createMessageParser({ maxLineSize: 100 });
+        expect(() => parser.feed('short partial')).not.toThrow();
+      });
+
+      test('does not throw for complete messages regardless of size', () => {
+        const parser = createMessageParser({ maxLineSize: 100 });
+        // A long complete line (terminated by \n) is consumed immediately,
+        // so the buffer is empty after processing.
+        const longLine = JSON.stringify({ type: 'ping', data: 'x'.repeat(200) }) + '\n';
+        expect(() => parser.feed(longLine)).not.toThrow();
+      });
+
+      test('throws with MAX_LINE_SIZE constant', () => {
+        const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
+        const oversized = 'x'.repeat(MAX_LINE_SIZE + 1);
+        expect(() => parser.feed(oversized)).toThrow(
+          /exceeds maximum line size/,
+        );
+      });
+    });
+  });
+});

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -224,8 +224,9 @@ export function serialize(msg: ClientMessage | ServerMessage): string {
   return JSON.stringify(msg) + '\n';
 }
 
-export function createMessageParser() {
+export function createMessageParser(options?: { maxLineSize?: number }) {
   let buffer = '';
+  const maxLineSize = options?.maxLineSize;
 
   return {
     feed(data: string): Array<ClientMessage | ServerMessage> {
@@ -244,10 +245,10 @@ export function createMessageParser() {
           }
         }
       }
-      if (buffer.length > MAX_LINE_SIZE) {
+      if (maxLineSize != null && buffer.length > maxLineSize) {
         buffer = '';
         throw new Error(
-          `IPC message exceeds maximum line size of ${MAX_LINE_SIZE} bytes. Message discarded.`,
+          `IPC message exceeds maximum line size of ${maxLineSize} bytes. Message discarded.`,
         );
       }
       return messages;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -13,6 +13,7 @@ import { Session } from './session.js';
 import {
   serialize,
   createMessageParser,
+  MAX_LINE_SIZE,
   type ClientMessage,
   type ServerMessage,
 } from './ipc-protocol.js';
@@ -181,7 +182,7 @@ export class DaemonServer {
   private handleConnection(socket: net.Socket): void {
     log.info('Client connected');
     this.connectedSockets.add(socket);
-    const parser = createMessageParser();
+    const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
 
     // Send initial session info
     this.sendInitialSession(socket).catch((err) => {


### PR DESCRIPTION
Addresses review feedback on #281. The 64KB buffer limit was applied to all parsers including client-side ones, which would crash on legitimate large server messages (file diffs, history responses). Made the limit opt-in via an options parameter — only the server passes `maxLineSize`.

## Changes

- **`ipc-protocol.ts`**: `createMessageParser()` now accepts an optional `{ maxLineSize?: number }` parameter. The buffer size check only runs when `maxLineSize` is provided.
- **`server.ts`**: The server's parser creation passes `{ maxLineSize: MAX_LINE_SIZE }` to enforce the 64KB limit on incoming client messages.
- Client-side callers in `cli.ts` and `index.ts` continue calling `createMessageParser()` without options (no limit).
- Added `ipc-protocol.test.ts` with 12 tests covering both limited and unlimited parser behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
