### PR TITLE
fix: remove fuzzy-match mock leakage in secret-scanner tests

### DIFF
--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -62,21 +62,19 @@ mock.module('../tools/registry.js', () => ({
   },
 }));
 
-mock.module('../tools/filesystem/fuzzy-match.js', () => ({
-  findAllMatches: () => [],
-  adjustIndentation: () => '',
-}));
 mock.module('../tools/filesystem/path-guard.js', () => ({
   validateFilePath: () => ({ ok: false }),
 }));
 mock.module('../tools/terminal/sandbox.js', () => ({
   wrapCommand: () => ({ command: '', sandboxed: false }),
 }));
-// NOTE: trust-store.js is intentionally NOT mocked here.  The executor only
-// calls addRule() in the always_allow / always_deny code paths, which these
-// tests never exercise (the mock checker always returns 'allow').  Mocking
-// trust-store here would leak a stub addRule into trust-store.test.ts via
-// Bun's process-global mock.module, breaking its 22 tests.
+// NOTE: fuzzy-match.js and trust-store.js are intentionally NOT mocked here.
+// fuzzy-match.js is a pure-function module (no side effects) that doesn't
+// need mocking, and mocking it would leak stubs into fuzzy-match.test.ts.
+// trust-store.js is only called in always_allow / always_deny code paths
+// which these tests never exercise (the mock checker always returns 'allow').
+// Mocking either here would break their respective test files via Bun's
+// process-global mock.module.
 
 // Now import the module under test — mocks are already in place
 import { ToolExecutor } from '../tools/executor.js';


### PR DESCRIPTION
## Summary

- Removed the unnecessary `mock.module('../tools/filesystem/fuzzy-match.js', ...)` from `secret-scanner-executor.test.ts`
- `fuzzy-match.ts` is a pure-function module with zero imports — it doesn't need mocking
- Bun's `mock.module` is process-global, so the mock leaked into `fuzzy-match.test.ts` when file ordering differed on CI (Ubuntu), causing 6 test failures

## Test plan

- [x] `bun test src/__tests__/fuzzy-match.test.ts src/__tests__/secret-scanner-executor.test.ts` — 25 pass, 0 fail
- [x] Type check passes (`bunx tsc --noEmit`)
- [ ] CI should pass with all fuzzy-match tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
