### PR TITLE
Implement Memory V2 for long-horizon global recall

### DIFF
--- a/assistant/docs/memory-v2-architecture.md
+++ b/assistant/docs/memory-v2-architecture.md
@@ -1,0 +1,80 @@
+# Memory V2 Architecture
+
+This document describes the daemon-side long-horizon memory system added in v2.
+
+## Goals
+
+- Preserve globally shared memory across sessions in `~/.vellum/data/assistant.db`.
+- Support lexical + semantic recall for conversations that can span months/years.
+- Keep recall injection bounded and deterministic for stable prompt cost.
+
+## Data Model
+
+Memory v2 adds:
+
+- `memory_segments`: segmented message text for retrieval/indexing.
+- `memory_segment_fts`: FTS5 index over segment text.
+- `memory_items`: distilled facts/preferences/decisions.
+- `memory_item_sources`: evidence links from items to messages.
+- `memory_summaries`: conversation + periodic global summaries.
+- `memory_embeddings`: vectors for segments/items/summaries.
+- `memory_jobs`: persistent async queue.
+- `memory_checkpoints`: resumable state for backfill/periodic tasks.
+
+## Ingestion Pipeline
+
+On each persisted message:
+
+1. Extract text from stored content blocks.
+2. Segment text with overlap.
+3. Upsert segments (FTS synced via triggers).
+4. Enqueue embedding + item extraction + summary jobs.
+
+## Retrieval Pipeline
+
+For each user turn:
+
+1. Build query from user message + current context summary.
+2. Compute query embedding (required by default).
+3. Fetch lexical candidates from FTS.
+4. Fetch semantic candidates from item/summary embeddings.
+5. Fetch recency candidates from same-conversation segments.
+6. Score using:
+   - `0.50 * semantic + 0.25 * lexical + 0.15 * recency + 0.10 * confidence`.
+7. Inject top items under token budget as an ephemeral `[Memory Recall v1]` message.
+
+Injected memory is runtime-only and stripped from persisted history.
+
+## Embedding Backends
+
+Configured in `config.json` `memory.embeddings`:
+
+- OpenAI
+- Gemini
+- Ollama (local)
+
+`provider = "auto"` prefers `openai -> gemini -> ollama`.
+
+If `required = true` and no backend is available, memory recall degrades safely while chat continues.
+
+## Worker Jobs
+
+Background worker handles:
+
+- `embed_segment`, `embed_item`, `embed_summary`
+- `extract_items`
+- `build_conversation_summary`
+- `refresh_weekly_summary`, `refresh_monthly_summary`
+- `backfill`
+- `rebuild_index`
+
+Jobs are persistent and retry with backoff.
+
+## CLI
+
+New commands:
+
+- `vellum memory status`
+- `vellum memory backfill`
+- `vellum memory query "<text>"`
+- `vellum memory rebuild-index`

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -307,3 +307,26 @@ exports[`IPC message snapshots ServerMessage types context_compacted serializes 
   "type": "context_compacted",
 }
 `;
+
+exports[`IPC message snapshots ServerMessage types memory_recalled serializes to expected JSON 1`] = `
+{
+  "injectedTokens": 480,
+  "latencyMs": 55,
+  "lexicalHits": 12,
+  "model": "text-embedding-3-small",
+  "provider": "openai",
+  "recencyHits": 6,
+  "semanticHits": 8,
+  "type": "memory_recalled",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types memory_status serializes to expected JSON 1`] = `
+{
+  "degraded": false,
+  "enabled": true,
+  "model": "text-embedding-3-small",
+  "provider": "openai",
+  "type": "memory_status",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -204,6 +204,23 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     ],
     action: 'redact',
   },
+  memory_recalled: {
+    type: 'memory_recalled',
+    provider: 'openai',
+    model: 'text-embedding-3-small',
+    lexicalHits: 12,
+    semanticHits: 8,
+    recencyHits: 6,
+    injectedTokens: 480,
+    latencyMs: 55,
+  },
+  memory_status: {
+    type: 'memory_status',
+    enabled: true,
+    degraded: false,
+    provider: 'openai',
+    model: 'text-embedding-3-small',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -29,9 +29,9 @@ import { estimateTextTokens } from '../context/token-estimator.js';
 import { requestMemoryBackfill } from '../memory/admin.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
-import { indexMessageNow } from '../memory/indexer.js';
+import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
-import { enqueueMemoryJob } from '../memory/jobs-store.js';
+import { claimMemoryJobs, enqueueMemoryJob } from '../memory/jobs-store.js';
 import { currentWeekWindow, runMemoryJobsOnce } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
@@ -276,6 +276,98 @@ describe('Memory V2 regressions', () => {
     expect(embedSegmentJobs).toHaveLength(0);
   });
 
+  test('indexing skips durable item extraction for non-user messages', () => {
+    const db = getDb();
+    const createdAt = 2_100;
+    db.insert(conversations).values({
+      id: 'conv-assistant-index',
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-assistant-index',
+      conversationId: 'conv-assistant-index',
+      role: 'assistant',
+      content: JSON.stringify([{ type: 'text', text: 'I think your timezone is PST.' }]),
+      createdAt,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-assistant-index',
+      conversationId: 'conv-assistant-index',
+      role: 'assistant',
+      content: JSON.stringify([{ type: 'text', text: 'I think your timezone is PST.' }]),
+      createdAt,
+    }, DEFAULT_CONFIG.memory);
+    expect(result.enqueuedJobs).toBe(1);
+
+    const extractionJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, 'extract_items'))
+      .all();
+    expect(extractionJobs).toHaveLength(0);
+  });
+
+  test('recent segment helper returns newest segments first', () => {
+    const db = getDb();
+    db.insert(conversations).values({
+      id: 'conv-recent',
+      title: null,
+      createdAt: 2_200,
+      updatedAt: 2_200,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values([
+      {
+        id: 'msg-recent-1',
+        conversationId: 'conv-recent',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'old' }]),
+        createdAt: 2_201,
+      },
+      {
+        id: 'msg-recent-2',
+        conversationId: 'conv-recent',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'newer' }]),
+        createdAt: 2_202,
+      },
+      {
+        id: 'msg-recent-3',
+        conversationId: 'conv-recent',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'newest' }]),
+        createdAt: 2_203,
+      },
+    ]).run();
+    db.run(`
+      INSERT INTO memory_segments (
+        id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at
+      ) VALUES
+      ('seg-recent-1', 'msg-recent-1', 'conv-recent', 'user', 0, 'old', 1, 2201, 2201),
+      ('seg-recent-2', 'msg-recent-2', 'conv-recent', 'user', 0, 'newer', 1, 2202, 2202),
+      ('seg-recent-3', 'msg-recent-3', 'conv-recent', 'user', 0, 'newest', 1, 2203, 2203)
+    `);
+
+    const recent = getRecentSegmentsForConversation('conv-recent', 2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0]?.id).toBe('seg-recent-3');
+    expect(recent[1]?.id).toBe('seg-recent-2');
+  });
+
   test('embed jobs are skipped (not failed) when no embedding backend is configured', async () => {
     const db = getDb();
     const now = 3_000;
@@ -405,5 +497,31 @@ describe('Memory V2 regressions', () => {
     const recall = await buildMemoryRecall('budget sentinel', 'conv-budget', config);
     expect(recall.injectedText).toBe('');
     expect(recall.injectedTokens).toBe(0);
+  });
+
+  test('claimMemoryJobs only returns rows it actually claimed', () => {
+    const db = getDb();
+    const jobId = enqueueMemoryJob('build_conversation_summary', { conversationId: 'conv-lock' });
+    db.run(`
+      CREATE TEMP TRIGGER memory_jobs_claim_ignore
+      BEFORE UPDATE ON memory_jobs
+      WHEN NEW.status = 'running' AND OLD.id = '${jobId}'
+      BEGIN
+        SELECT RAISE(IGNORE);
+      END;
+    `);
+
+    try {
+      const claimed = claimMemoryJobs(10);
+      expect(claimed).toHaveLength(0);
+      const row = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.id, jobId))
+        .get();
+      expect(row?.status).toBe('pending');
+    } finally {
+      db.run('DROP TRIGGER IF EXISTS memory_jobs_claim_ignore');
+    }
   });
 });

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -504,24 +504,94 @@ describe('Memory V2 regressions', () => {
   });
 
   test('memory recall injection remains user-role and is stripped from runtime history', () => {
+    const memoryRecallText = '[Memory Recall v1]\n- [item:abc] user prefers concise answers';
     const originalUserMessage = {
       role: 'user' as const,
       content: [{ type: 'text', text: 'Actual user request' }],
     };
     const injected = injectMemoryRecallIntoUserMessage(
       originalUserMessage,
-      '[Memory Recall v1]\n- [item:abc] user prefers concise answers',
+      memoryRecallText,
     );
 
     expect(injected.role).toBe('user');
     expect(injected.content[0]).toEqual({
       type: 'text',
-      text: '[Memory Recall v1]\n- [item:abc] user prefers concise answers',
+      text: memoryRecallText,
     });
 
-    const cleaned = stripMemoryRecallMessages([injected]);
+    const cleaned = stripMemoryRecallMessages([injected], memoryRecallText);
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0]).toEqual(originalUserMessage);
+  });
+
+  test('memory recall stripping preserves literal marker text outside the injected block', () => {
+    const memoryRecallText = '[Memory Recall v1]\n- [item:abc] user prefers concise answers';
+    const literalUserMessage = {
+      role: 'user' as const,
+      content: [{ type: 'text', text: '[Memory Recall v1] this is user-authored content' }],
+    };
+    const literalAssistantMessage = {
+      role: 'assistant' as const,
+      content: [{ type: 'text', text: memoryRecallText }],
+    };
+    const originalUserTail = {
+      role: 'user' as const,
+      content: [{ type: 'text', text: 'Actual user request' }],
+    };
+    const injectedTail = injectMemoryRecallIntoUserMessage(originalUserTail, memoryRecallText);
+
+    const cleaned = stripMemoryRecallMessages(
+      [literalUserMessage, literalAssistantMessage, injectedTail],
+      memoryRecallText,
+    );
+
+    expect(cleaned).toHaveLength(3);
+    expect(cleaned[0]).toEqual(literalUserMessage);
+    expect(cleaned[1]).toEqual(literalAssistantMessage);
+    expect(cleaned[2]).toEqual(originalUserTail);
+  });
+
+  test('aborting memory recall embedding returns a non-degraded aborted recall result', async () => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+
+    globalThis.fetch = ((_: string | URL | Request, init?: RequestInit) => {
+      seenSignal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (!signal) {
+          reject(new Error('Expected abort signal'));
+          return;
+        }
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        if (signal.aborted) {
+          reject(abortError);
+          return;
+        }
+        signal.addEventListener('abort', () => reject(abortError), { once: true });
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      const recallPromise = buildMemoryRecall(
+        'timezone',
+        'conv-abort',
+        semanticRecallConfig(),
+        { signal: controller.signal },
+      );
+      controller.abort();
+      const recall = await recallPromise;
+      expect(seenSignal).toBe(controller.signal);
+      expect(recall.degraded).toBe(false);
+      expect(recall.reason).toBe('memory.aborted');
+      expect(recall.injectedText).toBe('');
+      expect(recall.injectedTokens).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test('memory item lastSeenAt follows message.createdAt and does not move backwards', () => {

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'memory-v2-regressions-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { and, eq } from 'drizzle-orm';
+import { DEFAULT_CONFIG } from '../config/defaults.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
+import {
+  buildMemoryRecall,
+  injectMemoryRecallIntoUserMessage,
+  stripMemoryRecallMessages,
+} from '../memory/retriever.js';
+import { conversations, memoryItems, messages } from '../memory/schema.js';
+
+describe('Memory V2 regressions', () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM memory_item_sources');
+    db.run('DELETE FROM memory_embeddings');
+    db.run('DELETE FROM memory_summaries');
+    db.run('DELETE FROM memory_items');
+    db.run('DELETE FROM memory_segment_fts');
+    db.run('DELETE FROM memory_segments');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+    db.run('DELETE FROM memory_jobs');
+    db.run('DELETE FROM memory_checkpoints');
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best effort cleanup
+    }
+  });
+
+  test('lexical recall accepts punctuation-heavy user queries without degrading', async () => {
+    const db = getDb();
+    const createdAt = 1_700_000_000_000;
+    db.insert(conversations).values({
+      id: 'conv-1',
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-1',
+      conversationId: 'conv-1',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'error timeout in src index ts' }]),
+      createdAt,
+    }).run();
+    db.run(`
+      INSERT INTO memory_segments (
+        id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at
+      ) VALUES (
+        'seg-1', 'msg-1', 'conv-1', 'user', 0, 'error timeout in src index ts', 8, ${createdAt}, ${createdAt}
+      )
+    `);
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall('error: timeout src/index.ts foo-bar', 'conv-1', config);
+    expect(recall.degraded).toBe(false);
+    expect(recall.lexicalHits).toBeGreaterThan(0);
+  });
+
+  test('memory recall injection remains user-role and is stripped from runtime history', () => {
+    const originalUserMessage = {
+      role: 'user' as const,
+      content: [{ type: 'text', text: 'Actual user request' }],
+    };
+    const injected = injectMemoryRecallIntoUserMessage(
+      originalUserMessage,
+      '[Memory Recall v1]\n- [item:abc] user prefers concise answers',
+    );
+
+    expect(injected.role).toBe('user');
+    expect(injected.content[0]).toEqual({
+      type: 'text',
+      text: '[Memory Recall v1]\n- [item:abc] user prefers concise answers',
+    });
+
+    const cleaned = stripMemoryRecallMessages([injected]);
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0]).toEqual(originalUserMessage);
+  });
+
+  test('memory item lastSeenAt follows message.createdAt and does not move backwards', () => {
+    const db = getDb();
+    db.insert(conversations).values({
+      id: 'conv-2',
+      title: null,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+
+    db.insert(messages).values({
+      id: 'msg-newer',
+      conversationId: 'conv-2',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'We decided to use sqlite for local persistence because reliability matters.' }]),
+      createdAt: 1_000,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-older',
+      conversationId: 'conv-2',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'We decided to use sqlite for local persistence because reliability matters.' }]),
+      createdAt: 500,
+    }).run();
+
+    extractAndUpsertMemoryItemsForMessage('msg-newer');
+    extractAndUpsertMemoryItemsForMessage('msg-older');
+
+    const row = db
+      .select()
+      .from(memoryItems)
+      .where(and(eq(memoryItems.kind, 'decision'), eq(memoryItems.status, 'active')))
+      .get();
+
+    expect(row).not.toBeNull();
+    expect(row?.lastSeenAt).toBe(1_000);
+  });
+});

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -26,13 +26,16 @@ mock.module('../util/logger.js', () => ({
 import { and, eq } from 'drizzle-orm';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
+import { enqueueMemoryJob } from '../memory/jobs-store.js';
+import { currentWeekWindow, runMemoryJobsOnce } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
   injectMemoryRecallIntoUserMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
-import { conversations, memoryItems, messages } from '../memory/schema.js';
+import { conversations, memoryItems, memoryJobs, messages } from '../memory/schema.js';
 
 describe('Memory V2 regressions', () => {
   beforeAll(() => {
@@ -108,6 +111,64 @@ describe('Memory V2 regressions', () => {
     expect(recall.lexicalHits).toBeGreaterThan(0);
   });
 
+  test('recall excludes current-turn message ids from injected candidates', async () => {
+    const db = getDb();
+    const now = 1_700_000_100_000;
+    db.insert(conversations).values({
+      id: 'conv-exclude',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-old',
+      conversationId: 'conv-exclude',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Remember my timezone is PST.' }]),
+      createdAt: now - 10_000,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-current',
+      conversationId: 'conv-exclude',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'What is my timezone again?' }]),
+      createdAt: now,
+    }).run();
+    db.run(`
+      INSERT INTO memory_segments (
+        id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at
+      ) VALUES
+      ('seg-old', 'msg-old', 'conv-exclude', 'user', 0, 'Remember my timezone is PST.', 7, ${now - 10_000}, ${now - 10_000}),
+      ('seg-current', 'msg-current', 'conv-exclude', 'user', 0, 'What is my timezone again?', 7, ${now}, ${now})
+    `);
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall(
+      'timezone',
+      'conv-exclude',
+      config,
+      { excludeMessageIds: ['msg-current'] },
+    );
+    expect(recall.injectedText).toContain('[segment:seg-old]');
+    expect(recall.injectedText).not.toContain('[segment:seg-current]');
+  });
+
   test('memory recall injection remains user-role and is stripped from runtime history', () => {
     const originalUserMessage = {
       role: 'user' as const,
@@ -170,5 +231,80 @@ describe('Memory V2 regressions', () => {
 
     expect(row).not.toBeNull();
     expect(row?.lastSeenAt).toBe(1_000);
+  });
+
+  test('indexing no longer enqueues segment embedding jobs', () => {
+    const db = getDb();
+    const createdAt = 2_000;
+    db.insert(conversations).values({
+      id: 'conv-index',
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-index',
+      conversationId: 'conv-index',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Please remember this implementation detail.' }]),
+      createdAt,
+    }).run();
+
+    const result = indexMessageNow({
+      messageId: 'msg-index',
+      conversationId: 'conv-index',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Please remember this implementation detail.' }]),
+      createdAt,
+    }, DEFAULT_CONFIG.memory);
+    expect(result.enqueuedJobs).toBe(2);
+
+    const embedSegmentJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, 'embed_segment'))
+      .all();
+    expect(embedSegmentJobs).toHaveLength(0);
+  });
+
+  test('embed jobs are skipped (not failed) when no embedding backend is configured', async () => {
+    const db = getDb();
+    const now = 3_000;
+    db.insert(memoryItems).values({
+      id: 'item-no-backend',
+      kind: 'fact',
+      subject: 'backend',
+      statement: 'No embedding backend configured in test',
+      status: 'active',
+      confidence: 0.8,
+      fingerprint: 'item-no-backend-fingerprint',
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastUsedAt: null,
+    }).run();
+    const jobId = enqueueMemoryJob('embed_item', { itemId: 'item-no-backend' });
+
+    const processed = await runMemoryJobsOnce();
+    expect(processed).toBe(1);
+
+    const row = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, jobId))
+      .get();
+    expect(row?.status).toBe('completed');
+  });
+
+  test('weekly window uses UTC boundaries for stable scope keys', () => {
+    const window = currentWeekWindow(new Date('2025-01-06T00:30:00.000Z'));
+    expect(window.scopeKey).toBe('2025-W02');
+    expect(window.startMs).toBe(Date.parse('2025-01-06T00:00:00.000Z'));
+    expect(window.endMs).toBe(Date.parse('2025-01-13T00:00:00.000Z'));
   });
 });

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -25,7 +25,10 @@ mock.module('../util/logger.js', () => ({
 
 import { and, eq } from 'drizzle-orm';
 import { DEFAULT_CONFIG } from '../config/defaults.js';
+import { estimateTextTokens } from '../context/token-estimator.js';
+import { requestMemoryBackfill } from '../memory/admin.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
 import { enqueueMemoryJob } from '../memory/jobs-store.js';
@@ -306,5 +309,101 @@ describe('Memory V2 regressions', () => {
     expect(window.scopeKey).toBe('2025-W02');
     expect(window.startMs).toBe(Date.parse('2025-01-06T00:00:00.000Z'));
     expect(window.endMs).toBe(Date.parse('2025-01-13T00:00:00.000Z'));
+  });
+
+  test('explicit ollama memory embedding provider is honored without extra ollama config', () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      provider: 'anthropic' as const,
+      apiKeys: {},
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          provider: 'ollama' as const,
+        },
+      },
+    };
+
+    const selection = selectEmbeddingBackend(config);
+    expect(selection.backend?.provider).toBe('ollama');
+    expect(selection.reason).toBeNull();
+  });
+
+  test('memory backfill request resumes by default and only restarts when forced', () => {
+    const db = getDb();
+    const resumeJobId = requestMemoryBackfill();
+    const forceJobId = requestMemoryBackfill(true);
+
+    const resumeRow = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, resumeJobId))
+      .get();
+    const forceRow = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, forceJobId))
+      .get();
+
+    expect(resumeRow).not.toBeNull();
+    expect(forceRow).not.toBeNull();
+    expect(JSON.parse(resumeRow?.payload ?? '{}')).toMatchObject({ force: false });
+    expect(JSON.parse(forceRow?.payload ?? '{}')).toMatchObject({ force: true });
+  });
+
+  test('memory recall token budgeting includes recall marker overhead', async () => {
+    const db = getDb();
+    const createdAt = 1_700_000_300_000;
+    db.insert(conversations).values({
+      id: 'conv-budget',
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-budget',
+      conversationId: 'conv-budget',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'remember budget token sentinel' }]),
+      createdAt,
+    }).run();
+    db.run(`
+      INSERT INTO memory_segments (
+        id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at
+      ) VALUES (
+        'seg-budget', 'msg-budget', 'conv-budget', 'user', 0, 'remember budget token sentinel', 6, ${createdAt}, ${createdAt}
+      )
+    `);
+
+    const candidateLine = '- [segment:seg-budget] remember budget token sentinel';
+    const lineOnlyTokens = estimateTextTokens(candidateLine);
+    const fullRecallTokens = estimateTextTokens(`[Memory Recall v1]\n${candidateLine}`);
+    expect(fullRecallTokens).toBeGreaterThan(lineOnlyTokens);
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+        retrieval: {
+          ...DEFAULT_CONFIG.memory.retrieval,
+          maxInjectTokens: lineOnlyTokens,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall('budget sentinel', 'conv-budget', config);
+    expect(recall.injectedText).toBe('');
+    expect(recall.injectedTokens).toBe(0);
   });
 });

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -38,7 +38,15 @@ import {
   injectMemoryRecallIntoUserMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
-import { conversations, memoryItems, memoryJobs, messages } from '../memory/schema.js';
+import {
+  conversations,
+  memoryEmbeddings,
+  memoryItems,
+  memoryItemSources,
+  memoryJobs,
+  memorySummaries,
+  messages,
+} from '../memory/schema.js';
 
 describe('Memory V2 regressions', () => {
   beforeAll(() => {
@@ -67,6 +75,44 @@ describe('Memory V2 regressions', () => {
       // best effort cleanup
     }
   });
+
+  async function withMockOllamaQueryEmbedding<T>(run: () => Promise<T>): Promise<T> {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => (
+      new Response(
+        JSON.stringify({ data: [{ embedding: [1, 0, 0] }] }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )
+    )) as unknown as typeof globalThis.fetch;
+    try {
+      return await run();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  function semanticRecallConfig() {
+    return {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          provider: 'ollama' as const,
+          required: true,
+        },
+        retrieval: {
+          ...DEFAULT_CONFIG.memory.retrieval,
+          lexicalTopK: 0,
+          semanticTopK: 10,
+          maxInjectTokens: 2000,
+        },
+      },
+    };
+  }
 
   test('lexical recall accepts punctuation-heavy user queries without degrading', async () => {
     const db = getDb();
@@ -170,6 +216,291 @@ describe('Memory V2 regressions', () => {
     );
     expect(recall.injectedText).toContain('[segment:seg-old]');
     expect(recall.injectedText).not.toContain('[segment:seg-current]');
+  });
+
+  test('semantic recall excludes items backed only by excluded message ids', async () => {
+    const db = getDb();
+    const now = 1_700_000_120_000;
+    db.insert(conversations).values({
+      id: 'conv-semantic-exclude',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values([
+      {
+        id: 'msg-semantic-old',
+        conversationId: 'conv-semantic-exclude',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Timezone is PST.' }]),
+        createdAt: now - 10_000,
+      },
+      {
+        id: 'msg-semantic-current',
+        conversationId: 'conv-semantic-exclude',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Remember timezone PST for this turn.' }]),
+        createdAt: now,
+      },
+    ]).run();
+    db.insert(memoryItems).values([
+      {
+        id: 'item-semantic-old',
+        kind: 'fact',
+        subject: 'timezone',
+        statement: 'User timezone is PST',
+        status: 'active',
+        confidence: 0.9,
+        fingerprint: 'item-semantic-old-fingerprint',
+        firstSeenAt: now - 10_000,
+        lastSeenAt: now - 10_000,
+        lastUsedAt: null,
+      },
+      {
+        id: 'item-semantic-current',
+        kind: 'fact',
+        subject: 'timezone',
+        statement: 'User timezone is PST (current turn)',
+        status: 'active',
+        confidence: 0.9,
+        fingerprint: 'item-semantic-current-fingerprint',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        lastUsedAt: null,
+      },
+    ]).run();
+    db.insert(memoryItemSources).values([
+      {
+        memoryItemId: 'item-semantic-old',
+        messageId: 'msg-semantic-old',
+        evidence: 'old source',
+        createdAt: now - 10_000,
+      },
+      {
+        memoryItemId: 'item-semantic-current',
+        messageId: 'msg-semantic-current',
+        evidence: 'current turn source',
+        createdAt: now,
+      },
+    ]).run();
+    db.insert(memoryEmbeddings).values([
+      {
+        id: 'emb-semantic-old',
+        targetType: 'item',
+        targetId: 'item-semantic-old',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'emb-semantic-current',
+        targetType: 'item',
+        targetId: 'item-semantic-current',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run();
+
+    const recall = await withMockOllamaQueryEmbedding(() => (
+      buildMemoryRecall(
+        'timezone',
+        'conv-semantic-exclude',
+        semanticRecallConfig(),
+        { excludeMessageIds: ['msg-semantic-current'] },
+      )
+    ));
+    expect(recall.semanticHits).toBe(1);
+    expect(recall.injectedText).toContain('[item:item-semantic-old]');
+    expect(recall.injectedText).not.toContain('[item:item-semantic-current]');
+  });
+
+  test('semantic recall skips active items that have no remaining evidence rows', async () => {
+    const db = getDb();
+    const now = 1_700_000_130_000;
+    db.insert(conversations).values({
+      id: 'conv-semantic-evidence',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-semantic-evidence',
+      conversationId: 'conv-semantic-evidence',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Timezone is PST.' }]),
+      createdAt: now,
+    }).run();
+    db.insert(memoryItems).values([
+      {
+        id: 'item-semantic-with-evidence',
+        kind: 'fact',
+        subject: 'timezone',
+        statement: 'User timezone is PST',
+        status: 'active',
+        confidence: 0.9,
+        fingerprint: 'item-semantic-with-evidence-fingerprint',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        lastUsedAt: null,
+      },
+      {
+        id: 'item-semantic-orphan',
+        kind: 'fact',
+        subject: 'timezone',
+        statement: 'Stale orphan fact',
+        status: 'active',
+        confidence: 0.9,
+        fingerprint: 'item-semantic-orphan-fingerprint',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        lastUsedAt: null,
+      },
+    ]).run();
+    db.insert(memoryItemSources).values({
+      memoryItemId: 'item-semantic-with-evidence',
+      messageId: 'msg-semantic-evidence',
+      evidence: 'message evidence',
+      createdAt: now,
+    }).run();
+    db.insert(memoryEmbeddings).values([
+      {
+        id: 'emb-semantic-with-evidence',
+        targetType: 'item',
+        targetId: 'item-semantic-with-evidence',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'emb-semantic-orphan',
+        targetType: 'item',
+        targetId: 'item-semantic-orphan',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run();
+
+    const recall = await withMockOllamaQueryEmbedding(() => (
+      buildMemoryRecall(
+        'timezone',
+        'conv-semantic-evidence',
+        semanticRecallConfig(),
+      )
+    ));
+    expect(recall.semanticHits).toBe(1);
+    expect(recall.injectedText).toContain('[item:item-semantic-with-evidence]');
+    expect(recall.injectedText).not.toContain('[item:item-semantic-orphan]');
+  });
+
+  test('semantic recall excludes conversation summaries that overlap excluded messages', async () => {
+    const db = getDb();
+    const now = 1_700_000_140_000;
+    const conversationId = 'conv-semantic-summary';
+    db.insert(conversations).values({
+      id: conversationId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-semantic-summary-excluded',
+      conversationId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'This is the current turn message.' }]),
+      createdAt: now,
+    }).run();
+    db.insert(memorySummaries).values([
+      {
+        id: 'summary-semantic-conversation',
+        scope: 'conversation',
+        scopeKey: conversationId,
+        summary: 'Conversation summary containing current turn details',
+        tokenEstimate: 12,
+        startAt: now - 500,
+        endAt: now + 500,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'summary-semantic-weekly',
+        scope: 'weekly_global',
+        scopeKey: '2026-W07',
+        summary: 'Weekly summary that should remain eligible',
+        tokenEstimate: 12,
+        startAt: now - 10_000,
+        endAt: now + 10_000,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run();
+    db.insert(memoryEmbeddings).values([
+      {
+        id: 'emb-summary-semantic-conversation',
+        targetType: 'summary',
+        targetId: 'summary-semantic-conversation',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'emb-summary-semantic-weekly',
+        targetType: 'summary',
+        targetId: 'summary-semantic-weekly',
+        provider: 'ollama',
+        model: DEFAULT_CONFIG.memory.embeddings.ollamaModel,
+        dimensions: 3,
+        vectorJson: JSON.stringify([1, 0, 0]),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run();
+
+    const recall = await withMockOllamaQueryEmbedding(() => (
+      buildMemoryRecall(
+        'summary',
+        conversationId,
+        semanticRecallConfig(),
+        { excludeMessageIds: ['msg-semantic-summary-excluded'] },
+      )
+    ));
+    expect(recall.semanticHits).toBe(1);
+    expect(recall.injectedText).not.toContain('[summary:summary-semantic-conversation]');
+    expect(recall.injectedText).toContain('[summary:summary-semantic-weekly]');
   });
 
   test('memory recall injection remains user-role and is stripped from runtime history', () => {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -291,6 +291,22 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         break;
       }
 
+      case 'memory_status':
+        if (msg.degraded) {
+          spinner.stop();
+          process.stdout.write(`\n\x1B[2m[Memory degraded: ${msg.reason ?? 'unknown'}]\x1B[0m\n`);
+          spinner.start('Thinking...');
+        }
+        break;
+
+      case 'memory_recalled':
+        spinner.stop();
+        process.stdout.write(
+          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
+        );
+        spinner.start('Thinking...');
+        break;
+
       case 'message_complete': {
         spinner.stop();
         generating = false;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -19,6 +19,31 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     summaryMaxTokens: 1200,
     chunkTokens: 12000,
   },
+  memory: {
+    enabled: true,
+    embeddings: {
+      required: true,
+      provider: 'auto',
+      openaiModel: 'text-embedding-3-small',
+      geminiModel: 'gemini-embedding-001',
+      ollamaModel: 'nomic-embed-text',
+    },
+    retrieval: {
+      lexicalTopK: 80,
+      semanticTopK: 40,
+      maxInjectTokens: 1800,
+    },
+    segmentation: {
+      targetTokens: 450,
+      overlapTokens: 60,
+    },
+    jobs: {
+      workerConcurrency: 2,
+    },
+    retention: {
+      keepRawForever: true,
+    },
+  },
   dataDir: getDataDir(),
   timeouts: {
     shellDefaultTimeoutSec: 120,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,6 +3,7 @@ import { getDataDir } from '../util/platform.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
+const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'openai', 'gemini', 'ollama'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -113,6 +114,99 @@ export const ContextWindowConfigSchema = z.object({
     .default(12000),
 });
 
+export const MemoryEmbeddingsConfigSchema = z.object({
+  required: z
+    .boolean({ error: 'memory.embeddings.required must be a boolean' })
+    .default(true),
+  provider: z
+    .enum(VALID_MEMORY_EMBEDDING_PROVIDERS, {
+      error: `memory.embeddings.provider must be one of: ${VALID_MEMORY_EMBEDDING_PROVIDERS.join(', ')}`,
+    })
+    .default('auto'),
+  openaiModel: z
+    .string({ error: 'memory.embeddings.openaiModel must be a string' })
+    .default('text-embedding-3-small'),
+  geminiModel: z
+    .string({ error: 'memory.embeddings.geminiModel must be a string' })
+    .default('gemini-embedding-001'),
+  ollamaModel: z
+    .string({ error: 'memory.embeddings.ollamaModel must be a string' })
+    .default('nomic-embed-text'),
+});
+
+export const MemoryRetrievalConfigSchema = z.object({
+  lexicalTopK: z
+    .number({ error: 'memory.retrieval.lexicalTopK must be a number' })
+    .int('memory.retrieval.lexicalTopK must be an integer')
+    .positive('memory.retrieval.lexicalTopK must be a positive integer')
+    .default(80),
+  semanticTopK: z
+    .number({ error: 'memory.retrieval.semanticTopK must be a number' })
+    .int('memory.retrieval.semanticTopK must be an integer')
+    .positive('memory.retrieval.semanticTopK must be a positive integer')
+    .default(40),
+  maxInjectTokens: z
+    .number({ error: 'memory.retrieval.maxInjectTokens must be a number' })
+    .int('memory.retrieval.maxInjectTokens must be an integer')
+    .positive('memory.retrieval.maxInjectTokens must be a positive integer')
+    .default(1800),
+});
+
+export const MemorySegmentationConfigSchema = z.object({
+  targetTokens: z
+    .number({ error: 'memory.segmentation.targetTokens must be a number' })
+    .int('memory.segmentation.targetTokens must be an integer')
+    .positive('memory.segmentation.targetTokens must be a positive integer')
+    .default(450),
+  overlapTokens: z
+    .number({ error: 'memory.segmentation.overlapTokens must be a number' })
+    .int('memory.segmentation.overlapTokens must be an integer')
+    .nonnegative('memory.segmentation.overlapTokens must be a non-negative integer')
+    .default(60),
+});
+
+export const MemoryJobsConfigSchema = z.object({
+  workerConcurrency: z
+    .number({ error: 'memory.jobs.workerConcurrency must be a number' })
+    .int('memory.jobs.workerConcurrency must be an integer')
+    .positive('memory.jobs.workerConcurrency must be a positive integer')
+    .default(2),
+});
+
+export const MemoryRetentionConfigSchema = z.object({
+  keepRawForever: z
+    .boolean({ error: 'memory.retention.keepRawForever must be a boolean' })
+    .default(true),
+});
+
+export const MemoryConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.enabled must be a boolean' })
+    .default(true),
+  embeddings: MemoryEmbeddingsConfigSchema.default({
+    required: true,
+    provider: 'auto',
+    openaiModel: 'text-embedding-3-small',
+    geminiModel: 'gemini-embedding-001',
+    ollamaModel: 'nomic-embed-text',
+  }),
+  retrieval: MemoryRetrievalConfigSchema.default({
+    lexicalTopK: 80,
+    semanticTopK: 40,
+    maxInjectTokens: 1800,
+  }),
+  segmentation: MemorySegmentationConfigSchema.default({
+    targetTokens: 450,
+    overlapTokens: 60,
+  }),
+  jobs: MemoryJobsConfigSchema.default({
+    workerConcurrency: 2,
+  }),
+  retention: MemoryRetentionConfigSchema.default({
+    keepRawForever: true,
+  }),
+});
+
 export const AssistantConfigSchema = z.object({
   provider: z
     .enum(VALID_PROVIDERS, {
@@ -146,6 +240,31 @@ export const AssistantConfigSchema = z.object({
     summaryMaxTokens: 1200,
     chunkTokens: 12000,
   }),
+  memory: MemoryConfigSchema.default({
+    enabled: true,
+    embeddings: {
+      required: true,
+      provider: 'auto',
+      openaiModel: 'text-embedding-3-small',
+      geminiModel: 'gemini-embedding-001',
+      ollamaModel: 'nomic-embed-text',
+    },
+    retrieval: {
+      lexicalTopK: 80,
+      semanticTopK: 40,
+      maxInjectTokens: 1800,
+    },
+    segmentation: {
+      targetTokens: 450,
+      overlapTokens: 60,
+    },
+    jobs: {
+      workerConcurrency: 2,
+    },
+    retention: {
+      keepRawForever: true,
+    },
+  }),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
     .default(getDataDir()),
@@ -177,6 +296,13 @@ export const AssistantConfigSchema = z.object({
       message: 'contextWindow.targetInputTokens must be less than contextWindow.maxInputTokens',
     });
   }
+  if (config.memory.segmentation.overlapTokens >= config.memory.segmentation.targetTokens) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['memory', 'segmentation', 'overlapTokens'],
+      message: 'memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens',
+    });
+  }
 });
 
 export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;
@@ -187,3 +313,9 @@ export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;
 export type ContextWindowConfig = z.infer<typeof ContextWindowConfigSchema>;
+export type MemoryEmbeddingsConfig = z.infer<typeof MemoryEmbeddingsConfigSchema>;
+export type MemoryRetrievalConfig = z.infer<typeof MemoryRetrievalConfigSchema>;
+export type MemorySegmentationConfig = z.infer<typeof MemorySegmentationConfigSchema>;
+export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
+export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
+export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -7,4 +7,10 @@ export type {
   AuditLogConfig,
   ThinkingConfig,
   ContextWindowConfig,
+  MemoryEmbeddingsConfig,
+  MemoryRetrievalConfig,
+  MemorySegmentationConfig,
+  MemoryJobsConfig,
+  MemoryRetentionConfig,
+  MemoryConfig,
 } from './schema.js';

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -214,6 +214,26 @@ export interface SecretDetected {
   action: 'redact' | 'warn' | 'block';
 }
 
+export interface MemoryRecalled {
+  type: 'memory_recalled';
+  provider: string;
+  model: string;
+  lexicalHits: number;
+  semanticHits: number;
+  recencyHits: number;
+  injectedTokens: number;
+  latencyMs: number;
+}
+
+export interface MemoryStatus {
+  type: 'memory_status';
+  enabled: boolean;
+  degraded: boolean;
+  reason?: string;
+  provider?: string;
+  model?: string;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | AssistantThinkingDelta
@@ -233,7 +253,9 @@ export type ServerMessage =
   | UsageUpdate
   | UsageResponse
   | ContextCompacted
-  | SecretDetected;
+  | SecretDetected
+  | MemoryRecalled
+  | MemoryStatus;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -14,6 +14,7 @@ import { loadConfig } from '../config/loader.js';
 import { DaemonServer } from './server.js';
 import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
+import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
 
 const log = getLogger('lifecycle');
 
@@ -173,6 +174,7 @@ export async function runDaemon(): Promise<void> {
 
   const server = new DaemonServer();
   await server.start();
+  const memoryWorker = startMemoryJobsWorker();
 
   writePid(process.pid);
   log.info({ pid: process.pid }, 'Daemon started');
@@ -204,6 +206,7 @@ export async function runDaemon(): Promise<void> {
     forceTimer.unref();
 
     await server.stop();
+    memoryWorker.stop();
     cleanupPidFile();
     process.exit(0);
   };

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -25,7 +25,7 @@ import {
 } from '../context/window-manager.js';
 import {
   buildMemoryRecall,
-  createMemoryRecallMessage,
+  injectMemoryRecallIntoUserMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 
@@ -238,11 +238,10 @@ export class Session {
 
       if (recall.injectedText.length > 0) {
         const userTail = this.messages[this.messages.length - 1];
-        if (userTail) {
+        if (userTail && userTail.role === 'user') {
           runMessages = [
             ...this.messages.slice(0, -1),
-            createMemoryRecallMessage(recall.injectedText),
-            userTail,
+            injectMemoryRecallIntoUserMessage(userTail, recall.injectedText),
           ];
           onEvent({
             type: 'memory_recalled',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -23,6 +23,11 @@ import {
   ContextWindowManager,
   createContextSummaryMessage,
 } from '../context/window-manager.js';
+import {
+  buildMemoryRecall,
+  createMemoryRecallMessage,
+  stripMemoryRecallMessages,
+} from '../memory/retriever.js';
 
 const log = getLogger('session');
 
@@ -217,8 +222,43 @@ export class Session {
       let exchangeInputTokens = 0;
       let exchangeOutputTokens = 0;
       let model = '';
+      let runMessages = this.messages;
+      const runtimeConfig = getConfig();
+      const recallQuery = buildMemoryQuery(content, this.messages);
+      const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig);
+
+      onEvent({
+        type: 'memory_status',
+        enabled: recall.enabled,
+        degraded: recall.degraded,
+        reason: recall.reason,
+        provider: recall.provider,
+        model: recall.model,
+      });
+
+      if (recall.injectedText.length > 0) {
+        const userTail = this.messages[this.messages.length - 1];
+        if (userTail) {
+          runMessages = [
+            ...this.messages.slice(0, -1),
+            createMemoryRecallMessage(recall.injectedText),
+            userTail,
+          ];
+          onEvent({
+            type: 'memory_recalled',
+            provider: recall.provider ?? 'unknown',
+            model: recall.model ?? 'unknown',
+            lexicalHits: recall.lexicalHits,
+            semanticHits: recall.semanticHits,
+            recencyHits: recall.recencyHits,
+            injectedTokens: recall.injectedTokens,
+            latencyMs: recall.latencyMs,
+          });
+        }
+      }
+
       const updatedHistory = await this.agentLoop.run(
-        this.messages,
+        runMessages,
         (event) => {
           switch (event.type) {
             case 'text_delta':
@@ -258,7 +298,7 @@ export class Session {
         this.abortController.signal,
       );
 
-      this.messages = updatedHistory;
+      this.messages = stripMemoryRecallMessages(updatedHistory);
 
       // Update cumulative token usage
       if (exchangeInputTokens > 0 || exchangeOutputTokens > 0) {
@@ -365,4 +405,21 @@ export class Session {
       log.info({ conversationId: this.conversationId, title }, 'Auto-generated conversation title');
     }
   }
+}
+
+function buildMemoryQuery(content: string, messages: Message[]): string {
+  const summaryMessage = messages.find((message) =>
+    message.role === 'assistant'
+    && message.content.some((block) => block.type === 'text' && block.text.includes('[Context Summary v1]')),
+  );
+  const summaryText = summaryMessage
+    ? summaryMessage.content
+      .filter((block): block is Extract<typeof summaryMessage.content[number], { type: 'text' }> => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n')
+    : '';
+  const compactSummary = summaryText.slice(0, 1200);
+  return compactSummary.length > 0
+    ? `${content}\n\nContext summary:\n${compactSummary}`
+    : content;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -227,6 +227,7 @@ export class Session {
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
         excludeMessageIds: [persistedUserMessage.id],
+        signal: this.abortController.signal,
       });
 
       onEvent({
@@ -299,7 +300,7 @@ export class Session {
         this.abortController.signal,
       );
 
-      this.messages = stripMemoryRecallMessages(updatedHistory);
+      this.messages = stripMemoryRecallMessages(updatedHistory, recall.injectedText);
 
       // Update cumulative token usage
       if (exchangeInputTokens > 0 || exchangeOutputTokens > 0) {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -185,7 +185,7 @@ export class Session {
       // Add user message
       const userMessage = createUserMessage(content);
       this.messages.push(userMessage);
-      conversationStore.addMessage(
+      const persistedUserMessage = conversationStore.addMessage(
         this.conversationId,
         'user',
         JSON.stringify(userMessage.content),
@@ -225,7 +225,9 @@ export class Session {
       let runMessages = this.messages;
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
-      const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig);
+      const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
+        excludeMessageIds: [persistedUserMessage.id],
+      });
 
       onEvent({
         type: 'memory_status',

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -445,9 +445,10 @@ memory
 memory
   .command('backfill')
   .description('Queue a memory backfill job')
-  .action(() => {
+  .option('-f, --force', 'Restart backfill from the beginning')
+  .action((opts: { force?: boolean }) => {
     initializeDb();
-    const jobId = requestMemoryBackfill();
+    const jobId = requestMemoryBackfill(Boolean(opts?.force));
     console.log(`Queued backfill job: ${jobId}`);
   });
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -44,6 +44,12 @@ import {
 } from './memory/conversation-store.js';
 import { initializeDb } from './memory/db.js';
 import { formatMarkdown, formatJson } from './export/formatter.js';
+import {
+  getMemorySystemStatus,
+  queryMemory,
+  requestMemoryBackfill,
+  requestMemoryRebuildIndex,
+} from './memory/admin.js';
 
 function sendOneMessage(
   msg: ClientMessage,
@@ -409,6 +415,79 @@ trust
     }
   });
 
+// --- Memory commands ---
+const memory = program.command('memory').description('Manage long-term memory indexing/retrieval');
+
+memory
+  .command('status')
+  .description('Show memory subsystem status')
+  .action(() => {
+    initializeDb();
+    const status = getMemorySystemStatus();
+    console.log(`Memory enabled: ${status.enabled ? 'yes' : 'no'}`);
+    console.log(`Memory degraded: ${status.degraded ? 'yes' : 'no'}`);
+    if (status.reason) console.log(`Reason: ${status.reason}`);
+    if (status.provider && status.model) {
+      console.log(`Embedding backend: ${status.provider}/${status.model}`);
+    } else {
+      console.log('Embedding backend: none');
+    }
+    console.log(`Segments: ${status.counts.segments.toLocaleString()}`);
+    console.log(`Items: ${status.counts.items.toLocaleString()}`);
+    console.log(`Summaries: ${status.counts.summaries.toLocaleString()}`);
+    console.log(`Embeddings: ${status.counts.embeddings.toLocaleString()}`);
+    console.log('Jobs:');
+    for (const [key, value] of Object.entries(status.jobs)) {
+      console.log(`  ${key}: ${value}`);
+    }
+  });
+
+memory
+  .command('backfill')
+  .description('Queue a memory backfill job')
+  .action(() => {
+    initializeDb();
+    const jobId = requestMemoryBackfill();
+    console.log(`Queued backfill job: ${jobId}`);
+  });
+
+memory
+  .command('query <text>')
+  .description('Run a memory recall query and print the injected memory payload')
+  .option('-s, --session <id>', 'Optional conversation/session ID')
+  .action(async (text: string, opts?: { session?: string }) => {
+    initializeDb();
+    let sessionId = opts?.session;
+    if (!sessionId) {
+      const latest = listConversations(1)[0];
+      sessionId = latest?.id ?? '';
+    }
+    const result = await queryMemory(text, sessionId ?? '');
+    if (result.degraded) {
+      console.log(`Memory degraded: ${result.reason ?? 'unknown reason'}`);
+    }
+    console.log(`Lexical hits: ${result.lexicalHits}`);
+    console.log(`Semantic hits: ${result.semanticHits}`);
+    console.log(`Recency hits: ${result.recencyHits}`);
+    console.log(`Injected tokens: ${result.injectedTokens}`);
+    console.log(`Latency: ${result.latencyMs}ms`);
+    if (result.injectedText.length > 0) {
+      console.log('');
+      console.log(result.injectedText);
+    } else {
+      console.log('No memory injected.');
+    }
+  });
+
+memory
+  .command('rebuild-index')
+  .description('Queue a memory FTS+embedding index rebuild job')
+  .action(() => {
+    initializeDb();
+    const jobId = requestMemoryRebuildIndex();
+    console.log(`Queued rebuild-index job: ${jobId}`);
+  });
+
 // --- Audit command ---
 program
   .command('audit')
@@ -707,9 +786,10 @@ program
       config: ['set', 'get', 'list'],
       keys: ['list', 'set', 'delete'],
       trust: ['list', 'remove', 'clear'],
+      memory: ['status', 'backfill', 'query', 'rebuild-index'],
     };
     const topLevel = [
-      'daemon', 'sessions', 'config', 'keys', 'trust',
+      'daemon', 'sessions', 'config', 'keys', 'trust', 'memory',
       'audit', 'doctor', 'completions', 'help',
     ];
 
@@ -777,6 +857,7 @@ _vellum() {
         'config:Manage configuration'
         'keys:Manage API keys in secure storage'
         'trust:Manage trust rules'
+        'memory:Manage long-term memory'
         'audit:Show recent tool invocations'
         'doctor:Run diagnostic checks'
         'completions:Generate shell completion script'
@@ -817,6 +898,7 @@ function generateFishCompletion(
     config: 'Manage configuration',
     keys: 'Manage API keys in secure storage',
     trust: 'Manage trust rules',
+    memory: 'Manage long-term memory',
     audit: 'Show recent tool invocations',
     doctor: 'Run diagnostic checks',
     completions: 'Generate shell completion script',

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -1,0 +1,70 @@
+import { getConfig } from '../config/loader.js';
+import { getLogger } from '../util/logger.js';
+import { getMemoryBackendStatus } from './embedding-backend.js';
+import { getDb } from './db.js';
+import { enqueueBackfillJob, enqueueRebuildIndexJob } from './indexer.js';
+import { getMemoryJobCounts } from './jobs-store.js';
+import { queryMemoryForCli } from './retriever.js';
+
+const log = getLogger('memory-admin');
+
+export interface MemorySystemStatus {
+  enabled: boolean;
+  degraded: boolean;
+  reason: string | null;
+  provider: string | null;
+  model: string | null;
+  counts: {
+    segments: number;
+    items: number;
+    summaries: number;
+    embeddings: number;
+  };
+  jobs: Record<string, number>;
+}
+
+export function getMemorySystemStatus(): MemorySystemStatus {
+  const config = getConfig();
+  const backend = getMemoryBackendStatus(config);
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { get: () => unknown } } }).$client;
+  const counts = {
+    segments: countTable('memory_segments'),
+    items: countTable('memory_items'),
+    summaries: countTable('memory_summaries'),
+    embeddings: countTable('memory_embeddings'),
+  };
+  return {
+    enabled: backend.enabled,
+    degraded: backend.degraded,
+    reason: backend.reason,
+    provider: backend.provider,
+    model: backend.model,
+    counts,
+    jobs: getMemoryJobCounts(),
+  };
+
+  function countTable(table: string): number {
+    const row = raw.query(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number } | null;
+    return row?.c ?? 0;
+  }
+}
+
+export function requestMemoryBackfill(): string {
+  const id = enqueueBackfillJob(true);
+  log.info({ jobId: id }, 'Queued memory backfill job');
+  return id;
+}
+
+export function requestMemoryRebuildIndex(): string {
+  const id = enqueueRebuildIndexJob();
+  log.info({ jobId: id }, 'Queued memory index rebuild job');
+  return id;
+}
+
+export async function queryMemory(
+  query: string,
+  conversationId: string,
+) {
+  return queryMemoryForCli(query, conversationId, getConfig());
+}

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -50,8 +50,8 @@ export function getMemorySystemStatus(): MemorySystemStatus {
   }
 }
 
-export function requestMemoryBackfill(): string {
-  const id = enqueueBackfillJob(true);
+export function requestMemoryBackfill(force = false): string {
+  const id = enqueueBackfillJob(force);
   log.info({ jobId: id }, 'Queued memory backfill job');
   return id;
 }

--- a/assistant/src/memory/checkpoints.ts
+++ b/assistant/src/memory/checkpoints.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm';
+import { getDb } from './db.js';
+import { memoryCheckpoints } from './schema.js';
+
+export function getMemoryCheckpoint(key: string): string | null {
+  const db = getDb();
+  const row = db
+    .select({ value: memoryCheckpoints.value })
+    .from(memoryCheckpoints)
+    .where(eq(memoryCheckpoints.key, key))
+    .get();
+  return row?.value ?? null;
+}
+
+export function setMemoryCheckpoint(key: string, value: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(memoryCheckpoints)
+    .values({ key, value, updatedAt: now })
+    .onConflictDoUpdate({
+      target: memoryCheckpoints.key,
+      set: { value, updatedAt: now },
+    })
+    .run();
+}

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -2,6 +2,11 @@ import { eq, desc, asc, and, count, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { conversations, messages } from './schema.js';
+import { getConfig } from '../config/loader.js';
+import { indexMessageNow } from './indexer.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('conversation-store');
 
 export function createConversation(title?: string) {
   const db = getDb();
@@ -71,6 +76,20 @@ export function addMessage(conversationId: string, role: string, content: string
       .where(eq(conversations.id, conversationId))
       .run();
   });
+
+  try {
+    const config = getConfig();
+    indexMessageNow({
+      messageId: message.id,
+      conversationId: message.conversationId,
+      role: message.role,
+      content: message.content,
+      createdAt: message.createdAt,
+    }, config.memory);
+  } catch (err) {
+    log.warn({ err, conversationId, messageId: message.id }, 'Failed to index message for memory');
+  }
+
   return message;
 }
 

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -67,6 +67,130 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_segments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      segment_index INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_items (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      statement TEXT NOT NULL,
+      status TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      fingerprint TEXT NOT NULL UNIQUE,
+      first_seen_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL,
+      last_used_at INTEGER
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_item_sources (
+      memory_item_id TEXT NOT NULL REFERENCES memory_items(id) ON DELETE CASCADE,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      evidence TEXT,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (memory_item_id, message_id)
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_summaries (
+      id TEXT PRIMARY KEY,
+      scope TEXT NOT NULL,
+      scope_key TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      start_at INTEGER NOT NULL,
+      end_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (scope, scope_key)
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_embeddings (
+      id TEXT PRIMARY KEY,
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      dimensions INTEGER NOT NULL,
+      vector_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (target_type, target_id, provider, model)
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_jobs (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      run_after INTEGER NOT NULL,
+      last_error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  // FTS table for lexical retrieval over memory_segments.text.
+  database.run(/*sql*/ `
+    CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
+      segment_id UNINDEXED,
+      text
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS memory_segments_ai
+    AFTER INSERT ON memory_segments
+    BEGIN
+      INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text);
+    END
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS memory_segments_ad
+    AFTER DELETE ON memory_segments
+    BEGIN
+      DELETE FROM memory_segment_fts WHERE segment_id = old.id;
+    END
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TRIGGER IF NOT EXISTS memory_segments_au
+    AFTER UPDATE ON memory_segments
+    BEGIN
+      DELETE FROM memory_segment_fts WHERE segment_id = old.id;
+      INSERT INTO memory_segment_fts(segment_id, text) VALUES (new.id, new.text);
+    END
+  `);
+
   // Migrations — ALTER TABLE ADD COLUMN throws if column already exists
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
@@ -81,6 +205,16 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_tool_invocations_conversation_id ON tool_invocations(conversation_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at)`);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_segments_message_segment ON memory_segments(message_id, segment_index)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_created ON memory_segments(conversation_id, created_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_sources_message_id ON memory_item_sources(message_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_kind_status ON memory_items(kind, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time ON memory_summaries(scope, end_at DESC)`);
+
+  migrateMemoryFtsBackfill(database);
 }
 
 /**
@@ -123,4 +257,20 @@ function migrateToolInvocationsFk(database: ReturnType<typeof drizzle<typeof sch
   } finally {
     raw.exec('PRAGMA foreign_keys = ON');
   }
+}
+
+/**
+ * Backfill FTS rows for existing memory_segments records when upgrading from a
+ * version that may not have had trigger-managed FTS.
+ */
+function migrateMemoryFtsBackfill(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  const ftsCountRow = raw.query(`SELECT COUNT(*) AS c FROM memory_segment_fts`).get() as { c: number } | null;
+  const ftsCount = ftsCountRow?.c ?? 0;
+  if (ftsCount > 0) return;
+
+  raw.exec(/*sql*/ `
+    INSERT INTO memory_segment_fts(segment_id, text)
+    SELECT id, text FROM memory_segments
+  `);
 }

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,0 +1,119 @@
+import type { AssistantConfig } from '../config/types.js';
+import { getLogger } from '../util/logger.js';
+import { GeminiEmbeddingBackend } from './embedding-gemini.js';
+import { OllamaEmbeddingBackend } from './embedding-ollama.js';
+import { OpenAIEmbeddingBackend } from './embedding-openai.js';
+
+const log = getLogger('memory-embeddings');
+
+export type EmbeddingProviderName = 'openai' | 'gemini' | 'ollama';
+
+export interface EmbeddingBackend {
+  readonly provider: EmbeddingProviderName;
+  readonly model: string;
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface EmbeddingBackendSelection {
+  backend: EmbeddingBackend | null;
+  reason: string | null;
+}
+
+export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBackendSelection {
+  const requested = config.memory.embeddings.provider;
+  const order: EmbeddingProviderName[] = requested === 'auto'
+    ? ['openai', 'gemini', 'ollama']
+    : [requested];
+
+  for (const provider of order) {
+    switch (provider) {
+      case 'openai':
+        if (!config.apiKeys.openai) continue;
+        return {
+          backend: new OpenAIEmbeddingBackend(config.apiKeys.openai, config.memory.embeddings.openaiModel),
+          reason: null,
+        };
+      case 'gemini':
+        if (!config.apiKeys.gemini) continue;
+        return {
+          backend: new GeminiEmbeddingBackend(config.apiKeys.gemini, config.memory.embeddings.geminiModel),
+          reason: null,
+        };
+      case 'ollama':
+        if (!isOllamaConfigured(config)) continue;
+        return {
+          backend: new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
+            apiKey: config.apiKeys.ollama,
+          }),
+          reason: null,
+        };
+    }
+  }
+
+  const reason = requested === 'auto'
+    ? 'No embedding backend configured (openai/gemini keys missing and ollama not configured)'
+    : `Embedding backend "${requested}" is not configured`;
+  return { backend: null, reason };
+}
+
+export function getMemoryBackendStatus(config: AssistantConfig): {
+  enabled: boolean;
+  degraded: boolean;
+  provider: EmbeddingProviderName | null;
+  model: string | null;
+  reason: string | null;
+} {
+  if (!config.memory.enabled) {
+    return { enabled: false, degraded: false, provider: null, model: null, reason: 'memory.disabled' };
+  }
+  const selection = selectEmbeddingBackend(config);
+  if (!selection.backend) {
+    return {
+      enabled: true,
+      degraded: config.memory.embeddings.required,
+      provider: null,
+      model: null,
+      reason: selection.reason,
+    };
+  }
+  return {
+    enabled: true,
+    degraded: false,
+    provider: selection.backend.provider,
+    model: selection.backend.model,
+    reason: null,
+  };
+}
+
+export async function embedWithBackend(
+  config: AssistantConfig,
+  texts: string[],
+): Promise<{
+  provider: EmbeddingProviderName;
+  model: string;
+  vectors: number[][];
+}> {
+  const selection = selectEmbeddingBackend(config);
+  if (!selection.backend) {
+    throw new Error(selection.reason ?? 'No memory embedding backend configured');
+  }
+  const vectors = await selection.backend.embed(texts);
+  if (vectors.length !== texts.length) {
+    throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
+  }
+  return {
+    provider: selection.backend.provider,
+    model: selection.backend.model,
+    vectors,
+  };
+}
+
+export function logMemoryEmbeddingWarning(err: unknown, context: string): void {
+  log.warn({ err }, `Memory embeddings failed (${context})`);
+}
+
+function isOllamaConfigured(config: AssistantConfig): boolean {
+  return config.provider === 'ollama'
+    || Boolean(config.apiKeys.ollama)
+    || Boolean(process.env.OLLAMA_BASE_URL);
+}

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -21,6 +21,14 @@ export interface EmbeddingBackendSelection {
 
 export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBackendSelection {
   const requested = config.memory.embeddings.provider;
+  if (requested === 'ollama') {
+    return {
+      backend: new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
+        apiKey: config.apiKeys.ollama,
+      }),
+      reason: null,
+    };
+  }
   const order: EmbeddingProviderName[] = requested === 'auto'
     ? ['openai', 'gemini', 'ollama']
     : [requested];

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -8,10 +8,14 @@ const log = getLogger('memory-embeddings');
 
 export type EmbeddingProviderName = 'openai' | 'gemini' | 'ollama';
 
+export interface EmbeddingRequestOptions {
+  signal?: AbortSignal;
+}
+
 export interface EmbeddingBackend {
   readonly provider: EmbeddingProviderName;
   readonly model: string;
-  embed(texts: string[]): Promise<number[][]>;
+  embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]>;
 }
 
 export interface EmbeddingBackendSelection {
@@ -96,6 +100,7 @@ export function getMemoryBackendStatus(config: AssistantConfig): {
 export async function embedWithBackend(
   config: AssistantConfig,
   texts: string[],
+  options?: EmbeddingRequestOptions,
 ): Promise<{
   provider: EmbeddingProviderName;
   model: string;
@@ -105,7 +110,7 @@ export async function embedWithBackend(
   if (!selection.backend) {
     throw new Error(selection.reason ?? 'No memory embedding backend configured');
   }
-  const vectors = await selection.backend.embed(texts);
+  const vectors = await selection.backend.embed(texts, options);
   if (vectors.length !== texts.length) {
     throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
   }

--- a/assistant/src/memory/embedding-gemini.ts
+++ b/assistant/src/memory/embedding-gemini.ts
@@ -1,4 +1,4 @@
-import type { EmbeddingBackend } from './embedding-backend.js';
+import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
 
 interface GeminiEmbedResponse {
   embedding?: {
@@ -16,16 +16,16 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
     this.model = model;
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
     const vectors: number[][] = [];
     for (const text of texts) {
-      const values = await this.embedSingle(text);
+      const values = await this.embedSingle(text, options);
       vectors.push(values);
     }
     return vectors;
   }
 
-  private async embedSingle(text: string): Promise<number[]> {
+  private async embedSingle(text: string, options?: EmbeddingRequestOptions): Promise<number[]> {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(this.model)}:embedContent?key=${encodeURIComponent(this.apiKey)}`;
     const response = await fetch(url, {
       method: 'POST',
@@ -36,6 +36,7 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
           parts: [{ text }],
         },
       }),
+      signal: options?.signal,
     });
     if (!response.ok) {
       const body = await response.text();

--- a/assistant/src/memory/embedding-gemini.ts
+++ b/assistant/src/memory/embedding-gemini.ts
@@ -1,0 +1,51 @@
+import type { EmbeddingBackend } from './embedding-backend.js';
+
+interface GeminiEmbedResponse {
+  embedding?: {
+    values?: number[];
+  };
+}
+
+export class GeminiEmbeddingBackend implements EmbeddingBackend {
+  readonly provider = 'gemini' as const;
+  readonly model: string;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string, model: string) {
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    const vectors: number[][] = [];
+    for (const text of texts) {
+      const values = await this.embedSingle(text);
+      vectors.push(values);
+    }
+    return vectors;
+  }
+
+  private async embedSingle(text: string): Promise<number[]> {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(this.model)}:embedContent?key=${encodeURIComponent(this.apiKey)}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: `models/${this.model}`,
+        content: {
+          parts: [{ text }],
+        },
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gemini embeddings request failed (${response.status}): ${body}`);
+    }
+    const payload = await response.json() as GeminiEmbedResponse;
+    const values = payload.embedding?.values;
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error('Gemini embeddings response missing vector values');
+    }
+    return values;
+  }
+}

--- a/assistant/src/memory/embedding-ollama.ts
+++ b/assistant/src/memory/embedding-ollama.ts
@@ -1,0 +1,54 @@
+import type { EmbeddingBackend } from './embedding-backend.js';
+
+interface OllamaEmbeddingsResponse {
+  data?: Array<{ embedding: number[] }>;
+  embeddings?: number[][];
+}
+
+const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434/v1';
+
+export class OllamaEmbeddingBackend implements EmbeddingBackend {
+  readonly provider = 'ollama' as const;
+  readonly model: string;
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(model: string, options?: { baseUrl?: string; apiKey?: string }) {
+    this.model = model;
+    this.baseUrl = resolveBaseUrl(options?.baseUrl);
+    this.apiKey = options?.apiKey ?? 'ollama';
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const response = await fetch(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Ollama embeddings request failed (${response.status}): ${body}`);
+    }
+    const payload = await response.json() as OllamaEmbeddingsResponse;
+    if (Array.isArray(payload.data)) {
+      return payload.data.map((item) => item.embedding);
+    }
+    if (Array.isArray(payload.embeddings)) {
+      return payload.embeddings;
+    }
+    throw new Error('Ollama embeddings response missing vectors');
+  }
+}
+
+function resolveBaseUrl(override?: string): string {
+  const value = (override ?? process.env.OLLAMA_BASE_URL ?? DEFAULT_OLLAMA_BASE_URL).trim();
+  if (value.endsWith('/')) return value.slice(0, -1);
+  return value;
+}

