### PR TITLE
Rewrite GitHub recipe to use GitHub Desktop with high-level outline

### DIFF
--- a/clients/macos/recipes/github-app-setup.md
+++ b/clients/macos/recipes/github-app-setup.md
@@ -1,184 +1,63 @@
 # Recipe: GitHub App Setup
 
-> A computer-use recipe for an orchestration agent to register, configure, and install
-> a GitHub App on behalf of the user's assistant — fully hands-free.
-
-## When This Recipe Fires
-
-This recipe is invoked as a **just-in-time skill** during onboarding when:
-
-1. The user answers **"GitHub"** to _"Where do you spend most of your time?"_
-2. The orchestration agent presents: _"Let me get {assistant-name} set up on GitHub. Can I take it from here?"_
-3. The user selects **"Yes (I'll use your mouse and keyboard)"**
+> High-level outline for setting up GitHub integration using GitHub Desktop.
+> The computer-use agent should follow these steps flexibly, adapting to
+> what it sees on screen rather than following rigid click sequences.
 
 ## Prerequisites
 
-- User is signed into github.com in their default browser
-- User has admin access to the target GitHub organization or personal account
+- GitHub Desktop is installed (if not, open App Store or download from desktop.github.com)
+- User is signed into their GitHub account in GitHub Desktop
 - macOS Accessibility + Screen Recording permissions are granted (handled by prior onboarding steps)
 
 ---
 
 ## Recipe Steps
 
-### Phase 1: Navigate to GitHub App Creation
+### Phase 1: Open GitHub Desktop
 
 ```
-STEP 1: Open GitHub Developer Settings
-  ACTION: open_app("default browser")
-  ACTION: key("cmd+l")  // focus address bar
-  ACTION: type_text("github.com/settings/apps/new")
-  ACTION: key("return")
-  WAIT: page loads — look for "Register new GitHub App" heading
-  VERIFY: AX tree contains "Register new GitHub App" or "New GitHub App"
+STEP 1: Launch GitHub Desktop
+  Open the GitHub Desktop application.
+  If it's not installed, open Safari and navigate to desktop.github.com to download it.
+  Wait for the app to finish launching and show its main window.
 ```
 
-### Phase 2: Fill Out App Registration Form
+### Phase 2: Sign In (if needed)
 
 ```
-STEP 2: Set App Name
-  LOCATE: text field labeled "GitHub App name"
-  ACTION: click([field_id])
-  ACTION: type_text("{assistant-name}-github-app")
-  NOTE: Must be globally unique on GitHub. If taken, append random 4-digit suffix.
-
-STEP 3: Set Homepage URL
-  LOCATE: text field labeled "Homepage URL"
-  ACTION: click([field_id])
-  ACTION: type_text("{assistant-homepage-url}")
-  NOTE: Can be any valid URL. Use the assistant's web page or a placeholder.
-
-STEP 4: Skip Webhook Configuration (for now)
-  LOCATE: checkbox "Active" under Webhooks section
-  ACTION: click([checkbox_id]) to UNCHECK it
-  NOTE: Webhooks can be configured later. Not necessary to get started.
+STEP 2: Ensure User is Signed In
+  Check if GitHub Desktop shows a signed-in state (shows repositories or "Clone a Repository" option).
+  If not signed in, click "Sign in to GitHub.com" and wait for the user to complete authentication.
+  Once signed in, verify the user's GitHub username is visible in the app.
 ```
 
-### Phase 3: Set Permissions
+### Phase 3: Clone a Repository
 
 ```
-STEP 5: Configure Repository Permissions
-  LOCATE: "Repository permissions" section (may need to scroll)
-  ACTION: scroll(down) until "Repository permissions" is visible
-
-  STEP 5a: Contents → Read and write
-    LOCATE: "Contents" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5b: Issues → Read and write
-    LOCATE: "Issues" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5c: Pull requests → Read and write
-    LOCATE: "Pull requests" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5d: (Optional) Metadata → Read-only
-    NOTE: Usually auto-granted. Verify it shows "Read-only".
+STEP 3: Clone the Target Repository
+  Use the "Clone a Repository" option (File menu or welcome screen).
+  Search for or select {target-repo} from the user's available repositories.
+  Choose a local path for the clone and confirm.
+  Wait for the clone to complete.
 ```
 
