### PR TITLE
fix: wrap FK migration in transaction and filter orphan rows

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -79,6 +79,8 @@ function migrateToolInvocationsFk(database: ReturnType<typeof drizzle<typeof sch
   if (row.sql.includes('REFERENCES')) return;
 
   raw.exec(/*sql*/ `
+    PRAGMA foreign_keys = OFF;
+    BEGIN;
     CREATE TABLE tool_invocations_new (
       id TEXT PRIMARY KEY,
       conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
@@ -90,8 +92,11 @@ function migrateToolInvocationsFk(database: ReturnType<typeof drizzle<typeof sch
       duration_ms INTEGER NOT NULL,
       created_at INTEGER NOT NULL
     );
-    INSERT INTO tool_invocations_new SELECT * FROM tool_invocations;
+    INSERT INTO tool_invocations_new SELECT t.* FROM tool_invocations t
+      WHERE EXISTS (SELECT 1 FROM conversations c WHERE c.id = t.conversation_id);
     DROP TABLE tool_invocations;
     ALTER TABLE tool_invocations_new RENAME TO tool_invocations;
+    COMMIT;
+    PRAGMA foreign_keys = ON;
   `);
 }


### PR DESCRIPTION
## Summary
Addresses review feedback on #277:
- **Transaction safety**: Wraps the `tool_invocations` FK migration in `BEGIN`/`COMMIT` with `PRAGMA foreign_keys = OFF` so a mid-migration crash cannot leave the DB in a broken state (table dropped but not yet renamed).
- **Orphan row filtering**: Filters out rows referencing non-existent `conversation_id` values during the INSERT, preventing `SQLITE_CONSTRAINT_FOREIGNKEY` errors on databases where the old table (without FK) accumulated orphans.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify migration runs cleanly on a fresh DB
- [ ] Verify migration handles orphaned tool_invocation rows gracefully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
