### PR TITLE
Add local daemon connection mode for web assistant

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -10,6 +10,19 @@ import { randomBytes } from 'node:crypto';
 
 const TEST_DIR = join(tmpdir(), `vellum-schema-test-${randomBytes(4).toString('hex')}`);
 
+function ensureTestDir(): void {
+  const dirs = [
+    TEST_DIR,
+    join(TEST_DIR, 'data'),
+    join(TEST_DIR, 'memory'),
+    join(TEST_DIR, 'memory', 'knowledge'),
+    join(TEST_DIR, 'logs'),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
 mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
@@ -19,18 +32,7 @@ mock.module('../util/logger.js', () => ({
 mock.module('../util/platform.js', () => ({
   getDataDir: () => TEST_DIR,
   getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
-  ensureDataDir: () => {
-    const dirs = [
-      TEST_DIR,
-      join(TEST_DIR, 'data'),
-      join(TEST_DIR, 'memory'),
-      join(TEST_DIR, 'memory', 'knowledge'),
-      join(TEST_DIR, 'logs'),
-    ];
-    for (const dir of dirs) {
-      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    }
-  },
+  ensureDataDir: () => ensureTestDir(),
   isMacOS: () => false,
   isLinux: () => false,
   isWindows: () => false,
@@ -273,10 +275,20 @@ describe('AssistantConfigSchema', () => {
 
 describe('loadConfig with schema validation', () => {
   beforeEach(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
+    // Keep TEST_DIR and logs in place to avoid racing async logger stream init.
+    ensureTestDir();
+    const resetPaths = [
+      join(TEST_DIR, 'config.json'),
+      join(TEST_DIR, 'keys.enc'),
+      join(TEST_DIR, 'data'),
+      join(TEST_DIR, 'memory'),
+    ];
+    for (const path of resetPaths) {
+      if (existsSync(path)) {
+        rmSync(path, { recursive: true, force: true });
+      }
     }
-    mkdirSync(TEST_DIR, { recursive: true });
+    ensureTestDir();
     _setStorePath(join(TEST_DIR, 'keys.enc'));
     _setBackend('encrypted');
     invalidateConfigCache();
@@ -286,12 +298,6 @@ describe('loadConfig with schema validation', () => {
     _setStorePath(null);
     _setBackend(undefined);
     invalidateConfigCache();
-  });
-
-  afterAll(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
   });
 
   test('loads valid config', () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -3,7 +3,6 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { AssistantConfigSchema } from '../config/schema.js';
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before imports that depend on platform/logger
@@ -19,8 +18,18 @@ mock.module('../util/logger.js', () => ({
 
 mock.module('../util/platform.js', () => ({
   getDataDir: () => TEST_DIR,
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => {
-    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const dirs = [
+      TEST_DIR,
+      join(TEST_DIR, 'data'),
+      join(TEST_DIR, 'memory'),
+      join(TEST_DIR, 'memory', 'knowledge'),
+      join(TEST_DIR, 'logs'),
+    ];
+    for (const dir of dirs) {
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    }
   },
   isMacOS: () => false,
   isLinux: () => false,
@@ -30,6 +39,7 @@ mock.module('../util/platform.js', () => ({
 import { _setStorePath } from '../security/encrypted-store.js';
 import { _setBackend } from '../security/secure-keys.js';
 import { loadConfig, invalidateConfigCache } from '../config/loader.js';
+import { AssistantConfigSchema } from '../config/schema.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type * as net from 'node:net';
+
+const conversation = {
+  id: 'conv-1',
+  title: 'Test Conversation',
+  updatedAt: Date.now(),
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalEstimatedCost: 0,
+};
+
+class MockSession {
+  public readonly conversationId: string;
+  public updateClientCalls = 0;
+  private stale = false;
+  private processing = false;
+
+  constructor(conversationId: string) {
+    this.conversationId = conversationId;
+  }
+
+  async loadFromDb(): Promise<void> {}
+
+  updateClient(): void {
+    this.updateClientCalls += 1;
+  }
+
+  setSandboxOverride(): void {}
+
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  isStale(): boolean {
+    return this.stale;
+  }
+
+  markStale(): void {
+    this.stale = true;
+  }
+
+  abort(): void {}
+
+  handleConfirmationResponse(): void {}
+
+  async processMessage(): Promise<void> {}
+
+  undo(): number {
+    return 1;
+  }
+}
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../providers/ratelimit.js', () => ({
+  RateLimitProvider: class {
+    constructor(..._args: unknown[]) {}
+  },
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    systemPrompt: {},
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: {
+      maxRequestsPerMinute: 0,
+      maxTokensPerSession: 0,
+    },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getLatestConversation: () => conversation,
+  createConversation: () => conversation,
+  getConversation: (id: string) => (id === conversation.id ? conversation : null),
+  getMessages: () => [],
+  listConversations: () => [conversation],
+}));
+
+mock.module('../daemon/session.js', () => ({
+  Session: MockSession,
+}));
+
+import { DaemonServer } from '../daemon/server.js';
+
+function createFakeSocket() {
+  const writes: string[] = [];
+  const socket = {
+    destroyed: false,
+    write(chunk: string): boolean {
+      writes.push(chunk);
+      return true;
+    },
+  } as unknown as net.Socket;
+
+  return { socket, writes };
+}
+
+function decodeMessages(writes: string[]): Array<Record<string, unknown>> {
+  return writes
+    .flatMap((chunk) => chunk.split('\n'))
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('DaemonServer initial session hydration', () => {
+  beforeEach(() => {
+    conversation.updatedAt = Date.now();
+  });
+
+  test('hydrates latest session before session_info so undo works after reconnect', async () => {
+    const server = new DaemonServer();
+    const { socket, writes } = createFakeSocket();
+
+    await (server as any).sendInitialSession(socket);
+    (server as any).handleUndo(conversation.id, socket);
+
+    const messages = decodeMessages(writes);
+    const sessionInfo = messages.find((msg) => msg.type === 'session_info');
+    const undoComplete = messages.find((msg) => msg.type === 'undo_complete');
+    const error = messages.find((msg) => msg.type === 'error');
+
+    expect(sessionInfo).toBeDefined();
+    expect(undoComplete).toBeDefined();
+    expect(error).toBeUndefined();
+  });
+
+  test('does not rebind existing session client during initial handshake', async () => {
+    const server = new DaemonServer();
+    const existingSession = new MockSession(conversation.id);
+    (server as any).sessions.set(conversation.id, existingSession);
+
+    const { socket } = createFakeSocket();
+    await (server as any).sendInitialSession(socket);
+
+    expect(existingSession.updateClientCalls).toBe(0);
+    expect((server as any).socketToSession.size).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -122,6 +122,17 @@ mock.module('../daemon/session.js', () => ({
 
 import { DaemonServer } from '../daemon/server.js';
 
+type DaemonServerTestAccess = {
+  sendInitialSession: (socket: net.Socket) => Promise<void>;
+  handleUndo: (sessionId: string, socket: net.Socket) => void;
+  sessions: Map<string, MockSession>;
+  socketToSession: Map<net.Socket, string>;
+};
+
+function asDaemonServerTestAccess(server: DaemonServer): DaemonServerTestAccess {
+  return server as unknown as DaemonServerTestAccess;
+}
+
 function createFakeSocket() {
   const writes: string[] = [];
   const socket = {
@@ -149,10 +160,11 @@ describe('DaemonServer initial session hydration', () => {
 
   test('hydrates latest session before session_info so undo works after reconnect', async () => {
     const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
     const { socket, writes } = createFakeSocket();
 
-    await (server as any).sendInitialSession(socket);
-    (server as any).handleUndo(conversation.id, socket);
+    await internal.sendInitialSession(socket);
+    internal.handleUndo(conversation.id, socket);
 
     const messages = decodeMessages(writes);
     const sessionInfo = messages.find((msg) => msg.type === 'session_info');
@@ -166,13 +178,14 @@ describe('DaemonServer initial session hydration', () => {
 
   test('does not rebind existing session client during initial handshake', async () => {
     const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
     const existingSession = new MockSession(conversation.id);
-    (server as any).sessions.set(conversation.id, existingSession);
+    internal.sessions.set(conversation.id, existingSession);
 
     const { socket } = createFakeSocket();
-    await (server as any).sendInitialSession(socket);
+    await internal.sendInitialSession(socket);
 
     expect(existingSession.updateClientCalls).toBe(0);
-    expect((server as any).socketToSession.size).toBe(0);
+    expect(internal.socketToSession.size).toBe(0);
   });
 });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -45,11 +45,6 @@ describe('Trust Store', () => {
     clearCache();
     const trustPath = join(testDir, 'trust.json');
     try { rmSync(trustPath); } catch { /* may not exist */ }
-  });
-
-  afterAll(() => {
-    // Clean up temp directory
-    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
   });
 
   // ── addRule ─────────────────────────────────────────────────────

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -250,6 +250,10 @@ export class DaemonServer {
       conversation = conversationStore.createConversation('New Conversation');
     }
 
+    // Warm session state for commands like undo/usage after reconnect without
+    // rebinding the active IPC output client to this passive socket.
+    await this.getOrCreateSession(conversation.id, undefined, false);
+
     this.send(socket, {
       type: 'session_info',
       sessionId: conversation.id,
@@ -257,9 +261,20 @@ export class DaemonServer {
     });
   }
 
-  private async getOrCreateSession(conversationId: string, socket: net.Socket): Promise<Session> {
+  private async getOrCreateSession(
+    conversationId: string,
+    socket?: net.Socket,
+    rebindClient = true,
+  ): Promise<Session> {
     let session = this.sessions.get(conversationId);
-    const sendToClient = (msg: ServerMessage) => this.send(socket, msg);
+    const sendToClient = socket
+      ? (msg: ServerMessage) => this.send(socket, msg)
+      : () => {};
+    const maybeBindClient = (target: Session): void => {
+      if (!rebindClient || !socket) return;
+      target.updateClient(sendToClient);
+      target.setSandboxOverride(this.socketSandboxOverride.get(socket));
+    };
 
     if (!session || (session.isStale() && !session.isProcessing())) {
       // Check if another caller is already creating this session.
@@ -269,8 +284,7 @@ export class DaemonServer {
       const pending = this.sessionCreating.get(conversationId);
       if (pending) {
         session = await pending;
-        session.updateClient(sendToClient);
-        session.setSandboxOverride(this.socketSandboxOverride.get(socket));
+        maybeBindClient(session);
         return session;
       }
 
@@ -288,11 +302,13 @@ export class DaemonServer {
           provider,
           buildSystemPrompt(config.systemPrompt),
           config.maxTokens,
-          sendToClient,
+          rebindClient ? sendToClient : () => {},
           workingDir,
         );
         await newSession.loadFromDb();
-        newSession.setSandboxOverride(this.socketSandboxOverride.get(socket));
+        if (rebindClient && socket) {
+          newSession.setSandboxOverride(this.socketSandboxOverride.get(socket));
+        }
         this.sessions.set(conversationId, newSession);
         return newSession;
       })();
@@ -304,9 +320,8 @@ export class DaemonServer {
         this.sessionCreating.delete(conversationId);
       }
     } else {
-      // Rebind to the new socket so IPC goes to the current client
-      session.updateClient(sendToClient);
-      session.setSandboxOverride(this.socketSandboxOverride.get(socket));
+      // Rebind to the new socket so IPC goes to the current client.
+      maybeBindClient(session);
     }
     return session;
   }
@@ -381,7 +396,7 @@ export class DaemonServer {
   ): Promise<void> {
     try {
       this.socketToSession.set(socket, sessionId);
-      const session = await this.getOrCreateSession(sessionId, socket);
+      const session = await this.getOrCreateSession(sessionId, socket, true);
       await session.processMessage(content, (event) => {
         this.send(socket, event);
       });
@@ -411,7 +426,7 @@ export class DaemonServer {
     const conversation = conversationStore.createConversation(
       title ?? 'New Conversation',
     );
-    await this.getOrCreateSession(conversation.id, socket);
+    await this.getOrCreateSession(conversation.id, socket, true);
     this.send(socket, {
       type: 'session_info',
       sessionId: conversation.id,
@@ -429,7 +444,7 @@ export class DaemonServer {
       return;
     }
     this.socketToSession.set(socket, sessionId);
-    await this.getOrCreateSession(sessionId, socket);
+    await this.getOrCreateSession(sessionId, socket, true);
     this.send(socket, {
       type: 'session_info',
       sessionId: conversation.id,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -250,8 +250,6 @@ export class DaemonServer {
       conversation = conversationStore.createConversation('New Conversation');
     }
 
-    await this.getOrCreateSession(conversation.id, socket);
-    this.socketToSession.set(socket, conversation.id);
     this.send(socket, {
       type: 'session_info',
       sessionId: conversation.id,

--- a/web/README.md
+++ b/web/README.md
@@ -12,6 +12,24 @@ Next.js web application for Vellum Assistant.
 
 See the [root README](../README.md) for local development setup instructions.
 
+## Connection Mode
+
+The web API supports two deployment-level assistant connection modes:
+
+- `ASSISTANT_CONNECTION_MODE=cloud` (default): use cloud compute instance routes.
+- `ASSISTANT_CONNECTION_MODE=local`: use a running local daemon over a Unix socket.
+
+Optional socket override for local mode:
+
+- `LOCAL_DAEMON_SOCKET_PATH` (default: `~/.vellum/vellum.sock`)
+
+### Local Daemon Notes
+
+- Local mode is strict: there is no fallback to demo or cloud behavior if the daemon is unavailable.
+- Current local-mode scope is chat + health only.
+- File system and logs APIs return unsupported in local mode.
+- Daemon lifecycle is managed outside the web UI (for example, `vellum daemon start`).
+
 ## Database
 
 This project uses [Drizzle ORM](https://orm.drizzle.team/) for database management.

--- a/web/editor-templates/default-editor.tsx
+++ b/web/editor-templates/default-editor.tsx
@@ -39,6 +39,8 @@ type AssistantStatus =
   | "setting_up"
   | "provisioning_failed";
 
+type ConnectionMode = "cloud" | "local";
+
 const SETUP_GRACE_PERIOD_MS = 10 * 60 * 1000;
 
 type TabId =
@@ -264,6 +266,7 @@ function InteractionView({
   assistantCreatedAt: string;
 }) {
   const [assistantStatus, setAssistantStatus] = useState<AssistantStatus>("checking");
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode>("cloud");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -308,9 +311,27 @@ function InteractionView({
       const response = await fetch(`/api/assistants/${assistantId}/health`);
       if (!response.ok) {
         setAssistantStatus("unknown");
+        setConnectionMode("cloud");
         return;
       }
       const data = await response.json();
+      if (data.connectionMode === "local") {
+        setConnectionMode("local");
+        if (data.daemon?.reachable) {
+          setAssistantStatus("healthy");
+          setStatusMessage("Connected to local daemon");
+        } else {
+          setAssistantStatus("unreachable");
+          setStatusMessage(
+            data.daemon?.error ||
+              data.message ||
+              "Local daemon is not reachable"
+          );
+        }
+        return;
+      }
+
+      setConnectionMode("cloud");
       if (
         data.status === "unknown" &&
         data.message === "No compute instance configured"
@@ -437,6 +458,35 @@ function InteractionView({
   );
 
   const getStatusDisplay = () => {
+    if (connectionMode === "local") {
+      switch (assistantStatus) {
+        case "healthy":
+          return {
+            text: "Local daemon connected",
+            color: "bg-green-500",
+            pulse: true,
+          };
+        case "checking":
+          return {
+            text: "Checking local daemon...",
+            color: "bg-yellow-500",
+            pulse: true,
+          };
+        case "unreachable":
+          return {
+            text: "Local daemon disconnected",
+            color: "bg-red-500",
+            pulse: false,
+          };
+        default:
+          return {
+            text: "Local daemon status unknown",
+            color: "bg-zinc-400 dark:bg-zinc-600",
+            pulse: false,
+          };
+      }
+    }
+
     switch (assistantStatus) {
       case "healthy":
         return { text: "Assistant is alive", color: "bg-green-500", pulse: true };
@@ -510,62 +560,73 @@ function InteractionView({
               {statusDisplay.text}
             </span>
           </div>
-          <button
-            onClick={() => (isAlive ? handleStop() : handleStart())}
-            disabled={
-              isToggling ||
-              assistantStatus === "checking" ||
-              assistantStatus === "starting" ||
-              assistantStatus === "getting_set_up" ||
-              assistantStatus === "setting_up" ||
-              assistantStatus === "provisioning_failed" ||
-              assistantStatus === "unreachable"
-            }
-            className={`flex cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
-              isAlive
-                ? "bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:hover:bg-amber-900"
-                : "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-950 dark:text-green-400 dark:hover:bg-green-900"
-            }`}
-          >
-            {isToggling
-              ? isAlive
-                ? "Stopping..."
-                : "Starting..."
-              : isAlive
-                ? "Pause"
-                : "Start"}
-          </button>
+          {connectionMode !== "local" && (
+            <button
+              onClick={() => (isAlive ? handleStop() : handleStart())}
+              disabled={
+                isToggling ||
+                assistantStatus === "checking" ||
+                assistantStatus === "starting" ||
+                assistantStatus === "getting_set_up" ||
+                assistantStatus === "setting_up" ||
+                assistantStatus === "provisioning_failed" ||
+                assistantStatus === "unreachable"
+              }
+              className={`flex cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+                isAlive
+                  ? "bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:hover:bg-amber-900"
+                  : "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-950 dark:text-green-400 dark:hover:bg-green-900"
+              }`}
+            >
+              {isToggling
+                ? isAlive
+                  ? "Stopping..."
+                  : "Starting..."
+                : isAlive
+                  ? "Pause"
+                  : "Start"}
+            </button>
+          )}
         </div>
       </div>
 
       {!isAlive ? (
         <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
           <h3 className="mt-4 text-lg font-medium text-zinc-900 dark:text-white">
-            {assistantStatus === "checking"
-              ? "Checking assistant status..."
-              : assistantStatus === "starting"
-                ? "Assistant is starting up..."
-                : assistantStatus === "getting_set_up"
-                  ? "Getting set up..."
-                  : assistantStatus === "setting_up"
-                    ? "Setting up..."
-                    : assistantStatus === "provisioning_failed"
-                      ? "Setup failed"
-                      : "Assistant is not running"}
+            {connectionMode === "local"
+              ? assistantStatus === "checking"
+                ? "Checking local daemon..."
+                : "Local daemon is not reachable"
+              : assistantStatus === "checking"
+                ? "Checking assistant status..."
+                : assistantStatus === "starting"
+                  ? "Assistant is starting up..."
+                  : assistantStatus === "getting_set_up"
+                    ? "Getting set up..."
+                    : assistantStatus === "setting_up"
+                      ? "Setting up..."
+                      : assistantStatus === "provisioning_failed"
+                        ? "Setup failed"
+                        : "Assistant is not running"}
           </h3>
           <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-            {assistantStatus === "checking"
-              ? "Please wait while we check the assistant status"
-              : assistantStatus === "starting"
-                ? "Your assistant's compute instance is booting up. This may take a minute."
-                : assistantStatus === "getting_set_up"
-                  ? "Your assistant's compute instance is being created."
-                  : assistantStatus === "setting_up"
-                    ? statusMessage ?? "Your assistant is being configured."
-                    : assistantStatus === "provisioning_failed"
-                      ? statusMessage ??
-                        "Failed to create the compute instance for this assistant."
-                      : "Start the assistant to interact with it directly"}
+            {connectionMode === "local"
+              ? assistantStatus === "checking"
+                ? "Please wait while we check local daemon status."
+                : statusMessage ??
+                  "Run 'vellum daemon start' on this machine to connect chat."
+              : assistantStatus === "checking"
+                ? "Please wait while we check the assistant status"
+                : assistantStatus === "starting"
+                  ? "Your assistant's compute instance is booting up. This may take a minute."
+                  : assistantStatus === "getting_set_up"
+                    ? "Your assistant's compute instance is being created."
+                    : assistantStatus === "setting_up"
+                      ? statusMessage ?? "Your assistant is being configured."
+                      : assistantStatus === "provisioning_failed"
+                        ? statusMessage ??
+                          "Failed to create the compute instance for this assistant."
+                        : "Start the assistant to interact with it directly"}
           </p>
         </div>
       ) : (

--- a/web/src/app/api/assistants/[id]/cat/route.ts
+++ b/web/src/app/api/assistants/[id]/cat/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 function obfuscateEnvContent(content: string): string {
   // Obfuscate values in .env files while preserving keys
@@ -82,6 +85,17 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (result.length === 0) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    if (getAssistantConnectionMode() === "local") {
+      return NextResponse.json(
+        {
+          error:
+            "File reads are not supported in local-daemon mode in this rollout (chat + health only).",
+          connectionMode: "local",
+        },
+        { status: 501 }
+      );
     }
 
     const assistant = result[0] as Assistant;

--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -1,10 +1,27 @@
 import { NextResponse } from "next/server";
 
+import {
+  getAssistantConnectionMode,
+  getLocalDaemonSocketPath,
+} from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp, getInstanceStatus } from "@/lib/gcp";
+import {
+  LocalDaemonClient,
+  describeLocalDaemonError,
+} from "@/lib/local-daemon-ipc";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+export const runtime = "nodejs";
+
+function cloudResponse(payload: Record<string, unknown>) {
+  return NextResponse.json({
+    connectionMode: "cloud",
+    ...payload,
+  });
 }
 
 export async function GET(request: Request, { params }: RouteParams) {
@@ -18,6 +35,38 @@ export async function GET(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
     }
 
+    const connectionMode = getAssistantConnectionMode();
+    if (connectionMode === "local") {
+      const socketPath = getLocalDaemonSocketPath();
+      let daemon: LocalDaemonClient | null = null;
+      let reachable = false;
+      let errorDetail: string | null = null;
+
+      try {
+        daemon = await LocalDaemonClient.connect(socketPath);
+        await daemon.ping(3000);
+        reachable = true;
+      } catch (error: unknown) {
+        reachable = false;
+        errorDetail = describeLocalDaemonError(error);
+      } finally {
+        daemon?.close();
+      }
+
+      return NextResponse.json({
+        status: reachable ? "healthy" : "unreachable",
+        message: reachable
+          ? "Connected to local daemon"
+          : "Local daemon is not reachable",
+        connectionMode: "local",
+        daemon: {
+          socketPath,
+          reachable,
+          ...(errorDetail ? { error: errorDetail } : {}),
+        },
+      });
+    }
+
     const assistant = result[0] as Assistant;
     const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
       | { instanceName?: string; zone?: string }
@@ -26,7 +75,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     // If no compute instance is configured, report as healthy so the chat UI is usable
     // TODO: Remove this once we have a way to reproduce our production environment kubernetes locally
     if (!computeConfig?.instanceName || !computeConfig?.zone) {
-      return NextResponse.json({
+      return cloudResponse({
         status: "healthy",
         message: "Running in demo mode",
       });
@@ -34,7 +83,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     const provisioningError = (assistant.configuration as Record<string, unknown>)?.provisioningError as string | undefined;
     if (provisioningError) {
-      return NextResponse.json({
+      return cloudResponse({
         status: "provisioning_failed",
         message: provisioningError,
       });
@@ -56,13 +105,13 @@ export async function GET(request: Request, { params }: RouteParams) {
         instanceStatus === "PROVISIONING" ||
         instanceStatus === "RUNNING"
       ) {
-        return NextResponse.json({
+        return cloudResponse({
           status: "starting",
           message: "Agent instance is starting up",
         });
       }
 
-      return NextResponse.json({
+      return cloudResponse({
         status: "stopped",
         message: "Instance has no external IP (likely stopped)",
       });
@@ -77,7 +126,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       });
 
       if (!response.ok) {
-        return NextResponse.json({
+        return cloudResponse({
           status: "unhealthy",
           message: `Health check returned ${response.status}`,
           ip: externalIp,
@@ -87,7 +136,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       const healthData = await response.json();
 
       if (healthData.status === "setting_up") {
-        return NextResponse.json({
+        return cloudResponse({
           status: "setting_up",
           progress: healthData.progress || null,
           ip: externalIp,
@@ -95,7 +144,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       }
 
       if (healthData.status === "error") {
-        return NextResponse.json({
+        return cloudResponse({
           status: "provisioning_failed",
           message: healthData.error || healthData.progress || "Setup failed",
           ip: externalIp,
@@ -118,7 +167,7 @@ export async function GET(request: Request, { params }: RouteParams) {
         // Stats fetch failed, continue without them
       }
 
-      return NextResponse.json({
+      return cloudResponse({
         status: "healthy",
         data: healthData,
         ip: externalIp,
@@ -127,7 +176,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     } catch (fetchError: unknown) {
       console.log("Health check failed:", fetchError);
       const errorDetail = fetchError instanceof Error ? fetchError.message : "Unknown error";
-      return NextResponse.json({
+      return cloudResponse({
         status: "unreachable",
         message: `Health check failed: ${errorDetail}`,
         ip: externalIp,

--- a/web/src/app/api/assistants/[id]/logs/route.ts
+++ b/web/src/app/api/assistants/[id]/logs/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
@@ -17,6 +20,17 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (result.length === 0) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    if (getAssistantConnectionMode() === "local") {
+      return NextResponse.json(
+        {
+          error:
+            "Log streaming is not supported in local-daemon mode in this rollout (chat + health only).",
+          connectionMode: "local",
+        },
+        { status: 501 }
+      );
     }
 
     const assistant = result[0] as Assistant;

--- a/web/src/app/api/assistants/[id]/ls/route.ts
+++ b/web/src/app/api/assistants/[id]/ls/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 interface FileEntry {
   name: string;
@@ -44,6 +47,19 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (result.length === 0) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    if (getAssistantConnectionMode() === "local") {
+      return NextResponse.json(
+        {
+          error:
+            "File system browsing is not supported in local-daemon mode in this rollout (chat + health only).",
+          connectionMode: "local",
+          files: [],
+          path,
+        },
+        { status: 501 }
+      );
     }
 
     const assistant = result[0] as Assistant;

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -87,33 +87,6 @@ function getStoredLocalDaemonSessionId(config: AssistantConfig): string | null {
   return sessionId;
 }
 
-async function persistLocalDaemonSessionId(
-  sql: ReturnType<typeof getDb>,
-  assistantId: string,
-  config: AssistantConfig,
-  sessionId: string
-): Promise<void> {
-  const existingLocalDaemon =
-    config.localDaemon && typeof config.localDaemon === "object"
-      ? (config.localDaemon as Record<string, unknown>)
-      : {};
-
-  const nextConfig: AssistantConfig = {
-    ...config,
-    localDaemon: {
-      ...existingLocalDaemon,
-      sessionId,
-    },
-  };
-
-  await sql`
-    UPDATE assistants
-    SET configuration = ${JSON.stringify(nextConfig)}::jsonb,
-        updated_at = NOW()
-    WHERE id = ${assistantId}
-  `;
-}
-
 async function ensureLocalDaemonSession(
   daemon: LocalDaemonClient,
   storedSessionId: string | null
@@ -131,6 +104,70 @@ async function ensureLocalDaemonSession(
 
   const createdSession = await daemon.createSession("Web Assistant Session");
   return createdSession.sessionId;
+}
+
+function withLocalDaemonSessionId(
+  config: AssistantConfig,
+  sessionId: string
+): AssistantConfig {
+  const existingLocalDaemon =
+    config.localDaemon && typeof config.localDaemon === "object"
+      ? (config.localDaemon as Record<string, unknown>)
+      : {};
+
+  return {
+    ...config,
+    localDaemon: {
+      ...existingLocalDaemon,
+      sessionId,
+    },
+  };
+}
+
+async function ensurePersistedLocalDaemonSessionId(
+  sql: ReturnType<typeof getDb>,
+  daemon: LocalDaemonClient,
+  assistantId: string
+): Promise<string> {
+  return sql.begin(async (tx) => {
+    const rows = await tx.unsafe<{ configuration: unknown }[]>(
+      `
+        SELECT configuration
+        FROM assistants
+        WHERE id = $1
+        FOR UPDATE
+      `,
+      [assistantId]
+    );
+
+    if (rows.length === 0) {
+      throw new Error("Agent not found");
+    }
+
+    const rawConfig = rows[0]?.configuration;
+    const lockedConfig =
+      rawConfig && typeof rawConfig === "object"
+        ? (rawConfig as AssistantConfig)
+        : {};
+
+    const storedSessionId = getStoredLocalDaemonSessionId(lockedConfig);
+    const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
+
+    if (sessionId !== storedSessionId) {
+      const nextConfig = withLocalDaemonSessionId(lockedConfig, sessionId);
+      await tx.unsafe(
+        `
+          UPDATE assistants
+          SET configuration = $1::jsonb,
+              updated_at = NOW()
+          WHERE id = $2
+        `,
+        [JSON.stringify(nextConfig), assistantId]
+      );
+    }
+
+    return sessionId;
+  });
 }
 
 function localDaemonErrorStatus(error: unknown): number {
@@ -399,21 +436,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (connectionMode === "local") {
       const socketPath = getLocalDaemonSocketPath();
-      const assistantConfig = getAssistantConfig(assistant);
-      const storedSessionId = getStoredLocalDaemonSessionId(assistantConfig);
 
       let daemon: LocalDaemonClient | null = null;
       try {
         daemon = await LocalDaemonClient.connect(socketPath);
-        const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
-        if (sessionId !== storedSessionId) {
-          await persistLocalDaemonSessionId(
-            sql,
-            assistantId,
-            assistantConfig,
-            sessionId
-          );
-        }
+        const sessionId = await ensurePersistedLocalDaemonSessionId(
+          sql,
+          daemon,
+          assistantId
+        );
 
         const localResponse = await daemon.sendUserMessage(sessionId, content);
         const timestamp = new Date().toISOString();

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import {
+  getAssistantConnectionMode,
+  getLocalDaemonSocketPath,
+} from "@/lib/assistant-connection";
+import {
   Assistant,
   ChatMessage,
   createChatMessage,
@@ -9,10 +13,18 @@ import {
   getMessageByGcsId,
 } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
+import {
+  LocalDaemonClient,
+  LocalDaemonError,
+  describeLocalDaemonError,
+  isLocalDaemonErrorWithCode,
+} from "@/lib/local-daemon-ipc";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 interface OutboxMessage {
   id: string;
@@ -54,6 +66,112 @@ const GITHUB_APP_HTML = `<div style="border:1px solid #d0d7de;border-radius:12px
   </div>
 </div>`;
 
+type AssistantConfig = Record<string, unknown>;
+
+function getAssistantConfig(assistant: Assistant): AssistantConfig {
+  const config = assistant.configuration as Record<string, unknown> | null;
+  return config ?? {};
+}
+
+function getStoredLocalDaemonSessionId(config: AssistantConfig): string | null {
+  const localDaemonConfig = config.localDaemon;
+  if (!localDaemonConfig || typeof localDaemonConfig !== "object") {
+    return null;
+  }
+
+  const sessionId = (localDaemonConfig as { sessionId?: unknown }).sessionId;
+  if (typeof sessionId !== "string" || sessionId.trim().length === 0) {
+    return null;
+  }
+
+  return sessionId;
+}
+
+async function persistLocalDaemonSessionId(
+  sql: ReturnType<typeof getDb>,
+  assistantId: string,
+  config: AssistantConfig,
+  sessionId: string
+): Promise<void> {
+  const existingLocalDaemon =
+    config.localDaemon && typeof config.localDaemon === "object"
+      ? (config.localDaemon as Record<string, unknown>)
+      : {};
+
+  const nextConfig: AssistantConfig = {
+    ...config,
+    localDaemon: {
+      ...existingLocalDaemon,
+      sessionId,
+    },
+  };
+
+  await sql`
+    UPDATE assistants
+    SET configuration = ${JSON.stringify(nextConfig)}::jsonb,
+        updated_at = NOW()
+    WHERE id = ${assistantId}
+  `;
+}
+
+async function ensureLocalDaemonSession(
+  daemon: LocalDaemonClient,
+  storedSessionId: string | null
+): Promise<string> {
+  if (storedSessionId) {
+    try {
+      await daemon.switchSession(storedSessionId);
+      return storedSessionId;
+    } catch (error: unknown) {
+      if (!isLocalDaemonErrorWithCode(error, "SESSION_NOT_FOUND")) {
+        throw error;
+      }
+    }
+  }
+
+  const createdSession = await daemon.createSession("Web Assistant Session");
+  return createdSession.sessionId;
+}
+
+function localDaemonErrorStatus(error: unknown): number {
+  if (!(error instanceof LocalDaemonError)) {
+    return 500;
+  }
+
+  switch (error.code) {
+    case "UNREACHABLE":
+      return 503;
+    case "TIMEOUT":
+      return 504;
+    case "BUSY":
+      return 409;
+    case "SESSION_NOT_FOUND":
+      return 409;
+    case "DAEMON_ERROR":
+      return 502;
+    case "PROTOCOL_ERROR":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+function localDaemonErrorResponse(
+  error: unknown,
+  fallbackMessage: string
+): NextResponse {
+  const status = localDaemonErrorStatus(error);
+  const detail = describeLocalDaemonError(error);
+
+  return NextResponse.json(
+    {
+      error: detail || fallbackMessage,
+      connectionMode: "local",
+    },
+    { status }
+  );
+}
+
 function getCannedResponse(assistantMessageCount: number): { content: string; action?: string } {
   switch (assistantMessageCount) {
     case 0:
@@ -88,6 +206,49 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const assistant = result[0] as Assistant;
+    const connectionMode = getAssistantConnectionMode();
+
+    if (connectionMode === "local") {
+      const socketPath = getLocalDaemonSocketPath();
+      const assistantConfig = getAssistantConfig(assistant);
+      const storedSessionId = getStoredLocalDaemonSessionId(assistantConfig);
+
+      let daemon: LocalDaemonClient | null = null;
+      try {
+        daemon = await LocalDaemonClient.connect(socketPath);
+        const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
+        if (sessionId !== storedSessionId) {
+          await persistLocalDaemonSessionId(
+            sql,
+            assistantId,
+            assistantConfig,
+            sessionId
+          );
+        }
+
+        const history = await daemon.getHistory(sessionId);
+        const formattedMessages = history.map((msg, index) => ({
+          id: `local-${msg.timestamp}-${index}`,
+          role: msg.role,
+          content: msg.text,
+          timestamp: new Date(msg.timestamp).toISOString(),
+        }));
+
+        return NextResponse.json({
+          messages: formattedMessages,
+          errors: [],
+          connectionMode: "local",
+        });
+      } catch (error: unknown) {
+        console.error("Error fetching local daemon messages:", error);
+        return localDaemonErrorResponse(
+          error,
+          "Failed to fetch messages from local daemon"
+        );
+      } finally {
+        daemon?.close();
+      }
+    }
 
     // In local dev, return a hardcoded greeting if no messages exist yet
     if (process.env.NODE_ENV !== "production") {
@@ -235,6 +396,56 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const assistant = result[0] as Assistant;
+    const connectionMode = getAssistantConnectionMode();
+
+    if (connectionMode === "local") {
+      const socketPath = getLocalDaemonSocketPath();
+      const assistantConfig = getAssistantConfig(assistant);
+      const storedSessionId = getStoredLocalDaemonSessionId(assistantConfig);
+
+      let daemon: LocalDaemonClient | null = null;
+      try {
+        daemon = await LocalDaemonClient.connect(socketPath);
+        const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
+        if (sessionId !== storedSessionId) {
+          await persistLocalDaemonSessionId(
+            sql,
+            assistantId,
+            assistantConfig,
+            sessionId
+          );
+        }
+
+        const localResponse = await daemon.sendUserMessage(sessionId, content);
+        const timestamp = new Date().toISOString();
+        const assistantMessage =
+          localResponse.assistantText.length > 0
+            ? {
+                id: `local-${sessionId}-${Date.now()}`,
+                role: "assistant" as const,
+                content: localResponse.assistantText,
+                timestamp,
+              }
+            : null;
+
+        return NextResponse.json({
+          success: true,
+          connectionMode: "local",
+          sessionId,
+          ...(assistantMessage ? { assistantMessage } : {}),
+          message: "Message processed by local daemon",
+        });
+      } catch (error: unknown) {
+        console.error("Error sending local daemon message:", error);
+        return localDaemonErrorResponse(
+          error,
+          "Failed to send message to local daemon"
+        );
+      } finally {
+        daemon?.close();
+      }
+    }
+
     const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
       | { instanceName?: string; zone?: string }
       | undefined;
@@ -250,7 +461,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
       // Count user messages to determine which canned response to give
       const existingMessages = await getChatMessages(assistantId);
-      const userMessageCount = existingMessages.filter(m => m.role === "user").length;
+      const userMessageCount = existingMessages.filter(
+        (m: ChatMessage) => m.role === "user"
+      ).length;
 
       const { content: responseContent, action } = getCannedResponse(userMessageCount - 1);
 

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -73,6 +73,13 @@ function getAssistantConfig(assistant: Assistant): AssistantConfig {
   return config ?? {};
 }
 
+function toAssistantConfig(rawConfig: unknown): AssistantConfig {
+  if (!rawConfig || typeof rawConfig !== "object") {
+    return {};
+  }
+  return rawConfig as AssistantConfig;
+}
+
 function getStoredLocalDaemonSessionId(config: AssistantConfig): string | null {
   const localDaemonConfig = config.localDaemon;
   if (!localDaemonConfig || typeof localDaemonConfig !== "object") {
@@ -124,11 +131,32 @@ function withLocalDaemonSessionId(
   };
 }
 
-async function ensurePersistedLocalDaemonSessionId(
+async function loadAssistantConfig(
   sql: ReturnType<typeof getDb>,
-  daemon: LocalDaemonClient,
   assistantId: string
-): Promise<string> {
+): Promise<AssistantConfig> {
+  const rows = await sql.unsafe<{ configuration: unknown }[]>(
+    `
+      SELECT configuration
+      FROM assistants
+      WHERE id = $1
+    `,
+    [assistantId]
+  );
+
+  if (rows.length === 0) {
+    throw new Error("Agent not found");
+  }
+
+  return toAssistantConfig(rows[0]?.configuration);
+}
+
+async function tryPersistLocalDaemonSessionId(
+  sql: ReturnType<typeof getDb>,
+  assistantId: string,
+  expectedSessionId: string | null,
+  nextSessionId: string
+): Promise<boolean> {
   return sql.begin(async (tx) => {
     const rows = await tx.unsafe<{ configuration: unknown }[]>(
       `
@@ -144,30 +172,70 @@ async function ensurePersistedLocalDaemonSessionId(
       throw new Error("Agent not found");
     }
 
-    const rawConfig = rows[0]?.configuration;
-    const lockedConfig =
-      rawConfig && typeof rawConfig === "object"
-        ? (rawConfig as AssistantConfig)
-        : {};
+    const lockedConfig = toAssistantConfig(rows[0]?.configuration);
+    const lockedSessionId = getStoredLocalDaemonSessionId(lockedConfig);
 
-    const storedSessionId = getStoredLocalDaemonSessionId(lockedConfig);
-    const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
-
-    if (sessionId !== storedSessionId) {
-      const nextConfig = withLocalDaemonSessionId(lockedConfig, sessionId);
-      await tx.unsafe(
-        `
-          UPDATE assistants
-          SET configuration = $1::jsonb,
-              updated_at = NOW()
-          WHERE id = $2
-        `,
-        [JSON.stringify(nextConfig), assistantId]
-      );
+    if (lockedSessionId !== expectedSessionId) {
+      return false;
     }
 
-    return sessionId;
+    if (lockedSessionId === nextSessionId) {
+      return true;
+    }
+
+    const nextConfig = withLocalDaemonSessionId(lockedConfig, nextSessionId);
+    await tx.unsafe(
+      `
+        UPDATE assistants
+        SET configuration = $1::jsonb,
+            updated_at = NOW()
+        WHERE id = $2
+      `,
+      [JSON.stringify(nextConfig), assistantId]
+    );
+
+    return true;
   });
+}
+
+const MAX_LOCAL_DAEMON_SESSION_ATTEMPTS = 5;
+
+async function ensurePersistedLocalDaemonSessionId(
+  sql: ReturnType<typeof getDb>,
+  daemon: LocalDaemonClient,
+  assistantId: string,
+  initialConfig?: AssistantConfig
+): Promise<string> {
+  let expectedSessionId = getStoredLocalDaemonSessionId(
+    initialConfig ?? (await loadAssistantConfig(sql, assistantId))
+  );
+
+  for (let attempt = 0; attempt < MAX_LOCAL_DAEMON_SESSION_ATTEMPTS; attempt += 1) {
+    const sessionId = await ensureLocalDaemonSession(daemon, expectedSessionId);
+
+    if (sessionId === expectedSessionId) {
+      return sessionId;
+    }
+
+    const didPersist = await tryPersistLocalDaemonSessionId(
+      sql,
+      assistantId,
+      expectedSessionId,
+      sessionId
+    );
+
+    if (didPersist) {
+      return sessionId;
+    }
+
+    const latestConfig = await loadAssistantConfig(sql, assistantId);
+    expectedSessionId = getStoredLocalDaemonSessionId(latestConfig);
+  }
+
+  throw new LocalDaemonError(
+    "DAEMON_ERROR",
+    "Failed to establish a stable local daemon session"
+  );
 }
 
 function localDaemonErrorStatus(error: unknown): number {
@@ -436,6 +504,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (connectionMode === "local") {
       const socketPath = getLocalDaemonSocketPath();
+      const assistantConfig = getAssistantConfig(assistant);
 
       let daemon: LocalDaemonClient | null = null;
       try {
@@ -443,7 +512,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const sessionId = await ensurePersistedLocalDaemonSessionId(
           sql,
           daemon,
-          assistantId
+          assistantId,
+          assistantConfig
         );
 
         const localResponse = await daemon.sendUserMessage(sessionId, content);

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -210,23 +210,22 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (connectionMode === "local") {
       const socketPath = getLocalDaemonSocketPath();
-      const assistantConfig = getAssistantConfig(assistant);
-      const storedSessionId = getStoredLocalDaemonSessionId(assistantConfig);
+      const storedSessionId = getStoredLocalDaemonSessionId(
+        getAssistantConfig(assistant)
+      );
+
+      if (!storedSessionId) {
+        return NextResponse.json({
+          messages: [],
+          errors: [],
+          connectionMode: "local",
+        });
+      }
 
       let daemon: LocalDaemonClient | null = null;
       try {
         daemon = await LocalDaemonClient.connect(socketPath);
-        const sessionId = await ensureLocalDaemonSession(daemon, storedSessionId);
-        if (sessionId !== storedSessionId) {
-          await persistLocalDaemonSessionId(
-            sql,
-            assistantId,
-            assistantConfig,
-            sessionId
-          );
-        }
-
-        const history = await daemon.getHistory(sessionId);
+        const history = await daemon.getHistory(storedSessionId);
         const formattedMessages = history.map((msg, index) => ({
           id: `local-${msg.timestamp}-${index}`,
           role: msg.role,

--- a/web/src/app/api/assistants/[id]/start/route.ts
+++ b/web/src/app/api/assistants/[id]/start/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { startInstance } from "@/lib/gcp";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 export async function POST(request: Request, { params }: RouteParams) {
   try {
@@ -16,6 +19,17 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     if (result.length === 0) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    if (getAssistantConnectionMode() === "local") {
+      return NextResponse.json(
+        {
+          error:
+            "Start is not supported in local-daemon mode. Manage daemon lifecycle outside the web UI.",
+          connectionMode: "local",
+        },
+        { status: 501 }
+      );
     }
 
     const assistant = result[0] as Assistant;

--- a/web/src/app/api/assistants/[id]/stop/route.ts
+++ b/web/src/app/api/assistants/[id]/stop/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { Assistant, getDb } from "@/lib/db";
 import { stopInstance } from "@/lib/gcp";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
+
+export const runtime = "nodejs";
 
 export async function POST(request: Request, { params }: RouteParams) {
   try {
@@ -16,6 +19,17 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     if (result.length === 0) {
       return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    if (getAssistantConnectionMode() === "local") {
+      return NextResponse.json(
+        {
+          error:
+            "Stop is not supported in local-daemon mode. Manage daemon lifecycle outside the web UI.",
+          connectionMode: "local",
+        },
+        { status: 501 }
+      );
     }
 
     const assistant = result[0] as Assistant;

--- a/web/src/lib/assistant-connection.ts
+++ b/web/src/lib/assistant-connection.ts
@@ -1,0 +1,42 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type AssistantConnectionMode = "cloud" | "local";
+
+const DEFAULT_CONNECTION_MODE: AssistantConnectionMode = "cloud";
+
+function normalizeConnectionMode(
+  rawMode: string | undefined
+): AssistantConnectionMode {
+  const normalized = rawMode?.trim().toLowerCase();
+  if (normalized === "local") {
+    return "local";
+  }
+  return DEFAULT_CONNECTION_MODE;
+}
+
+function expandHomePath(pathValue: string): string {
+  if (pathValue === "~") {
+    return homedir();
+  }
+  if (pathValue.startsWith("~/")) {
+    return join(homedir(), pathValue.slice(2));
+  }
+  return pathValue;
+}
+
+export function getAssistantConnectionMode(): AssistantConnectionMode {
+  return normalizeConnectionMode(process.env.ASSISTANT_CONNECTION_MODE);
+}
+
+export function isLocalDaemonMode(): boolean {
+  return getAssistantConnectionMode() === "local";
+}
+
+export function getLocalDaemonSocketPath(): string {
+  const configuredPath = process.env.LOCAL_DAEMON_SOCKET_PATH?.trim();
+  if (!configuredPath) {
+    return join(homedir(), ".vellum", "vellum.sock");
+  }
+  return expandHomePath(configuredPath);
+}

--- a/web/src/lib/local-daemon-ipc.ts
+++ b/web/src/lib/local-daemon-ipc.ts
@@ -153,20 +153,24 @@ export class LocalDaemonClient {
     const socket = net.createConnection(socketPath);
     const client = new LocalDaemonClient(socket, socketPath);
 
-    await waitForSocketConnect(socket, socketPath, connectTimeoutMs);
+    try {
+      await waitForSocketConnect(socket, socketPath, connectTimeoutMs);
 
-    const handshakeMessage = await client.waitFor(
-      (msg) => msg.type === "session_info" || msg.type === "error",
-      handshakeTimeoutMs
-    );
+      const handshakeMessage = await client.waitFor(
+        (msg) => msg.type === "session_info" || msg.type === "error",
+        handshakeTimeoutMs
+      );
 
-    if (handshakeMessage.type === "error") {
-      const daemonMessage =
-        typeof handshakeMessage.message === "string"
-          ? handshakeMessage.message
-          : "Daemon handshake failed";
+      if (handshakeMessage.type === "error") {
+        const daemonMessage =
+          typeof handshakeMessage.message === "string"
+            ? handshakeMessage.message
+            : "Daemon handshake failed";
+        throw classifyDaemonError(daemonMessage);
+      }
+    } catch (error: unknown) {
       client.close();
-      throw classifyDaemonError(daemonMessage);
+      throw error;
     }
 
     return client;

--- a/web/src/lib/local-daemon-ipc.ts
+++ b/web/src/lib/local-daemon-ipc.ts
@@ -1,0 +1,575 @@
+import * as net from "node:net";
+import { once } from "node:events";
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 3000;
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+const USER_MESSAGE_TIMEOUT_MS = 120000;
+const MAX_BUFFER_BYTES = 1024 * 1024;
+
+type DaemonMessage = Record<string, unknown> & { type: string };
+
+export type LocalDaemonErrorCode =
+  | "UNREACHABLE"
+  | "TIMEOUT"
+  | "DAEMON_ERROR"
+  | "SESSION_NOT_FOUND"
+  | "BUSY"
+  | "PROTOCOL_ERROR";
+
+export class LocalDaemonError extends Error {
+  constructor(
+    public readonly code: LocalDaemonErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "LocalDaemonError";
+  }
+}
+
+export interface DaemonSessionInfo {
+  sessionId: string;
+  title: string;
+}
+
+export interface DaemonHistoryMessage {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: number;
+}
+
+export interface DaemonUsageUpdate {
+  inputTokens: number;
+  outputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedCost: number;
+  model: string;
+}
+
+export interface DaemonUserMessageResult {
+  assistantText: string;
+  usage: DaemonUsageUpdate | null;
+}
+
+interface Waiter {
+  predicate: (msg: DaemonMessage) => boolean;
+  resolve: (msg: DaemonMessage) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asDaemonMessage(value: unknown): DaemonMessage | null {
+  if (!isObject(value)) return null;
+  const type = value.type;
+  if (typeof type !== "string") return null;
+  return value as DaemonMessage;
+}
+
+function getErrorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return "Unknown error";
+}
+
+function classifyDaemonError(message: string): LocalDaemonError {
+  if (/already processing a message/i.test(message)) {
+    return new LocalDaemonError("BUSY", message);
+  }
+  if (/session .* not found/i.test(message)) {
+    return new LocalDaemonError("SESSION_NOT_FOUND", message);
+  }
+  return new LocalDaemonError("DAEMON_ERROR", message);
+}
+
+function toLocalDaemonError(
+  error: unknown,
+  fallbackMessage: string
+): LocalDaemonError {
+  if (error instanceof LocalDaemonError) {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (
+      nodeError.code === "ENOENT" ||
+      nodeError.code === "ECONNREFUSED" ||
+      nodeError.code === "EACCES" ||
+      nodeError.code === "EPERM"
+    ) {
+      return new LocalDaemonError("UNREACHABLE", error.message);
+    }
+    return new LocalDaemonError("DAEMON_ERROR", error.message);
+  }
+
+  return new LocalDaemonError("DAEMON_ERROR", fallbackMessage);
+}
+
+function parseSessionInfo(msg: DaemonMessage): DaemonSessionInfo {
+  const sessionId = msg.sessionId;
+  const title = msg.title;
+  if (typeof sessionId !== "string" || typeof title !== "string") {
+    throw new LocalDaemonError(
+      "PROTOCOL_ERROR",
+      "Daemon returned an invalid session_info payload"
+    );
+  }
+  return { sessionId, title };
+}
+
+export class LocalDaemonClient {
+  private readonly socket: net.Socket;
+  private readonly socketPath: string;
+  private closed = false;
+  private closeError: LocalDaemonError | null = null;
+  private buffer = "";
+  private queue: DaemonMessage[] = [];
+  private waiters: Waiter[] = [];
+
+  private constructor(socket: net.Socket, socketPath: string) {
+    this.socket = socket;
+    this.socketPath = socketPath;
+
+    this.socket.setEncoding("utf8");
+    this.socket.on("data", (chunk) => this.handleSocketData(chunk));
+    this.socket.on("error", (error) => this.handleSocketError(error));
+    this.socket.on("close", () => this.handleSocketClose());
+  }
+
+  static async connect(
+    socketPath: string,
+    options?: { connectTimeoutMs?: number; handshakeTimeoutMs?: number }
+  ): Promise<LocalDaemonClient> {
+    const connectTimeoutMs =
+      options?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    const handshakeTimeoutMs =
+      options?.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
+
+    const socket = net.createConnection(socketPath);
+    const client = new LocalDaemonClient(socket, socketPath);
+
+    await waitForSocketConnect(socket, socketPath, connectTimeoutMs);
+
+    const handshakeMessage = await client.waitFor(
+      (msg) => msg.type === "session_info" || msg.type === "error",
+      handshakeTimeoutMs
+    );
+
+    if (handshakeMessage.type === "error") {
+      const daemonMessage =
+        typeof handshakeMessage.message === "string"
+          ? handshakeMessage.message
+          : "Daemon handshake failed";
+      client.close();
+      throw classifyDaemonError(daemonMessage);
+    }
+
+    return client;
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const error =
+      this.closeError ??
+      new LocalDaemonError("UNREACHABLE", "Local daemon connection closed");
+    this.rejectAllWaiters(error);
+    this.socket.destroy();
+  }
+
+  async ping(timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<void> {
+    this.send({ type: "ping" });
+    const response = await this.waitFor(
+      (msg) => msg.type === "pong" || msg.type === "error",
+      timeoutMs
+    );
+
+    if (response.type === "error") {
+      const message =
+        typeof response.message === "string"
+          ? response.message
+          : "Daemon ping failed";
+      throw classifyDaemonError(message);
+    }
+  }
+
+  async createSession(
+    title?: string,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  ): Promise<DaemonSessionInfo> {
+    this.send({
+      type: "session_create",
+      ...(title ? { title } : {}),
+    });
+
+    const response = await this.waitFor(
+      (msg) => msg.type === "session_info" || msg.type === "error",
+      timeoutMs
+    );
+
+    if (response.type === "error") {
+      const message =
+        typeof response.message === "string"
+          ? response.message
+          : "Failed to create daemon session";
+      throw classifyDaemonError(message);
+    }
+
+    return parseSessionInfo(response);
+  }
+
+  async switchSession(
+    sessionId: string,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  ): Promise<DaemonSessionInfo> {
+    this.send({
+      type: "session_switch",
+      sessionId,
+    });
+
+    const response = await this.waitFor(
+      (msg) => msg.type === "session_info" || msg.type === "error",
+      timeoutMs
+    );
+
+    if (response.type === "error") {
+      const message =
+        typeof response.message === "string"
+          ? response.message
+          : `Failed to switch daemon session ${sessionId}`;
+      throw classifyDaemonError(message);
+    }
+
+    return parseSessionInfo(response);
+  }
+
+  async getHistory(
+    sessionId: string,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  ): Promise<DaemonHistoryMessage[]> {
+    this.send({
+      type: "history_request",
+      sessionId,
+    });
+
+    const response = await this.waitFor(
+      (msg) => msg.type === "history_response" || msg.type === "error",
+      timeoutMs
+    );
+
+    if (response.type === "error") {
+      const message =
+        typeof response.message === "string"
+          ? response.message
+          : `Failed to fetch history for session ${sessionId}`;
+      throw classifyDaemonError(message);
+    }
+
+    const rawMessages = Array.isArray(response.messages) ? response.messages : [];
+
+    return rawMessages
+      .map((entry): DaemonHistoryMessage | null => {
+        if (!isObject(entry)) return null;
+        const role = entry.role;
+        const text = entry.text;
+        const timestamp = entry.timestamp;
+        if (
+          (role !== "user" && role !== "assistant") ||
+          typeof text !== "string" ||
+          typeof timestamp !== "number"
+        ) {
+          return null;
+        }
+        return {
+          role,
+          text,
+          timestamp,
+        };
+      })
+      .filter((entry): entry is DaemonHistoryMessage => entry !== null);
+  }
+
+  async sendUserMessage(
+    sessionId: string,
+    content: string,
+    timeoutMs = USER_MESSAGE_TIMEOUT_MS
+  ): Promise<DaemonUserMessageResult> {
+    this.send({
+      type: "user_message",
+      sessionId,
+      content,
+    });
+
+    let assistantText = "";
+    let usage: DaemonUsageUpdate | null = null;
+
+    while (true) {
+      const message = await this.waitFor(() => true, timeoutMs);
+
+      switch (message.type) {
+        case "assistant_text_delta": {
+          if (typeof message.text === "string") {
+            assistantText += message.text;
+          }
+          break;
+        }
+        case "usage_update": {
+          const parsed = parseUsageUpdate(message);
+          if (parsed) {
+            usage = parsed;
+          }
+          break;
+        }
+        case "message_complete":
+          return {
+            assistantText: assistantText.trim(),
+            usage,
+          };
+        case "error": {
+          const daemonMessage =
+            typeof message.message === "string"
+              ? message.message
+              : "Daemon failed to process message";
+          throw classifyDaemonError(daemonMessage);
+        }
+        case "generation_cancelled":
+          throw new LocalDaemonError(
+            "DAEMON_ERROR",
+            "Daemon cancelled message generation"
+          );
+        default:
+          break;
+      }
+    }
+  }
+
+  private send(message: Record<string, unknown>): void {
+    if (this.closed || this.socket.destroyed) {
+      throw new LocalDaemonError(
+        "UNREACHABLE",
+        `Socket is closed (${this.socketPath})`
+      );
+    }
+    this.socket.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private waitFor(
+    predicate: (msg: DaemonMessage) => boolean,
+    timeoutMs: number
+  ): Promise<DaemonMessage> {
+    if (this.closed) {
+      throw this.closeError ??
+        new LocalDaemonError("UNREACHABLE", "Daemon connection is closed");
+    }
+
+    const queuedIndex = this.queue.findIndex(predicate);
+    if (queuedIndex >= 0) {
+      const [message] = this.queue.splice(queuedIndex, 1);
+      return Promise.resolve(message);
+    }
+
+    return new Promise<DaemonMessage>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.waiters = this.waiters.filter((waiter) => waiter !== entry);
+        reject(
+          new LocalDaemonError(
+            "TIMEOUT",
+            `Timed out waiting for daemon response after ${timeoutMs}ms`
+          )
+        );
+      }, timeoutMs);
+
+      const entry: Waiter = {
+        predicate,
+        resolve: (msg) => {
+          clearTimeout(timeout);
+          resolve(msg);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+        timeout,
+      };
+
+      this.waiters.push(entry);
+      this.flushWaiters();
+    });
+  }
+
+  private handleSocketData(chunk: Buffer | string): void {
+    if (this.closed) return;
+    this.buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+
+    if (Buffer.byteLength(this.buffer, "utf8") > MAX_BUFFER_BYTES) {
+      const error = new LocalDaemonError(
+        "PROTOCOL_ERROR",
+        "Daemon IPC buffer exceeded maximum size"
+      );
+      this.closeError = error;
+      this.close();
+      this.rejectAllWaiters(error);
+      return;
+    }
+
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+
+      const message = asDaemonMessage(parsed);
+      if (!message) continue;
+
+      if (message.type === "confirmation_request") {
+        this.autoDenyConfirmation(message);
+        continue;
+      }
+
+      this.queue.push(message);
+    }
+
+    this.flushWaiters();
+  }
+
+  private autoDenyConfirmation(message: DaemonMessage): void {
+    const requestId = message.requestId;
+    if (typeof requestId !== "string" || requestId.length === 0) {
+      return;
+    }
+
+    try {
+      this.send({
+        type: "confirmation_response",
+        requestId,
+        decision: "deny",
+      });
+    } catch {
+      // Best effort only.
+    }
+  }
+
+  private flushWaiters(): void {
+    if (this.waiters.length === 0 || this.queue.length === 0) {
+      return;
+    }
+
+    const pending = [...this.waiters];
+    for (const waiter of pending) {
+      const matchIndex = this.queue.findIndex(waiter.predicate);
+      if (matchIndex < 0) continue;
+
+      const [message] = this.queue.splice(matchIndex, 1);
+      this.waiters = this.waiters.filter((entry) => entry !== waiter);
+      waiter.resolve(message);
+    }
+  }
+
+  private handleSocketError(error: Error): void {
+    if (this.closed) return;
+    this.closeError = toLocalDaemonError(error, "Local daemon socket error");
+  }
+
+  private handleSocketClose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const error =
+      this.closeError ??
+      new LocalDaemonError("UNREACHABLE", "Local daemon socket closed");
+    this.rejectAllWaiters(error);
+  }
+
+  private rejectAllWaiters(error: LocalDaemonError): void {
+    const pending = [...this.waiters];
+    this.waiters = [];
+    for (const waiter of pending) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(error);
+    }
+  }
+}
+
+function parseUsageUpdate(message: DaemonMessage): DaemonUsageUpdate | null {
+  const inputTokens = message.inputTokens;
+  const outputTokens = message.outputTokens;
+  const totalInputTokens = message.totalInputTokens;
+  const totalOutputTokens = message.totalOutputTokens;
+  const estimatedCost = message.estimatedCost;
+  const model = message.model;
+
+  if (
+    typeof inputTokens !== "number" ||
+    typeof outputTokens !== "number" ||
+    typeof totalInputTokens !== "number" ||
+    typeof totalOutputTokens !== "number" ||
+    typeof estimatedCost !== "number" ||
+    typeof model !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalInputTokens,
+    totalOutputTokens,
+    estimatedCost,
+    model,
+  };
+}
+
+async function waitForSocketConnect(
+  socket: net.Socket,
+  socketPath: string,
+  timeoutMs: number
+): Promise<void> {
+  const timeout = setTimeout(() => {
+    socket.destroy(
+      new LocalDaemonError(
+        "TIMEOUT",
+        `Timed out connecting to daemon socket ${socketPath}`
+      )
+    );
+  }, timeoutMs);
+
+  try {
+    if (socket.readyState === "open") {
+      return;
+    }
+    await once(socket, "connect");
+  } catch (error: unknown) {
+    throw toLocalDaemonError(
+      error,
+      `Failed connecting to daemon socket ${socketPath}`
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function isLocalDaemonErrorWithCode(
+  error: unknown,
+  code: LocalDaemonErrorCode
+): boolean {
+  return error instanceof LocalDaemonError && error.code === code;
+}
+
+export function describeLocalDaemonError(error: unknown): string {
+  if (error instanceof LocalDaemonError) {
+    return error.message;
+  }
+  return getErrorMessage(error);
+}


### PR DESCRIPTION
## Summary
- add deployment-level assistant connection mode helpers (`ASSISTANT_CONNECTION_MODE`, `LOCAL_DAEMON_SOCKET_PATH`)
- add a local daemon IPC client over the Unix socket with handshake, timeouts, auto-deny for confirmations, and session/history/message operations
- add full local-mode routing behavior for assistant health/messages and strict unsupported responses for start/stop/ls/cat/logs
- persist per-assistant local daemon session IDs at `configuration.localDaemon.sessionId`
- update default editor template to show local-daemon connection status and hide start/stop controls in local mode
- document local daemon mode configuration and rollout scope in `web/README.md`

## Verification
- bunx tsc --noEmit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