--- a/assistant/src/memory/embedding-ollama.ts
+++ b/assistant/src/memory/embedding-ollama.ts
@@ -1,4 +1,4 @@
-import type { EmbeddingBackend } from './embedding-backend.js';
+import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
 
 interface OllamaEmbeddingsResponse {
   data?: Array<{ embedding: number[] }>;
@@ -19,7 +19,7 @@ export class OllamaEmbeddingBackend implements EmbeddingBackend {
     this.apiKey = options?.apiKey ?? 'ollama';
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
     if (texts.length === 0) return [];
     const response = await fetch(`${this.baseUrl}/embeddings`, {
       method: 'POST',
@@ -31,6 +31,7 @@ export class OllamaEmbeddingBackend implements EmbeddingBackend {
         model: this.model,
         input: texts,
       }),
+      signal: options?.signal,
     });
     if (!response.ok) {
       const body = await response.text();

--- a/assistant/src/memory/embedding-openai.ts
+++ b/assistant/src/memory/embedding-openai.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import type { EmbeddingBackend } from './embedding-backend.js';
+import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
 
 export class OpenAIEmbeddingBackend implements EmbeddingBackend {
   readonly provider = 'openai' as const;
@@ -11,12 +11,14 @@ export class OpenAIEmbeddingBackend implements EmbeddingBackend {
     this.client = new OpenAI({ apiKey });
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
     if (texts.length === 0) return [];
     const response = await this.client.embeddings.create({
       model: this.model,
       input: texts,
       encoding_format: 'float',
+    }, {
+      signal: options?.signal,
     });
     return response.data.map((item) => item.embedding);
   }

--- a/assistant/src/memory/embedding-openai.ts
+++ b/assistant/src/memory/embedding-openai.ts
@@ -1,0 +1,23 @@
+import OpenAI from 'openai';
+import type { EmbeddingBackend } from './embedding-backend.js';
+
+export class OpenAIEmbeddingBackend implements EmbeddingBackend {
+  readonly provider = 'openai' as const;
+  readonly model: string;
+  private readonly client: OpenAI;
+
+  constructor(apiKey: string, model: string) {
+    this.model = model;
+    this.client = new OpenAI({ apiKey });
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: texts,
+      encoding_format: 'float',
+    });
+    return response.data.map((item) => item.embedding);
+  }
+}

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -64,7 +64,6 @@ export function indexMessageNow(
         updatedAt: now,
       },
     }).run();
