### PR TITLE
fix: reset pendingCopySession on error and guard send

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -348,9 +348,10 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       case 'error':
         spinner.stop();
         generating = false;
-        if (pendingConfirmation || pendingSessionPick) {
+        if (pendingConfirmation || pendingSessionPick || pendingCopySession) {
           pendingConfirmation = false;
           pendingSessionPick = false;
+          pendingCopySession = false;
           rl.removeAllListeners('line');
           rl.on('line', handleLine);
         }
@@ -605,8 +606,12 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
 
     if (content === '/copy-session') {
+      if (!send({ type: 'history_request', sessionId })) {
+        process.stdout.write('[Not connected — command not sent]\n');
+        prompt();
+        return;
+      }
       pendingCopySession = true;
-      send({ type: 'history_request', sessionId });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Reset `pendingCopySession` in the `error` message handler alongside `pendingConfirmation` and `pendingSessionPick`, preventing the flag from staying stuck when the server sends an error during a pending copy-session request.
- Check `send()` return value before setting `pendingCopySession` in the `/copy-session` command handler, so a disconnected socket doesn't leave the flag stuck true and cause the next `/history` response to be routed to clipboard instead of display.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify existing tests pass (`bun test`)
- [ ] Manual: disconnect socket, run `/copy-session`, confirm error message shown and flag not stuck
- [ ] Manual: trigger server error while `/copy-session` is pending, confirm next `/history` displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
