### PR TITLE
feat: add /copy-session command for session export to clipboard

### DIFF
--- a/assistant/src/__tests__/clipboard.test.ts
+++ b/assistant/src/__tests__/clipboard.test.ts
@@ -1,5 +1,31 @@
 import { describe, test, expect } from 'bun:test';
-import { extractLastCodeBlock } from '../util/clipboard.js';
+import { extractLastCodeBlock, formatSessionForExport } from '../util/clipboard.js';
+
+describe('formatSessionForExport', () => {
+  test('formats user and assistant messages', () => {
+    const messages = [
+      { role: 'user', text: 'Hello' },
+      { role: 'assistant', text: 'Hi there!' },
+    ];
+    expect(formatSessionForExport(messages)).toBe('you> Hello\n\nassistant> Hi there!');
+  });
+
+  test('handles a single message', () => {
+    const messages = [{ role: 'user', text: 'Just me' }];
+    expect(formatSessionForExport(messages)).toBe('you> Just me');
+  });
+
+  test('handles empty messages array', () => {
+    expect(formatSessionForExport([])).toBe('');
+  });
+
+  test('preserves multiline message text', () => {
+    const messages = [
+      { role: 'assistant', text: 'Line 1\nLine 2\nLine 3' },
+    ];
+    expect(formatSessionForExport(messages)).toBe('assistant> Line 1\nLine 2\nLine 3');
+  });
+});
 
 describe('extractLastCodeBlock', () => {
   test('extracts a simple code block', () => {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -10,7 +10,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
 import { Spinner } from './util/spinner.js';
-import { copyToClipboard, extractLastCodeBlock } from './util/clipboard.js';
+import { copyToClipboard, extractLastCodeBlock, formatSessionForExport } from './util/clipboard.js';
 import { timeAgo } from './util/time.js';
 import { ensureDaemonRunning } from './daemon/lifecycle.js';
 
@@ -33,6 +33,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
   let lastUsage: { inputTokens: number; outputTokens: number; totalInputTokens: number; totalOutputTokens: number; estimatedCost: number; model: string } | null = null;
   let pendingSessionPick = false;
   let pendingConfirmation = false;
+  let pendingCopySession = false;
   let toolStreaming = false;
   let reconnecting = false;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -388,6 +389,22 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         break;
 
       case 'history_response':
+        if (pendingCopySession) {
+          pendingCopySession = false;
+          if (msg.messages.length === 0) {
+            process.stdout.write('\n  No messages to copy.\n\n');
+          } else {
+            try {
+              const formatted = formatSessionForExport(msg.messages);
+              copyToClipboard(formatted);
+              process.stdout.write(`\n  Copied session (${msg.messages.length} messages) to clipboard.\n\n`);
+            } catch (err) {
+              process.stdout.write(`\n  Clipboard error: ${(err as Error).message}\n\n`);
+            }
+          }
+          prompt();
+          break;
+        }
         process.stdout.write('\n');
         if (msg.messages.length === 0) {
           process.stdout.write('  No messages in this session.\n');
@@ -473,6 +490,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     toolStreaming = false;
     pendingSessionPick = false;
     pendingConfirmation = false;
+    pendingCopySession = false;
     lastUsage = null;
 
     // Remove stale rl.once('line') handlers from confirmation/selection prompts
@@ -586,6 +604,12 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       return;
     }
 
+    if (content === '/copy-session') {
+      pendingCopySession = true;
+      send({ type: 'history_request', sessionId });
+      return;
+    }
+
     if (content === '/new') {
       send({ type: 'session_create' });
       return;
@@ -635,6 +659,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       process.stdout.write('  /usage            Show token usage and cost\n');
       process.stdout.write('  /copy             Copy last response to clipboard\n');
       process.stdout.write('  /copy-code        Copy last code block to clipboard\n');
+      process.stdout.write('  /copy-session     Copy entire session to clipboard\n');
       process.stdout.write('  /help             Show this help\n');
       process.stdout.write('\n');
       prompt();

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -14,6 +14,17 @@ export function copyToClipboard(text: string): void {
   execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
 }
 
+export function formatSessionForExport(
+  messages: Array<{ role: string; text: string }>,
+): string {
+  return messages
+    .map((m) => {
+      const label = m.role === 'user' ? 'you' : 'assistant';
+      return `${label}> ${m.text}`;
+    })
+    .join('\n\n');
+}
+
 export function extractLastCodeBlock(text: string): string | null {
   const re = /```[^\n]*\n((?:[\s\S]*?\n)?)```/g;
   let last: RegExpExecArray | null = null;


### PR DESCRIPTION
## Summary
- Adds `/copy-session` CLI command that exports the entire conversation to the system clipboard
- Reuses existing `history_request`/`history_response` IPC flow with a `pendingCopySession` flag to route the response to clipboard instead of display
- Adds `formatSessionForExport()` helper in `clipboard.ts` that formats messages as `role> text` pairs separated by blank lines
- Includes 4 new unit tests for the formatter

## Changes
- `assistant/src/util/clipboard.ts` — added `formatSessionForExport()` function
- `assistant/src/cli.ts` — added `/copy-session` command handler, updated help text, added clipboard routing in `history_response` handler
- `assistant/src/__tests__/clipboard.test.ts` — added tests for `formatSessionForExport`

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/clipboard.test.ts` — all 14 tests pass (4 new + 10 existing)
- [x] Full test suite: 520 pass, 1 pre-existing fail (unrelated `audit-log-rotation.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
