### PR TITLE
Add typed event bus foundation for daemon/tool domains

### DIFF
--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from 'bun:test';
+import { EventBus, EventBusDisposedError } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+
+describe('EventBus', () => {
+  test('emits typed events to direct listeners in registration order', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    const seen: string[] = [];
+
+    bus.on('tool.execution.started', (event) => {
+      seen.push(`first:${event.toolName}`);
+    });
+    bus.on('tool.execution.started', async (event) => {
+      await Promise.resolve();
+      seen.push(`second:${event.sessionId}`);
+    });
+
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'shell',
+      input: { command: 'ls' },
+      startedAtMs: Date.now(),
+    });
+
+    expect(seen).toEqual(['first:shell', 'second:sess-1']);
+  });
+
+  test('supports onAny listeners with event envelopes', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    let seenType = '';
+    let seenConversationId = '';
+
+    bus.onAny((event) => {
+      seenType = event.type;
+      seenConversationId = event.payload.conversationId;
+      expect(typeof event.emittedAtMs).toBe('number');
+    });
+
+    await bus.emit('daemon.session.created', {
+      conversationId: 'conv-2',
+      createdAtMs: Date.now(),
+    });
+
+    expect(seenType).toBe('daemon.session.created');
+    expect(seenConversationId).toBe('conv-2');
+  });
+
+  test('subscription disposal is idempotent and prevents future callbacks', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    let calls = 0;
+
+    const sub = bus.on('daemon.lifecycle.stopped', () => {
+      calls += 1;
+    });
+
+    sub.dispose();
+    sub.dispose();
+
+    await bus.emit('daemon.lifecycle.stopped', {
+      stoppedAtMs: Date.now(),
+    });
+
+    expect(calls).toBe(0);
+    expect(sub.active).toBe(false);
+  });
+
+  test('dispose clears listeners and rejects new registrations/emits', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    const sub = bus.on('daemon.lifecycle.started', () => {});
+    const anySub = bus.onAny(() => {});
+
+    expect(bus.listenerCount('daemon.lifecycle.started')).toBe(1);
+    expect(bus.anyListenerCount()).toBe(1);
+
+    bus.dispose();
+
+    expect(bus.listenerCount()).toBe(0);
+    expect(bus.anyListenerCount()).toBe(0);
+    expect(sub.active).toBe(true);
+    expect(anySub.active).toBe(true);
+
+    expect(() => bus.on('daemon.lifecycle.started', () => {})).toThrow(EventBusDisposedError);
+    expect(() => bus.onAny(() => {})).toThrow(EventBusDisposedError);
+    await expect(
+      bus.emit('daemon.lifecycle.started', {
+        pid: 1,
+        socketPath: '/tmp/sock',
+        startedAtMs: Date.now(),
+      }),
+    ).rejects.toBeInstanceOf(EventBusDisposedError);
+  });
+
+  test('emit continues after listener failures and throws AggregateError', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    let ranAfterFailure = false;
+
+    bus.on('tool.execution.finished', () => {
+      throw new Error('listener failed');
+    });
+    bus.on('tool.execution.finished', () => {
+      ranAfterFailure = true;
+    });
+
+    await expect(
+      bus.emit('tool.execution.finished', {
+        conversationId: 'conv-3',
+        sessionId: 'sess-3',
+        toolName: 'file_read',
+        decision: 'allow',
+        riskLevel: 'low',
+        isError: false,
+        durationMs: 12,
+        finishedAtMs: Date.now(),
+      }),
+    ).rejects.toBeInstanceOf(AggregateError);
+
+    expect(ranAfterFailure).toBe(true);
+  });
+});

