### PR TITLE
fix: move debug log after secret detection to prevent leakage

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -135,18 +135,6 @@ export class ToolExecutor {
       // Execute the tool
       const execResult = await tool.execute(input, context);
 
-      if (debug) {
-        const execDurationMs = Date.now() - startTime;
-        log.debug({
-          tool: name,
-          execDurationMs,
-          riskLevel,
-          decision,
-          isError: execResult.isError,
-          output: truncateForLog(execResult.content, 300),
-        }, 'Tool execute result');
-      }
-
       // Secret detection on tool output
       const sdConfig = getConfig().secretDetection;
       if (sdConfig.enabled && !execResult.isError) {
@@ -201,6 +189,18 @@ export class ToolExecutor {
             };
           }
         }
+      }
+
+      if (debug) {
+        const execDurationMs = Date.now() - startTime;
+        log.debug({
+          tool: name,
+          execDurationMs,
+          riskLevel,
+          decision,
+          isError: execResult.isError,
+          output: truncateForLog(execResult.content, 300),
+        }, 'Tool execute result');
       }
 
       const durationMs = Date.now() - startTime;

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -23,11 +23,7 @@ function getRootLogger(): pino.Logger {
   return rootLogger;
 }
 
-/**
- * Returns a lazy logger that only initializes pino when a log method is called.
- * This avoids "sonic boom is not ready yet" errors when the process exits
- * quickly (e.g. `assistant --help`).
- */
+/** Returns true when VELLUM_DEBUG=1 is set. */
 export function isDebug(): boolean {
   return process.env.VELLUM_DEBUG === '1';
 }
@@ -41,6 +37,11 @@ export function truncateForLog(value: string, maxLen = 500): string {
   return value.slice(0, maxLen) + `... (${value.length - maxLen} chars truncated)`;
 }
 
+/**
+ * Returns a lazy logger that only initializes pino when a log method is called.
+ * This avoids "sonic boom is not ready yet" errors when the process exits
+ * quickly (e.g. `assistant --help`).
+ */
 export function getLogger(name: string): pino.Logger {
   let child: pino.Logger | null = null;
   const handler: ProxyHandler<pino.Logger> = {


### PR DESCRIPTION
## Summary
- **Security fix**: Moved the debug log in `ToolExecutor.execute()` to AFTER secret detection runs, so that when `VELLUM_DEBUG=1` is set, only sanitized/redacted output is logged to stderr — previously raw tool output (potentially containing secrets) was logged before scanning.
- **JSDoc fix**: Added correct JSDoc to `isDebug()` and moved the lazy logger initialization JSDoc back to `getLogger()` where it belongs.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 598/599 pass (1 pre-existing failure in audit-log-rotation unrelated to this change)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
