### PR TITLE
Migrate tool metrics/logging to event listeners

### DIFF
--- a/assistant/src/__tests__/tool-metrics-listener.test.ts
+++ b/assistant/src/__tests__/tool-metrics-listener.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { EventBus } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
+
+let debugEnabled = false;
+const debugCalls: unknown[][] = [];
+const infoCalls: unknown[][] = [];
+const warnCalls: unknown[][] = [];
+const errorCalls: unknown[][] = [];
+
+const testLogger = {
+  debug: (...args: unknown[]) => debugCalls.push(args),
+  info: (...args: unknown[]) => infoCalls.push(args),
+  warn: (...args: unknown[]) => warnCalls.push(args),
+  error: (...args: unknown[]) => errorCalls.push(args),
+};
+
+function truncate(value: string, maxLen: number): string {
+  if (value.length <= maxLen) return value;
+  return value.slice(0, maxLen) + `... (${value.length - maxLen} chars truncated)`;
+}
+
+function clearCalls(): void {
+  debugCalls.length = 0;
+  infoCalls.length = 0;
+  warnCalls.length = 0;
+  errorCalls.length = 0;
+}
+
+describe('registerToolMetricsLoggingListener', () => {
+  beforeEach(() => {
+    debugEnabled = false;
+    clearCalls();
+  });
+
+  test('logs execution start and finish diagnostics in debug mode', async () => {
+    debugEnabled = true;
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      input: { path: 'README.md' },
+      startedAtMs: 100,
+    });
+
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 12,
+      finishedAtMs: 112,
+    });
+
+    expect(debugCalls).toHaveLength(2);
+    expect(debugCalls[0][1]).toBe('Tool execute start');
+    expect(debugCalls[1][1]).toBe('Tool execute result');
+
+    const startPayload = debugCalls[0][0] as Record<string, unknown>;
+    expect(startPayload.tool).toBe('file_read');
+    expect(startPayload.input as string).toContain('"path":"README.md"');
+
+    const finishPayload = debugCalls[1][0] as Record<string, unknown>;
+    expect(finishPayload.execDurationMs).toBe(12);
+    expect(finishPayload.decision).toBe('allow');
+  });
+
+  test('does not emit debug execution logs when debug mode is disabled', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      input: { path: 'README.md' },
+      startedAtMs: 100,
+    });
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 12,
+      finishedAtMs: 112,
+    });
+
+    expect(debugCalls).toHaveLength(0);
+  });
+
+  test('logs permission request and deny decisions as info', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.permission.requested', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'shell',
+      riskLevel: 'high',
+      requestedAtMs: 120,
+    });
+    await bus.emit('tool.permission.decided', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'shell',
+      decision: 'deny',
+      riskLevel: 'high',
+      decidedAtMs: 125,
+    });
+
+    expect(infoCalls).toHaveLength(2);
+    expect(infoCalls[0][1]).toBe('Tool permission requested');
+    expect(infoCalls[1][1]).toBe('Tool permission denied');
+  });
+
+  test('logs secret detection warnings with aggregate details', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.secret.detected', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'file_read',
+      action: 'warn',
+      matches: [
+        { type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' },
+        { type: 'GitHub Token', redactedValue: '[REDACTED:GitHub Token]' },
+      ],
+      detectedAtMs: 130,
+    });
+
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0][1]).toBe('Secrets detected in tool output');
+    const payload = warnCalls[0][0] as Record<string, unknown>;
+    expect(payload.matchCount).toBe(2);
+    expect(payload.types as string[]).toEqual(['AWS Access Key', 'GitHub Token']);
+  });
+
+  test('logs execution failures as errors', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.execution.failed', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'shell',
+      decision: 'error',
+      riskLevel: 'high',
+      durationMs: 42,
+      error: 'boom',
+      failedAtMs: 142,
+    });
+
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0][1]).toBe('Tool execution error');
+    const payload = errorCalls[0][0] as Record<string, unknown>;
+    expect(payload.tool).toBe('shell');
+    expect(payload.error).toBe('boom');
+    expect(payload.execDurationMs).toBe(42);
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -16,6 +16,7 @@ import { getLogger } from '../util/logger.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
 import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
