### PR TITLE
feat: default max_tokens to 64000 for Anthropic models

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -17,7 +17,7 @@ export type AgentEvent =
   | { type: 'usage'; inputTokens: number; outputTokens: number; model: string };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
-  maxTokens: 4096,
+  maxTokens: 64000,
 };
 
 const PROGRESS_CHECK_INTERVAL = 5;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -5,7 +5,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   provider: 'anthropic',
   model: 'claude-sonnet-4-5-20250929', // alias: claude-sonnet-4-5
   apiKeys: {},
-  maxTokens: 4096,
+  maxTokens: 64000,
   dataDir: getDataDir(),
   timeouts: {
     shellDefaultTimeoutSec: 120,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -29,7 +29,7 @@ export class AnthropicProvider implements Provider {
     try {
       const params: Anthropic.MessageCreateParams = {
         model: this.model,
-        max_tokens: 8192,
+        max_tokens: 64000,
         messages: messages.map((m) => ({
           role: m.role,
           content: m.content.map((block) => this.toAnthropicBlock(block)),


### PR DESCRIPTION
## Summary
- Updates the default `maxTokens` from 4096 to 64000 in the config defaults and agent loop
- Updates the Anthropic provider fallback from 8192 to 64000
- Modern Claude models support large output windows; the old defaults were unnecessarily restrictive, causing truncated responses on complex tasks

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify responses are no longer truncated on complex multi-step tool use
- [ ] Existing users with `maxTokens` set in their config file are unaffected (their value takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
