### PR TITLE
fix: restore PRAGMA foreign_keys on migration failure

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -78,25 +78,31 @@ function migrateToolInvocationsFk(database: ReturnType<typeof drizzle<typeof sch
   // If the DDL already contains REFERENCES, the FK is in place
   if (row.sql.includes('REFERENCES')) return;
 
-  raw.exec(/*sql*/ `
-    PRAGMA foreign_keys = OFF;
-    BEGIN;
-    CREATE TABLE tool_invocations_new (
-      id TEXT PRIMARY KEY,
-      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
-      tool_name TEXT NOT NULL,
-      input TEXT NOT NULL,
-      result TEXT NOT NULL,
-      decision TEXT NOT NULL,
-      risk_level TEXT NOT NULL,
-      duration_ms INTEGER NOT NULL,
-      created_at INTEGER NOT NULL
-    );
-    INSERT INTO tool_invocations_new SELECT t.* FROM tool_invocations t
-      WHERE EXISTS (SELECT 1 FROM conversations c WHERE c.id = t.conversation_id);
-    DROP TABLE tool_invocations;
-    ALTER TABLE tool_invocations_new RENAME TO tool_invocations;
-    COMMIT;
-    PRAGMA foreign_keys = ON;
-  `);
+  raw.exec('PRAGMA foreign_keys = OFF');
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+      CREATE TABLE tool_invocations_new (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+        tool_name TEXT NOT NULL,
+        input TEXT NOT NULL,
+        result TEXT NOT NULL,
+        decision TEXT NOT NULL,
+        risk_level TEXT NOT NULL,
+        duration_ms INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO tool_invocations_new SELECT t.* FROM tool_invocations t
+        WHERE EXISTS (SELECT 1 FROM conversations c WHERE c.id = t.conversation_id);
+      DROP TABLE tool_invocations;
+      ALTER TABLE tool_invocations_new RENAME TO tool_invocations;
+      COMMIT;
+    `);
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  } finally {
+    raw.exec('PRAGMA foreign_keys = ON');
+  }
 }


### PR DESCRIPTION
## Summary
- Separates `PRAGMA foreign_keys = OFF/ON` from the transactional migration SQL in `migrateToolInvocationsFk`
- Wraps the migration in try/catch/finally to guarantee `PRAGMA foreign_keys = ON` is always restored, even if the migration fails mid-way
- Rolls back any in-progress transaction on error to avoid leaving the connection in a broken state

Addresses review feedback from both Devin and Codex on #298: if `raw.exec()` threw after disabling foreign keys but before re-enabling them, FK enforcement would remain disabled for the entire lifetime of the cached database connection.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify existing migration still works on a fresh DB
- [ ] Verify that a simulated failure mid-migration correctly restores FK enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
