### PR TITLE
fix: generate unique fallback tool-call IDs in Gemini provider

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -238,12 +238,40 @@ describe('GeminiProvider', () => {
     );
 
     expect(result.content).toHaveLength(1);
-    expect(result.content[0]).toEqual({
-      type: 'tool_use',
-      id: 'call_0',
-      name: 'test',
-      input: { x: 1 },
-    });
+    const block = result.content[0] as { type: string; id: string; name: string; input: unknown };
+    expect(block.type).toBe('tool_use');
+    expect(block.id).toStartWith('call_');
+    expect(block.id.length).toBeGreaterThan(5); // call_ + UUID
+    expect(block.name).toBe('test');
+    expect(block.input).toEqual({ x: 1 });
+  });
+
+  test('generates unique fallback ids across multiple calls', async () => {
+    fakeChunks = [
+      functionCallChunk([
+        { name: 'tool_a', args: {} },
+      ]),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const result1 = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'call 1' }] }],
+    );
+
+    fakeChunks = [
+      functionCallChunk([
+        { name: 'tool_b', args: {} },
+      ]),
+      finishChunk('STOP', 10, 5),
+    ];
+
+    const result2 = await provider.sendMessage(
+      [{ role: 'user', content: [{ type: 'text', text: 'call 2' }] }],
+    );
+
+    const id1 = (result1.content[0] as { id: string }).id;
+    const id2 = (result2.content[0] as { id: string }).id;
+    expect(id1).not.toBe(id2);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -81,7 +81,7 @@ export class GeminiProvider implements Provider {
         if (calls) {
           for (const fc of calls) {
             functionCalls.push({
-              id: fc.id ?? `call_${functionCalls.length}`,
+              id: fc.id ?? `call_${crypto.randomUUID()}`,
               name: fc.name ?? '',
               args: fc.args ?? {},
             });


### PR DESCRIPTION
## Summary
- Use `crypto.randomUUID()` instead of an index-based counter (`call_0`, `call_1`, ...) for fallback tool-call IDs when Gemini omits `functionCall.id`
- The old scheme restarted from `call_0` on each `sendMessage` call, so multi-turn sessions could reuse the same ID for different tools, corrupting the `tool_use_id → name` lookup map in `toGeminiContents`
- Added a test verifying that fallback IDs are unique across multiple `sendMessage` calls

## Test plan
- [x] TypeScript typecheck passes
- [x] All 23 Gemini provider tests pass (including new uniqueness test)
- [ ] Manual: use Gemini provider with a multi-turn tool-use conversation where Gemini omits `functionCall.id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
