### PR TITLE
fix: tighten precondition in fuzzy-match property test

### DIFF
--- a/assistant/src/__tests__/fuzzy-match-property.test.ts
+++ b/assistant/src/__tests__/fuzzy-match-property.test.ts
@@ -93,6 +93,9 @@ describe('fuzzy-match property-based tests', () => {
           if (prefix.includes(target) || suffix.includes(target)) return;
 
           const content = prefix + target + suffix;
+          // Ensure target's first occurrence is exactly at the inserted position,
+          // not at an earlier overlapping boundary (e.g. prefix='ab', target='aba')
+          fc.pre(content.indexOf(target) === prefix.length);
           const result = findMatch(content, target);
           expect(result).not.toBeNull();
           expect(result!.method).toBe('exact');


### PR DESCRIPTION
## Summary
- Fixes flaky "exact match start and end indices are correct" property test in `fuzzy-match-property.test.ts`
- The test was nondeterministic because `target` could overlap across the `prefix`/`target` boundary (e.g. `prefix='ab'`, `target='aba'` produces `content='ababax'`, where `indexOf(target)` returns 0 instead of `prefix.length`)
- Added `fc.pre(content.indexOf(target) === prefix.length)` guard to skip cases where the target's first occurrence isn't at the expected insertion point

## Test plan
- [x] All 12 property tests pass (3800 expect() calls)
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
