### PR TITLE
fix: enforce exhaustive IPC snapshot coverage via discriminant-keyed records

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -15,7 +15,8 @@ import type {
 // Client → Server messages
 // ---------------------------------------------------------------------------
 
-const clientMessages: Record<string, ClientMessage> = {
+type ClientMessageType = ClientMessage['type'];
+const clientMessages: Record<ClientMessageType, ClientMessage> = {
   user_message: {
     type: 'user_message',
     sessionId: 'sess-001',
@@ -74,7 +75,8 @@ const clientMessages: Record<string, ClientMessage> = {
 // Server → Client messages
 // ---------------------------------------------------------------------------
 
-const serverMessages: Record<string, ServerMessage> = {
+type ServerMessageType = ServerMessage['type'];
+const serverMessages: Record<ServerMessageType, ServerMessage> = {
   assistant_text_delta: {
     type: 'assistant_text_delta',
     text: 'Here is some output',


### PR DESCRIPTION
## Summary
- Changed IPC snapshot test fixture types from `Record<string, ClientMessage>` and `Record<string, ServerMessage>` to `Record<ClientMessage['type'], ClientMessage>` and `Record<ServerMessage['type'], ServerMessage>`.
- This ensures TypeScript will error if a new message type is added to the `ClientMessage` or `ServerMessage` union in `ipc-protocol.ts` without a corresponding entry in the snapshot fixtures.

Addresses review feedback on #326.

## Test plan
- [x] All 33 snapshot tests pass
- [x] `tsc --noEmit` passes with no type errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