-    enqueueMemoryJob('embed_segment', { segmentId });
   }
 
   enqueueMemoryJob('extract_items', { messageId: input.messageId });
@@ -73,7 +72,7 @@ export function indexMessageNow(
 
   return {
     indexedSegments: segments.length,
-    enqueuedJobs: segments.length + 2,
+    enqueuedJobs: 2,
   };
 }
 

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,0 +1,116 @@
+import { eq } from 'drizzle-orm';
+import type { MemoryConfig } from '../config/types.js';
+import { getLogger } from '../util/logger.js';
+import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
+import { getDb } from './db.js';
+import { enqueueMemoryJob } from './jobs-store.js';
+import { extractTextFromStoredMessageContent } from './message-content.js';
+import { segmentText } from './segmenter.js';
+import { memorySegments } from './schema.js';
+
+const log = getLogger('memory-indexer');
+const SUMMARY_JOB_CHECKPOINT_KEY = 'memory:summary_jobs:last_scheduled_at';
+const SUMMARY_SCHEDULE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export interface IndexMessageInput {
+  messageId: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+}
+
+export interface IndexMessageResult {
+  indexedSegments: number;
+  enqueuedJobs: number;
+}
+
+export function indexMessageNow(
+  input: IndexMessageInput,
+  config: MemoryConfig,
+): IndexMessageResult {
+  if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
+
+  const text = extractTextFromStoredMessageContent(input.content);
+  if (text.length === 0) {
+    enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
+    return { indexedSegments: 0, enqueuedJobs: 1 };
+  }
+
+  const db = getDb();
+  const now = Date.now();
+  const segments = segmentText(
+    text,
+    config.segmentation.targetTokens,
+    config.segmentation.overlapTokens,
+  );
+  for (const segment of segments) {
+    const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
+    db.insert(memorySegments).values({
+      id: segmentId,
+      messageId: input.messageId,
+      conversationId: input.conversationId,
+      role: input.role,
+      segmentIndex: segment.segmentIndex,
+      text: segment.text,
+      tokenEstimate: segment.tokenEstimate,
+      createdAt: input.createdAt,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: memorySegments.id,
+      set: {
+        text: segment.text,
+        tokenEstimate: segment.tokenEstimate,
+        updatedAt: now,
+      },
+    }).run();
+    enqueueMemoryJob('embed_segment', { segmentId });
+  }
+
+  enqueueMemoryJob('extract_items', { messageId: input.messageId });
+  enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
+  enqueueSummaryRollupJobsIfDue();
+
+  return {
+    indexedSegments: segments.length,
+    enqueuedJobs: segments.length + 2,
+  };
+}
+
+export function enqueueBackfillJob(force = false): string {
+  return enqueueMemoryJob('backfill', { force });
+}
+
+export function enqueueRebuildIndexJob(): string {
+  return enqueueMemoryJob('rebuild_index', {});
+}
+
+export function getRecentSegmentsForConversation(
+  conversationId: string,
+  limit: number,
+): Array<typeof memorySegments.$inferSelect> {
+  const db = getDb();
+  return db
+    .select()
+    .from(memorySegments)
+    .where(eq(memorySegments.conversationId, conversationId))
+    .orderBy(memorySegments.createdAt)
+    .limit(limit)
+    .all();
+}
+
+function enqueueSummaryRollupJobsIfDue(): void {
+  const now = Date.now();
+  const raw = getMemoryCheckpoint(SUMMARY_JOB_CHECKPOINT_KEY);
+  const last = raw ? Number.parseInt(raw, 10) : 0;
+  if (Number.isFinite(last) && now - last < SUMMARY_SCHEDULE_INTERVAL_MS) return;
+
+  enqueueMemoryJob('refresh_weekly_summary', {});
+  enqueueMemoryJob('refresh_monthly_summary', {});
+  setMemoryCheckpoint(SUMMARY_JOB_CHECKPOINT_KEY, String(now));
+  log.debug('Scheduled periodic global summary jobs');
+}
+
+function buildSegmentId(messageId: string, segmentIndex: number): string {
+  return `${messageId}:${segmentIndex}`;
+}

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import type { MemoryConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
@@ -66,13 +66,16 @@ export function indexMessageNow(
     }).run();
   }
 
