### PR TITLE
Address PR #392 feedback on failure logging and diagnostics

### DIFF
--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -102,6 +102,7 @@ describe('tool audit listener', () => {
       decision: 'error',
       durationMs: 9,
       errorMessage: 'boom',
+      isExpected: false,
     });
 
     expect(records).toHaveLength(1);

--- a/assistant/src/__tests__/tool-domain-event-publisher.test.ts
+++ b/assistant/src/__tests__/tool-domain-event-publisher.test.ts
@@ -134,4 +134,40 @@ describe('createToolDomainEventPublisher', () => {
       detectedAtMs: 55,
     });
   });
+
+  test('maps error lifecycle event to execution.failed with diagnostics', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'error',
+      toolName: 'shell',
+      input: { command: 'cat /missing' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'medium',
+      decision: 'error',
+      durationMs: 9,
+      errorMessage: 'ENOENT',
+      isExpected: false,
+      errorName: 'Error',
+      errorStack: 'Error: ENOENT\n    at test',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool.execution.failed');
+    expect(events[0].payload).toMatchObject({
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'shell',
+      riskLevel: 'medium',
+      decision: 'error',
+      durationMs: 9,
+      error: 'ENOENT',
+      isExpected: false,
+      errorName: 'Error',
+      errorStack: 'Error: ENOENT\n    at test',
+    });
+  });
 });

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -78,6 +78,7 @@ mock.module('../tools/terminal/sandbox.js', () => ({
 
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
+import { ToolError } from '../util/errors.js';
 
 function makeContext(events: ToolLifecycleEvent[]) {
   return {
@@ -199,6 +200,25 @@ describe('ToolExecutor lifecycle events', () => {
     const errorEvent = events[1];
     if (errorEvent.type !== 'error') throw new Error('Expected error event');
     expect(errorEvent.errorMessage).toBe('boom');
+    expect(errorEvent.isExpected).toBe(false);
+    expect(errorEvent.errorName).toBe('Error');
+    expect(errorEvent.errorStack).toContain('Error: boom');
+  });
+
+  test('marks ToolError failures as expected', async () => {
+    toolThrow = new ToolError('tool failed', 'file_read');
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('file_read', {}, makeContext(events));
+
+    expect(result).toEqual({ content: 'tool failed', isError: true });
+    expect(events.map((event) => event.type)).toEqual(['start', 'error']);
+    const errorEvent = events[1];
+    if (errorEvent.type !== 'error') throw new Error('Expected error event');
+    expect(errorEvent.isExpected).toBe(true);
+    expect(errorEvent.errorName).toBe('ToolError');
   });
 
   test('emits start and error for unknown tools', async () => {
@@ -213,6 +233,7 @@ describe('ToolExecutor lifecycle events', () => {
     if (errorEvent.type !== 'error') throw new Error('Expected error event');
     expect(errorEvent.errorMessage).toBe('Unknown tool: unknown_tool');
     expect(errorEvent.decision).toBe('error');
+    expect(errorEvent.isExpected).toBe(true);
   });
 
   test('does not block tool execution on unresolved lifecycle callbacks', async () => {

--- a/assistant/src/__tests__/tool-metrics-listener.test.ts
+++ b/assistant/src/__tests__/tool-metrics-listener.test.ts
@@ -176,14 +176,50 @@ describe('registerToolMetricsLoggingListener', () => {
       riskLevel: 'high',
       durationMs: 42,
       error: 'boom',
+      isExpected: false,
+      errorName: 'Error',
+      errorStack: 'Error: boom\n    at test',
       failedAtMs: 142,
     });
 
     expect(errorCalls).toHaveLength(1);
+    expect(warnCalls).toHaveLength(0);
     expect(errorCalls[0][1]).toBe('Tool execution error');
     const payload = errorCalls[0][0] as Record<string, unknown>;
     expect(payload.tool).toBe('shell');
     expect(payload.error).toBe('boom');
+    expect(payload.errorStack).toBe('Error: boom\n    at test');
     expect(payload.execDurationMs).toBe(42);
+  });
+
+  test('logs expected execution failures as warnings', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    registerToolMetricsLoggingListener(bus, {
+      logger: testLogger,
+      debugEnabled: () => debugEnabled,
+      truncate,
+    });
+
+    await bus.emit('tool.execution.failed', {
+      conversationId: 'conversation-1',
+      sessionId: 'session-1',
+      toolName: 'shell',
+      decision: 'error',
+      riskLevel: 'medium',
+      durationMs: 14,
+      error: 'Permission denied by user',
+      isExpected: true,
+      errorName: 'PermissionDeniedError',
+      errorStack: 'PermissionDeniedError: Permission denied by user\n    at test',
+      failedAtMs: 201,
+    });
+
+    expect(warnCalls).toHaveLength(1);
+    expect(errorCalls).toHaveLength(0);
+    expect(warnCalls[0][1]).toBe('Tool execution failed (expected)');
+    const payload = warnCalls[0][0] as Record<string, unknown>;
+    expect(payload.tool).toBe('shell');
+    expect(payload.isExpected).toBe(true);
+    expect(payload.errorName).toBe('PermissionDeniedError');
   });
 });

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -47,6 +47,9 @@ export interface ToolDomainEvents {
     riskLevel: string;
     durationMs: number;
     error: string;
+    isExpected: boolean;
+    errorName?: string;
+    errorStack?: string;
     failedAtMs: number;
   };
 }

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -82,6 +82,9 @@ export function createToolDomainEventPublisher(
           riskLevel: event.riskLevel,
           durationMs: event.durationMs,
           error: event.errorMessage,
+          isExpected: event.isExpected,
+          errorName: event.errorName,
+          errorStack: event.errorStack,
           failedAtMs: Date.now(),
         });
         break;

--- a/assistant/src/events/tool-metrics-listener.ts
+++ b/assistant/src/events/tool-metrics-listener.ts
@@ -100,6 +100,24 @@ export function registerToolMetricsLoggingListener(
         );
         return;
       case 'tool.execution.failed':
+        if (event.payload.isExpected) {
+          logger.warn(
+            {
+              tool: event.payload.toolName,
+              execDurationMs: event.payload.durationMs,
+              riskLevel: event.payload.riskLevel,
+              decision: event.payload.decision,
+              error: event.payload.error,
+              errorName: event.payload.errorName,
+              errorStack: event.payload.errorStack,
+              isExpected: event.payload.isExpected,
+              sessionId: event.payload.sessionId,
+              conversationId: event.payload.conversationId,
+            },
+            'Tool execution failed (expected)',
+          );
+          return;
+        }
         logger.error(
           {
             tool: event.payload.toolName,
@@ -107,6 +125,9 @@ export function registerToolMetricsLoggingListener(
             riskLevel: event.payload.riskLevel,
             decision: event.payload.decision,
             error: event.payload.error,
+            errorName: event.payload.errorName,
+            errorStack: event.payload.errorStack,
+            isExpected: event.payload.isExpected,
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
           },

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -57,6 +57,7 @@ export class ToolExecutor {
         decision: 'error',
         durationMs,
         errorMessage: msg,
+        isExpected: true,
       });
       return { content: msg, isError: true };
     }
@@ -253,6 +254,7 @@ export class ToolExecutor {
     } catch (err) {
       const durationMs = Date.now() - startTime;
       const msg = err instanceof Error ? err.message : String(err);
+      const isExpected = err instanceof PermissionDeniedError || err instanceof ToolError;
 
       emitLifecycleEvent(context, {
         type: 'error',
@@ -265,9 +267,12 @@ export class ToolExecutor {
         decision: 'error',
         durationMs,
         errorMessage: msg,
+        isExpected,
+        errorName: err instanceof Error ? err.name : undefined,
+        errorStack: err instanceof Error ? err.stack : undefined,
       });
 
-      if (err instanceof PermissionDeniedError || err instanceof ToolError) {
+      if (isExpected) {
         return { content: msg, isError: true };
       }
       return { content: `Tool error: ${msg}`, isError: true };

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -46,6 +46,9 @@ export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
   decision: string;
   durationMs: number;
   errorMessage: string;
+  isExpected: boolean;
+  errorName?: string;
+  errorStack?: string;
 }
 
 export interface ToolSecretDetectedEvent extends ToolLifecycleEventBase {


### PR DESCRIPTION
## Summary
- classify tool execution failures as expected vs unexpected in lifecycle/domain events
- downgrade expected failures (for example ToolError and PermissionDeniedError) to warning-level metrics logs
- preserve failure diagnostics by propagating error name and stack through events to metrics logs
- add regression tests for executor classification, domain-event mapping, and metrics logging behavior

## Verification
- export PATH="/Users/sidd/.bun/bin:/Users/sidd/.local/bin:/Users/sidd/.codex/tmp/arg0/codex-arg0HvgaWL:/Users/sidd/.bun/bin:/Users/sidd/.antigravity/antigravity/bin:/Users/sidd/.local/bin:/Users/sidd/Library/pnpm:/Users/sidd/google-cloud-sdk/bin:/Users/sidd/bin:/usr/local/bin:/usr/local/go/bin:/Users/sidd/.local/bin:/Applications/Docker.app/Contents/Resources/bin/:/Applications/Docker.app/Contents/Resources/bin/:/Users/sidd/.nvm/versions/node/v22.17.0/bin/:/Users/sidd/.local/share/solana/install/active_release/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/sidd/.local/bin:/Users/sidd/.cargo/bin:/usr/local/opt/fzf/bin:/Users/sidd/.kube/plugins/jordanwilson230:/Applications/Codex.app/Contents/Resources"; bun test assistant/src/__tests__/tool-executor-lifecycle-events.test.ts assistant/src/__tests__/tool-domain-event-publisher.test.ts assistant/src/__tests__/tool-metrics-listener.test.ts assistant/src/__tests__/tool-audit-listener.test.ts
- export PATH="/Users/sidd/.bun/bin:/Users/sidd/.local/bin:/Users/sidd/.codex/tmp/arg0/codex-arg0HvgaWL:/Users/sidd/.bun/bin:/Users/sidd/.antigravity/antigravity/bin:/Users/sidd/.local/bin:/Users/sidd/Library/pnpm:/Users/sidd/google-cloud-sdk/bin:/Users/sidd/bin:/usr/local/bin:/usr/local/go/bin:/Users/sidd/.local/bin:/Applications/Docker.app/Contents/Resources/bin/:/Applications/Docker.app/Contents/Resources/bin/:/Users/sidd/.nvm/versions/node/v22.17.0/bin/:/Users/sidd/.local/share/solana/install/active_release/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/sidd/.local/bin:/Users/sidd/.cargo/bin:/usr/local/opt/fzf/bin:/Users/sidd/.kube/plugins/jordanwilson230:/Applications/Codex.app/Contents/Resources"; bun run lint src/tools/types.ts src/events/domain-events.ts src/tools/executor.ts src/events/tool-domain-event-publisher.ts src/events/tool-metrics-listener.ts src/__tests__/tool-executor-lifecycle-events.test.ts src/__tests__/tool-domain-event-publisher.test.ts src/__tests__/tool-metrics-listener.test.ts src/__tests__/tool-audit-listener.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
