### PR TITLE
Strengthen shell parser determinism fuzz test

### DIFF
--- a/assistant/src/__tests__/shell-parser-fuzz.test.ts
+++ b/assistant/src/__tests__/shell-parser-fuzz.test.ts
@@ -534,9 +534,7 @@ describe('Shell Parser Fuzz Tests', () => {
           async (input) => {
             const result1 = await parse(input);
             const result2 = await parse(input);
-            expect(result1.segments.length).toBe(result2.segments.length);
-            expect(result1.dangerousPatterns.length).toBe(result2.dangerousPatterns.length);
-            expect(result1.hasOpaqueConstructs).toBe(result2.hasOpaqueConstructs);
+            expect(result1).toEqual(result2);
           },
         ),
         { numRuns: 200 },


### PR DESCRIPTION
Address follow-up feedback on #337 by comparing full parse outputs for determinism, not just aggregate counts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
