### PR TITLE
Rich ambient suggestion cards with structured output

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -194,10 +194,10 @@ final class AmbientAgent: ObservableObject {
             }
 
         case .suggest:
-            if let suggestion = result.suggestion, result.confidence > 0.8 {
-                log.info("[\(cycle)] Suggestion: \(suggestion)")
-                lastSuggestion = suggestion
-                showSuggestion(suggestion)
+            if let detail = result.suggestionDetail, result.confidence > 0.8 {
+                log.info("[\(cycle)] Suggestion: \(detail.title) — \(detail.taskDescription)")
+                lastSuggestion = detail.taskDescription
+                showSuggestion(detail)
             } else {
                 log.debug("[\(cycle)] Suggestion below confidence threshold (\(String(format: "%.2f", result.confidence)))")
             }
@@ -206,15 +206,16 @@ final class AmbientAgent: ObservableObject {
         state = .watching
     }
 
-    private func showSuggestion(_ suggestion: String) {
+    private func showSuggestion(_ detail: AmbientSuggestionDetail) {
         guard let appDelegate = appDelegate else { return }
+        let taskDescription = detail.taskDescription
         let window = AmbientSuggestionWindow(
-            suggestion: suggestion,
+            detail: detail,
             onAccept: { [weak self] in
                 self?.activeSuggestionWindow = nil
                 self?.lastSuggestion = nil
                 self?.suggestionWindow = nil
-                appDelegate.startSession(task: suggestion)
+                appDelegate.startSession(task: taskDescription)
             },
             onDismiss: { [weak self] in
                 self?.activeSuggestionWindow = nil

--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -9,10 +9,49 @@ enum AmbientDecision: String, Codable {
     case suggest
 }
 
+enum SuggestionIcon: String, Codable {
+    case cleanup       // trash, inbox cleanup, file organization
+    case error         // visible errors, warnings, failures
+    case automation    // repetitive tasks, manual work
+    case update        // stale items, pending updates
+    case organize      // tabs, windows, desktop clutter
+    case security      // expired certs, outdated software
+
+    var sfSymbol: String {
+        switch self {
+        case .cleanup: return "archivebox.fill"
+        case .error: return "exclamationmark.triangle.fill"
+        case .automation: return "gearshape.2.fill"
+        case .update: return "arrow.clockwise.circle.fill"
+        case .organize: return "square.grid.2x2.fill"
+        case .security: return "shield.lefthalf.filled"
+        }
+    }
+
+    var tintColor: String {
+        switch self {
+        case .cleanup: return "blue"
+        case .error: return "red"
+        case .automation: return "purple"
+        case .update: return "orange"
+        case .organize: return "teal"
+        case .security: return "yellow"
+        }
+    }
+}
+
+struct AmbientSuggestionDetail {
+    let title: String
+    let icon: SuggestionIcon
+    let headlineStat: String?
+    let actionSteps: [String]
+    let taskDescription: String  // full description sent to startSession
+}
+
 struct AmbientAnalysisResult {
     let decision: AmbientDecision
     let observation: String?
-    let suggestion: String?
+    let suggestionDetail: AmbientSuggestionDetail?
     let confidence: Double
     let reasoning: String
 }
@@ -54,6 +93,7 @@ final class AmbientAnalyzer {
         - NEVER suggest help for: sensitive/private content (banking, passwords, personal messages), creative flow states (writing, coding in focus), or casual browsing.
         - Keep observations concise (one sentence).
         - Keep suggestions actionable and specific (describe what the computer-use agent should do to help).
+        - When suggesting, also provide: a short punchy title (2-4 words), a category icon, an optional headline stat (the key number that jumps out, e.g. "8,312 unread"), and 2-3 short action steps (what the agent will do, each under 10 words).
         - Do NOT observe the same activity repeatedly. If the user is still doing the same thing as a recent observation, choose "ignore" instead.
         - Check the knowledge context below — if a similar observation already exists, do not create a duplicate.
         - Observations should capture NEW learnings about the user, not restate what is already known.
@@ -90,7 +130,25 @@ final class AmbientAnalyzer {
                     ],
                     "suggestion": [
                         "type": "string",
-                        "description": "When decision is 'suggest': a specific, actionable description of what the computer-use agent should do to help. Required for 'suggest'."
+                        "description": "When decision is 'suggest': a full description of what the computer-use agent should do to help. Required for 'suggest'."
+                    ],
+                    "suggestion_title": [
+                        "type": "string",
+                        "description": "When decision is 'suggest': a short punchy title, 2-4 words (e.g. 'Inbox Cleanup', 'Fix Build Error', 'Close Stale Tabs'). Required for 'suggest'."
+                    ],
+                    "suggestion_icon": [
+                        "type": "string",
+                        "enum": ["cleanup", "error", "automation", "update", "organize", "security"],
+                        "description": "When decision is 'suggest': category icon. cleanup=inbox/file cleanup, error=visible errors/warnings, automation=repetitive tasks, update=stale/pending items, organize=tabs/windows/desktop, security=expired certs/outdated software. Required for 'suggest'."
+                    ],
+                    "headline_stat": [
+                        "type": "string",
+                        "description": "When decision is 'suggest': optional key metric that jumps out (e.g. '8,312 unread', '47 open tabs', '3 failed builds'). Short, punchy. Omit if no clear number."
+                    ],
+                    "action_steps": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description": "When decision is 'suggest': 2-3 short action steps describing what the agent will do (each under 10 words, e.g. 'Archive promotional emails older than 30 days'). Required for 'suggest'."
                     ],
                     "confidence": [
                         "type": "number",
@@ -124,15 +182,36 @@ final class AmbientAnalyzer {
             throw InferenceError.parseError("Failed to parse analyze_screen tool response")
         }
 
+        // Build rich suggestion detail if this is a suggest decision
+        var suggestionDetail: AmbientSuggestionDetail?
+        if decision == .suggest, let suggestion = input["suggestion"] as? String {
+            let title = input["suggestion_title"] as? String ?? "Suggestion"
+            let iconStr = input["suggestion_icon"] as? String ?? "cleanup"
+            let icon = SuggestionIcon(rawValue: iconStr) ?? .cleanup
+            let headlineStat = input["headline_stat"] as? String
+            let actionSteps = input["action_steps"] as? [String] ?? []
+
+            suggestionDetail = AmbientSuggestionDetail(
+                title: title,
+                icon: icon,
+                headlineStat: headlineStat,
+                actionSteps: actionSteps,
+                taskDescription: suggestion
+            )
+        }
+
         let result = AmbientAnalysisResult(
             decision: decision,
             observation: input["observation"] as? String,
-            suggestion: input["suggestion"] as? String,
+            suggestionDetail: suggestionDetail,
             confidence: confidence,
             reasoning: reasoning
         )
 
         log.info("Analysis: \(decision.rawValue) (confidence: \(String(format: "%.2f", confidence))) — \(reasoning)")
+        if let detail = suggestionDetail {
+            log.info("Suggestion: \(detail.title) — \(detail.actionSteps.joined(separator: "; "))")
+        }
         return result
     }
 }

--- a/clients/macos/vellum-assistant/UI/AmbientSuggestionWindow.swift
+++ b/clients/macos/vellum-assistant/UI/AmbientSuggestionWindow.swift
@@ -3,19 +3,19 @@ import SwiftUI
 
 final class AmbientSuggestionWindow {
     private var panel: NSPanel?
-    private let suggestion: String
+    private let detail: AmbientSuggestionDetail
     private let onAccept: () -> Void
     private let onDismiss: () -> Void
 
-    init(suggestion: String, onAccept: @escaping () -> Void, onDismiss: @escaping () -> Void) {
-        self.suggestion = suggestion
+    init(detail: AmbientSuggestionDetail, onAccept: @escaping () -> Void, onDismiss: @escaping () -> Void) {
+        self.detail = detail
         self.onAccept = onAccept
         self.onDismiss = onDismiss
     }
 
     func show() {
         let view = AmbientSuggestionView(
-            suggestion: suggestion,
+            detail: detail,
             onAccept: { [weak self] in
                 self?.close()
                 self?.onAccept()
@@ -28,7 +28,7 @@ final class AmbientSuggestionWindow {
         let hostingController = NSHostingController(rootView: view)
 
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 340, height: 140),
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 200),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -46,7 +46,7 @@ final class AmbientSuggestionWindow {
         // Position bottom-right, above where session overlay would appear
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.maxX - 340 - 20
+            let x = screenFrame.maxX - 360 - 20
             let y = screenFrame.minY + 20 + 160 + 10
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
@@ -70,25 +70,58 @@ final class AmbientSuggestionWindow {
 }
 
 private struct AmbientSuggestionView: View {
-    let suggestion: String
+    let detail: AmbientSuggestionDetail
     let onAccept: () -> Void
     let onDismiss: () -> Void
 
+    private var iconColor: Color {
+        switch detail.icon.tintColor {
+        case "blue": return .blue
+        case "red": return .red
+        case "purple": return .purple
+        case "orange": return .orange
+        case "teal": return .teal
+        case "yellow": return .yellow
+        default: return .blue
+        }
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Image(systemName: "eye.fill")
-                    .foregroundStyle(.blue)
-                Text("Ambient Suggestion")
+        VStack(alignment: .leading, spacing: 10) {
+            // Header: icon + title
+            HStack(spacing: 8) {
+                Image(systemName: detail.icon.sfSymbol)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(iconColor)
+                Text(detail.title)
                     .font(.headline)
                 Spacer()
             }
 
-            Text(suggestion)
-                .font(.body)
-                .lineLimit(3)
-                .foregroundStyle(.secondary)
+            // Headline stat (if present)
+            if let stat = detail.headlineStat {
+                Text(stat)
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .foregroundStyle(iconColor)
+            }
 
+            // Action steps
+            if !detail.actionSteps.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(detail.actionSteps, id: \.self) { step in
+                        HStack(alignment: .top, spacing: 6) {
+                            Text("\u{2022}")
+                                .foregroundStyle(.secondary)
+                            Text(step)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+            }
+
+            // Buttons
             HStack {
                 Spacer()
                 Button("Dismiss") {
@@ -96,14 +129,15 @@ private struct AmbientSuggestionView: View {
                 }
                 .keyboardShortcut(.escape, modifiers: [])
 
-                Button("Accept") {
+                Button("Let\u{2019}s do it") {
                     onAccept()
                 }
                 .keyboardShortcut(.return, modifiers: [])
                 .buttonStyle(.borderedProminent)
+                .tint(iconColor)
             }
         }
         .padding()
-        .frame(width: 340)
+        .frame(width: 360)
     }
 }


### PR DESCRIPTION
The purpose of this PR is to replace the plain-text ambient suggestion card with a rich, structured component that showcases the assistant's awareness — with category icons, headline stats, and action step bullets.

## Changes Made
- Add `SuggestionIcon` enum (6 categories: cleanup, error, automation, update, organize, security) with SF Symbol and tint color mappings
- Add `AmbientSuggestionDetail` struct with title, icon, headline stat, action steps, and task description
- Expand the Haiku tool schema with `suggestion_title`, `suggestion_icon`, `headline_stat`, and `action_steps` fields
- Redesign `AmbientSuggestionView` to render category-colored icon + punchy title, bold headline stat, bulleted action steps, and a tinted "Let's do it" button
- All new fields have graceful fallbacks if Haiku omits them — no regression risk

## Before / After
**Before:** Generic eye icon, "Ambient Suggestion" header, truncated text blob, "Accept" button
**After:** Category-specific icon + title (e.g. 📦 "Inbox Cleanup"), bold stat ("8,312 unread"), 2-3 bullet action steps, color-matched "Let's do it" button

## Testing
- `swift build` passes
- All 50 tests pass (`swift test`)
- No change to ignore/observe paths — only the suggest path is enriched

---
*This PR was created with Claude Code*