### PR TITLE
Migrate tool audit logging to lifecycle listener

### DIFF
--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import type { SecretDetectionEvent, ToolExecutionResult } from '../tools/types.js';
+import type { SecretDetectionEvent, ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — MUST be declared before importing executor
@@ -79,16 +79,21 @@ mock.module('../tools/terminal/sandbox.js', () => ({
 // Now import the module under test — mocks are already in place
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
+import { createToolAuditListener } from '../events/tool-audit-listener.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeContext(overrides?: Partial<{ onSecretDetected: (e: SecretDetectionEvent) => void }>) {
+function makeContext(overrides?: Partial<{
+  onSecretDetected: (e: SecretDetectionEvent) => void;
+  onToolLifecycleEvent: ToolLifecycleEventHandler;
+}>) {
   return {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
+    onToolLifecycleEvent: createToolAuditListener(),
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from 'bun:test';
+import { createToolAuditListener } from '../events/tool-audit-listener.js';
+import type { ToolInvocationRecord } from '../memory/tool-usage-store.js';
+
+describe('tool audit listener', () => {
+  test('records executed events with truncated output', () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: 'executed',
+      toolName: 'file_read',
+      input: { path: '/tmp/a' },
+      workingDir: '/tmp',
+      sessionId: 'sess-1',
+      conversationId: 'conv-1',
+      riskLevel: 'low',
+      decision: 'allow',
+      durationMs: 12,
+      result: { content: 'x'.repeat(1200), isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].conversationId).toBe('conv-1');
+    expect(records[0].toolName).toBe('file_read');
+    expect(records[0].input).toBe(JSON.stringify({ path: '/tmp/a' }));
+    expect(records[0].result).toHaveLength(1000);
+    expect(records[0].decision).toBe('allow');
+    expect(records[0].riskLevel).toBe('low');
+    expect(records[0].durationMs).toBe(12);
+  });
+
+  test('records deny events with expected normalized results', () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: 'permission_denied',
+      toolName: 'shell',
+      input: { command: 'rm -rf /tmp' },
+      workingDir: '/tmp',
+      sessionId: 'sess-2',
+      conversationId: 'conv-2',
+      riskLevel: 'high',
+      decision: 'deny',
+      reason: 'Blocked by deny rule: rm *',
+      durationMs: 20,
+    });
+    listener({
+      type: 'permission_denied',
+      toolName: 'shell',
+      input: { command: 'sudo rm -rf /tmp' },
+      workingDir: '/tmp',
+      sessionId: 'sess-2',
+      conversationId: 'conv-2',
+      riskLevel: 'high',
+      decision: 'always_deny',
+      reason: 'Permission denied by user (rule saved)',
+      durationMs: 22,
+    });
+
+    expect(records).toHaveLength(2);
+    expect(records[0].result).toBe('denied: Blocked by deny rule: rm *');
+    expect(records[0].decision).toBe('denied');
+    expect(records[1].result).toBe('denied (permanent)');
+    expect(records[1].decision).toBe('denied');
+  });
+
+  test('records error events and ignores non-terminal events', () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: 'start',
+      toolName: 'file_read',
+      input: { path: '/tmp/a' },
+      workingDir: '/tmp',
+      sessionId: 'sess-3',
+      conversationId: 'conv-3',
+      startedAtMs: Date.now(),
+    });
+    listener({
+      type: 'permission_prompt',
+      toolName: 'shell',
+      input: { command: 'rm -rf /tmp' },
+      workingDir: '/tmp',
+      sessionId: 'sess-3',
+      conversationId: 'conv-3',
+      riskLevel: 'high',
+      reason: 'High risk: always requires approval',
+      allowlistOptions: [],
+      scopeOptions: [],
+    });
+    listener({
+      type: 'error',
+      toolName: 'file_read',
+      input: { path: '/tmp/secret' },
+      workingDir: '/tmp',
+      sessionId: 'sess-3',
+      conversationId: 'conv-3',
+      riskLevel: 'low',
+      decision: 'error',
+      durationMs: 9,
+      errorMessage: 'boom',
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].result).toBe('error: boom');
+    expect(records[0].decision).toBe('error');
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -12,6 +12,7 @@ import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
+import { createToolAuditListener } from '../events/tool-audit-listener.js';
 
 const log = getLogger('session');
 
@@ -42,6 +43,7 @@ export class Session {
     this.sendToClient = sendToClient;
     this.prompter = new PermissionPrompter(sendToClient);
     this.executor = new ToolExecutor(this.prompter);
+    const auditToolLifecycleEvent = createToolAuditListener();
 
     const toolDefs = getAllToolDefinitions();
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
@@ -59,6 +61,7 @@ export class Session {
             action: event.action,
           });
         },
+        onToolLifecycleEvent: auditToolLifecycleEvent,
       });
     };
 

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -1,0 +1,79 @@
+import { recordToolInvocation, type ToolInvocationRecord } from '../memory/tool-usage-store.js';
+import type { ToolLifecycleEvent, ToolLifecycleEventHandler } from '../tools/types.js';
+import { getLogger } from '../util/logger.js';
+
+const RESULT_PREVIEW_LIMIT = 1000;
+const log = getLogger('tool-audit-listener');
+
+type InvocationRecorder = (record: ToolInvocationRecord) => void;
+
+export function createToolAuditListener(
+  recorder: InvocationRecorder = recordToolInvocation,
+): ToolLifecycleEventHandler {
+  return (event) => {
+    const record = toInvocationRecord(event);
+    if (!record) return;
+
+    try {
+      recorder(record);
+    } catch (err) {
+      log.warn({ err, eventType: event.type, toolName: event.toolName }, 'Failed to record tool invocation');
+    }
+  };
+}
+
+function toInvocationRecord(event: ToolLifecycleEvent): ToolInvocationRecord | null {
+  switch (event.type) {
+    case 'executed':
+      return {
+        conversationId: event.conversationId,
+        toolName: event.toolName,
+        input: stringifyInput(event.input),
+        result: event.result.content.slice(0, RESULT_PREVIEW_LIMIT),
+        decision: event.decision,
+        riskLevel: event.riskLevel,
+        durationMs: event.durationMs,
+      };
+    case 'error':
+      return {
+        conversationId: event.conversationId,
+        toolName: event.toolName,
+        input: stringifyInput(event.input),
+        result: `error: ${event.errorMessage}`,
+        decision: 'error',
+        riskLevel: event.riskLevel,
+        durationMs: event.durationMs,
+      };
+    case 'permission_denied':
+      return {
+        conversationId: event.conversationId,
+        toolName: event.toolName,
+        input: stringifyInput(event.input),
+        result: formatDeniedResult(event.reason, event.decision),
+        decision: 'denied',
+        riskLevel: event.riskLevel,
+        durationMs: event.durationMs,
+      };
+    case 'start':
+    case 'permission_prompt':
+      return null;
+  }
+}
+
+function stringifyInput(input: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return '[unserializable-input]';
+  }
+}
+
+function formatDeniedResult(reason: string, decision: 'deny' | 'always_deny'): string {
+  if (reason.startsWith('Blocked by deny rule:')) {
+    return `denied: ${reason}`;
+  }
+  if (decision === 'always_deny' && reason.includes('rule saved')) {
+    return 'denied (permanent)';
+  }
+  return 'denied';
+}

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -5,7 +5,6 @@ import { RiskLevel } from '../permissions/types.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
-import { recordToolInvocation } from '../memory/tool-usage-store.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
@@ -91,15 +90,6 @@ export class ToolExecutor {
           reason: result.reason,
           durationMs,
         });
