### PR TITLE
feat: support Claude extended thinking mode

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -5,10 +5,12 @@ const log = getLogger('agent-loop');
 
 export interface AgentLoopConfig {
   maxTokens: number;
+  thinking?: { enabled: boolean; budgetTokens: number };
 }
 
 export type AgentEvent =
   | { type: 'text_delta'; text: string }
+  | { type: 'thinking_delta'; thinking: string }
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
@@ -56,15 +58,25 @@ export class AgentLoop {
       if (signal?.aborted) break;
 
       try {
+        const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
+        if (this.config.thinking?.enabled) {
+          providerConfig.thinking = {
+            type: 'enabled',
+            budget_tokens: this.config.thinking.budgetTokens,
+          };
+        }
+
         const response = await this.provider.sendMessage(
           history,
           this.tools.length > 0 ? this.tools : undefined,
           this.systemPrompt,
           {
-            config: { max_tokens: this.config.maxTokens },
+            config: providerConfig,
             onEvent: (event) => {
               if (event.type === 'text_delta') {
                 onEvent({ type: 'text_delta', text: event.text });
+              } else if (event.type === 'thinking_delta') {
+                onEvent({ type: 'thinking_delta', thinking: event.thinking });
               }
             },
             signal,

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -269,6 +269,11 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         process.stdout.write(msg.text);
         break;
 
+      case 'assistant_thinking_delta':
+        spinner.stop();
+        process.stdout.write(`\x1B[2m${msg.thinking}\x1B[0m`);
+        break;
+
       case 'usage_update':
         lastUsage = msg;
         break;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -6,6 +6,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   model: 'claude-sonnet-4-5-20250929', // alias: claude-sonnet-4-5
   apiKeys: {},
   maxTokens: 64000,
+  thinking: {
+    enabled: false,
+    budgetTokens: 10000,
+  },
   dataDir: getDataDir(),
   timeouts: {
     shellDefaultTimeoutSec: 120,

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -27,7 +27,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, secretDetection: { ...DEFAULT_CONFIG.secretDetection }, auditLog: { ...DEFAULT_CONFIG.auditLog } };
+  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, thinking: { ...DEFAULT_CONFIG.thinking }, secretDetection: { ...DEFAULT_CONFIG.secretDetection }, auditLog: { ...DEFAULT_CONFIG.auditLog } };
   loading = true;
 
   try {
@@ -106,6 +106,7 @@ export function loadConfig(): AssistantConfig {
       timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
       sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
       rateLimit: { ...DEFAULT_CONFIG.rateLimit, ...(fileConfig as Record<string, unknown>).rateLimit as Partial<AssistantConfig['rateLimit']> },
+      thinking: { ...DEFAULT_CONFIG.thinking, ...(fileConfig as Record<string, unknown>).thinking as Partial<AssistantConfig['thinking']> },
       secretDetection: { ...DEFAULT_CONFIG.secretDetection, ...(fileConfig as Record<string, unknown>).secretDetection as Partial<AssistantConfig['secretDetection']> },
       auditLog: { ...DEFAULT_CONFIG.auditLog, ...(fileConfig as Record<string, unknown>).auditLog as Partial<AssistantConfig['auditLog']> },
     };
@@ -189,6 +190,16 @@ function validateConfig(config: AssistantConfig): void {
       );
       config.timeouts[field] = DEFAULT_CONFIG.timeouts[field];
     }
+  }
+
+  if (typeof config.thinking.enabled !== 'boolean') {
+    log.warn(`Invalid thinking.enabled "${config.thinking.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.thinking.enabled}.`);
+    config.thinking.enabled = DEFAULT_CONFIG.thinking.enabled;
+  }
+
+  if (typeof config.thinking.budgetTokens !== 'number' || !Number.isFinite(config.thinking.budgetTokens) || config.thinking.budgetTokens <= 0 || !Number.isInteger(config.thinking.budgetTokens)) {
+    log.warn(`Invalid thinking.budgetTokens "${config.thinking.budgetTokens}". Must be a positive integer. Falling back to ${DEFAULT_CONFIG.thinking.budgetTokens}.`);
+    config.thinking.budgetTokens = DEFAULT_CONFIG.thinking.budgetTokens;
   }
 
   if (typeof config.sandbox.enabled !== 'boolean') {

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -33,12 +33,20 @@ export interface AuditLogConfig {
   retentionDays: number;
 }
 
+export interface ThinkingConfig {
+  /** Enable extended thinking. Default: false. */
+  enabled: boolean;
+  /** Thinking budget in tokens. Default: 10000. */
+  budgetTokens: number;
+}
+
 export interface AssistantConfig {
   provider: string;
   model: string;
   apiKeys: Record<string, string>;
   systemPrompt?: string;
   maxTokens: number;
+  thinking: ThinkingConfig;
   dataDir: string;
   timeouts: TimeoutConfig;
   sandbox: SandboxConfig;

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -95,6 +95,11 @@ export interface AssistantTextDelta {
   text: string;
 }
 
+export interface AssistantThinkingDelta {
+  type: 'assistant_thinking_delta';
+  thinking: string;
+}
+
 export interface ToolUseStart {
   type: 'tool_use_start';
   toolName: string;
@@ -198,6 +203,7 @@ export interface SecretDetected {
 
 export type ServerMessage =
   | AssistantTextDelta
+  | AssistantThinkingDelta
   | ToolUseStart
   | ToolOutputChunk
   | ToolResult

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -62,10 +62,11 @@ export class Session {
       });
     };
 
+    const config = getConfig();
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
-      { maxTokens },
+      { maxTokens, thinking: config.thinking },
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,
     );
@@ -164,6 +165,9 @@ export class Session {
             case 'text_delta':
               onEvent({ type: 'assistant_text_delta', text: event.text });
               if (isFirstMessage) firstAssistantText += event.text;
+              break;
+            case 'thinking_delta':
+              onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
               break;
             case 'tool_use':
               onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -55,6 +55,10 @@ export class AnthropicProvider implements Provider {
         onEvent?.({ type: "text_delta", text });
       });
 
+      stream.on("thinking", (thinking) => {
+        onEvent?.({ type: "thinking_delta", thinking });
+      });
+
       const response = await stream.finalMessage();
 
       return {
@@ -91,6 +95,10 @@ export class AnthropicProvider implements Provider {
     switch (block.type) {
       case "text":
         return { type: "text", text: block.text };
+      case "thinking":
+        return { type: "thinking", thinking: block.thinking, signature: block.signature };
+      case "redacted_thinking":
+        return { type: "redacted_thinking", data: block.data };
       case "image":
         return {
           type: "image",
@@ -115,6 +123,10 @@ export class AnthropicProvider implements Provider {
           content: block.content,
           is_error: block.is_error,
         };
+      default: {
+        const _exhaustive: never = block;
+        throw new Error(`Unsupported content block type: ${(_exhaustive as ContentBlock).type}`);
+      }
     }
   }
 
@@ -124,6 +136,10 @@ export class AnthropicProvider implements Provider {
     switch (block.type) {
       case "text":
         return { type: "text", text: block.text };
+      case "thinking":
+        return { type: "thinking", thinking: block.thinking, signature: block.signature };
+      case "redacted_thinking":
+        return { type: "redacted_thinking", data: block.data };
       case "tool_use":
         return {
           type: "tool_use",
@@ -132,7 +148,7 @@ export class AnthropicProvider implements Provider {
           input: block.input as Record<string, unknown>,
         };
       default:
-        return { type: "text", text: `[unsupported block type: ${block.type}]` };
+        return { type: "text", text: `[unsupported block type: ${(block as { type: string }).type}]` };
     }
   }
 }

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -19,6 +19,17 @@ export interface ToolUseContent {
   input: Record<string, unknown>;
 }
 
+export interface ThinkingContent {
+  type: "thinking";
+  thinking: string;
+  signature: string;
+}
+
+export interface RedactedThinkingContent {
+  type: "redacted_thinking";
+  data: string;
+}
+
 export interface ToolResultContent {
   type: "tool_result";
   tool_use_id: string;
@@ -28,6 +39,8 @@ export interface ToolResultContent {
 
 export type ContentBlock =
   | TextContent
+  | ThinkingContent
+  | RedactedThinkingContent
   | ImageContent
   | ToolUseContent
   | ToolResultContent;
@@ -54,7 +67,8 @@ export interface ProviderResponse {
 }
 
 export type ProviderEvent =
-  | { type: 'text_delta'; text: string };
+  | { type: 'text_delta'; text: string }
+  | { type: 'thinking_delta'; thinking: string };
 
 export interface SendMessageOptions {
   config?: object;


### PR DESCRIPTION
## Summary
- Adds end-to-end support for Claude's extended thinking feature
- New `ThinkingConfig` in config (`thinking.enabled`, `thinking.budgetTokens`) with defaults (disabled, 10K budget)
- Streams thinking deltas through the full pipeline: Anthropic SDK → provider → agent loop → session → IPC → CLI
- Renders thinking text in dim/muted style in the terminal
- Preserves thinking and redacted_thinking blocks in conversation history for multi-turn continuity
- Handles both `thinking` and `redacted_thinking` content blocks from the API

### Files changed (9 files, +85/-5)
- `providers/types.ts` — Added `ThinkingContent`, `RedactedThinkingContent`, `thinking_delta` event
- `providers/anthropic/client.ts` — Handle thinking blocks in both directions, stream thinking events
- `agent/loop.ts` — Pass thinking config to provider, forward thinking_delta events
- `daemon/ipc-protocol.ts` — New `AssistantThinkingDelta` IPC message type
- `daemon/session.ts` — Forward thinking events to client, pass thinking config to agent loop
- `config/types.ts` — New `ThinkingConfig` interface
- `config/defaults.ts` — Default thinking config (disabled, 10K budget)
- `config/loader.ts` — Merge and validate thinking config
- `cli.ts` — Render thinking deltas in dim text

### Usage
```bash
vellum config set thinking.enabled true
vellum config set thinking.budgetTokens 20000
```

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing tests pass (config, IPC protocol)
- [ ] Manual test: enable thinking and verify thinking text streams in dim style
- [ ] Verify thinking blocks are preserved in conversation history for multi-turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
