### PR TITLE
fix: preserve tool error flag in OpenAI provider

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -355,6 +355,67 @@ describe('OpenAIProvider', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Tool result with is_error flag
+  // -----------------------------------------------------------------------
+  test('prepends [ERROR] prefix when tool_result has is_error true', async () => {
+    fakeChunks = [textChunk('I see the error'), usageChunk(20, 10)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Read /tmp/secret' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_err', name: 'file_read', input: { path: '/tmp/secret' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_err', content: 'Permission denied', is_error: true },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_err',
+      content: '[ERROR] Permission denied',
+    });
+  });
+
+  test('does not prepend [ERROR] prefix when is_error is false', async () => {
+    fakeChunks = [textChunk('OK'), usageChunk(20, 10)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Read /tmp/test' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_ok', name: 'file_read', input: { path: '/tmp/test' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_ok', content: 'file content here', is_error: false },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_ok',
+      content: 'file content here',
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Mixed tool_result + text in user message
   // -----------------------------------------------------------------------
   test('splits user message with tool_result + text into separate messages', async () => {

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -167,7 +167,7 @@ export class OpenAIProvider implements Provider {
           result.push({
             role: 'tool',
             tool_call_id: tr.tool_use_id,
-            content: tr.content,
+            content: tr.is_error ? `[ERROR] ${tr.content}` : tr.content,
           });
         }
 


### PR DESCRIPTION
## Summary
- When converting `tool_result` blocks to OpenAI `role: 'tool'` messages, the `is_error` flag was being dropped, making failed tool calls look identical to successful ones.
- Now prepends `[ERROR] ` to the tool message content when `is_error` is true, which is the standard OpenAI pattern since their API lacks a dedicated error field for tool messages.
- Added two new tests verifying the error prefix is applied when `is_error: true` and omitted when `is_error: false`.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 21 tests pass in `openai-provider.test.ts`
- [x] New test: verifies `[ERROR] ` prefix when `is_error: true`
- [x] New test: verifies no prefix when `is_error: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
