### PR TITLE
Add ambient agent remote sync and automation insight approval flow

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import Combine
+import UserNotifications
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientAgent")
@@ -46,7 +47,7 @@ final class AmbientAgent: ObservableObject {
     private var analyzer: AmbientAnalyzer?
     private var watchTask: Task<Void, Never>?
     private(set) var knowledgeCron: KnowledgeCron?
-    private var syncClient: AmbientSyncClient?
+    private(set) var syncClient: AmbientSyncClient?
     private var activeSuggestionWindow: AmbientSuggestionWindow?
     private var insightNotificationWindow: InsightNotificationWindow?
     private var previousOCRText: String = ""
@@ -261,6 +262,11 @@ final class AmbientAgent: ObservableObject {
     }
 
     private func showInsightNotification(_ insight: KnowledgeInsight) {
+        if insight.category == .automation && Bundle.main.bundleIdentifier != nil {
+            showAutomationNotification(insight)
+            return
+        }
+
         let window = InsightNotificationWindow(
             insight: insight,
             onDismiss: { [weak self] in
@@ -273,6 +279,30 @@ final class AmbientAgent: ObservableObject {
         )
         insightNotificationWindow = window
         window.show()
+    }
+
+    private func showAutomationNotification(_ insight: KnowledgeInsight) {
+        let content = UNMutableNotificationContent()
+        content.title = "Automation Opportunity"
+        content.body = insight.title
+        content.categoryIdentifier = "AUTOMATION_INSIGHT"
+        content.sound = .default
+        content.userInfo = [
+            "insightId": insight.id.uuidString,
+            "insightTitle": insight.title,
+            "insightDescription": insight.description
+        ]
+
+        let request = UNNotificationRequest(
+            identifier: "automation-\(insight.id.uuidString)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                log.warning("Failed to deliver automation notification: \(error.localizedDescription)")
+            }
+        }
     }
 
     private func currentWindowTitle() -> String? {

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -48,6 +48,7 @@ final class AmbientAgent: ObservableObject {
     private var watchTask: Task<Void, Never>?
     private(set) var knowledgeCron: KnowledgeCron?
     private(set) var syncClient: AmbientSyncClient?
+    private var syncTask: Task<Void, Never>?
     private var activeSuggestionWindow: AmbientSuggestionWindow?
     private var insightNotificationWindow: InsightNotificationWindow?
     private var previousOCRText: String = ""
@@ -88,20 +89,23 @@ final class AmbientAgent: ObservableObject {
         syncClient = sync
 
         knowledgeStore.onEntryAdded = { [weak sync] entry in
-            sync?.sendObservation(entry)
+            Task { await sync?.sendObservation(entry) }
         }
         cron.onInsightsAdded = { [weak sync] insights in
-            sync?.sendInsights(insights)
+            Task { await sync?.sendInsights(insights) }
         }
 
-        Task.detached {
+        syncTask = Task.detached { [weak self] in
+            guard !Task.isCancelled else { return }
             let healthy = await sync.checkHealth()
             if healthy {
                 log.info("Remote sync: healthy, uploading existing data")
             } else {
                 log.warning("Remote sync: health check failed, will queue")
             }
-            sync.syncExisting(
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            await sync.syncExisting(
                 observations: await self.knowledgeStore.entries,
                 insights: await self.knowledgeCron?.insightStore.insights ?? []
             )
@@ -115,6 +119,8 @@ final class AmbientAgent: ObservableObject {
     func stop() {
         watchTask?.cancel()
         watchTask = nil
+        syncTask?.cancel()
+        syncTask = nil
         knowledgeCron?.stop()
         knowledgeCron = nil
         syncClient = nil
@@ -233,9 +239,9 @@ final class AmbientAgent: ObservableObject {
 
         // Sync non-ignore analysis results and flush retry queue
         if result.decision != .ignore {
-            syncClient?.sendAnalysis(result)
+            await syncClient?.sendAnalysis(result)
         }
-        syncClient?.flushQueue()
+        await syncClient?.flushQueue()
 
         state = .watching
     }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -46,6 +46,7 @@ final class AmbientAgent: ObservableObject {
     private var analyzer: AmbientAnalyzer?
     private var watchTask: Task<Void, Never>?
     private(set) var knowledgeCron: KnowledgeCron?
+    private var syncClient: AmbientSyncClient?
     private var activeSuggestionWindow: AmbientSuggestionWindow?
     private var insightNotificationWindow: InsightNotificationWindow?
     private var previousOCRText: String = ""
@@ -81,6 +82,30 @@ final class AmbientAgent: ObservableObject {
         cron.start(apiKey: apiKey)
         knowledgeCron = cron
 
+        // Remote sync
+        let sync = AmbientSyncClient()
+        syncClient = sync
+
+        knowledgeStore.onEntryAdded = { [weak sync] entry in
+            sync?.sendObservation(entry)
+        }
+        cron.onInsightsAdded = { [weak sync] insights in
+            sync?.sendInsights(insights)
+        }
+
+        Task.detached {
+            let healthy = await sync.checkHealth()
+            if healthy {
+                log.info("Remote sync: healthy, uploading existing data")
+            } else {
+                log.warning("Remote sync: health check failed, will queue")
+            }
+            sync.syncExisting(
+                observations: await self.knowledgeStore.entries,
+                insights: await self.knowledgeCron?.insightStore.insights ?? []
+            )
+        }
+
         watchTask = Task { @MainActor [weak self] in
             await self?.watchLoop()
         }
@@ -91,6 +116,8 @@ final class AmbientAgent: ObservableObject {
         watchTask = nil
         knowledgeCron?.stop()
         knowledgeCron = nil
+        syncClient = nil
+        knowledgeStore.onEntryAdded = nil
         analyzer = nil
         state = .disabled
         log.info("Ambient agent stopped")
@@ -202,6 +229,12 @@ final class AmbientAgent: ObservableObject {
                 log.debug("[\(cycle)] Suggestion below confidence threshold (\(String(format: "%.2f", result.confidence)))")
             }
         }
+
+        // Sync non-ignore analysis results and flush retry queue
+        if result.decision != .ignore {
+            syncClient?.sendAnalysis(result)
+        }
+        syncClient?.flushQueue()
 
         state = .watching
     }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -9,7 +9,7 @@ enum AmbientDecision: String, Codable {
     case suggest
 }
 
-struct AmbientAnalysisResult {
+struct AmbientAnalysisResult: Codable {
     let decision: AmbientDecision
     let observation: String?
     let suggestion: String?

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -65,6 +65,10 @@ final class AmbientSyncClient {
         encodeThenSend(endpoint: "api/analysis", body: result)
     }
 
+    func sendDecision(_ decision: AutomationDecision) {
+        encodeThenSend(endpoint: "api/decision", body: decision)
+    }
+
     // MARK: - Batch Sync (on launch)
 
     func syncExisting(observations: [KnowledgeEntry], insights: [KnowledgeInsight]) {
@@ -142,4 +146,13 @@ final class AmbientSyncClient {
             }
         }
     }
+}
+
+struct AutomationDecision: Encodable {
+    let insightId: String
+    let insightTitle: String
+    let description: String
+    let schedule: String
+    let approved: Bool
+    let source: String
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -1,0 +1,145 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientSync")
+
+final class AmbientSyncClient {
+    private let baseURL = URL(string: "http://100.77.178.101:3457")!
+    private let session: URLSession
+    private let encoder: JSONEncoder
+
+    private var pendingQueue: [PendingSync] = []
+    private let maxQueueSize = 100
+
+    private struct PendingSync {
+        let endpoint: String
+        let data: Data
+    }
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 10
+        self.session = URLSession(configuration: config)
+
+        self.encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+    }
+
+    // MARK: - Health Check
+
+    func checkHealth() async -> Bool {
+        let url = baseURL.appendingPathComponent("api/health")
+        do {
+            let (_, response) = try await session.data(from: url)
+            guard let http = response as? HTTPURLResponse else { return false }
+            let healthy = http.statusCode == 200
+            log.info("Health check: \(healthy ? "OK" : "FAIL (status \(http.statusCode))")")
+            return healthy
+        } catch {
+            log.warning("Health check failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    // MARK: - Send Methods
+
+    func sendObservation(_ entry: KnowledgeEntry) {
+        encodeThenSend(endpoint: "api/observation", body: entry)
+    }
+
+    func sendObservations(_ entries: [KnowledgeEntry]) {
+        guard !entries.isEmpty else { return }
+        encodeThenSend(endpoint: "api/observations", body: ObservationBatchPayload(entries: entries))
+    }
+
+    func sendInsight(_ insight: KnowledgeInsight) {
+        encodeThenSend(endpoint: "api/insight", body: insight)
+    }
+
+    func sendInsights(_ insights: [KnowledgeInsight]) {
+        guard !insights.isEmpty else { return }
+        encodeThenSend(endpoint: "api/insights", body: InsightBatchPayload(entries: insights))
+    }
+
+    func sendAnalysis(_ result: AmbientAnalysisResult) {
+        encodeThenSend(endpoint: "api/analysis", body: result)
+    }
+
+    // MARK: - Batch Sync (on launch)
+
+    func syncExisting(observations: [KnowledgeEntry], insights: [KnowledgeInsight]) {
+        sendObservations(observations)
+        sendInsights(insights)
+    }
+
+    // MARK: - Retry Queue
+
+    func flushQueue() {
+        let items = pendingQueue
+        pendingQueue.removeAll()
+        for item in items {
+            postAsync(endpoint: item.endpoint, data: item.data)
+        }
+    }
+
+    // MARK: - Internal
+
+    private func encodeThenSend<T: Encodable>(endpoint: String, body: T) {
+        guard let data = try? encoder.encode(body) else {
+            log.warning("Failed to encode payload for \(endpoint)")
+            return
+        }
+        postAsync(endpoint: endpoint, data: data)
+    }
+
+    private func postAsync(endpoint: String, data: Data) {
+        Task.detached { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.postRaw(endpoint: endpoint, data: data)
+            } catch {
+                log.warning("Sync failed (\(endpoint)): \(error.localizedDescription)")
+                self.enqueue(endpoint: endpoint, data: data)
+            }
+        }
+    }
+
+    private func postRaw(endpoint: String, data: Data) async throws {
+        let url = baseURL.appendingPathComponent(endpoint)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw SyncError.httpError(status)
+        }
+    }
+
+    private func enqueue(endpoint: String, data: Data) {
+        if pendingQueue.count >= maxQueueSize {
+            pendingQueue.removeFirst()
+        }
+        pendingQueue.append(PendingSync(endpoint: endpoint, data: data))
+    }
+
+    private struct ObservationBatchPayload: Encodable {
+        let entries: [KnowledgeEntry]
+    }
+
+    private struct InsightBatchPayload: Encodable {
+        let entries: [KnowledgeInsight]
+    }
+
+    private enum SyncError: Error, LocalizedError {
+        case httpError(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .httpError(let code): return "HTTP \(code)"
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -3,7 +3,7 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientSync")
 
-final class AmbientSyncClient {
+actor AmbientSyncClient {
     private let baseURL = URL(string: "http://100.77.178.101:3457")!
     private let session: URLSession
     private let encoder: JSONEncoder
@@ -97,13 +97,13 @@ final class AmbientSyncClient {
     }
 
     private func postAsync(endpoint: String, data: Data) {
-        Task.detached { [weak self] in
+        Task { [weak self] in
             guard let self else { return }
             do {
                 try await self.postRaw(endpoint: endpoint, data: data)
             } catch {
                 log.warning("Sync failed (\(endpoint)): \(error.localizedDescription)")
-                self.enqueue(endpoint: endpoint, data: data)
+                await self.enqueue(endpoint: endpoint, data: data)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeCron.swift
@@ -16,6 +16,7 @@ final class KnowledgeCron {
     private var analysisTask: Task<Void, Never>?
 
     var onInsight: ((KnowledgeInsight) -> Void)?
+    var onInsightsAdded: (([KnowledgeInsight]) -> Void)?
 
     private var lastRunTimestamp: TimeInterval {
         get { UserDefaults.standard.double(forKey: "knowledgeCronLastRun") }
@@ -175,6 +176,7 @@ final class KnowledgeCron {
             if !insights.isEmpty {
                 insightStore.addInsights(insights)
                 log.info("Cron: added \(insights.count) insights")
+                onInsightsAdded?(insights)
 
                 // Fire callback for the highest-confidence insight
                 if let best = insights.max(by: { $0.confidence < $1.confidence }) {

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
@@ -22,6 +22,8 @@ final class KnowledgeStore: ObservableObject {
     @Published private var knowledge: KnowledgeFile
     private let fileURL: URL
 
+    var onEntryAdded: ((KnowledgeEntry) -> Void)?
+
     init() {
         let fileManager = FileManager.default
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -78,6 +80,7 @@ final class KnowledgeStore: ObservableObject {
 
         save()
         log.info("Added knowledge entry: \(observation.prefix(80))")
+        onEntryAdded?(entry)
     }
 
     func removeEntry(id: UUID) {

--- a/clients/macos/vellum-assistant/Ambient/ScheduleParser.swift
+++ b/clients/macos/vellum-assistant/Ambient/ScheduleParser.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum ScheduleParser {
+    static func parse(from text: String) -> String {
+        let lower = text.lowercased()
+        var parts: [String] = []
+
+        // Time patterns: "9:30 am", "3pm", "9 am"
+        let timeRegex = try! NSRegularExpression(pattern: #"\b\d{1,2}(:\d{2})?\s*(am|pm)\b"#, options: .caseInsensitive)
+        let timeMatches = timeRegex.matches(in: lower, range: NSRange(lower.startIndex..., in: lower))
+        for match in timeMatches {
+            if let range = Range(match.range, in: lower) {
+                parts.append(String(lower[range]))
+            }
+        }
+
+        // Time keywords
+        let timeKeywords = ["morning", "evening", "afternoon", "night", "midnight", "noon"]
+        for keyword in timeKeywords where lower.contains(keyword) {
+            parts.append(keyword)
+        }
+
+        // Day patterns
+        let dayKeywords = ["weekdays", "weekends", "daily", "weekly", "monthly"]
+        for keyword in dayKeywords where lower.contains(keyword) {
+            parts.append(keyword)
+        }
+
+        // "every Monday", "every Tuesday", etc.
+        let everyDayRegex = try! NSRegularExpression(pattern: #"\bevery\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b"#, options: .caseInsensitive)
+        let everyDayMatches = everyDayRegex.matches(in: lower, range: NSRange(lower.startIndex..., in: lower))
+        for match in everyDayMatches {
+            if let range = Range(match.range, in: lower) {
+                parts.append(String(lower[range]))
+            }
+        }
+
+        // Frequency patterns: "every N hours/minutes", "hourly", "periodically"
+        let freqRegex = try! NSRegularExpression(pattern: #"\bevery\s+\d+\s+(hours?|minutes?)\b"#, options: .caseInsensitive)
+        let freqMatches = freqRegex.matches(in: lower, range: NSRange(lower.startIndex..., in: lower))
+        for match in freqMatches {
+            if let range = Range(match.range, in: lower) {
+                parts.append(String(lower[range]))
+            }
+        }
+
+        let freqKeywords = ["hourly", "periodically"]
+        for keyword in freqKeywords where lower.contains(keyword) {
+            parts.append(keyword)
+        }
+
+        return parts.isEmpty ? "on demand" : parts.joined(separator: ", ")
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -323,7 +323,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             return
         }
 
-        let approved = response.actionIdentifier == "APPROVE_ACTION"
+        let approved: Bool
+        switch response.actionIdentifier {
+        case "APPROVE_ACTION":
+            approved = true
+        case "DISMISS_ACTION":
+            approved = false
+        default:
+            return  // Ignore default tap and other actions
+        }
+
         let schedule = ScheduleParser.parse(from: description)
 
         let decision = AutomationDecision(
@@ -335,8 +344,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             source: "alexs-macbook-pro-2"
         )
 
-        await MainActor.run {
-            ambientAgent.syncClient?.sendDecision(decision)
-        }
+        let syncClient = await MainActor.run { ambientAgent.syncClient }
+        await syncClient?.sendDecision(decision)
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import HotKey
+import UserNotifications
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -35,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupVoiceInput()
         setupAmbientAgent()
         setupWindowObserver()
+        setupNotifications()
     }
 
     private func setupWindowObserver() {
@@ -211,6 +213,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupVoiceInput()
             self?.setupAmbientAgent()
             self?.setupWindowObserver()
+            self?.setupNotifications()
 
             NSApp.setActivationPolicy(.accessory)
         }
@@ -267,11 +270,73 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Notifications
+
+    private func setupNotifications() {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                print("Notification authorization error: \(error.localizedDescription)")
+            }
+        }
+
+        let approveAction = UNNotificationAction(identifier: "APPROVE_ACTION", title: "Approve", options: [])
+        let dismissAction = UNNotificationAction(identifier: "DISMISS_ACTION", title: "Dismiss", options: [])
+        let automationCategory = UNNotificationCategory(
+            identifier: "AUTOMATION_INSIGHT",
+            actions: [approveAction, dismissAction],
+            intentIdentifiers: []
+        )
+        center.setNotificationCategories([automationCategory])
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }
         voiceInput?.stop()
         ambientAgent.stop()
+    }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let userInfo = response.notification.request.content.userInfo
+        guard response.notification.request.content.categoryIdentifier == "AUTOMATION_INSIGHT",
+              let insightId = userInfo["insightId"] as? String,
+              let insightTitle = userInfo["insightTitle"] as? String,
+              let description = userInfo["insightDescription"] as? String else {
+            return
+        }
+
+        let approved = response.actionIdentifier == "APPROVE_ACTION"
+        let schedule = ScheduleParser.parse(from: description)
+
+        let decision = AutomationDecision(
+            insightId: insightId,
+            insightTitle: insightTitle,
+            description: description,
+            schedule: schedule,
+            approved: approved,
+            source: "alexs-macbook-pro-2"
+        )
+
+        await MainActor.run {
+            ambientAgent.syncClient?.sendDecision(decision)
+        }
     }
 }


### PR DESCRIPTION
The purpose of this PR is to add remote sync for the ambient agent's observations, insights, and analysis, plus a native macOS notification-based approval flow for automation insights.

## Changes Made
- Create `AmbientSyncClient` — fire-and-forget HTTP client that POSTs to remote API with in-memory retry queue (capped at 100 items)
- Add `sendDecision()` endpoint and `AutomationDecision` struct for posting user approval/dismissal decisions
- Add native `UNUserNotification` flow for `.automation` insights with Approve/Dismiss actions, POSTing decisions to `/api/decision`
- Add `ScheduleParser` utility for regex-based schedule extraction from insight descriptions
- Add `Codable` to `AmbientAnalysisResult` for JSON serialization
- Wire sync client into `AmbientAgent`: batch-uploads existing data on start, streams new observations/insights/analysis as they occur
- Guard `UNUserNotificationCenter` usage against nil `bundleIdentifier` in SPM builds (falls back to existing NSPanel)

## Testing
- `swift build` compiles cleanly
- All 50 existing tests pass
- Manual verification that SPM debug builds no longer crash on missing bundle identifier

---
*This PR was created with Claude Code*