### PR TITLE
test: add snapshot tests for all IPC message types

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1,0 +1,294 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
+{
+  "content": "Hello, assistant!",
+  "sessionId": "sess-001",
+  "type": "user_message",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types confirmation_response serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "requestId": "req-001",
+  "selectedPattern": "bash:npm *",
+  "selectedScope": "/projects/my-app",
+  "type": "confirmation_response",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_list serializes to expected JSON 1`] = `
+{
+  "type": "session_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_create serializes to expected JSON 1`] = `
+{
+  "title": "New session",
+  "type": "session_create",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types session_switch serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-002",
+  "type": "session_switch",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types ping serializes to expected JSON 1`] = `
+{
+  "type": "ping",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types cancel serializes to expected JSON 1`] = `
+{
+  "type": "cancel",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types model_get serializes to expected JSON 1`] = `
+{
+  "type": "model_get",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types model_set serializes to expected JSON 1`] = `
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "type": "model_set",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types history_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "history_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types undo serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "undo",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types usage_request serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "usage_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types sandbox_set serializes to expected JSON 1`] = `
+{
+  "enabled": true,
+  "type": "sandbox_set",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
+{
+  "text": "Here is some output",
+  "type": "assistant_text_delta",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types assistant_thinking_delta serializes to expected JSON 1`] = `
+{
+  "thinking": "Let me consider this...",
+  "type": "assistant_thinking_delta",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_use_start serializes to expected JSON 1`] = `
+{
+  "input": {
+    "command": "ls -la",
+  },
+  "toolName": "bash",
+  "type": "tool_use_start",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_output_chunk serializes to expected JSON 1`] = `
+{
+  "chunk": 
+"file1.ts
+file2.ts
+"
+,
+  "type": "tool_output_chunk",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types tool_result serializes to expected JSON 1`] = `
+{
+  "diff": {
+    "filePath": "/tmp/test.ts",
+    "isNewFile": false,
+    "newContent": "const x = 2;",
+    "oldContent": "const x = 1;",
+  },
+  "isError": false,
+  "result": "Command completed successfully",
+  "status": "success",
+  "toolName": "bash",
+  "type": "tool_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types confirmation_request serializes to expected JSON 1`] = `
+{
+  "allowlistOptions": [
+    {
+      "label": "Allow rm commands",
+      "pattern": "bash:rm *",
+    },
+  ],
+  "diff": {
+    "filePath": "/tmp/test.ts",
+    "isNewFile": false,
+    "newContent": "new",
+    "oldContent": "old",
+  },
+  "input": {
+    "command": "rm -rf /tmp/test",
+  },
+  "requestId": "req-002",
+  "riskLevel": "high",
+  "sandboxed": false,
+  "scopeOptions": [
+    {
+      "label": "In /tmp",
+      "scope": "/tmp",
+    },
+  ],
+  "toolName": "bash",
+  "type": "confirmation_request",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types message_complete serializes to expected JSON 1`] = `
+{
+  "type": "message_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types session_info serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "title": "My session",
+  "type": "session_info",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types session_list_response serializes to expected JSON 1`] = `
+{
+  "sessions": [
+    {
+      "id": "sess-001",
+      "title": "First session",
+      "updatedAt": 1700000000,
+    },
+    {
+      "id": "sess-002",
+      "title": "Second session",
+      "updatedAt": 1700001000,
+    },
+  ],
+  "type": "session_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types error serializes to expected JSON 1`] = `
+{
+  "message": "Something went wrong",
+  "type": "error",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types pong serializes to expected JSON 1`] = `
+{
+  "type": "pong",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types generation_cancelled serializes to expected JSON 1`] = `
+{
+  "type": "generation_cancelled",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types model_info serializes to expected JSON 1`] = `
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "provider": "anthropic",
+  "type": "model_info",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types history_response serializes to expected JSON 1`] = `
+{
+  "messages": [
+    {
+      "role": "user",
+      "text": "Hello",
+      "timestamp": 1700000000,
+    },
+    {
+      "role": "assistant",
+      "text": "Hi there!",
+      "timestamp": 1700000001,
+    },
+  ],
+  "type": "history_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types undo_complete serializes to expected JSON 1`] = `
+{
+  "removedCount": 2,
+  "type": "undo_complete",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types usage_update serializes to expected JSON 1`] = `
+{
+  "estimatedCost": 0.025,
+  "inputTokens": 150,
+  "model": "claude-sonnet-4-5-20250929",
+  "outputTokens": 50,
+  "totalInputTokens": 1500,
+  "totalOutputTokens": 500,
+  "type": "usage_update",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types usage_response serializes to expected JSON 1`] = `
+{
+  "estimatedCost": 0.025,
+  "model": "claude-sonnet-4-5-20250929",
+  "totalInputTokens": 1500,
+  "totalOutputTokens": 500,
+  "type": "usage_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types secret_detected serializes to expected JSON 1`] = `
+{
+  "action": "redact",
+  "matches": [
+    {
+      "redactedValue": "sk-****abcd",
+      "type": "api_key",
+    },
+  ],
+  "toolName": "bash",
+  "type": "secret_detected",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1,0 +1,236 @@
+import { describe, test, expect } from 'bun:test';
+import { serialize } from '../daemon/ipc-protocol.js';
+import type {
+  ClientMessage,
+  ServerMessage,
+} from '../daemon/ipc-protocol.js';
+
+/**
+ * Snapshot tests for every IPC message type.
+ * If any field is added, removed, or renamed, these tests will fail,
+ * catching accidental protocol changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Client → Server messages
+// ---------------------------------------------------------------------------
+
+const clientMessages: Record<string, ClientMessage> = {
+  user_message: {
+    type: 'user_message',
+    sessionId: 'sess-001',
+    content: 'Hello, assistant!',
+  },
+  confirmation_response: {
+    type: 'confirmation_response',
+    requestId: 'req-001',
+    decision: 'allow',
+    selectedPattern: 'bash:npm *',
+    selectedScope: '/projects/my-app',
+  },
+  session_list: {
+    type: 'session_list',
+  },
+  session_create: {
+    type: 'session_create',
+    title: 'New session',
+  },
+  session_switch: {
+    type: 'session_switch',
+    sessionId: 'sess-002',
+  },
+  ping: {
+    type: 'ping',
+  },
+  cancel: {
+    type: 'cancel',
+  },
+  model_get: {
+    type: 'model_get',
+  },
+  model_set: {
+    type: 'model_set',
+    model: 'claude-sonnet-4-5-20250929',
+  },
+  history_request: {
+    type: 'history_request',
+    sessionId: 'sess-001',
+  },
+  undo: {
+    type: 'undo',
+    sessionId: 'sess-001',
+  },
+  usage_request: {
+    type: 'usage_request',
+    sessionId: 'sess-001',
+  },
+  sandbox_set: {
+    type: 'sandbox_set',
+    enabled: true,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Server → Client messages
+// ---------------------------------------------------------------------------
+
+const serverMessages: Record<string, ServerMessage> = {
+  assistant_text_delta: {
+    type: 'assistant_text_delta',
+    text: 'Here is some output',
+  },
+  assistant_thinking_delta: {
+    type: 'assistant_thinking_delta',
+    thinking: 'Let me consider this...',
+  },
+  tool_use_start: {
+    type: 'tool_use_start',
+    toolName: 'bash',
+    input: { command: 'ls -la' },
+  },
+  tool_output_chunk: {
+    type: 'tool_output_chunk',
+    chunk: 'file1.ts\nfile2.ts\n',
+  },
+  tool_result: {
+    type: 'tool_result',
+    toolName: 'bash',
+    result: 'Command completed successfully',
+    isError: false,
+    diff: {
+      filePath: '/tmp/test.ts',
+      oldContent: 'const x = 1;',
+      newContent: 'const x = 2;',
+      isNewFile: false,
+    },
+    status: 'success',
+  },
+  confirmation_request: {
+    type: 'confirmation_request',
+    requestId: 'req-002',
+    toolName: 'bash',
+    input: { command: 'rm -rf /tmp/test' },
+    riskLevel: 'high',
+    allowlistOptions: [
+      { label: 'Allow rm commands', pattern: 'bash:rm *' },
+    ],
+    scopeOptions: [
+      { label: 'In /tmp', scope: '/tmp' },
+    ],
+    diff: {
+      filePath: '/tmp/test.ts',
+      oldContent: 'old',
+      newContent: 'new',
+      isNewFile: false,
+    },
+    sandboxed: false,
+  },
+  message_complete: {
+    type: 'message_complete',
+  },
+  session_info: {
+    type: 'session_info',
+    sessionId: 'sess-001',
+    title: 'My session',
+  },
+  session_list_response: {
+    type: 'session_list_response',
+    sessions: [
+      { id: 'sess-001', title: 'First session', updatedAt: 1700000000 },
+      { id: 'sess-002', title: 'Second session', updatedAt: 1700001000 },
+    ],
+  },
+  error: {
+    type: 'error',
+    message: 'Something went wrong',
+  },
+  pong: {
+    type: 'pong',
+  },
+  generation_cancelled: {
+    type: 'generation_cancelled',
+  },
+  model_info: {
+    type: 'model_info',
+    model: 'claude-sonnet-4-5-20250929',
+    provider: 'anthropic',
+  },
+  history_response: {
+    type: 'history_response',
+    messages: [
+      { role: 'user', text: 'Hello', timestamp: 1700000000 },
+      { role: 'assistant', text: 'Hi there!', timestamp: 1700000001 },
+    ],
+  },
+  undo_complete: {
+    type: 'undo_complete',
+    removedCount: 2,
+  },
+  usage_update: {
+    type: 'usage_update',
+    inputTokens: 150,
+    outputTokens: 50,
+    totalInputTokens: 1500,
+    totalOutputTokens: 500,
+    estimatedCost: 0.025,
+    model: 'claude-sonnet-4-5-20250929',
+  },
+  usage_response: {
+    type: 'usage_response',
+    totalInputTokens: 1500,
+    totalOutputTokens: 500,
+    estimatedCost: 0.025,
+    model: 'claude-sonnet-4-5-20250929',
+  },
+  secret_detected: {
+    type: 'secret_detected',
+    toolName: 'bash',
+    matches: [
+      { type: 'api_key', redactedValue: 'sk-****abcd' },
+    ],
+    action: 'redact',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IPC message snapshots', () => {
+  describe('ClientMessage types', () => {
+    for (const [name, msg] of Object.entries(clientMessages)) {
+      test(`${name} serializes to expected JSON`, () => {
+        const serialized = serialize(msg);
+        // serialize appends a newline; strip it for the snapshot comparison
+        const json = JSON.parse(serialized);
+        expect(json).toMatchSnapshot();
+      });
+    }
+  });
+
+  describe('ServerMessage types', () => {
+    for (const [name, msg] of Object.entries(serverMessages)) {
+      test(`${name} serializes to expected JSON`, () => {
+        const serialized = serialize(msg);
+        const json = JSON.parse(serialized);
+        expect(json).toMatchSnapshot();
+      });
+    }
+  });
+
+  test('round-trip: serialize then parse matches original for all ClientMessages', () => {
+    for (const msg of Object.values(clientMessages)) {
+      const serialized = serialize(msg);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed).toEqual(msg);
+    }
+  });
+
+  test('round-trip: serialize then parse matches original for all ServerMessages', () => {
+    for (const msg of Object.values(serverMessages)) {
+      const serialized = serialize(msg);
+      const parsed = JSON.parse(serialized.trimEnd());
+      expect(parsed).toEqual(msg);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds snapshot tests for every IPC message type (13 ClientMessage types, 18 ServerMessage types)
- Serializes each message using `serialize()` and snapshots the JSON output with `toMatchSnapshot()`
- Includes round-trip serialization assertions to verify serialize/parse consistency
- Any accidental protocol change (added, removed, or renamed fields) will cause test failures

## Test plan
- [x] All 33 tests pass (`bun test src/__tests__/ipc-snapshot.test.ts`)
- [x] 31 snapshots generated and committed
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