+import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
 import { createToolAuditListener } from '../events/tool-audit-listener.js';
 
@@ -49,6 +50,7 @@ export class Session {
     this.sendToClient = sendToClient;
     this.prompter = new PermissionPrompter(sendToClient);
     this.executor = new ToolExecutor(this.prompter);
+    registerToolMetricsLoggingListener(this.eventBus);
     registerToolNotificationListener(this.eventBus, (msg) => this.sendToClient(msg));
     const auditToolLifecycleEvent = createToolAuditListener();
     const publishToolDomainEvent = createToolDomainEventPublisher(this.eventBus);

--- a/assistant/src/events/index.ts
+++ b/assistant/src/events/index.ts
@@ -13,4 +13,5 @@ export type {
   AssistantDomainEvents,
 } from './domain-events.js';
 export { createToolDomainEventPublisher } from './tool-domain-event-publisher.js';
+export { registerToolMetricsLoggingListener } from './tool-metrics-listener.js';
 export { registerToolNotificationListener } from './tool-notification-listener.js';

--- a/assistant/src/events/tool-metrics-listener.ts
+++ b/assistant/src/events/tool-metrics-listener.ts
@@ -1,0 +1,131 @@
+import type { EventBus, Subscription } from './bus.js';
+import type { AssistantDomainEvents } from './domain-events.js';
+import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
+
+const INPUT_PREVIEW_LIMIT = 300;
+const defaultLogger = getLogger('tool-metrics-listener');
+
+interface MetricsLogger {
+  debug(meta: object, message: string): void;
+  info(meta: object, message: string): void;
+  warn(meta: object, message: string): void;
+  error(meta: object, message: string): void;
+}
+
+interface MetricsListenerOptions {
+  logger?: MetricsLogger;
+  debugEnabled?: () => boolean;
+  truncate?: (value: string, maxLen: number) => string;
+}
+
+export function registerToolMetricsLoggingListener(
+  eventBus: EventBus<AssistantDomainEvents>,
+  options?: MetricsListenerOptions,
+): Subscription {
+  const logger = options?.logger ?? defaultLogger;
+  const debugEnabled = options?.debugEnabled ?? isDebug;
+  const truncate = options?.truncate ?? truncateForLog;
+
+  return eventBus.onAny((event) => {
+    switch (event.type) {
+      case 'tool.execution.started':
+        if (!debugEnabled()) return;
+        logger.debug(
+          {
+            tool: event.payload.toolName,
+            input: formatInputForLog(event.payload.input, truncate),
+            sessionId: event.payload.sessionId,
+            conversationId: event.payload.conversationId,
+          },
+          'Tool execute start',
+        );
+        return;
+      case 'tool.permission.requested':
+        logger.info(
+          {
+            tool: event.payload.toolName,
+            riskLevel: event.payload.riskLevel,
+            sessionId: event.payload.sessionId,
+            conversationId: event.payload.conversationId,
+          },
+          'Tool permission requested',
+        );
+        return;
+      case 'tool.permission.decided': {
+        const meta = {
+          tool: event.payload.toolName,
+          decision: event.payload.decision,
+          riskLevel: event.payload.riskLevel,
+          sessionId: event.payload.sessionId,
+          conversationId: event.payload.conversationId,
+        };
+
+        if (event.payload.decision === 'deny' || event.payload.decision === 'always_deny') {
+          logger.info(meta, 'Tool permission denied');
+          return;
+        }
+        if (debugEnabled()) {
+          logger.debug(meta, 'Tool permission decided');
+        }
+        return;
+      }
+      case 'tool.secret.detected': {
+        const types = [...new Set(event.payload.matches.map((match) => match.type))];
+        logger.warn(
+          {
+            toolName: event.payload.toolName,
+            matchCount: event.payload.matches.length,
+            types,
+            action: event.payload.action,
+            sessionId: event.payload.sessionId,
+            conversationId: event.payload.conversationId,
+          },
+          'Secrets detected in tool output',
+        );
+        return;
+      }
+      case 'tool.execution.finished':
+        if (!debugEnabled()) return;
+        logger.debug(
+          {
+            tool: event.payload.toolName,
+            execDurationMs: event.payload.durationMs,
+            riskLevel: event.payload.riskLevel,
+            decision: event.payload.decision,
+            isError: event.payload.isError,
+            sessionId: event.payload.sessionId,
+            conversationId: event.payload.conversationId,
+          },
+          'Tool execute result',
+        );
+        return;
+      case 'tool.execution.failed':
+        logger.error(
+          {
+            tool: event.payload.toolName,
+            execDurationMs: event.payload.durationMs,
+            riskLevel: event.payload.riskLevel,
+            decision: event.payload.decision,
+            error: event.payload.error,
+            sessionId: event.payload.sessionId,
+            conversationId: event.payload.conversationId,
+          },
+          'Tool execution error',
+        );
+        return;
+      default:
+        return;
+    }
+  });
+}
+
+function formatInputForLog(
+  input: Record<string, unknown>,
+  truncate: (value: string, maxLen: number) => string,
+): string {
+  try {
+    return truncate(JSON.stringify(input), INPUT_PREVIEW_LIMIT);
+  } catch {
+    return '[unserializable-input]';
+  }
+}

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -6,7 +6,7 @@ import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } f
 import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