--- a/assistant/src/events/bus.ts
+++ b/assistant/src/events/bus.ts
@@ -1,0 +1,131 @@
+export type EventMap = Record<string, object>;
+
+export type EventListener<TPayload extends object> = (payload: TPayload) => void | Promise<void>;
+
+export type AnyEventEnvelope<TEvents extends EventMap> = {
+  [K in keyof TEvents & string]: {
+    type: K;
+    payload: TEvents[K];
+    emittedAtMs: number;
+  };
+}[keyof TEvents & string];
+
+export type AnyEventListener<TEvents extends EventMap> = (event: AnyEventEnvelope<TEvents>) => void | Promise<void>;
+
+export interface Subscription {
+  readonly active: boolean;
+  dispose(): void;
+}
+
+class BasicSubscription implements Subscription {
+  private _active = true;
+  private readonly disposer: () => void;
+
+  constructor(disposer: () => void) {
+    this.disposer = disposer;
+  }
+
+  get active(): boolean {
+    return this._active;
+  }
+
+  dispose(): void {
+    if (!this._active) return;
+    this._active = false;
+    this.disposer();
+  }
+}
+
+export class EventBusDisposedError extends Error {
+  constructor() {
+    super('Event bus has been disposed');
+    this.name = 'EventBusDisposedError';
+  }
+}
+
+export class EventBus<TEvents extends EventMap> {
+  private readonly listeners = new Map<keyof TEvents & string, Set<EventListener<object>>>();
+  private readonly anyListeners = new Set<AnyEventListener<TEvents>>();
+  private disposed = false;
+
+  on<K extends keyof TEvents & string>(type: K, listener: EventListener<TEvents[K]>): Subscription {
+    this.ensureActive();
+    const set = this.getOrCreateSet(type);
+    set.add(listener as EventListener<object>);
+
+    return new BasicSubscription(() => {
+      set.delete(listener as EventListener<object>);
+      if (set.size === 0) this.listeners.delete(type);
+    });
+  }
+
+  onAny(listener: AnyEventListener<TEvents>): Subscription {
+    this.ensureActive();
+    this.anyListeners.add(listener);
+    return new BasicSubscription(() => {
+      this.anyListeners.delete(listener);
+    });
+  }
+
+  listenerCount(type?: keyof TEvents & string): number {
+    if (type) return this.listeners.get(type)?.size ?? 0;
+    let total = 0;
+    for (const set of this.listeners.values()) total += set.size;
+    return total;
+  }
+
+  anyListenerCount(): number {
+    return this.anyListeners.size;
+  }
+
+  async emit<K extends keyof TEvents & string>(type: K, payload: TEvents[K]): Promise<void> {
+    this.ensureActive();
+
+    const emittedAtMs = Date.now();
+    const directListeners = [...(this.listeners.get(type) ?? [])] as Array<EventListener<TEvents[K]>>;
+    const anyListeners = [...this.anyListeners];
+    const errors: unknown[] = [];
+
+    for (const listener of directListeners) {
+      try {
+        await listener(payload);
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+
+    if (anyListeners.length > 0) {
+      const event = { type, payload, emittedAtMs } as AnyEventEnvelope<TEvents>;
+      for (const listener of anyListeners) {
+        try {
+          await listener(event);
+        } catch (err) {
+          errors.push(err);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `One or more listeners failed for event "${type}"`);
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.listeners.clear();
+    this.anyListeners.clear();
+  }
+
+  private ensureActive(): void {
+    if (this.disposed) throw new EventBusDisposedError();
+  }
+
+  private getOrCreateSet(type: keyof TEvents & string): Set<EventListener<object>> {
+    const existing = this.listeners.get(type);
+    if (existing) return existing;
+    const created = new Set<EventListener<object>>();
+    this.listeners.set(type, created);
+    return created;
+  }
+}

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -1,0 +1,76 @@
+import type { EventMap } from './bus.js';
+
+export interface ToolDomainEvents extends EventMap {
+  'tool.execution.started': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    input: Record<string, unknown>;
+    startedAtMs: number;
+  };
+  'tool.permission.requested': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    riskLevel: string;
+    requestedAtMs: number;
+  };
+  'tool.permission.decided': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
+    riskLevel: string;
+    decidedAtMs: number;
+  };
+  'tool.secret.detected': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    action: 'redact' | 'warn' | 'block';
+    matches: Array<{ type: string; redactedValue: string }>;
+    detectedAtMs: number;
+  };
+  'tool.execution.finished': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    decision: string;
+    riskLevel: string;
+    isError: boolean;
+    durationMs: number;
+    finishedAtMs: number;
+  };
+  'tool.execution.failed': {
+    conversationId: string;
+    sessionId: string;
+    toolName: string;
+    decision: string;
+    riskLevel: string;
+    durationMs: number;
+    error: string;
+    failedAtMs: number;
+  };
+}
+
+export interface DaemonDomainEvents extends EventMap {
+  'daemon.lifecycle.started': {
+    pid: number;
+    socketPath: string;
+    startedAtMs: number;
+  };
+  'daemon.lifecycle.stopped': {
+    stoppedAtMs: number;
+  };
+  'daemon.session.created': {
+    conversationId: string;
+    createdAtMs: number;
+  };
+  'daemon.session.evicted': {
+    conversationId: string;
+    reason: 'idle' | 'stale' | 'shutdown';
+    evictedAtMs: number;
+  };
+}
+
+export type AssistantDomainEvents = ToolDomainEvents & DaemonDomainEvents;

--- a/assistant/src/events/index.ts
+++ b/assistant/src/events/index.ts
@@ -1,0 +1,14 @@
+export {
+  EventBus,
+  EventBusDisposedError,
+  type EventMap,
+  type EventListener,
+  type AnyEventEnvelope,
+  type AnyEventListener,
+  type Subscription,
+} from './bus.js';
+export type {
+  ToolDomainEvents,
+  DaemonDomainEvents,
+  AssistantDomainEvents,
+} from './domain-events.js';


### PR DESCRIPTION
Adds a typed event bus abstraction (listener registration + disposal semantics), domain event maps for daemon/tool concerns, and focused bus behavior tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
