### PR TITLE
Fix misleading socket permission error message

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -604,7 +604,7 @@ program
         if (mode === 0o600 || mode === 0o700) {
           pass(`Socket permissions (${mode.toString(8).padStart(4, '0')})`);
         } else {
-          fail('Socket permissions', `expected 0600, got 0${mode.toString(8)}`);
+          fail('Socket permissions', `expected 0600 or 0700, got 0${mode.toString(8)}`);
         }
       } catch {
         fail('Socket permissions', 'could not stat socket');


### PR DESCRIPTION
Update doctor socket-permission failure text to say expected 0600 or 0700, matching the actual validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
