### PR TITLE
Fix regex pattern for RSA private key detection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,7 +27,7 @@ declare -a PATTERNS=(
     "aws[_-]?secret[_-]?access[_-]?key"
 
     # Private Keys
-    "-----BEGIN (RSA|DSA )?PRIVATE KEY-----"
+    "-----BEGIN (RSA |DSA )?PRIVATE KEY-----"
     "-----BEGIN PRIVATE KEY-----"
     "private[_-]?key['\"]?[[:space:]]*[:=]"
 


### PR DESCRIPTION
Move the space outside the RSA|DSA alternation so that RSA keys are correctly matched. Previously, the pattern matched "-----BEGIN RSAPRIVATE KEY-----" (no space) which never matches real RSA key headers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
