### PR TITLE
Address PR #371 feedback on unknown-tool events and non-blocking callbacks

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -200,4 +200,39 @@ describe('ToolExecutor lifecycle events', () => {
     if (errorEvent.type !== 'error') throw new Error('Expected error event');
     expect(errorEvent.errorMessage).toBe('boom');
   });
+
+  test('emits start and error for unknown tools', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('unknown_tool', { test: true }, makeContext(events));
+
+    expect(result).toEqual({ content: 'Unknown tool: unknown_tool', isError: true });
+    expect(events.map((event) => event.type)).toEqual(['start', 'error']);
+    const errorEvent = events[1];
+    if (errorEvent.type !== 'error') throw new Error('Expected error event');
+    expect(errorEvent.errorMessage).toBe('Unknown tool: unknown_tool');
+    expect(errorEvent.decision).toBe('error');
+  });
+
+  test('does not block tool execution on unresolved lifecycle callbacks', async () => {
+    const executor = new ToolExecutor(makePrompter());
+    const timeoutMs = 100;
+
+    const resultPromise = executor.execute('file_read', {}, {
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      onToolLifecycleEvent: () => new Promise<void>(() => {}),
+    });
+
+    const raced = Promise.race([
+      resultPromise,
+      new Promise<ToolExecutionResult>((_, reject) => {
+        setTimeout(() => reject(new Error('execute timed out')), timeoutMs);
+      }),
+    ]);
+
+    await expect(raced).resolves.toEqual({ content: 'ok', isError: false });
+  });
 });

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -29,11 +29,6 @@ export class ToolExecutor {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const tool = getTool(name);
-    if (!tool) {
-      return { content: `Unknown tool: ${name}`, isError: true };
-    }
-
     const startTime = Date.now();
     let decision = 'allow';
     let riskLevel: string = RiskLevel.Low;
@@ -46,7 +41,7 @@ export class ToolExecutor {
       }, 'Tool execute start');
     }
 
-    await emitLifecycleEvent(context, {
+    emitLifecycleEvent(context, {
       type: 'start',
       toolName: name,
       input,
@@ -55,6 +50,25 @@ export class ToolExecutor {
       conversationId: context.conversationId,
       startedAtMs: startTime,
     });
+
+    const tool = getTool(name);
+    if (!tool) {
+      const msg = `Unknown tool: ${name}`;
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent(context, {
+        type: 'error',
+        toolName: name,
+        input,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+        conversationId: context.conversationId,
+        riskLevel,
+        decision: 'error',
+        durationMs,
+        errorMessage: msg,
+      });
+      return { content: msg, isError: true };
+    }
 
     try {
       // Check permissions
@@ -65,7 +79,7 @@ export class ToolExecutor {
       if (result.decision === 'deny') {
         decision = 'denied';
         const durationMs = Date.now() - startTime;
-        await emitLifecycleEvent(context, {
+        emitLifecycleEvent(context, {
           type: 'permission_denied',
           toolName: name,
           input,
@@ -105,7 +119,7 @@ export class ToolExecutor {
           sandboxed = wrapped.sandboxed;
         }
 
-        await emitLifecycleEvent(context, {
+        emitLifecycleEvent(context, {
           type: 'permission_prompt',
           toolName: name,
           input,
@@ -134,7 +148,7 @@ export class ToolExecutor {
 
         if (response.decision === 'deny') {
           const durationMs = Date.now() - startTime;
-          await emitLifecycleEvent(context, {
+          emitLifecycleEvent(context, {
             type: 'permission_denied',
             toolName: name,
             input,
@@ -164,7 +178,7 @@ export class ToolExecutor {
             addRule(name, response.selectedPattern!, response.selectedScope!, 'deny');
           }
           const durationMs = Date.now() - startTime;
-          await emitLifecycleEvent(context, {
+          emitLifecycleEvent(context, {
             type: 'permission_denied',
             toolName: name,
             input,
@@ -239,7 +253,7 @@ export class ToolExecutor {
               content: blockedContent,
               isError: true,
             };
-            await emitLifecycleEvent(context, {
+            emitLifecycleEvent(context, {
               type: 'executed',
               toolName: name,
               input,
@@ -278,7 +292,7 @@ export class ToolExecutor {
       }
 
       const durationMs = Date.now() - startTime;
-      await emitLifecycleEvent(context, {
+      emitLifecycleEvent(context, {
         type: 'executed',
         toolName: name,
         input,
@@ -314,7 +328,7 @@ export class ToolExecutor {
         riskLevel,
         durationMs,
       });
-      await emitLifecycleEvent(context, {
+      emitLifecycleEvent(context, {
         type: 'error',
         toolName: name,
         input,
@@ -337,9 +351,20 @@ export class ToolExecutor {
   }
 }
 
-async function emitLifecycleEvent(context: ToolContext, event: ToolLifecycleEvent): Promise<void> {
+function emitLifecycleEvent(context: ToolContext, event: ToolLifecycleEvent): void {
+  const handler = context.onToolLifecycleEvent;
+  if (!handler) return;
+
   try {
-    await context.onToolLifecycleEvent?.(event);
+    const maybePromise = handler(event);
+    if (maybePromise) {
+      void maybePromise.catch((err) => {
+        log.warn(
+          { err, eventType: event.type, toolName: event.toolName },
+          'Tool lifecycle event handler failed',
+        );
+      });
+    }
   } catch (err) {
     log.warn(
       { err, eventType: event.type, toolName: event.toolName },


### PR DESCRIPTION
## Summary
- emit lifecycle start/error events for unknown tool invocations
- make lifecycle callback delivery fire-and-forget so async handlers cannot stall tool execution
- add regression tests for unknown-tool lifecycle emission and unresolved async lifecycle handlers

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/tool-executor-lifecycle-events.test.ts src/__tests__/secret-scanner-executor.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/tools/executor.ts src/__tests__/tool-executor-lifecycle-events.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
