### PR TITLE
Fix Bundle.module build for Xcode and sync project.pbxproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ yarn-error.log*
 # vercel
 .vercel
 
+# xcode / spm build artifacts
+.derivedData/
+*.xcactivitylog
+DerivedData/
+**/Library/Logs/CoreSimulator/
+
 # drizzle
 web/drizzle/
 

--- a/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
+++ b/clients/macos/vellum-assistant.xcodeproj/project.pbxproj
@@ -13,40 +13,59 @@
 		1602CEC331C383C46984277A /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB2E3A6215CE30550FE5E61 /* AnthropicProvider.swift */; };
 		1D3F4B2FE6DF331921F9F662 /* ChromeAccessibilityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2629FF17F2DCED2C27B5C7B /* ChromeAccessibilityHelper.swift */; };
 		1DEE9818AE627F372EADF74A /* ActionVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */; };
+		21BC84E4F1F3C0B75FF10226 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E313A4176AECFE3CAB39B4 /* OnboardingButton.swift */; };
 		23E47F126C62659F8CFFB9E1 /* AmbientAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3D1A1DE8CD5DA3C9E222C4 /* AmbientAgent.swift */; };
 		24539EB93D0273F1439687A8 /* VellumAssistantApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7288C576664B021EF155B9C /* VellumAssistantApp.swift */; };
 		276E0F3405EDFF3346E01494 /* AXTreeDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A1CAAAD324097345D0EB38 /* AXTreeDiff.swift */; };
 		29E492439AEE36E5F9B7ED8F /* ToolDefinitionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D9802001C0CCEFD3078EB8 /* ToolDefinitionsTests.swift */; };
+		3903C4AB6B5A423A7DE03A31 /* MicPermissionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C950550E09216706C1C3641D /* MicPermissionStepView.swift */; };
 		3CBEF918BC31B5CDA67AB307 /* ToolDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */; };
 		43B58A748C33955C52226B4B /* AccessibilityTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */; };
+		4A4C383FD11988A0D90D36FD /* ReactionBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B9961EAD17B40BE4F4B926 /* ReactionBubble.swift */; };
 		4D469EED4BFBA43F6B759AAC /* SessionLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */; };
 		5099794339FDE050C79700BB /* LogViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C691BD0FDCE6190A60F45F5C /* LogViewer.swift */; };
+		50F13AABF591DA61DAD6324F /* OnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9248A375A3CD04022D841A0 /* OnboardingFlowView.swift */; };
 		535ADB8BECF9E185F1BD3E19 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF062AE5C6B78D85CEDC7C3B /* Session.swift */; };
 		60CDA80564833C4E9EC115AB /* VoiceTranscriptionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B923D05524A1E51EBB318E /* VoiceTranscriptionWindow.swift */; };
+		618CFADDA61EAB49D86B6066 /* AmbientSyncClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C213C818F731BC907FBBDC /* AmbientSyncClient.swift */; };
 		658A24BC47071CE83C3645B1 /* AccessibilityTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33DCEFE581D93580243939 /* AccessibilityTreeTests.swift */; };
+		67A2A215787AE82A3D38A644 /* IntegrationPickerStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6E7FE932CBC9D8A520867 /* IntegrationPickerStepView.swift */; };
 		6A077380F3286DD96EFD3522 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A751A31DD82FE6622EA4CD /* PermissionManager.swift */; };
 		6AD6CEEFD8DA3B5E15FB28C6 /* ActionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93BDB5AED0253CF3298634F3 /* ActionTypes.swift */; };
 		6CB40FE359E8E66B2112DD8F /* ActionVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7699446B63C8A3B7CAC33CC /* ActionVerifierTests.swift */; };
+		7E0F0C6E5D1A654C35C52E34 /* FnKeyStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC323580C5C2F389D04FED41 /* FnKeyStepView.swift */; };
 		7F1E97ABA962B7ECB1511DAE /* ActionInferenceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */; };
 		838F86592B4B71C8C09E52A9 /* AnthropicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90114A8759B9BCF2CD7111A6 /* AnthropicClient.swift */; };
 		8A677CC74636049BC83014BC /* ScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */; };
 		8E3A4AB9B4851B641760BF97 /* InsightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9E10E0E97C7353CC9F2B0B /* InsightStore.swift */; };
