### PR TITLE
test: add property-based tests for fuzzy matching with fast-check

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -22,6 +22,7 @@
         "@types/uuid": "^10.0.0",
         "drizzle-kit": "^0.30.4",
         "eslint": "^10.0.0",
+        "fast-check": "^4.5.3",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.54.0",
       },
@@ -280,6 +281,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fast-check": ["fast-check@4.5.3", "", { "dependencies": { "pure-rand": "^7.0.0" } }, "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA=="],
+
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -451,6 +454,8 @@
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -30,6 +30,7 @@
     "@types/uuid": "^10.0.0",
     "drizzle-kit": "^0.30.4",
     "eslint": "^10.0.0",
+    "fast-check": "^4.5.3",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.54.0"
   }

--- a/assistant/src/__tests__/fuzzy-match-property.test.ts
+++ b/assistant/src/__tests__/fuzzy-match-property.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from 'bun:test';
+import fc from 'fast-check';
+import { findMatch, findAllMatches } from '../tools/filesystem/fuzzy-match.js';
+
+describe('fuzzy-match property-based tests', () => {
+  test('exact match always has similarity 1', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 200 }),
+        (s) => {
+          const result = findMatch(s, s);
+          expect(result).not.toBeNull();
+          expect(result!.similarity).toBe(1);
+          expect(result!.method).toBe('exact');
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  test('similarity score is always in [0, 1] range', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 200 }),
+        fc.string({ minLength: 1, maxLength: 200 }),
+        (content, target) => {
+          const result = findMatch(content, target);
+          if (result !== null) {
+            expect(result.similarity).toBeGreaterThanOrEqual(0);
+            expect(result.similarity).toBeLessThanOrEqual(1);
+          }
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  test('empty target always returns null', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: 200 }),
+        (content) => {
+          const result = findMatch(content, '');
+          expect(result).toBeNull();
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('findAllMatches with empty target returns empty array', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: 200 }),
+        (content) => {
+          const results = findAllMatches(content, '');
+          expect(results).toEqual([]);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  test('substring of content always produces a match', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 3, maxLength: 200 }),
+        (content) => {
+          // Pick a non-empty substring from the content
+          if (content.length < 2) return;
+          const start = 0;
+          const end = Math.min(content.length, 3);
+          const target = content.slice(start, end);
+          if (target.length === 0) return;
+
+          const result = findMatch(content, target);
+          expect(result).not.toBeNull();
+          expect(result!.similarity).toBeGreaterThan(0);
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('exact match start and end indices are correct', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 100 }),
+        fc.string({ minLength: 1, maxLength: 50 }),
+        fc.string({ minLength: 1, maxLength: 100 }),
+        (prefix, target, suffix) => {
+          // Avoid cases where target appears in prefix or suffix
+          if (prefix.includes(target) || suffix.includes(target)) return;
+
+          const content = prefix + target + suffix;
+          const result = findMatch(content, target);
+          expect(result).not.toBeNull();
+          expect(result!.method).toBe('exact');
+          expect(result!.start).toBe(prefix.length);
+          expect(result!.end).toBe(prefix.length + target.length);
+          expect(result!.matched).toBe(target);
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('findAllMatches returns at least as many exact matches as occurrences', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 10 }),
+        fc.integer({ min: 1, max: 5 }),
+        (word, repeats) => {
+          if (word.length === 0) return;
+          // Build content with the word repeated, separated by a delimiter
+          const separator = '|||';
+          if (word.includes(separator)) return;
+          const content = Array(repeats).fill(word).join(separator);
+
+          const results = findAllMatches(content, word);
+          expect(results.length).toBeGreaterThanOrEqual(repeats);
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  test('matched text is always a substring of content for exact matches', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 200 }),
+        fc.string({ minLength: 1, maxLength: 50 }),
+        (content, target) => {
+          const result = findMatch(content, target);
+          if (result !== null && result.method === 'exact') {
+            expect(content.includes(result.matched)).toBe(true);
+            expect(content.slice(result.start, result.end)).toBe(result.matched);
+          }
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('findMatch result is consistent with findAllMatches', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 100 }),
+        fc.string({ minLength: 1, maxLength: 50 }),
+        (content, target) => {
+          const single = findMatch(content, target);
+          const all = findAllMatches(content, target);
+
+          if (single === null) {
+            expect(all.length).toBe(0);
+          } else {
+            expect(all.length).toBeGreaterThanOrEqual(1);
+          }
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('similarity of 1 implies exact or whitespace method', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 200 }),
+        fc.string({ minLength: 1, maxLength: 100 }),
+        (content, target) => {
+          const result = findMatch(content, target);
+          if (result !== null && result.similarity === 1) {
+            expect(['exact', 'whitespace']).toContain(result.method);
+          }
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('start is always less than or equal to end', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 200 }),
+        fc.string({ minLength: 1, maxLength: 100 }),
+        (content, target) => {
+          const result = findMatch(content, target);
+          if (result !== null) {
+            expect(result.start).toBeLessThanOrEqual(result.end);
+          }
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  test('multiline exact self-match works', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ minLength: 1, maxLength: 50 }), { minLength: 1, maxLength: 10 }),
+        (lines) => {
+          const content = lines.join('\n');
+          if (content.length === 0) return;
+
+          const result = findMatch(content, content);
+          expect(result).not.toBeNull();
+          expect(result!.similarity).toBe(1);
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add property-based tests using `fast-check` for `findMatch` and `findAllMatches` in `fuzzy-match.ts`
- 12 property tests covering: exact self-match always scores 1, similarity always in [0,1], empty target handling, substring matching, index correctness, consistency between findMatch and findAllMatches, multiline self-match, and more
- Install `fast-check` as a dev dependency

## Test plan
- [x] All 12 property-based tests pass (3809 expect() calls across 200-500 random inputs each)
- [x] Type-check passes with `bunx tsc --noEmit`
- [x] Existing fuzzy-match tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
