### PR TITLE
Add focused event-bus coverage for listener and lifecycle paths

### DIFF
--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -46,6 +46,35 @@ describe('EventBus', () => {
     expect(seenConversationId).toBe('conv-2');
   });
 
+  test('invokes direct listeners before onAny listeners for each emission', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    const seen: string[] = [];
+
+    bus.on('tool.permission.decided', async () => {
+      await Promise.resolve();
+      seen.push('direct-1');
+    });
+    bus.on('tool.permission.decided', () => {
+      seen.push('direct-2');
+    });
+    bus.onAny((event) => {
+      if (event.type === 'tool.permission.decided') {
+        seen.push('any');
+      }
+    });
+
+    await bus.emit('tool.permission.decided', {
+      conversationId: 'conv-2',
+      sessionId: 'sess-2',
+      toolName: 'shell',
+      decision: 'allow',
+      riskLevel: 'medium',
+      decidedAtMs: Date.now(),
+    });
+
+    expect(seen).toEqual(['direct-1', 'direct-2', 'any']);
+  });
+
   test('subscription disposal is idempotent and prevents future callbacks', async () => {
     const bus = new EventBus<AssistantDomainEvents>();
     let calls = 0;
@@ -140,5 +169,52 @@ describe('EventBus', () => {
     ).rejects.toBeInstanceOf(AggregateError);
 
     expect(ranAfterFailure).toBe(true);
+  });
+
+  test('emit aggregates direct and onAny listener failures while still invoking remaining listeners', async () => {
+    const bus = new EventBus<AssistantDomainEvents>();
+    let directRanAfterFailure = false;
+    let anyRanAfterFailure = false;
+
+    bus.on('tool.execution.failed', () => {
+      throw new Error('direct listener failed');
+    });
+    bus.on('tool.execution.failed', () => {
+      directRanAfterFailure = true;
+    });
+    bus.onAny((event) => {
+      if (event.type === 'tool.execution.failed') {
+        throw new Error('any listener failed');
+      }
+    });
+    bus.onAny((event) => {
+      if (event.type === 'tool.execution.failed') {
+        anyRanAfterFailure = true;
+      }
+    });
+
+    let caught: unknown;
+    try {
+      await bus.emit('tool.execution.failed', {
+        conversationId: 'conv-4',
+        sessionId: 'sess-4',
+        toolName: 'shell',
+        decision: 'error',
+        riskLevel: 'high',
+        durationMs: 31,
+        error: 'boom',
+        isExpected: false,
+        failedAtMs: Date.now(),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = caught as AggregateError;
+    const messages = aggregate.errors.map((err) => (err instanceof Error ? err.message : String(err)));
+    expect(messages).toEqual(['direct listener failed', 'any listener failed']);
+    expect(directRanAfterFailure).toBe(true);
+    expect(anyRanAfterFailure).toBe(true);
   });
 });

--- a/assistant/src/__tests__/tool-domain-event-publisher.test.ts
+++ b/assistant/src/__tests__/tool-domain-event-publisher.test.ts
@@ -107,6 +107,43 @@ describe('createToolDomainEventPublisher', () => {
     });
   });
 
+  test('maps timeout-like executed lifecycle event to permission.decided + execution.finished', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'executed',
+      toolName: 'shell',
+      input: { command: 'sleep 30' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'high',
+      decision: 'always_allow',
+      durationMs: 5000,
+      result: {
+        content: '[Command timed out after 5s]',
+        isError: true,
+        status: 'timeout',
+      },
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'tool.permission.decided',
+      'tool.execution.finished',
+    ]);
+    expect(events[0].payload).toMatchObject({
+      decision: 'always_allow',
+      riskLevel: 'high',
+    });
+    expect(events[1].payload).toMatchObject({
+      toolName: 'shell',
+      decision: 'always_allow',
+      isError: true,
+      durationMs: 5000,
+    });
+  });
+
   test('maps secret_detected lifecycle event to tool.secret.detected domain event', async () => {
     const { bus, events } = makeEventsCollector();
     const publish = createToolDomainEventPublisher(bus);
@@ -132,6 +169,45 @@ describe('createToolDomainEventPublisher', () => {
       action: 'redact',
       matches: [{ type: 'AWS Access Key', redactedValue: '[REDACTED:AWS Access Key]' }],
       detectedAtMs: 55,
+    });
+  });
+
+  test('maps allow-decision error lifecycle event to permission.decided + execution.failed', async () => {
+    const { bus, events } = makeEventsCollector();
+    const publish = createToolDomainEventPublisher(bus);
+
+    await publish({
+      type: 'error',
+      toolName: 'shell',
+      input: { command: 'cat /missing' },
+      workingDir: '/tmp/project',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      riskLevel: 'high',
+      decision: 'allow',
+      durationMs: 12,
+      errorMessage: 'cat: /missing: No such file or directory',
+      isExpected: false,
+      errorName: 'Error',
+      errorStack: 'Error: cat: /missing: No such file or directory',
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'tool.permission.decided',
+      'tool.execution.failed',
+    ]);
+    expect(events[0].payload).toMatchObject({
+      decision: 'allow',
+      riskLevel: 'high',
+    });
+    expect(events[1].payload).toMatchObject({
+      toolName: 'shell',
+      decision: 'allow',
+      durationMs: 12,
+      error: 'cat: /missing: No such file or directory',
+      isExpected: false,
+      errorName: 'Error',
+      errorStack: 'Error: cat: /missing: No such file or directory',
     });
   });
 


### PR DESCRIPTION
## Summary
- add event-bus tests that verify direct-listener vs onAny listener ordering for a single emission
- add event-bus tests that verify aggregate failure behavior across direct and onAny listeners while ensuring later listeners still run
- add domain-event-publisher tests for timeout-like executed lifecycle events and allow-decision error lifecycle events

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/event-bus.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/tool-domain-event-publisher.test.ts assistant/src/__tests__/tool-executor-lifecycle-events.test.ts assistant/src/__tests__/secret-scanner-executor.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
