### PR TITLE
feat: add OpenAI provider with GPT-5.x support

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -9,6 +9,7 @@
         "commander": "^13.1.0",
         "drizzle-orm": "^0.38.4",
         "minimatch": "^10.1.2",
+        "openai": "^6.18.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.1.3",
         "tree-sitter-bash": "0.25.1",
@@ -325,6 +326,8 @@
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "openai": ["openai@6.18.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -17,6 +17,7 @@
     "commander": "^13.1.0",
     "drizzle-orm": "^0.38.4",
     "minimatch": "^10.1.2",
+    "openai": "^6.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.1.3",
     "tree-sitter-bash": "0.25.1",

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1,0 +1,612 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { Message, ToolDefinition, ProviderEvent, ContentBlock } from '../providers/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock openai module — must be before importing the provider
+// ---------------------------------------------------------------------------
+
+interface FakeChunk {
+  choices: Array<{
+    delta: {
+      content?: string | null;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: 'function';
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason: string | null;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null;
+  model: string;
+}
+
+let fakeChunks: FakeChunk[] = [];
+let lastCreateParams: Record<string, unknown> | null = null;
+let lastCreateOptions: Record<string, unknown> | null = null;
+let shouldThrow: Error | null = null;
+
+// Simulate OpenAI.APIError
+class FakeAPIError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'APIError';
+  }
+}
+
+mock.module('openai', () => ({
+  default: class MockOpenAI {
+    static APIError = FakeAPIError;
+    constructor(_opts: Record<string, unknown>) {}
+    chat = {
+      completions: {
+        create: async (params: Record<string, unknown>, options?: Record<string, unknown>) => {
+          lastCreateParams = params;
+          lastCreateOptions = options ?? null;
+          if (shouldThrow) throw shouldThrow;
+
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              for (const chunk of fakeChunks) {
+                yield chunk;
+              }
+            },
+          };
+        },
+      },
+    };
+  },
+}));
+
+// Import after mocking
+import { OpenAIProvider } from '../providers/openai/client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function textChunk(content: string, finish: string | null = null): FakeChunk {
+  return {
+    choices: [{ delta: { content }, finish_reason: finish }],
+    usage: null,
+    model: 'gpt-5.2',
+  };
+}
+
+function toolCallChunks(calls: Array<{ id: string; name: string; args: string }>): FakeChunk[] {
+  const chunks: FakeChunk[] = [];
+  for (let i = 0; i < calls.length; i++) {
+    // First chunk: id + name
+    chunks.push({
+      choices: [{
+        delta: {
+          tool_calls: [{
+            index: i,
+            id: calls[i].id,
+            type: 'function',
+            function: { name: calls[i].name },
+          }],
+        },
+        finish_reason: null,
+      }],
+      usage: null,
+      model: 'gpt-5.2',
+    });
+    // Second chunk: arguments
+    chunks.push({
+      choices: [{
+        delta: {
+          tool_calls: [{
+            index: i,
+            function: { arguments: calls[i].args },
+          }],
+        },
+        finish_reason: null,
+      }],
+      usage: null,
+      model: 'gpt-5.2',
+    });
+  }
+  return chunks;
+}
+
+function usageChunk(prompt: number, completion: number): FakeChunk {
+  return {
+    choices: [{ delta: {}, finish_reason: 'stop' }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion },
+    model: 'gpt-5.2',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenAIProvider', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    provider = new OpenAIProvider('sk-test-key', 'gpt-5.2');
+    fakeChunks = [];
+    lastCreateParams = null;
+    lastCreateOptions = null;
+    shouldThrow = null;
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic text response
+  // -----------------------------------------------------------------------
+  test('returns text response from streaming chunks', async () => {
+    fakeChunks = [
+      textChunk('Hello'),
+      textChunk(', world!'),
+      usageChunk(10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Hello, world!' });
+    expect(result.model).toBe('gpt-5.2');
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(result.stopReason).toBe('stop');
+  });
+
+  // -----------------------------------------------------------------------
+  // Streaming events
+  // -----------------------------------------------------------------------
+  test('fires text_delta events during streaming', async () => {
+    fakeChunks = [
+      textChunk('Hello'),
+      textChunk(', world!'),
+      usageChunk(10, 5),
+    ];
+
+    const events: ProviderEvent[] = [];
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { onEvent: (e) => events.push(e) },
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'text_delta', text: 'Hello' });
+    expect(events[1]).toEqual({ type: 'text_delta', text: ', world!' });
+  });
+
+  // -----------------------------------------------------------------------
+  // System prompt
+  // -----------------------------------------------------------------------
+  test('places system prompt as first message', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      'You are a helpful assistant.',
+    );
+
+    const messages = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(messages[0]).toEqual({ role: 'system', content: 'You are a helpful assistant.' });
+    expect(messages[1]).toEqual({ role: 'user', content: 'Hi' });
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool definitions
+  // -----------------------------------------------------------------------
+  test('converts tool definitions to OpenAI function format', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    const tools: ToolDefinition[] = [{
+      name: 'file_read',
+      description: 'Read a file',
+      input_schema: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    }];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] }],
+      tools,
+    );
+
+    const sentTools = lastCreateParams!.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(1);
+    expect(sentTools[0]).toEqual({
+      type: 'function',
+      function: {
+        name: 'file_read',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool call response
+  // -----------------------------------------------------------------------
+  test('parses tool calls from streaming chunks', async () => {
+    fakeChunks = [
+      ...toolCallChunks([
+        { id: 'call_abc', name: 'file_read', args: '{"path":"/tmp/test"}' },
+      ]),
+      usageChunk(10, 15),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use',
+      id: 'call_abc',
+      name: 'file_read',
+      input: { path: '/tmp/test' },
+    });
+    expect(result.stopReason).toBe('stop');
+  });
+
+  // -----------------------------------------------------------------------
+  // Mixed text + tool calls
+  // -----------------------------------------------------------------------
+  test('handles text + tool calls in same response', async () => {
+    fakeChunks = [
+      textChunk('I will read that file.'),
+      ...toolCallChunks([
+        { id: 'call_1', name: 'file_read', args: '{"path":"/a"}' },
+      ]),
+      usageChunk(10, 20),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /a' }] }],
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({ type: 'text', text: 'I will read that file.' });
+    expect(result.content[1]).toEqual({
+      type: 'tool_use',
+      id: 'call_1',
+      name: 'file_read',
+      input: { path: '/a' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple tool calls
+  // -----------------------------------------------------------------------
+  test('handles multiple parallel tool calls', async () => {
+    fakeChunks = [
+      ...toolCallChunks([
+        { id: 'call_1', name: 'file_read', args: '{"path":"/a"}' },
+        { id: 'call_2', name: 'file_read', args: '{"path":"/b"}' },
+      ]),
+      usageChunk(10, 30),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /a and /b' }] }],
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use', id: 'call_1', name: 'file_read', input: { path: '/a' },
+    });
+    expect(result.content[1]).toEqual({
+      type: 'tool_use', id: 'call_2', name: 'file_read', input: { path: '/b' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool result messages
+  // -----------------------------------------------------------------------
+  test('converts tool_result blocks to tool-role messages', async () => {
+    fakeChunks = [textChunk('The file contains...'), usageChunk(20, 10)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_abc', name: 'file_read', input: { path: '/tmp/test' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_abc', content: 'file content here', is_error: false },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    // user → assistant → tool → (no extra user since no text blocks)
+    expect(sent).toHaveLength(3);
+    expect(sent[0]).toEqual({ role: 'user', content: 'Read /tmp/test' });
+    expect(sent[1]).toEqual({
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: 'call_abc',
+        type: 'function',
+        function: { name: 'file_read', arguments: '{"path":"/tmp/test"}' },
+      }],
+    });
+    expect(sent[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_abc',
+      content: 'file content here',
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mixed tool_result + text in user message
+  // -----------------------------------------------------------------------
+  test('splits user message with tool_result + text into separate messages', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(20, 5)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'test', input: {} },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'result' },
+          { type: 'text', text: '[System: progress reminder]' },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent).toHaveLength(4);
+    // tool result first, then text as user message
+    expect(sent[2]).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'result' });
+    expect(sent[3]).toEqual({ role: 'user', content: '[System: progress reminder]' });
+  });
+
+  // -----------------------------------------------------------------------
+  // Image content
+  // -----------------------------------------------------------------------
+  test('converts image blocks to image_url parts', async () => {
+    fakeChunks = [textChunk('A cat'), usageChunk(100, 5)];
+
+    const messages: Message[] = [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What is this?' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' },
+        },
+      ],
+    }];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent).toHaveLength(1);
+    const userMsg = sent[0] as { role: string; content: Array<Record<string, unknown>> };
+    expect(userMsg.content).toHaveLength(2);
+    expect(userMsg.content[0]).toEqual({ type: 'text', text: 'What is this?' });
+    expect(userMsg.content[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // max_tokens config
+  // -----------------------------------------------------------------------
+  test('passes max_tokens as max_completion_tokens', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { config: { max_tokens: 32000 } },
+    );
+
+    expect(lastCreateParams!.max_completion_tokens).toBe(32000);
+  });
+
+  // -----------------------------------------------------------------------
+  // Thinking blocks are skipped
+  // -----------------------------------------------------------------------
+  test('skips thinking blocks in user messages', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    const messages: Message[] = [{
+      role: 'user',
+      content: [
+        { type: 'thinking', thinking: 'hmm...', signature: 'sig' } as ContentBlock,
+        { type: 'text', text: 'Hello' },
+      ],
+    }];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ role: 'user', content: 'Hello' });
+  });
+
+  // -----------------------------------------------------------------------
+  // Signal passthrough
+  // -----------------------------------------------------------------------
+  test('passes abort signal to API call', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+    const controller = new AbortController();
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { signal: controller.signal },
+    );
+
+    expect(lastCreateOptions!.signal).toBe(controller.signal);
+  });
+
+  // -----------------------------------------------------------------------
+  // API error handling
+  // -----------------------------------------------------------------------
+  test('wraps API errors in ProviderError', async () => {
+    shouldThrow = new FakeAPIError(429, 'Rate limit exceeded');
+
+    try {
+      await provider.sendMessage(
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      );
+      expect(true).toBe(false); // should not reach
+    } catch (error) {
+      expect((error as Error).message).toContain('OpenAI API error (429)');
+      expect((error as Error).message).toContain('Rate limit exceeded');
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Generic error handling
+  // -----------------------------------------------------------------------
+  test('wraps generic errors in ProviderError', async () => {
+    shouldThrow = new Error('Network failure');
+
+    try {
+      await provider.sendMessage(
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect((error as Error).message).toContain('OpenAI request failed');
+      expect((error as Error).message).toContain('Network failure');
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Malformed tool call JSON
+  // -----------------------------------------------------------------------
+  test('handles malformed tool call arguments gracefully', async () => {
+    fakeChunks = [
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: 'call_bad',
+              type: 'function' as const,
+              function: { name: 'test', arguments: 'not valid json{' },
+            }],
+          },
+          finish_reason: null,
+        }],
+        usage: null,
+        model: 'gpt-5.2',
+      },
+      usageChunk(10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use',
+      id: 'call_bad',
+      name: 'test',
+      input: { _raw: 'not valid json{' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // stream_options and model
+  // -----------------------------------------------------------------------
+  test('sends stream_options and correct model', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    expect(lastCreateParams!.stream).toBe(true);
+    expect(lastCreateParams!.stream_options).toEqual({ include_usage: true });
+    expect(lastCreateParams!.model).toBe('gpt-5.2');
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty content response
+  // -----------------------------------------------------------------------
+  test('handles response with no text content', async () => {
+    fakeChunks = [
+      ...toolCallChunks([{ id: 'call_1', name: 'test', args: '{}' }]),
+      usageChunk(10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+    );
+
+    // Only tool_use, no text block
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('tool_use');
+  });
+
+  // -----------------------------------------------------------------------
+  // Assistant message with text preserves content
+  // -----------------------------------------------------------------------
+  test('preserves assistant text + tool_use in message conversion', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me check.' },
+          { type: 'tool_use', id: 'call_1', name: 'test', input: { x: 1 } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'done' },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: 'assistant',
+      content: 'Let me check.',
+      tool_calls: [{
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'test', arguments: '{"x":1}' },
+      }],
+    });
+  });
+});

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -1,0 +1,250 @@
+import OpenAI from 'openai';
+import type {
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  Message,
+  ToolDefinition,
+  ContentBlock,
+} from '../types.js';
+import { ProviderError } from '../../util/errors.js';
+
+export class OpenAIProvider implements Provider {
+  public readonly name = 'openai';
+  private client: OpenAI;
+  private model: string;
+
+  constructor(apiKey: string, model: string) {
+    this.client = new OpenAI({ apiKey });
+    this.model = model;
+  }
+
+  async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const { config, onEvent, signal } = options ?? {};
+    const maxTokens = (config as Record<string, unknown> | undefined)?.max_tokens as number | undefined;
+
+    try {
+      const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
+
+      const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
+        model: this.model,
+        messages: openaiMessages,
+        stream: true as const,
+        stream_options: { include_usage: true },
+      };
+
+      if (maxTokens) {
+        params.max_completion_tokens = maxTokens;
+      }
+
+      if (tools && tools.length > 0) {
+        params.tools = tools.map((t) => ({
+          type: 'function' as const,
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.input_schema as OpenAI.FunctionParameters,
+          },
+        }));
+      }
+
+      const stream = await this.client.chat.completions.create(params, { signal });
+
+      // Accumulate the response from chunks
+      let contentText = '';
+      const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
+      let finishReason = 'unknown';
+      let responseModel = this.model;
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      for await (const chunk of stream) {
+        const choice = chunk.choices[0];
+        if (choice) {
+          if (choice.delta.content) {
+            contentText += choice.delta.content;
+            onEvent?.({ type: 'text_delta', text: choice.delta.content });
+          }
+
+          if (choice.delta.tool_calls) {
+            for (const tc of choice.delta.tool_calls) {
+              if (!toolCallMap.has(tc.index)) {
+                toolCallMap.set(tc.index, { id: '', name: '', args: '' });
+              }
+              const entry = toolCallMap.get(tc.index)!;
+              if (tc.id) entry.id = tc.id;
+              if (tc.function?.name) entry.name += tc.function.name;
+              if (tc.function?.arguments) entry.args += tc.function.arguments;
+            }
+          }
+
+          if (choice.finish_reason) {
+            finishReason = choice.finish_reason;
+          }
+        }
+
+        if (chunk.usage) {
+          promptTokens = chunk.usage.prompt_tokens;
+          completionTokens = chunk.usage.completion_tokens;
+        }
+
+        responseModel = chunk.model;
+      }
+
+      // Build content blocks
+      const content: ContentBlock[] = [];
+      if (contentText) {
+        content.push({ type: 'text', text: contentText });
+      }
+      for (const [, tc] of toolCallMap) {
+        let input: Record<string, unknown>;
+        try {
+          input = JSON.parse(tc.args);
+        } catch {
+          input = { _raw: tc.args };
+        }
+        content.push({
+          type: 'tool_use',
+          id: tc.id,
+          name: tc.name,
+          input,
+        });
+      }
+
+      return {
+        content,
+        model: responseModel,
+        usage: { inputTokens: promptTokens, outputTokens: completionTokens },
+        stopReason: finishReason,
+      };
+    } catch (error) {
+      if (error instanceof OpenAI.APIError) {
+        throw new ProviderError(
+          `OpenAI API error (${error.status}): ${error.message}`,
+          'openai',
+          error.status,
+        );
+      }
+      throw new ProviderError(
+        `OpenAI request failed: ${error instanceof Error ? error.message : String(error)}`,
+        'openai',
+        undefined,
+        { cause: error },
+      );
+    }
+  }
+
+  /** Convert neutral messages + system prompt to OpenAI message format. */
+  private toOpenAIMessages(
+    messages: Message[],
+    systemPrompt?: string,
+  ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+    const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+
+    if (systemPrompt) {
+      result.push({ role: 'system', content: systemPrompt });
+    }
+
+    for (const msg of messages) {
+      if (msg.role === 'assistant') {
+        result.push(this.toOpenAIAssistantMessage(msg));
+      } else {
+        // User messages may contain tool_result blocks mixed with text/image
+        const toolResults = msg.content.filter(
+          (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+        );
+        const otherBlocks = msg.content.filter(
+          (b) => b.type !== 'tool_result' && b.type !== 'thinking' && b.type !== 'redacted_thinking',
+        );
+
+        // Emit tool results as separate tool-role messages
+        for (const tr of toolResults) {
+          result.push({
+            role: 'tool',
+            tool_call_id: tr.tool_use_id,
+            content: tr.content,
+          });
+        }
+
+        // Emit remaining content as a user message (if any)
+        if (otherBlocks.length > 0) {
+          result.push(this.toOpenAIUserMessage(otherBlocks));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /** Convert an assistant message with text + tool_use blocks to OpenAI format. */
+  private toOpenAIAssistantMessage(
+    msg: Message,
+  ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
+    const textParts: string[] = [];
+    const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] = [];
+
+    for (const block of msg.content) {
+      switch (block.type) {
+        case 'text':
+          textParts.push(block.text);
+          break;
+        case 'tool_use':
+          toolCalls.push({
+            id: block.id,
+            type: 'function',
+            function: {
+              name: block.name,
+              arguments: JSON.stringify(block.input),
+            },
+          });
+          break;
+        // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
+      }
+    }
+
+    const result: OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam = {
+      role: 'assistant',
+      content: textParts.length > 0 ? textParts.join('') : null,
+    };
+
+    if (toolCalls.length > 0) {
+      result.tool_calls = toolCalls;
+    }
+
+    return result;
+  }
+
+  /** Convert user content blocks (text, image) to an OpenAI user message. */
+  private toOpenAIUserMessage(
+    blocks: ContentBlock[],
+  ): OpenAI.Chat.Completions.ChatCompletionUserMessageParam {
+    // If only a single text block, use plain string (simpler, fewer tokens)
+    if (blocks.length === 1 && blocks[0].type === 'text') {
+      return { role: 'user', content: blocks[0].text };
+    }
+
+    const parts: OpenAI.Chat.Completions.ChatCompletionContentPart[] = [];
+    for (const block of blocks) {
+      switch (block.type) {
+        case 'text':
+          parts.push({ type: 'text', text: block.text });
+          break;
+        case 'image':
+          parts.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${block.source.media_type};base64,${block.source.data}`,
+            },
+          });
+          break;
+      }
+    }
+
+    return { role: 'user', content: parts };
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,7 +1,13 @@
 import type { Provider } from "./types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
+import { OpenAIProvider } from "./openai/client.js";
 import { RetryProvider } from "./retry.js";
 import { ConfigError } from "../util/errors.js";
+
+const DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-5-20250929',
+  openai: 'gpt-5.2',
+};
 
 const providers = new Map<string, Provider>();
 
@@ -31,9 +37,15 @@ export interface ProvidersConfig {
 
 export function initializeProviders(config: ProvidersConfig): void {
   if (config.apiKeys.anthropic) {
-    const provider: Provider = new RetryProvider(
-      new AnthropicProvider(config.apiKeys.anthropic, config.model),
-    );
-    registerProvider("anthropic", provider);
+    const model = config.provider === 'anthropic' ? config.model : DEFAULT_MODELS.anthropic;
+    registerProvider('anthropic', new RetryProvider(
+      new AnthropicProvider(config.apiKeys.anthropic, model),
+    ));
+  }
+  if (config.apiKeys.openai) {
+    const model = config.provider === 'openai' ? config.model : DEFAULT_MODELS.openai;
+    registerProvider('openai', new RetryProvider(
+      new OpenAIProvider(config.apiKeys.openai, model),
+    ));
   }
 }


### PR DESCRIPTION
## Summary

- Adds `OpenAIProvider` implementing the `Provider` interface for OpenAI's chat completions API
- Streaming response handling via async iteration over chunks with incremental tool call argument accumulation
- Full bidirectional message format conversion: neutral ContentBlock types ↔ OpenAI message format (system prompt as system-role message, tool_result blocks as tool-role messages, image blocks as data URI image_url parts, thinking blocks filtered out)
- Updates provider registry to initialize OpenAI providers when an API key is configured
- 19 tests covering: text responses, streaming events, tool definitions, tool calls (single/parallel), tool results, mixed content, image handling, abort signal passthrough, error wrapping, malformed JSON fallback

## Test plan

- [x] `bun test src/__tests__/openai-provider.test.ts` — 19 pass, 0 fail
- [x] Full suite: 490 pass, 1 pre-existing fail (audit-log-rotation, unrelated)
- [x] Type check passes (`bunx tsc --noEmit`)
- [ ] CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