+		904E9E266C2B6CCB5C00F2F5 /* OnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDADBDB2C6173AD5EE2DD35B /* OnboardingState.swift */; };
+		91104276CDE49DA5B6A11EBF /* RecipeExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CB2D1D1463716EE55D2F41 /* RecipeExecutor.swift */; };
 		9141EE67DA21DA6752556CBC /* AmbientAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D30A82CDD870C48EFE78D1 /* AmbientAnalyzer.swift */; };
 		A2215F8493C316D8E139D1E6 /* ActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */; };
 		A22ACF7097DF1475D184958A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */; };
 		A2B8C0BC3677B95F736E9DF4 /* ConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0760D7F261720758A5FAC3E /* ConfirmationView.swift */; };
+		A5333B213590DF19C80034FE /* WakeUpStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EA3161619F48AB46E799D4 /* WakeUpStepView.swift */; };
+		B2384EBFE76DFC252D4E20F4 /* ScreenPermissionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0160FF866563054CD6037E /* ScreenPermissionStepView.swift */; };
 		B2F397A8BF97D509B58F67C0 /* KnowledgeCron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887067B3646D8643FE2DA7F2 /* KnowledgeCron.swift */; };
 		B609076A4DE741205CB2D3A4 /* SessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC306D40EC020E7A284F2A7 /* SessionTests.swift */; };
 		B8E68D3E4BAE108BA4DFAD15 /* SessionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */; };
 		C12CF51CE1378D77F77732CB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4932108265C798B9FDE108 /* AppDelegate.swift */; };
+		C576D834F2AAA8926CF88F46 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C60B3EB46D5EBBF3224F58 /* OnboardingWindow.swift */; };
+		D14E35161DBA6C7DC6FA9C0D /* ScheduleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DBDAF2C13BEAF70BA12DA8 /* ScheduleParser.swift */; };
 		D221DDF07D84CEFFA28CB596 /* ScreenOCR.swift in Sources */ = {isa = PBXBuildFile; fileRef = C372E6C0EBAC12EE67226107 /* ScreenOCR.swift */; };
+		D64DE05C945BF8D93250EAB9 /* AliveStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A7043AC3F0D4C2FFD8CA56 /* AliveStepView.swift */; };
 		DC3B028DC386EFE1436E30FF /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = F6CB2EC7443D3897D22E6D3E /* HotKey */; };
+		DF6ED1C8479925E21FFD1EA8 /* TypewriterText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A84C07DE87C22D3B1A6768 /* TypewriterText.swift */; };
 		E079EDED2AA9AE71CBE2C2DA /* KnowledgeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE6E192E05E051AF75167BC /* KnowledgeStore.swift */; };
+		E89E30CAD1E9A2D744FBC86A /* github-app-setup.md in Resources */ = {isa = PBXBuildFile; fileRef = 0BF430BAC39C736BAC73AC8B /* github-app-setup.md */; };
 		E96230E4CB5C96C982458657 /* APIKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822B891B496900302404DF02 /* APIKeyManager.swift */; };
 		EE8D6587E18994C45CB48652 /* SessionOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */; };
+		F03863827F2C0C1B9A77FA51 /* SoulOrbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CC91600EB6733CA0749FF7 /* SoulOrbView.swift */; };
 		F0A2099B99CD3421E5126401 /* InsightNotificationWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5EA33A2627649D591424F3 /* InsightNotificationWindow.swift */; };
 		F18D712D0E89F3DAD30D747C /* ActionPreviewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B2FD36E44863204BB546D0 /* ActionPreviewWindow.swift */; };
 		F29831F8092D9BBB259BAF7C /* TaskInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ABA40D80D70550AA640AF8 /* TaskInputView.swift */; };
