### PR TITLE
feat: compose system prompt from SOUL.md and IDENTITY.md

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock platform to use a temp directory
+const TEST_DIR = join(tmpdir(), `vellum-sysprompt-test-${crypto.randomUUID()}`);
+
+import { mock } from 'bun:test';
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+}));
+
+// Import after mock
+const { buildSystemPrompt } = await import('../config/system-prompt.js');
+const { DEFAULT_SYSTEM_PROMPT } = await import('../config/defaults.js');
+
+describe('buildSystemPrompt', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('returns DEFAULT_SYSTEM_PROMPT when no files exist and no config', () => {
+    const result = buildSystemPrompt();
+    expect(result).toBe(DEFAULT_SYSTEM_PROMPT);
+  });
+
+  test('returns config systemPrompt when no files exist', () => {
+    const result = buildSystemPrompt('Custom config prompt');
+    expect(result).toBe('Custom config prompt');
+  });
+
+  test('uses SOUL.md when it exists', () => {
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), '# My Soul\n\nBe awesome.');
+    const result = buildSystemPrompt();
+    expect(result).toBe('# My Soul\n\nBe awesome.');
+  });
+
+  test('uses IDENTITY.md when it exists', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), '# My Identity\n\nI am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toBe('# My Identity\n\nI am Vellum.');
+  });
+
+  test('composes IDENTITY.md + SOUL.md when both exist', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), '# Identity\n\nI am Vellum.');
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), '# Soul\n\nBe thoughtful.');
+    const result = buildSystemPrompt();
+    expect(result).toBe('# Identity\n\nI am Vellum.\n\n# Soul\n\nBe thoughtful.');
+  });
+
+  test('SOUL.md and IDENTITY.md take priority over config systemPrompt', () => {
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), 'Soul content');
+    const result = buildSystemPrompt('Should be ignored');
+    expect(result).toBe('Soul content');
+  });
+
+  test('ignores empty SOUL.md', () => {
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), '   \n  \n  ');
+    const result = buildSystemPrompt('Fallback');
+    expect(result).toBe('Fallback');
+  });
+
+  test('ignores empty IDENTITY.md', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), '');
+    const result = buildSystemPrompt('Fallback');
+    expect(result).toBe('Fallback');
+  });
+
+  test('trims whitespace from file content', () => {
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), '\n  Be kind  \n\n');
+    const result = buildSystemPrompt();
+    expect(result).toBe('Be kind');
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -1,0 +1,51 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { getDataDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+import { DEFAULT_SYSTEM_PROMPT } from './defaults.js';
+
+const log = getLogger('system-prompt');
+
+/**
+ * Build the system prompt by composing optional SOUL.md and IDENTITY.md files
+ * from ~/.vellum/. Falls back to the config systemPrompt or DEFAULT_SYSTEM_PROMPT.
+ *
+ * Priority:
+ *   1. If SOUL.md and/or IDENTITY.md exist, compose from those files
+ *   2. If config.systemPrompt is set, use it
+ *   3. Otherwise, use DEFAULT_SYSTEM_PROMPT
+ *
+ * When both SOUL.md and IDENTITY.md exist, the prompt is composed as:
+ *   IDENTITY.md content + "\n\n" + SOUL.md content
+ */
+export function buildSystemPrompt(configSystemPrompt?: string): string {
+  const baseDir = getDataDir();
+  const soulPath = join(baseDir, 'SOUL.md');
+  const identityPath = join(baseDir, 'IDENTITY.md');
+
+  const soul = readPromptFile(soulPath);
+  const identity = readPromptFile(identityPath);
+
+  if (identity || soul) {
+    const parts: string[] = [];
+    if (identity) parts.push(identity);
+    if (soul) parts.push(soul);
+    return parts.join('\n\n');
+  }
+
+  return configSystemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+}
+
+function readPromptFile(path: string): string | null {
+  if (!existsSync(path)) return null;
+
+  try {
+    const content = readFileSync(path, 'utf-8').trim();
+    if (content.length === 0) return null;
+    log.debug({ path }, 'Loaded prompt file');
+    return content;
+  } catch (err) {
+    log.warn({ err, path }, 'Failed to read prompt file');
+    return null;
+  }
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -5,7 +5,7 @@ import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
-import { DEFAULT_SYSTEM_PROMPT } from '../config/defaults.js';
+import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -274,7 +274,7 @@ export class DaemonServer {
         const newSession = new Session(
           conversationId,
           provider,
-          config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+          buildSystemPrompt(config.systemPrompt),
           config.maxTokens,
           sendToClient,
           workingDir,


### PR DESCRIPTION
## Summary
- Adds support for customizing the system prompt via markdown files in `~/.vellum/`
- **`SOUL.md`**: Defines the agent's core personality, values, and internal behavior guidelines
- **`IDENTITY.md`**: Defines the agent's external presentation, voice, and persona
- When both files exist, the prompt is composed as: IDENTITY.md + "\n\n" + SOUL.md
- Files take priority over the `systemPrompt` config field
- Falls back gracefully: SOUL/IDENTITY files → config.systemPrompt → DEFAULT_SYSTEM_PROMPT
- Empty files are ignored (treated as non-existent)

### New files
- `assistant/src/config/system-prompt.ts` — `buildSystemPrompt()` function that reads and composes the prompt files
- `assistant/src/__tests__/system-prompt.test.ts` — 9 tests covering all composition, priority, and fallback scenarios

### Modified files
- `assistant/src/daemon/server.ts` — Uses `buildSystemPrompt(config.systemPrompt)` instead of `config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT`

### Usage
Create `~/.vellum/SOUL.md`:
```markdown
# Core Philosophy
You are a thoughtful, capable assistant running on the user's machine.

## Values
- Helpfulness: solve real problems
- Clarity: explain your reasoning
- Caution: respect system boundaries
```

Create `~/.vellum/IDENTITY.md`:
```markdown
# Vellum Assistant
A local AI companion. Direct, friendly, opinionated about good practices
but respectful of user autonomy.
```

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] 9 new tests pass covering all scenarios
- [ ] Manual test: create SOUL.md, verify prompt changes
- [ ] Manual test: create both files, verify composition order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
