### PR TITLE
Address PR #374 feedback: EventBus generic compatibility

### DIFF
--- a/assistant/src/events/bus.ts
+++ b/assistant/src/events/bus.ts
@@ -1,8 +1,9 @@
 export type EventMap = Record<string, object>;
+type EventShape<TEvents> = Record<keyof TEvents & string, object>;
 
 export type EventListener<TPayload extends object> = (payload: TPayload) => void | Promise<void>;
 
-export type AnyEventEnvelope<TEvents extends EventMap> = {
+export type AnyEventEnvelope<TEvents extends EventShape<TEvents>> = {
   [K in keyof TEvents & string]: {
     type: K;
     payload: TEvents[K];
@@ -10,7 +11,7 @@ export type AnyEventEnvelope<TEvents extends EventMap> = {
   };
 }[keyof TEvents & string];
 
-export type AnyEventListener<TEvents extends EventMap> = (event: AnyEventEnvelope<TEvents>) => void | Promise<void>;
+export type AnyEventListener<TEvents extends EventShape<TEvents>> = (event: AnyEventEnvelope<TEvents>) => void | Promise<void>;
 
 export interface Subscription {
   readonly active: boolean;
@@ -21,7 +22,7 @@ interface DirectListenerEntry {
   listener: EventListener<object>;
 }
 
-interface AnyListenerEntry<TEvents extends EventMap> {
+interface AnyListenerEntry<TEvents extends EventShape<TEvents>> {
   listener: AnyEventListener<TEvents>;
 }
 
@@ -51,7 +52,7 @@ export class EventBusDisposedError extends Error {
   }
 }
 
-export class EventBus<TEvents extends EventMap> {
+export class EventBus<TEvents extends EventShape<TEvents>> {
   private readonly listeners = new Map<keyof TEvents & string, Set<DirectListenerEntry>>();
   private readonly anyListeners = new Set<AnyListenerEntry<TEvents>>();
   private readonly subscriptions = new Set<BasicSubscription>();


### PR DESCRIPTION
## Summary
- update EventBus generic constraints to require object payloads without requiring a string index signature
- keep literal-key domain event typing intact while restoring compatibility for `AssistantDomainEvents`

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/event-bus.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/events/bus.ts src/events/domain-events.ts src/__tests__/event-bus.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