-  enqueueMemoryJob('extract_items', { messageId: input.messageId });
+  if (input.role === 'user') {
+    enqueueMemoryJob('extract_items', { messageId: input.messageId });
+  }
   enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
   enqueueSummaryRollupJobsIfDue();
 
+  const enqueuedJobs = input.role === 'user' ? 2 : 1;
   return {
     indexedSegments: segments.length,
-    enqueuedJobs: 2,
+    enqueuedJobs,
   };
 }
 
@@ -93,7 +96,7 @@ export function getRecentSegmentsForConversation(
     .select()
     .from(memorySegments)
     .where(eq(memorySegments.conversationId, conversationId))
-    .orderBy(memorySegments.createdAt)
+    .orderBy(desc(memorySegments.createdAt))
     .limit(limit)
     .all();
 }

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -42,6 +42,7 @@ export function extractAndUpsertMemoryItemsForMessage(messageId: string): number
   let upserted = 0;
   for (const item of extracted) {
     const now = Date.now();
+    const seenAt = message.createdAt;
     const existing = db
       .select()
       .from(memoryItems)
@@ -55,7 +56,7 @@ export function extractAndUpsertMemoryItemsForMessage(messageId: string): number
         .set({
           status: 'active',
           confidence: Math.max(existing.confidence, item.confidence),
-          lastSeenAt: now,
+          lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
         })
         .where(eq(memoryItems.id, existing.id))
         .run();
@@ -70,7 +71,7 @@ export function extractAndUpsertMemoryItemsForMessage(messageId: string): number
         confidence: item.confidence,
         fingerprint: item.fingerprint,
         firstSeenAt: message.createdAt,
-        lastSeenAt: now,
+        lastSeenAt: seenAt,
         lastUsedAt: null,
       }).run();
       upserted += 1;

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getLogger } from '../util/logger.js';
+import { enqueueMemoryJob } from './jobs-store.js';
+import { extractTextFromStoredMessageContent } from './message-content.js';
+import { getDb } from './db.js';
+import { memoryItems, memoryItemSources, messages } from './schema.js';
+
+const log = getLogger('memory-items-extractor');
+
+type MemoryItemKind = 'preference' | 'profile' | 'project' | 'decision' | 'todo' | 'fact' | 'constraint';
+
+interface ExtractedItem {
+  kind: MemoryItemKind;
+  subject: string;
+  statement: string;
+  confidence: number;
+  fingerprint: string;
+}
+
+const SUPERSEDE_KINDS = new Set<MemoryItemKind>(['decision', 'preference', 'constraint']);
+
+export function extractAndUpsertMemoryItemsForMessage(messageId: string): number {
+  const db = getDb();
+  const message = db
+    .select({
+      id: messages.id,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+
+  if (!message) return 0;
+
+  const text = extractTextFromStoredMessageContent(message.content);
+  const extracted = extractItems(text);
+  if (extracted.length === 0) return 0;
+
+  let upserted = 0;
+  for (const item of extracted) {
+    const now = Date.now();
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.fingerprint, item.fingerprint))
+      .get();
+
+    let memoryItemId: string;
+    if (existing) {
+      memoryItemId = existing.id;
+      db.update(memoryItems)
+        .set({
+          status: 'active',
+          confidence: Math.max(existing.confidence, item.confidence),
+          lastSeenAt: now,
+        })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+    } else {
+      memoryItemId = uuid();
+      db.insert(memoryItems).values({
+        id: memoryItemId,
+        kind: item.kind,
+        subject: item.subject,
+        statement: item.statement,
+        status: 'active',
+        confidence: item.confidence,
+        fingerprint: item.fingerprint,
+        firstSeenAt: message.createdAt,
+        lastSeenAt: now,
+        lastUsedAt: null,
+      }).run();
+      upserted += 1;
+    }
+
+    if (SUPERSEDE_KINDS.has(item.kind)) {
+      db.update(memoryItems)
+        .set({ status: 'superseded' })
+        .where(and(
+          eq(memoryItems.kind, item.kind),
+          eq(memoryItems.subject, item.subject),
+          eq(memoryItems.status, 'active'),
+          sql`${memoryItems.id} <> ${memoryItemId}`,
+        ))
+        .run();
+    }
+
+    db.insert(memoryItemSources).values({
+      memoryItemId,
+      messageId,
+      evidence: item.statement.slice(0, 500),
+      createdAt: now,
+    }).onConflictDoNothing().run();
+
+    enqueueMemoryJob('embed_item', { itemId: memoryItemId });
+  }
+
+  log.debug({ messageId, extracted: extracted.length, upserted }, 'Extracted memory items from message');
+  return upserted;
+}
+
+function extractItems(text: string): ExtractedItem[] {
+  const sentences = text
+    .split(/[\n\r]+|(?<=[.!?])\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 20 && s.length <= 500);
+
+  const items: ExtractedItem[] = [];
+  for (const sentence of sentences) {
+    const lower = sentence.toLowerCase();
+    const classification = classifySentence(lower);
+    if (!classification) continue;
+    const subject = inferSubject(sentence, classification.kind);
+    const statement = sentence.replace(/\s+/g, ' ').trim();
+    const normalized = `${classification.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+    items.push({
+      kind: classification.kind,
+      subject,
+      statement,
+      confidence: classification.confidence,
+      fingerprint,
+    });
+  }
+
+  // Deduplicate within a single extraction run.
+  const seen = new Set<string>();
+  const unique: ExtractedItem[] = [];
+  for (const item of items) {
+    if (seen.has(item.fingerprint)) continue;
+    seen.add(item.fingerprint);
+    unique.push(item);
+  }
+  return unique;
+}
+
+function classifySentence(lower: string): { kind: MemoryItemKind; confidence: number } | null {
+  if (includesAny(lower, ['i prefer', 'prefer to', 'favorite', 'i like', 'i dislike'])) {
+    return { kind: 'preference', confidence: 0.78 };
+  }
+  if (includesAny(lower, ['my name is', 'i am ', 'i work as', 'i live in', 'timezone'])) {
+    return { kind: 'profile', confidence: 0.72 };
+  }
+  if (includesAny(lower, ['project', 'repository', 'repo', 'codebase'])) {
+    return { kind: 'project', confidence: 0.68 };
+  }
+  if (includesAny(lower, ['we decided', 'decision', 'chosen approach', 'we will'])) {
+    return { kind: 'decision', confidence: 0.75 };
+  }
+  if (includesAny(lower, ['todo', 'to do', 'next step', 'follow up', 'need to'])) {
+    return { kind: 'todo', confidence: 0.74 };
+  }
+  if (includesAny(lower, ['must', 'cannot', 'should not', 'constraint', 'requirement'])) {
+    return { kind: 'constraint', confidence: 0.7 };
+  }
+  if (includesAny(lower, ['remember', 'important', 'fact', 'noted'])) {
+    return { kind: 'fact', confidence: 0.62 };
+  }
+  return null;
+}
+
+function inferSubject(sentence: string, kind: MemoryItemKind): string {
+  const trimmed = sentence.trim();
+  if (kind === 'project') {
+    const match = trimmed.match(/(?:project|repo(?:sitory)?)\s+([A-Za-z0-9._/-]{2,80})/i);
+    if (match) return match[1];
+  }
+  const words = trimmed.split(/\s+/).slice(0, 6).join(' ');
+  return words.slice(0, 80);
+}
+
+function includesAny(text: string, needles: string[]): boolean {
+  for (const needle of needles) {
+    if (text.includes(needle)) return true;
+  }
+  return false;
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -1,0 +1,173 @@
+import { and, asc, eq, lte } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { memoryJobs } from './schema.js';
+
+export type MemoryJobType =
+  | 'embed_segment'
+  | 'embed_item'
+  | 'embed_summary'
+  | 'extract_items'
+  | 'refresh_weekly_summary'
+  | 'refresh_monthly_summary'
+  | 'build_conversation_summary'
+  | 'backfill'
+  | 'rebuild_index';
+
+export interface MemoryJob<T = Record<string, unknown>> {
+  id: string;
+  type: MemoryJobType;
+  payload: T;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  attempts: number;
+  runAfter: number;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function enqueueMemoryJob(
+  type: MemoryJobType,
+  payload: Record<string, unknown>,
+  runAfter = Date.now(),
+): string {
+  const db = getDb();
+  const id = uuid();
+  const now = Date.now();
+  db.insert(memoryJobs).values({
+    id,
+    type,
+    payload: JSON.stringify(payload),
+    status: 'pending',
+    attempts: 0,
+    runAfter,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  return id;
+}
+
+export function claimMemoryJobs(limit: number): MemoryJob[] {
+  if (limit <= 0) return [];
+  const db = getDb();
+  const now = Date.now();
+  const candidates = db
+    .select()
+    .from(memoryJobs)
+    .where(and(eq(memoryJobs.status, 'pending'), lte(memoryJobs.runAfter, now)))
+    .orderBy(asc(memoryJobs.runAfter), asc(memoryJobs.createdAt))
+    .limit(limit)
+    .all();
+
+  const claimed: MemoryJob[] = [];
+  for (const row of candidates) {
+    db.update(memoryJobs)
+      .set({ status: 'running', updatedAt: now })
+      .where(and(eq(memoryJobs.id, row.id), eq(memoryJobs.status, 'pending')))
+      .run();
+    claimed.push(parseRow({
+      ...row,
+      status: 'running',
+      updatedAt: now,
+    }));
+  }
+  return claimed;
+}
+
+export function completeMemoryJob(id: string): void {
+  const db = getDb();
+  db.update(memoryJobs)
+    .set({ status: 'completed', updatedAt: Date.now(), lastError: null })
+    .where(eq(memoryJobs.id, id))
+    .run();
+}
+
+export function failMemoryJob(
+  id: string,
+  error: string,
+  options?: { retryDelayMs?: number; maxAttempts?: number },
+): void {
+  const retryDelayMs = options?.retryDelayMs ?? 30_000;
+  const maxAttempts = options?.maxAttempts ?? 5;
+  const db = getDb();
+  const row = db
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, id))
+    .get();
+  if (!row) return;
+  const attempts = row.attempts + 1;
+  const now = Date.now();
+  if (attempts >= maxAttempts) {
+    db.update(memoryJobs)
+      .set({
+        status: 'failed',
+        attempts,
+        updatedAt: now,
+        lastError: error.slice(0, 2000),
+      })
+      .where(eq(memoryJobs.id, id))
+      .run();
+    return;
+  }
+  db.update(memoryJobs)
+    .set({
+      status: 'pending',
+      attempts,
+      runAfter: now + retryDelayMs,
+      updatedAt: now,
+      lastError: error.slice(0, 2000),
+    })
+    .where(eq(memoryJobs.id, id))
+    .run();
+}
+
+export function resetRunningJobsToPending(): number {
+  const db = getDb();
+  const runningRows = db
+    .select({ id: memoryJobs.id })
+    .from(memoryJobs)
+    .where(eq(memoryJobs.status, 'running'))
+    .all();
+  db.update(memoryJobs)
+    .set({ status: 'pending', updatedAt: Date.now() })
+    .where(eq(memoryJobs.status, 'running'))
+    .run();
+  return runningRows.length;
+}
+
+export function getMemoryJobCounts(): Record<string, number> {
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: () => unknown[] } } }).$client;
+  const rows = raw.query(`
+    SELECT status, COUNT(*) AS c
+    FROM memory_jobs
+    GROUP BY status
+  `).all() as Array<{ status: string; c: number }>;
+  const counts: Record<string, number> = { pending: 0, running: 0, completed: 0, failed: 0 };
+  for (const row of rows) {
+    counts[row.status] = row.c;
+  }
+  return counts;
+}
+
+function parseRow(row: typeof memoryJobs.$inferSelect): MemoryJob {
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = JSON.parse(row.payload) as Record<string, unknown>;
+  } catch {
+    payload = { raw: row.payload };
+  }
+  return {
+    id: row.id,
+    type: row.type as MemoryJobType,
+    payload,
+    status: row.status as MemoryJob['status'],
+    attempts: row.attempts,
+    runAfter: row.runAfter,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -62,10 +62,11 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
 
   const claimed: MemoryJob[] = [];
   for (const row of candidates) {
-    db.update(memoryJobs)
+    const result = db.update(memoryJobs)
       .set({ status: 'running', updatedAt: now })
       .where(and(eq(memoryJobs.id, row.id), eq(memoryJobs.status, 'pending')))
-      .run();
+      .run() as unknown as { changes?: number };
+    if ((result.changes ?? 0) === 0) continue;
     claimed.push(parseRow({
       ...row,
       status: 'running',

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,0 +1,447 @@
+import { and, asc, desc, eq, gt, gte, lt, or } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import type { AssistantConfig } from '../config/types.js';
+import { getConfig } from '../config/loader.js';
+import { estimateTextTokens } from '../context/token-estimator.js';
+import { getLogger } from '../util/logger.js';
+import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
+import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';
+import { getDb } from './db.js';
+import {
+  claimMemoryJobs,
+  completeMemoryJob,
+  enqueueMemoryJob,
+  failMemoryJob,
+  type MemoryJob,
+  resetRunningJobsToPending,
+} from './jobs-store.js';
+import { indexMessageNow } from './indexer.js';
+import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
+import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries, messages } from './schema.js';
+
+const log = getLogger('memory-jobs-worker');
+const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';
+const BACKFILL_CHECKPOINT_ID_KEY = 'memory:backfill:last_message_id';
+
+export interface MemoryJobsWorker {
+  runOnce(): Promise<number>;
+  stop(): void;
+}
+
+export function startMemoryJobsWorker(): MemoryJobsWorker {
+  const recovered = resetRunningJobsToPending();
+  if (recovered > 0) {
+    log.info({ recovered }, 'Recovered stale running memory jobs');
+  }
+
+  let stopped = false;
+  let tickRunning = false;
+
+  const tick = async () => {
+    if (stopped || tickRunning) return;
+    tickRunning = true;
+    try {
+      await runMemoryJobsOnce();
+    } catch (err) {
+      log.error({ err }, 'Memory worker tick failed');
+    } finally {
+      tickRunning = false;
+    }
+  };
+
+  const timer = setInterval(() => { void tick(); }, 1500);
+  timer.unref();
+  void tick();
+
+  return {
+    async runOnce(): Promise<number> {
+      return runMemoryJobsOnce();
+    },
+    stop(): void {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}
+
+export async function runMemoryJobsOnce(): Promise<number> {
+  const config = getConfig();
+  if (!config.memory.enabled) return 0;
+  const concurrency = Math.max(1, config.memory.jobs.workerConcurrency);
+  const jobs = claimMemoryJobs(concurrency);
+  if (jobs.length === 0) return 0;
+
+  let processed = 0;
+  for (const job of jobs) {
+    try {
+      await processJob(job, config);
+      completeMemoryJob(job.id);
+      processed += 1;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      failMemoryJob(job.id, message);
+      log.warn({ err, jobId: job.id, type: job.type }, 'Memory job failed');
+    }
+  }
+  return processed;
+}
+
+async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  switch (job.type) {
+    case 'embed_segment':
+      await embedSegmentJob(job, config);
+      return;
+    case 'embed_item':
+      await embedItemJob(job, config);
+      return;
+    case 'embed_summary':
+      await embedSummaryJob(job, config);
+      return;
+    case 'extract_items':
+      extractItemsJob(job);
+      return;
+    case 'build_conversation_summary':
+      buildConversationSummaryJob(job);
+      return;
+    case 'refresh_weekly_summary':
+      buildGlobalSummaryJob('weekly_global');
+      return;
+    case 'refresh_monthly_summary':
+      buildGlobalSummaryJob('monthly_global');
+      return;
+    case 'backfill':
+      backfillJob(job, config);
+      return;
+    case 'rebuild_index':
+      rebuildIndexJob();
+      return;
+    default:
+      throw new Error(`Unknown memory job type: ${(job as { type: string }).type}`);
+  }
+}
+
+async function embedSegmentJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  const segmentId = asString(job.payload.segmentId);
+  if (!segmentId) return;
+  const db = getDb();
+  const segment = db
+    .select({ id: memorySegments.id, text: memorySegments.text })
+    .from(memorySegments)
+    .where(eq(memorySegments.id, segmentId))
+    .get();
+  if (!segment) return;
+  await embedAndUpsert(config, 'segment', segment.id, segment.text);
+}
+
+async function embedItemJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  const itemId = asString(job.payload.itemId);
+  if (!itemId) return;
+  const db = getDb();
+  const item = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, itemId))
+    .get();
+  if (!item || item.status !== 'active') return;
+  const text = `[${item.kind}] ${item.subject}: ${item.statement}`;
+  await embedAndUpsert(config, 'item', item.id, text);
+}
+
+async function embedSummaryJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  const summaryId = asString(job.payload.summaryId);
+  if (!summaryId) return;
+  const db = getDb();
+  const summary = db
+    .select()
+    .from(memorySummaries)
+    .where(eq(memorySummaries.id, summaryId))
+    .get();
+  if (!summary) return;
+  await embedAndUpsert(config, 'summary', summary.id, `[${summary.scope}] ${summary.summary}`);
+}
+
+function extractItemsJob(job: MemoryJob): void {
+  const messageId = asString(job.payload.messageId);
+  if (!messageId) return;
+  extractAndUpsertMemoryItemsForMessage(messageId);
+}
+
+function buildConversationSummaryJob(job: MemoryJob): void {
+  const conversationId = asString(job.payload.conversationId);
+  if (!conversationId) return;
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memorySegments)
+    .where(eq(memorySegments.conversationId, conversationId))
+    .orderBy(desc(memorySegments.createdAt))
+    .limit(40)
+    .all();
+  if (rows.length === 0) return;
+  const snippets = rows
+    .slice(0, 20)
+    .map((row) => `- ${truncate(row.text, 180)}`);
+  const summaryText = [
+    `Conversation ${conversationId}`,
+    '',
+    ...snippets,
+  ].join('\n');
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(memorySummaries)
+    .where(and(
+      eq(memorySummaries.scope, 'conversation'),
+      eq(memorySummaries.scopeKey, conversationId),
+    ))
+    .get();
+  const summaryId = existing?.id ?? uuid();
+  if (existing) {
+    db.update(memorySummaries)
+      .set({
+        summary: summaryText,
+        tokenEstimate: estimateTextTokens(summaryText),
+        startAt: rows[rows.length - 1].createdAt,
+        endAt: rows[0].createdAt,
+        updatedAt: now,
+      })
+      .where(eq(memorySummaries.id, existing.id))
+      .run();
+  } else {
+    db.insert(memorySummaries).values({
+      id: summaryId,
+      scope: 'conversation',
+      scopeKey: conversationId,
+      summary: summaryText,
+      tokenEstimate: estimateTextTokens(summaryText),
+      startAt: rows[rows.length - 1].createdAt,
+      endAt: rows[0].createdAt,
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+  }
+  enqueueMemoryJob('embed_summary', { summaryId });
+}
+
+function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_global'): void {
+  const db = getDb();
+  const now = new Date();
+  const { startMs, endMs, scopeKey } = scope === 'weekly_global'
+    ? currentWeekWindow(now)
+    : currentMonthWindow(now);
+
+  const items = db
+    .select()
+    .from(memoryItems)
+    .where(and(
+      eq(memoryItems.status, 'active'),
+      gte(memoryItems.lastSeenAt, startMs),
+      lt(memoryItems.lastSeenAt, endMs),
+    ))
+    .orderBy(desc(memoryItems.lastSeenAt))
+    .limit(80)
+    .all();
+
+  if (items.length === 0) return;
+  const lines = items.slice(0, 40).map((item) => `- [${item.kind}] ${item.subject}: ${truncate(item.statement, 180)}`);
+  const summaryText = [
+    scope === 'weekly_global' ? `Weekly memory summary (${scopeKey})` : `Monthly memory summary (${scopeKey})`,
+    '',
+    ...lines,
+  ].join('\n');
+
+  const existing = db
+    .select()
+    .from(memorySummaries)
+    .where(and(
+      eq(memorySummaries.scope, scope),
+      eq(memorySummaries.scopeKey, scopeKey),
+    ))
+    .get();
+
+  const ts = Date.now();
+  const summaryId = existing?.id ?? uuid();
+  if (existing) {
+    db.update(memorySummaries)
+      .set({
+        summary: summaryText,
+        tokenEstimate: estimateTextTokens(summaryText),
+        startAt: startMs,
+        endAt: endMs,
+        updatedAt: ts,
+      })
+      .where(eq(memorySummaries.id, existing.id))
+      .run();
+  } else {
+    db.insert(memorySummaries).values({
+      id: summaryId,
+      scope,
+      scopeKey,
+      summary: summaryText,
+      tokenEstimate: estimateTextTokens(summaryText),
+      startAt: startMs,
+      endAt: endMs,
+      createdAt: ts,
+      updatedAt: ts,
+    }).run();
+  }
+  enqueueMemoryJob('embed_summary', { summaryId });
+}
+
+function backfillJob(job: MemoryJob, config: AssistantConfig): void {
+  const db = getDb();
+  const force = job.payload.force === true;
+  if (force) {
+    setMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY, '0');
+    setMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY, '');
+  }
+
+  const lastCreatedAt = Number.parseInt(getMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY) ?? '0', 10) || 0;
+  const lastMessageId = getMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY) ?? '';
+  const batch = db
+    .select()
+    .from(messages)
+    .where(or(
+      gt(messages.createdAt, lastCreatedAt),
+      and(eq(messages.createdAt, lastCreatedAt), gt(messages.id, lastMessageId)),
+    ))
+    .orderBy(asc(messages.createdAt), asc(messages.id))
+    .limit(200)
+    .all();
+  if (batch.length === 0) return;
+  for (const message of batch) {
+    indexMessageNow({
+      messageId: message.id,
+      conversationId: message.conversationId,
+      role: message.role,
+      content: message.content,
+      createdAt: message.createdAt,
+    }, config.memory);
+  }
+  const lastMessage = batch[batch.length - 1];
+  setMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY, String(lastMessage.createdAt));
+  setMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY, lastMessage.id);
+  if (batch.length === 200) {
+    enqueueMemoryJob('backfill', {});
+  }
+}
+
+function rebuildIndexJob(): void {
+  const db = getDb();
+  db.run(/*sql*/ `DELETE FROM memory_segment_fts`);
+  db.run(/*sql*/ `
+    INSERT INTO memory_segment_fts(segment_id, text)
+    SELECT id, text FROM memory_segments
+  `);
+  db.delete(memoryEmbeddings).run();
+
+  const segments = db.select({ id: memorySegments.id }).from(memorySegments).all();
+  for (const segment of segments) {
+    enqueueMemoryJob('embed_segment', { segmentId: segment.id });
+  }
+
+  const items = db
+    .select({ id: memoryItems.id })
+    .from(memoryItems)
+    .where(eq(memoryItems.status, 'active'))
+    .all();
+  for (const item of items) {
+    enqueueMemoryJob('embed_item', { itemId: item.id });
+  }
+
+  const summaries = db.select({ id: memorySummaries.id }).from(memorySummaries).all();
+  for (const summary of summaries) {
+    enqueueMemoryJob('embed_summary', { summaryId: summary.id });
+  }
+}
+
+async function embedAndUpsert(
+  config: AssistantConfig,
+  targetType: 'segment' | 'item' | 'summary',
+  targetId: string,
+  text: string,
+): Promise<void> {
+  const status = getMemoryBackendStatus(config);
+  if (!status.provider) {
+    if (config.memory.embeddings.required) {
+      throw new Error(status.reason ?? 'Memory embeddings backend unavailable');
+    }
+    return;
+  }
+
+  const embedded = await embedWithBackend(config, [text]);
+  const vector = embedded.vectors[0];
+  if (!vector) return;
+
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(memoryEmbeddings)
+    .where(and(
+      eq(memoryEmbeddings.targetType, targetType),
+      eq(memoryEmbeddings.targetId, targetId),
+      eq(memoryEmbeddings.provider, embedded.provider),
+      eq(memoryEmbeddings.model, embedded.model),
+    ))
+    .get();
+
+  if (existing) {
+    db.update(memoryEmbeddings)
+      .set({
+        dimensions: vector.length,
+        vectorJson: JSON.stringify(vector),
+        updatedAt: now,
+      })
+      .where(eq(memoryEmbeddings.id, existing.id))
+      .run();
+    return;
+  }
+
+  db.insert(memoryEmbeddings).values({
+    id: uuid(),
+    targetType,
+    targetId,
+    provider: embedded.provider,
+    model: embedded.model,
+    dimensions: vector.length,
+    vectorJson: JSON.stringify(vector),
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 3)}...`;
+}
+
+function currentWeekWindow(now: Date): { scopeKey: string; startMs: number; endMs: number } {
+  const start = new Date(now);
+  const day = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - day);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 7);
+  const scopeKey = `${start.getUTCFullYear()}-W${weekNumber(start).toString().padStart(2, '0')}`;
+  return { scopeKey, startMs: start.getTime(), endMs: end.getTime() };
+}
+
+function currentMonthWindow(now: Date): { scopeKey: string; startMs: number; endMs: number } {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+  const scopeKey = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, '0')}`;
+  return { scopeKey, startMs: start.getTime(), endMs: end.getTime() };
+}
+
+function weekNumber(date: Date): number {
+  const tmp = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = tmp.getUTCDay() || 7;
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  return Math.ceil((((tmp.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+}

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -120,17 +120,12 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
   }
 }
 
-async function embedSegmentJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+async function embedSegmentJob(job: MemoryJob, _config: AssistantConfig): Promise<void> {
   const segmentId = asString(job.payload.segmentId);
   if (!segmentId) return;
-  const db = getDb();
-  const segment = db
-    .select({ id: memorySegments.id, text: memorySegments.text })
-    .from(memorySegments)
-    .where(eq(memorySegments.id, segmentId))
-    .get();
-  if (!segment) return;
-  await embedAndUpsert(config, 'segment', segment.id, segment.text);
+  // Segment embeddings are intentionally disabled: retrieval only consumes
+  // semantic vectors for items and summaries.
+  log.debug({ segmentId }, 'Skipping segment embedding job');
 }
 
 async function embedItemJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
@@ -335,11 +330,6 @@ function rebuildIndexJob(): void {
   `);
   db.delete(memoryEmbeddings).run();
 
