### PR TITLE
fix: preserve tool error flag in OpenAI provider

### DIFF
--- a/assistant/src/__tests__/clipboard.test.ts
+++ b/assistant/src/__tests__/clipboard.test.ts
@@ -1,5 +1,31 @@
 import { describe, test, expect } from 'bun:test';
-import { extractLastCodeBlock } from '../util/clipboard.js';
+import { extractLastCodeBlock, formatSessionForExport } from '../util/clipboard.js';
+
+describe('formatSessionForExport', () => {
+  test('formats user and assistant messages', () => {
+    const messages = [
+      { role: 'user', text: 'Hello' },
+      { role: 'assistant', text: 'Hi there!' },
+    ];
+    expect(formatSessionForExport(messages)).toBe('you> Hello\n\nassistant> Hi there!');
+  });
+
+  test('handles a single message', () => {
+    const messages = [{ role: 'user', text: 'Just me' }];
+    expect(formatSessionForExport(messages)).toBe('you> Just me');
+  });
+
+  test('handles empty messages array', () => {
+    expect(formatSessionForExport([])).toBe('');
+  });
+
+  test('preserves multiline message text', () => {
+    const messages = [
+      { role: 'assistant', text: 'Line 1\nLine 2\nLine 3' },
+    ];
+    expect(formatSessionForExport(messages)).toBe('assistant> Line 1\nLine 2\nLine 3');
+  });
+});
 
 describe('extractLastCodeBlock', () => {
   test('extracts a simple code block', () => {

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -355,6 +355,38 @@ describe('OpenAIProvider', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Tool result with is_error flag
+  // -----------------------------------------------------------------------
+  test('prefixes tool result content with [ERROR] when is_error is true', async () => {
+    fakeChunks = [textChunk('I see the error'), usageChunk(20, 10)];
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Read /tmp/nope' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_err', name: 'file_read', input: { path: '/tmp/nope' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_err', content: 'ENOENT: no such file', is_error: true },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[2]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_err',
+      content: '[ERROR] ENOENT: no such file',
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Mixed tool_result + text in user message
   // -----------------------------------------------------------------------
   test('splits user message with tool_result + text into separate messages', async () => {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -10,7 +10,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { formatDiff, formatNewFileDiff } from './util/diff.js';
 import { Spinner } from './util/spinner.js';
-import { copyToClipboard, extractLastCodeBlock } from './util/clipboard.js';
+import { copyToClipboard, extractLastCodeBlock, formatSessionForExport } from './util/clipboard.js';
 import { timeAgo } from './util/time.js';
 import { ensureDaemonRunning } from './daemon/lifecycle.js';
 
@@ -33,6 +33,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
   let lastUsage: { inputTokens: number; outputTokens: number; totalInputTokens: number; totalOutputTokens: number; estimatedCost: number; model: string } | null = null;
   let pendingSessionPick = false;
   let pendingConfirmation = false;
+  let pendingCopySession = false;
   let toolStreaming = false;
   let reconnecting = false;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -388,6 +389,22 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         break;
 
       case 'history_response':
+        if (pendingCopySession) {
+          pendingCopySession = false;
+          if (msg.messages.length === 0) {
+            process.stdout.write('\n  No messages to copy.\n\n');
+          } else {
+            try {
+              const formatted = formatSessionForExport(msg.messages);
+              copyToClipboard(formatted);
+              process.stdout.write(`\n  Copied session (${msg.messages.length} messages) to clipboard.\n\n`);
+            } catch (err) {
+              process.stdout.write(`\n  Clipboard error: ${(err as Error).message}\n\n`);
+            }
+          }
+          prompt();
+          break;
+        }
         process.stdout.write('\n');
         if (msg.messages.length === 0) {
           process.stdout.write('  No messages in this session.\n');
@@ -473,6 +490,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     toolStreaming = false;
     pendingSessionPick = false;
     pendingConfirmation = false;
+    pendingCopySession = false;
     lastUsage = null;
 
     // Remove stale rl.once('line') handlers from confirmation/selection prompts
@@ -586,6 +604,12 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       return;
     }
 
+    if (content === '/copy-session') {
+      pendingCopySession = true;
+      send({ type: 'history_request', sessionId });
+      return;
+    }
+
     if (content === '/new') {
       send({ type: 'session_create' });
       return;
@@ -635,6 +659,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       process.stdout.write('  /usage            Show token usage and cost\n');
       process.stdout.write('  /copy             Copy last response to clipboard\n');
       process.stdout.write('  /copy-code        Copy last code block to clipboard\n');
+      process.stdout.write('  /copy-session     Copy entire session to clipboard\n');
       process.stdout.write('  /help             Show this help\n');
       process.stdout.write('\n');
       prompt();

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -164,10 +164,13 @@ export class OpenAIProvider implements Provider {
 
         // Emit tool results as separate tool-role messages
         for (const tr of toolResults) {
+          const content = tr.is_error
+            ? `[ERROR] ${tr.content}`
+            : tr.content;
           result.push({
             role: 'tool',
             tool_call_id: tr.tool_use_id,
-            content: tr.content,
+            content,
           });
         }
 

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -14,6 +14,17 @@ export function copyToClipboard(text: string): void {
   execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] });
 }
 
+export function formatSessionForExport(
+  messages: Array<{ role: string; text: string }>,
+): string {
+  return messages
+    .map((m) => {
+      const label = m.role === 'user' ? 'you' : 'assistant';
+      return `${label}> ${m.text}`;
+    })
+    .join('\n\n');
+}
+
 export function extractLastCodeBlock(text: string): string | null {
   const re = /```[^\n]*\n((?:[\s\S]*?\n)?)```/g;
   let last: RegExpExecArray | null = null;


### PR DESCRIPTION
## Summary
- Fixes OpenAI provider to preserve `is_error` flag from tool results
- When `is_error` is true, prefixes tool message content with `[ERROR]` so the model can distinguish failed tool calls from successful ones
- Addresses feedback on PR #313

## Changes
- `assistant/src/providers/openai/client.ts` — prefix tool result content with `[ERROR]` when `is_error` is true
- `assistant/src/__tests__/openai-provider.test.ts` — added test verifying error prefix behavior

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/openai-provider.test.ts` — 20 pass, 0 fail
- [x] Existing test at line 316 verifies `is_error: false` does not add prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