+		FB5AA406DF1C151BE95BC24A /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6424D539B569C172CA270594 /* OnboardingBackground.swift */; };
+		FCA710DF68BF32C0E3433E68 /* NamingStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1769E71B6FFA105762112583 /* NamingStepView.swift */; };
 		FDB24168B7548DA9112747EB /* VoiceInputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6554B9F2EF61617575B63118 /* VoiceInputManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -63,46 +82,65 @@
 /* Begin PBXFileReference section */
 		08ABA40D80D70550AA640AF8 /* TaskInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInputView.swift; sourceTree = "<group>"; };
 		09137E88F2AB02DF31D32BD0 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		0B0160FF866563054CD6037E /* ScreenPermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenPermissionStepView.swift; sourceTree = "<group>"; };
+		0BF430BAC39C736BAC73AC8B /* github-app-setup.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "github-app-setup.md"; sourceTree = "<group>"; };
 		12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionVerifier.swift; sourceTree = "<group>"; };
+		16A7043AC3F0D4C2FFD8CA56 /* AliveStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliveStepView.swift; sourceTree = "<group>"; };
+		1769E71B6FFA105762112583 /* NamingStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamingStepView.swift; sourceTree = "<group>"; };
+		19CC91600EB6733CA0749FF7 /* SoulOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoulOrbView.swift; sourceTree = "<group>"; };
 		1CB8813503311E10F158679D /* vellum-assistant.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "vellum-assistant.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		24486EB2442797096CD3CC38 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		244CA8647EA7EA0E89AF1577 /* Info-generated.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Info-generated.plist"; sourceTree = "<group>"; };
 		2D9E10E0E97C7353CC9F2B0B /* InsightStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightStore.swift; sourceTree = "<group>"; };
 		2FB2E3A6215CE30550FE5E61 /* AnthropicProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProvider.swift; sourceTree = "<group>"; };
+		32A84C07DE87C22D3B1A6768 /* TypewriterText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypewriterText.swift; sourceTree = "<group>"; };
 		3F3A04455B6DC1C1F89CB685 /* ToolDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDefinitions.swift; sourceTree = "<group>"; };
 		4A3D1A1DE8CD5DA3C9E222C4 /* AmbientAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientAgent.swift; sourceTree = "<group>"; };
 		4AC306D40EC020E7A284F2A7 /* SessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTests.swift; sourceTree = "<group>"; };
 		4BD264E70E6D22EE5E53B20F /* SessionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayView.swift; sourceTree = "<group>"; };
 		56FE5799AF5C42990EF37C42 /* AccessibilityTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTree.swift; sourceTree = "<group>"; };
+		6424D539B569C172CA270594 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
 		6554B9F2EF61617575B63118 /* VoiceInputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputManager.swift; sourceTree = "<group>"; };
 		6679C7528847C8E31C861F34 /* vellum-assistantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "vellum-assistantTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		77A1CAAAD324097345D0EB38 /* AXTreeDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTreeDiff.swift; sourceTree = "<group>"; };
 		822B891B496900302404DF02 /* APIKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyManager.swift; sourceTree = "<group>"; };
+		83C213C818F731BC907FBBDC /* AmbientSyncClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientSyncClient.swift; sourceTree = "<group>"; };
 		83CC29E51897B98BDD9F7796 /* ActionInferenceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionInferenceProvider.swift; sourceTree = "<group>"; };
 		8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapture.swift; sourceTree = "<group>"; };
 		87B2FD36E44863204BB546D0 /* ActionPreviewWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPreviewWindow.swift; sourceTree = "<group>"; };
+		87CB2D1D1463716EE55D2F41 /* RecipeExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeExecutor.swift; sourceTree = "<group>"; };
 		887067B3646D8643FE2DA7F2 /* KnowledgeCron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeCron.swift; sourceTree = "<group>"; };
+		88C60B3EB46D5EBBF3224F58 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
 		90114A8759B9BCF2CD7111A6 /* AnthropicClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicClient.swift; sourceTree = "<group>"; };
 		93BDB5AED0253CF3298634F3 /* ActionTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionTypes.swift; sourceTree = "<group>"; };
+		94E313A4176AECFE3CAB39B4 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
+		A4EA3161619F48AB46E799D4 /* WakeUpStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakeUpStepView.swift; sourceTree = "<group>"; };
 		A7288C576664B021EF155B9C /* VellumAssistantApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumAssistantApp.swift; sourceTree = "<group>"; };
 		A7699446B63C8A3B7CAC33CC /* ActionVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionVerifierTests.swift; sourceTree = "<group>"; };
 		A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A9248A375A3CD04022D841A0 /* OnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowView.swift; sourceTree = "<group>"; };
 		BC313FB9D43F0FD9389049EF /* AmbientSuggestionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientSuggestionWindow.swift; sourceTree = "<group>"; };
+		BC323580C5C2F389D04FED41 /* FnKeyStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FnKeyStepView.swift; sourceTree = "<group>"; };
 		BC4932108265C798B9FDE108 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD33DCEFE581D93580243939 /* AccessibilityTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTreeTests.swift; sourceTree = "<group>"; };
+		BDADBDB2C6173AD5EE2DD35B /* OnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingState.swift; sourceTree = "<group>"; };
 		BE4EE4DD3EA49608F227A7C3 /* ActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExecutor.swift; sourceTree = "<group>"; };
 		BEE6E192E05E051AF75167BC /* KnowledgeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeStore.swift; sourceTree = "<group>"; };
 		C0760D7F261720758A5FAC3E /* ConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationView.swift; sourceTree = "<group>"; };
 		C2629FF17F2DCED2C27B5C7B /* ChromeAccessibilityHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeAccessibilityHelper.swift; sourceTree = "<group>"; };
 		C372E6C0EBAC12EE67226107 /* ScreenOCR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenOCR.swift; sourceTree = "<group>"; };
 		C691BD0FDCE6190A60F45F5C /* LogViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewer.swift; sourceTree = "<group>"; };
+		C950550E09216706C1C3641D /* MicPermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicPermissionStepView.swift; sourceTree = "<group>"; };
 		CC5EA33A2627649D591424F3 /* InsightNotificationWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightNotificationWindow.swift; sourceTree = "<group>"; };
 		D6D30A82CDD870C48EFE78D1 /* AmbientAnalyzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientAnalyzer.swift; sourceTree = "<group>"; };
+		D7B9961EAD17B40BE4F4B926 /* ReactionBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionBubble.swift; sourceTree = "<group>"; };
 		DF062AE5C6B78D85CEDC7C3B /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		E0D9802001C0CCEFD3078EB8 /* ToolDefinitionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolDefinitionsTests.swift; sourceTree = "<group>"; };
 		E4A751A31DD82FE6622EA4CD /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
+		E6DBDAF2C13BEAF70BA12DA8 /* ScheduleParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleParser.swift; sourceTree = "<group>"; };
 		E8B923D05524A1E51EBB318E /* VoiceTranscriptionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptionWindow.swift; sourceTree = "<group>"; };
 		E9F692FD82187BA84D6FB66B /* SessionOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionOverlayWindow.swift; sourceTree = "<group>"; };
+		F2A6E7FE932CBC9D8A520867 /* IntegrationPickerStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationPickerStepView.swift; sourceTree = "<group>"; };
 		FE229BFCE748FF4A968E86B1 /* SessionLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -118,6 +156,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		12B2CFE042F38B0976D1CD0F /* Recipes */ = {
+			isa = PBXGroup;
+			children = (
+				0BF430BAC39C736BAC73AC8B /* github-app-setup.md */,
+			);
+			path = Recipes;
+			sourceTree = "<group>";
+		};
 		240BE551C8B6D79A8D0A192D /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +177,7 @@
 				24486EB2442797096CD3CC38 /* SettingsView.swift */,
 				08ABA40D80D70550AA640AF8 /* TaskInputView.swift */,
 				E8B923D05524A1E51EBB318E /* VoiceTranscriptionWindow.swift */,
