### PR TITLE
Fix local web startup/runtime in mixed-arch environments

### DIFF
--- a/vel/src/commands/up.ts
+++ b/vel/src/commands/up.ts
@@ -60,7 +60,7 @@ export async function up(): Promise<void> {
 
     // Step 5: Push schema to database
     console.log('🔄 Pushing database schema...');
-    const push = spawn('bunx', ['drizzle-kit', 'push', '--force'], {
+    const push = spawn('bunx', ['--bun', 'drizzle-kit', 'push', '--force'], {
       cwd: webDir,
       stdio: ['inherit', 'pipe', 'pipe'],
       env: {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vellum-assistant",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web/package.json
+++ b/web/package.json
@@ -6,13 +6,13 @@
     "pull": "scripts/pull.mjs"
   },
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "bunx --bun next dev",
+    "build": "bunx --bun next build",
     "db:push": "bun run scripts/migrate.mts",
     "db:push:preview": "bun run scripts/migrate.mts --preview",
     "lint": "eslint",
     "pull": "node scripts/pull.mjs",
-    "start": "next start"
+    "start": "bunx --bun next start"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.72.1",

--- a/web/scripts/migrate.mts
+++ b/web/scripts/migrate.mts
@@ -16,14 +16,14 @@ if (preview) {
     writeFileSync(join(diffDir, "base-schema.ts"), baseSchema);
 
     execSync(
-      `bunx drizzle-kit generate --schema "${join(diffDir, "base-schema.ts")}" --out "${diffDir}" --dialect postgresql`,
+      `bunx --bun drizzle-kit generate --schema "${join(diffDir, "base-schema.ts")}" --out "${diffDir}" --dialect postgresql`,
       { stdio: "pipe" }
     );
     const baseline = readdirSync(diffDir).filter((f) => f.endsWith(".sql"));
 
     // Generate diff migration from current PR schema
     execSync(
-      `bunx drizzle-kit generate --schema ./src/lib/schema.ts --out "${diffDir}" --dialect postgresql`,
+      `bunx --bun drizzle-kit generate --schema ./src/lib/schema.ts --out "${diffDir}" --dialect postgresql`,
       { stdio: "pipe" }
     );
     const total = readdirSync(diffDir).filter((f) => f.endsWith(".sql"));
@@ -44,6 +44,6 @@ if (preview) {
   console.log("Ensuring database exists...\n");
   execSync("bun run scripts/ensure-db.mts", { stdio: "inherit" });
   console.log("\nPushing schema changes to database...\n");
-  execSync("bunx drizzle-kit push --force", { stdio: "inherit" });
+  execSync("bunx --bun drizzle-kit push --force", { stdio: "inherit" });
   console.log("\nSchema push completed successfully.");
 }


### PR DESCRIPTION
## Summary
- run Drizzle CLI under Bun in `vel up` and web migration scripts to avoid esbuild platform mismatch
- run Next scripts (`dev`, `build`, `start`) via `bunx --bun` so SWC binary matches Bun runtime arch
- add `web/package-lock.json` so Next detects npm for registry lookup instead of failing on Yarn/Corepack in this Bun-managed repo

## Verification
- `bun run scripts/migrate.mts --preview`
- `node -e "const {getPkgManager}=require(./node_modules/next/dist/lib/helpers/get-pkg-manager); console.log(getPkgManager(process.cwd()));"` (from `web/`, outputs `npm`)
- `bunx --bun next --version`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