-        recordToolInvocation({
-          conversationId: context.conversationId,
-          toolName: name,
-          input: JSON.stringify(input),
-          result: `denied: ${result.reason}`,
-          decision: 'denied',
-          riskLevel,
-          durationMs,
-        });
         return { content: result.reason, isError: true };
       }
 
@@ -160,15 +150,6 @@ export class ToolExecutor {
             reason: 'Permission denied by user',
             durationMs,
           });
-          recordToolInvocation({
-            conversationId: context.conversationId,
-            toolName: name,
-            input: JSON.stringify(input),
-            result: 'denied',
-            decision: 'denied',
-            riskLevel,
-            durationMs,
-          });
           return { content: 'Permission denied by user', isError: true };
         }
 
@@ -188,15 +169,6 @@ export class ToolExecutor {
             riskLevel,
             decision: 'always_deny',
             reason: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user',
-            durationMs,
-          });
-          recordToolInvocation({
-            conversationId: context.conversationId,
-            toolName: name,
-            input: JSON.stringify(input),
-            result: ruleSaved ? 'denied (permanent)' : 'denied',
-            decision: 'denied',
-            riskLevel,
             durationMs,
           });
           return { content: ruleSaved ? 'Permission denied by user (rule saved)' : 'Permission denied by user', isError: true };
@@ -265,15 +237,6 @@ export class ToolExecutor {
               durationMs,
               result: blockedResult,
             });
-            recordToolInvocation({
-              conversationId: context.conversationId,
-              toolName: name,
-              input: JSON.stringify(input),
-              result: blockedContent.slice(0, 1000),
-              decision,
-              riskLevel,
-              durationMs,
-            });
             return blockedResult;
           }
         }
@@ -304,30 +267,12 @@ export class ToolExecutor {
         durationMs,
         result: execResult,
       });
-      recordToolInvocation({
-        conversationId: context.conversationId,
-        toolName: name,
-        input: JSON.stringify(input),
-        result: execResult.content.slice(0, 1000), // Truncate for storage
-        decision,
-        riskLevel,
-        durationMs,
-      });
 
       return execResult;
     } catch (err) {
       const durationMs = Date.now() - startTime;
       const msg = err instanceof Error ? err.message : String(err);
 
-      recordToolInvocation({
-        conversationId: context.conversationId,
-        toolName: name,
-        input: JSON.stringify(input),
-        result: `error: ${msg}`,
-        decision: 'error',
-        riskLevel,
-        durationMs,
-      });
       emitLifecycleEvent(context, {
         type: 'error',
         toolName: name,


### PR DESCRIPTION
## Summary
- add a dedicated tool audit lifecycle listener that persists terminal lifecycle events
- remove direct `recordToolInvocation` writes from ToolExecutor
- wire audit listener into session tool execution context via `onToolLifecycleEvent`
- add listener-focused tests and update executor integration tests to use the listener path

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/tool-audit-listener.test.ts src/__tests__/tool-executor-lifecycle-events.test.ts src/__tests__/secret-scanner-executor.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/events/tool-audit-listener.ts src/daemon/session.ts src/tools/executor.ts src/__tests__/tool-audit-listener.test.ts src/__tests__/secret-scanner-executor.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
