### PR TITLE
Make ambient sync base URL configurable via AMBIENT_SYNC_URL env var

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -20,10 +20,10 @@ actor AmbientSyncClient {
         if let baseURL {
             self.baseURL = baseURL
         } else if let envURL = ProcessInfo.processInfo.environment["AMBIENT_SYNC_URL"] {
-            if let parsed = URL(string: envURL),
-               let scheme = parsed.scheme?.lowercased(),
-               (scheme == "http" || scheme == "https"),
-               parsed.host != nil {
+            let normalized = envURL.hasPrefix("http://") || envURL.hasPrefix("https://")
+                ? envURL
+                : "http://\(envURL)"
+            if let parsed = URL(string: normalized), parsed.host != nil {
                 self.baseURL = parsed
             } else {
                 log.error("AMBIENT_SYNC_URL is set but contains an invalid URL: '\(envURL)' — sync client disabled")

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -19,9 +19,16 @@ actor AmbientSyncClient {
     init(baseURL: URL? = nil) {
         if let baseURL {
             self.baseURL = baseURL
-        } else if let envURL = ProcessInfo.processInfo.environment["AMBIENT_SYNC_URL"],
-                  let parsed = URL(string: envURL) {
-            self.baseURL = parsed
+        } else if let envURL = ProcessInfo.processInfo.environment["AMBIENT_SYNC_URL"] {
+            if let parsed = URL(string: envURL),
+               let scheme = parsed.scheme?.lowercased(),
+               (scheme == "http" || scheme == "https"),
+               parsed.host != nil {
+                self.baseURL = parsed
+            } else {
+                log.error("AMBIENT_SYNC_URL is set but contains an invalid URL: '\(envURL)' — sync client disabled")
+                self.baseURL = URL(string: "http://localhost:0")!
+            }
         } else {
             log.warning("AMBIENT_SYNC_URL not set — sync client disabled")
             self.baseURL = URL(string: "http://localhost:0")!

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -4,7 +4,9 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientSync")
 
 actor AmbientSyncClient {
-    private let baseURL = URL(string: "http://100.77.178.101:3457")!
+    private static let defaultBaseURL = URL(string: "http://100.77.178.101:3457")!
+
+    private let baseURL: URL
     private let session: URLSession
     private let encoder: JSONEncoder
 
@@ -16,13 +18,24 @@ actor AmbientSyncClient {
         let data: Data
     }
 
-    init() {
+    init(baseURL: URL? = nil) {
+        if let baseURL {
+            self.baseURL = baseURL
+        } else if let envURL = ProcessInfo.processInfo.environment["AMBIENT_SYNC_URL"],
+                  let parsed = URL(string: envURL) {
+            self.baseURL = parsed
+        } else {
+            self.baseURL = Self.defaultBaseURL
+        }
+
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
         self.session = URLSession(configuration: config)
 
         self.encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
+
+        log.info("Sync base URL: \(self.baseURL.absoluteString)")
     }
 
     // MARK: - Health Check

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -4,8 +4,6 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientSync")
 
 actor AmbientSyncClient {
-    private static let defaultBaseURL = URL(string: "http://100.77.178.101:3457")!
-
     private let baseURL: URL
     private let session: URLSession
     private let encoder: JSONEncoder
@@ -25,7 +23,8 @@ actor AmbientSyncClient {
                   let parsed = URL(string: envURL) {
             self.baseURL = parsed
         } else {
-            self.baseURL = Self.defaultBaseURL
+            log.warning("AMBIENT_SYNC_URL not set — sync client disabled")
+            self.baseURL = URL(string: "http://localhost:0")!
         }
 
         let config = URLSessionConfiguration.default


### PR DESCRIPTION
The purpose of this PR is to make the ambient agent's backend sync URL configurable via env var instead of hardcoding the Tailscale IP.

## Changes Made
- Remove hardcoded `http://100.77.178.101:3457` default
- Read base URL from `AMBIENT_SYNC_URL` env var
- When env var is not set, log a warning and disable sync (points to `localhost:0`)
- Accept optional `baseURL` init parameter for test/programmatic overrides
- Log the resolved base URL on init for easier debugging

## Testing
- Verified build passes
- Existing call site (`AmbientSyncClient()`) unchanged

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
