### PR TITLE
Refine low-risk property tests for shell risk classification

### DIFF
--- a/assistant/src/__tests__/shell-parser-property.test.ts
+++ b/assistant/src/__tests__/shell-parser-property.test.ts
@@ -120,12 +120,13 @@ describe('Shell parser property-based tests', () => {
       'grep', 'find', 'which', 'date', 'whoami', 'hostname', 'uname',
       'wc', 'file', 'stat', 'realpath', 'dirname', 'basename',
       'man', 'help', 'tree', 'du', 'df'];
+    const safeOperand = fc.stringMatching(/^[a-zA-Z0-9_./][a-zA-Z0-9_./-]*$/);
 
-    test('low-risk programs with safe args are classified low', async () => {
+    test('low-risk programs with safe operand args are classified low', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.constantFrom(...lowRiskPrograms),
-          fc.array(fc.stringMatching(/^[a-zA-Z0-9_./-]+$/), { minLength: 0, maxLength: 4 }),
+          fc.array(safeOperand, { minLength: 0, maxLength: 4 }),
           async (program, args) => {
             const command = [program, ...args].join(' ');
             const risk = await classifyRisk('shell', { command });
@@ -137,16 +138,15 @@ describe('Shell parser property-based tests', () => {
     });
 
     test('git read-only subcommands are low-risk', async () => {
-      const readOnlyGit = ['status', 'log', 'diff', 'show', 'branch', 'tag',
-        'remote', 'stash', 'blame', 'shortlog', 'describe', 'rev-parse',
-        'ls-files', 'ls-tree', 'cat-file', 'reflog'];
+      const readOnlyGit = ['status', 'log', 'diff', 'show',
+        'blame', 'shortlog', 'describe', 'rev-parse',
+        'ls-files', 'ls-tree', 'cat-file'];
 
       await fc.assert(
         fc.asyncProperty(
           fc.constantFrom(...readOnlyGit),
-          fc.array(fc.stringMatching(/^[a-zA-Z0-9_./-]+$/), { minLength: 0, maxLength: 3 }),
-          async (subcommand, args) => {
-            const command = ['git', subcommand, ...args].join(' ');
+          async (subcommand) => {
+            const command = `git ${subcommand}`;
             const risk = await classifyRisk('shell', { command });
             expect(risk).toBe(RiskLevel.Low);
           }


### PR DESCRIPTION
Address follow-up feedback from #336 by tightening low-risk property test generators and removing mutating git subcommands from the read-only invariant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