-### Phase 4: Set Visibility & Create
+### Phase 4: Verify Setup
 
 ```
-STEP 6: Make the App Public (if org install needed)
-  LOCATE: radio button or section "Where can this GitHub App be installed?"
-  ACTION: select "Any account" (public)
-  NOTE: Making it public allows the Vellum organization to install it.
-        If private, only the owning account can install.
-
-STEP 7: Create the GitHub App
-  LOCATE: "Create GitHub App" button (green, bottom of form)
-  ACTION: click([button_id])
-  WAIT: page navigates to the new app's settings page
-  VERIFY: page title or heading contains the app name
-  CAPTURE: App ID from the "App ID" field on the About page
+STEP 4: Verify Repository Access
+  Confirm the cloned repository appears in GitHub Desktop's repository list.
+  Verify the current branch is visible and the repository status shows correctly.
+  Open the repository in Finder to confirm files are present on disk.
 ```
 
-### Phase 5: Generate Private Key
+### Phase 5: Report Completion
 
 ```
-STEP 8: Navigate to Private Key Section
-  ACTION: scroll(down) to "Private keys" section
-  LOCATE: "Generate a private key" button (green)
-
-STEP 9: Generate, Download, and Import Key
-  ACTION: click([generate_button_id])
-  WAIT: .pem file downloads (browser download notification or file appears)
-  VERIFY: download completes — look for .pem in ~/Downloads/
-  CAPTURE: path to downloaded .pem file
-  ACTION: Read the .pem file contents and pass them to the credential store
-  VERIFY: PEM content starts with "-----BEGIN RSA PRIVATE KEY-----"
-  STORE: PEM content directly into assistant's secure credential store (Keychain)
-  ACTION: Securely delete the .pem file from ~/Downloads/ after import
-  NOTE: The private key MUST be read and stored immediately — ~/Downloads/ is
-        ephemeral and the file may be moved or cleaned up at any time. Never
-        rely on the filesystem path for long-term credential access.
-```
-
-### Phase 6: Install the App
-
-```
-STEP 10: Click "Install App" in Sidebar
-  LOCATE: "Install App" link in left sidebar navigation
-  ACTION: click([install_link_id])
-  WAIT: installation page loads
-
-STEP 11: Select Target Account/Org
-  LOCATE: the target organization or personal account
-  LOCATE: the button next to it — check if it says "Install" or "Request"
-
-  IF button says "Install":
-    ACTION: click "Install" button
-    → continue to Step 12
-
-  IF button says "Request":
-    NOTE: This org has third-party app restrictions requiring admin approval.
-    ACTION: click "Request" button to submit the request
-    WAIT: confirmation that the request was submitted
-    VERIFY: page shows "Request submitted" or similar confirmation
-    DONE (partial): "I've requested installation of {assistant-name} on {org}.
-          An org admin needs to approve the request before I can access
-          your repos. I'll check back — or you can let me know once
-          it's approved so I can finish setup."
-    → ABORT remaining steps (12-15). Recipe is incomplete — mark as
-      "pending_approval" in credential store. The orchestration agent
-      should schedule a follow-up check or prompt the user later.
-
-STEP 12: Choose Repository Access
-  LOCATE: "Only select repositories" radio button
-  ACTION: click([radio_id])
-  LOCATE: repository dropdown/selector
-  ACTION: click([dropdown_id])
-  ACTION: type_text("{target-repo-name}")
-  ACTION: click the matching repo option
-  NOTE: Scoping to specific repos follows principle of least privilege.
-
-STEP 13: Confirm Installation
-  LOCATE: "Install" button (green)
-  ACTION: click([install_button_id])
-  WAIT: redirects to installation confirmation or app settings
-  VERIFY: page shows "Installed" status or installation ID
-```
-
-### Phase 7: Capture Credentials
-
-```
-STEP 14: Record App ID and Installation Details
-  CAPTURE: App ID (from app settings page, numeric)
-  CAPTURE: Installation ID (from installation confirmation page)
-  VERIFY: Private key content was already stored in Keychain during Step 9
-  STORE: App ID and Installation ID in assistant's secure credential store
-  NOTE: The private key was imported directly into the Keychain in Step 9.
-        These three pieces — App ID + Private Key + Installation ID — are
-        all the assistant needs to authenticate as the GitHub App via JWT.
-
-STEP 15: Report Success
-  DONE: "I've set up {assistant-name} as a GitHub App and installed it
-         on {target-repo}. I can now open PRs, review code, and respond
-         to issues on your behalf."
+STEP 5: Report Success
+  DONE: "{assistant-name} is now set up with GitHub Desktop.
+         The repository {target-repo} has been cloned and is ready.
+         I can help you manage branches, commits, and pull requests."
 ```
 
 ---
