### PR TITLE
Isolate assistant tests per file in CI

### DIFF
--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -33,4 +33,4 @@ jobs:
         run: bun run lint
 
       - name: Test
-        run: bun test
+        run: bun run test

--- a/assistant/scripts/test.sh
+++ b/assistant/scripts/test.sh
@@ -1,39 +1,23 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Test runner with process isolation for mock.module conflicts
+# Test runner with full process isolation for Bun mock.module conflicts
 #
 # Bun's mock.module is process-global: the last mock.module call for a given
 # specifier wins across ALL test files in the process.  This means test files
 # that mock a module break other test files that need the real implementation.
-#
-# Conflicting pairs:
-#   secure-keys.test.ts  mocks  keychain.js              → breaks  keychain.test.ts
-#   secret-scanner-executor.test.ts  mocks  config/loader.js     → breaks  key-migration.test.ts
-#   secret-scanner-executor.test.ts  mocks  tool-usage-store.js  → breaks  audit-log-rotation.test.ts
-#
-# We run the "victim" files in their own bun processes, then run the rest
-# together in a single process for speed.
+# To avoid order-dependent CI flakes, run each test file in its own Bun process.
 # ---------------------------------------------------------------------------
 
-# Files that need process isolation (their dependencies are mocked by other files)
-bun test src/__tests__/keychain.test.ts
-bun test src/__tests__/key-migration.test.ts
-bun test src/__tests__/audit-log-rotation.test.ts
+found_test=0
+while IFS= read -r test_file; do
+  found_test=1
+  echo "==> Running ${test_file}"
+  bun test "${test_file}"
+done < <(find src/__tests__ -maxdepth 1 -type f -name '*.test.ts' | sort)
 
-# Remaining tests run together — no mock conflicts among these
-bun test \
-  src/__tests__/checker.test.ts \
-  src/__tests__/clipboard.test.ts \
-  src/__tests__/diff.test.ts \
-  src/__tests__/encrypted-store.test.ts \
-  src/__tests__/fuzzy-match.test.ts \
-  src/__tests__/parser.test.ts \
-  src/__tests__/ratelimit.test.ts \
-  src/__tests__/secret-allowlist.test.ts \
-  src/__tests__/secret-scanner.test.ts \
-  src/__tests__/secret-scanner-executor.test.ts \
-  src/__tests__/secure-keys.test.ts \
-  src/__tests__/trust-store.test.ts \
-  src/__tests__/web-search.test.ts
+if [[ ${found_test} -eq 0 ]]; then
+  echo "No test files found under src/__tests__"
+  exit 1
+fi


### PR DESCRIPTION
Run assistant tests via the isolated script in CI and execute each test file in a separate Bun process to prevent process-global mock leakage between test files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
