### PR TITLE
feat: add Zod schema validation for config

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -16,6 +16,7 @@
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
         "web-tree-sitter": "0.26.5",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "^1.2.4",
@@ -537,6 +538,8 @@
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -23,7 +23,8 @@
     "pino-pretty": "^13.1.3",
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",
-    "web-tree-sitter": "0.26.5"
+    "web-tree-sitter": "0.26.5",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "^1.2.4",

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,0 +1,360 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { AssistantConfigSchema } from '../config/schema.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(tmpdir(), `vellum-schema-test-${randomBytes(4).toString('hex')}`);
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+  },
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+}));
+
+import { _setStorePath } from '../security/encrypted-store.js';
+import { _setBackend } from '../security/secure-keys.js';
+import { loadConfig, invalidateConfigCache } from '../config/loader.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(join(TEST_DIR, 'config.json'), JSON.stringify(obj));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Zod schema (unit)
+// ---------------------------------------------------------------------------
+
+describe('AssistantConfigSchema', () => {
+  test('parses empty object with full defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.provider).toBe('anthropic');
+    expect(result.model).toBe('claude-sonnet-4-5-20250929');
+    expect(result.maxTokens).toBe(64000);
+    expect(result.apiKeys).toEqual({});
+    expect(result.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
+    expect(result.timeouts).toEqual({
+      shellDefaultTimeoutSec: 120,
+      shellMaxTimeoutSec: 600,
+      permissionTimeoutSec: 300,
+    });
+    expect(result.sandbox).toEqual({ enabled: false });
+    expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
+    expect(result.secretDetection).toEqual({ enabled: true, action: 'warn', entropyThreshold: 4.0 });
+    expect(result.auditLog).toEqual({ retentionDays: 0 });
+  });
+
+  test('accepts valid complete config', () => {
+    const input = {
+      provider: 'openai',
+      model: 'gpt-4',
+      maxTokens: 4096,
+      apiKeys: { openai: 'sk-test' },
+      thinking: { enabled: true, budgetTokens: 5000 },
+      timeouts: { shellDefaultTimeoutSec: 30, shellMaxTimeoutSec: 300, permissionTimeoutSec: 60 },
+      sandbox: { enabled: true },
+      rateLimit: { maxRequestsPerMinute: 10, maxTokensPerSession: 100000 },
+      secretDetection: { enabled: false, action: 'block' as const, entropyThreshold: 5.5 },
+      auditLog: { retentionDays: 30 },
+    };
+    const result = AssistantConfigSchema.parse(input);
+    expect(result.provider).toBe('openai');
+    expect(result.model).toBe('gpt-4');
+    expect(result.maxTokens).toBe(4096);
+    expect(result.thinking.enabled).toBe(true);
+    expect(result.secretDetection.action).toBe('block');
+  });
+
+  test('rejects invalid provider', () => {
+    const result = AssistantConfigSchema.safeParse({ provider: 'invalid' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('provider'))).toBe(true);
+    }
+  });
+
+  test('rejects negative maxTokens', () => {
+    const result = AssistantConfigSchema.safeParse({ maxTokens: -100 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.path.includes('maxTokens'))).toBe(true);
+    }
+  });
+
+  test('rejects non-integer maxTokens', () => {
+    const result = AssistantConfigSchema.safeParse({ maxTokens: 3.14 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.path.includes('maxTokens'))).toBe(true);
+    }
+  });
+
+  test('rejects string maxTokens', () => {
+    const result = AssistantConfigSchema.safeParse({ maxTokens: 'not-a-number' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.path.includes('maxTokens'))).toBe(true);
+    }
+  });
+
+  test('rejects invalid timeout values', () => {
+    const result = AssistantConfigSchema.safeParse({
+      timeouts: { shellDefaultTimeoutSec: -5, shellMaxTimeoutSec: 'bad', permissionTimeoutSec: 0 },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test('rejects invalid thinking config', () => {
+    const result = AssistantConfigSchema.safeParse({
+      thinking: { enabled: 'yes', budgetTokens: -100 },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test('rejects invalid secretDetection.action', () => {
+    const result = AssistantConfigSchema.safeParse({
+      secretDetection: { action: 'explode' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('secretDetection.action'))).toBe(true);
+    }
+  });
+
+  test('rejects negative secretDetection.entropyThreshold', () => {
+    const result = AssistantConfigSchema.safeParse({
+      secretDetection: { entropyThreshold: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects negative rateLimit values', () => {
+    const result = AssistantConfigSchema.safeParse({
+      rateLimit: { maxRequestsPerMinute: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-integer rateLimit values', () => {
+    const result = AssistantConfigSchema.safeParse({
+      rateLimit: { maxTokensPerSession: 3.5 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects negative auditLog.retentionDays', () => {
+    const result = AssistantConfigSchema.safeParse({
+      auditLog: { retentionDays: -7 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-string apiKeys values', () => {
+    const result = AssistantConfigSchema.safeParse({
+      apiKeys: { anthropic: 123 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts partial nested objects with defaults', () => {
+    const result = AssistantConfigSchema.parse({
+      timeouts: { shellDefaultTimeoutSec: 30 },
+    });
+    expect(result.timeouts.shellDefaultTimeoutSec).toBe(30);
+    expect(result.timeouts.shellMaxTimeoutSec).toBe(600);
+    expect(result.timeouts.permissionTimeoutSec).toBe(300);
+  });
+
+  test('accepts zero for non-negative fields', () => {
+    const result = AssistantConfigSchema.parse({
+      rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+      auditLog: { retentionDays: 0 },
+    });
+    expect(result.rateLimit.maxRequestsPerMinute).toBe(0);
+    expect(result.rateLimit.maxTokensPerSession).toBe(0);
+    expect(result.auditLog.retentionDays).toBe(0);
+  });
+
+  test('accepts all valid provider values', () => {
+    for (const provider of ['anthropic', 'openai', 'gemini', 'ollama'] as const) {
+      const result = AssistantConfigSchema.safeParse({ provider });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test('accepts all valid secretDetection.action values', () => {
+    for (const action of ['redact', 'warn', 'block'] as const) {
+      const result = AssistantConfigSchema.safeParse({ secretDetection: { action } });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test('provides helpful error messages', () => {
+    const result = AssistantConfigSchema.safeParse({
+      provider: 'invalid',
+      maxTokens: -1,
+      secretDetection: { action: 'explode' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map(i => i.message);
+      // Should mention the valid options
+      expect(messages.some(m => m.includes('anthropic') && m.includes('openai'))).toBe(true);
+      expect(messages.some(m => m.includes('positive'))).toBe(true);
+      expect(messages.some(m => m.includes('redact') && m.includes('warn') && m.includes('block'))).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: loader integration (config file -> loadConfig with fallback)
+// ---------------------------------------------------------------------------
+
+describe('loadConfig with schema validation', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(join(TEST_DIR, 'keys.enc'));
+    _setBackend('encrypted');
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    _setStorePath(null);
+    _setBackend(undefined);
+    invalidateConfigCache();
+  });
+
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  test('loads valid config', () => {
+    writeConfig({
+      provider: 'openai',
+      model: 'gpt-4',
+      maxTokens: 4096,
+    });
+    const config = loadConfig();
+    expect(config.provider).toBe('openai');
+    expect(config.model).toBe('gpt-4');
+    expect(config.maxTokens).toBe(4096);
+  });
+
+  test('applies defaults for missing fields', () => {
+    writeConfig({});
+    const config = loadConfig();
+    expect(config.provider).toBe('anthropic');
+    expect(config.model).toBe('claude-sonnet-4-5-20250929');
+    expect(config.maxTokens).toBe(64000);
+    expect(config.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
+  });
+
+  test('falls back to default for invalid provider', () => {
+    writeConfig({ provider: 'invalid-provider' });
+    const config = loadConfig();
+    expect(config.provider).toBe('anthropic');
+  });
+
+  test('falls back to default for invalid maxTokens', () => {
+    writeConfig({ maxTokens: -100 });
+    const config = loadConfig();
+    expect(config.maxTokens).toBe(64000);
+  });
+
+  test('falls back to defaults for invalid nested values', () => {
+    writeConfig({
+      timeouts: { shellDefaultTimeoutSec: -5, shellMaxTimeoutSec: 'bad' },
+    });
+    const config = loadConfig();
+    expect(config.timeouts.shellDefaultTimeoutSec).toBe(120);
+    expect(config.timeouts.shellMaxTimeoutSec).toBe(600);
+    expect(config.timeouts.permissionTimeoutSec).toBe(300);
+  });
+
+  test('preserves valid fields when other fields are invalid', () => {
+    writeConfig({
+      provider: 'openai',
+      model: 'gpt-4',
+      maxTokens: -1,
+      thinking: { enabled: true, budgetTokens: 5000 },
+    });
+    const config = loadConfig();
+    expect(config.provider).toBe('openai');
+    expect(config.model).toBe('gpt-4');
+    expect(config.thinking.enabled).toBe(true);
+    expect(config.thinking.budgetTokens).toBe(5000);
+    expect(config.maxTokens).toBe(64000);
+  });
+
+  test('handles no config file', () => {
+    const config = loadConfig();
+    expect(config.provider).toBe('anthropic');
+    expect(config.maxTokens).toBe(64000);
+  });
+
+  test('partial nested objects get defaults for missing fields', () => {
+    writeConfig({
+      timeouts: { shellDefaultTimeoutSec: 30 },
+    });
+    const config = loadConfig();
+    expect(config.timeouts.shellDefaultTimeoutSec).toBe(30);
+    expect(config.timeouts.shellMaxTimeoutSec).toBe(600);
+    expect(config.timeouts.permissionTimeoutSec).toBe(300);
+  });
+
+  test('falls back for invalid secretDetection.action', () => {
+    writeConfig({ secretDetection: { action: 'explode' } });
+    const config = loadConfig();
+    expect(config.secretDetection.action).toBe('warn');
+  });
+
+  test('falls back for invalid sandbox.enabled', () => {
+    writeConfig({ sandbox: { enabled: 'yes' } });
+    const config = loadConfig();
+    expect(config.sandbox.enabled).toBe(false);
+  });
+
+  test('falls back for invalid rateLimit values', () => {
+    writeConfig({ rateLimit: { maxRequestsPerMinute: -1, maxTokensPerSession: 3.5 } });
+    const config = loadConfig();
+    expect(config.rateLimit.maxRequestsPerMinute).toBe(0);
+    expect(config.rateLimit.maxTokensPerSession).toBe(0);
+  });
+
+  test('falls back for invalid auditLog.retentionDays', () => {
+    writeConfig({ auditLog: { retentionDays: -7 } });
+    const config = loadConfig();
+    expect(config.auditLog.retentionDays).toBe(0);
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -4,12 +4,11 @@ import { getDataDir, ensureDataDir } from '../util/platform.js';
 import { ConfigError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
 import { DEFAULT_CONFIG } from './defaults.js';
+import { AssistantConfigSchema } from './schema.js';
 import { getSecureKey, setSecureKey, deleteSecureKey } from '../security/secure-keys.js';
 import type { AssistantConfig } from './types.js';
 
 const log = getLogger('config');
-
-const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 
 // Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
 const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'brave'] as const;
@@ -19,6 +18,54 @@ let loading = false;
 
 function getConfigPath(): string {
   return join(getDataDir(), 'config.json');
+}
+
+/**
+ * Validate a raw config object with Zod. Invalid fields are logged as warnings
+ * and replaced with defaults (matching prior behavior of per-field fallback).
+ */
+function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
+  const result = AssistantConfigSchema.safeParse(raw);
+  if (result.success) {
+    return result.data;
+  }
+
+  // Log each validation issue as a warning
+  for (const issue of result.error.issues) {
+    const path = issue.path.join('.');
+    log.warn(`Invalid config${path ? ` at "${path}"` : ''}: ${issue.message}. Falling back to default.`);
+  }
+
+  // Strip invalid fields by setting them to undefined so Zod defaults apply,
+  // then re-parse. We walk the error paths and delete the offending keys.
+  const cleaned = structuredClone(raw);
+  for (const issue of result.error.issues) {
+    if (issue.path.length === 0) {
+      // Top-level error — return full defaults
+      return { ...DEFAULT_CONFIG };
+    }
+    deleteNestedKey(cleaned, issue.path as (string | number)[]);
+  }
+
+  const retry = AssistantConfigSchema.safeParse(cleaned);
+  if (retry.success) {
+    return retry.data;
+  }
+
+  // If still failing, fall back to full defaults
+  log.warn('Config validation failed after cleanup. Using full defaults.');
+  return { ...DEFAULT_CONFIG };
+}
+
+function deleteNestedKey(obj: Record<string, unknown>, path: (string | number)[]): void {
+  let current: unknown = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    if (current === null || current === undefined || typeof current !== 'object') return;
+    current = (current as Record<string, unknown>)[String(path[i])];
+  }
+  if (current !== null && current !== undefined && typeof current === 'object') {
+    delete (current as Record<string, unknown>)[String(path[path.length - 1])];
+  }
 }
 
 export function loadConfig(): AssistantConfig {
@@ -34,7 +81,7 @@ export function loadConfig(): AssistantConfig {
     ensureDataDir();
     const configPath = getConfigPath();
 
-    let fileConfig: Partial<AssistantConfig> = {};
+    let fileConfig: Record<string, unknown> = {};
     if (existsSync(configPath)) {
       const mode = statSync(configPath).mode;
       if (mode & 0o077) {
@@ -51,6 +98,7 @@ export function loadConfig(): AssistantConfig {
       }
     }
 
+    // Pre-validate apiKeys shape before migration (must be a plain object)
     if (
       fileConfig.apiKeys !== undefined &&
       (typeof fileConfig.apiKeys !== 'object' || fileConfig.apiKeys === null || Array.isArray(fileConfig.apiKeys))
@@ -61,8 +109,9 @@ export function loadConfig(): AssistantConfig {
 
     // Auto-migrate plaintext apiKeys from config.json to secure storage
     if (fileConfig.apiKeys && typeof fileConfig.apiKeys === 'object') {
-      const plaintextKeys = Object.entries(fileConfig.apiKeys).filter(
-        ([, v]) => typeof v === 'string' && v.length > 0,
+      const apiKeysObj = fileConfig.apiKeys as Record<string, unknown>;
+      const plaintextKeys = Object.entries(apiKeysObj).filter(
+        ([, v]) => typeof v === 'string' && (v as string).length > 0,
       );
       if (plaintextKeys.length > 0) {
         const migratedProviders: string[] = [];
@@ -91,33 +140,20 @@ export function loadConfig(): AssistantConfig {
         }
         // Clear only migrated keys from fileConfig so failed keys still flow into config
         for (const p of migratedProviders) {
-          delete fileConfig.apiKeys![p];
+          delete apiKeysObj[p];
         }
-        if (Object.keys(fileConfig.apiKeys!).length === 0) {
+        if (Object.keys(apiKeysObj).length === 0) {
           delete fileConfig.apiKeys;
         }
       }
     }
 
-    const config: AssistantConfig = {
-      ...DEFAULT_CONFIG,
-      ...fileConfig,
-      apiKeys: { ...DEFAULT_CONFIG.apiKeys, ...fileConfig.apiKeys },
-      timeouts: { ...DEFAULT_CONFIG.timeouts, ...(fileConfig as Record<string, unknown>).timeouts as Partial<AssistantConfig['timeouts']> },
-      sandbox: { ...DEFAULT_CONFIG.sandbox, ...(fileConfig as Record<string, unknown>).sandbox as Partial<AssistantConfig['sandbox']> },
-      rateLimit: { ...DEFAULT_CONFIG.rateLimit, ...(fileConfig as Record<string, unknown>).rateLimit as Partial<AssistantConfig['rateLimit']> },
-      thinking: { ...DEFAULT_CONFIG.thinking, ...(fileConfig as Record<string, unknown>).thinking as Partial<AssistantConfig['thinking']> },
-      secretDetection: { ...DEFAULT_CONFIG.secretDetection, ...(fileConfig as Record<string, unknown>).secretDetection as Partial<AssistantConfig['secretDetection']> },
-      auditLog: { ...DEFAULT_CONFIG.auditLog, ...(fileConfig as Record<string, unknown>).auditLog as Partial<AssistantConfig['auditLog']> },
-    };
+    // Validate and apply defaults via Zod schema
+    const config = validateWithSchema(fileConfig);
 
-    // Set cached before validation so re-entrant calls (e.g. validateConfig
-    // logging triggers loadConfig) return the in-flight config instead of
-    // bare defaults. Validation mutates the same object, so callers see
-    // corrected values.
+    // Set cached before secure-key/env overrides so re-entrant calls
+    // return the in-flight config instead of bare defaults.
     cached = config;
-
-    validateConfig(config);
 
     // Secure storage keys override plaintext config file
     try {
@@ -131,7 +167,7 @@ export function loadConfig(): AssistantConfig {
       log.debug({ err }, 'Failed to load keys from secure storage');
     }
 
-    // Environment variables override everything (after validation so apiKeys is a valid object)
+    // Environment variables override everything
     if (process.env.ANTHROPIC_API_KEY) {
       config.apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
     }
@@ -152,90 +188,6 @@ export function loadConfig(): AssistantConfig {
     cached = null;
     loading = false;
     throw err;
-  }
-}
-
-function validateConfig(config: AssistantConfig): void {
-  if (!VALID_PROVIDERS.includes(config.provider as (typeof VALID_PROVIDERS)[number])) {
-    log.warn(
-      `Invalid provider "${config.provider}". Valid providers: ${VALID_PROVIDERS.join(', ')}. Falling back to "${DEFAULT_CONFIG.provider}".`,
-    );
-    config.provider = DEFAULT_CONFIG.provider;
-  }
-
-  if (!Number.isInteger(config.maxTokens) || config.maxTokens <= 0) {
-    log.warn(
-      `Invalid maxTokens "${config.maxTokens}". Must be a positive integer. Falling back to ${DEFAULT_CONFIG.maxTokens}.`,
-    );
-    config.maxTokens = DEFAULT_CONFIG.maxTokens;
-  }
-
-  if (typeof config.apiKeys !== 'object' || config.apiKeys === null || Array.isArray(config.apiKeys)) {
-    log.warn('Invalid apiKeys: must be an object with string values. Falling back to empty object.');
-    config.apiKeys = {};
-  } else {
-    for (const [key, value] of Object.entries(config.apiKeys)) {
-      if (typeof value !== 'string') {
-        log.warn(`Invalid apiKeys.${key}: value must be a string. Removing entry.`);
-        delete config.apiKeys[key];
-      }
-    }
-  }
-
-  for (const field of ['shellDefaultTimeoutSec', 'shellMaxTimeoutSec', 'permissionTimeoutSec'] as const) {
-    const val = config.timeouts[field];
-    if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) {
-      log.warn(
-        `Invalid timeouts.${field} "${val}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.timeouts[field]}.`,
-      );
-      config.timeouts[field] = DEFAULT_CONFIG.timeouts[field];
-    }
-  }
-
-  if (typeof config.thinking.enabled !== 'boolean') {
-    log.warn(`Invalid thinking.enabled "${config.thinking.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.thinking.enabled}.`);
-    config.thinking.enabled = DEFAULT_CONFIG.thinking.enabled;
-  }
-
-  if (typeof config.thinking.budgetTokens !== 'number' || !Number.isFinite(config.thinking.budgetTokens) || config.thinking.budgetTokens <= 0 || !Number.isInteger(config.thinking.budgetTokens)) {
-    log.warn(`Invalid thinking.budgetTokens "${config.thinking.budgetTokens}". Must be a positive integer. Falling back to ${DEFAULT_CONFIG.thinking.budgetTokens}.`);
-    config.thinking.budgetTokens = DEFAULT_CONFIG.thinking.budgetTokens;
-  }
-
-  if (typeof config.sandbox.enabled !== 'boolean') {
-    log.warn(`Invalid sandbox.enabled "${config.sandbox.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.sandbox.enabled}.`);
-    config.sandbox.enabled = DEFAULT_CONFIG.sandbox.enabled;
-  }
-
-  for (const field of ['maxRequestsPerMinute', 'maxTokensPerSession'] as const) {
-    const val = config.rateLimit[field];
-    if (typeof val !== 'number' || !Number.isFinite(val) || val < 0 || !Number.isInteger(val)) {
-      log.warn(
-        `Invalid rateLimit.${field} "${val}". Must be a non-negative integer. Falling back to ${DEFAULT_CONFIG.rateLimit[field]}.`,
-      );
-      config.rateLimit[field] = DEFAULT_CONFIG.rateLimit[field];
-    }
-  }
-
-  if (typeof config.secretDetection.enabled !== 'boolean') {
-    log.warn(`Invalid secretDetection.enabled "${config.secretDetection.enabled}". Must be a boolean. Falling back to ${DEFAULT_CONFIG.secretDetection.enabled}.`);
-    config.secretDetection.enabled = DEFAULT_CONFIG.secretDetection.enabled;
-  }
-
-  const validActions = ['redact', 'warn', 'block'] as const;
-  if (!validActions.includes(config.secretDetection.action as (typeof validActions)[number])) {
-    log.warn(`Invalid secretDetection.action "${config.secretDetection.action}". Must be one of: ${validActions.join(', ')}. Falling back to "${DEFAULT_CONFIG.secretDetection.action}".`);
-    config.secretDetection.action = DEFAULT_CONFIG.secretDetection.action;
-  }
-
-  if (typeof config.secretDetection.entropyThreshold !== 'number' || !Number.isFinite(config.secretDetection.entropyThreshold) || config.secretDetection.entropyThreshold <= 0) {
-    log.warn(`Invalid secretDetection.entropyThreshold "${config.secretDetection.entropyThreshold}". Must be a positive number. Falling back to ${DEFAULT_CONFIG.secretDetection.entropyThreshold}.`);
-    config.secretDetection.entropyThreshold = DEFAULT_CONFIG.secretDetection.entropyThreshold;
-  }
-
-  if (typeof config.auditLog.retentionDays !== 'number' || !Number.isFinite(config.auditLog.retentionDays) || config.auditLog.retentionDays < 0 || !Number.isInteger(config.auditLog.retentionDays)) {
-    log.warn(`Invalid auditLog.retentionDays "${config.auditLog.retentionDays}". Must be a non-negative integer. Falling back to ${DEFAULT_CONFIG.auditLog.retentionDays}.`);
-    config.auditLog.retentionDays = DEFAULT_CONFIG.auditLog.retentionDays;
   }
 }
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+import { getDataDir } from '../util/platform.js';
+
+const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
+const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
+
+export const TimeoutConfigSchema = z.object({
+  shellMaxTimeoutSec: z
+    .number({ error: 'timeouts.shellMaxTimeoutSec must be a number' })
+    .finite('timeouts.shellMaxTimeoutSec must be finite')
+    .positive('timeouts.shellMaxTimeoutSec must be a positive number')
+    .default(600),
+  shellDefaultTimeoutSec: z
+    .number({ error: 'timeouts.shellDefaultTimeoutSec must be a number' })
+    .finite('timeouts.shellDefaultTimeoutSec must be finite')
+    .positive('timeouts.shellDefaultTimeoutSec must be a positive number')
+    .default(120),
+  permissionTimeoutSec: z
+    .number({ error: 'timeouts.permissionTimeoutSec must be a number' })
+    .finite('timeouts.permissionTimeoutSec must be finite')
+    .positive('timeouts.permissionTimeoutSec must be a positive number')
+    .default(300),
+});
+
+export const SandboxConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'sandbox.enabled must be a boolean' })
+    .default(false),
+});
+
+export const RateLimitConfigSchema = z.object({
+  maxRequestsPerMinute: z
+    .number({ error: 'rateLimit.maxRequestsPerMinute must be a number' })
+    .int('rateLimit.maxRequestsPerMinute must be an integer')
+    .nonnegative('rateLimit.maxRequestsPerMinute must be a non-negative integer')
+    .default(0),
+  maxTokensPerSession: z
+    .number({ error: 'rateLimit.maxTokensPerSession must be a number' })
+    .int('rateLimit.maxTokensPerSession must be an integer')
+    .nonnegative('rateLimit.maxTokensPerSession must be a non-negative integer')
+    .default(0),
+});
+
+export const SecretDetectionConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'secretDetection.enabled must be a boolean' })
+    .default(true),
+  action: z
+    .enum(VALID_SECRET_ACTIONS, {
+      error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(', ')}`,
+    })
+    .default('warn'),
+  entropyThreshold: z
+    .number({ error: 'secretDetection.entropyThreshold must be a number' })
+    .finite('secretDetection.entropyThreshold must be finite')
+    .positive('secretDetection.entropyThreshold must be a positive number')
+    .default(4.0),
+});
+
+export const AuditLogConfigSchema = z.object({
+  retentionDays: z
+    .number({ error: 'auditLog.retentionDays must be a number' })
+    .int('auditLog.retentionDays must be an integer')
+    .nonnegative('auditLog.retentionDays must be a non-negative integer')
+    .default(0),
+});
+
+export const ThinkingConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'thinking.enabled must be a boolean' })
+    .default(false),
+  budgetTokens: z
+    .number({ error: 'thinking.budgetTokens must be a number' })
+    .int('thinking.budgetTokens must be an integer')
+    .positive('thinking.budgetTokens must be a positive integer')
+    .default(10000),
+});
+
+export const AssistantConfigSchema = z.object({
+  provider: z
+    .enum(VALID_PROVIDERS, {
+      error: `provider must be one of: ${VALID_PROVIDERS.join(', ')}`,
+    })
+    .default('anthropic'),
+  model: z
+    .string({ error: 'model must be a string' })
+    .default('claude-sonnet-4-5-20250929'),
+  apiKeys: z
+    .record(z.string(), z.string({ error: 'Each apiKeys value must be a string' }))
+    .default({}),
+  systemPrompt: z
+    .string({ error: 'systemPrompt must be a string' })
+    .optional(),
+  maxTokens: z
+    .number({ error: 'maxTokens must be a number' })
+    .int('maxTokens must be an integer')
+    .positive('maxTokens must be a positive integer')
+    .default(64000),
+  thinking: ThinkingConfigSchema.default({
+    enabled: false,
+    budgetTokens: 10000,
+  }),
+  dataDir: z
+    .string({ error: 'dataDir must be a string' })
+    .default(getDataDir()),
+  timeouts: TimeoutConfigSchema.default({
+    shellMaxTimeoutSec: 600,
+    shellDefaultTimeoutSec: 120,
+    permissionTimeoutSec: 300,
+  }),
+  sandbox: SandboxConfigSchema.default({
+    enabled: false,
+  }),
+  rateLimit: RateLimitConfigSchema.default({
+    maxRequestsPerMinute: 0,
+    maxTokensPerSession: 0,
+  }),
+  secretDetection: SecretDetectionConfigSchema.default({
+    enabled: true,
+    action: 'warn',
+    entropyThreshold: 4.0,
+  }),
+  auditLog: AuditLogConfigSchema.default({
+    retentionDays: 0,
+  }),
+});
+
+export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;
+export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
+export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
+export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
+export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
+export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;
+export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -1,56 +1,9 @@
-export interface TimeoutConfig {
-  /** Maximum shell command timeout in seconds. LLM can request up to this. */
-  shellMaxTimeoutSec: number;
-  /** Default shell command timeout in seconds when LLM doesn't specify one. */
-  shellDefaultTimeoutSec: number;
-  /** Permission prompt timeout in seconds. */
-  permissionTimeoutSec: number;
-}
-
-export interface SandboxConfig {
-  /** Whether to run shell commands in a sandbox. Default: false. */
-  enabled: boolean;
-}
-
-export interface RateLimitConfig {
-  /** Maximum API requests per minute. 0 = unlimited. */
-  maxRequestsPerMinute: number;
-  /** Maximum total tokens (input + output) per session. 0 = unlimited. */
-  maxTokensPerSession: number;
-}
-
-export interface SecretDetectionConfig {
-  /** Whether secret detection is enabled. Default: true. */
-  enabled: boolean;
-  /** What to do when a secret is detected: redact, warn, or block. Default: 'warn'. */
-  action: 'redact' | 'warn' | 'block';
-  /** Shannon entropy threshold for entropy-based detection. Default: 4.0. */
-  entropyThreshold: number;
-}
-
-export interface AuditLogConfig {
-  /** Number of days to retain tool invocation records. 0 = retain forever. Default: 0. */
-  retentionDays: number;
-}
-
-export interface ThinkingConfig {
-  /** Enable extended thinking. Default: false. */
-  enabled: boolean;
-  /** Thinking budget in tokens. Default: 10000. */
-  budgetTokens: number;
-}
-
-export interface AssistantConfig {
-  provider: string;
-  model: string;
-  apiKeys: Record<string, string>;
-  systemPrompt?: string;
-  maxTokens: number;
-  thinking: ThinkingConfig;
-  dataDir: string;
-  timeouts: TimeoutConfig;
-  sandbox: SandboxConfig;
-  rateLimit: RateLimitConfig;
-  secretDetection: SecretDetectionConfig;
-  auditLog: AuditLogConfig;
-}
+export type {
+  AssistantConfig,
+  TimeoutConfig,
+  SandboxConfig,
+  RateLimitConfig,
+  SecretDetectionConfig,
+  AuditLogConfig,
+  ThinkingConfig,
+} from './schema.js';


### PR DESCRIPTION
## Summary
- Replace manual if-check validation in `config/loader.ts` with a Zod schema (`config/schema.ts`)
- Zod schema provides type-safe validation with descriptive error messages and applies defaults via `.default()`
- Invalid fields log warnings and fall back to defaults, preserving existing behavior
- TypeScript types are now inferred from the Zod schema instead of manually defined interfaces

## Changes
- **New**: `assistant/src/config/schema.ts` - Zod schemas for all config sections with custom error messages
- **Modified**: `assistant/src/config/types.ts` - Re-exports types inferred from the Zod schema
- **Modified**: `assistant/src/config/loader.ts` - Replaced ~80 lines of manual `validateConfig()` with `validateWithSchema()` using Zod `safeParse`
- **New**: `assistant/src/__tests__/config-schema.test.ts` - 31 tests covering schema unit tests and loader integration
- **Modified**: `assistant/package.json` + `bun.lock` - Added `zod@4.3.6` dependency

## Test plan
- [x] 31 new tests pass (schema validation + loader integration)
- [x] All 547 existing tests pass (1 pre-existing SQLite failure unrelated)
- [x] TypeScript type-checking passes (`bunx tsc --noEmit`)
- [x] Key migration tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