@@ -187,60 +66,19 @@ STEP 15: Report Success
 
 | Scenario | Recovery |
 |----------|----------|
-| App name taken | Append `-{random-4-digits}` and retry Step 2 |
-| Not signed into GitHub | Navigate to github.com/login, pause, ask user to sign in |
-| No admin access to org | Fall back to personal account installation |
-| Org requires approval (Request instead of Install) | Submit request, mark recipe as pending_approval, notify user, schedule follow-up |
-| Download blocked by browser | Check ~/Downloads for .pem, or look for browser download bar; import to Keychain immediately once found |
-| Permissions dropdown not visible | Scroll down, expand collapsed sections |
-| Page layout changed | Fall back to screenshot-only mode, use visual matching |
+| GitHub Desktop not installed | Navigate to desktop.github.com in Safari, download and install it |
+| Not signed in | Click sign-in button, wait for user to authenticate in browser |
+| Repository not found | Ask user to confirm the repository name, check spelling |
+| Clone fails (permissions) | Check if user has access to the repository, suggest requesting access |
+| Clone fails (disk space) | Notify user about disk space issue |
+| App not responding | Wait a few seconds, try clicking the app in the Dock |
 
 ## Credentials Output
 
 ```json
 {
-  "github_app_id": "123456",
-  "github_app_name": "{assistant-name}-github-app",
-  "private_key": "(stored in Keychain — never persisted to disk or returned to LLM)",
-  "installed_on": "{org}/{repo}",
-  "installation_id": "78901234"
+  "github_username": "(from GitHub Desktop profile)",
+  "cloned_repo": "{target-repo}",
+  "local_path": "(path where repo was cloned)"
 }
 ```
-
----
-
-## Architecture Notes
-
-### How This Fits Into Onboarding
-
-This recipe is one of several **integration recipes** that fire during onboarding
-based on user selections. The pattern:
-
-```
-Onboarding Step: "Where do you spend most of your time?"
-├── GitHub  → github-app-setup.md (this recipe)
-├── Gmail   → gmail-oauth-setup.md
-├── Slack   → slack-app-setup.md
-├── Linear  → linear-oauth-setup.md
-├── Notion  → notion-integration-setup.md
-└── ...
-```
-
-Each recipe follows the same structure:
-1. **Prerequisites** — what must be true before starting
-2. **Steps** — atomic, verifiable computer-use actions
-3. **Captures** — credentials/config the assistant stores
-4. **Error recovery** — fallback strategies
-5. **Completion message** — what to tell the user
-
-### Recipe Execution Model
-
-Recipes are executed by the `ComputerUseSession` with a structured task prompt
-derived from the recipe steps. The orchestration agent:
-
-1. Reads the recipe markdown
-2. Converts steps into a task description for the session
-3. Monitors step execution via `SessionState`
-4. Captures output credentials
-5. Stores them in the assistant's secure config
-6. Reports completion to the onboarding flow

