### PR TITLE
fix: register zsh completion with compdef instead of direct call

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -637,7 +637,7 @@ ${subcmdCases}
         completions) compadd bash zsh fish ;;
     esac
 }
-_vellum "$@"
+compdef _vellum vellum
 `;
 }
 


### PR DESCRIPTION
Addresses review feedback on #285. The zsh completion script used `_vellum "$@"` which invokes the function immediately but never registers it as a completion handler when installed via `eval`. Changed to `compdef _vellum vellum` for proper binding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
