### PR TITLE
fix: guard file size check in file_edit against ENOENT

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -73,9 +73,13 @@ class FileEditTool implements Tool {
     }
     const filePath = pathCheck.resolved;
 
-    const sizeError = checkFileSizeOnDisk(filePath);
-    if (sizeError) {
-      return { content: `Error: ${sizeError}`, isError: true };
+    try {
+      const sizeError = checkFileSizeOnDisk(filePath);
+      if (sizeError) {
+        return { content: `Error: ${sizeError}`, isError: true };
+      }
+    } catch {
+      // File may not exist — will be caught by readFileSync below
     }
 
     try {


### PR DESCRIPTION
Addresses review feedback on #283. The `checkFileSizeOnDisk` call in `file_edit` was outside the try-catch block, causing `statSync` to throw ENOENT for non-existent files instead of falling through to the existing friendly error handler.

## Changes

Wrapped the `checkFileSizeOnDisk(filePath)` call in its own try-catch so that if the file doesn't exist, the error is silently caught and execution continues to the `readFileSync` call inside the main try-catch, which produces the expected friendly error message.

## Files modified

- `assistant/src/tools/filesystem/edit.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
