### PR TITLE
refactor: consolidate platform detection into platform.ts

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -20,7 +20,7 @@ import {
 import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { hostname, userInfo } from 'node:os';
-import { getDataDir } from '../util/platform.js';
+import { getDataDir, getPlatformName } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('encrypted-store');
@@ -75,7 +75,7 @@ function getMachineEntropy(): string {
   const parts: string[] = [];
   try { parts.push(hostname()); } catch { parts.push('unknown-host'); }
   try { parts.push(userInfo().username); } catch { parts.push('unknown-user'); }
-  parts.push(process.platform);
+  parts.push(getPlatformName());
   parts.push(process.arch);
   try { parts.push(userInfo().homedir); } catch { parts.push('/tmp'); }
   return parts.join(':');

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -1,14 +1,10 @@
 import { execSync } from 'node:child_process';
-import { isMacOS, isLinux } from './platform.js';
+import { getClipboardCommand } from './platform.js';
 import { PlatformError } from './errors.js';
 
 export function copyToClipboard(text: string): void {
-  let cmd: string;
-  if (isMacOS()) {
-    cmd = 'pbcopy';
-  } else if (isLinux()) {
-    cmd = 'xclip -selection clipboard';
-  } else {
+  const cmd = getClipboardCommand();
+  if (!cmd) {
     throw new PlatformError('Clipboard not supported on this platform');
   }
   execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -14,6 +14,25 @@ export function isWindows(): boolean {
   return process.platform === 'win32';
 }
 
+/**
+ * Returns the raw platform string from Node.js (e.g. 'darwin', 'linux', 'win32').
+ * Prefer this over accessing process.platform directly so all platform
+ * detection is routed through this module.
+ */
+export function getPlatformName(): string {
+  return process.platform;
+}
+
+/**
+ * Returns the platform-specific clipboard copy command, or null if
+ * clipboard access is not supported on the current platform.
+ */
+export function getClipboardCommand(): string | null {
+  if (isMacOS()) return 'pbcopy';
+  if (isLinux()) return 'xclip -selection clipboard';
+  return null;
+}
+
 export function getDataDir(): string {
   return join(homedir(), '.vellum');
 }


### PR DESCRIPTION
## Summary
- Added `getPlatformName()` to `platform.ts` as a centralized wrapper for `process.platform`, replacing direct access in `encrypted-store.ts`
- Added `getClipboardCommand()` to `platform.ts` to centralize platform-specific clipboard command resolution (previously inline in `clipboard.ts`)
- Updated `clipboard.ts` to delegate to `getClipboardCommand()` instead of checking `isMacOS()`/`isLinux()` inline
- Updated `encrypted-store.ts` to use `getPlatformName()` instead of raw `process.platform`

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 516/516 pass (1 pre-existing flaky test in audit-log-rotation unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
