### PR TITLE
Use webpack for next dev to avoid AWS SDK external resolution error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "pull": "scripts/pull.mjs"
   },
   "scripts": {
-    "dev": "bunx --bun next dev",
+    "dev": "bunx --bun next dev --webpack",
     "build": "bunx --bun next build",
     "db:push": "bun run scripts/migrate.mts",
     "db:push:preview": "bun run scripts/migrate.mts --preview",


### PR DESCRIPTION
## Summary
- switch `web` dev script from Turbopack to webpack by adding `--webpack`
- avoid dev-time `@aws-sdk/client-s3-*` external module resolution failure in API routes

## Verification
- `bun run dev --help` shows webpack dev option
- confirmed `web/package.json` script now runs `bunx --bun next dev --webpack`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
