### PR TITLE
feat: enhance debug mode with request/response logging and timing

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,5 +1,5 @@
 import type { Provider, Message, ToolDefinition, ContentBlock } from '../providers/types.js';
-import { getLogger } from '../util/logger.js';
+import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 
 const log = getLogger('agent-loop');
 
@@ -53,9 +53,12 @@ export class AgentLoop {
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
+    const debug = isDebug();
 
     while (true) {
       if (signal?.aborted) break;
+
+      const turnStart = Date.now();
 
       try {
         const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
@@ -70,6 +73,20 @@ export class AgentLoop {
             budget_tokens: budgetTokens,
           };
         }
+
+        if (debug) {
+          log.debug({
+            systemPrompt: truncateForLog(this.systemPrompt, 200),
+            messageCount: history.length,
+            lastMessage: history.length > 0
+              ? summarizeMessage(history[history.length - 1])
+              : null,
+            toolCount: this.tools.length,
+            config: providerConfig,
+          }, 'Sending request to provider');
+        }
+
+        const providerStart = Date.now();
 
         const response = await this.provider.sendMessage(
           history,
@@ -87,6 +104,23 @@ export class AgentLoop {
             signal,
           },
         );
+
+        const providerDurationMs = Date.now() - providerStart;
+
+        if (debug) {
+          log.debug({
+            providerDurationMs,
+            model: response.model,
+            stopReason: response.stopReason,
+            inputTokens: response.usage.inputTokens,
+            outputTokens: response.usage.outputTokens,
+            contentBlocks: response.content.map((b) => ({
+              type: b.type,
+              ...(b.type === 'text' ? { text: truncateForLog(b.text, 200) } : {}),
+              ...(b.type === 'tool_use' ? { name: b.name, input: truncateForLog(JSON.stringify(b.input), 200) } : {}),
+            })),
+          }, 'Provider response received');
+        }
 
         onEvent({
           type: 'usage',
@@ -125,9 +159,29 @@ export class AgentLoop {
             input: toolUse.input,
           });
 
+          if (debug) {
+            log.debug({
+              tool: toolUse.name,
+              input: truncateForLog(JSON.stringify(toolUse.input), 300),
+            }, 'Executing tool');
+          }
+
+          const toolStart = Date.now();
+
           const result = await this.toolExecutor(toolUse.name, toolUse.input, (chunk) => {
             onEvent({ type: 'tool_output_chunk', toolUseId: toolUse.id, chunk });
           });
+
+          const toolDurationMs = Date.now() - toolStart;
+
+          if (debug) {
+            log.debug({
+              tool: toolUse.name,
+              toolDurationMs,
+              isError: result.isError,
+              output: truncateForLog(result.content, 300),
+            }, 'Tool execution complete');
+          }
 
           onEvent({
             type: 'tool_result',
@@ -180,6 +234,16 @@ export class AgentLoop {
 
         // Add tool results as a user message and continue the loop
         history.push({ role: 'user', content: resultBlocks });
+
+        if (debug) {
+          const turnDurationMs = Date.now() - turnStart;
+          log.debug({
+            turnDurationMs,
+            providerDurationMs,
+            toolCount: toolUseBlocks.length,
+            turn: toolUseTurns,
+          }, 'Turn complete');
+        }
       } catch (error) {
         // Abort errors are expected when user cancels — don't emit as errors
         if (signal?.aborted) break;
@@ -192,4 +256,11 @@ export class AgentLoop {
 
     return history;
   }
+}
+
+function summarizeMessage(msg: Message): { role: string; blockTypes: string[] } {
+  return {
+    role: msg.role,
+    blockTypes: msg.content.map((b) => b.type),
+  };
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,6 +1,6 @@
 import type { Provider, ProviderResponse, SendMessageOptions, Message, ToolDefinition } from './types.js';
 import { ProviderError } from '../util/errors.js';
-import { getLogger } from '../util/logger.js';
+import { getLogger, isDebug } from '../util/logger.js';
 
 const log = getLogger('retry');
 
@@ -55,10 +55,31 @@ export class RetryProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     let lastError: unknown;
+    const debug = isDebug();
+
+    if (debug) {
+      log.debug({
+        provider: this.name,
+        messageCount: messages.length,
+        toolCount: tools?.length ?? 0,
+      }, 'Provider sendMessage start');
+    }
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        return await this.inner.sendMessage(messages, tools, systemPrompt, options);
+        const start = Date.now();
+        const result = await this.inner.sendMessage(messages, tools, systemPrompt, options);
+        if (debug) {
+          log.debug({
+            provider: this.name,
+            durationMs: Date.now() - start,
+            attempt: attempt + 1,
+            model: result.model,
+            inputTokens: result.usage.inputTokens,
+            outputTokens: result.usage.outputTokens,
+          }, 'Provider sendMessage success');
+        }
+        return result;
       } catch (error) {
         lastError = error;
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -7,7 +7,7 @@ import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { recordToolInvocation } from '../memory/tool-usage-store.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
-import { getLogger } from '../util/logger.js';
+import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
 import { MAX_FILE_SIZE_BYTES } from './filesystem/size-guard.js';
@@ -37,6 +37,14 @@ export class ToolExecutor {
     const startTime = Date.now();
     let decision = 'allow';
     let riskLevel: string = RiskLevel.Low;
+    const debug = isDebug();
+
+    if (debug) {
+      log.debug({
+        tool: name,
+        input: truncateForLog(JSON.stringify(input), 300),
+      }, 'Tool execute start');
+    }
 
     try {
       // Check permissions
@@ -126,6 +134,18 @@ export class ToolExecutor {
 
       // Execute the tool
       const execResult = await tool.execute(input, context);
+
+      if (debug) {
+        const execDurationMs = Date.now() - startTime;
+        log.debug({
+          tool: name,
+          execDurationMs,
+          riskLevel,
+          decision,
+          isError: execResult.isError,
+          output: truncateForLog(execResult.content, 300),
+        }, 'Tool execute result');
+      }
 
       // Secret detection on tool output
       const sdConfig = getConfig().secretDetection;

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -28,6 +28,19 @@ function getRootLogger(): pino.Logger {
  * This avoids "sonic boom is not ready yet" errors when the process exits
  * quickly (e.g. `assistant --help`).
  */
+export function isDebug(): boolean {
+  return process.env.VELLUM_DEBUG === '1';
+}
+
+/**
+ * Truncate a string for debug logging. Returns the original if under maxLen,
+ * otherwise returns the first maxLen chars with a suffix indicating how much was cut.
+ */
+export function truncateForLog(value: string, maxLen = 500): string {
+  if (value.length <= maxLen) return value;
+  return value.slice(0, maxLen) + `... (${value.length - maxLen} chars truncated)`;
+}
+
 export function getLogger(name: string): pino.Logger {
   let child: pino.Logger | null = null;
   const handler: ProxyHandler<pino.Logger> = {


### PR DESCRIPTION
## Summary
- Added `isDebug()` and `truncateForLog()` utilities to the logger module for consistent debug output
- Enhanced the agent loop with request/response logging (system prompt, message counts, provider config, response metadata with content block summaries) and per-turn timing breakdowns (provider call duration, tool count, total turn time)
- Added tool execution tracing in both the agent loop and tool executor with tool name, input/output (truncated), duration, and success/failure status
- Added provider-level debug logging in the retry wrapper with call duration, attempt number, and token usage

All debug logs are gated behind `VELLUM_DEBUG=1` so there is zero overhead in normal operation.

## Files modified
- `assistant/src/util/logger.ts` — added `isDebug()` and `truncateForLog()` exports
- `assistant/src/agent/loop.ts` — request/response logging, tool tracing, turn timing
- `assistant/src/tools/executor.ts` — tool execution start/result debug logs
- `assistant/src/providers/retry.ts` — provider call debug logs with timing

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 516 tests pass (1 pre-existing failure in `audit-log-rotation.test.ts` unrelated to these changes)
- [ ] Manual verification: set `VELLUM_DEBUG=1` and confirm debug output appears on stderr with timing data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
