### PR TITLE
Fix TypeScript test callback typing errors

### DIFF
--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -33,7 +33,9 @@ describe('EventBus', () => {
 
     bus.onAny((event) => {
       seenType = event.type;
-      seenConversationId = event.payload.conversationId;
+      if (event.type === 'daemon.session.created') {
+        seenConversationId = event.payload.conversationId;
+      }
       expect(typeof event.emittedAtMs).toBe('number');
     });
 

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -133,7 +133,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -158,7 +162,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -177,7 +185,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: `Found key: ${secret}`, isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -202,7 +214,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: 'Found key: AKIAIOSFODNN7REALKEY', isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -218,7 +234,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: 'Error: AKIAIOSFODNN7REALKEY', isError: true };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -245,7 +265,11 @@ describe('Secret scanner executor integration', () => {
     };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_write', {}, ctx);
 
@@ -262,7 +286,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: 'Hello, world!', isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     const result = await executor.execute('file_read', {}, ctx);
 
@@ -299,7 +327,11 @@ describe('Secret scanner executor integration', () => {
     fakeToolResult = { content: `AWS: ${aws}\nGitHub: ${ghToken}`, isError: false };
 
     const lifecycleEvents: ToolLifecycleEvent[] = [];
-    const ctx = makeContext({ onToolLifecycleEvent: (event) => lifecycleEvents.push(event) });
+    const ctx = makeContext({
+      onToolLifecycleEvent: (event) => {
+        lifecycleEvents.push(event);
+      },
+    });
 
     await executor.execute('file_read', {}, ctx);
 

--- a/assistant/src/__tests__/tool-domain-event-publisher.test.ts
+++ b/assistant/src/__tests__/tool-domain-event-publisher.test.ts
@@ -6,7 +6,9 @@ import { createToolDomainEventPublisher } from '../events/tool-domain-event-publ
 function makeEventsCollector() {
   const bus = new EventBus<AssistantDomainEvents>();
   const events: AnyEventEnvelope<AssistantDomainEvents>[] = [];
-  bus.onAny((event) => events.push(event));
+  bus.onAny((event) => {
+    events.push(event);
+  });
   return { bus, events };
 }
 


### PR DESCRIPTION
## Summary
- narrow `onAny` event payload access in event bus test before reading `conversationId`
- update lifecycle handler callbacks in secret scanner tests to return `void` instead of `number`
- update domain event publisher test collector callback to return `void`

## Verification
- bunx tsc --noEmit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
