### PR TITLE
fix: resolve test failures from mock.module leakage

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/assistant/src/__tests__/keychain.test.ts
+++ b/assistant/src/__tests__/keychain.test.ts
@@ -1,49 +1,21 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
-
-// ---------------------------------------------------------------------------
-// Mocks — declared before imports
-// ---------------------------------------------------------------------------
-
-let mockPlatform = 'darwin';
-let execFileCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
-let execFileResults: Map<string, string | Error> = new Map();
-
-mock.module('../util/platform.js', () => ({
-  isMacOS: () => mockPlatform === 'darwin',
-  isLinux: () => mockPlatform === 'linux',
-  isWindows: () => mockPlatform === 'win32',
-  getDataDir: () => '/tmp/vellum-test',
-}));
-
-mock.module('../util/logger.js', () => ({
-  getLogger: () => new Proxy({} as Record<string, unknown>, {
-    get: () => () => {},
-  }),
-}));
-
-mock.module('node:child_process', () => ({
-  execFileSync: (cmd: string, args: string[], opts: Record<string, unknown>) => {
-    execFileCalls.push({ cmd, args: [...args], opts: { ...opts } });
-
-    // Build a key from the command for result lookup
-    const key = `${cmd} ${args.join(' ')}`;
-    for (const [pattern, result] of execFileResults) {
-      if (key.includes(pattern)) {
-        if (result instanceof Error) throw result;
-        return result;
-      }
-    }
-    // Default: return empty string (success)
-    return '';
-  },
-}));
-
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
 import {
   isKeychainAvailable,
   getKey,
   setKey,
   deleteKey,
+  _overrideDeps,
+  _resetDeps,
 } from '../security/keychain.js';
+
+// ---------------------------------------------------------------------------
+// Test state — uses _overrideDeps instead of mock.module to avoid
+// process-global mock leakage between test files in Bun's shared runner.
+// ---------------------------------------------------------------------------
+
+let mockPlatform = 'darwin';
+let execFileCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+let execFileResults: Map<string, string | Error> = new Map();
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -54,6 +26,27 @@ describe('keychain', () => {
     execFileCalls = [];
     execFileResults = new Map();
     mockPlatform = 'darwin';
+
+    _overrideDeps({
+      isMacOS: () => mockPlatform === 'darwin',
+      isLinux: () => mockPlatform === 'linux',
+      execFileSync: ((cmd: string, args: string[], opts: Record<string, unknown>) => {
+        execFileCalls.push({ cmd, args: [...args], opts: { ...opts } });
+
+        const key = `${cmd} ${args.join(' ')}`;
+        for (const [pattern, result] of execFileResults) {
+          if (key.includes(pattern)) {
+            if (result instanceof Error) throw result;
+            return result;
+          }
+        }
+        return '';
+      }) as typeof import('node:child_process').execFileSync,
+    });
+  });
+
+  afterAll(() => {
+    _resetDeps();
   });
 
   // -----------------------------------------------------------------------
