### PR TITLE
Emit ToolExecutor lifecycle events

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -1,0 +1,203 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { ToolExecutionResult, ToolLifecycleEvent } from '../tools/types.js';
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600, permissionTimeoutSec: 300 },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: false, action: 'warn' as const, entropyThreshold: 4.0 },
+};
+
+let checkerDecision: 'allow' | 'prompt' | 'deny' = 'allow';
+let checkerReason = 'allowed';
+let checkerRisk = 'low';
+let promptDecision: 'allow' | 'always_allow' | 'deny' | 'always_deny' = 'allow';
+let sandboxed = false;
+let fakeToolResult: ToolExecutionResult = { content: 'ok', isError: false };
+let toolThrow: Error | null = null;
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module('../permissions/checker.js', () => ({
+  classifyRisk: async () => checkerRisk,
+  check: async () => ({ decision: checkerDecision, reason: checkerReason }),
+  generateAllowlistOptions: () => [{ label: 'exact', pattern: 'exact' }],
+  generateScopeOptions: () => [{ label: '/tmp', scope: '/tmp' }],
+}));
+
+mock.module('../memory/tool-usage-store.js', () => ({
+  recordToolInvocation: () => {},
+}));
+
+mock.module('../tools/registry.js', () => ({
+  getTool: (name: string) => {
+    if (name === 'unknown_tool') return undefined;
+    return {
+      name,
+      description: 'test tool',
+      category: 'test',
+      defaultRiskLevel: 'low',
+      getDefinition: () => ({}),
+      execute: async () => {
+        if (toolThrow) throw toolThrow;
+        return fakeToolResult;
+      },
+    };
+  },
+}));
+
+mock.module('../tools/filesystem/path-guard.js', () => ({
+  validateFilePath: () => ({ ok: false }),
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: () => ({ command: '', sandboxed }),
+}));
+
+import { ToolExecutor } from '../tools/executor.js';
+import { PermissionPrompter } from '../permissions/prompter.js';
+
+function makeContext(events: ToolLifecycleEvent[]) {
+  return {
+    workingDir: '/tmp/project',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+    onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+      events.push(event);
+    },
+  };
+}
+
+function makePrompter(promptImpl?: () => Promise<{ decision: 'allow' | 'always_allow' | 'deny' | 'always_deny' }>) {
+  return {
+    prompt: promptImpl ?? (async () => ({ decision: promptDecision })),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+describe('ToolExecutor lifecycle events', () => {
+  beforeEach(() => {
+    checkerDecision = 'allow';
+    checkerReason = 'allowed';
+    checkerRisk = 'low';
+    promptDecision = 'allow';
+    sandboxed = false;
+    fakeToolResult = { content: 'ok', isError: false };
+    toolThrow = null;
+  });
+
+  test('emits start then executed for allowed execution', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('file_read', { path: 'README.md' }, makeContext(events));
+
+    expect(result).toEqual({ content: 'ok', isError: false });
+    expect(events.map((event) => event.type)).toEqual(['start', 'executed']);
+    expect(events[0]).toMatchObject({
+      type: 'start',
+      toolName: 'file_read',
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      workingDir: '/tmp/project',
+    });
+    const executed = events[1];
+    if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.riskLevel).toBe('low');
+    expect(executed.result).toEqual({ content: 'ok', isError: false });
+    expect(executed.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('emits permission_prompt then permission_denied when user denies prompt', async () => {
+    checkerDecision = 'prompt';
+    checkerReason = 'medium risk: requires approval';
+    checkerRisk = 'medium';
+    promptDecision = 'deny';
+    sandboxed = true;
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('shell', { command: 'ls -la' }, makeContext(events));
+
+    expect(result).toEqual({ content: 'Permission denied by user', isError: true });
+    expect(events.map((event) => event.type)).toEqual([
+      'start',
+      'permission_prompt',
+      'permission_denied',
+    ]);
+
+    const promptEvent = events[1];
+    if (promptEvent.type !== 'permission_prompt') throw new Error('Expected permission_prompt event');
+    expect(promptEvent.riskLevel).toBe('medium');
+    expect(promptEvent.reason).toBe('medium risk: requires approval');
+    expect(promptEvent.sandboxed).toBe(true);
+    expect(promptEvent.allowlistOptions).toEqual([{ label: 'exact', pattern: 'exact' }]);
+    expect(promptEvent.scopeOptions).toEqual([{ label: '/tmp', scope: '/tmp' }]);
+
+    const deniedEvent = events[2];
+    if (deniedEvent.type !== 'permission_denied') throw new Error('Expected permission_denied event');
+    expect(deniedEvent.decision).toBe('deny');
+    expect(deniedEvent.reason).toBe('Permission denied by user');
+  });
+
+  test('emits permission_denied when blocked by deny rule', async () => {
+    checkerDecision = 'deny';
+    checkerReason = 'Blocked by deny rule: rm *';
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(
+      makePrompter(async () => {
+        throw new Error('prompter should not be called');
+      }),
+    );
+
+    const result = await executor.execute('shell', { command: 'rm -rf /tmp' }, makeContext(events));
+
+    expect(result).toEqual({ content: 'Blocked by deny rule: rm *', isError: true });
+    expect(events.map((event) => event.type)).toEqual(['start', 'permission_denied']);
+    const deniedEvent = events[1];
+    if (deniedEvent.type !== 'permission_denied') throw new Error('Expected permission_denied event');
+    expect(deniedEvent.reason).toBe('Blocked by deny rule: rm *');
+  });
+
+  test('emits error when tool execution throws', async () => {
+    toolThrow = new Error('boom');
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('file_read', {}, makeContext(events));
+
+    expect(result.content).toContain('boom');
+    expect(result.isError).toBe(true);
+    expect(events.map((event) => event.type)).toEqual(['start', 'error']);
+    const errorEvent = events[1];
+    if (errorEvent.type !== 'error') throw new Error('Expected error event');
+    expect(errorEvent.errorMessage).toBe('boom');
+  });
+});

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { getTool } from './registry.js';
-import type { ToolContext, ToolExecutionResult } from './types.js';
+import type { ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
@@ -46,6 +46,16 @@ export class ToolExecutor {
       }, 'Tool execute start');
     }
 
+    await emitLifecycleEvent(context, {
+      type: 'start',
+      toolName: name,
+      input,
+      workingDir: context.workingDir,
+      sessionId: context.sessionId,
+      conversationId: context.conversationId,
+      startedAtMs: startTime,
+    });
+
     try {
       // Check permissions
       const risk = await classifyRisk(name, input);
@@ -55,6 +65,18 @@ export class ToolExecutor {
       if (result.decision === 'deny') {
         decision = 'denied';
         const durationMs = Date.now() - startTime;
+        await emitLifecycleEvent(context, {
+          type: 'permission_denied',
+          toolName: name,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          riskLevel,
+          decision: 'deny',
+          reason: result.reason,
+          durationMs,
+        });
         recordToolInvocation({
           conversationId: context.conversationId,
           toolName: name,
@@ -83,6 +105,21 @@ export class ToolExecutor {
           sandboxed = wrapped.sandboxed;
         }
 
+        await emitLifecycleEvent(context, {
+          type: 'permission_prompt',
+          toolName: name,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          riskLevel,
+          reason: result.reason,
+          allowlistOptions,
+          scopeOptions,
+          diff: previewDiff,
+          sandboxed,
+        });
+
         const response = await this.prompter.prompt(
           name,
           input,
@@ -97,6 +134,18 @@ export class ToolExecutor {
 
         if (response.decision === 'deny') {
           const durationMs = Date.now() - startTime;
+          await emitLifecycleEvent(context, {
+            type: 'permission_denied',
+            toolName: name,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            riskLevel,
+            decision: 'deny',
+            reason: 'Permission denied by user',
+            durationMs,
+          });
           recordToolInvocation({
             conversationId: context.conversationId,
             toolName: name,
@@ -115,6 +164,18 @@ export class ToolExecutor {
             addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
           }
           const durationMs = Date.now() - startTime;
+          await emitLifecycleEvent(context, {
+            type: 'permission_denied',
+            toolName: name,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            riskLevel,
+            decision: 'always_deny',
+            reason: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user',
+            durationMs,
+          });
           recordToolInvocation({
             conversationId: context.conversationId,
             toolName: name,
@@ -174,6 +235,22 @@ export class ToolExecutor {
             const types = [...new Set(allMatches.map((m) => m.type))].join(', ');
             const blockedContent = `Tool output blocked: detected ${allMatches.length} potential secret(s) (${types}). Configure secretDetection.action to "redact" or "warn" to allow output.`;
             const durationMs = Date.now() - startTime;
+            const blockedResult = {
+              content: blockedContent,
+              isError: true,
+            };
+            await emitLifecycleEvent(context, {
+              type: 'executed',
+              toolName: name,
+              input,
+              workingDir: context.workingDir,
+              sessionId: context.sessionId,
+              conversationId: context.conversationId,
+              riskLevel,
+              decision,
+              durationMs,
+              result: blockedResult,
+            });
             recordToolInvocation({
               conversationId: context.conversationId,
               toolName: name,
@@ -183,10 +260,7 @@ export class ToolExecutor {
               riskLevel,
               durationMs,
             });
-            return {
-              content: blockedContent,
-              isError: true,
-            };
+            return blockedResult;
           }
         }
       }
@@ -204,6 +278,18 @@ export class ToolExecutor {
       }
 
       const durationMs = Date.now() - startTime;
+      await emitLifecycleEvent(context, {
+        type: 'executed',
+        toolName: name,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        riskLevel,
+        decision,
+        durationMs,
+        result: execResult,
+      });
       recordToolInvocation({
         conversationId: context.conversationId,
         toolName: name,
@@ -228,6 +314,18 @@ export class ToolExecutor {
         riskLevel,
         durationMs,
       });
+      await emitLifecycleEvent(context, {
+        type: 'error',
+        toolName: name,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        riskLevel,
+        decision: 'error',
+        durationMs,
+        errorMessage: msg,
+      });
 
       if (err instanceof PermissionDeniedError || err instanceof ToolError) {
         return { content: msg, isError: true };
@@ -236,6 +334,17 @@ export class ToolExecutor {
       log.error({ err, name }, 'Tool execution error');
       return { content: `Tool error: ${msg}`, isError: true };
     }
+  }
+}
+
+async function emitLifecycleEvent(context: ToolContext, event: ToolLifecycleEvent): Promise<void> {
+  try {
+    await context.onToolLifecycleEvent?.(event);
+  } catch (err) {
+    log.warn(
+      { err, eventType: event.type, toolName: event.toolName },
+      'Tool lifecycle event handler failed',
+    );
   }
 }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { RiskLevel } from '../permissions/types.js';
+import type { RiskLevel, AllowlistOption, ScopeOption } from '../permissions/types.js';
 import type { ToolDefinition } from '../providers/types.js';
 
 export interface SecretDetectionEvent {
@@ -6,6 +6,62 @@ export interface SecretDetectionEvent {
   matches: Array<{ type: string; redactedValue: string }>;
   action: 'redact' | 'warn' | 'block';
 }
+
+interface ToolLifecycleEventBase {
+  toolName: string;
+  input: Record<string, unknown>;
+  workingDir: string;
+  sessionId: string;
+  conversationId: string;
+}
+
+export interface ToolExecutionStartEvent extends ToolLifecycleEventBase {
+  type: 'start';
+  startedAtMs: number;
+}
+
+export interface ToolPermissionPromptEvent extends ToolLifecycleEventBase {
+  type: 'permission_prompt';
+  riskLevel: string;
+  reason: string;
+  allowlistOptions: AllowlistOption[];
+  scopeOptions: ScopeOption[];
+  diff?: DiffInfo;
+  sandboxed?: boolean;
+}
+
+export interface ToolPermissionDeniedEvent extends ToolLifecycleEventBase {
+  type: 'permission_denied';
+  riskLevel: string;
+  decision: 'deny' | 'always_deny';
+  reason: string;
+  durationMs: number;
+}
+
+export interface ToolExecutedEvent extends ToolLifecycleEventBase {
+  type: 'executed';
+  riskLevel: string;
+  decision: string;
+  durationMs: number;
+  result: ToolExecutionResult;
+}
+
+export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
+  type: 'error';
+  riskLevel: string;
+  decision: string;
+  durationMs: number;
+  errorMessage: string;
+}
+
+export type ToolLifecycleEvent =
+  | ToolExecutionStartEvent
+  | ToolPermissionPromptEvent
+  | ToolPermissionDeniedEvent
+  | ToolExecutedEvent
+  | ToolExecutionErrorEvent;
+
+export type ToolLifecycleEventHandler = (event: ToolLifecycleEvent) => void | Promise<void>;
 
 export interface ToolContext {
   workingDir: string;
@@ -17,6 +73,8 @@ export interface ToolContext {
   sandboxOverride?: boolean;
   /** Optional callback when secrets are detected in tool output. */
   onSecretDetected?: (event: SecretDetectionEvent) => void;
+  /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error). */
+  onToolLifecycleEvent?: ToolLifecycleEventHandler;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- add typed ToolExecutor lifecycle event contracts in assistant/src/tools/types.ts
- emit lifecycle events (start, permission_prompt, permission_denied, executed, error) from ToolExecutor
- add focused lifecycle event ordering/payload tests

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/tool-executor-lifecycle-events.test.ts src/__tests__/secret-scanner-executor.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/tools/types.ts src/tools/executor.ts src/__tests__/tool-executor-lifecycle-events.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
