### PR TITLE
feat: add Gemini provider with streaming and tool support

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -6,6 +6,7 @@
       "name": "vellum-assistant",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@google/genai": "^1.40.0",
         "commander": "^13.1.0",
         "drizzle-orm": "^0.38.4",
         "minimatch": "^10.1.2",
@@ -95,6 +96,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.0", "", { "dependencies": { "@eslint/core": "^1.1.0", "levn": "^0.4.1" } }, "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ=="],
 
+    "@google/genai": ["@google/genai@1.40.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-fhIww8smT0QYRX78qWOiz/nIQhHMF5wXOrlXvj33HBrz3vKDBb+wibLcEmTA+L9dmPD4KmfNr7UF3LDQVTXNjA=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -107,9 +110,33 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@petamoriken/float16": ["@petamoriken/float16@3.9.3", "", {}, "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
@@ -151,9 +178,15 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -161,13 +194,23 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -176,6 +219,8 @@
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
@@ -190,6 +235,12 @@
     "drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -227,6 +278,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -239,6 +292,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
@@ -247,13 +302,21 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "gel": ["gel@2.2.0", "", { "dependencies": { "@petamoriken/float16": "^3.8.7", "debug": "^4.3.4", "env-paths": "^3.0.0", "semver": "^7.6.2", "shell-quote": "^1.8.1", "which": "^4.0.0" }, "bin": { "gel": "dist/cli.mjs" } }, "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ=="],
 
@@ -263,9 +326,17 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -275,6 +346,8 @@
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -283,11 +356,17 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "isexe": ["isexe@3.1.3", "", {}, "sha512-+DAwQUtT9h86RsYHuBuSf583mEx34Z8ZTf8BXVrDDvHkUN/0e9c+UX3SHUUxSsZ3ZDfKY6sK7VdCJ96269O5+A=="],
 
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -295,11 +374,19 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -310,6 +397,8 @@
     "minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -335,9 +424,13 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
@@ -353,6 +446,8 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -362,6 +457,10 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -375,6 +474,8 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -382,6 +483,14 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -419,7 +528,13 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -435,7 +550,25 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -482,5 +615,11 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@google/genai": "^1.40.0",
     "commander": "^13.1.0",
     "drizzle-orm": "^0.38.4",
     "minimatch": "^10.1.2",

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -1,0 +1,599 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { Message, ToolDefinition, ProviderEvent, ContentBlock } from '../providers/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock @google/genai module — must be before importing the provider
+// ---------------------------------------------------------------------------
+
+interface FakeChunk {
+  text?: string;
+  functionCalls?: Array<{
+    id?: string;
+    name?: string;
+    args?: Record<string, unknown>;
+  }>;
+  candidates?: Array<{
+    finishReason?: string;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+  };
+  modelVersion?: string;
+}
+
+let fakeChunks: FakeChunk[] = [];
+let lastStreamParams: Record<string, unknown> | null = null;
+let shouldThrow: Error | null = null;
+
+class FakeApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'ApiError';
+  }
+}
+
+mock.module('@google/genai', () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    constructor(_opts: Record<string, unknown>) {}
+    models = {
+      generateContentStream: async (params: Record<string, unknown>) => {
+        lastStreamParams = params;
+        if (shouldThrow) throw shouldThrow;
+
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            for (const chunk of fakeChunks) {
+              yield chunk;
+            }
+          },
+        };
+      },
+    };
+  },
+  ApiError: FakeApiError,
+}));
+
+// Import after mocking
+import { GeminiProvider } from '../providers/gemini/client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function textChunk(text: string): FakeChunk {
+  return { text };
+}
+
+function finishChunk(reason: string, prompt: number, output: number): FakeChunk {
+  return {
+    candidates: [{ finishReason: reason }],
+    usageMetadata: { promptTokenCount: prompt, candidatesTokenCount: output },
+    modelVersion: 'gemini-3-flash-001',
+  };
+}
+
+function functionCallChunk(
+  calls: Array<{ id?: string; name: string; args: Record<string, unknown> }>,
+): FakeChunk {
+  return {
+    functionCalls: calls.map((c) => ({
+      id: c.id,
+      name: c.name,
+      args: c.args,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GeminiProvider', () => {
+  let provider: GeminiProvider;
+
+  beforeEach(() => {
+    provider = new GeminiProvider('test-api-key', 'gemini-3-flash');
+    fakeChunks = [];
+    lastStreamParams = null;
+    shouldThrow = null;
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic text response
+  // -----------------------------------------------------------------------
+  test('returns text response from streaming chunks', async () => {
+    fakeChunks = [
+      textChunk('Hello'),
+      textChunk(', world!'),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Hello, world!' });
+    expect(result.model).toBe('gemini-3-flash-001');
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(result.stopReason).toBe('STOP');
+  });
+
+  // -----------------------------------------------------------------------
+  // Streaming events
+  // -----------------------------------------------------------------------
+  test('fires text_delta events during streaming', async () => {
+    fakeChunks = [
+      textChunk('Hello'),
+      textChunk(', world!'),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const events: ProviderEvent[] = [];
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { onEvent: (e) => events.push(e) },
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'text_delta', text: 'Hello' });
+    expect(events[1]).toEqual({ type: 'text_delta', text: ', world!' });
+  });
+
+  // -----------------------------------------------------------------------
+  // System prompt
+  // -----------------------------------------------------------------------
+  test('passes system prompt in config.systemInstruction', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      'You are a helpful assistant.',
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.systemInstruction).toBe('You are a helpful assistant.');
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool definitions
+  // -----------------------------------------------------------------------
+  test('converts tool definitions to Gemini functionDeclarations', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    const tools: ToolDefinition[] = [{
+      name: 'file_read',
+      description: 'Read a file',
+      input_schema: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    }];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] }],
+      tools,
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    const sentTools = config.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toHaveLength(1);
+    const decls = (sentTools[0] as { functionDeclarations: unknown[] }).functionDeclarations;
+    expect(decls).toHaveLength(1);
+    expect(decls[0]).toEqual({
+      name: 'file_read',
+      description: 'Read a file',
+      parametersJsonSchema: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Function call response
+  // -----------------------------------------------------------------------
+  test('parses function calls from streaming chunks', async () => {
+    fakeChunks = [
+      functionCallChunk([
+        { id: 'call_abc', name: 'file_read', args: { path: '/tmp/test' } },
+      ]),
+      finishChunk('STOP', 10, 15),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use',
+      id: 'call_abc',
+      name: 'file_read',
+      input: { path: '/tmp/test' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Function call without id — fallback to call_N
+  // -----------------------------------------------------------------------
+  test('generates fallback id when function call has no id', async () => {
+    fakeChunks = [
+      functionCallChunk([
+        { name: 'test', args: { x: 1 } },
+      ]),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use',
+      id: 'call_0',
+      name: 'test',
+      input: { x: 1 },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple function calls
+  // -----------------------------------------------------------------------
+  test('handles multiple function calls', async () => {
+    fakeChunks = [
+      functionCallChunk([
+        { id: 'call_1', name: 'file_read', args: { path: '/a' } },
+        { id: 'call_2', name: 'file_read', args: { path: '/b' } },
+      ]),
+      finishChunk('STOP', 10, 30),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /a and /b' }] }],
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: 'tool_use', id: 'call_1', name: 'file_read', input: { path: '/a' },
+    });
+    expect(result.content[1]).toEqual({
+      type: 'tool_use', id: 'call_2', name: 'file_read', input: { path: '/b' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mixed text + function calls
+  // -----------------------------------------------------------------------
+  test('handles text + function calls in same response', async () => {
+    fakeChunks = [
+      textChunk('I will read that file.'),
+      functionCallChunk([
+        { id: 'call_1', name: 'file_read', args: { path: '/a' } },
+      ]),
+      finishChunk('STOP', 10, 20),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Read /a' }] }],
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({ type: 'text', text: 'I will read that file.' });
+    expect(result.content[1]).toEqual({
+      type: 'tool_use', id: 'call_1', name: 'file_read', input: { path: '/a' },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Message conversion — role mapping
+  // -----------------------------------------------------------------------
+  test('maps assistant role to model and user role to user', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 20, 5)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] },
+      { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    expect(contents).toHaveLength(3);
+    expect(contents[0].role).toBe('user');
+    expect(contents[1].role).toBe('model');
+    expect(contents[2].role).toBe('user');
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool result conversion — functionResponse with name lookup
+  // -----------------------------------------------------------------------
+  test('converts tool_result blocks to functionResponse with name lookup', async () => {
+    fakeChunks = [textChunk('The file contains...'), finishChunk('STOP', 20, 10)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_abc', name: 'file_read', input: { path: '/tmp/test' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_abc', content: 'file content here', is_error: false },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    // assistant → model with functionCall, user → user with functionResponse
+    expect(contents).toHaveLength(3);
+    expect(contents[1].role).toBe('model');
+    expect(contents[1].parts[0]).toEqual({
+      functionCall: {
+        id: 'call_abc',
+        name: 'file_read',
+        args: { path: '/tmp/test' },
+      },
+    });
+    expect(contents[2].role).toBe('user');
+    expect(contents[2].parts[0]).toEqual({
+      functionResponse: {
+        id: 'call_abc',
+        name: 'file_read',
+        response: { output: 'file content here' },
+      },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool result with unknown tool_use_id — falls back to id as name
+  // -----------------------------------------------------------------------
+  test('falls back to tool_use_id as name when tool_use not found', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'unknown_id', content: 'some result' },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    expect(contents[0].parts[0]).toEqual({
+      functionResponse: {
+        id: 'unknown_id',
+        name: 'unknown_id',
+        response: { output: 'some result' },
+      },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Image content
+  // -----------------------------------------------------------------------
+  test('converts image blocks to inlineData parts', async () => {
+    fakeChunks = [textChunk('A cat'), finishChunk('STOP', 100, 5)];
+
+    const messages: Message[] = [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What is this?' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' },
+        },
+      ],
+    }];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    expect(contents).toHaveLength(1);
+    expect(contents[0].parts).toHaveLength(2);
+    expect(contents[0].parts[0]).toEqual({ text: 'What is this?' });
+    expect(contents[0].parts[1]).toEqual({
+      inlineData: {
+        mimeType: 'image/png',
+        data: 'iVBORw0KGgo=',
+      },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // max_tokens config
+  // -----------------------------------------------------------------------
+  test('passes max_tokens as maxOutputTokens', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { config: { max_tokens: 32000 } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.maxOutputTokens).toBe(32000);
+  });
+
+  // -----------------------------------------------------------------------
+  // Abort signal
+  // -----------------------------------------------------------------------
+  test('passes abort signal in config', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+    const controller = new AbortController();
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      undefined,
+      undefined,
+      { signal: controller.signal },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.abortSignal).toBe(controller.signal);
+  });
+
+  // -----------------------------------------------------------------------
+  // Thinking blocks are skipped
+  // -----------------------------------------------------------------------
+  test('skips thinking blocks in message conversion', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    const messages: Message[] = [{
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'hmm...', signature: 'sig' } as ContentBlock,
+        { type: 'text', text: 'Hello' },
+      ],
+    }];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    expect(contents).toHaveLength(1);
+    // Only the text part, no thinking part
+    expect(contents[0].parts).toHaveLength(1);
+    expect(contents[0].parts[0]).toEqual({ text: 'Hello' });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty parts are filtered (message with only thinking blocks)
+  // -----------------------------------------------------------------------
+  test('filters out messages that produce no parts', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'hmm...', signature: 'sig' } as ContentBlock,
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    // The assistant message with only thinking should be filtered out
+    expect(contents).toHaveLength(1);
+    expect(contents[0].role).toBe('user');
+  });
+
+  // -----------------------------------------------------------------------
+  // API error handling
+  // -----------------------------------------------------------------------
+  test('wraps ApiError in ProviderError', async () => {
+    shouldThrow = new FakeApiError(429, 'Rate limit exceeded');
+
+    try {
+      await provider.sendMessage(
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      );
+      expect(true).toBe(false); // should not reach
+    } catch (error) {
+      expect((error as Error).message).toContain('Gemini API error (429)');
+      expect((error as Error).message).toContain('Rate limit exceeded');
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Generic error handling
+  // -----------------------------------------------------------------------
+  test('wraps generic errors in ProviderError', async () => {
+    shouldThrow = new Error('Network failure');
+
+    try {
+      await provider.sendMessage(
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect((error as Error).message).toContain('Gemini request failed');
+      expect((error as Error).message).toContain('Network failure');
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Model and contents passed correctly
+  // -----------------------------------------------------------------------
+  test('sends correct model and contents to API', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    expect(lastStreamParams!.model).toBe('gemini-3-flash');
+    const contents = lastStreamParams!.contents as Array<{ role: string; parts: unknown[] }>;
+    expect(contents).toHaveLength(1);
+    expect(contents[0]).toEqual({
+      role: 'user',
+      parts: [{ text: 'Hi' }],
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty content response (only function calls)
+  // -----------------------------------------------------------------------
+  test('handles response with no text content', async () => {
+    fakeChunks = [
+      functionCallChunk([{ id: 'call_1', name: 'test', args: {} }]),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('tool_use');
+  });
+
+  // -----------------------------------------------------------------------
+  // No tools → no tools in config
+  // -----------------------------------------------------------------------
+  test('does not include tools in config when none provided', async () => {
+    fakeChunks = [textChunk('OK'), finishChunk('STOP', 10, 2)];
+
+    await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.tools).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Default usage when no metadata
+  // -----------------------------------------------------------------------
+  test('returns zero usage when no usageMetadata in chunks', async () => {
+    fakeChunks = [{ text: 'Hello' }]; // No usage metadata
+
+    const result = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    );
+
+    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+});

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,0 +1,214 @@
+import { GoogleGenAI, ApiError } from '@google/genai';
+import type * as genai from '@google/genai';
+import type {
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  Message,
+  ToolDefinition,
+  ContentBlock,
+} from '../types.js';
+import { ProviderError } from '../../util/errors.js';
+
+export class GeminiProvider implements Provider {
+  public readonly name = 'gemini';
+  private client: GoogleGenAI;
+  private model: string;
+
+  constructor(apiKey: string, model: string) {
+    this.client = new GoogleGenAI({ apiKey });
+    this.model = model;
+  }
+
+  async sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const { config, onEvent, signal } = options ?? {};
+    const maxTokens = (config as Record<string, unknown> | undefined)?.max_tokens as number | undefined;
+
+    try {
+      const geminiContents = this.toGeminiContents(messages);
+
+      const geminiConfig: genai.GenerateContentConfig = {};
+
+      if (systemPrompt) {
+        geminiConfig.systemInstruction = systemPrompt;
+      }
+      if (maxTokens) {
+        geminiConfig.maxOutputTokens = maxTokens;
+      }
+      if (signal) {
+        geminiConfig.abortSignal = signal;
+      }
+
+      if (tools && tools.length > 0) {
+        geminiConfig.tools = [{
+          functionDeclarations: tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            parametersJsonSchema: t.input_schema,
+          })),
+        }];
+      }
+
+      const stream = await this.client.models.generateContentStream({
+        model: this.model,
+        contents: geminiContents,
+        config: geminiConfig,
+      });
+
+      // Accumulate from streaming chunks
+      let fullText = '';
+      const functionCalls: Array<{ id: string; name: string; args: Record<string, unknown> }> = [];
+      let finishReason = 'unknown';
+      let promptTokens = 0;
+      let outputTokens = 0;
+      let responseModel = this.model;
+
+      for await (const chunk of stream) {
+        // Extract text delta
+        const chunkText = chunk.text;
+        if (chunkText) {
+          fullText += chunkText;
+          onEvent?.({ type: 'text_delta', text: chunkText });
+        }
+
+        // Extract function calls
+        const calls = chunk.functionCalls;
+        if (calls) {
+          for (const fc of calls) {
+            functionCalls.push({
+              id: fc.id ?? `call_${functionCalls.length}`,
+              name: fc.name ?? '',
+              args: fc.args ?? {},
+            });
+          }
+        }
+
+        // Extract metadata from chunks
+        const candidate = chunk.candidates?.[0];
+        if (candidate?.finishReason) {
+          finishReason = candidate.finishReason;
+        }
+
+        if (chunk.usageMetadata) {
+          promptTokens = chunk.usageMetadata.promptTokenCount ?? 0;
+          outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+        }
+
+        if (chunk.modelVersion) {
+          responseModel = chunk.modelVersion;
+        }
+      }
+
+      // Build content blocks
+      const content: ContentBlock[] = [];
+      if (fullText) {
+        content.push({ type: 'text', text: fullText });
+      }
+      for (const fc of functionCalls) {
+        content.push({
+          type: 'tool_use',
+          id: fc.id,
+          name: fc.name,
+          input: fc.args,
+        });
+      }
+
+      return {
+        content,
+        model: responseModel,
+        usage: { inputTokens: promptTokens, outputTokens },
+        stopReason: finishReason,
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw new ProviderError(
+          `Gemini API error (${error.status}): ${error.message}`,
+          'gemini',
+          error.status,
+        );
+      }
+      throw new ProviderError(
+        `Gemini request failed: ${error instanceof Error ? error.message : String(error)}`,
+        'gemini',
+        undefined,
+        { cause: error },
+      );
+    }
+  }
+
+  /** Convert neutral messages to Gemini Content[] format. */
+  private toGeminiContents(messages: Message[]): genai.Content[] {
+    const result: genai.Content[] = [];
+
+    // Build a map from tool_use id → function name so tool_result blocks
+    // can provide the required `name` field on Gemini's FunctionResponse.
+    const toolCallNames = new Map<string, string>();
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type === 'tool_use') {
+          toolCallNames.set(block.id, block.name);
+        }
+      }
+    }
+
+    for (const msg of messages) {
+      const role = msg.role === 'assistant' ? 'model' : 'user';
+      const parts = this.toGeminiParts(msg.content, toolCallNames);
+      if (parts.length > 0) {
+        result.push({ role, parts });
+      }
+    }
+
+    return result;
+  }
+
+  /** Convert ContentBlock[] to Gemini Part[]. */
+  private toGeminiParts(
+    blocks: ContentBlock[],
+    toolCallNames: Map<string, string>,
+  ): genai.Part[] {
+    const parts: genai.Part[] = [];
+
+    for (const block of blocks) {
+      switch (block.type) {
+        case 'text':
+          parts.push({ text: block.text });
+          break;
+        case 'image':
+          parts.push({
+            inlineData: {
+              mimeType: block.source.media_type,
+              data: block.source.data,
+            },
+          });
+          break;
+        case 'tool_use':
+          parts.push({
+            functionCall: {
+              id: block.id,
+              name: block.name,
+              args: block.input,
+            },
+          });
+          break;
+        case 'tool_result':
+          parts.push({
+            functionResponse: {
+              id: block.tool_use_id,
+              name: toolCallNames.get(block.tool_use_id) ?? block.tool_use_id,
+              response: { output: block.content },
+            },
+          });
+          break;
+        // thinking, redacted_thinking — not applicable for Gemini
+      }
+    }
+
+    return parts;
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,12 +1,14 @@
 import type { Provider } from "./types.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { OpenAIProvider } from "./openai/client.js";
+import { GeminiProvider } from "./gemini/client.js";
 import { RetryProvider } from "./retry.js";
 import { ConfigError } from "../util/errors.js";
 
 const DEFAULT_MODELS: Record<string, string> = {
   anthropic: 'claude-sonnet-4-5-20250929',
   openai: 'gpt-5.2',
+  gemini: 'gemini-3-flash',
 };
 
 const providers = new Map<string, Provider>();
@@ -46,6 +48,12 @@ export function initializeProviders(config: ProvidersConfig): void {
     const model = config.provider === 'openai' ? config.model : DEFAULT_MODELS.openai;
     registerProvider('openai', new RetryProvider(
       new OpenAIProvider(config.apiKeys.openai, model),
+    ));
+  }
+  if (config.apiKeys.gemini) {
+    const model = config.provider === 'gemini' ? config.model : DEFAULT_MODELS.gemini;
+    registerProvider('gemini', new RetryProvider(
+      new GeminiProvider(config.apiKeys.gemini, model),
     ));
   }
 }


### PR DESCRIPTION
## Summary
- Added a complete Gemini provider implementation (`GeminiProvider`) using the `@google/genai` v1.40.0 SDK
- Implements the existing `Provider` interface with streaming responses via `generateContentStream`, function calling, image support, and full bidirectional message format conversion
- Registered in provider registry with `gemini-3-flash` as the default model
- 22 passing tests covering text responses, streaming events, system prompt, tool definitions, function calls (with/without IDs, multiple), tool results with name lookup, images, max_tokens, abort signal, thinking block filtering, error handling, and edge cases

## Test plan
- [x] All 22 Gemini provider tests pass
- [x] Full test suite passes (512 pass, 1 pre-existing failure in audit-log-rotation)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