-import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
+import { getLogger } from '../util/logger.js';
 import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
 import { MAX_FILE_SIZE_BYTES } from './filesystem/size-guard.js';
@@ -31,14 +31,6 @@ export class ToolExecutor {
     const startTime = Date.now();
     let decision = 'allow';
     let riskLevel: string = RiskLevel.Low;
-    const debug = isDebug();
-
-    if (debug) {
-      log.debug({
-        tool: name,
-        input: truncateForLog(JSON.stringify(input), 300),
-      }, 'Tool execute start');
-    }
 
     emitLifecycleEvent(context, {
       type: 'start',
@@ -198,11 +190,6 @@ export class ToolExecutor {
             redactedValue: m.redactedValue,
           }));
 
-          log.warn(
-            { toolName: name, matchCount: allMatches.length, types: [...new Set(allMatches.map((m) => m.type))] },
-            'Secrets detected in tool output',
-          );
-
           emitLifecycleEvent(context, {
             type: 'secret_detected',
             toolName: name,
@@ -248,18 +235,6 @@ export class ToolExecutor {
         }
       }
 
-      if (debug) {
-        const execDurationMs = Date.now() - startTime;
-        log.debug({
-          tool: name,
-          execDurationMs,
-          riskLevel,
-          decision,
-          isError: execResult.isError,
-          output: truncateForLog(execResult.content, 300),
-        }, 'Tool execute result');
-      }
-
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent(context, {
         type: 'executed',
@@ -295,8 +270,6 @@ export class ToolExecutor {
       if (err instanceof PermissionDeniedError || err instanceof ToolError) {
         return { content: msg, isError: true };
       }
-
-      log.error({ err, name }, 'Tool execution error');
       return { content: `Tool error: ${msg}`, isError: true };
     }
   }


### PR DESCRIPTION
## Summary
- add `registerToolMetricsLoggingListener` to centralize execution timing/diagnostic logs from tool and permission domain events
- wire the new metrics listener in `Session` alongside existing audit and notification listeners
- remove duplicate execution-path logging from `ToolExecutor` so tool logging is listener-driven
- add focused listener tests that validate debug/info/warn/error behavior and payload metadata

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; HOME=/tmp bun test src/__tests__/tool-metrics-listener.test.ts src/__tests__/tool-domain-event-publisher.test.ts src/__tests__/tool-notification-listener.test.ts src/__tests__/tool-executor-lifecycle-events.test.ts src/__tests__/secret-scanner-executor.test.ts src/__tests__/tool-audit-listener.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun run lint src/events/tool-metrics-listener.ts src/events/index.ts src/daemon/session.ts src/tools/executor.ts src/__tests__/tool-metrics-listener.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
