### PR TITLE
Add ~/.vellum SKILLS.md catalog support with lazy skill loading

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -1,0 +1,72 @@
+# Skills Support (`~/.vellum/skills`)
+
+Vellum Assistant supports a skills catalog at:
+
+- `~/.vellum/skills/SKILLS.md`
+
+Each skill lives in its own directory:
+
+- `~/.vellum/skills/<skill-id>/SKILL.md`
+
+## `SKILLS.md` Format
+
+`SKILLS.md` is a Markdown list of paths, one skill per list item, resolved relative to `~/.vellum/skills/`.
+
+Supported entry forms:
+
+- `- my-skill`
+- `- my-skill/SKILL.md`
+- `- [My Skill](my-skill)`
+
+Notes:
+
+- Absolute paths are ignored.
+- Paths resolving outside `~/.vellum/skills/` are ignored.
+- Duplicate entries are deduplicated (first entry wins).
+- If `SKILLS.md` exists, it is authoritative for which skills are exposed.
+- If `SKILLS.md` is missing, skills are auto-discovered from `~/.vellum/skills/*/SKILL.md`.
+
+## `SKILL.md` Requirements
+
+Each `SKILL.md` must include YAML frontmatter with:
+
+- `name`
+- `description`
+
+Example:
+
+```md
+---
+name: "Release Checklist"
+description: "Run pre-release validation and deployment checks."
+---
+
+1. Run tests
+2. Build artifacts
+3. Verify release notes
+```
+
+Skills missing valid frontmatter are skipped.
+
+## Runtime Behavior
+
+- System prompt appends a **Skills Catalog** with skill id, name, and description.
+- The assistant can lazily load full skill instructions with the `skill_load` tool.
+
+## `skill_load` Tool
+
+Tool schema:
+
+```json
+{
+  "skill": "string"
+}
+```
+
+Resolution order:
+
+1. Exact skill id
+2. Exact skill name (case-insensitive)
+3. Unique skill id prefix
+
+If the selector is ambiguous or missing, `skill_load` returns an error.

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -69,6 +69,13 @@ describe('Permission Checker', () => {
       });
     });
 
