### PR TITLE
fix: correct socket permissions and WASM filename in doctor

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -601,7 +601,7 @@ program
       try {
         const sockStat = statSync(sockPath);
         const mode = sockStat.mode & 0o777;
-        if (mode === 0o600 || mode === 0o755) {
+        if (mode === 0o600 || mode === 0o700) {
           pass(`Socket permissions (${mode.toString(8).padStart(4, '0')})`);
         } else {
           fail('Socket permissions', `expected 0600, got 0${mode.toString(8)}`);
@@ -648,7 +648,7 @@ program
 
     // 11. WASM files
     const wasmFiles = [
-      'node_modules/web-tree-sitter/tree-sitter.wasm',
+      'node_modules/web-tree-sitter/web-tree-sitter.wasm',
       'node_modules/tree-sitter-bash/tree-sitter-bash.wasm',
     ];
     let wasmOk = true;


### PR DESCRIPTION
## Summary
- Fix socket permissions check: reject `0o755` (allows other-user access) and accept `0o700` instead (OS-set for sockets). The daemon sets `0o600` in `server.ts:72`.
- Fix WASM filename mismatch: doctor checked for `tree-sitter.wasm` but `parser.ts` loads `web-tree-sitter.wasm`, causing false failures.

Addresses feedback from PR #325.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 598/599 pass; 1 pre-existing flaky failure in `audit-log-rotation.test.ts` (SQLite concurrency, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
