### PR TITLE
Fix default-config mutation in loader fallback paths

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -357,4 +357,28 @@ describe('loadConfig with schema validation', () => {
     const config = loadConfig();
     expect(config.auditLog.retentionDays).toBe(0);
   });
+
+  test('does not mutate default apiKeys when fallback config is overridden by env keys', () => {
+    const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+    try {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-in-memory-default-leak';
+      writeConfig('this is not a config object');
+
+      const configWithEnv = loadConfig();
+      expect(configWithEnv.apiKeys.anthropic).toBe('sk-test-in-memory-default-leak');
+
+      invalidateConfigCache();
+      delete process.env.ANTHROPIC_API_KEY;
+      writeConfig('still not a config object');
+
+      const configWithoutEnv = loadConfig();
+      expect(configWithoutEnv.apiKeys.anthropic).toBeUndefined();
+    } finally {
+      if (originalAnthropicApiKey !== undefined) {
+        process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+  });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -20,6 +20,10 @@ function getConfigPath(): string {
   return join(getDataDir(), 'config.json');
 }
 
+function cloneDefaultConfig(): AssistantConfig {
+  return structuredClone(DEFAULT_CONFIG);
+}
+
 /**
  * Validate a raw config object with Zod. Invalid fields are logged as warnings
  * and replaced with defaults (matching prior behavior of per-field fallback).
@@ -42,7 +46,7 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   for (const issue of result.error.issues) {
     if (issue.path.length === 0) {
       // Top-level error — return full defaults
-      return { ...DEFAULT_CONFIG };
+      return cloneDefaultConfig();
     }
     deleteNestedKey(cleaned, issue.path as (string | number)[]);
   }
@@ -54,7 +58,7 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
 
   // If still failing, fall back to full defaults
   log.warn('Config validation failed after cleanup. Using full defaults.');
-  return { ...DEFAULT_CONFIG };
+  return cloneDefaultConfig();
 }
 
 function deleteNestedKey(obj: Record<string, unknown>, path: (string | number)[]): void {
@@ -74,7 +78,7 @@ export function loadConfig(): AssistantConfig {
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
   // invalid apiKeys) can trigger loadConfig again. Return defaults to
   // break the cycle instead of recursing to stack overflow.
-  if (loading) return { ...DEFAULT_CONFIG, apiKeys: { ...DEFAULT_CONFIG.apiKeys }, timeouts: { ...DEFAULT_CONFIG.timeouts }, sandbox: { ...DEFAULT_CONFIG.sandbox }, rateLimit: { ...DEFAULT_CONFIG.rateLimit }, thinking: { ...DEFAULT_CONFIG.thinking }, secretDetection: { ...DEFAULT_CONFIG.secretDetection }, auditLog: { ...DEFAULT_CONFIG.auditLog } };
+  if (loading) return cloneDefaultConfig();
   loading = true;
 
   try {


### PR DESCRIPTION
Fixes feedback from #328 by deep-cloning DEFAULT_CONFIG in fallback paths and adding a regression test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
