### PR TITLE
Address PR #370 feedback on event bus typing and subscription semantics

### DIFF
--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -65,6 +65,30 @@ describe('EventBus', () => {
     expect(sub.active).toBe(false);
   });
 
+  test('same callback can be subscribed independently', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    let calls = 0;
+
+    const listener = () => {
+      calls += 1;
+    };
+
+    const first = bus.on('daemon.lifecycle.stopped', listener);
+    const second = bus.on('daemon.lifecycle.stopped', listener);
+
+    expect(bus.listenerCount('daemon.lifecycle.stopped')).toBe(2);
+    first.dispose();
+    expect(first.active).toBe(false);
+    expect(second.active).toBe(true);
+
+    await bus.emit('daemon.lifecycle.stopped', { stoppedAtMs: Date.now() });
+    expect(calls).toBe(1);
+
+    second.dispose();
+    await bus.emit('daemon.lifecycle.stopped', { stoppedAtMs: Date.now() });
+    expect(calls).toBe(1);
+  });
+
   test('dispose clears listeners and rejects new registrations/emits', async () => {
     const bus = new EventBus<AssistantDomainEvents>();
     const sub = bus.on('daemon.lifecycle.started', () => {});
@@ -77,8 +101,8 @@ describe('EventBus', () => {
 
     expect(bus.listenerCount()).toBe(0);
     expect(bus.anyListenerCount()).toBe(0);
-    expect(sub.active).toBe(true);
-    expect(anySub.active).toBe(true);
+    expect(sub.active).toBe(false);
+    expect(anySub.active).toBe(false);
 
     expect(() => bus.on('daemon.lifecycle.started', () => {})).toThrow(EventBusDisposedError);
     expect(() => bus.onAny(() => {})).toThrow(EventBusDisposedError);

--- a/assistant/src/events/bus.ts
+++ b/assistant/src/events/bus.ts
@@ -17,6 +17,14 @@ export interface Subscription {
   dispose(): void;
 }
 
+interface DirectListenerEntry {
+  listener: EventListener<object>;
+}
+
+interface AnyListenerEntry<TEvents extends EventMap> {
+  listener: AnyEventListener<TEvents>;
+}
+
 class BasicSubscription implements Subscription {
   private _active = true;
   private readonly disposer: () => void;
@@ -44,26 +52,30 @@ export class EventBusDisposedError extends Error {
 }
 
 export class EventBus<TEvents extends EventMap> {
-  private readonly listeners = new Map<keyof TEvents & string, Set<EventListener<object>>>();
-  private readonly anyListeners = new Set<AnyEventListener<TEvents>>();
+  private readonly listeners = new Map<keyof TEvents & string, Set<DirectListenerEntry>>();
+  private readonly anyListeners = new Set<AnyListenerEntry<TEvents>>();
+  private readonly subscriptions = new Set<BasicSubscription>();
   private disposed = false;
 
   on<K extends keyof TEvents & string>(type: K, listener: EventListener<TEvents[K]>): Subscription {
     this.ensureActive();
     const set = this.getOrCreateSet(type);
-    set.add(listener as EventListener<object>);
+    const entry: DirectListenerEntry = { listener: listener as EventListener<object> };
+    set.add(entry);
 
-    return new BasicSubscription(() => {
-      set.delete(listener as EventListener<object>);
+    return this.createSubscription(() => {
+      set.delete(entry);
       if (set.size === 0) this.listeners.delete(type);
     });
   }
 
   onAny(listener: AnyEventListener<TEvents>): Subscription {
     this.ensureActive();
-    this.anyListeners.add(listener);
-    return new BasicSubscription(() => {
-      this.anyListeners.delete(listener);
+    const entry: AnyListenerEntry<TEvents> = { listener };
+    this.anyListeners.add(entry);
+
+    return this.createSubscription(() => {
+      this.anyListeners.delete(entry);
     });
   }
 
@@ -82,13 +94,13 @@ export class EventBus<TEvents extends EventMap> {
     this.ensureActive();
 
     const emittedAtMs = Date.now();
-    const directListeners = [...(this.listeners.get(type) ?? [])] as Array<EventListener<TEvents[K]>>;
+    const directListeners = [...(this.listeners.get(type) ?? [])];
     const anyListeners = [...this.anyListeners];
     const errors: unknown[] = [];
 
-    for (const listener of directListeners) {
+    for (const entry of directListeners) {
       try {
-        await listener(payload);
+        await (entry.listener as EventListener<TEvents[K]>)(payload);
       } catch (err) {
         errors.push(err);
       }
@@ -96,9 +108,9 @@ export class EventBus<TEvents extends EventMap> {
 
     if (anyListeners.length > 0) {
       const event = { type, payload, emittedAtMs } as AnyEventEnvelope<TEvents>;
-      for (const listener of anyListeners) {
+      for (const entry of anyListeners) {
         try {
-          await listener(event);
+          await entry.listener(event);
         } catch (err) {
           errors.push(err);
         }
@@ -113,19 +125,32 @@ export class EventBus<TEvents extends EventMap> {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    for (const subscription of [...this.subscriptions]) {
+      subscription.dispose();
+    }
     this.listeners.clear();
     this.anyListeners.clear();
+    this.subscriptions.clear();
   }
 
   private ensureActive(): void {
     if (this.disposed) throw new EventBusDisposedError();
   }
 
-  private getOrCreateSet(type: keyof TEvents & string): Set<EventListener<object>> {
+  private getOrCreateSet(type: keyof TEvents & string): Set<DirectListenerEntry> {
     const existing = this.listeners.get(type);
     if (existing) return existing;
-    const created = new Set<EventListener<object>>();
+    const created = new Set<DirectListenerEntry>();
     this.listeners.set(type, created);
     return created;
+  }
+
+  private createSubscription(disposer: () => void): Subscription {
+    const subscription = new BasicSubscription(() => {
+      disposer();
+      this.subscriptions.delete(subscription);
+    });
+    this.subscriptions.add(subscription);
+    return subscription;
   }
 }

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -1,6 +1,4 @@
-import type { EventMap } from './bus.js';
-
-export interface ToolDomainEvents extends EventMap {
+export interface ToolDomainEvents {
   'tool.execution.started': {
     conversationId: string;
     sessionId: string;
@@ -53,7 +51,7 @@ export interface ToolDomainEvents extends EventMap {
   };
 }
 
-export interface DaemonDomainEvents extends EventMap {
+export interface DaemonDomainEvents {
   'daemon.lifecycle.started': {
     pid: number;
     socketPath: string;


### PR DESCRIPTION
## Summary
- preserve literal domain-event keys by removing EventMap extension from domain event interfaces
- make each listener registration independent, even for the same callback reference
- mark all outstanding subscriptions inactive during bus disposal
- add regression coverage for duplicate callback subscriptions and disposal active state

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/event-bus.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/events/bus.ts src/events/domain-events.ts src/__tests__/event-bus.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