-  const segments = db.select({ id: memorySegments.id }).from(memorySegments).all();
-  for (const segment of segments) {
-    enqueueMemoryJob('embed_segment', { segmentId: segment.id });
-  }
-
   const items = db
     .select({ id: memoryItems.id })
     .from(memoryItems)
@@ -363,9 +353,10 @@ async function embedAndUpsert(
 ): Promise<void> {
   const status = getMemoryBackendStatus(config);
   if (!status.provider) {
-    if (config.memory.embeddings.required) {
-      throw new Error(status.reason ?? 'Memory embeddings backend unavailable');
-    }
+    log.debug(
+      { targetType, targetId, reason: status.reason ?? 'backend unavailable' },
+      'Skipping embedding job because no backend is configured',
+    );
     return;
   }
 
@@ -420,13 +411,19 @@ function truncate(text: string, max: number): string {
   return `${text.slice(0, max - 3)}...`;
 }
 
-function currentWeekWindow(now: Date): { scopeKey: string; startMs: number; endMs: number } {
-  const start = new Date(now);
-  const day = (start.getDay() + 6) % 7;
-  start.setDate(start.getDate() - day);
-  start.setHours(0, 0, 0, 0);
+export function currentWeekWindow(now: Date): { scopeKey: string; startMs: number; endMs: number } {
+  const day = (now.getUTCDay() + 6) % 7;
+  const start = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() - day,
+    0,
+    0,
+    0,
+    0,
+  ));
   const end = new Date(start);
-  end.setDate(end.getDate() + 7);
+  end.setUTCDate(end.getUTCDate() + 7);
   const scopeKey = `${start.getUTCFullYear()}-W${weekNumber(start).toString().padStart(2, '0')}`;
   return { scopeKey, startMs: start.getTime(), endMs: end.getTime() };
 }

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -1,0 +1,46 @@
+import type { ContentBlock } from '../providers/types.js';
+
+export function extractTextFromStoredMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === 'string') return parsed;
+    if (!Array.isArray(parsed)) return raw;
+    const blocks = parsed as ContentBlock[];
+    const lines: string[] = [];
+    for (const block of blocks) {
+      switch (block.type) {
+        case 'text':
+          lines.push(block.text);
+          break;
+        case 'tool_use':
+          lines.push(`Tool use (${block.name}): ${stableJson(block.input)}`);
+          break;
+        case 'tool_result':
+          lines.push(`Tool result${block.is_error ? ' [error]' : ''}: ${block.content}`);
+          break;
+        case 'thinking':
+          lines.push(block.thinking);
+          break;
+        case 'redacted_thinking':
+          lines.push('[redacted_thinking]');
+          break;
+        case 'image':
+          lines.push(`[image ${block.source.media_type}]`);
+          break;
+        default:
+          lines.push('[unknown content block]');
+      }
+    }
+    return lines.join('\n').trim();
+  } catch {
+    return raw;
+  }
+}
+
+function stableJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -146,25 +146,33 @@ export async function buildMemoryRecall(
 export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
   messages: T[],
 ): T[] {
-  return messages.filter((message) => {
-    if (message.role !== 'assistant') return true;
-    const text = message.content
-      .filter((block) => block.type === 'text')
-      .map((block) => block.text ?? '')
-      .join('\n')
-      .trim();
-    return !text.startsWith(MEMORY_RECALL_MARKER);
-  });
+  const cleaned: T[] = [];
+  for (const message of messages) {
+    const filteredContent = message.content.filter((block) => {
+      if (block.type !== 'text') return true;
+      return !(block.text ?? '').trim().startsWith(MEMORY_RECALL_MARKER);
+    });
+    if (filteredContent.length === 0) continue;
+    if (filteredContent.length === message.content.length) {
+      cleaned.push(message);
+      continue;
+    }
+    cleaned.push({ ...message, content: filteredContent } as T);
+  }
+  return cleaned;
 }
 
