### PR TITLE
Fix recipe loading in Xcode builds

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -142,8 +142,8 @@ final class RecipeExecutor {
             }
         #endif
 
-        // Xcode builds: recipes bundled via xcassets or copy phase
-        if let url = Bundle.main.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {
+        // Xcode builds: individual files are copied flat into the bundle (no subdirectory)
+        if let url = Bundle.main.url(forResource: name, withExtension: "md") {
             return try? String(contentsOf: url, encoding: .utf8)
         }
 


### PR DESCRIPTION
The purpose of this PR is to fix recipe loading that silently fails in Xcode builds due to a resource bundling mismatch.

## Changes Made
- Remove `subdirectory: "Recipes"` from the `Bundle.main` fallback path in `RecipeExecutor.loadRecipeMarkdown`
- Xcode copies PBXGroup resource files flat into the bundle root, so the subdirectory lookup always returned `nil`

## Context
PR #387 added `github-app-setup.md` as an individual file in a PBXGroup, which Xcode copies flat (no directory structure preserved). The `Bundle.main.url(forResource:withExtension:subdirectory:)` call with `subdirectory: "Recipes"` would never find the file. The SPM path (`Bundle.module`) correctly preserves the subdirectory and remains unchanged.

## Testing
- SPM build: passes
- All 62 tests pass with 0 failures

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