+				5725138E078DDE50C50E2D17 /* Onboarding */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -163,9 +210,11 @@
 			children = (
 				4A3D1A1DE8CD5DA3C9E222C4 /* AmbientAgent.swift */,
 				D6D30A82CDD870C48EFE78D1 /* AmbientAnalyzer.swift */,
+				83C213C818F731BC907FBBDC /* AmbientSyncClient.swift */,
 				2D9E10E0E97C7353CC9F2B0B /* InsightStore.swift */,
 				887067B3646D8643FE2DA7F2 /* KnowledgeCron.swift */,
 				BEE6E192E05E051AF75167BC /* KnowledgeStore.swift */,
+				E6DBDAF2C13BEAF70BA12DA8 /* ScheduleParser.swift */,
 				C372E6C0EBAC12EE67226107 /* ScreenOCR.swift */,
 			);
 			path = Ambient;
@@ -176,6 +225,7 @@
 			children = (
 				A85D8A6EFE72B2A9326B16AD /* Assets.xcassets */,
 				244CA8647EA7EA0E89AF1577 /* Info-generated.plist */,
+				12B2CFE042F38B0976D1CD0F /* Recipes */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -190,6 +240,28 @@
 				6554B9F2EF61617575B63118 /* VoiceInputManager.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		5725138E078DDE50C50E2D17 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				16A7043AC3F0D4C2FFD8CA56 /* AliveStepView.swift */,
+				BC323580C5C2F389D04FED41 /* FnKeyStepView.swift */,
+				F2A6E7FE932CBC9D8A520867 /* IntegrationPickerStepView.swift */,
+				C950550E09216706C1C3641D /* MicPermissionStepView.swift */,
+				1769E71B6FFA105762112583 /* NamingStepView.swift */,
+				6424D539B569C172CA270594 /* OnboardingBackground.swift */,
+				94E313A4176AECFE3CAB39B4 /* OnboardingButton.swift */,
+				A9248A375A3CD04022D841A0 /* OnboardingFlowView.swift */,
+				BDADBDB2C6173AD5EE2DD35B /* OnboardingState.swift */,
+				88C60B3EB46D5EBBF3224F58 /* OnboardingWindow.swift */,
+				D7B9961EAD17B40BE4F4B926 /* ReactionBubble.swift */,
+				0B0160FF866563054CD6037E /* ScreenPermissionStepView.swift */,
+				19CC91600EB6733CA0749FF7 /* SoulOrbView.swift */,
+				32A84C07DE87C22D3B1A6768 /* TypewriterText.swift */,
+				A4EA3161619F48AB46E799D4 /* WakeUpStepView.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		6795C8638FF2B8939D24D72C = {
@@ -210,6 +282,7 @@
 				12CA14B79D8E0E84EB07D6E4 /* ActionVerifier.swift */,
 				77A1CAAAD324097345D0EB38 /* AXTreeDiff.swift */,
 				C2629FF17F2DCED2C27B5C7B /* ChromeAccessibilityHelper.swift */,
+				87CB2D1D1463716EE55D2F41 /* RecipeExecutor.swift */,
 				8713F420A1D6E04F9FD6CC4C /* ScreenCapture.swift */,
 				DF062AE5C6B78D85CEDC7C3B /* Session.swift */,
 			);
