### PR TITLE
Route undo through injected executor for DI consistency

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -171,12 +171,6 @@ final class ActionExecutor: ActionExecuting {
         keyUp.post(tap: .cghidEventTap)
     }
 
-    // MARK: - Undo
-
-    func undo() throws {
-        try pressKey("cmd+z")
-    }
-
     // MARK: - Scroll
 
     func scroll(at point: CGPoint, direction: String, amount: Int) throws {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -522,13 +522,15 @@ final class ComputerUseSession: ObservableObject {
     }
 
     func undo() {
-        let undoExecutor = ActionExecutor()
-        do {
-            try undoExecutor.pressKey("cmd+z")
-            undoCount += 1
-            log.info("Undo #\(self.undoCount) sent")
-        } catch {
-            log.error("Undo failed: \(error.localizedDescription)")
+        let undoAction = AgentAction(type: .key, reasoning: "User-initiated undo", key: "cmd+z")
+        Task { @MainActor in
+            do {
+                _ = try await executor.execute(undoAction)
+                undoCount += 1
+                log.info("Undo #\(self.undoCount) sent")
+            } catch {
+                log.error("Undo failed: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -774,13 +774,21 @@ final class SessionTests: XCTestCase {
         let provider = MockInferenceProvider(actions: [
             AgentAction(type: .done, reasoning: "done", summary: "Done")
         ])
-        let session = makeSession(provider: provider)
+        let executor = MockActionExecutor()
+        let session = makeSession(provider: provider, executor: executor)
 
         XCTAssertEqual(session.undoCount, 0)
         session.undo()
+        try? await Task.sleep(nanoseconds: 10_000_000) // let async undo complete
         XCTAssertEqual(session.undoCount, 1)
         session.undo()
+        try? await Task.sleep(nanoseconds: 10_000_000)
         XCTAssertEqual(session.undoCount, 2)
+
+        // Verify undo went through the injected executor
+        XCTAssertEqual(executor.executedActions.count, 2)
+        XCTAssertEqual(executor.executedActions[0].type, .key)
+        XCTAssertEqual(executor.executedActions[0].key, "cmd+z")
     }
 
     @MainActor
@@ -788,7 +796,8 @@ final class SessionTests: XCTestCase {
         let provider = MockInferenceProvider(actions: [
             AgentAction(type: .done, reasoning: "done", summary: "Done")
         ])
-        let session = makeSession(provider: provider)
+        let executor = MockActionExecutor()
+        let session = makeSession(provider: provider, executor: executor)
 
         await session.run()
 
@@ -800,9 +809,15 @@ final class SessionTests: XCTestCase {
 
         // Undo should work even after session is completed
         session.undo()
+        try? await Task.sleep(nanoseconds: 10_000_000)
         XCTAssertEqual(session.undoCount, 1)
         session.undo()
+        try? await Task.sleep(nanoseconds: 10_000_000)
         XCTAssertEqual(session.undoCount, 2)
+
+        // Verify undo actions went through the mock executor (not a real ActionExecutor)
+        let undoActions = executor.executedActions.filter { $0.type == .key && $0.key == "cmd+z" }
+        XCTAssertEqual(undoActions.count, 2)
     }
 
     // MARK: - Thinking State


### PR DESCRIPTION
The purpose of this PR is to fix the undo() method bypassing dependency injection, which caused real CGEvent keystrokes to fire during tests.

## Changes Made
- Route `undo()` through the injected `self.executor` by constructing an `AgentAction(.key, "cmd+z")` instead of instantiating a concrete `ActionExecutor` directly
- Remove unused `undo()` convenience method from `ActionExecutor`
- Update undo tests to inject `MockActionExecutor` and verify actions flow through it

## Testing
- All 62 tests pass
- Undo tests now verify the mock executor receives the correct `.key` actions instead of sending real keystrokes

## Notes
Addresses review feedback from Codex and Devin on PR #383, both of which flagged the DI bypass.

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
