### PR TITLE
Address PR #368 feedback: treat empty OLLAMA_BASE_URL as unset

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -174,6 +174,25 @@ describe('OpenAIProvider', () => {
     }
   });
 
+  test('ollama wrapper treats empty OLLAMA_BASE_URL as unset', () => {
+    const previousBaseUrl = process.env.OLLAMA_BASE_URL;
+    try {
+      process.env.OLLAMA_BASE_URL = '   ';
+      const ollama = new OllamaProvider('llama3.2');
+      expect(ollama.name).toBe('ollama');
+      expect(lastConstructorOptions).toEqual({
+        apiKey: 'ollama',
+        baseURL: 'http://127.0.0.1:11434/v1',
+      });
+    } finally {
+      if (previousBaseUrl !== undefined) {
+        process.env.OLLAMA_BASE_URL = previousBaseUrl;
+      } else {
+        delete process.env.OLLAMA_BASE_URL;
+      }
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Basic text response
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/ollama/client.ts
+++ b/assistant/src/providers/ollama/client.ts
@@ -10,9 +10,19 @@ const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434/v1';
 export class OllamaProvider extends OpenAIProvider {
   constructor(model: string, options: OllamaProviderOptions = {}) {
     super(options.apiKey ?? 'ollama', model, {
-      baseURL: options.baseURL ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_OLLAMA_BASE_URL,
+      baseURL: resolveBaseUrl(options.baseURL),
       providerName: 'ollama',
       providerLabel: 'Ollama',
     });
   }
+}
+
+function resolveBaseUrl(optionBaseUrl?: string): string {
+  for (const candidate of [optionBaseUrl, process.env.OLLAMA_BASE_URL]) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return DEFAULT_OLLAMA_BASE_URL;
 }


### PR DESCRIPTION
## Summary
- fix Ollama base URL resolution to ignore empty or whitespace-only values
- preserve precedence (explicit option -> env var -> default) while normalizing blanks
- add regression test for empty OLLAMA_BASE_URL fallback behavior

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/openai-provider.test.ts src/__tests__/provider-registry-ollama.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/providers/ollama/client.ts src/__tests__/openai-provider.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
