### PR TITLE
fix: recompute system prompt when SOUL.md or IDENTITY.md change

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -148,6 +148,20 @@ export class DaemonServer {
       },
     };
 
+    // Prompt files (SOUL.md, IDENTITY.md) affect the system prompt.
+    // When they change, evict idle sessions so they pick up the new prompt.
+    const evictSessions = () => {
+      for (const [id, session] of this.sessions) {
+        if (!session.isProcessing()) {
+          this.sessions.delete(id);
+        } else {
+          session.markStale();
+        }
+      }
+    };
+    handlers['SOUL.md'] = evictSessions;
+    handlers['IDENTITY.md'] = evictSessions;
+
     try {
       const watcher = watch(dataDir, (_eventType, filename) => {
         if (!filename || !handlers[filename]) return;
@@ -162,7 +176,7 @@ export class DaemonServer {
         this.debounceTimers.set(filename, timer);
       });
       this.watchers.push(watcher);
-      log.info({ dir: dataDir }, 'Watching data directory for config/trust changes');
+      log.info({ dir: dataDir }, 'Watching data directory for config/trust/prompt changes');
     } catch (err) {
       log.warn({ err }, 'Failed to watch data directory');
     }


### PR DESCRIPTION
## Summary
- Watch `SOUL.md` and `IDENTITY.md` in the data directory for changes, same as `config.json` and `trust.json`
- When either prompt file changes, evict idle sessions and mark busy ones as stale so they pick up the updated system prompt on the next message
- Addresses review feedback from #309: sessions were cached and reused, so edits to prompt files during a running daemon did not affect existing conversations

## Test plan
- [x] TypeScript typecheck passes
- [x] All existing tests pass (515/515)
- [ ] Manual: start daemon, edit `~/.vellum/SOUL.md`, send a message — verify the new prompt is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