@@ -331,6 +404,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A22ACF7097DF1475D184958A /* Assets.xcassets in Resources */,
+				E89E30CAD1E9A2D744FBC86A /* github-app-setup.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -360,33 +434,51 @@
 				F18D712D0E89F3DAD30D747C /* ActionPreviewWindow.swift in Sources */,
 				6AD6CEEFD8DA3B5E15FB28C6 /* ActionTypes.swift in Sources */,
 				1DEE9818AE627F372EADF74A /* ActionVerifier.swift in Sources */,
+				D64DE05C945BF8D93250EAB9 /* AliveStepView.swift in Sources */,
 				23E47F126C62659F8CFFB9E1 /* AmbientAgent.swift in Sources */,
 				9141EE67DA21DA6752556CBC /* AmbientAnalyzer.swift in Sources */,
 				11195B895BA484A8C5564FA0 /* AmbientSuggestionWindow.swift in Sources */,
+				618CFADDA61EAB49D86B6066 /* AmbientSyncClient.swift in Sources */,
 				838F86592B4B71C8C09E52A9 /* AnthropicClient.swift in Sources */,
 				1602CEC331C383C46984277A /* AnthropicProvider.swift in Sources */,
 				C12CF51CE1378D77F77732CB /* AppDelegate.swift in Sources */,
 				1D3F4B2FE6DF331921F9F662 /* ChromeAccessibilityHelper.swift in Sources */,
 				A2B8C0BC3677B95F736E9DF4 /* ConfirmationView.swift in Sources */,
+				7E0F0C6E5D1A654C35C52E34 /* FnKeyStepView.swift in Sources */,
 				F0A2099B99CD3421E5126401 /* InsightNotificationWindow.swift in Sources */,
 				8E3A4AB9B4851B641760BF97 /* InsightStore.swift in Sources */,
