### PR TITLE
Add pre-commit hook to check for plain text keys

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,55 @@
+# Git Hooks
+
+This directory contains shared git hooks for the vellum-assistant repository.
+
+## Installation
+
+To install the hooks, run:
+
+```bash
+./.githooks/install.sh
+```
+
+Or, you can configure git to use this directory directly:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Available Hooks
+
+### pre-commit
+
+Automatically checks for plain text keys and secrets before allowing a commit.
+
+**What it detects:**
+- API keys and tokens
+- AWS credentials (access keys, secret keys)
+- Private keys (RSA, DSA, PEM)
+- Passwords in plain text
+- Database connection strings with credentials
+- Bearer tokens
+- Slack and GitHub tokens
+- Generic secrets and high-entropy strings
+
+**Behavior:**
+- ✅ Blocks commits containing potential secrets
+- ✅ Provides detailed feedback on what was detected and where
+- ✅ Allows clean commits to proceed without interruption
+
+**Bypass (not recommended):**
+If you need to bypass this check in exceptional cases:
+```bash
+git commit --no-verify
+```
+
+## Why Use Git Hooks?
+
+Git hooks help maintain code quality and security by automatically running checks before certain git operations. The pre-commit hook specifically helps prevent accidentally committing sensitive information like API keys, passwords, and tokens to the repository.
+
+## Maintenance
+
+When updating hooks, make sure to:
+1. Update the hook file in `.githooks/`
+2. Run `./.githooks/install.sh` to update your local `.git/hooks/`
+3. Commit and push the changes so other developers can update their hooks

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Install git hooks from .githooks directory to .git/hooks
+
+HOOKS_DIR=".githooks"
+GIT_HOOKS_DIR=".git/hooks"
+
+echo "Installing git hooks..."
+
+# Check if we're in a git repository
+if [ ! -d ".git" ]; then
+    echo "Error: Not in a git repository root directory"
+    exit 1
+fi
+
+# Create .git/hooks directory if it doesn't exist
+mkdir -p "$GIT_HOOKS_DIR"
+
+# Copy all executable files from .githooks to .git/hooks
+for hook in "$HOOKS_DIR"/*; do
+    # Skip this install script itself
+    if [[ "$(basename "$hook")" == "install.sh" ]] || [[ "$(basename "$hook")" == "README.md" ]]; then
+        continue
+    fi
+
+    # Skip if not a file
+    if [ ! -f "$hook" ]; then
+        continue
+    fi
+
+    hook_name=$(basename "$hook")
+    destination="$GIT_HOOKS_DIR/$hook_name"
+
+    cp "$hook" "$destination"
+    chmod +x "$destination"
+
+    echo "✅ Installed: $hook_name"
+done
+
+echo ""
+echo "Git hooks installed successfully!"
+echo "These hooks will now run automatically on git operations."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,18 +9,17 @@ NC='\033[0m' # No Color
 
 echo "🔍 Checking for plain text keys and secrets..."
 
-# Get list of staged files
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
-
-if [ -z "$STAGED_FILES" ]; then
+# Check if there are any staged files
+if ! git diff --cached --name-only --diff-filter=ACM | grep -q .; then
     exit 0
 fi
 
 # Patterns to check for sensitive information
+# Note: Using [[:space:]] instead of \s for grep -E compatibility
 declare -a PATTERNS=(
     # API Keys
     "api[_-]?key[_-]?=['\"]?[a-zA-Z0-9_\-]{20,}['\"]?"
-    "apikey['\"]?\s*[:=]\s*['\"]?[a-zA-Z0-9_\-]{20,}"
+    "apikey['\"]?[[:space:]]*[:=][[:space:]]*['\"]?[a-zA-Z0-9_\-]{20,}"
 
     # AWS Keys
     "AKIA[0-9A-Z]{16}"
@@ -30,27 +29,27 @@ declare -a PATTERNS=(
     # Private Keys
     "-----BEGIN (RSA|DSA )?PRIVATE KEY-----"
     "-----BEGIN PRIVATE KEY-----"
-    "private[_-]?key['\"]?\s*[:=]"
+    "private[_-]?key['\"]?[[:space:]]*[:=]"
 
     # Passwords
-    "password['\"]?\s*[:=]\s*['\"][^'\"]{3,}['\"]"
-    "passwd['\"]?\s*[:=]\s*['\"][^'\"]{3,}['\"]"
+    "password['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{3,}['\"]"
+    "passwd['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{3,}['\"]"
 
     # Secrets
-    "secret['\"]?\s*[:=]\s*['\"][^'\"]{8,}['\"]"
+    "secret['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{8,}['\"]"
     "client[_-]?secret"
 
     # Tokens
-    "token['\"]?\s*[:=]\s*['\"][a-zA-Z0-9_\-\.]{20,}['\"]"
-    "bearer['\"]?\s*[:=]?\s*[a-zA-Z0-9_\-\.]{20,}"
+    "token['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-\.]{20,}['\"]"
+    "bearer['\"]?[[:space:]]*[:=]?[[:space:]]*[a-zA-Z0-9_\-\.]{20,}"
     "auth[_-]?token"
 
     # Database URLs with credentials
     "://[a-zA-Z0-9]+:[a-zA-Z0-9]+@[a-zA-Z0-9]"
 
     # Generic secret patterns
-    "['\"]?[a-z0-9_]*secret[a-z0-9_]*['\"]?\s*[:=]\s*['\"][^'\"]{8,}['\"]"
-    "['\"]?[a-z0-9_]*key[a-z0-9_]*['\"]?\s*[:=]\s*['\"][a-zA-Z0-9_\-]{16,}['\"]"
+    "['\"]?[a-z0-9_]*secret[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{8,}['\"]"
+    "['\"]?[a-z0-9_]*key[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
 
     # Slack tokens
     "xox[baprs]-[0-9a-zA-Z]{10,}"
@@ -65,7 +64,8 @@ declare -a PATTERNS=(
 FOUND_SECRETS=0
 CHECKED_FILES=0
 
-for FILE in $STAGED_FILES; do
+# Use NUL-delimited list to safely handle filenames with spaces
+while IFS= read -r -d '' FILE; do
     # Skip hook files themselves (they contain patterns to detect secrets)
     if [[ "$FILE" =~ ^\.githooks/ ]]; then
         continue
@@ -103,7 +103,7 @@ for FILE in $STAGED_FILES; do
             FOUND_SECRETS=1
         fi
     done
-done
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
 
 if [ $FOUND_SECRETS -eq 1 ]; then
     echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Pre-commit hook to check for plain text keys and secrets
+# This hook scans staged files for common patterns of sensitive information
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "🔍 Checking for plain text keys and secrets..."
+
+# Get list of staged files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+# Patterns to check for sensitive information
+declare -a PATTERNS=(
+    # API Keys
+    "api[_-]?key[_-]?=['\"]?[a-zA-Z0-9_\-]{20,}['\"]?"
+    "apikey['\"]?\s*[:=]\s*['\"]?[a-zA-Z0-9_\-]{20,}"
+
+    # AWS Keys
+    "AKIA[0-9A-Z]{16}"
+    "aws[_-]?access[_-]?key[_-]?id"
+    "aws[_-]?secret[_-]?access[_-]?key"
+
+    # Private Keys
+    "-----BEGIN (RSA|DSA )?PRIVATE KEY-----"
+    "-----BEGIN PRIVATE KEY-----"
+    "private[_-]?key['\"]?\s*[:=]"
+
+    # Passwords
+    "password['\"]?\s*[:=]\s*['\"][^'\"]{3,}['\"]"
+    "passwd['\"]?\s*[:=]\s*['\"][^'\"]{3,}['\"]"
+
+    # Secrets
+    "secret['\"]?\s*[:=]\s*['\"][^'\"]{8,}['\"]"
+    "client[_-]?secret"
+
+    # Tokens
+    "token['\"]?\s*[:=]\s*['\"][a-zA-Z0-9_\-\.]{20,}['\"]"
+    "bearer['\"]?\s*[:=]?\s*[a-zA-Z0-9_\-\.]{20,}"
+    "auth[_-]?token"
+
+    # Database URLs with credentials
+    "://[a-zA-Z0-9]+:[a-zA-Z0-9]+@[a-zA-Z0-9]"
+
+    # Generic secret patterns
+    "['\"]?[a-z0-9_]*secret[a-z0-9_]*['\"]?\s*[:=]\s*['\"][^'\"]{8,}['\"]"
+    "['\"]?[a-z0-9_]*key[a-z0-9_]*['\"]?\s*[:=]\s*['\"][a-zA-Z0-9_\-]{16,}['\"]"
+
+    # Slack tokens
+    "xox[baprs]-[0-9a-zA-Z]{10,}"
+
+    # GitHub tokens
+    "gh[pousr]_[0-9a-zA-Z]{36,}"
+
+    # Generic high entropy strings (likely keys)
+    "['\"][a-zA-Z0-9+/]{40,}={0,2}['\"]"
+)
+
+FOUND_SECRETS=0
+CHECKED_FILES=0
+
+for FILE in $STAGED_FILES; do
+    # Skip hook files themselves (they contain patterns to detect secrets)
+    if [[ "$FILE" =~ ^\.githooks/ ]]; then
+        continue
+    fi
+
+    # Skip binary files and common exclusions
+    if [[ "$FILE" =~ \.(jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|eot|pdf|zip|tar|gz)$ ]]; then
+        continue
+    fi
+
+    # Skip if file doesn't exist (deleted files)
+    if [ ! -f "$FILE" ]; then
+        continue
+    fi
+
+    CHECKED_FILES=$((CHECKED_FILES + 1))
+
+    # Check each pattern
+    for PATTERN in "${PATTERNS[@]}"; do
+        # Use git show to check the staged content, not the working directory
+        # Use -- to indicate end of options for patterns starting with dashes
+        MATCHES=$(git show ":$FILE" 2>/dev/null | grep -niE -- "$PATTERN" 2>/dev/null)
+
+        if [ ! -z "$MATCHES" ]; then
+            if [ $FOUND_SECRETS -eq 0 ]; then
+                echo -e "${RED}❌ Found potential secrets in staged files:${NC}\n"
+            fi
+
+            echo -e "${YELLOW}File: $FILE${NC}"
+            echo "$MATCHES" | while read -r line; do
+                echo "  Line: $line"
+            done
+            echo ""
+
+            FOUND_SECRETS=1
+        fi
+    done
+done
+
+if [ $FOUND_SECRETS -eq 1 ]; then
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}COMMIT REJECTED: Potential secrets detected!${NC}"
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "Please remove sensitive information before committing."
+    echo "If this is a false positive, you can:"
+    echo "  1. Move secrets to environment variables or a .env file"
+    echo "  2. Use a secrets management system"
+    echo "  3. Skip this hook with: git commit --no-verify (NOT recommended)"
+    echo ""
+    exit 1
+fi
+
+echo "✅ No plain text keys detected in $CHECKED_FILES files"
+exit 0

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The setup script creates a symlink at `~/.local/bin/vel` for easy access from an
 
 See [vel/README.md](./vel/README.md) for more details.
 
+## Git Hooks
+
+This repository includes git hooks to help maintain code quality and security. The hooks are automatically installed when you run `./setup.sh`.
+
+To manually install or update hooks:
+```bash
+./.githooks/install.sh
+```
+
+See [.githooks/README.md](./.githooks/README.md) for more details about available hooks.
+
 ## Web Application
 
 The web app lives in `/web`. See [web/README.md](./web/README.md) for setup instructions.

--- a/setup.sh
+++ b/setup.sh
@@ -101,6 +101,14 @@ fi
 
 cd "$PROJECT_ROOT"
 
+# Install git hooks
+echo "🔒 Installing git hooks..."
+if [ -f ".githooks/install.sh" ]; then
+    ./.githooks/install.sh
+else
+    echo "⚠️  Git hooks installer not found"
+fi
+
 # Ensure vel is available even if ~/.local/bin isn't in PATH yet
 export PATH="$SYMLINK_DIR:$PATH"
 

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+password = "test123"

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-password = "test123"


### PR DESCRIPTION
This commit adds a security-focused pre-commit hook that automatically scans staged files for potential secrets and API keys before allowing commits.

Changes:
- Add .githooks/pre-commit hook that detects API keys, AWS credentials, passwords, tokens, and other secrets
- Add .githooks/install.sh script to easily install hooks for all developers
- Add .githooks/README.md documenting the hooks and how to use them
- Update setup.sh to automatically install git hooks during initial setup
- Update main README.md to document the git hooks feature

The pre-commit hook helps prevent accidentally committing sensitive information to the repository by checking for common patterns of secrets in staged files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
