### PR TITLE
make credit card component readable

### DIFF
--- a/web/src/components/CreditCardModal/CreditCardModal.tsx
+++ b/web/src/components/CreditCardModal/CreditCardModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@stripe/react-stripe-js";
 import { loadStripe, Stripe as StripeJs } from "@stripe/stripe-js";
 import { CreditCard, Loader2, X } from "lucide-react";
-import { MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface CreditCardModalProps {
   username: string;
@@ -40,6 +40,29 @@ function CardForm({ username, onSuccess, onClose }: CardFormProps) {
   const elements = useElements();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [foreground, setForeground] = useState("");
+
+  useEffect(() => {
+    const readForeground = () =>
+      getComputedStyle(document.documentElement).getPropertyValue("--foreground").trim();
+    setForeground(readForeground());
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => setForeground(readForeground());
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const cardStyle = useMemo(
+    () => ({
+      base: {
+        fontSize: "16px",
+        color: foreground,
+        "::placeholder": { color: foreground, opacity: "0.5" },
+      },
+    }),
+    [foreground]
+  );
 
   const handleSubmit = useCallback(async () => {
     if (!stripe || !elements) {
@@ -89,13 +112,7 @@ function CardForm({ username, onSuccess, onClose }: CardFormProps) {
       <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
         <CardElement
           options={{
-            style: {
-              base: {
-                fontSize: "16px",
-                color: "#18181b",
-                "::placeholder": { color: "#a1a1aa" },
-              },
-            },
+            style: cardStyle,
           }}
         />
       </div>


### PR DESCRIPTION
Previously had black text on dark background. Hoping we can have a sane design system in this repo

<img width="434" height="202" alt="Screenshot 2026-02-09 at 1 56 04 PM" src="https://github.com/user-attachments/assets/943747a5-d7d2-48b4-836a-6440dc864b58" />

<img width="434" height="202" alt="Screenshot 2026-02-09 at 1 56 24 PM" src="https://github.com/user-attachments/assets/9b048024-84b1-4278-a8b1-9afb0056e765" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