@@ -132,7 +125,6 @@ describe('keychain', () => {
       setKey('anthropic', 'sk-ant-key123');
       const addCall = execFileCalls.find((c) => c.args.includes('add-generic-password'));
       expect(addCall).toBeDefined();
-      // macOS security CLI requires password as the -w argument value
       const wIndex = addCall!.args.indexOf('-w');
       expect(wIndex).toBeGreaterThanOrEqual(0);
       expect(addCall!.args[wIndex + 1]).toBe('sk-ant-key123');

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
-// Mock logger and keychain
+// Mock logger (no-op — compatible with other test files' identical mock)
 // ---------------------------------------------------------------------------
 
 mock.module('../util/logger.js', () => ({
@@ -14,27 +14,56 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-// Track keychain availability, stored keys, and runtime failures for mock
+// ---------------------------------------------------------------------------
+// Keychain simulation via _overrideDeps — avoids process-global mock.module
+// for keychain.js which leaks into keychain.test.ts.
+// ---------------------------------------------------------------------------
+
+import { _overrideDeps, _resetDeps } from '../security/keychain.js';
+
 let keychainAvailable = false;
 let keychainFailAtRuntime = false;
 const keychainStore = new Map<string, string>();
 
-mock.module('../security/keychain.js', () => ({
-  isKeychainAvailable: () => keychainAvailable,
-  getKey: (account: string): string | null => {
-    if (keychainFailAtRuntime) throw new Error('Keychain runtime error');
-    return keychainStore.get(account) ?? null;
-  },
-  setKey: (account: string, value: string) => {
-    if (keychainFailAtRuntime) return false;
-    keychainStore.set(account, value);
-    return true;
-  },
-  deleteKey: (account: string) => {
-    if (keychainFailAtRuntime) return false;
-    return keychainStore.delete(account);
-  },
-}));
+function installKeychainDeps(): void {
+  _overrideDeps({
+    isMacOS: () => keychainAvailable,
+    isLinux: () => false,
+    execFileSync: ((cmd: string, args: string[]) => {
+      if (keychainFailAtRuntime) throw new Error('Keychain runtime error');
+
+      if (cmd === 'security') {
+        if (args.includes('list-keychains')) return '';
+
+        if (args.includes('find-generic-password')) {
+          const aIdx = args.indexOf('-a');
+          const account = args[aIdx + 1];
+          const val = keychainStore.get(account);
+          if (!val) throw Object.assign(new Error('not found'), { status: 44 });
+          return val + '\n';
+        }
+
+        if (args.includes('add-generic-password')) {
+          const aIdx = args.indexOf('-a');
+          const account = args[aIdx + 1];
+          const wIdx = args.indexOf('-w');
+          const value = args[wIdx + 1];
+          keychainStore.set(account, value);
+          return '';
+        }
+
+        if (args.includes('delete-generic-password')) {
+          const aIdx = args.indexOf('-a');
+          const account = args[aIdx + 1];
+          keychainStore.delete(account);
+          return '';
+        }
+      }
+
+      return '';
+    }) as typeof import('node:child_process').execFileSync,
+  });
+}
 
 import {
   getSecureKey,
@@ -60,6 +89,7 @@ describe('secure-keys', () => {
     keychainFailAtRuntime = false;
     keychainStore.clear();
     _resetBackend();
+    installKeychainDeps();
 
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
@@ -74,6 +104,7 @@ describe('secure-keys', () => {
   });
 
   afterAll(() => {
+    _resetDeps();
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
@@ -188,12 +219,14 @@ describe('secure-keys', () => {
     });
 
     test('forces keychain backend', () => {
+      keychainAvailable = true;
       _setBackend('keychain');
       setSecureKey('test', 'value');
       expect(keychainStore.get('test')).toBe('value');
     });
 
     test('reset re-evaluates backend', () => {
+      keychainAvailable = true;
       _setBackend('keychain');
       setSecureKey('k1', 'v1');
       expect(keychainStore.get('k1')).toBe('v1');

--- a/assistant/src/security/keychain.ts
+++ b/assistant/src/security/keychain.ts
@@ -17,21 +17,43 @@ const log = getLogger('keychain');
 
 const SERVICE_NAME = 'vellum-assistant';
 
+// ---------------------------------------------------------------------------
+// Injectable deps — avoids process-global mock.module for testing
+// ---------------------------------------------------------------------------
+
+const deps = {
+  execFileSync: execFileSync as typeof execFileSync,
+  isMacOS,
+  isLinux,
+};
+
+/** @internal test-only — override deps to avoid mock.module conflicts */
+export function _overrideDeps(overrides: Partial<typeof deps>): void {
+  Object.assign(deps, overrides);
+}
+
+/** @internal test-only — restore original deps */
+export function _resetDeps(): void {
+  deps.execFileSync = execFileSync;
+  deps.isMacOS = isMacOS;
+  deps.isLinux = isLinux;
+}
+
 /** Check if the OS keychain is available on this system. */
 export function isKeychainAvailable(): boolean {
   try {
-    if (isMacOS()) {
+    if (deps.isMacOS()) {
       // Verify `security` CLI exists and can list keychains
-      execFileSync('security', ['list-keychains'], {
+      deps.execFileSync('security', ['list-keychains'], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       });
       return true;
     }
 
-    if (isLinux()) {
+    if (deps.isLinux()) {
       // Verify `secret-tool` exists
-      execFileSync('which', ['secret-tool'], {
+      deps.execFileSync('which', ['secret-tool'], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       });
@@ -50,10 +72,10 @@ export function isKeychainAvailable(): boolean {
  * Throws on runtime errors (keychain unavailable, locked, etc.).
  */
 export function getKey(account: string): string | null {
-  if (isMacOS()) {
+  if (deps.isMacOS()) {
     return macosGetKey(account);
   }
-  if (isLinux()) {
+  if (deps.isLinux()) {
     return linuxGetKey(account);
   }
   return null;
@@ -65,10 +87,10 @@ export function getKey(account: string): string | null {
  */
 export function setKey(account: string, value: string): boolean {
   try {
-    if (isMacOS()) {
+    if (deps.isMacOS()) {
       return macosSetKey(account, value);
     }
-    if (isLinux()) {
+    if (deps.isLinux()) {
       return linuxSetKey(account, value);
     }
     return false;
@@ -84,10 +106,10 @@ export function setKey(account: string, value: string): boolean {
  */
 export function deleteKey(account: string): boolean {
   try {
-    if (isMacOS()) {
+    if (deps.isMacOS()) {
       return macosDeleteKey(account);
     }
-    if (isLinux()) {
+    if (deps.isLinux()) {
       return linuxDeleteKey(account);
     }
     return false;
@@ -103,7 +125,7 @@ export function deleteKey(account: string): boolean {
 
 function macosGetKey(account: string): string | null {
   try {
-    const result = execFileSync('security', [
+    const result = deps.execFileSync('security', [
       'find-generic-password',
       '-s', SERVICE_NAME,
       '-a', account,
@@ -131,7 +153,7 @@ function macosSetKey(account: string, value: string): boolean {
   // it does NOT read from stdin. Using `-w` without a value causes
   // the next flag to be consumed as the password.
   try {
-    execFileSync('security', [
+    deps.execFileSync('security', [
       'add-generic-password',
       '-s', SERVICE_NAME,
       '-a', account,
@@ -149,7 +171,7 @@ function macosSetKey(account: string, value: string): boolean {
 
 function macosDeleteKey(account: string): boolean {
   try {
-    execFileSync('security', [
+    deps.execFileSync('security', [
       'delete-generic-password',
       '-s', SERVICE_NAME,
       '-a', account,
@@ -169,7 +191,7 @@ function macosDeleteKey(account: string): boolean {
 
 function linuxGetKey(account: string): string | null {
   try {
-    const result = execFileSync('secret-tool', [
+    const result = deps.execFileSync('secret-tool', [
       'lookup',
       'service', SERVICE_NAME,
       'account', account,
@@ -197,7 +219,7 @@ function linuxGetKey(account: string): string | null {
 
 function linuxSetKey(account: string, value: string): boolean {
   try {
-    execFileSync('secret-tool', [
+    deps.execFileSync('secret-tool', [
       'store',
       '--label', `${SERVICE_NAME}: ${account}`,
       'service', SERVICE_NAME,
@@ -215,7 +237,7 @@ function linuxSetKey(account: string, value: string): boolean {
 
 function linuxDeleteKey(account: string): boolean {
   try {
-    execFileSync('secret-tool', [
+    deps.execFileSync('secret-tool', [
       'clear',
       'service', SERVICE_NAME,
       'account', account,


### PR DESCRIPTION
## Summary
- Bun's `mock.module` is process-global — mocks from one test file leak into all others in the same run. `secure-keys.test.ts` mocked `keychain.js`, overwriting the real module that `keychain.test.ts` needed to test (19 test failures). In Bun 1.3.9, `secret-scanner-executor.test.ts` mocking `fuzzy-match.js` also leaked into `fuzzy-match.test.ts` (6 failures).
- Added injectable deps pattern (`_overrideDeps`/`_resetDeps`) to `keychain.ts` so both `keychain.test.ts` and `secure-keys.test.ts` can control behavior without `mock.module` conflicts
- Pinned Bun to 1.3.8 in CI to prevent `fuzzy-match.test.ts` failures from Bun 1.3.9 mock behavior changes

## Test plan
- [x] `bun test src/__tests__/keychain.test.ts` — 24 pass in isolation
- [x] `bun test src/__tests__/secure-keys.test.ts` — 19 pass in isolation
- [x] `bun test src/__tests__/keychain.test.ts src/__tests__/secure-keys.test.ts` — 43 pass together (was 19 fail)
- [x] `bun test` full suite — 471 pass, 1 pre-existing fail (audit-log-rotation, same mock.module pattern)
- [x] `bunx tsc --noEmit` — type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