+				67A2A215787AE82A3D38A644 /* IntegrationPickerStepView.swift in Sources */,
 				B2F397A8BF97D509B58F67C0 /* KnowledgeCron.swift in Sources */,
 				E079EDED2AA9AE71CBE2C2DA /* KnowledgeStore.swift in Sources */,
 				5099794339FDE050C79700BB /* LogViewer.swift in Sources */,
 				0654885DAD8FFD16D639D50F /* MenuBarController.swift in Sources */,
+				3903C4AB6B5A423A7DE03A31 /* MicPermissionStepView.swift in Sources */,
+				FCA710DF68BF32C0E3433E68 /* NamingStepView.swift in Sources */,
+				FB5AA406DF1C151BE95BC24A /* OnboardingBackground.swift in Sources */,
+				21BC84E4F1F3C0B75FF10226 /* OnboardingButton.swift in Sources */,
+				50F13AABF591DA61DAD6324F /* OnboardingFlowView.swift in Sources */,
+				904E9E266C2B6CCB5C00F2F5 /* OnboardingState.swift in Sources */,
+				C576D834F2AAA8926CF88F46 /* OnboardingWindow.swift in Sources */,
 				6A077380F3286DD96EFD3522 /* PermissionManager.swift in Sources */,
+				4A4C383FD11988A0D90D36FD /* ReactionBubble.swift in Sources */,
+				91104276CDE49DA5B6A11EBF /* RecipeExecutor.swift in Sources */,
+				D14E35161DBA6C7DC6FA9C0D /* ScheduleParser.swift in Sources */,
 				8A677CC74636049BC83014BC /* ScreenCapture.swift in Sources */,
 				D221DDF07D84CEFFA28CB596 /* ScreenOCR.swift in Sources */,
+				B2384EBFE76DFC252D4E20F4 /* ScreenPermissionStepView.swift in Sources */,
 				535ADB8BECF9E185F1BD3E19 /* Session.swift in Sources */,
 				4D469EED4BFBA43F6B759AAC /* SessionLogger.swift in Sources */,
 				B8E68D3E4BAE108BA4DFAD15 /* SessionOverlayView.swift in Sources */,
 				EE8D6587E18994C45CB48652 /* SessionOverlayWindow.swift in Sources */,
 				0BAED176454C59993573CA0A /* SettingsView.swift in Sources */,
+				F03863827F2C0C1B9A77FA51 /* SoulOrbView.swift in Sources */,
 				F29831F8092D9BBB259BAF7C /* TaskInputView.swift in Sources */,
 				3CBEF918BC31B5CDA67AB307 /* ToolDefinitions.swift in Sources */,
+				DF6ED1C8479925E21FFD1EA8 /* TypewriterText.swift in Sources */,
 				24539EB93D0273F1439687A8 /* VellumAssistantApp.swift in Sources */,
 				FDB24168B7548DA9112747EB /* VoiceInputManager.swift in Sources */,
 				60CDA80564833C4E9EC115AB /* VoiceTranscriptionWindow.swift in Sources */,
+				A5333B213590DF19C80034FE /* WakeUpStepView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -135,10 +135,12 @@ final class RecipeExecutor {
     // MARK: - Recipe Loading
 
     private func loadRecipeMarkdown(_ name: String) -> String? {
-        // SPM builds: recipes are copied into Bundle.module via .copy("Resources/Recipes")
-        if let url = Bundle.module.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {
-            return try? String(contentsOf: url, encoding: .utf8)
-        }
+        #if SWIFT_PACKAGE
+            // SPM builds: recipes are copied into Bundle.module via .copy("Resources/Recipes")
+            if let url = Bundle.module.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {
+                return try? String(contentsOf: url, encoding: .utf8)
+            }
+        #endif
 
         // Xcode builds: recipes bundled via xcassets or copy phase
         if let url = Bundle.main.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {


### PR DESCRIPTION
The purpose of this PR is to fix the RecipeExecutor script loading and sync the Xcode project file with all recently added source files.

## Changes Made
- Wrap `Bundle.module` recipe loading in `#if SWIFT_PACKAGE` guard to fix Xcode builds (Bundle.module is only available in SPM)
- Sync `project.pbxproj` with ~20 new source files (onboarding views, ambient sync, recipe executor, schedule parser, etc.)
- Add `.derivedData/`, `DerivedData/`, and CoreSimulator logs to `.gitignore`

## Testing
- Verified SPM build still works with the `SWIFT_PACKAGE` conditional

---
*This PR was created with Claude Code*