### PR TITLE
Fix confirmation accept breaking the session flow

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -266,6 +266,15 @@ final class ComputerUseSession: ObservableObject {
                 verifier.recordConfirmedAction(action)
                 state = .running(step: stepNumber, maxSteps: maxSteps, lastAction: action.displayDescription, reasoning: action.reasoning)
 
+                // Re-activate the target app after the confirmation panel interaction,
+                // which may have briefly taken key window focus. Without this, key events
+                // (like Enter to send a message) get delivered to the panel instead.
+                if let pid = primaryPID,
+                   let app = NSRunningApplication(processIdentifier: pid) {
+                    app.activate()
+                    try? await Task.sleep(nanoseconds: 200_000_000) // 200ms for focus to settle
+                }
+
             case .blocked(let reason):
                 log.warning("[\(stepNumber)] BLOCKED: \(reason)")
                 let record = ActionRecord(step: stepNumber, action: action, result: "BLOCKED: \(reason)", timestamp: Date())


### PR DESCRIPTION
The purpose of this PR is to fix the confirmation accept button breaking the session flow by re-activating the target app after the user clicks Allow.

## Changes Made
- Re-activate the target app by PID after confirmation approval in `Session.swift`, with a 200ms delay for focus to settle
- Fixes a focus race condition where clicking "Allow" on the confirmation panel briefly makes it the key window, causing key events (e.g., Enter to send a message) to be delivered to the panel instead of the target app

## Testing
- All 62 existing tests pass, including 5 confirmation-specific tests

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
