### PR TITLE
fix: clamp thinking budget_tokens to max_tokens - 1

### DIFF
--- a/assistant/src/__tests__/agent-loop-thinking.test.ts
+++ b/assistant/src/__tests__/agent-loop-thinking.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'bun:test';
+import { AgentLoop } from '../agent/loop.js';
+import type { Provider, Message, ProviderResponse, SendMessageOptions, ToolDefinition } from '../providers/types.js';
+
+/** Minimal mock provider that captures the config passed to sendMessage. */
+function createMockProvider(): { provider: Provider; lastConfig: () => Record<string, unknown> | undefined } {
+  let capturedConfig: Record<string, unknown> | undefined;
+
+  const provider: Provider = {
+    name: 'mock',
+    async sendMessage(
+      _messages: Message[],
+      _tools?: ToolDefinition[],
+      _systemPrompt?: string,
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      capturedConfig = options?.config as Record<string, unknown> | undefined;
+      return {
+        content: [{ type: 'text', text: 'Hello' }],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+
+  return { provider, lastConfig: () => capturedConfig };
+}
+
+describe('AgentLoop thinking budget clamping', () => {
+  test('clamps budget_tokens when it exceeds max_tokens', async () => {
+    const { provider, lastConfig } = createMockProvider();
+    const loop = new AgentLoop(provider, 'test', {
+      maxTokens: 4096,
+      thinking: { enabled: true, budgetTokens: 10000 },
+    });
+
+    await loop.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      () => {},
+    );
+
+    const config = lastConfig()!;
+    const thinking = config.thinking as { type: string; budget_tokens: number };
+    expect(thinking.type).toBe('enabled');
+    expect(thinking.budget_tokens).toBe(4095); // clamped to maxTokens - 1
+  });
+
+  test('does not clamp when budget_tokens is within max_tokens', async () => {
+    const { provider, lastConfig } = createMockProvider();
+    const loop = new AgentLoop(provider, 'test', {
+      maxTokens: 64000,
+      thinking: { enabled: true, budgetTokens: 10000 },
+    });
+
+    await loop.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      () => {},
+    );
+
+    const config = lastConfig()!;
+    const thinking = config.thinking as { type: string; budget_tokens: number };
+    expect(thinking.budget_tokens).toBe(10000); // unchanged
+  });
+
+  test('does not include thinking config when thinking is disabled', async () => {
+    const { provider, lastConfig } = createMockProvider();
+    const loop = new AgentLoop(provider, 'test', {
+      maxTokens: 64000,
+      thinking: { enabled: false, budgetTokens: 10000 },
+    });
+
+    await loop.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      () => {},
+    );
+
+    const config = lastConfig()!;
+    expect(config.thinking).toBeUndefined();
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -60,9 +60,14 @@ export class AgentLoop {
       try {
         const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
         if (this.config.thinking?.enabled) {
+          // Anthropic requires budget_tokens < max_tokens
+          const budgetTokens = Math.min(
+            this.config.thinking.budgetTokens,
+            this.config.maxTokens - 1,
+          );
           providerConfig.thinking = {
             type: 'enabled',
-            budget_tokens: this.config.thinking.budgetTokens,
+            budget_tokens: budgetTokens,
           };
         }
 


### PR DESCRIPTION
## Summary
- Clamps `budget_tokens` to `Math.min(configured, maxTokens - 1)` in the agent loop before sending to the provider
- Anthropic requires `budget_tokens < max_tokens`; without this clamp, a user with a small `maxTokens` but a larger `thinking.budgetTokens` would get every request rejected
- Addresses feedback from PR #308

## Test plan
- [x] New test: budget_tokens clamped when it exceeds max_tokens (4096 max → 4095 budget)
- [x] New test: budget_tokens unchanged when within max_tokens (64000 max, 10000 budget → 10000)
- [x] New test: thinking config not included when thinking is disabled
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
