### PR TITLE
Session loop performance optimizations

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/AXTreeDiff.swift
@@ -40,7 +40,15 @@ enum AXTreeDiff {
     static func diff(previous: [AXElement], current: [AXElement]) -> String? {
         let prevFlat = AccessibilityTreeEnumerator.flattenElements(previous)
         let currFlat = AccessibilityTreeEnumerator.flattenElements(current)
+        return computeDiff(prevFlat: prevFlat, currFlat: currFlat)
+    }
 
+    /// Diff overload accepting pre-flattened element arrays to avoid redundant traversals.
+    static func diff(previousFlat: [AXElement], currentFlat: [AXElement]) -> String? {
+        return computeDiff(prevFlat: previousFlat, currFlat: currentFlat)
+    }
+
+    private static func computeDiff(prevFlat: [AXElement], currFlat: [AXElement]) -> String? {
         // Build multimaps so duplicate structural keys are preserved
         var prevByKey: [StableKey: [ElementSnapshot]] = [:]
         for el in prevFlat {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -173,13 +173,18 @@ final class ComputerUseSession: ObservableObject {
                     log.debug("[\(stepNumber)] Secondary windows text:\n\(secText)")
                 }
 
-                // Also capture a screenshot so the model can see content beyond the AX tree
-                do {
-                    screenshot = try await screenCapture.captureScreen()
-                    log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
-                } catch {
-                    log.warning("[\(stepNumber)] Screenshot capture failed alongside AX tree: \(error.localizedDescription)")
-                    // Non-fatal — we still have the AX tree
+                // Conditionally capture a screenshot — skip on middle steps when AX tree is sufficient
+                let lastAction = actionHistory.last?.action
+                if shouldCaptureScreenshot(stepNumber: stepNumber, flatElements: flat, lastAction: lastAction) {
+                    do {
+                        screenshot = try await screenCapture.captureScreen()
+                        log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
+                    } catch {
+                        log.warning("[\(stepNumber)] Screenshot capture failed alongside AX tree: \(error.localizedDescription)")
+                        // Non-fatal — we still have the AX tree
+                    }
+                } else {
+                    log.debug("[\(stepNumber)] Screenshot skipped — AX tree is sufficient")
                 }
             } else {
                 // No focused window — try screenshot as last resort
@@ -399,6 +404,28 @@ final class ComputerUseSession: ObservableObject {
         }
 
         log.debug("UI settle timeout after \(elapsed)ms (polls: \(pollCount))")
+    }
+
+    // MARK: - Conditional Screenshot
+
+    /// Decide whether to capture a screenshot alongside the AX tree.
+    /// Skips on middle steps when the AX tree provides sufficient context.
+    private func shouldCaptureScreenshot(stepNumber: Int, flatElements: [AXElement], lastAction: AgentAction?) -> Bool {
+        // Always capture on step 1 (model needs full visual context to start)
+        if stepNumber == 1 { return true }
+
+        // Capture after openApp (visual context for new app)
+        if lastAction?.type == .openApp { return true }
+
+        // Capture when AX tree is too sparse to be useful (< 3 interactive elements)
+        let interactiveCount = flatElements.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }.count
+        if interactiveCount < 3 { return true }
+
+        // Capture when UI appears stuck (model may need visual clues to break out)
+        if consecutiveUnchangedSteps >= 2 { return true }
+
+        // AX tree is sufficient — skip screenshot
+        return false
     }
 
     // MARK: - No-Op Detection

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -45,7 +45,7 @@ final class ComputerUseSession: ObservableObject {
     private let adaptiveDelayEnabled: Bool
     private let minDelayMs: UInt64 = 100
     private let maxDelayMs: UInt64 = 2000
-    private let pollIntervalMs: UInt64 = 50
+    private let pollIntervalMs: UInt64 = 100
 
     init(
         task: String,
@@ -334,7 +334,8 @@ final class ComputerUseSession: ObservableObject {
 
             // 7. WAIT — adaptive delay: poll for AX tree changes instead of fixed sleep
             if adaptiveDelayEnabled && axTreeText != nil {
-                await waitForUISettle(previousTree: axTreeText)
+                let prevCount = flatElements?.count ?? 0
+                await waitForUISettle(previousTree: axTreeText, previousElementCount: prevCount)
             } else {
                 try? await Task.sleep(nanoseconds: stepDelayMs * 1_000_000)
             }
@@ -347,54 +348,39 @@ final class ComputerUseSession: ObservableObject {
 
     // MARK: - Adaptive Delay
 
-    /// Poll the AX tree until it changes or stabilizes.
-    /// Returns early when:
-    /// 1. The tree differs from `previousTree` (action took effect)
-    /// 2. The tree has been identical for `stableExitThreshold` consecutive polls (UI is stable)
-    /// 3. `maxPollCount` polls are exhausted
-    /// 4. `maxDelayMs` timeout is reached
-    private func waitForUISettle(previousTree: String?) async {
+    /// Poll the AX tree until it changes or max polls are exhausted.
+    /// Uses a fast path (element count comparison) for most polls and only
+    /// does a full tree format+compare on the first and last poll.
+    private func waitForUISettle(previousTree: String?, previousElementCount: Int) async {
         // Always wait the minimum delay to let CGEvents propagate
         try? await Task.sleep(nanoseconds: minDelayMs * 1_000_000)
 
         var elapsed = minDelayMs
-        var consecutiveStablePolls = 0
-        var lastPollTree: String? = previousTree
         var pollCount = 0
-        let maxPollCount = 10
-        let stableExitThreshold = 3
-        var hasChangedFromPrevious = false
+        let maxPollCount = 6
 
         while elapsed < maxDelayMs && !isCancelled && pollCount < maxPollCount {
-            // Quick check if the AX tree has changed
             if let result = enumerator.enumerateCurrentWindow() {
-                let currentTree = AccessibilityTreeEnumerator.formatAXTree(
-                    elements: result.elements,
-                    windowTitle: result.windowTitle,
-                    appName: result.appName
-                )
+                let isFirstOrLastPoll = pollCount == 0 || pollCount == maxPollCount - 1
 
-                // Exit: tree changed from pre-action state (action took effect)
-                if currentTree != previousTree {
-                    hasChangedFromPrevious = true
-                    log.debug("UI settled after \(elapsed)ms (tree changed)")
-                    return
-                }
-
-                // Track consecutive identical polls for early stability exit,
-                // but ONLY use this shortcut after we've seen the tree change
-                // at least once. Otherwise slow UI updates (app launches,
-                // delayed renders) get declared "stable" prematurely.
-                if currentTree == lastPollTree {
-                    consecutiveStablePolls += 1
+                if isFirstOrLastPoll {
+                    // Full comparison on first and last poll
+                    let currentTree = AccessibilityTreeEnumerator.formatAXTree(
+                        elements: result.elements,
+                        windowTitle: result.windowTitle,
+                        appName: result.appName
+                    )
+                    if currentTree != previousTree {
+                        log.debug("UI settled after \(elapsed)ms (tree changed)")
+                        return
+                    }
                 } else {
-                    consecutiveStablePolls = 0
-                }
-                lastPollTree = currentTree
-
-                if hasChangedFromPrevious && consecutiveStablePolls >= stableExitThreshold {
-                    log.debug("UI stable after \(elapsed)ms (\(consecutiveStablePolls) identical polls after change)")
-                    return
+                    // Fast path: just compare element count (O(1) vs full tree format)
+                    let currentCount = AccessibilityTreeEnumerator.flattenElements(result.elements).count
+                    if currentCount != previousElementCount {
+                        log.debug("UI settled after \(elapsed)ms (element count changed: \(previousElementCount) → \(currentCount))")
+                        return
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -162,19 +162,19 @@ final class ComputerUseSession: ObservableObject {
                 // which may be our own app when we fell back to enumeratePreviousApp)
                 primaryPID = result.pid
 
-                // Enumerate secondary windows for cross-app awareness
-                let secondaryWindows = enumerator.enumerateSecondaryWindows(
-                    excludingPID: primaryPID,
-                    maxWindows: 2
-                )
-                secondaryWindowsText = AccessibilityTreeEnumerator.formatSecondaryWindows(secondaryWindows)
-                if let secText = secondaryWindowsText {
-                    log.info("[\(stepNumber)] Secondary windows: \(secondaryWindows.count)")
-                    log.debug("[\(stepNumber)] Secondary windows text:\n\(secText)")
-                }
-
-                // Conditionally capture a screenshot — skip on middle steps when AX tree is sufficient
+                // Enumerate secondary windows for cross-app awareness (skip for single-app tasks)
                 let lastAction = actionHistory.last?.action
+                if shouldEnumerateSecondaryWindows(stepNumber: stepNumber, lastAction: lastAction) {
+                    let secondaryWindows = enumerator.enumerateSecondaryWindows(
+                        excludingPID: primaryPID,
+                        maxWindows: 2
+                    )
+                    secondaryWindowsText = AccessibilityTreeEnumerator.formatSecondaryWindows(secondaryWindows)
+                    if let secText = secondaryWindowsText {
+                        log.info("[\(stepNumber)] Secondary windows: \(secondaryWindows.count)")
+                        log.debug("[\(stepNumber)] Secondary windows text:\n\(secText)")
+                    }
+                }
                 if shouldCaptureScreenshot(stepNumber: stepNumber, flatElements: flat, lastAction: lastAction) {
                     do {
                         screenshot = try await screenCapture.captureScreen()
@@ -404,6 +404,56 @@ final class ComputerUseSession: ObservableObject {
         }
 
         log.debug("UI settle timeout after \(elapsed)ms (polls: \(pollCount))")
+    }
+
+    // MARK: - Conditional Secondary Windows
+
+    /// Decide whether to enumerate secondary windows.
+    /// Skips on middle steps for single-app tasks where cross-app context isn't needed.
+    private func shouldEnumerateSecondaryWindows(stepNumber: Int, lastAction: AgentAction?) -> Bool {
+        // Always enumerate on step 1 (need full context)
+        if stepNumber == 1 { return true }
+
+        // Enumerate after openApp (just switched apps, secondary context is relevant)
+        if lastAction?.type == .openApp { return true }
+
+        // Enumerate if the task mentions multiple apps or cross-app phrases
+        if taskMentionsMultipleApps() { return true }
+
+        return false
+    }
+
+    private static let appKeywords: Set<String> = [
+        "safari", "chrome", "firefox", "slack", "finder", "notes", "mail",
+        "messages", "terminal", "vscode", "code", "xcode", "spotify",
+        "discord", "notion", "figma", "teams", "zoom", "preview",
+        "textedit", "pages", "numbers", "keynote", "calendar"
+    ]
+
+    private static let crossAppPhrases = [
+        "copy from", "paste into", "switch to", "drag from", "move to",
+        "from safari", "from chrome", "from slack", "to safari", "to chrome",
+        "to slack", "between"
+    ]
+
+    private func taskMentionsMultipleApps() -> Bool {
+        let lower = task.lowercased()
+
+        // Check for cross-app phrases first
+        for phrase in Self.crossAppPhrases {
+            if lower.contains(phrase) { return true }
+        }
+
+        // Check if 2+ app names appear in the task
+        var appCount = 0
+        for keyword in Self.appKeywords {
+            if lower.contains(keyword) {
+                appCount += 1
+                if appCount >= 2 { return true }
+            }
+        }
+
+        return false
     }
 
     // MARK: - Conditional Screenshot

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -38,6 +38,7 @@ final class ComputerUseSession: ObservableObject {
     private var didChromeAccessibilityCheck = false
     private var previousAXTreeText: String?
     private var previousElements: [AXElement]?
+    private var previousFlatElements: [AXElement]?
     private var consecutiveUnchangedSteps = 0
 
     /// Adaptive delay configuration
@@ -77,6 +78,7 @@ final class ComputerUseSession: ObservableObject {
         isPaused = false
         previousAXTreeText = nil
         previousElements = nil
+        previousFlatElements = nil
         consecutiveUnchangedSteps = 0
         state = .running(step: 0, maxSteps: maxSteps, lastAction: "Starting...", reasoning: "")
 
@@ -100,6 +102,7 @@ final class ComputerUseSession: ObservableObject {
             // 1. PERCEIVE — always prefer accessibility tree
             var axTreeText: String?
             var elements: [AXElement]?
+            var flatElements: [AXElement]?
             var screenshot: Data?
             var usedVision = false
             var axDiffText: String?
@@ -138,13 +141,14 @@ final class ComputerUseSession: ObservableObject {
                 elements = result.elements
                 currentAppName = result.appName
                 let flat = AccessibilityTreeEnumerator.flattenElements(result.elements)
+                flatElements = flat
                 let interactiveCount = flat.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }.count
                 log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
                 log.debug("[\(stepNumber)] AX tree text:\n\(axTreeText ?? "(empty)")")
 
-                // Compute AX tree diff if we have a previous snapshot
-                if let prevElements = previousElements {
-                    axDiffText = AXTreeDiff.diff(previous: prevElements, current: result.elements)
+                // Compute AX tree diff if we have a previous snapshot (using pre-flattened arrays)
+                if let prevFlat = previousFlatElements {
+                    axDiffText = AXTreeDiff.diff(previousFlat: prevFlat, currentFlat: flat)
                     if let diff = axDiffText {
                         log.info("[\(stepNumber)] AX diff:\n\(diff)")
                         consecutiveUnchangedSteps = 0
@@ -205,7 +209,7 @@ final class ComputerUseSession: ObservableObject {
                     screenSize: screenCapture.screenSize(),
                     task: task,
                     history: actionHistory,
-                    elements: elements.flatMap { AccessibilityTreeEnumerator.flattenElements($0) },
+                    elements: flatElements,
                     consecutiveUnchangedSteps: consecutiveUnchangedSteps
                 )
                 action = result.action
@@ -275,6 +279,7 @@ final class ComputerUseSession: ObservableObject {
                 state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: "\(action.displayDescription) (skipped)", reasoning: action.reasoning)
                 previousAXTreeText = axTreeText
                 previousElements = elements
+                previousFlatElements = flatElements
                 continue
             }
 
@@ -293,6 +298,7 @@ final class ComputerUseSession: ObservableObject {
                     state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: "\(action.displayDescription) (error)", reasoning: action.reasoning)
                     previousAXTreeText = axTreeText
                     previousElements = elements
+                    previousFlatElements = flatElements
                     continue
                 }
 
@@ -319,6 +325,7 @@ final class ComputerUseSession: ObservableObject {
             // Save current AX tree for next step's context
             previousAXTreeText = axTreeText
             previousElements = elements
+            previousFlatElements = flatElements
 
             // 7. WAIT — adaptive delay: poll for AX tree changes instead of fixed sleep
             if adaptiveDelayEnabled && axTreeText != nil {

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -314,10 +314,10 @@ final class AnthropicProvider: ActionInferenceProvider {
         }
     }
 
+    /// Resolve an element ID to screen coordinates. `elements` is expected to be pre-flattened.
     private func resolvePosition(elementId: Int?, inputX: Int?, inputY: Int?, elements: [AXElement]?) -> (x: Int?, y: Int?, resolvedId: Int?, desc: String?) {
         if let elementId = elementId, let elements = elements {
-            let flat = AccessibilityTreeEnumerator.flattenElements(elements)
-            if let element = flat.first(where: { $0.id == elementId }) {
+            if let element = elements.first(where: { $0.id == elementId }) {
                 let x = Int(element.frame.midX)
                 let y = Int(element.frame.midY)
                 let desc = element.title ?? element.roleDescription ?? element.role

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -47,6 +47,7 @@ final class MockInferenceProvider: ActionInferenceProvider {
 
 final class MockAccessibilityTreeEnumerator: AccessibilityTreeProviding {
     var result: (elements: [AXElement], windowTitle: String, appName: String, pid: pid_t)?
+    var secondaryWindowCallCount = 0
 
     init(result: (elements: [AXElement], windowTitle: String, appName: String)? = nil) {
         if let r = result {
@@ -61,12 +62,16 @@ final class MockAccessibilityTreeEnumerator: AccessibilityTreeProviding {
     }
 
     func enumerateSecondaryWindows(excludingPID: pid_t?, maxWindows: Int) -> [WindowInfo] {
+        secondaryWindowCallCount += 1
         return []
     }
 }
 
 final class MockScreenCapture: ScreenCaptureProviding {
+    var captureCallCount = 0
+
     func captureScreen(maxWidth: Int, maxHeight: Int) async throws -> Data {
+        captureCallCount += 1
         return Data([0xFF, 0xD8, 0xFF]) // Minimal JPEG-like stub
     }
 
@@ -160,6 +165,7 @@ private func makeDefaultEnumerator() -> MockAccessibilityTreeEnumerator {
     task: String = "test task",
     provider: ActionInferenceProvider,
     enumerator: AccessibilityTreeProviding? = nil,
+    screenCapture: MockScreenCapture? = nil,
     executor: MockActionExecutor? = nil,
     maxSteps: Int = 50
 ) -> ComputerUseSession {
@@ -167,7 +173,7 @@ private func makeDefaultEnumerator() -> MockAccessibilityTreeEnumerator {
         task: task,
         provider: provider,
         enumerator: enumerator ?? makeDefaultEnumerator(),
-        screenCapture: MockScreenCapture(),
+        screenCapture: screenCapture ?? MockScreenCapture(),
         executor: executor ?? MockActionExecutor(),
         maxSteps: maxSteps,
         stepDelayMs: 0,
@@ -781,4 +787,164 @@ final class SessionTests: XCTestCase {
             XCTFail("Expected completed state (AppleScript errors are non-fatal), got \(session.state)")
         }
     }
+
+    // MARK: - Performance Optimization Tests
+
+    @MainActor
+    func testScreenshot_skippedOnMiddleSteps() async {
+        // 3-step session with enough interactive elements — screenshot should only be captured on step 1
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .click, reasoning: "Click button", x: 140, y: 215),
+            AgentAction(type: .click, reasoning: "Click another", x: 200, y: 215),
+            AgentAction(type: .done, reasoning: "Task complete", summary: "Done")
+        ])
+        let screenCapture = MockScreenCapture()
+        let enumerator = MockAccessibilityTreeEnumerator(
+            result: (elements: makeInteractiveTestElements(), windowTitle: "Test Window", appName: "TestApp")
+        )
+        let session = makeSession(provider: provider, enumerator: enumerator, screenCapture: screenCapture)
+
+        await session.run()
+
+        if case .completed(_, let steps) = session.state {
+            XCTAssertEqual(steps, 3)
+        } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+
+        // Step 1: captured (first step). Step 2: skipped (AX tree sufficient).
+        // Step 3: captured (consecutiveUnchangedSteps reaches 2 since mock returns identical elements).
+        XCTAssertEqual(screenCapture.captureCallCount, 2, "Screenshot should be captured on step 1 and when stuck")
+    }
+
+    @MainActor
+    func testScreenshot_capturedAfterOpenApp() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .openApp, reasoning: "Switch app", appName: "Safari"),
+            AgentAction(type: .click, reasoning: "Click link", x: 200, y: 300),
+            AgentAction(type: .done, reasoning: "done", summary: "Done")
+        ])
+        let screenCapture = MockScreenCapture()
+        let enumerator = MockAccessibilityTreeEnumerator(
+            result: (elements: makeInteractiveTestElements(), windowTitle: "Test Window", appName: "TestApp")
+        )
+        let session = makeSession(provider: provider, enumerator: enumerator, screenCapture: screenCapture)
+
+        await session.run()
+
+        if case .completed(_, _) = session.state { } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+
+        // Step 1: captured (first step). Step 2: captured (after openApp).
+        // Step 3: captured (consecutiveUnchangedSteps reaches 2 since mock returns identical elements).
+        XCTAssertEqual(screenCapture.captureCallCount, 3, "Screenshot should be captured on step 1, after openApp, and when stuck")
+    }
+
+    @MainActor
+    func testSecondaryWindows_skippedForSingleAppTask() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .click, reasoning: "Click button", x: 140, y: 215),
+            AgentAction(type: .click, reasoning: "Click another", x: 200, y: 215),
+            AgentAction(type: .done, reasoning: "done", summary: "Done")
+        ])
+        let enumerator = MockAccessibilityTreeEnumerator(
+            result: (elements: makeTestElements(), windowTitle: "Test Window", appName: "TestApp")
+        )
+        let session = makeSession(task: "click the submit button", provider: provider, enumerator: enumerator)
+
+        await session.run()
+
+        if case .completed(_, _) = session.state { } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+
+        // Single-app task: secondary windows only enumerated on step 1
+        XCTAssertEqual(enumerator.secondaryWindowCallCount, 1, "Secondary windows should only be enumerated on step 1 for single-app tasks")
+    }
+
+    @MainActor
+    func testSecondaryWindows_enumeratedForCrossAppTask() async {
+        let provider = MockInferenceProvider(actions: [
+            AgentAction(type: .click, reasoning: "Click button", x: 140, y: 215),
+            AgentAction(type: .click, reasoning: "Click another", x: 200, y: 215),
+            AgentAction(type: .done, reasoning: "done", summary: "Done")
+        ])
+        let enumerator = MockAccessibilityTreeEnumerator(
+            result: (elements: makeTestElements(), windowTitle: "Test Window", appName: "TestApp")
+        )
+        // Task mentions two apps — should enumerate secondary windows on every step
+        let session = makeSession(task: "copy from Safari and paste into Notes", provider: provider, enumerator: enumerator)
+
+        await session.run()
+
+        if case .completed(_, _) = session.state { } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+
+        // Cross-app task: secondary windows enumerated on all 3 steps
+        XCTAssertEqual(enumerator.secondaryWindowCallCount, 3, "Secondary windows should be enumerated on every step for cross-app tasks")
+    }
+}
+
+/// Test elements with 3+ interactive elements (enough for screenshot skip)
+private func makeInteractiveTestElements() -> [AXElement] {
+    [
+        AXElement(
+            id: 1,
+            role: "AXButton",
+            title: "Submit",
+            value: nil,
+            frame: CGRect(x: 100, y: 200, width: 80, height: 30),
+            isEnabled: true,
+            isFocused: false,
+            children: [],
+            roleDescription: "button",
+            identifier: nil,
+            url: nil,
+            placeholderValue: nil
+        ),
+        AXElement(
+            id: 2,
+            role: "AXTextField",
+            title: nil,
+            value: "",
+            frame: CGRect(x: 100, y: 150, width: 200, height: 30),
+            isEnabled: true,
+            isFocused: true,
+            children: [],
+            roleDescription: "text field",
+            identifier: nil,
+            url: nil,
+            placeholderValue: "Enter name"
+        ),
+        AXElement(
+            id: 3,
+            role: "AXButton",
+            title: "Cancel",
+            value: nil,
+            frame: CGRect(x: 200, y: 200, width: 80, height: 30),
+            isEnabled: true,
+            isFocused: false,
+            children: [],
+            roleDescription: "button",
+            identifier: nil,
+            url: nil,
+            placeholderValue: nil
+        ),
+        AXElement(
+            id: 4,
+            role: "AXCheckBox",
+            title: "Remember me",
+            value: "0",
+            frame: CGRect(x: 100, y: 250, width: 120, height: 20),
+            isEnabled: true,
+            isFocused: false,
+            children: [],
+            roleDescription: "checkbox",
+            identifier: nil,
+            url: nil,
+            placeholderValue: nil
+        ),
+    ]
 }


### PR DESCRIPTION
The purpose of this PR is to optimize the computer use session loop (PERCEIVE → INFER → VERIFY → EXECUTE → WAIT) to reduce per-step token cost and latency.

## Changes Made
- **Cache flattened elements**: Flatten AX elements once after enumeration and reuse across logging, diff, and inference — previously called 4-6x per step
- **Conditional screenshots**: Skip screenshot capture on middle steps when the AX tree has 3+ interactive elements and UI isn't stuck — saves ~1,600-2,000 input tokens per skipped step
- **Skip secondary windows**: Only enumerate secondary windows on step 1, after `openApp`, or when the task mentions multiple apps — saves ~200-800 tokens and ~50-300ms per step
- **Lighter adaptive wait**: Reduce polls from 10→6, increase interval from 50→100ms, use fast-path element count comparison for middle polls instead of full tree formatting

## Testing
- 4 new tests covering screenshot skip, screenshot-after-openApp, secondary window skip for single-app tasks, and secondary window enumeration for cross-app tasks
- All 58 tests pass (54 existing + 4 new)

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