-export function createMemoryRecallMessage(text: string): {
-  role: 'assistant';
-  content: Array<{ type: 'text'; text: string }>;
-} {
+export function injectMemoryRecallIntoUserMessage<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
+  message: T,
+  memoryRecallText: string,
+): T {
+  if (message.role !== 'user') return message;
+  if (memoryRecallText.trim().length === 0) return message;
+  const memoryBlock = { type: 'text', text: memoryRecallText } as const;
   return {
-    role: 'assistant',
-    content: [{ type: 'text', text }],
-  };
+    ...message,
+    content: [memoryBlock, ...message.content] as T['content'],
+  } as T;
 }
 
 export function queryMemoryForCli(
@@ -178,28 +186,47 @@ export function queryMemoryForCli(
 function lexicalSearch(query: string, limit: number): Candidate[] {
   const trimmed = query.trim();
   if (trimmed.length === 0 || limit <= 0) return [];
+  const matchQuery = buildFtsMatchQuery(trimmed);
+  if (!matchQuery) return [];
   const db = getDb();
   const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
-  const rows = raw.query(`
-    SELECT
-      f.segment_id AS segment_id,
-      s.text AS text,
-      s.created_at AS created_at,
-      bm25(memory_segment_fts) AS rank
-    FROM memory_segment_fts f
-    JOIN memory_segments s ON s.id = f.segment_id
-    WHERE memory_segment_fts MATCH ?
-    ORDER BY rank
-    LIMIT ?
-  `).all(trimmed, limit) as Array<{
+  let rows: Array<{
     segment_id: string;
     text: string;
     created_at: number;
     rank: number;
-  }>;
+  }> = [];
+  try {
+    rows = raw.query(`
+      SELECT
+        f.segment_id AS segment_id,
+        s.text AS text,
+        s.created_at AS created_at,
+        bm25(memory_segment_fts) AS rank
+      FROM memory_segment_fts f
+      JOIN memory_segments s ON s.id = f.segment_id
+      WHERE memory_segment_fts MATCH ?
+      ORDER BY rank
+      LIMIT ?
+    `).all(matchQuery, limit) as Array<{
+      segment_id: string;
+      text: string;
+      created_at: number;
+      rank: number;
+    }>;
+  } catch (err) {
+    log.warn({ err, query: truncate(trimmed, 80) }, 'Memory lexical search query parse failed');
+    return [];
+  }
+
+  const finiteRanks = rows
+    .map((row) => row.rank)
+    .filter((rank) => Number.isFinite(rank));
+  const minRank = finiteRanks.length > 0 ? Math.min(...finiteRanks) : 0;
+  const maxRank = finiteRanks.length > 0 ? Math.max(...finiteRanks) : 0;
 
   return rows.map((row) => {
-    const lexical = lexicalRankToScore(row.rank);
+    const lexical = lexicalRankToScore(row.rank, minRank, maxRank);
     return {
       key: `segment:${row.segment_id}`,
       type: 'segment',
@@ -392,10 +419,13 @@ function markItemUsage(candidates: Candidate[]): void {
     .run();
 }
 
-function lexicalRankToScore(rank: number): number {
-  const safe = Number.isFinite(rank) ? rank : 0;
-  if (safe <= 0) return 1;
-  return 1 / (1 + safe);
+function lexicalRankToScore(rank: number, minRank: number, maxRank: number): number {
+  if (!Number.isFinite(rank)) return 0;
+  if (!Number.isFinite(minRank) || !Number.isFinite(maxRank)) return 0;
+  const span = maxRank - minRank;
+  if (span <= 0) return 1;
+  // Lower BM25 rank is better in FTS5; normalize to [0,1] where 1 is best.
+  return (maxRank - rank) / span;
 }
 
 function computeRecencyScore(createdAt: number): number {
@@ -455,4 +485,17 @@ function emptyResult(
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max - 3)}...`;
+}
+
+function buildFtsMatchQuery(text: string): string | null {
+  const tokens = text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2);
+  if (tokens.length === 0) return null;
+  const unique = [...new Set(tokens)].slice(0, 24);
+  return unique
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(' OR ');
 }

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -119,13 +119,10 @@ export async function buildMemoryRecall(
   }
 
   const merged = mergeCandidates(lexicalCandidates, semanticCandidates, recencyCandidates);
-  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens);
+  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens, MEMORY_RECALL_MARKER);
   markItemUsage(selected);
 
-  const lines = selected.map((candidate) => `- [${candidate.type}:${candidate.id}] ${truncate(candidate.text, 320)}`);
-  const injectedText = lines.length > 0
-    ? `${MEMORY_RECALL_MARKER}\n${lines.join('\n')}`
-    : '';
+  const injectedText = buildInjectedText(selected, MEMORY_RECALL_MARKER);
 
   const latencyMs = Date.now() - start;
   log.debug({
@@ -419,20 +416,26 @@ function mergeCandidates(
   return rows;
 }
 
-function trimToTokenBudget(candidates: Candidate[], maxTokens: number): Candidate[] {
+function trimToTokenBudget(candidates: Candidate[], maxTokens: number, marker: string): Candidate[] {
   if (maxTokens <= 0) return [];
   const selected: Candidate[] = [];
-  let used = 0;
   for (const candidate of candidates) {
-    const line = `- [${candidate.type}:${candidate.id}] ${truncate(candidate.text, 320)}`;
-    const cost = estimateTextTokens(line);
+    const tentativeText = buildInjectedText([...selected, candidate], marker);
+    const cost = estimateTextTokens(tentativeText);
     if (cost > maxTokens) continue;
-    if (used + cost > maxTokens) continue;
     selected.push(candidate);
-    used += cost;
-    if (used >= maxTokens) break;
+    if (cost >= maxTokens) break;
   }
   return selected;
+}
+
+function buildInjectedText(candidates: Candidate[], marker: string): string {
+  if (candidates.length === 0) return '';
+  return `${marker}\n${candidates.map(formatCandidateLine).join('\n')}`;
+}
+
+function formatCandidateLine(candidate: Candidate): string {
+  return `- [${candidate.type}:${candidate.id}] ${truncate(candidate.text, 320)}`;
 }
 
 function markItemUsage(candidates: Candidate[]): void {

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -4,7 +4,7 @@ import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
-import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries } from './schema.js';
+import { memoryEmbeddings, memoryItems, memoryItemSources, memorySegments, memorySummaries, messages } from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_MARKER = '[Memory Recall v1]';
@@ -104,7 +104,7 @@ export async function buildMemoryRecall(
       excludeMessageIds,
     );
     semanticCandidates = queryVector
-      ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK)
+      ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK, excludeMessageIds)
       : [];
   } catch (err) {
     log.warn({ err }, 'Memory retrieval failed, returning degraded empty recall');
@@ -265,9 +265,11 @@ async function semanticSearch(
   provider: string,
   model: string,
   limit: number,
+  excludedMessageIds: string[] = [],
 ): Promise<Candidate[]> {
   if (limit <= 0) return [];
   const db = getDb();
+  const excludedMessageSet = new Set(excludedMessageIds);
   const rows = db
     .select()
     .from(memoryEmbeddings)
@@ -301,11 +303,46 @@ async function semanticSearch(
   const itemRows = itemIds.length > 0
     ? db.select().from(memoryItems).where(inArray(memoryItems.id, itemIds)).all()
     : [];
+  const itemSourceRows = itemIds.length > 0
+    ? db
+      .select({
+        memoryItemId: memoryItemSources.memoryItemId,
+        messageId: memoryItemSources.messageId,
+      })
+      .from(memoryItemSources)
+      .where(inArray(memoryItemSources.memoryItemId, itemIds))
+      .all()
+    : [];
   const summaryRows = summaryIds.length > 0
     ? db.select().from(memorySummaries).where(inArray(memorySummaries.id, summaryIds)).all()
     : [];
+  const excludedMessagesByConversation = summaryIds.length > 0 && excludedMessageSet.size > 0
+    ? db
+      .select({
+        conversationId: messages.conversationId,
+        createdAt: messages.createdAt,
+      })
+      .from(messages)
+      .where(inArray(messages.id, [...excludedMessageSet]))
+      .all()
+    : [];
   const itemMap = new Map(itemRows.map((item) => [item.id, item]));
   const summaryMap = new Map(summaryRows.map((summary) => [summary.id, summary]));
+  const itemEvidenceStats = new Map<string, { total: number; nonExcluded: number }>();
+  for (const source of itemSourceRows) {
+    const existing = itemEvidenceStats.get(source.memoryItemId) ?? { total: 0, nonExcluded: 0 };
+    existing.total += 1;
+    if (!excludedMessageSet.has(source.messageId)) {
+      existing.nonExcluded += 1;
+    }
+    itemEvidenceStats.set(source.memoryItemId, existing);
+  }
+  const excludedSummaryTimestampsByConversation = new Map<string, number[]>();
+  for (const row of excludedMessagesByConversation) {
+    const existing = excludedSummaryTimestampsByConversation.get(row.conversationId) ?? [];
+    existing.push(row.createdAt);
+    excludedSummaryTimestampsByConversation.set(row.conversationId, existing);
+  }
 
   const candidates: Candidate[] = [];
   for (const entry of top) {
@@ -313,6 +350,9 @@ async function semanticSearch(
     if (entry.row.targetType === 'item') {
       const item = itemMap.get(entry.row.targetId);
       if (!item || item.status !== 'active') continue;
+      const evidence = itemEvidenceStats.get(item.id);
+      if (!evidence || evidence.total <= 0) continue;
+      if (excludedMessageSet.size > 0 && evidence.nonExcluded <= 0) continue;
       candidates.push({
         key: `item:${item.id}`,
         type: 'item',
@@ -329,6 +369,13 @@ async function semanticSearch(
     }
     const summary = summaryMap.get(entry.row.targetId);
     if (!summary) continue;
+    if (summary.scope === 'conversation' && excludedMessageSet.size > 0) {
+      const excludedTimestamps = excludedSummaryTimestampsByConversation.get(summary.scopeKey) ?? [];
+      const overlapsExcludedMessage = excludedTimestamps.some((timestamp) => (
+        timestamp >= summary.startAt && timestamp <= summary.endAt
+      ));
+      if (overlapsExcludedMessage) continue;
+    }
     candidates.push({
       key: `summary:${summary.id}`,
       type: 'summary',

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray, notInArray } from 'drizzle-orm';
 import type { AssistantConfig } from '../config/types.js';
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
@@ -38,12 +38,18 @@ export interface MemoryRecallResult {
   latencyMs: number;
 }
 
+interface MemoryRecallOptions {
+  excludeMessageIds?: string[];
+}
+
 export async function buildMemoryRecall(
   query: string,
   conversationId: string,
   config: AssistantConfig,
+  options?: MemoryRecallOptions,
 ): Promise<MemoryRecallResult> {
   const start = Date.now();
+  const excludeMessageIds = options?.excludeMessageIds?.filter((id) => id.length > 0) ?? [];
   if (!config.memory.enabled) {
     return emptyResult({ enabled: false, degraded: false, reason: 'memory.disabled', latencyMs: Date.now() - start });
   }
@@ -91,8 +97,12 @@ export async function buildMemoryRecall(
   let recencyCandidates: Candidate[] = [];
   let semanticCandidates: Candidate[] = [];
   try {
-    lexicalCandidates = lexicalSearch(query, config.memory.retrieval.lexicalTopK);
-    recencyCandidates = recencySearch(conversationId, Math.max(10, Math.floor(config.memory.retrieval.semanticTopK / 2)));
+    lexicalCandidates = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds);
+    recencyCandidates = recencySearch(
+      conversationId,
+      Math.max(10, Math.floor(config.memory.retrieval.semanticTopK / 2)),
+      excludeMessageIds,
+    );
     semanticCandidates = queryVector
       ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK)
       : [];
@@ -183,23 +193,29 @@ export function queryMemoryForCli(
   return buildMemoryRecall(query, conversationId, config);
 }
 
-function lexicalSearch(query: string, limit: number): Candidate[] {
+function lexicalSearch(query: string, limit: number, excludedMessageIds: string[] = []): Candidate[] {
   const trimmed = query.trim();
   if (trimmed.length === 0 || limit <= 0) return [];
   const matchQuery = buildFtsMatchQuery(trimmed);
   if (!matchQuery) return [];
+  const excluded = new Set(excludedMessageIds);
   const db = getDb();
   const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
   let rows: Array<{
     segment_id: string;
+    message_id: string;
     text: string;
     created_at: number;
     rank: number;
   }> = [];
+  const queryLimit = excluded.size > 0
+    ? Math.max(limit + 24, limit * 2)
+    : limit;
   try {
     rows = raw.query(`
       SELECT
         f.segment_id AS segment_id,
+        s.message_id AS message_id,
         s.text AS text,
         s.created_at AS created_at,
         bm25(memory_segment_fts) AS rank
@@ -208,8 +224,9 @@ function lexicalSearch(query: string, limit: number): Candidate[] {
       WHERE memory_segment_fts MATCH ?
       ORDER BY rank
       LIMIT ?
-    `).all(matchQuery, limit) as Array<{
+    `).all(matchQuery, queryLimit) as Array<{
       segment_id: string;
+      message_id: string;
       text: string;
       created_at: number;
       rank: number;
@@ -219,13 +236,17 @@ function lexicalSearch(query: string, limit: number): Candidate[] {
     return [];
   }
 
-  const finiteRanks = rows
+  const visibleRows = excluded.size > 0
+    ? rows.filter((row) => !excluded.has(row.message_id)).slice(0, limit)
+    : rows;
+
+  const finiteRanks = visibleRows
     .map((row) => row.rank)
     .filter((rank) => Number.isFinite(rank));
   const minRank = finiteRanks.length > 0 ? Math.min(...finiteRanks) : 0;
   const maxRank = finiteRanks.length > 0 ? Math.max(...finiteRanks) : 0;
 
-  return rows.map((row) => {
+  return visibleRows.map((row) => {
     const lexical = lexicalRankToScore(row.rank, minRank, maxRank);
     return {
       key: `segment:${row.segment_id}`,
@@ -327,13 +348,19 @@ async function semanticSearch(
   return candidates;
 }
 
-function recencySearch(conversationId: string, limit: number): Candidate[] {
+function recencySearch(conversationId: string, limit: number, excludedMessageIds: string[] = []): Candidate[] {
   if (!conversationId || limit <= 0) return [];
   const db = getDb();
+  const whereClause = excludedMessageIds.length > 0
+    ? and(
+      eq(memorySegments.conversationId, conversationId),
+      notInArray(memorySegments.messageId, excludedMessageIds),
+    )
+    : eq(memorySegments.conversationId, conversationId);
   const rows = db
     .select()
     .from(memorySegments)
-    .where(eq(memorySegments.conversationId, conversationId))
+    .where(whereClause)
     .orderBy(desc(memorySegments.createdAt))
     .limit(limit)
     .all();

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,0 +1,458 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import type { AssistantConfig } from '../config/types.js';
+import { estimateTextTokens } from '../context/token-estimator.js';
+import { getLogger } from '../util/logger.js';
+import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
+import { getDb } from './db.js';
+import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries } from './schema.js';
+
+const log = getLogger('memory-retriever');
+const MEMORY_RECALL_MARKER = '[Memory Recall v1]';
+
+type CandidateType = 'segment' | 'item' | 'summary';
+
+interface Candidate {
+  key: string;
+  type: CandidateType;
+  id: string;
+  text: string;
+  confidence: number;
+  createdAt: number;
+  lexical: number;
+  semantic: number;
+  recency: number;
+  finalScore: number;
+}
+
+export interface MemoryRecallResult {
+  enabled: boolean;
+  degraded: boolean;
+  reason?: string;
+  provider?: string;
+  model?: string;
+  lexicalHits: number;
+  semanticHits: number;
+  recencyHits: number;
+  injectedTokens: number;
+  injectedText: string;
+  latencyMs: number;
+}
+
+export async function buildMemoryRecall(
+  query: string,
+  conversationId: string,
+  config: AssistantConfig,
+): Promise<MemoryRecallResult> {
+  const start = Date.now();
+  if (!config.memory.enabled) {
+    return emptyResult({ enabled: false, degraded: false, reason: 'memory.disabled', latencyMs: Date.now() - start });
+  }
+
+  const backendStatus = getMemoryBackendStatus(config);
+  let queryVector: number[] | null = null;
+  let provider: string | undefined;
+  let model: string | undefined;
+  let degraded = backendStatus.degraded;
+  let reason = backendStatus.reason ?? undefined;
+
+  if (backendStatus.provider) {
+    try {
+      const embedded = await embedWithBackend(config, [query]);
+      queryVector = embedded.vectors[0] ?? null;
+      provider = embedded.provider;
+      model = embedded.model;
+      degraded = false;
+      reason = undefined;
+    } catch (err) {
+      logMemoryEmbeddingWarning(err, 'query');
+      degraded = config.memory.embeddings.required;
+      reason = `memory.embedding_failure: ${err instanceof Error ? err.message : String(err)}`;
+      if (config.memory.embeddings.required) {
+        return emptyResult({
+          enabled: true,
+          degraded,
+          reason,
+          provider: backendStatus.provider,
+          model: backendStatus.model ?? undefined,
+          latencyMs: Date.now() - start,
+        });
+      }
+    }
+  } else if (config.memory.embeddings.required) {
+    return emptyResult({
+      enabled: true,
+      degraded: true,
+      reason: reason ?? 'memory.embedding_backend_missing',
+      latencyMs: Date.now() - start,
+    });
+  }
+
+  let lexicalCandidates: Candidate[] = [];
+  let recencyCandidates: Candidate[] = [];
+  let semanticCandidates: Candidate[] = [];
+  try {
+    lexicalCandidates = lexicalSearch(query, config.memory.retrieval.lexicalTopK);
+    recencyCandidates = recencySearch(conversationId, Math.max(10, Math.floor(config.memory.retrieval.semanticTopK / 2)));
+    semanticCandidates = queryVector
+      ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK)
+      : [];
+  } catch (err) {
+    log.warn({ err }, 'Memory retrieval failed, returning degraded empty recall');
+    return emptyResult({
+      enabled: true,
+      degraded: true,
+      reason: `memory.retrieval_failure: ${err instanceof Error ? err.message : String(err)}`,
+      provider,
+      model,
+      latencyMs: Date.now() - start,
+    });
+  }
+
+  const merged = mergeCandidates(lexicalCandidates, semanticCandidates, recencyCandidates);
+  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens);
+  markItemUsage(selected);
+
+  const lines = selected.map((candidate) => `- [${candidate.type}:${candidate.id}] ${truncate(candidate.text, 320)}`);
+  const injectedText = lines.length > 0
+    ? `${MEMORY_RECALL_MARKER}\n${lines.join('\n')}`
+    : '';
+
+  const latencyMs = Date.now() - start;
+  log.debug({
+    query: truncate(query, 120),
+    lexicalHits: lexicalCandidates.length,
+    semanticHits: semanticCandidates.length,
+    recencyHits: recencyCandidates.length,
+    selected: selected.length,
+    injectedTokens: estimateTextTokens(injectedText),
+    latencyMs,
+  }, 'Memory recall completed');
+
+  return {
+    enabled: true,
+    degraded,
+    reason,
+    provider,
+    model,
+    lexicalHits: lexicalCandidates.length,
+    semanticHits: semanticCandidates.length,
+    recencyHits: recencyCandidates.length,
+    injectedTokens: estimateTextTokens(injectedText),
+    injectedText,
+    latencyMs,
+  };
+}
+
+export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
+  messages: T[],
+): T[] {
+  return messages.filter((message) => {
+    if (message.role !== 'assistant') return true;
+    const text = message.content
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('\n')
+      .trim();
+    return !text.startsWith(MEMORY_RECALL_MARKER);
+  });
+}
+
+export function createMemoryRecallMessage(text: string): {
+  role: 'assistant';
+  content: Array<{ type: 'text'; text: string }>;
+} {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  };
+}
+
+export function queryMemoryForCli(
+  query: string,
+  conversationId: string,
+  config: AssistantConfig,
+): Promise<MemoryRecallResult> {
+  return buildMemoryRecall(query, conversationId, config);
+}
+
+function lexicalSearch(query: string, limit: number): Candidate[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0 || limit <= 0) return [];
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+  const rows = raw.query(`
+    SELECT
+      f.segment_id AS segment_id,
+      s.text AS text,
+      s.created_at AS created_at,
+      bm25(memory_segment_fts) AS rank
+    FROM memory_segment_fts f
+    JOIN memory_segments s ON s.id = f.segment_id
+    WHERE memory_segment_fts MATCH ?
+    ORDER BY rank
+    LIMIT ?
+  `).all(trimmed, limit) as Array<{
+    segment_id: string;
+    text: string;
+    created_at: number;
+    rank: number;
+  }>;
+
+  return rows.map((row) => {
+    const lexical = lexicalRankToScore(row.rank);
+    return {
+      key: `segment:${row.segment_id}`,
+      type: 'segment',
+      id: row.segment_id,
+      text: row.text,
+      confidence: 0.55,
+      createdAt: row.created_at,
+      lexical,
+      semantic: 0,
+      recency: computeRecencyScore(row.created_at),
+      finalScore: 0,
+    };
+  });
+}
+
+async function semanticSearch(
+  queryVector: number[],
+  provider: string,
+  model: string,
+  limit: number,
+): Promise<Candidate[]> {
+  if (limit <= 0) return [];
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memoryEmbeddings)
+    .where(and(
+      eq(memoryEmbeddings.provider, provider),
+      eq(memoryEmbeddings.model, model),
+      inArray(memoryEmbeddings.targetType, ['item', 'summary']),
+    ))
+    .orderBy(desc(memoryEmbeddings.updatedAt))
+    .limit(5000)
+    .all();
+
+  type Scored = { row: typeof memoryEmbeddings.$inferSelect; score: number };
+  const scored: Scored[] = [];
+  for (const row of rows) {
+    const vector = parseVector(row.vectorJson);
+    if (!vector) continue;
+    const score = cosineSimilarity(queryVector, vector);
+    scored.push({ row, score });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, limit);
+  const itemIds = top
+    .filter((entry) => entry.row.targetType === 'item')
+    .map((entry) => entry.row.targetId);
+  const summaryIds = top
+    .filter((entry) => entry.row.targetType === 'summary')
+    .map((entry) => entry.row.targetId);
+
+  const itemRows = itemIds.length > 0
+    ? db.select().from(memoryItems).where(inArray(memoryItems.id, itemIds)).all()
+    : [];
+  const summaryRows = summaryIds.length > 0
+    ? db.select().from(memorySummaries).where(inArray(memorySummaries.id, summaryIds)).all()
+    : [];
+  const itemMap = new Map(itemRows.map((item) => [item.id, item]));
+  const summaryMap = new Map(summaryRows.map((summary) => [summary.id, summary]));
+
+  const candidates: Candidate[] = [];
+  for (const entry of top) {
+    const semantic = mapCosineToUnit(entry.score);
+    if (entry.row.targetType === 'item') {
+      const item = itemMap.get(entry.row.targetId);
+      if (!item || item.status !== 'active') continue;
+      candidates.push({
+        key: `item:${item.id}`,
+        type: 'item',
+        id: item.id,
+        text: `[${item.kind}] ${item.subject}: ${item.statement}`,
+        confidence: item.confidence,
+        createdAt: item.lastSeenAt,
+        lexical: 0,
+        semantic,
+        recency: computeRecencyScore(item.lastSeenAt),
+        finalScore: 0,
+      });
+      continue;
+    }
+    const summary = summaryMap.get(entry.row.targetId);
+    if (!summary) continue;
+    candidates.push({
+      key: `summary:${summary.id}`,
+      type: 'summary',
+      id: summary.id,
+      text: `[${summary.scope}] ${summary.summary}`,
+      confidence: 0.6,
+      createdAt: summary.endAt,
+      lexical: 0,
+      semantic,
+      recency: computeRecencyScore(summary.endAt),
+      finalScore: 0,
+    });
+  }
+  return candidates;
+}
+
+function recencySearch(conversationId: string, limit: number): Candidate[] {
+  if (!conversationId || limit <= 0) return [];
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memorySegments)
+    .where(eq(memorySegments.conversationId, conversationId))
+    .orderBy(desc(memorySegments.createdAt))
+    .limit(limit)
+    .all();
+  return rows.map((row) => ({
+    key: `segment:${row.id}`,
+    type: 'segment',
+    id: row.id,
+    text: row.text,
+    confidence: 0.55,
+    createdAt: row.createdAt,
+    lexical: 0,
+    semantic: 0,
+    recency: computeRecencyScore(row.createdAt),
+    finalScore: 0,
+  }));
+}
+
+function mergeCandidates(
+  lexical: Candidate[],
+  semantic: Candidate[],
+  recency: Candidate[],
+): Candidate[] {
+  const merged = new Map<string, Candidate>();
+  for (const candidate of [...lexical, ...semantic, ...recency]) {
+    const existing = merged.get(candidate.key);
+    if (!existing) {
+      merged.set(candidate.key, { ...candidate });
+      continue;
+    }
+    existing.lexical = Math.max(existing.lexical, candidate.lexical);
+    existing.semantic = Math.max(existing.semantic, candidate.semantic);
+    existing.recency = Math.max(existing.recency, candidate.recency);
+    existing.confidence = Math.max(existing.confidence, candidate.confidence);
+    if (candidate.text.length > existing.text.length) {
+      existing.text = candidate.text;
+    }
+  }
+
+  const rows = [...merged.values()];
+  for (const row of rows) {
+    row.finalScore = (
+      0.50 * row.semantic
+      + 0.25 * row.lexical
+      + 0.15 * row.recency
+      + 0.10 * row.confidence
+    );
+  }
+
+  rows.sort((a, b) => {
+    const scoreDelta = b.finalScore - a.finalScore;
+    if (scoreDelta !== 0) return scoreDelta;
+    const createdAtDelta = b.createdAt - a.createdAt;
+    if (createdAtDelta !== 0) return createdAtDelta;
+    return a.key.localeCompare(b.key);
+  });
+  return rows;
+}
+
+function trimToTokenBudget(candidates: Candidate[], maxTokens: number): Candidate[] {
+  if (maxTokens <= 0) return [];
+  const selected: Candidate[] = [];
+  let used = 0;
+  for (const candidate of candidates) {
+    const line = `- [${candidate.type}:${candidate.id}] ${truncate(candidate.text, 320)}`;
+    const cost = estimateTextTokens(line);
+    if (cost > maxTokens) continue;
+    if (used + cost > maxTokens) continue;
+    selected.push(candidate);
+    used += cost;
+    if (used >= maxTokens) break;
+  }
+  return selected;
+}
+
+function markItemUsage(candidates: Candidate[]): void {
+  const itemIds = candidates.filter((candidate) => candidate.type === 'item').map((candidate) => candidate.id);
+  if (itemIds.length === 0) return;
+  const db = getDb();
+  const now = Date.now();
+  db.update(memoryItems)
+    .set({ lastUsedAt: now })
+    .where(inArray(memoryItems.id, itemIds))
+    .run();
+}
+
+function lexicalRankToScore(rank: number): number {
+  const safe = Number.isFinite(rank) ? rank : 0;
+  if (safe <= 0) return 1;
+  return 1 / (1 + safe);
+}
+
+function computeRecencyScore(createdAt: number): number {
+  const ageMs = Math.max(0, Date.now() - createdAt);
+  const ageDays = ageMs / (24 * 60 * 60 * 1000);
+  return 1 / (1 + ageDays);
+}
+
+function mapCosineToUnit(value: number): number {
+  return Math.max(0, Math.min(1, (value + 1) / 2));
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return -1;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return -1;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function parseVector(raw: string): number[] | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    if (parsed.length === 0) return null;
+    if (!parsed.every((value) => typeof value === 'number')) return null;
+    return parsed as number[];
+  } catch {
+    return null;
+  }
+}
+
+function emptyResult(
+  init: Partial<MemoryRecallResult> & Pick<MemoryRecallResult, 'enabled' | 'degraded' | 'latencyMs'>,
+): MemoryRecallResult {
+  return {
+    enabled: init.enabled,
+    degraded: init.degraded,
+    reason: init.reason,
+    provider: init.provider,
+    model: init.model,
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    injectedTokens: 0,
+    injectedText: '',
+    latencyMs: init.latencyMs,
+  };
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 3)}...`;
+}

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -40,6 +40,7 @@ export interface MemoryRecallResult {
 
 interface MemoryRecallOptions {
   excludeMessageIds?: string[];
+  signal?: AbortSignal;
 }
 
 export async function buildMemoryRecall(
@@ -50,8 +51,12 @@ export async function buildMemoryRecall(
 ): Promise<MemoryRecallResult> {
   const start = Date.now();
   const excludeMessageIds = options?.excludeMessageIds?.filter((id) => id.length > 0) ?? [];
+  const signal = options?.signal;
   if (!config.memory.enabled) {
     return emptyResult({ enabled: false, degraded: false, reason: 'memory.disabled', latencyMs: Date.now() - start });
+  }
+  if (signal?.aborted) {
+    return emptyResult({ enabled: true, degraded: false, reason: 'memory.aborted', latencyMs: Date.now() - start });
   }
 
   const backendStatus = getMemoryBackendStatus(config);
@@ -63,13 +68,23 @@ export async function buildMemoryRecall(
 
   if (backendStatus.provider) {
     try {
-      const embedded = await embedWithBackend(config, [query]);
+      const embedded = await embedWithBackend(config, [query], { signal });
       queryVector = embedded.vectors[0] ?? null;
       provider = embedded.provider;
       model = embedded.model;
       degraded = false;
       reason = undefined;
     } catch (err) {
+      if (signal?.aborted || isAbortError(err)) {
+        return emptyResult({
+          enabled: true,
+          degraded: false,
+          reason: 'memory.aborted',
+          provider: backendStatus.provider,
+          model: backendStatus.model ?? undefined,
+          latencyMs: Date.now() - start,
+        });
+      }
       logMemoryEmbeddingWarning(err, 'query');
       degraded = config.memory.embeddings.required;
       reason = `memory.embedding_failure: ${err instanceof Error ? err.message : String(err)}`;
@@ -107,6 +122,16 @@ export async function buildMemoryRecall(
       ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK, excludeMessageIds)
       : [];
   } catch (err) {
+    if (signal?.aborted || isAbortError(err)) {
+      return emptyResult({
+        enabled: true,
+        degraded: false,
+        reason: 'memory.aborted',
+        provider,
+        model,
+        latencyMs: Date.now() - start,
+      });
+    }
     log.warn({ err }, 'Memory retrieval failed, returning degraded empty recall');
     return emptyResult({
       enabled: true,
@@ -152,18 +177,32 @@ export async function buildMemoryRecall(
 
 export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
   messages: T[],
+  memoryRecallText?: string,
 ): T[] {
+  const recallText = memoryRecallText ?? '';
+  if (recallText.trim().length === 0) return messages;
+
+  let targetIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role !== 'user' || message.content.length === 0) continue;
+    const firstBlock = message.content[0];
+    if (firstBlock.type === 'text' && firstBlock.text === recallText) {
+      targetIndex = index;
+      break;
+    }
+  }
+  if (targetIndex === -1) return messages;
+
   const cleaned: T[] = [];
-  for (const message of messages) {
-    const filteredContent = message.content.filter((block) => {
-      if (block.type !== 'text') return true;
-      return !(block.text ?? '').trim().startsWith(MEMORY_RECALL_MARKER);
-    });
-    if (filteredContent.length === 0) continue;
-    if (filteredContent.length === message.content.length) {
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (index !== targetIndex) {
       cleaned.push(message);
       continue;
     }
+    const filteredContent = message.content.slice(1);
+    if (filteredContent.length === 0) continue;
     cleaned.push({ ...message, content: filteredContent } as T);
   }
   return cleaned;
@@ -575,4 +614,9 @@ function buildFtsMatchQuery(text: string): string | null {
   return unique
     .map((token) => `"${token.replace(/"/g, '""')}"`)
     .join(' OR ');
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'AbortError' || err.name === 'APIUserAbortError';
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -36,3 +36,85 @@ export const toolInvocations = sqliteTable('tool_invocations', {
   durationMs: integer('duration_ms').notNull(),
   createdAt: integer('created_at').notNull(),
 });
+
+export const memorySegments = sqliteTable('memory_segments', {
+  id: text('id').primaryKey(),
+  messageId: text('message_id')
+    .notNull()
+    .references(() => messages.id, { onDelete: 'cascade' }),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  role: text('role').notNull(),
+  segmentIndex: integer('segment_index').notNull(),
+  text: text('text').notNull(),
+  tokenEstimate: integer('token_estimate').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const memoryItems = sqliteTable('memory_items', {
+  id: text('id').primaryKey(),
+  kind: text('kind').notNull(),
+  subject: text('subject').notNull(),
+  statement: text('statement').notNull(),
+  status: text('status').notNull(),
+  confidence: real('confidence').notNull(),
+  fingerprint: text('fingerprint').notNull(),
+  firstSeenAt: integer('first_seen_at').notNull(),
+  lastSeenAt: integer('last_seen_at').notNull(),
+  lastUsedAt: integer('last_used_at'),
+});
+
+export const memoryItemSources = sqliteTable('memory_item_sources', {
+  memoryItemId: text('memory_item_id')
+    .notNull()
+    .references(() => memoryItems.id, { onDelete: 'cascade' }),
+  messageId: text('message_id')
+    .notNull()
+    .references(() => messages.id, { onDelete: 'cascade' }),
+  evidence: text('evidence'),
+  createdAt: integer('created_at').notNull(),
+});
+
+export const memorySummaries = sqliteTable('memory_summaries', {
+  id: text('id').primaryKey(),
+  scope: text('scope').notNull(),
+  scopeKey: text('scope_key').notNull(),
+  summary: text('summary').notNull(),
+  tokenEstimate: integer('token_estimate').notNull(),
+  startAt: integer('start_at').notNull(),
+  endAt: integer('end_at').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const memoryEmbeddings = sqliteTable('memory_embeddings', {
+  id: text('id').primaryKey(),
+  targetType: text('target_type').notNull(),
+  targetId: text('target_id').notNull(),
+  provider: text('provider').notNull(),
+  model: text('model').notNull(),
+  dimensions: integer('dimensions').notNull(),
+  vectorJson: text('vector_json').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const memoryJobs = sqliteTable('memory_jobs', {
+  id: text('id').primaryKey(),
+  type: text('type').notNull(),
+  payload: text('payload').notNull(),
+  status: text('status').notNull(),
+  attempts: integer('attempts').notNull().default(0),
+  runAfter: integer('run_after').notNull(),
+  lastError: text('last_error'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
+  key: text('key').primaryKey(),
+  value: text('value').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});

--- a/assistant/src/memory/segmenter.ts
+++ b/assistant/src/memory/segmenter.ts
@@ -1,0 +1,68 @@
+import { estimateTextTokens } from '../context/token-estimator.js';
+
+const CHARS_PER_TOKEN_APPROX = 4;
+const MIN_SEGMENT_CHARS = 256;
+
+export interface SegmentedText {
+  segmentIndex: number;
+  text: string;
+  tokenEstimate: number;
+}
+
+export function segmentText(
+  text: string,
+  targetTokens: number,
+  overlapTokens: number,
+): SegmentedText[] {
+  const normalized = normalizeInput(text);
+  if (normalized.length === 0) return [];
+
+  const maxChars = Math.max(MIN_SEGMENT_CHARS, targetTokens * CHARS_PER_TOKEN_APPROX);
+  const overlapChars = Math.min(Math.max(0, overlapTokens * CHARS_PER_TOKEN_APPROX), Math.floor(maxChars / 2));
+
+  if (normalized.length <= maxChars) {
+    return [{
+      segmentIndex: 0,
+      text: normalized,
+      tokenEstimate: estimateTextTokens(normalized),
+    }];
+  }
+
+  const segments: SegmentedText[] = [];
+  let start = 0;
+  let index = 0;
+  while (start < normalized.length) {
+    let end = Math.min(normalized.length, start + maxChars);
+
+    if (end < normalized.length) {
+      // Prefer cutting on a whitespace boundary to avoid splitting words.
+      const boundary = normalized.lastIndexOf(' ', end);
+      if (boundary > start + Math.floor(maxChars * 0.6)) {
+        end = boundary;
+      }
+    }
+
+    const chunk = normalized.slice(start, end).trim();
+    if (chunk.length > 0) {
+      segments.push({
+        segmentIndex: index,
+        text: chunk,
+        tokenEstimate: estimateTextTokens(chunk),
+      });
+      index += 1;
+    }
+
+    if (end >= normalized.length) break;
+    start = Math.max(start + 1, end - overlapChars);
+  }
+
+  return segments;
+}
+
+function normalizeInput(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\t/g, '  ')
+    .replace(/[ ]{2,}/g, ' ')
+    .trim();
+}

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -6,18 +6,36 @@ let rootLogger: pino.Logger | null = null;
 
 function getRootLogger(): pino.Logger {
   if (!rootLogger) {
-    ensureDataDir();
-    const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
+    const forceStderr =
+      process.env.BUN_TEST === '1'
+      || process.env.NODE_ENV === 'test'
+      || process.env.VELLUM_LOG_STDERR === '1';
+    if (forceStderr) {
+      rootLogger = pino(
+        { level: process.env.VELLUM_DEBUG === '1' ? 'debug' : 'info' },
+        pino.destination(2),
+      );
+      return rootLogger;
+    }
 
-    if (process.env.VELLUM_DEBUG === '1') {
-      const prettyStream = pinoPretty({ destination: 2 });
-      const multi = pino.multistream([
-        { stream: fileStream, level: 'info' as const },
-        { stream: prettyStream, level: 'debug' as const },
-      ]);
-      rootLogger = pino({ level: 'debug' }, multi);
-    } else {
-      rootLogger = pino({ level: 'info' }, fileStream);
+    try {
+      ensureDataDir();
+      const fileStream = pino.destination({ dest: getLogPath(), sync: false, mkdir: true });
+
+      if (process.env.VELLUM_DEBUG === '1') {
+        const prettyStream = pinoPretty({ destination: 2 });
+        const multi = pino.multistream([
+          { stream: fileStream, level: 'info' as const },
+          { stream: prettyStream, level: 'debug' as const },
+        ]);
+        rootLogger = pino({ level: 'debug' }, multi);
+      } else {
+        rootLogger = pino({ level: 'info' }, fileStream);
+      }
+    } catch {
+      // In restricted environments (tests/sandbox), writing under ~/.vellum
+      // can fail. Fall back to stderr so logging remains non-fatal.
+      rootLogger = pino({ level: process.env.VELLUM_DEBUG === '1' ? 'debug' : 'info' }, pino.destination(2));
     }
   }
   return rootLogger;


### PR DESCRIPTION
## Summary
- add Memory V2 storage schema in `assistant.db` with segment/item/summary/embedding/job/checkpoint tables, FTS5 lexical index, triggers, and migration/backfill support
- implement memory ingestion and indexing pipeline (message content extraction, segmentation, durable item extraction, embedding jobs, background worker)
- implement hybrid recall (lexical + semantic + recency + confidence rerank) and inject cited memory context into session runtime under token budget
- add multi-provider embedding backends (OpenAI, Gemini, Ollama) with `auto` provider selection and degraded-mode signaling when required embeddings are unavailable
- add memory config surface, daemon IPC events (`memory_status`, `memory_recalled`), CLI rendering, and `vellum memory` commands (`status`, `backfill`, `query`, `rebuild-index`)
- add Memory V2 architecture documentation
- harden recall token-cap behavior and backfill checkpointing/resume semantics (including `backfill --force` reset and same-timestamp ordering safety)

## Verification
- bunx tsc --noEmit
- bun run lint
- bun run test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