+    describe('skill_load', () => {
+      test('skill_load is always low risk', async () => {
+        const risk = await classifyRisk('skill_load', { skill: 'release-checklist' });
+        expect(risk).toBe(RiskLevel.Low);
+      });
+    });
+
     // shell commands - low risk
     describe('shell — low risk', () => {
       test('ls is low risk', async () => {

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -275,6 +275,19 @@ describe('Permission Checker', () => {
       expect(result.matchedRule).toBeDefined();
     });
 
+    test('deny rule for skill_load matches specific skill selectors', async () => {
+      addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
+      const result = await check('skill_load', { skill: 'dangerous-skill' }, '/tmp');
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toContain('deny rule');
+    });
+
+    test('non-matching skill_load deny rule does not block other skills', async () => {
+      addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
+      const result = await check('skill_load', { skill: 'safe-skill' }, '/tmp');
+      expect(result.decision).toBe('allow');
+    });
+
     test('high risk ignores allow rules', async () => {
       addRule('shell', 'sudo *', 'everywhere');
       const result = await check('shell', { command: 'sudo rm -rf /' }, '/tmp');

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, beforeEach, mock } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -28,6 +28,15 @@ import { classifyRisk, check, generateAllowlistOptions, generateScopeOptions } f
 import { RiskLevel } from '../permissions/types.js';
 import { addRule, clearCache } from '../permissions/trust-store.js';
 
+function writeSkill(skillId: string, name: string, description = 'Test skill'): void {
+  const skillDir = join(checkerTestDir, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nSkill body.\n`,
+  );
+}
+
 describe('Permission Checker', () => {
   beforeAll(async () => {
     // Warm up the shell parser (loads WASM)
@@ -38,6 +47,7 @@ describe('Permission Checker', () => {
     // Reset trust-store state between tests
     clearCache();
     try { rmSync(join(checkerTestDir, 'trust.json')); } catch { /* may not exist */ }
+    try { rmSync(join(checkerTestDir, 'skills'), { recursive: true, force: true }); } catch { /* may not exist */ }
   });
 
   // ── classifyRisk ────────────────────────────────────────────────
@@ -286,6 +296,20 @@ describe('Permission Checker', () => {
       addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
       const result = await check('skill_load', { skill: 'safe-skill' }, '/tmp');
       expect(result.decision).toBe('allow');
+    });
+
+    test('skill_load deny rule blocks aliases that resolve to the same skill id', async () => {
+      writeSkill('dangerous-skill', 'Dangerous Skill');
+      addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
+
+      const byName = await check('skill_load', { skill: 'Dangerous Skill' }, '/tmp');
+      expect(byName.decision).toBe('deny');
+
+      const byPrefix = await check('skill_load', { skill: 'danger' }, '/tmp');
+      expect(byPrefix.decision).toBe('deny');
+
+      const byWhitespace = await check('skill_load', { skill: '  dangerous-skill  ' }, '/tmp');
+      expect(byWhitespace.decision).toBe('deny');
     });
 
     test('high risk ignores allow rules', async () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -19,8 +19,11 @@ mock.module('../util/logger.js', () => ({
 
 mock.module('../util/platform.js', () => ({
   getDataDir: () => TEST_DIR,
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => {
     if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const logsDir = join(TEST_DIR, 'logs');
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
   },
   isMacOS: () => false,
   isLinux: () => false,
@@ -264,9 +267,10 @@ describe('AssistantConfigSchema', () => {
 describe('loadConfig with schema validation', () => {
   beforeEach(() => {
     if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
+      rmSync(TEST_DIR, { recursive: true, force: true });
     }
     mkdirSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_DIR, 'logs'), { recursive: true });
     _setStorePath(join(TEST_DIR, 'keys.enc'));
     _setBackend('encrypted');
     invalidateConfigCache();
@@ -276,12 +280,6 @@ describe('loadConfig with schema validation', () => {
     _setStorePath(null);
     _setBackend(undefined);
     invalidateConfigCache();
-  });
-
-  afterAll(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
   });
 
   test('loads valid config', () => {

--- a/assistant/src/__tests__/key-migration.test.ts
+++ b/assistant/src/__tests__/key-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -19,8 +19,11 @@ mock.module('../util/logger.js', () => ({
 
 mock.module('../util/platform.js', () => ({
   getDataDir: () => TEST_DIR,
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => {
     if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+    const logsDir = join(TEST_DIR, 'logs');
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
   },
   isMacOS: () => false,
   isLinux: () => false,
@@ -39,9 +42,10 @@ import { getSecureKey } from '../security/secure-keys.js';
 describe('key migration', () => {
   beforeEach(() => {
     if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
+      rmSync(TEST_DIR, { recursive: true, force: true });
     }
     mkdirSync(TEST_DIR, { recursive: true });
+    mkdirSync(join(TEST_DIR, 'logs'), { recursive: true });
     _setStorePath(STORE_PATH);
     _setBackend('encrypted');
     invalidateConfigCache();
@@ -51,12 +55,6 @@ describe('key migration', () => {
     _setStorePath(null);
     _setBackend(undefined);
     invalidateConfigCache();
-  });
-
-  afterAll(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true });
-    }
   });
 
   test('migrates plaintext apiKeys from config.json to secure storage', () => {

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_DIR = join(tmpdir(), `vellum-skill-load-tool-test-${crypto.randomUUID()}`);
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+await import('../tools/skills/load.js');
+const { getTool } = await import('../tools/registry.js');
+
+function writeSkill(skillId: string, name: string, description: string, body: string): void {
+  const skillDir = join(TEST_DIR, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
+  );
+}
+
+async function executeSkillLoad(input: Record<string, unknown>): Promise<{ content: string; isError: boolean }> {
+  const tool = getTool('skill_load');
+  if (!tool) throw new Error('skill_load tool was not registered');
+
+  const result = await tool.execute(input, {
+    workingDir: '/tmp',
+    sessionId: 'session-1',
+    conversationId: 'conversation-1',
+  });
+  return { content: result.content, isError: result.isError };
+}
+
+describe('skill_load tool', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('loads a skill by exact id', async () => {
+    writeSkill('release-checklist', 'Release Checklist', 'Runs release checks', '1. Run tests');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- release-checklist\n');
+
+    const result = await executeSkillLoad({ skill: 'release-checklist' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Skill: Release Checklist');
+    expect(result.content).toContain('ID: release-checklist');
+    expect(result.content).toContain('1. Run tests');
+    expect(result.content).not.toContain('name: "Release Checklist"');
+  });
+
+  test('loads a skill by exact name (case-insensitive)', async () => {
+    writeSkill('oncall', 'Oncall Runbook', 'Handles incidents', 'Page primary responder');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- oncall\n');
+
+    const result = await executeSkillLoad({ skill: 'oncall runbook' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Skill: Oncall Runbook');
+    expect(result.content).toContain('Page primary responder');
+  });
+
+  test('loads a skill by unique id prefix', async () => {
+    writeSkill('incident-response', 'Incident Response', 'Triage incidents', 'Run triage checklist');
+    writeSkill('release-checklist', 'Release Checklist', 'Release flow', 'Run release checklist');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- incident-response\n- release-checklist\n');
+
+    const result = await executeSkillLoad({ skill: 'incident' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('ID: incident-response');
+  });
+
+  test('returns an error when name resolution is ambiguous', async () => {
+    writeSkill('skill-a', 'Shared Name', 'First', 'Body A');
+    writeSkill('skill-b', 'Shared Name', 'Second', 'Body B');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- skill-a\n- skill-b\n');
+
+    const result = await executeSkillLoad({ skill: 'Shared Name' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Ambiguous skill name');
+  });
+
+  test('returns an error when skill is missing', async () => {
+    writeSkill('existing', 'Existing Skill', 'Exists', 'Body');
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- existing\n');
+
+    const result = await executeSkillLoad({ skill: 'does-not-exist' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No skill matched');
+  });
+});

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -95,6 +95,25 @@ describe('skills catalog loading', () => {
     expect(catalog).toHaveLength(0);
   });
 
+  test('rejects symlinked SKILL.md files that point outside ~/.vellum/skills', () => {
+    const linkedSkillDir = join(TEST_DIR, 'skills', 'linked-file-skill');
+    mkdirSync(linkedSkillDir, { recursive: true });
+
+    const outsideDir = join(TEST_DIR, 'outside');
+    mkdirSync(outsideDir, { recursive: true });
+    const externalSkillFile = join(outsideDir, 'external-skill.md');
+    writeFileSync(
+      externalSkillFile,
+      '---\nname: "External File Skill"\ndescription: "Outside skills root."\n---\n\nDo not load.\n',
+    );
+
+    symlinkSync(externalSkillFile, join(linkedSkillDir, 'SKILL.md'));
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- linked-file-skill\n');
+
+    const catalog = loadSkillCatalog();
+    expect(catalog).toHaveLength(0);
+  });
+
   test('uses SKILLS.md ordering when index exists', () => {
     writeSkill('first', 'First Skill', 'First');
     writeSkill('second', 'Second Skill', 'Second');

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -78,6 +78,21 @@ describe('skills catalog loading', () => {
 
     const catalog = loadSkillCatalog();
     expect(catalog.map((skill) => skill.id)).toEqual(['safe']);
+  });
+
+  test('rejects symlinked SKILLS.md entries that point outside ~/.vellum/skills', () => {
+    const externalSkillDir = join(TEST_DIR, 'outside', 'external-skill');
+    mkdirSync(externalSkillDir, { recursive: true });
+    writeFileSync(
+      join(externalSkillDir, 'SKILL.md'),
+      '---\nname: "External Skill"\ndescription: "Outside skills root."\n---\n\nDo not load.\n',
+    );
+
+    symlinkSync(externalSkillDir, join(TEST_DIR, 'skills', 'linked-skill'));
+    writeFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), '- linked-skill\n');
+
+    const catalog = loadSkillCatalog();
+    expect(catalog).toHaveLength(0);
   });
 
   test('uses SKILLS.md ordering when index exists', () => {

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_DIR = join(tmpdir(), `vellum-skills-test-${crypto.randomUUID()}`);
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { loadSkillCatalog } = await import('../config/skills.js');
+
+function writeSkill(skillId: string, name: string, description: string, body: string = 'Skill body'): void {
+  const skillDir = join(TEST_DIR, 'skills', skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
+  );
+}
+
+describe('skills catalog loading', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('parses markdown list path entries from SKILLS.md', () => {
+    writeSkill('alpha', 'Alpha Skill', 'First skill');
+    writeSkill('beta', 'Beta Skill', 'Second skill');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- alpha\n- beta/SKILL.md\n',
+    );
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(['alpha', 'beta']);
+  });
+
+  test('resolves markdown links from SKILLS.md', () => {
+    writeSkill('lint', 'Lint Skill', 'Runs lint checks');
+    writeSkill('test', 'Test Skill', 'Runs test checks');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- [Lint](lint)\n- [Tests](test)\n',
+    );
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(['lint', 'test']);
+  });
+
+  test('rejects SKILLS.md entries that resolve outside ~/.vellum/skills', () => {
+    writeSkill('safe', 'Safe Skill', 'Safe skill');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- ../escape\n- /tmp/absolute\n- safe\n',
+    );
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(['safe']);
+  });
+
+  test('uses SKILLS.md ordering when index exists', () => {
+    writeSkill('first', 'First Skill', 'First');
+    writeSkill('second', 'Second Skill', 'Second');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- second\n- first\n',
+    );
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(['second', 'first']);
+  });
+
+  test('falls back to auto-discovery when SKILLS.md is missing', () => {
+    writeSkill('zeta', 'Zeta Skill', 'Zeta');
+    writeSkill('alpha', 'Alpha Skill', 'Alpha');
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(['alpha', 'zeta']);
+  });
+
+  test('treats SKILLS.md as authoritative when present', () => {
+    writeSkill('available', 'Available Skill', 'Present on disk');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- ../invalid-only\n',
+    );
+
+    const catalog = loadSkillCatalog();
+    expect(catalog).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -20,6 +20,12 @@ mock.module('../util/platform.js', () => ({
   isWindows: () => process.platform === 'win32',
 }));
 
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
 // Import after mock
 const { buildSystemPrompt } = await import('../config/system-prompt.js');
 const { DEFAULT_SYSTEM_PROMPT } = await import('../config/defaults.js');
@@ -86,5 +92,44 @@ describe('buildSystemPrompt', () => {
     writeFileSync(join(TEST_DIR, 'SOUL.md'), '\n  Be kind  \n\n');
     const result = buildSystemPrompt();
     expect(result).toBe('Be kind');
+  });
+
+  test('appends skills catalog when skills are configured', () => {
+    const skillsDir = join(TEST_DIR, 'skills');
+    mkdirSync(join(skillsDir, 'release-checklist'), { recursive: true });
+    writeFileSync(
+      join(skillsDir, 'release-checklist', 'SKILL.md'),
+      '---\nname: "Release Checklist"\ndescription: "Deployment checks."\n---\n\nRun checks.\n',
+    );
+    writeFileSync(join(skillsDir, 'SKILLS.md'), '- release-checklist\n');
+
+    const result = buildSystemPrompt('Custom config prompt');
+    expect(result).toContain('Custom config prompt');
+    expect(result).toContain('## Skills Catalog');
+    expect(result).toContain('`release-checklist` - Release Checklist: Deployment checks.');
+    expect(result).toContain('call the `skill_load` tool');
+  });
+
+  test('keeps SOUL.md and IDENTITY.md additive with skills', () => {
+    const skillsDir = join(TEST_DIR, 'skills');
+    mkdirSync(join(skillsDir, 'incident-response'), { recursive: true });
+    writeFileSync(
+      join(skillsDir, 'incident-response', 'SKILL.md'),
+      '---\nname: "Incident Response"\ndescription: "Triage and mitigation."\n---\n\nFollow runbook.\n',
+    );
+    writeFileSync(join(skillsDir, 'SKILLS.md'), '- incident-response\n');
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'Identity content');
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), 'Soul content');
+
+    const result = buildSystemPrompt('Fallback');
+    expect(result).toContain('Identity content\n\nSoul content');
+    expect(result).toContain('## Skills Catalog');
+    expect(result.indexOf('Soul content')).toBeLessThan(result.indexOf('## Skills Catalog'));
+  });
+
+  test('omits skills catalog when no skills are available', () => {
+    const result = buildSystemPrompt('No skills prompt');
+    expect(result).toBe('No skills prompt');
+    expect(result).not.toContain('## Skills Catalog');
   });
 });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -45,11 +45,6 @@ describe('Trust Store', () => {
     clearCache();
     const trustPath = join(testDir, 'trust.json');
     try { rmSync(trustPath); } catch { /* may not exist */ }
-  });
-
-  afterAll(() => {
-    // Clean up temp directory
-    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
   });
 
   // ── addRule ─────────────────────────────────────────────────────

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -24,6 +24,11 @@ export interface SkillLookupResult {
   error?: string;
 }
 
+export interface SkillSelectorResult {
+  skill?: SkillSummary;
+  error?: string;
+}
+
 export function getSkillsDir(): string {
   return join(getDataDir(), 'skills');
 }
@@ -265,7 +270,7 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   return { skill: loaded };
 }
 
-export function loadSkillBySelector(selector: string): SkillLookupResult {
+export function resolveSkillSelector(selector: string): SkillSelectorResult {
   const needle = selector.trim();
   if (!needle) {
     return { error: 'Skill selector is required and must be a non-empty string.' };
@@ -278,14 +283,14 @@ export function loadSkillBySelector(selector: string): SkillLookupResult {
 
   const exactIdMatch = catalog.find((skill) => skill.id === needle);
   if (exactIdMatch) {
-    return loadSkillDefinition(exactIdMatch);
+    return { skill: exactIdMatch };
   }
 
   const exactNameMatches = catalog.filter(
     (skill) => skill.name.toLowerCase() === needle.toLowerCase(),
   );
   if (exactNameMatches.length === 1) {
-    return loadSkillDefinition(exactNameMatches[0]);
+    return { skill: exactNameMatches[0] };
   }
   if (exactNameMatches.length > 1) {
     const ids = exactNameMatches.map((skill) => skill.id).join(', ');
@@ -294,7 +299,7 @@ export function loadSkillBySelector(selector: string): SkillLookupResult {
 
   const idPrefixMatches = catalog.filter((skill) => skill.id.startsWith(needle));
   if (idPrefixMatches.length === 1) {
-    return loadSkillDefinition(idPrefixMatches[0]);
+    return { skill: idPrefixMatches[0] };
   }
   if (idPrefixMatches.length > 1) {
     const ids = idPrefixMatches.map((skill) => skill.id).join(', ');
@@ -303,4 +308,12 @@ export function loadSkillBySelector(selector: string): SkillLookupResult {
 
   const knownSkills = catalog.map((skill) => skill.id).join(', ');
   return { error: `No skill matched "${needle}". Available skills: ${knownSkills}` };
+}
+
+export function loadSkillBySelector(selector: string): SkillLookupResult {
+  const resolved = resolveSkillSelector(selector);
+  if (!resolved.skill) {
+    return { error: resolved.error ?? 'Failed to resolve skill selector.' };
+  }
+  return loadSkillDefinition(resolved.skill);
 }

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1,0 +1,280 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { getDataDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('skills');
+
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  directoryPath: string;
+  skillFilePath: string;
+}
+
+export interface SkillDefinition extends SkillSummary {
+  body: string;
+}
+
+export interface SkillLookupResult {
+  skill?: SkillDefinition;
+  error?: string;
+}
+
+export function getSkillsDir(): string {
+  return join(getDataDir(), 'skills');
+}
+
+function getSkillsIndexPath(skillsDir: string): string {
+  return join(skillsDir, 'SKILLS.md');
+}
+
+interface ParsedFrontmatter {
+  name: string;
+  description: string;
+  body: string;
+}
+
+function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontmatter | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) {
+    log.warn({ skillFilePath }, 'Skipping skill without YAML frontmatter');
+    return null;
+  }
+
+  const frontmatter = match[1];
+  const fields: Record<string, string> = {};
+  for (const line of frontmatter.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith('\'') && value.endsWith('\''))
+    ) {
+      value = value.slice(1, -1);
+    }
+    fields[key] = value;
+  }
+
+  const name = fields.name?.trim();
+  const description = fields.description?.trim();
+  if (!name || !description) {
+    log.warn({ skillFilePath }, 'Skipping skill missing required frontmatter keys "name" and/or "description"');
+    return null;
+  }
+
+  return {
+    name,
+    description,
+    body: content.slice(match[0].length).trim(),
+  };
+}
+
+function readSkillFromDirectory(directoryPath: string): SkillDefinition | null {
+  const skillFilePath = join(directoryPath, 'SKILL.md');
+  if (!existsSync(skillFilePath)) {
+    log.warn({ directoryPath }, 'Skipping skill directory without SKILL.md');
+    return null;
+  }
+
+  try {
+    const stat = statSync(skillFilePath);
+    if (!stat.isFile()) {
+      log.warn({ skillFilePath }, 'Skipping skill path because SKILL.md is not a file');
+      return null;
+    }
+
+    const content = readFileSync(skillFilePath, 'utf-8');
+    const parsed = parseFrontmatter(content, skillFilePath);
+    if (!parsed) return null;
+
+    return {
+      id: basename(directoryPath),
+      name: parsed.name,
+      description: parsed.description,
+      directoryPath,
+      skillFilePath,
+      body: parsed.body,
+    };
+  } catch (err) {
+    log.warn({ err, skillFilePath }, 'Failed to read skill file');
+    return null;
+  }
+}
+
+function parseIndexEntry(line: string): string | null {
+  const bulletMatch = line.trim().match(/^[-*]\s+(.+)$/);
+  if (!bulletMatch) return null;
+
+  let entry = bulletMatch[1].trim();
+  const markdownLinkMatch = entry.match(/^\[[^\]]+\]\(([^)]+)\)$/);
+  if (markdownLinkMatch) {
+    entry = markdownLinkMatch[1].trim();
+  }
+
+  if (entry.startsWith('`') && entry.endsWith('`')) {
+    entry = entry.slice(1, -1).trim();
+  }
+
+  return entry.length > 0 ? entry : null;
+}
+
+function resolveIndexEntryToDirectory(skillsDir: string, entry: string): string | null {
+  if (isAbsolute(entry)) {
+    log.warn({ entry }, 'Skipping SKILLS.md entry because absolute paths are not allowed');
+    return null;
+  }
+
+  const resolvedEntryPath = resolve(skillsDir, entry);
+  const resolvedDirectory = basename(resolvedEntryPath).toLowerCase() === 'skill.md'
+    ? dirname(resolvedEntryPath)
+    : resolvedEntryPath;
+
+  const relativePath = relative(skillsDir, resolvedDirectory);
+  if (relativePath.length === 0) {
+    log.warn({ entry }, 'Skipping SKILLS.md entry that resolves to the skills root');
+    return null;
+  }
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    log.warn({ entry, resolvedDirectory }, 'Skipping SKILLS.md entry that resolves outside ~/.vellum/skills');
+    return null;
+  }
+
+  return resolvedDirectory;
+}
+
+function getIndexedSkillDirectories(skillsDir: string): string[] | null {
+  const indexPath = getSkillsIndexPath(skillsDir);
+  if (!existsSync(indexPath)) return null;
+
+  let rawIndex = '';
+  try {
+    rawIndex = readFileSync(indexPath, 'utf-8');
+  } catch (err) {
+    log.warn({ err, indexPath }, 'Failed to read SKILLS.md; treating as empty catalog');
+    return [];
+  }
+
+  const directories: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of rawIndex.split(/\r?\n/)) {
+    const parsedEntry = parseIndexEntry(line);
+    if (!parsedEntry) continue;
+
+    const directory = resolveIndexEntryToDirectory(skillsDir, parsedEntry);
+    if (!directory || seen.has(directory)) continue;
+
+    seen.add(directory);
+    directories.push(directory);
+  }
+
+  return directories;
+}
+
+function discoverSkillDirectories(skillsDir: string): string[] {
+  if (!existsSync(skillsDir)) return [];
+
+  const dirs: string[] = [];
+  try {
+    const entries = readdirSync(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const directoryPath = join(skillsDir, entry.name);
+      if (existsSync(join(directoryPath, 'SKILL.md'))) {
+        dirs.push(directoryPath);
+      }
+    }
+  } catch (err) {
+    log.warn({ err, skillsDir }, 'Failed to discover skill directories');
+    return [];
+  }
+
+  return dirs.sort((a, b) => a.localeCompare(b));
+}
+
+export function loadSkillCatalog(): SkillSummary[] {
+  const skillsDir = getSkillsDir();
+  const indexedDirectories = getIndexedSkillDirectories(skillsDir);
+  const directories = indexedDirectories ?? discoverSkillDirectories(skillsDir);
+
+  const catalog: SkillSummary[] = [];
+  const seenIds = new Set<string>();
+
+  for (const directory of directories) {
+    const skill = readSkillFromDirectory(directory);
+    if (!skill) continue;
+
+    if (seenIds.has(skill.id)) {
+      log.warn({ id: skill.id, directory }, 'Skipping duplicate skill id');
+      continue;
+    }
+
+    seenIds.add(skill.id);
+    catalog.push({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      directoryPath: skill.directoryPath,
+      skillFilePath: skill.skillFilePath,
+    });
+  }
+
+  return catalog;
+}
+
+function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
+  const loaded = readSkillFromDirectory(skill.directoryPath);
+  if (!loaded) {
+    return { error: `Failed to load SKILL.md for "${skill.id}"` };
+  }
+  return { skill: loaded };
+}
+
+export function loadSkillBySelector(selector: string): SkillLookupResult {
+  const needle = selector.trim();
+  if (!needle) {
+    return { error: 'Skill selector is required and must be a non-empty string.' };
+  }
+
+  const catalog = loadSkillCatalog();
+  if (catalog.length === 0) {
+    return { error: 'No skills are available. Configure ~/.vellum/skills/SKILLS.md or add skill directories.' };
+  }
+
+  const exactIdMatch = catalog.find((skill) => skill.id === needle);
+  if (exactIdMatch) {
+    return loadSkillDefinition(exactIdMatch);
+  }
+
+  const exactNameMatches = catalog.filter(
+    (skill) => skill.name.toLowerCase() === needle.toLowerCase(),
+  );
+  if (exactNameMatches.length === 1) {
+    return loadSkillDefinition(exactNameMatches[0]);
+  }
+  if (exactNameMatches.length > 1) {
+    const ids = exactNameMatches.map((skill) => skill.id).join(', ');
+    return { error: `Ambiguous skill name "${needle}". Matching IDs: ${ids}` };
+  }
+
+  const idPrefixMatches = catalog.filter((skill) => skill.id.startsWith(needle));
+  if (idPrefixMatches.length === 1) {
+    return loadSkillDefinition(idPrefixMatches[0]);
+  }
+  if (idPrefixMatches.length > 1) {
+    const ids = idPrefixMatches.map((skill) => skill.id).join(', ');
+    return { error: `Ambiguous skill id prefix "${needle}". Matching IDs: ${ids}` };
+  }
+
+  const knownSkills = catalog.map((skill) => skill.id).join(', ');
+  return { error: `No skill matched "${needle}". Available skills: ${knownSkills}` };
+}

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
@@ -138,13 +138,21 @@ function resolveIndexEntryToDirectory(skillsDir: string, entry: string): string 
     ? dirname(resolvedEntryPath)
     : resolvedEntryPath;
 
-  const relativePath = relative(skillsDir, resolvedDirectory);
+  const boundaryRoot = existsSync(skillsDir) ? realpathSync(skillsDir) : resolve(skillsDir);
+  const boundaryCandidate = existsSync(resolvedDirectory)
+    ? realpathSync(resolvedDirectory)
+    : resolvedDirectory;
+
+  const relativePath = relative(boundaryRoot, boundaryCandidate);
   if (relativePath.length === 0) {
     log.warn({ entry }, 'Skipping SKILLS.md entry that resolves to the skills root');
     return null;
   }
   if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
-    log.warn({ entry, resolvedDirectory }, 'Skipping SKILLS.md entry that resolves outside ~/.vellum/skills');
+    log.warn(
+      { entry, resolvedDirectory: boundaryCandidate },
+      'Skipping SKILLS.md entry that resolves outside ~/.vellum/skills',
+    );
     return null;
   }
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -78,7 +78,20 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
   };
 }
 
-function readSkillFromDirectory(directoryPath: string): SkillDefinition | null {
+function getCanonicalPath(path: string): string {
+  return existsSync(path) ? realpathSync(path) : resolve(path);
+}
+
+function getRelativeToSkillsRoot(skillsDir: string, candidatePath: string): string {
+  return relative(getCanonicalPath(skillsDir), getCanonicalPath(candidatePath));
+}
+
+function isOutsideSkillsRoot(skillsDir: string, candidatePath: string): boolean {
+  const relativePath = getRelativeToSkillsRoot(skillsDir, candidatePath);
+  return relativePath.startsWith('..') || isAbsolute(relativePath);
+}
+
+function readSkillFromDirectory(directoryPath: string, skillsDir: string): SkillDefinition | null {
   const skillFilePath = join(directoryPath, 'SKILL.md');
   if (!existsSync(skillFilePath)) {
     log.warn({ directoryPath }, 'Skipping skill directory without SKILL.md');
@@ -86,9 +99,19 @@ function readSkillFromDirectory(directoryPath: string): SkillDefinition | null {
   }
 
   try {
+    if (isOutsideSkillsRoot(skillsDir, directoryPath)) {
+      log.warn({ directoryPath }, 'Skipping skill directory that resolves outside ~/.vellum/skills');
+      return null;
+    }
+
     const stat = statSync(skillFilePath);
     if (!stat.isFile()) {
       log.warn({ skillFilePath }, 'Skipping skill path because SKILL.md is not a file');
+      return null;
+    }
+
+    if (isOutsideSkillsRoot(skillsDir, skillFilePath)) {
+      log.warn({ skillFilePath }, 'Skipping SKILL.md that resolves outside ~/.vellum/skills');
       return null;
     }
 
@@ -138,19 +161,14 @@ function resolveIndexEntryToDirectory(skillsDir: string, entry: string): string 
     ? dirname(resolvedEntryPath)
     : resolvedEntryPath;
 
-  const boundaryRoot = existsSync(skillsDir) ? realpathSync(skillsDir) : resolve(skillsDir);
-  const boundaryCandidate = existsSync(resolvedDirectory)
-    ? realpathSync(resolvedDirectory)
-    : resolvedDirectory;
-
-  const relativePath = relative(boundaryRoot, boundaryCandidate);
+  const relativePath = getRelativeToSkillsRoot(skillsDir, resolvedDirectory);
   if (relativePath.length === 0) {
     log.warn({ entry }, 'Skipping SKILLS.md entry that resolves to the skills root');
     return null;
   }
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+  if (isOutsideSkillsRoot(skillsDir, resolvedDirectory)) {
     log.warn(
-      { entry, resolvedDirectory: boundaryCandidate },
+      { entry, resolvedDirectory: getCanonicalPath(resolvedDirectory) },
       'Skipping SKILLS.md entry that resolves outside ~/.vellum/skills',
     );
     return null;
@@ -218,7 +236,7 @@ export function loadSkillCatalog(): SkillSummary[] {
   const seenIds = new Set<string>();
 
   for (const directory of directories) {
-    const skill = readSkillFromDirectory(directory);
+    const skill = readSkillFromDirectory(directory, skillsDir);
     if (!skill) continue;
 
     if (seenIds.has(skill.id)) {
@@ -240,7 +258,7 @@ export function loadSkillCatalog(): SkillSummary[] {
 }
 
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
-  const loaded = readSkillFromDirectory(skill.directoryPath);
+  const loaded = readSkillFromDirectory(skill.directoryPath, getSkillsDir());
   if (!loaded) {
     return { error: `Failed to load SKILL.md for "${skill.id}"` };
   }

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -3,19 +3,21 @@ import { join } from 'node:path';
 import { getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { DEFAULT_SYSTEM_PROMPT } from './defaults.js';
+import { loadSkillCatalog, type SkillSummary } from './skills.js';
 
 const log = getLogger('system-prompt');
 
 /**
- * Build the system prompt by composing optional SOUL.md and IDENTITY.md files
- * from ~/.vellum/. Falls back to the config systemPrompt or DEFAULT_SYSTEM_PROMPT.
+ * Build the system prompt from ~/.vellum prompt files and configured fallback,
+ * then append a generated skills catalog (if any skills are available).
  *
  * Priority:
- *   1. If SOUL.md and/or IDENTITY.md exist, compose from those files
- *   2. If config.systemPrompt is set, use it
- *   3. Otherwise, use DEFAULT_SYSTEM_PROMPT
+ *   1. Base prompt: SOUL.md and/or IDENTITY.md when present
+ *   2. Base prompt fallback: config.systemPrompt
+ *   3. Base prompt fallback: DEFAULT_SYSTEM_PROMPT
+ *   4. Append skills catalog from ~/.vellum/skills
  *
- * When both SOUL.md and IDENTITY.md exist, the prompt is composed as:
+ * When both IDENTITY.md and SOUL.md exist, the base prompt is composed as:
  *   IDENTITY.md content + "\n\n" + SOUL.md content
  */
 export function buildSystemPrompt(configSystemPrompt?: string): string {
@@ -26,14 +28,16 @@ export function buildSystemPrompt(configSystemPrompt?: string): string {
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
 
+  let basePrompt = configSystemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+
   if (identity || soul) {
     const parts: string[] = [];
     if (identity) parts.push(identity);
     if (soul) parts.push(soul);
-    return parts.join('\n\n');
+    basePrompt = parts.join('\n\n');
   }
 
-  return configSystemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+  return appendSkillsCatalog(basePrompt);
 }
 
 function readPromptFile(path: string): string | null {
@@ -48,4 +52,26 @@ function readPromptFile(path: string): string | null {
     log.warn({ err, path }, 'Failed to read prompt file');
     return null;
   }
+}
+
+function appendSkillsCatalog(basePrompt: string): string {
+  const skills = loadSkillCatalog();
+  if (skills.length === 0) return basePrompt;
+
+  const catalog = formatSkillsCatalog(skills);
+  return `${basePrompt}\n\n${catalog}`;
+}
+
+function formatSkillsCatalog(skills: SkillSummary[]): string {
+  const lines: string[] = [
+    '## Skills Catalog',
+    'The following skills are available. Before executing one, call the `skill_load` tool with its id or name to load the full instructions.',
+    '',
+  ];
+
+  for (const skill of skills) {
+    lines.push(`- \`${skill.id}\` - ${skill.name}: ${skill.description}`);
+  }
+
+  return lines.join('\n');
 }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,5 +1,6 @@
 import * as net from 'node:net';
-import { unlinkSync, existsSync, chmodSync, watch, type FSWatcher } from 'node:fs';
+import { unlinkSync, existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:fs';
+import { join } from 'node:path';
 import { getSocketPath, getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
@@ -117,6 +118,17 @@ export class DaemonServer {
   private startFileWatchers(): void {
     const dataDir = getDataDir();
 
+    // Prompt/config changes should invalidate existing session prompts.
+    const evictSessions = () => {
+      for (const [id, session] of this.sessions) {
+        if (!session.isProcessing()) {
+          this.sessions.delete(id);
+        } else {
+          session.markStale();
+        }
+      }
+    };
+
     // Watch the data directory instead of individual files so we detect:
     // - Files that don't exist yet at startup (new config/trust creation)
     // - Atomic rename writes (trust-store uses renameSync)
@@ -131,14 +143,7 @@ export class DaemonServer {
           log.error({ err }, 'Failed to reload config');
           return;
         }
-        // Evict idle sessions; mark busy ones as stale
-        for (const [id, session] of this.sessions) {
-          if (!session.isProcessing()) {
-            this.sessions.delete(id);
-          } else {
-            session.markStale();
-          }
-        }
+        evictSessions();
       },
       'trust.json': () => {
         clearTrustCache();
@@ -150,36 +155,31 @@ export class DaemonServer {
 
     // Prompt files (SOUL.md, IDENTITY.md) affect the system prompt.
     // When they change, evict idle sessions so they pick up the new prompt.
-    const evictSessions = () => {
-      for (const [id, session] of this.sessions) {
-        if (!session.isProcessing()) {
-          this.sessions.delete(id);
-        } else {
-          session.markStale();
-        }
-      }
-    };
     handlers['SOUL.md'] = evictSessions;
     handlers['IDENTITY.md'] = evictSessions;
 
     try {
       const watcher = watch(dataDir, (_eventType, filename) => {
-        if (!filename || !handlers[filename]) return;
+        if (!filename) return;
+        const file = String(filename);
+        if (!handlers[file]) return;
         // Debounce: editors often write files in multiple steps
-        const existing = this.debounceTimers.get(filename);
+        const existing = this.debounceTimers.get(file);
         if (existing) clearTimeout(existing);
         const timer = setTimeout(() => {
-          this.debounceTimers.delete(filename);
-          log.info({ file: filename }, 'File changed, reloading');
-          handlers[filename]();
+          this.debounceTimers.delete(file);
+          log.info({ file }, 'File changed, reloading');
+          handlers[file]();
         }, 200);
-        this.debounceTimers.set(filename, timer);
+        this.debounceTimers.set(file, timer);
       });
       this.watchers.push(watcher);
       log.info({ dir: dataDir }, 'Watching data directory for config/trust/prompt changes');
     } catch (err) {
       log.warn({ err }, 'Failed to watch data directory');
     }
+
+    this.startSkillsWatchers(evictSessions);
   }
 
   private stopFileWatchers(): void {
@@ -191,6 +191,99 @@ export class DaemonServer {
       watcher.close();
     }
     this.watchers = [];
+  }
+
+  private startSkillsWatchers(evictSessions: () => void): void {
+    const skillsDir = join(getDataDir(), 'skills');
+    if (!existsSync(skillsDir)) return;
+
+    const scheduleSkillsReload = (file: string): void => {
+      const key = `skills:${file}`;
+      const existing = this.debounceTimers.get(key);
+      if (existing) clearTimeout(existing);
+      const timer = setTimeout(() => {
+        this.debounceTimers.delete(key);
+        log.info({ file }, 'Skill file changed, reloading');
+        evictSessions();
+      }, 200);
+      this.debounceTimers.set(key, timer);
+    };
+
+    try {
+      const recursiveWatcher = watch(skillsDir, { recursive: true }, (_eventType, filename) => {
+        scheduleSkillsReload(filename ? String(filename) : '(unknown)');
+      });
+      this.watchers.push(recursiveWatcher);
+      log.info({ dir: skillsDir }, 'Watching skills directory recursively');
+      return;
+    } catch (err) {
+      log.info({ err, dir: skillsDir }, 'Recursive skills watch unavailable; using per-directory watchers');
+    }
+
+    const childWatchers = new Map<string, FSWatcher>();
+
+    const watchDir = (dirPath: string, onChange: (filename: string) => void): FSWatcher | null => {
+      try {
+        const watcher = watch(dirPath, (_eventType, filename) => {
+          onChange(filename ? String(filename) : '(unknown)');
+        });
+        this.watchers.push(watcher);
+        return watcher;
+      } catch (err) {
+        log.warn({ err, dirPath }, 'Failed to watch skills directory');
+        return null;
+      }
+    };
+
+    const removeWatcher = (watcher: FSWatcher): void => {
+      const idx = this.watchers.indexOf(watcher);
+      if (idx !== -1) {
+        this.watchers.splice(idx, 1);
+      }
+    };
+
+    const refreshChildWatchers = (): void => {
+      const nextChildDirs = new Set<string>();
+
+      try {
+        const entries = readdirSync(skillsDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const childDir = join(skillsDir, entry.name);
+          nextChildDirs.add(childDir);
+
+          if (childWatchers.has(childDir)) continue;
+
+          const watcher = watchDir(childDir, (filename) => {
+            const label = filename === '(unknown)' ? entry.name : `${entry.name}/${filename}`;
+            scheduleSkillsReload(label);
+          });
+          if (watcher) {
+            childWatchers.set(childDir, watcher);
+          }
+        }
+      } catch (err) {
+        log.warn({ err, skillsDir }, 'Failed to enumerate skill directories');
+        return;
+      }
+
+      for (const [childDir, watcher] of childWatchers.entries()) {
+        if (nextChildDirs.has(childDir)) continue;
+        watcher.close();
+        childWatchers.delete(childDir);
+        removeWatcher(watcher);
+      }
+    };
+
+    const rootWatcher = watchDir(skillsDir, (filename) => {
+      scheduleSkillsReload(filename);
+      refreshChildWatchers();
+    });
+
+    if (!rootWatcher) return;
+
+    refreshChildWatchers();
+    log.info({ dir: skillsDir }, 'Watching skills directory with non-recursive fallback');
   }
 
   private handleConnection(socket: net.Socket): void {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -544,7 +544,7 @@ program
 
     // 5. ~/.vellum/ directory structure
     const dataDir = getDataDir();
-    const requiredDirs = [dataDir, `${dataDir}/data`, `${dataDir}/logs`];
+    const requiredDirs = [dataDir, `${dataDir}/data`, `${dataDir}/logs`, `${dataDir}/skills`];
     const missing = requiredDirs.filter((d) => !existsSync(d));
     if (missing.length === 0) {
       pass('Directory structure exists');

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -51,6 +51,14 @@ function isHighRiskRm(args: string[]): boolean {
   return false;
 }
 
+function getStringField(input: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
 export async function classifyRisk(toolName: string, input: Record<string, unknown>): Promise<RiskLevel> {
   if (toolName === 'file_read') return RiskLevel.Low;
   if (toolName === 'file_write') return RiskLevel.Medium;
@@ -128,9 +136,12 @@ export async function check(
   const risk = await classifyRisk(toolName, input);
 
   // Build command string for rule matching
-  const commandStr = toolName === 'shell'
-    ? (input.command as string) ?? ''
-    : `${toolName}:${(input.path as string) ?? (input.file_path as string) ?? ''}`;
+  const commandTarget = toolName === 'shell'
+    ? getStringField(input, 'command')
+    : toolName === 'skill_load'
+      ? getStringField(input, 'skill')
+      : getStringField(input, 'path', 'file_path');
+  const commandStr = toolName === 'shell' ? commandTarget : `${toolName}:${commandTarget}`;
 
   // Deny rules take precedence at ALL risk levels
   const denyRule = findDenyRule(toolName, commandStr, workingDir);

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,7 @@
 import { RiskLevel, type PermissionCheckResult, type AllowlistOption, type ScopeOption } from './types.js';
 import { findMatchingRule, findDenyRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
+import { resolveSkillSelector } from '../config/skills.js';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -57,6 +58,30 @@ function getStringField(input: Record<string, unknown>, ...keys: string[]): stri
     if (typeof value === 'string') return value;
   }
   return '';
+}
+
+function buildCommandCandidates(toolName: string, input: Record<string, unknown>): string[] {
+  if (toolName === 'shell') {
+    return [getStringField(input, 'command')];
+  }
+
+  if (toolName === 'skill_load') {
+    const rawSelector = getStringField(input, 'skill').trim();
+    const targets: string[] = [];
+    if (!rawSelector) {
+      targets.push('');
+    } else {
+      const resolved = resolveSkillSelector(rawSelector);
+      if (resolved.skill) {
+        targets.push(resolved.skill.id);
+      }
+      targets.push(rawSelector);
+    }
+    return [...new Set(targets)].map((target) => `${toolName}:${target}`);
+  }
+
+  const fileTarget = getStringField(input, 'path', 'file_path');
+  return [`${toolName}:${fileTarget}`];
 }
 
 export async function classifyRisk(toolName: string, input: Record<string, unknown>): Promise<RiskLevel> {
@@ -135,18 +160,15 @@ export async function check(
 ): Promise<PermissionCheckResult> {
   const risk = await classifyRisk(toolName, input);
 
-  // Build command string for rule matching
-  const commandTarget = toolName === 'shell'
-    ? getStringField(input, 'command')
-    : toolName === 'skill_load'
-      ? getStringField(input, 'skill')
-      : getStringField(input, 'path', 'file_path');
-  const commandStr = toolName === 'shell' ? commandTarget : `${toolName}:${commandTarget}`;
+  // Build command string candidates for rule matching
+  const commandCandidates = buildCommandCandidates(toolName, input);
 
   // Deny rules take precedence at ALL risk levels
-  const denyRule = findDenyRule(toolName, commandStr, workingDir);
-  if (denyRule) {
-    return { decision: 'deny', reason: `Blocked by deny rule: ${denyRule.pattern}`, matchedRule: denyRule };
+  for (const command of commandCandidates) {
+    const denyRule = findDenyRule(toolName, command, workingDir);
+    if (denyRule) {
+      return { decision: 'deny', reason: `Blocked by deny rule: ${denyRule.pattern}`, matchedRule: denyRule };
+    }
   }
 
   // High risk → always prompt, allow rules ignored
@@ -160,9 +182,11 @@ export async function check(
   }
 
   // Medium risk → check allow rules
-  const matchedRule = findMatchingRule(toolName, commandStr, workingDir);
-  if (matchedRule) {
-    return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };
+  for (const command of commandCandidates) {
+    const matchedRule = findMatchingRule(toolName, command, workingDir);
+    if (matchedRule) {
+      return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };
+    }
   }
 
   return { decision: 'prompt', reason: `${risk} risk: requires approval` };

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -56,6 +56,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'file_write') return RiskLevel.Medium;
   if (toolName === 'file_edit') return RiskLevel.Medium;
   if (toolName === 'web_search') return RiskLevel.Low;
+  if (toolName === 'skill_load') return RiskLevel.Low;
 
   if (toolName === 'shell') {
     const command = (input.command as string) ?? '';

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -93,6 +93,7 @@ export async function initializeTools(): Promise<void> {
   await import('./filesystem/write.js');
   await import('./filesystem/edit.js');
   await import('./network/web-search.js');
+  await import('./skills/load.js');
 
   // The shell tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,0 +1,57 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { loadSkillBySelector } from '../../config/skills.js';
+
+class SkillLoadTool implements Tool {
+  name = 'skill_load';
+  description = 'Load full instructions for a configured skill from ~/.vellum/skills.';
+  category = 'skills';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          skill: {
+            type: 'string',
+            description: 'The skill id or skill name to load.',
+          },
+        },
+        required: ['skill'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const selector = input.skill;
+    if (typeof selector !== 'string' || selector.trim().length === 0) {
+      return { content: 'Error: skill is required and must be a non-empty string', isError: true };
+    }
+
+    const loaded = loadSkillBySelector(selector);
+    if (!loaded.skill) {
+      return { content: `Error: ${loaded.error ?? 'Failed to load skill'}`, isError: true };
+    }
+
+    const skill = loaded.skill;
+    const body = skill.body.length > 0 ? skill.body : '(No body content)';
+    return {
+      content: [
+        `Skill: ${skill.name}`,
+        `ID: ${skill.id}`,
+        `Description: ${skill.description}`,
+        `Path: ${skill.skillFilePath}`,
+        '',
+        body,
+      ].join('\n'),
+      isError: false,
+    };
+  }
+}
+
+registerTool(new SkillLoadTool());

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -61,6 +61,7 @@ export function ensureDataDir(): void {
     join(base, 'memory'),
     join(base, 'memory', 'knowledge'),
     join(base, 'logs'),
+    join(base, 'skills'),
   ];
   for (const dir of dirs) {
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- add a new skills loader that reads `~/.vellum/skills/SKILLS.md`, validates relative entries, parses `SKILL.md` frontmatter (`name`, `description`), and supports auto-discovery fallback when index is missing
- append a generated Skills Catalog section to the system prompt while preserving existing `IDENTITY.md` + `SOUL.md` precedence
- add a new low-risk `skill_load` tool that lazily loads full skill instructions by exact id, case-insensitive exact name, or unique id prefix
- register `skill_load` in tool registry, classify it as low risk, and add daemon watchers to invalidate sessions on skills file changes
- update data-dir bootstrap (`~/.vellum/skills`), doctor checks, and add skills docs
- add/extend tests for catalog parsing, discovery, skill loading behavior, system prompt composition, and risk classification

## Verification
- `bun test src/__tests__/system-prompt.test.ts src/__tests__/skills.test.ts src/__tests__/skill-load-tool.test.ts src/__tests__/checker.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint src/config/skills.ts src/config/system-prompt.ts src/tools/skills/load.ts src/tools/registry.ts src/permissions/checker.ts src/daemon/server.ts src/util/platform.ts src/index.ts src/__tests__/skills.test.ts src/__tests__/skill-load-tool.test.ts src/__tests__/system-prompt.test.ts src/__tests__/checker.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
