### PR TITLE
Add run_applescript tool for scripting bridge control

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -1,7 +1,6 @@
 import CoreGraphics
 import AppKit
 import ApplicationServices
-import Carbon
 
 enum ExecutorError: LocalizedError {
     case eventCreationFailed
@@ -244,29 +243,44 @@ final class ActionExecutor: ActionExecuting {
     // MARK: - AppleScript
 
     func runAppleScript(_ source: String) async throws -> String? {
-        // Run NSAppleScript on main thread with a 5-second timeout
-        try await withThrowingTaskGroup(of: String?.self) { group in
-            group.addTask { @MainActor in
-                var errorInfo: NSDictionary?
-                let script = NSAppleScript(source: source)!
-                let descriptor = script.executeAndReturnError(&errorInfo)
+        // Run osascript as a subprocess so we can kill it on timeout and avoid blocking the main thread
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", source]
 
-                if let error = errorInfo {
-                    let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
-                    throw ExecutorError.appleScriptError(message)
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+
+        // 5-second timeout — terminate the subprocess if it takes too long
+        let timeoutTask = Task {
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            process.terminationHandler = { proc in
+                timeoutTask.cancel()
+
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let errorOutput = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if proc.terminationReason == .uncaughtSignal {
+                    continuation.resume(throwing: ExecutorError.appleScriptTimeout)
+                } else if proc.terminationStatus != 0 {
+                    let message = errorOutput ?? "Unknown AppleScript error (exit \(proc.terminationStatus))"
+                    continuation.resume(throwing: ExecutorError.appleScriptError(message))
+                } else {
+                    continuation.resume(returning: output)
                 }
-
-                return descriptor.stringValue
             }
-
-            group.addTask {
-                try await Task.sleep(nanoseconds: 5_000_000_000) // 5s timeout
-                throw ExecutorError.appleScriptTimeout
-            }
-
-            let value = try await group.next()!
-            group.cancelAll()
-            return value
         }
     }
 

--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import AppKit
 import ApplicationServices
+import Carbon
 
 enum ExecutorError: LocalizedError {
     case eventCreationFailed
@@ -10,6 +11,9 @@ enum ExecutorError: LocalizedError {
     case unknownKey(String)
     case accessibilityNotGranted
     case appNotFound(String)
+    case appleScriptError(String)
+    case appleScriptMissingScript
+    case appleScriptTimeout
 
     var errorDescription: String? {
         switch self {
@@ -20,12 +24,15 @@ enum ExecutorError: LocalizedError {
         case .unknownKey(let key): return "Unknown key: \(key)"
         case .accessibilityNotGranted: return "Accessibility permission not granted"
         case .appNotFound(let name): return "Application not found: \(name)"
+        case .appleScriptError(let msg): return "AppleScript error: \(msg)"
+        case .appleScriptMissingScript: return "run_applescript requires a script"
+        case .appleScriptTimeout: return "AppleScript timed out after 5 seconds"
         }
     }
 }
 
 protocol ActionExecuting {
-    func execute(_ action: AgentAction) async throws
+    func execute(_ action: AgentAction) async throws -> String?
 }
 
 final class ActionExecutor: ActionExecuting {
@@ -191,7 +198,8 @@ final class ActionExecutor: ActionExecuting {
 
     // MARK: - Dispatch
 
-    func execute(_ action: AgentAction) async throws {
+    @discardableResult
+    func execute(_ action: AgentAction) async throws -> String? {
         switch action.type {
         case .click:
             guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
@@ -221,11 +229,44 @@ final class ActionExecutor: ActionExecuting {
         case .openApp:
             guard let appName = action.appName else { throw ExecutorError.appNotFound("(no name)") }
             try await openApp(name: appName)
+        case .runAppleScript:
+            guard let source = action.script else { throw ExecutorError.appleScriptMissingScript }
+            return try await runAppleScript(source)
         case .wait:
             let ms = action.waitDuration ?? 500
             try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
         case .done:
             break
+        }
+        return nil
+    }
+
+    // MARK: - AppleScript
+
+    func runAppleScript(_ source: String) async throws -> String? {
+        // Run NSAppleScript on main thread with a 5-second timeout
+        try await withThrowingTaskGroup(of: String?.self) { group in
+            group.addTask { @MainActor in
+                var errorInfo: NSDictionary?
+                let script = NSAppleScript(source: source)!
+                let descriptor = script.executeAndReturnError(&errorInfo)
+
+                if let error = errorInfo {
+                    let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
+                    throw ExecutorError.appleScriptError(message)
+                }
+
+                return descriptor.stringValue
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: 5_000_000_000) // 5s timeout
+                throw ExecutorError.appleScriptTimeout
+            }
+
+            let value = try await group.next()!
+            group.cancelAll()
+            return value
         }
     }
 

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -12,6 +12,7 @@ enum ActionType: String, Codable {
     case done
     case drag
     case openApp = "open_app"
+    case runAppleScript = "run_applescript"
 }
 
 struct AgentAction: Codable {
@@ -27,6 +28,7 @@ struct AgentAction: Codable {
     var summary: String?
     var waitDuration: Int?
     var appName: String?
+    var script: String?
     var reasoning: String
     var resolvedFromElementId: Int?
     var elementDescription: String?
@@ -45,6 +47,7 @@ struct AgentAction: Codable {
         summary: String? = nil,
         waitDuration: Int? = nil,
         appName: String? = nil,
+        script: String? = nil,
         resolvedFromElementId: Int? = nil,
         elementDescription: String? = nil
     ) {
@@ -61,6 +64,7 @@ struct AgentAction: Codable {
         self.summary = summary
         self.waitDuration = waitDuration
         self.appName = appName
+        self.script = script
         self.resolvedFromElementId = resolvedFromElementId
         self.elementDescription = elementDescription
     }
@@ -121,6 +125,12 @@ struct AgentAction: Codable {
                 return "Open app: \(name)"
             }
             return "Open app"
+        case .runAppleScript:
+            if let script = script {
+                let preview = script.count > 60 ? String(script.prefix(60)) + "..." : script
+                return "AppleScript: \(preview)"
+            }
+            return "AppleScript"
         case .done:
             if let summary = summary {
                 let preview = summary.count > 60 ? String(summary.prefix(60)) + "..." : summary

--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -64,6 +64,24 @@ final class ActionVerifier {
             return .blocked("Action targets the system menu bar (y < 25)")
         }
 
+        // 7. AppleScript safety
+        if action.type == .runAppleScript, let script = action.script {
+            let lower = script.lowercased()
+            let blockedPatterns = [
+                "do shell script", "keychain", "password", "credential",
+                "sudo", "rm -rf", "defaults write", "defaults delete",
+                "osascript", "system events\" to keystroke",
+                "system events' to keystroke"
+            ]
+            for pattern in blockedPatterns {
+                if lower.contains(pattern) {
+                    return .blocked("AppleScript contains blocked pattern: \(pattern)")
+                }
+            }
+            let preview = script.count > 80 ? String(script.prefix(80)) + "..." : script
+            return .needsConfirmation("AppleScript execution: \(preview)")
+        }
+
         // All checks passed
         actionHistory.append(action)
         return .allowed
@@ -91,7 +109,7 @@ final class ActionVerifier {
     // MARK: - Comparison
 
     private func actionsAreIdentical(_ a: AgentAction, _ b: AgentAction) -> Bool {
-        a.type == b.type && a.x == b.x && a.y == b.y && a.text == b.text && a.key == b.key && a.appName == b.appName
+        a.type == b.type && a.x == b.x && a.y == b.y && a.text == b.text && a.key == b.key && a.appName == b.appName && a.script == b.script
     }
 
     // MARK: - Sensitive Data Detection

--- a/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionVerifier.swift
@@ -66,7 +66,10 @@ final class ActionVerifier {
 
         // 7. AppleScript safety
         if action.type == .runAppleScript, let script = action.script {
-            let lower = script.lowercased()
+            // Normalize whitespace to prevent bypass via "do shell\nscript" etc.
+            let normalized = script.lowercased()
+                .split(omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+                .joined(separator: " ")
             let blockedPatterns = [
                 "do shell script", "keychain", "password", "credential",
                 "sudo", "rm -rf", "defaults write", "defaults delete",
@@ -74,7 +77,7 @@ final class ActionVerifier {
                 "system events' to keystroke"
             ]
             for pattern in blockedPatterns {
-                if lower.contains(pattern) {
+                if normalized.contains(pattern) {
                     return .blocked("AppleScript contains blocked pattern: \(pattern)")
                 }
             }

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -279,17 +279,38 @@ final class ComputerUseSession: ObservableObject {
             }
 
             // 5. EXECUTE
+            let executionResult: String?
             do {
-                try await executor.execute(action)
+                executionResult = try await executor.execute(action)
             } catch {
-                let record = ActionRecord(step: stepNumber, action: action, result: "ERROR: \(error.localizedDescription)", timestamp: Date())
+                let errorMessage = error.localizedDescription
+                let record = ActionRecord(step: stepNumber, action: action, result: "ERROR: \(errorMessage)", timestamp: Date())
                 actionHistory.append(record)
-                state = .failed(reason: "Execution failed: \(error.localizedDescription)")
+
+                // AppleScript errors are non-fatal — let the model adapt
+                if action.type == .runAppleScript {
+                    log.warning("[\(stepNumber)] AppleScript error (non-fatal): \(errorMessage)")
+                    state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: "\(action.displayDescription) (error)", reasoning: action.reasoning)
+                    previousAXTreeText = axTreeText
+                    previousElements = elements
+                    continue
+                }
+
+                state = .failed(reason: "Execution failed: \(errorMessage)")
                 logger.finishSession(result: "failed: execution error")
                 return
             }
 
-            let record = ActionRecord(step: stepNumber, action: action, result: "executed", timestamp: Date())
+            // Format result string, including AppleScript output when present
+            let resultString: String
+            if let output = executionResult {
+                let truncated = output.count > 500 ? String(output.prefix(500)) + "..." : output
+                resultString = "executed (result: \(truncated))"
+            } else {
+                resultString = "executed"
+            }
+
+            let record = ActionRecord(step: stepNumber, action: action, result: resultString, timestamp: Date())
             actionHistory.append(record)
 
             // 6. UPDATE UI

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -55,7 +55,7 @@ final class AnthropicProvider: ActionInferenceProvider {
 
         You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements — this is much more reliable than pixel coordinates.
 
-        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, open_app, done.
+        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, open_app, run_applescript, done.
         You MUST only call one of these tools each turn. Do NOT attempt to call any other tool.
 
         RULES:
@@ -85,6 +85,13 @@ final class AnthropicProvider: ActionInferenceProvider {
         - VS Code: Use cmd+shift+p to open the command palette.
         - Finder: Use cmd+shift+g for "Go to Folder".
         - Messages: Click the search bar or use cmd+n for a new message.
+
+        APPLESCRIPT:
+        - Use run_applescript when scripting is more reliable than UI clicks — e.g., setting a browser URL, navigating Finder to a path, querying app state, or clicking deeply nested menus.
+        - The script result (if any) is returned to you so you can reason about it.
+        - NEVER use "do shell script" inside AppleScript — it is blocked for security.
+        - Keep scripts short and focused on a single operation.
+        - Examples of good use: `tell application "Safari" to set URL of current tab of front window to "https://example.com"`, `tell application "Finder" to open POSIX file "/Users/me/Documents"`.
         """
     }
 
@@ -291,6 +298,12 @@ final class AnthropicProvider: ActionInferenceProvider {
                 throw InferenceError.parseError("open_app requires 'app_name' field")
             }
             return AgentAction(type: .openApp, reasoning: reasoning, appName: appName)
+
+        case "run_applescript":
+            guard let script = input["script"] as? String else {
+                throw InferenceError.parseError("run_applescript requires 'script' field")
+            }
+            return AgentAction(type: .runAppleScript, reasoning: reasoning, script: script)
 
         case "done":
             let summary = input["summary"] as? String ?? "Task completed"

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -180,6 +180,32 @@ enum ToolDefinitions {
             ] as [String: Any]
         ],
         [
+            "name": "run_applescript",
+            "description": """
+            Execute an AppleScript to control applications via Apple's scripting bridge. \
+            Use this for operations that are more reliable through scripting than UI interaction: \
+            setting a browser URL directly, navigating Finder to a path, querying app state \
+            (tab count, window titles, document status), or clicking deeply nested menu items. \
+            The script's return value (if any) will be reported back. \
+            NEVER use "do shell script" — it is blocked for security. \
+            Keep scripts short and targeted to a single operation.
+            """,
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "script": [
+                        "type": "string",
+                        "description": "The AppleScript source code to execute"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of what this script does and why AppleScript is better than UI interaction for this step"
+                    ]
+                ],
+                "required": ["script", "reasoning"]
+            ] as [String: Any]
+        ],
+        [
             "name": "done",
             "description": "Task is complete",
             "input_schema": [

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -78,15 +78,26 @@ final class MockScreenCapture: ScreenCaptureProviding {
 final class MockActionExecutor: ActionExecuting {
     var executedActions: [AgentAction] = []
     var shouldFailOnCall: Int? = nil
+    var mockResult: String? = nil
+    var shouldThrowAppleScriptError: Bool = false
     private var callCount = 0
 
-    func execute(_ action: AgentAction) async throws {
+    func execute(_ action: AgentAction) async throws -> String? {
         if shouldFailOnCall == callCount {
             callCount += 1
             throw ExecutorError.eventCreationFailed
         }
+        if shouldThrowAppleScriptError && action.type == .runAppleScript {
+            callCount += 1
+            executedActions.append(action)
+            throw ExecutorError.appleScriptError("Mock AppleScript error")
+        }
         callCount += 1
         executedActions.append(action)
+        if action.type == .runAppleScript {
+            return mockResult
+        }
+        return nil
     }
 }
 
@@ -654,5 +665,120 @@ final class SessionTests: XCTestCase {
         let session = makeSession(task: "Open Safari and search for cats", provider: provider)
 
         XCTAssertEqual(session.task, "Open Safari and search for cats")
+    }
+
+    // MARK: - AppleScript
+
+    @MainActor
+    func testAppleScript_requiresConfirmation_approved() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .runAppleScript, reasoning: "Set Safari URL", script: "tell application \"Safari\" to set URL of current tab of front window to \"https://example.com\""),
+            AgentAction(type: .done, reasoning: "done", summary: "Set URL via AppleScript")
+        ])
+        let executor = MockActionExecutor()
+        executor.mockResult = "https://example.com"
+        let session = makeSession(provider: provider, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        // Wait for confirmation state
+        var sawConfirmation = false
+        for _ in 0..<200 {
+            if case .awaitingConfirmation = session.state {
+                sawConfirmation = true
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertTrue(sawConfirmation, "AppleScript should require confirmation")
+        session.approveConfirmation()
+        await runTask.value
+
+        if case .completed(let summary, _) = session.state {
+            XCTAssertEqual(summary, "Set URL via AppleScript")
+        } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+        XCTAssertEqual(executor.executedActions.count, 1)
+        XCTAssertEqual(executor.executedActions[0].type, .runAppleScript)
+    }
+
+    @MainActor
+    func testAppleScript_doShellScript_blocked() async {
+        let blockedScript = "do shell script \"rm -rf /\""
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .runAppleScript, reasoning: "bad", script: blockedScript),
+            AgentAction(type: .runAppleScript, reasoning: "bad2", script: blockedScript),
+            AgentAction(type: .runAppleScript, reasoning: "bad3", script: blockedScript),
+        ])
+        let executor = MockActionExecutor()
+        let session = makeSession(provider: provider, executor: executor)
+
+        await session.run()
+
+        if case .failed(let reason) = session.state {
+            XCTAssertTrue(reason.contains("blocked"), "Expected block-related failure, got: \(reason)")
+        } else {
+            XCTFail("Expected failed state, got \(session.state)")
+        }
+        // None should have been executed
+        XCTAssertEqual(executor.executedActions.count, 0)
+    }
+
+    @MainActor
+    func testAppleScript_confirmationRejected_cancelsSession() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .runAppleScript, reasoning: "Set URL", script: "tell application \"Safari\" to return name of front window"),
+            AgentAction(type: .done, reasoning: "done", summary: "Should not reach")
+        ])
+        let session = makeSession(provider: provider)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        for _ in 0..<200 {
+            if case .awaitingConfirmation = session.state { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        session.rejectConfirmation()
+        await runTask.value
+
+        XCTAssertEqual(session.state, .cancelled)
+    }
+
+    @MainActor
+    func testAppleScript_executionError_nonFatal() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .runAppleScript, reasoning: "Try script", script: "tell application \"NonExistentApp\" to activate"),
+            AgentAction(type: .done, reasoning: "done", summary: "Recovered from error")
+        ])
+        let executor = MockActionExecutor()
+        executor.shouldThrowAppleScriptError = true
+        let session = makeSession(provider: provider, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        // First action is AppleScript — needs confirmation
+        for _ in 0..<200 {
+            if case .awaitingConfirmation = session.state { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        session.approveConfirmation()
+
+        await runTask.value
+
+        // Should have completed (not failed) because AppleScript errors are non-fatal
+        if case .completed(let summary, _) = session.state {
+            XCTAssertEqual(summary, "Recovered from error")
+        } else {
+            XCTFail("Expected completed state (AppleScript errors are non-fatal), got \(session.state)")
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ToolDefinitionsTests: XCTestCase {
 
     func testToolCount() {
-        XCTAssertEqual(ToolDefinitions.tools.count, 10, "Should have 10 tools defined")
+        XCTAssertEqual(ToolDefinitions.tools.count, 11, "Should have 11 tools defined")
     }
 
     func testToolNames() {
@@ -18,6 +18,7 @@ final class ToolDefinitionsTests: XCTestCase {
         XCTAssertTrue(names.contains("wait"))
         XCTAssertTrue(names.contains("drag"))
         XCTAssertTrue(names.contains("open_app"))
+        XCTAssertTrue(names.contains("run_applescript"))
         XCTAssertTrue(names.contains("done"))
     }
 


### PR DESCRIPTION
The purpose of this PR is to add an 11th agent tool (`run_applescript`) that lets the agent control apps via Apple's scripting bridge when it's more reliable than UI interaction.

## Changes Made
- Add `run_applescript` tool with `script` and `reasoning` parameters to `ActionTypes`, `ToolDefinitions`, and `AnthropicProvider`
- Implement `NSAppleScript` execution in `ActionExecutor` with a 5-second timeout via task group; change `ActionExecuting.execute()` to return `String?` so script output flows back to the model
- Add safety checks in `ActionVerifier`: blocklist for dangerous patterns (`do shell script`, `keychain`, `sudo`, etc.) and mandatory user confirmation for all other scripts
- Make AppleScript execution errors non-fatal in `Session.swift` so the model can adapt; pipe script results into `ActionRecord` (truncated at 500 chars)
- Add system prompt guidance for when to use AppleScript vs UI interaction
- Add 4 new session tests: confirmation approved, `do shell script` blocked, confirmation rejected, execution error non-fatal

## Testing
- All 54 tests pass (12 AccessibilityTree, 13 ActionVerifier, 25 Session, 4 ToolDefinitions)
- New tests cover the key safety and integration flows

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
