### PR TITLE
Migrate secret detection notifications to domain event listeners

### DIFF
--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import type { SecretDetectionEvent, ToolExecutionResult, ToolLifecycleEventHandler } from '../tools/types.js';
+import type { ToolExecutionResult, ToolLifecycleEvent, ToolLifecycleEventHandler } from '../tools/types.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — MUST be declared before importing executor
@@ -86,16 +86,24 @@ import { createToolAuditListener } from '../events/tool-audit-listener.js';
 // ---------------------------------------------------------------------------
 
 function makeContext(overrides?: Partial<{
-  onSecretDetected: (e: SecretDetectionEvent) => void;
   onToolLifecycleEvent: ToolLifecycleEventHandler;
 }>) {
+  const auditListener = createToolAuditListener();
   return {
     workingDir: '/tmp',
     sessionId: 'test-session',
     conversationId: 'test-conversation',
-    onToolLifecycleEvent: createToolAuditListener(),
-    ...overrides,
+    onToolLifecycleEvent: (event: ToolLifecycleEvent) => {
+      auditListener(event);
+      return overrides?.onToolLifecycleEvent?.(event);
+    },
   };
+}
+
+function getSecretEvents(events: ToolLifecycleEvent[]) {
+  return events.filter(
+    (event): event is Extract<ToolLifecycleEvent, { type: 'secret_detected' }> => event.type === 'secret_detected',
+  );
 }
 
 function makeMockPrompter() {
@@ -119,13 +127,13 @@ describe('Secret scanner executor integration', () => {
   // -----------------------------------------------------------------------
   // warn mode
   // -----------------------------------------------------------------------
-  test('warn mode: passes through content unchanged and fires callback', async () => {
+  test('warn mode: passes through content unchanged and emits secret_detected lifecycle event', async () => {
     mockConfig.secretDetection.action = 'warn';
     const secret = 'AKIAIOSFODNN7REALKEY'; // 20-char AWS key
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -133,12 +141,12 @@ describe('Secret scanner executor integration', () => {
     expect(result.content).toContain(secret);
     expect(result.isError).toBe(false);
 
-    // Callback should have fired
-    expect(events).toHaveLength(1);
-    expect(events[0].toolName).toBe('file_read');
-    expect(events[0].action).toBe('warn');
-    expect(events[0].matches.length).toBeGreaterThan(0);
-    expect(events[0].matches[0].type).toBe('AWS Access Key');
+    const secretEvents = getSecretEvents(lifecycleEvents);
+    expect(secretEvents).toHaveLength(1);
+    expect(secretEvents[0].toolName).toBe('file_read');
+    expect(secretEvents[0].action).toBe('warn');
+    expect(secretEvents[0].matches.length).toBeGreaterThan(0);
+    expect(secretEvents[0].matches[0].type).toBe('AWS Access Key');
   });
 
   // -----------------------------------------------------------------------
@@ -149,15 +157,15 @@ describe('Secret scanner executor integration', () => {
     const secret = 'AKIAIOSFODNN7REALKEY';
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
     expect(result.content).not.toContain(secret);
     expect(result.content).toContain('[REDACTED:AWS Access Key]');
     expect(result.isError).toBe(false);
-    expect(events).toHaveLength(1);
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(1);
   });
 
   // -----------------------------------------------------------------------
@@ -168,16 +176,16 @@ describe('Secret scanner executor integration', () => {
     const secret = 'AKIAIOSFODNN7REALKEY';
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain('blocked');
     expect(result.content).toContain('AWS Access Key');
-    // Callback should still fire so the client gets notified
-    expect(events).toHaveLength(1);
+    // Lifecycle notification should still fire so session listeners can notify the user
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(1);
     // Invocation should be recorded for audit trail
     expect(recordedInvocations).toHaveLength(1);
     const inv = recordedInvocations[0] as Record<string, unknown>;
@@ -189,17 +197,17 @@ describe('Secret scanner executor integration', () => {
   // -----------------------------------------------------------------------
   // disabled
   // -----------------------------------------------------------------------
-  test('disabled: does not scan or fire callback', async () => {
+  test('disabled: does not scan or emit secret_detected event', async () => {
     mockConfig.secretDetection.enabled = false;
     fakeToolResult = { content: 'Found key: AKIAIOSFODNN7REALKEY', isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
     expect(result.content).toContain('AKIAIOSFODNN7REALKEY');
-    expect(events).toHaveLength(0);
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(0);
   });
 
   // -----------------------------------------------------------------------
@@ -209,14 +217,14 @@ describe('Secret scanner executor integration', () => {
     mockConfig.secretDetection.action = 'redact';
     fakeToolResult = { content: 'Error: AKIAIOSFODNN7REALKEY', isError: true };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
     // Error results should pass through without scanning
     expect(result.content).toContain('AKIAIOSFODNN7REALKEY');
-    expect(events).toHaveLength(0);
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(0);
   });
 
   // -----------------------------------------------------------------------
@@ -236,40 +244,44 @@ describe('Secret scanner executor integration', () => {
       },
     };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_write', {}, ctx);
 
     expect(result.diff).toBeDefined();
     expect(result.diff!.newContent).not.toContain(secret);
     expect(result.diff!.newContent).toContain('[REDACTED:AWS Access Key]');
-    expect(events).toHaveLength(1);
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(1);
   });
 
   // -----------------------------------------------------------------------
-  // no secrets: no callback fired
+  // no secrets: no secret-detected event emitted
   // -----------------------------------------------------------------------
-  test('no secrets: does not fire callback', async () => {
+  test('no secrets: does not emit secret_detected event', async () => {
     fakeToolResult = { content: 'Hello, world!', isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     const result = await executor.execute('file_read', {}, ctx);
 
     expect(result.content).toBe('Hello, world!');
-    expect(events).toHaveLength(0);
+    expect(getSecretEvents(lifecycleEvents)).toHaveLength(0);
   });
 
   // -----------------------------------------------------------------------
-  // no callback: does not throw
+  // no lifecycle handler: does not throw
   // -----------------------------------------------------------------------
-  test('works without onSecretDetected callback', async () => {
+  test('works without onToolLifecycleEvent handler', async () => {
     mockConfig.secretDetection.action = 'warn';
     fakeToolResult = { content: 'Found key: AKIAIOSFODNN7REALKEY', isError: false };
 
-    const ctx = makeContext(); // no onSecretDetected
+    const ctx = {
+      workingDir: '/tmp',
+      sessionId: 'test-session',
+      conversationId: 'test-conversation',
+    };
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -286,14 +298,15 @@ describe('Secret scanner executor integration', () => {
     const ghToken = 'ghp_ABCDEFghijklMN0123456789abcdefghijkl';
     fakeToolResult = { content: `AWS: ${aws}\nGitHub: ${ghToken}`, isError: false };
 
-    const events: SecretDetectionEvent[] = [];
-    const ctx = makeContext({ onSecretDetected: (e) => events.push(e) });
+    const lifecycleEvents: ToolLifecycleEvent[] = [];
+    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
 
     await executor.execute('file_read', {}, ctx);
 
-    expect(events).toHaveLength(1);
-    expect(events[0].matches.length).toBe(2);
-    const types = events[0].matches.map((m) => m.type);
+    const secretEvents = getSecretEvents(lifecycleEvents);
+    expect(secretEvents).toHaveLength(1);
+    expect(secretEvents[0].matches.length).toBe(2);
+    const types = secretEvents[0].matches.map((m) => m.type);
     expect(types).toContain('AWS Access Key');
     expect(types).toContain('GitHub Token');
   });

--- a/assistant/src/__tests__/tool-domain-event-publisher.test.ts
+++ b/assistant/src/__tests__/tool-domain-event-publisher.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect } from 'bun:test';
+import { EventBus, type AnyEventEnvelope } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
+
+function makeEventsCollector() {
+  const bus = new EventBus<AssistantDomainEvents>();
+  const events: AnyEventEnvelope<AssistantDomainEvents>[] = [];
+  bus.onAny((event) => events.push(event));
+  return { bus, events };
+}
+
+describe('createToolDomainEventPublisher', () => {
+  test('maps start and permission lifecycle events into domain events', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'start',
+      toolName: 'shell',
+      input: { command: 'ls' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      startedAtMs: 100,
+    });
+
+    await publish({
+      type: 'permission_prompt',
+      toolName: 'shell',
+      input: { command: 'ls' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'medium',
+      reason: 'needs approval',
+      allowlistOptions: [],
+      scopeOptions: [],
+      sandboxed: true,
+    });
+
+    await publish({
+      type: 'permission_denied',
+      toolName: 'shell',
+      input: { command: 'rm -rf /tmp' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'high',
+      decision: 'deny',
+      reason: 'Permission denied by user',
+      durationMs: 20,
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'tool.execution.started',
+      'tool.permission.requested',
+      'tool.permission.decided',
+    ]);
+    expect(events[0].payload).toMatchObject({
+      toolName: 'shell',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      startedAtMs: 100,
+    });
+    expect(events[1].payload).toMatchObject({
+      toolName: 'shell',
+      riskLevel: 'medium',
+    });
+    expect(events[2].payload).toMatchObject({
+      toolName: 'shell',
+      decision: 'deny',
+      riskLevel: 'high',
+    });
+  });
+
+  test('maps executed lifecycle event to permission.decided + execution.finished', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'executed',
+      toolName: 'file_read',
+      input: { path: 'README.md' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'low',
+      decision: 'allow',
+      durationMs: 15,
+      result: { content: 'ok', isError: false },
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'tool.permission.decided',
+      'tool.execution.finished',
+    ]);
+    expect(events[0].payload).toMatchObject({
+      decision: 'allow',
+      riskLevel: 'low',
+    });
+    expect(events[1].payload).toMatchObject({
+      toolName: 'file_read',
+      isError: false,
+      durationMs: 15,
+      decision: 'allow',
+    });
+  });
+
+  test('maps secret_detected lifecycle event to tool.secret.detected domain event', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'secret_detected',
+      toolName: 'file_read',
+      input: { path: 'secrets.txt' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      action: 'redact',
+      matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
+      detectedAtMs: 55,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool.secret.detected');
+    expect(events[0].payload).toEqual({
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      action: 'redact',
+      matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
+      detectedAtMs: 55,
+    });
+  });
+});

--- a/assistant/src/__tests__/tool-notification-listener.test.ts
+++ b/assistant/src/__tests__/tool-notification-listener.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'bun:test';
+import { EventBus } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+describe('registerToolNotificationListener', () => {
+  test('forwards tool.secret.detected events to IPC secret_detected messages', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    const messages: ServerMessage[] = [];
+    registerToolNotificationListener(bus, (msg) => messages.push(msg));
+
+    await bus.emit('tool.secret.detected', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      action: 'warn',
+      matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
+      detectedAtMs: 123,
+    });
+
+    expect(messages).toEqual([
+      {
+        type: 'secret_detected',
+        toolName: 'file_read',
+        action: 'warn',
+        matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
+      },
+    ]);
+  });
+
+  test('stops forwarding after subscription is disposed', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    const messages: ServerMessage[] = [];
+    const subscription = registerToolNotificationListener(bus, (msg) => messages.push(msg));
+
+    subscription.dispose();
+    await bus.emit('tool.secret.detected', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      action: 'warn',
+      matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
+      detectedAtMs: 123,
+    });
+
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -7,11 +7,16 @@ import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
+import type { ToolLifecycleEventHandler } from '../tools/types.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
+import { EventBus } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
+import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
 import { createToolAuditListener } from '../events/tool-audit-listener.js';
 
 const log = getLogger('session');
@@ -26,6 +31,7 @@ export class Session {
   private prompter: PermissionPrompter;
   private executor: ToolExecutor;
   private sendToClient: (msg: ServerMessage) => void;
+  private eventBus = new EventBus<AssistantDomainEvents>();
   private workingDir: string;
   private sandboxOverride?: boolean;
   private usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
@@ -43,7 +49,13 @@ export class Session {
     this.sendToClient = sendToClient;
     this.prompter = new PermissionPrompter(sendToClient);
     this.executor = new ToolExecutor(this.prompter);
+    registerToolNotificationListener(this.eventBus, (msg) => this.sendToClient(msg));
     const auditToolLifecycleEvent = createToolAuditListener();
+    const publishToolDomainEvent = createToolDomainEventPublisher(this.eventBus);
+    const handleToolLifecycleEvent: ToolLifecycleEventHandler = (event) => {
+      auditToolLifecycleEvent(event);
+      return publishToolDomainEvent(event);
+    };
 
     const toolDefs = getAllToolDefinitions();
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
@@ -53,15 +65,7 @@ export class Session {
         conversationId: this.conversationId,
         onOutput,
         sandboxOverride: this.sandboxOverride,
-        onSecretDetected: (event) => {
-          this.sendToClient({
-            type: 'secret_detected',
-            toolName: event.toolName,
-            matches: event.matches,
-            action: event.action,
-          });
-        },
-        onToolLifecycleEvent: auditToolLifecycleEvent,
+        onToolLifecycleEvent: handleToolLifecycleEvent,
       });
     };
 

--- a/assistant/src/events/index.ts
+++ b/assistant/src/events/index.ts
@@ -12,3 +12,5 @@ export type {
   DaemonDomainEvents,
   AssistantDomainEvents,
 } from './domain-events.js';
+export { createToolDomainEventPublisher } from './tool-domain-event-publisher.js';
+export { registerToolNotificationListener } from './tool-notification-listener.js';

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -56,6 +56,7 @@ function toInvocationRecord(event: ToolLifecycleEvent): ToolInvocationRecord | n
       };
     case 'start':
     case 'permission_prompt':
+    case 'secret_detected':
       return null;
   }
 }

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -1,0 +1,100 @@
+import type { EventBus } from './bus.js';
+import type { AssistantDomainEvents } from './domain-events.js';
+import type { ToolLifecycleEventHandler } from '../tools/types.js';
+
+const allowDecisions = new Set(['allow', 'always_allow']);
+
+function isAllowDecision(decision: string): decision is 'allow' | 'always_allow' {
+  return allowDecisions.has(decision);
+}
+
+export function createToolDomainEventPublisher(
+  eventBus: EventBus<AssistantDomainEvents>,
+): ToolLifecycleEventHandler {
+  return async (event) => {
+    switch (event.type) {
+      case 'start':
+        await eventBus.emit('tool.execution.started', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          input: event.input,
+          startedAtMs: event.startedAtMs,
+        });
+        break;
+      case 'permission_prompt':
+        await eventBus.emit('tool.permission.requested', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          riskLevel: event.riskLevel,
+          requestedAtMs: Date.now(),
+        });
+        break;
+      case 'permission_denied':
+        await eventBus.emit('tool.permission.decided', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          decision: event.decision,
+          riskLevel: event.riskLevel,
+          decidedAtMs: Date.now(),
+        });
+        break;
+      case 'executed':
+        if (isAllowDecision(event.decision)) {
+          await eventBus.emit('tool.permission.decided', {
+            conversationId: event.conversationId,
+            sessionId: event.sessionId,
+            toolName: event.toolName,
+            decision: event.decision,
+            riskLevel: event.riskLevel,
+            decidedAtMs: Date.now(),
+          });
+        }
+        await eventBus.emit('tool.execution.finished', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          decision: event.decision,
+          riskLevel: event.riskLevel,
+          isError: event.result.isError,
+          durationMs: event.durationMs,
+          finishedAtMs: Date.now(),
+        });
+        break;
+      case 'error':
+        if (isAllowDecision(event.decision)) {
+          await eventBus.emit('tool.permission.decided', {
+            conversationId: event.conversationId,
+            sessionId: event.sessionId,
+            toolName: event.toolName,
+            decision: event.decision,
+            riskLevel: event.riskLevel,
+            decidedAtMs: Date.now(),
+          });
+        }
+        await eventBus.emit('tool.execution.failed', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          decision: event.decision,
+          riskLevel: event.riskLevel,
+          durationMs: event.durationMs,
+          error: event.errorMessage,
+          failedAtMs: Date.now(),
+        });
+        break;
+      case 'secret_detected':
+        await eventBus.emit('tool.secret.detected', {
+          conversationId: event.conversationId,
+          sessionId: event.sessionId,
+          toolName: event.toolName,
+          action: event.action,
+          matches: event.matches,
+          detectedAtMs: event.detectedAtMs,
+        });
+        break;
+    }
+  };
+}

--- a/assistant/src/events/tool-notification-listener.ts
+++ b/assistant/src/events/tool-notification-listener.ts
@@ -1,0 +1,17 @@
+import type { EventBus, Subscription } from './bus.js';
+import type { AssistantDomainEvents } from './domain-events.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+export function registerToolNotificationListener(
+  eventBus: EventBus<AssistantDomainEvents>,
+  sendToClient: (message: ServerMessage) => void,
+): Subscription {
+  return eventBus.on('tool.secret.detected', (event) => {
+    sendToClient({
+      type: 'secret_detected',
+      toolName: event.toolName,
+      matches: event.matches,
+      action: event.action,
+    });
+  });
+}

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -203,10 +203,16 @@ export class ToolExecutor {
             'Secrets detected in tool output',
           );
 
-          context.onSecretDetected?.({
+          emitLifecycleEvent(context, {
+            type: 'secret_detected',
             toolName: name,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
             matches: matchSummary,
             action: sdConfig.action,
+            detectedAtMs: Date.now(),
           });
 
           if (sdConfig.action === 'redact') {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,12 +1,6 @@
 import type { RiskLevel, AllowlistOption, ScopeOption } from '../permissions/types.js';
 import type { ToolDefinition } from '../providers/types.js';
 
-export interface SecretDetectionEvent {
-  toolName: string;
-  matches: Array<{ type: string; redactedValue: string }>;
-  action: 'redact' | 'warn' | 'block';
-}
-
 interface ToolLifecycleEventBase {
   toolName: string;
   input: Record<string, unknown>;
@@ -54,12 +48,20 @@ export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
   errorMessage: string;
 }
 
+export interface ToolSecretDetectedEvent extends ToolLifecycleEventBase {
+  type: 'secret_detected';
+  matches: Array<{ type: string; redactedValue: string }>;
+  action: 'redact' | 'warn' | 'block';
+  detectedAtMs: number;
+}
+
 export type ToolLifecycleEvent =
   | ToolExecutionStartEvent
   | ToolPermissionPromptEvent
   | ToolPermissionDeniedEvent
   | ToolExecutedEvent
-  | ToolExecutionErrorEvent;
+  | ToolExecutionErrorEvent
+  | ToolSecretDetectedEvent;
 
 export type ToolLifecycleEventHandler = (event: ToolLifecycleEvent) => void | Promise<void>;
 
@@ -71,9 +73,7 @@ export interface ToolContext {
   onOutput?: (chunk: string) => void;
   /** Per-session sandbox override. When set, takes precedence over the global config. */
   sandboxOverride?: boolean;
-  /** Optional callback when secrets are detected in tool output. */
-  onSecretDetected?: (event: SecretDetectionEvent) => void;
-  /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error). */
+  /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error/secret_detected). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
 }
 


### PR DESCRIPTION
## Summary
- emit a new `secret_detected` tool lifecycle event from `ToolExecutor` instead of using a direct `onSecretDetected` callback
- add a lifecycle->domain event publisher and a tool notification listener that forwards `tool.secret.detected` domain events to IPC `secret_detected` messages
- wire `Session` to compose audit + domain-event publishing for tool lifecycle handling and remove inline secret notification callbacks
- add coverage for the new publisher/listener modules and update secret scanner executor tests to assert lifecycle event behavior

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/secret-scanner-executor.test.ts src/__tests__/tool-domain-event-publisher.test.ts src/__tests__/tool-notification-listener.test.ts src/__tests__/tool-audit-listener.test.ts src/__tests__/tool-executor-lifecycle-events.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/tools/types.ts src/tools/executor.ts src/events/tool-audit-listener.ts src/events/tool-domain-event-publisher.ts src/events/tool-notification-listener.ts src/events/index.ts src/daemon/session.ts src/__tests__/secret-scanner-executor.test.ts src/__tests__/tool-domain-event-publisher.test.ts src/__tests__/tool-notification-listener.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