--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -261,8 +261,9 @@ final class RecipeExecutor {
 
     func buildTaskPrompt(recipe: ParsedRecipe, context: RecipeContext) -> String {
         var prompt = """
-        You are executing a pre-planned recipe to set up an integration. Follow each step precisely.
-        Do NOT deviate from the plan. Execute the steps in order.
+        You are setting up an integration for the user. Follow the outline below as a guide,
+        adapting to what you see on screen. The steps describe what to accomplish, not exact
+        clicks — use your judgement to navigate the UI.
 
         RECIPE: \(recipe.name)
 
@@ -283,10 +284,10 @@ final class RecipeExecutor {
         prompt += """
 
         IMPORTANT INSTRUCTIONS:
-        - Execute each step one action at a time
-        - After each action, verify the expected result before moving on
-        - If a step fails, consult the error recovery section
-        - When all steps are complete, call done() with a summary including any captured values (App ID, file paths, etc.)
+        - Work through each step, taking one action at a time
+        - After each action, check the screen to see what changed before continuing
+        - If something doesn't look right, consult the error recovery section
+        - When all steps are complete, call done() with a summary of what was set up
         """
 
         // Interpolate context variables
@@ -306,19 +307,19 @@ final class RecipeExecutor {
     private func extractCredentials(from summary: String) -> [String: String] {
         var credentials: [String: String] = [:]
 
-        // Look for App ID pattern
-        if let match = firstCaptureGroup(in: summary, pattern: #"App\s*ID[\s:]+(\d+)"#) {
-            credentials["github_app_id"] = match
+        // Look for GitHub username
+        if let match = firstCaptureGroup(in: summary, pattern: #"[Uu]sername[\s:]+([^\s,]+)"#) {
+            credentials["github_username"] = match
         }
 
-        // Look for .pem file path
-        if let match = firstCaptureGroup(in: summary, pattern: #"([~/][^\s]+\.pem)"#) {
-            credentials["private_key_path"] = match
+        // Look for cloned repo
+        if let match = firstCaptureGroup(in: summary, pattern: #"[Rr]epository[\s:]+([^\s,]+)"#) {
+            credentials["cloned_repo"] = match
         }
 
-        // Look for installation ID
-        if let match = firstCaptureGroup(in: summary, pattern: #"[Ii]nstallation\s*ID[\s:]+(\d+)"#) {
-            credentials["installation_id"] = match
+        // Look for local path
+        if let match = firstCaptureGroup(in: summary, pattern: #"[Pp]ath[\s:]+([~/][^\s,]+)"#) {
+            credentials["local_path"] = match
         }
 
         return credentials

--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -78,7 +78,7 @@ final class RecipeExecutor {
         let session = ComputerUseSession(
             task: taskPrompt,
             provider: provider,
-            maxSteps: recipe.totalSteps * 4, // generous headroom for retries
+            maxSteps: max(recipe.totalSteps * 4, 40), // generous headroom; floor of 40 for high-level recipes
             initialDelayMs: 500
         )
 
@@ -287,7 +287,7 @@ final class RecipeExecutor {
         - Work through each step, taking one action at a time
         - After each action, check the screen to see what changed before continuing
         - If something doesn't look right, consult the error recovery section
-        - When all steps are complete, call done() with a summary of what was set up
+        - When all steps are complete, call done() with a summary that includes labeled fields: Username: <github-username>, Repository: <repo-name>, Path: <local-clone-path>
         """
 
         // Interpolate context variables

--- a/clients/macos/vellum-assistant/Resources/Recipes/github-app-setup.md
+++ b/clients/macos/vellum-assistant/Resources/Recipes/github-app-setup.md
@@ -1,184 +1,63 @@
 # Recipe: GitHub App Setup
 
-> A computer-use recipe for an orchestration agent to register, configure, and install
-> a GitHub App on behalf of the user's assistant — fully hands-free.
-
-## When This Recipe Fires
-
-This recipe is invoked as a **just-in-time skill** during onboarding when:
-
-1. The user answers **"GitHub"** to _"Where do you spend most of your time?"_
-2. The orchestration agent presents: _"Let me get {assistant-name} set up on GitHub. Can I take it from here?"_
-3. The user selects **"Yes (I'll use your mouse and keyboard)"**
+> High-level outline for setting up GitHub integration using GitHub Desktop.
+> The computer-use agent should follow these steps flexibly, adapting to
+> what it sees on screen rather than following rigid click sequences.
 
 ## Prerequisites
 
-- User is signed into github.com in their default browser
-- User has admin access to the target GitHub organization or personal account
+- GitHub Desktop is installed (if not, open App Store or download from desktop.github.com)
+- User is signed into their GitHub account in GitHub Desktop
 - macOS Accessibility + Screen Recording permissions are granted (handled by prior onboarding steps)
 
 ---
 
 ## Recipe Steps
 
-### Phase 1: Navigate to GitHub App Creation
+### Phase 1: Open GitHub Desktop
 
 ```
-STEP 1: Open GitHub Developer Settings
-  ACTION: open_app("default browser")
-  ACTION: key("cmd+l")  // focus address bar
-  ACTION: type_text("github.com/settings/apps/new")
-  ACTION: key("return")
-  WAIT: page loads — look for "Register new GitHub App" heading
-  VERIFY: AX tree contains "Register new GitHub App" or "New GitHub App"
+STEP 1: Launch GitHub Desktop
+  Open the GitHub Desktop application.
+  If it's not installed, open Safari and navigate to desktop.github.com to download it.
+  Wait for the app to finish launching and show its main window.
 ```
 
-### Phase 2: Fill Out App Registration Form
+### Phase 2: Sign In (if needed)
 
 ```
-STEP 2: Set App Name
-  LOCATE: text field labeled "GitHub App name"
-  ACTION: click([field_id])
-  ACTION: type_text("{assistant-name}-github-app")
-  NOTE: Must be globally unique on GitHub. If taken, append random 4-digit suffix.
-
-STEP 3: Set Homepage URL
-  LOCATE: text field labeled "Homepage URL"
-  ACTION: click([field_id])
-  ACTION: type_text("{assistant-homepage-url}")
-  NOTE: Can be any valid URL. Use the assistant's web page or a placeholder.
-
-STEP 4: Skip Webhook Configuration (for now)
-  LOCATE: checkbox "Active" under Webhooks section
-  ACTION: click([checkbox_id]) to UNCHECK it
-  NOTE: Webhooks can be configured later. Not necessary to get started.
+STEP 2: Ensure User is Signed In
+  Check if GitHub Desktop shows a signed-in state (shows repositories or "Clone a Repository" option).
+  If not signed in, click "Sign in to GitHub.com" and wait for the user to complete authentication.
+  Once signed in, verify the user's GitHub username is visible in the app.
 ```
 
-### Phase 3: Set Permissions
+### Phase 3: Clone a Repository
 
 ```
-STEP 5: Configure Repository Permissions
-  LOCATE: "Repository permissions" section (may need to scroll)
-  ACTION: scroll(down) until "Repository permissions" is visible
-
-  STEP 5a: Contents → Read and write
-    LOCATE: "Contents" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5b: Issues → Read and write
-    LOCATE: "Issues" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5c: Pull requests → Read and write
-    LOCATE: "Pull requests" dropdown
-    ACTION: click([dropdown_id])
-    ACTION: click option "Read and write"
-
-  STEP 5d: (Optional) Metadata → Read-only
-    NOTE: Usually auto-granted. Verify it shows "Read-only".
+STEP 3: Clone the Target Repository
+  Use the "Clone a Repository" option (File menu or welcome screen).
+  Search for or select {target-repo} from the user's available repositories.
+  Choose a local path for the clone and confirm.
+  Wait for the clone to complete.
 ```
 
-### Phase 4: Set Visibility & Create
+### Phase 4: Verify Setup
 
 ```
-STEP 6: Make the App Public (if org install needed)
-  LOCATE: radio button or section "Where can this GitHub App be installed?"
-  ACTION: select "Any account" (public)
-  NOTE: Making it public allows the Vellum organization to install it.
-        If private, only the owning account can install.
-
-STEP 7: Create the GitHub App
-  LOCATE: "Create GitHub App" button (green, bottom of form)
-  ACTION: click([button_id])
-  WAIT: page navigates to the new app's settings page
-  VERIFY: page title or heading contains the app name
-  CAPTURE: App ID from the "App ID" field on the About page
+STEP 4: Verify Repository Access
+  Confirm the cloned repository appears in GitHub Desktop's repository list.
+  Verify the current branch is visible and the repository status shows correctly.
+  Open the repository in Finder to confirm files are present on disk.
 ```
 
-### Phase 5: Generate Private Key
+### Phase 5: Report Completion
 
 ```
-STEP 8: Navigate to Private Key Section
-  ACTION: scroll(down) to "Private keys" section
-  LOCATE: "Generate a private key" button (green)
-
-STEP 9: Generate, Download, and Import Key
-  ACTION: click([generate_button_id])
-  WAIT: .pem file downloads (browser download notification or file appears)
-  VERIFY: download completes — look for .pem in ~/Downloads/
-  CAPTURE: path to downloaded .pem file
-  ACTION: Read the .pem file contents and pass them to the credential store
-  VERIFY: PEM content starts with "-----BEGIN RSA PRIVATE KEY-----"
-  STORE: PEM content directly into assistant's secure credential store (Keychain)
-  ACTION: Securely delete the .pem file from ~/Downloads/ after import
-  NOTE: The private key MUST be read and stored immediately — ~/Downloads/ is
-        ephemeral and the file may be moved or cleaned up at any time. Never
-        rely on the filesystem path for long-term credential access.
-```
-
-### Phase 6: Install the App
-
-```
-STEP 10: Click "Install App" in Sidebar
-  LOCATE: "Install App" link in left sidebar navigation
-  ACTION: click([install_link_id])
-  WAIT: installation page loads
-
-STEP 11: Select Target Account/Org
-  LOCATE: the target organization or personal account
-  LOCATE: the button next to it — check if it says "Install" or "Request"
-
-  IF button says "Install":
-    ACTION: click "Install" button
-    → continue to Step 12
-
-  IF button says "Request":
-    NOTE: This org has third-party app restrictions requiring admin approval.
-    ACTION: click "Request" button to submit the request
-    WAIT: confirmation that the request was submitted
-    VERIFY: page shows "Request submitted" or similar confirmation
-    DONE (partial): "I've requested installation of {assistant-name} on {org}.
-          An org admin needs to approve the request before I can access
-          your repos. I'll check back — or you can let me know once
-          it's approved so I can finish setup."
-    → ABORT remaining steps (12-15). Recipe is incomplete — mark as
-      "pending_approval" in credential store. The orchestration agent
-      should schedule a follow-up check or prompt the user later.
-
-STEP 12: Choose Repository Access
-  LOCATE: "Only select repositories" radio button
-  ACTION: click([radio_id])
-  LOCATE: repository dropdown/selector
-  ACTION: click([dropdown_id])
-  ACTION: type_text("{target-repo-name}")
-  ACTION: click the matching repo option
-  NOTE: Scoping to specific repos follows principle of least privilege.
-
-STEP 13: Confirm Installation
-  LOCATE: "Install" button (green)
-  ACTION: click([install_button_id])
-  WAIT: redirects to installation confirmation or app settings
-  VERIFY: page shows "Installed" status or installation ID
-```
-
-### Phase 7: Capture Credentials
-
-```
-STEP 14: Record App ID and Installation Details
-  CAPTURE: App ID (from app settings page, numeric)
-  CAPTURE: Installation ID (from installation confirmation page)
-  VERIFY: Private key content was already stored in Keychain during Step 9
-  STORE: App ID and Installation ID in assistant's secure credential store
-  NOTE: The private key was imported directly into the Keychain in Step 9.
-        These three pieces — App ID + Private Key + Installation ID — are
-        all the assistant needs to authenticate as the GitHub App via JWT.
-
-STEP 15: Report Success
-  DONE: "I've set up {assistant-name} as a GitHub App and installed it
-         on {target-repo}. I can now open PRs, review code, and respond
-         to issues on your behalf."
+STEP 5: Report Success
+  DONE: "{assistant-name} is now set up with GitHub Desktop.
+         The repository {target-repo} has been cloned and is ready.
+         I can help you manage branches, commits, and pull requests."
 ```
 
 ---
@@ -187,60 +66,19 @@ STEP 15: Report Success
 
 | Scenario | Recovery |
 |----------|----------|
-| App name taken | Append `-{random-4-digits}` and retry Step 2 |
-| Not signed into GitHub | Navigate to github.com/login, pause, ask user to sign in |
-| No admin access to org | Fall back to personal account installation |
-| Org requires approval (Request instead of Install) | Submit request, mark recipe as pending_approval, notify user, schedule follow-up |
-| Download blocked by browser | Check ~/Downloads for .pem, or look for browser download bar; import to Keychain immediately once found |
-| Permissions dropdown not visible | Scroll down, expand collapsed sections |
-| Page layout changed | Fall back to screenshot-only mode, use visual matching |
+| GitHub Desktop not installed | Navigate to desktop.github.com in Safari, download and install it |
+| Not signed in | Click sign-in button, wait for user to authenticate in browser |
+| Repository not found | Ask user to confirm the repository name, check spelling |
+| Clone fails (permissions) | Check if user has access to the repository, suggest requesting access |
+| Clone fails (disk space) | Notify user about disk space issue |
+| App not responding | Wait a few seconds, try clicking the app in the Dock |
 
 ## Credentials Output
 
 ```json
 {
-  "github_app_id": "123456",
-  "github_app_name": "{assistant-name}-github-app",
-  "private_key": "(stored in Keychain — never persisted to disk or returned to LLM)",
-  "installed_on": "{org}/{repo}",
-  "installation_id": "78901234"
+  "github_username": "(from GitHub Desktop profile)",
+  "cloned_repo": "{target-repo}",
+  "local_path": "(path where repo was cloned)"
 }
 ```
-
----
-
-## Architecture Notes
-
-### How This Fits Into Onboarding
-
-This recipe is one of several **integration recipes** that fire during onboarding
-based on user selections. The pattern:
-
-```
-Onboarding Step: "Where do you spend most of your time?"
-├── GitHub  → github-app-setup.md (this recipe)
-├── Gmail   → gmail-oauth-setup.md
-├── Slack   → slack-app-setup.md
-├── Linear  → linear-oauth-setup.md
-├── Notion  → notion-integration-setup.md
-└── ...
-```
-
-Each recipe follows the same structure:
-1. **Prerequisites** — what must be true before starting
-2. **Steps** — atomic, verifiable computer-use actions
-3. **Captures** — credentials/config the assistant stores
-4. **Error recovery** — fallback strategies
-5. **Completion message** — what to tell the user
-
-### Recipe Execution Model
-
-Recipes are executed by the `ComputerUseSession` with a structured task prompt
-derived from the recipe steps. The orchestration agent:
-
-1. Reads the recipe markdown
-2. Converts steps into a task description for the session
-3. Monitors step execution via `SessionState`
-4. Captures output credentials
-5. Stores them in the assistant's secure config
-6. Reports completion to the onboarding flow


### PR DESCRIPTION
The purpose of this PR is to replace the overly prescriptive browser-based GitHub App registration recipe with a simple GitHub Desktop-based outline that actually works with computer use.

## Changes Made
- Rewrote `github-app-setup.md` from a 15-step browser form-filling recipe to a 5-step GitHub Desktop outline (launch, sign in, clone repo, verify, done)
- Changed recipe style from rigid `ACTION/LOCATE/VERIFY` directives to high-level descriptions that let the agent adapt to what it sees on screen
- Updated `RecipeExecutor` task prompt to use softer guidance language ("adapt to what you see" instead of "follow precisely, do NOT deviate")
- Updated credential extraction to match GitHub Desktop outputs (username, cloned repo, local path) instead of GitHub App credentials (App ID, .pem, installation ID)

## Testing
- SPM build passes cleanly

## Notes
The previous recipe tried to navigate github.com web forms with prescriptive click sequences, which was fragile due to unreliable browser AX trees and complex dropdowns. GitHub Desktop is a native macOS app with proper accessibility support, making it far more suitable for computer use.

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
