### PR TITLE
fix: clear cached promise on lazy tool load failure to allow retry

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'bun:test';
+import { RiskLevel } from '../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../tools/types.js';
+import type { ToolDefinition } from '../providers/types.js';
+
+// We cannot import the private LazyTool class directly, so we test through
+// registerLazyTool + getTool which exercise the same code path.
+import { registerLazyTool, getTool } from '../tools/registry.js';
+
+function makeFakeTool(name: string): Tool {
+  return {
+    name,
+    description: `Fake ${name}`,
+    category: 'test',
+    defaultRiskLevel: RiskLevel.Low,
+    getDefinition(): ToolDefinition {
+      return {
+        name,
+        description: `Fake ${name}`,
+        input_schema: { type: 'object', properties: {}, required: [] },
+      };
+    },
+    async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+      return { content: 'ok', isError: false };
+    },
+  };
+}
+
+describe('LazyTool', () => {
+  test('clears cached promise on load failure so subsequent call can retry', async () => {
+    let callCount = 0;
+
+    registerLazyTool({
+      name: 'test-retry-tool',
+      description: 'A tool that fails on first load then succeeds',
+      category: 'test',
+      defaultRiskLevel: RiskLevel.Low,
+      definition: {
+        name: 'test-retry-tool',
+        description: 'A tool that fails on first load then succeeds',
+        input_schema: { type: 'object', properties: {}, required: [] },
+      },
+      loader: async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('transient load failure');
+        }
+        return makeFakeTool('test-retry-tool');
+      },
+    });
+
+    const tool = getTool('test-retry-tool')!;
+    expect(tool).toBeDefined();
+
+    const dummyContext = {} as ToolContext;
+
+    // First call should throw the transient error
+    await expect(tool.execute({}, dummyContext)).rejects.toThrow('transient load failure');
+    expect(callCount).toBe(1);
+
+    // Second call should retry the loader and succeed
+    const result = await tool.execute({}, dummyContext);
+    expect(result.content).toBe('ok');
+    expect(result.isError).toBe(false);
+    expect(callCount).toBe(2);
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -50,6 +50,9 @@ class LazyTool implements Tool {
           this.resolvedTool = tool;
           log.info({ name: this.name }, 'Lazy tool loaded');
           return tool;
+        }).catch((err) => {
+          this.loadPromise = null;
+          throw err;
         });
       }
       await this.loadPromise;


### PR DESCRIPTION
Addresses review feedback on #287.

If a lazy tool's `loader()` rejected (e.g., transient filesystem error), the rejected promise was permanently cached in `loadPromise`, making the tool permanently unusable. Subsequent calls would await the same rejected promise instead of retrying.

**Fix:** Added a `.catch()` handler to clear `loadPromise` on failure, allowing subsequent `execute()` calls to retry the loader.

**Test:** Added `registry.test.ts` verifying that a failed load attempt throws the error and a subsequent call retries successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
