### PR TITLE
Switch ambient agent from OCR to AX tree capture

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
@@ -1,0 +1,207 @@
+import ApplicationServices
+import AppKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientAX")
+
+struct ElementSummary {
+    let role: String
+    let label: String?
+    let value: String?
+    let depth: Int
+}
+
+struct AmbientSnapshot {
+    let timestamp: Date
+    let focusedApp: String?       // bundle ID
+    let focusedAppName: String
+    let focusedWindowTitle: String
+    let focusedElement: (role: String, label: String?)?
+    let visibleElements: [ElementSummary]
+    let ocrFallbackText: String?
+}
+
+enum AmbientAXCapture {
+
+    private static let maxDepth = 4
+    private static let maxElements = 50
+
+    /// Roles to skip — they add noise without meaningful content.
+    private static let decorationRoles: Set<String> = [
+        "AXScrollBar", "AXSplitter", "AXGrowArea", "AXRuler",
+        "AXMatte", "AXValueIndicator", "AXLayoutArea", "AXLayoutItem",
+        "AXUnknown"
+    ]
+
+    /// Roles that are only interesting when they carry a label or value.
+    private static let labelRequiredRoles: Set<String> = [
+        "AXGroup", "AXSplitGroup"
+    ]
+
+    // MARK: - Public API
+
+    static func capture() async -> AmbientSnapshot? {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+            log.debug("No frontmost app")
+            return nil
+        }
+
+        let pid = frontApp.processIdentifier
+        let bundleId = frontApp.bundleIdentifier
+        let appName = frontApp.localizedName ?? "Unknown"
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // Get focused window
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowValue) == .success,
+              let windowRef = windowValue else {
+            log.debug("No focused window for \(appName, privacy: .public)")
+            return nil
+        }
+        let windowElement = windowRef as! AXUIElement
+        let windowTitle = getStringAttribute(windowElement, kAXTitleAttribute as CFString) ?? "Untitled"
+
+        // Get focused element
+        var focusedRef: CFTypeRef?
+        var focusedElement: (role: String, label: String?)?
+        if AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
+           let focused = focusedRef {
+            let fe = focused as! AXUIElement
+            let role = getStringAttribute(fe, kAXRoleAttribute as CFString) ?? "unknown"
+            let label = getStringAttribute(fe, kAXTitleAttribute as CFString)
+                ?? getStringAttribute(fe, kAXDescriptionAttribute as CFString)
+                ?? getStringAttribute(fe, kAXRoleDescriptionAttribute as CFString)
+            focusedElement = (role: cleanRole(role), label: label)
+        }
+
+        // Enumerate elements (shallow)
+        var elements: [ElementSummary] = []
+        enumerateElement(element: windowElement, depth: 0, into: &elements)
+
+        return AmbientSnapshot(
+            timestamp: Date(),
+            focusedApp: bundleId,
+            focusedAppName: appName,
+            focusedWindowTitle: windowTitle,
+            focusedElement: focusedElement,
+            visibleElements: elements,
+            ocrFallbackText: nil
+        )
+    }
+
+    static func isUseful(_ snapshot: AmbientSnapshot) -> Bool {
+        let meaningful = snapshot.visibleElements.filter { element in
+            !labelRequiredRoles.contains("AX" + capitalizeFirst(element.role))
+            || element.label != nil
+        }
+        return meaningful.count >= 3
+    }
+
+    static func format(_ snapshot: AmbientSnapshot) -> String {
+        var lines: [String] = []
+        lines.append("[App: \(snapshot.focusedAppName)] [Window: \(snapshot.focusedWindowTitle)]")
+
+        if let focused = snapshot.focusedElement {
+            var focusLine = "[Focused: \(focused.role)"
+            if let label = focused.label, !label.isEmpty {
+                focusLine += " \"\(label)\""
+            }
+            focusLine += "]"
+            lines.append(focusLine)
+        }
+
+        if !snapshot.visibleElements.isEmpty {
+            lines.append("Elements:")
+            for element in snapshot.visibleElements {
+                let indent = String(repeating: "  ", count: element.depth + 1)
+                var line = "\(indent)\(element.role)"
+                if let label = element.label, !label.isEmpty {
+                    line += " \"\(label)\""
+                }
+                if let value = element.value, !value.isEmpty {
+                    let truncated = value.count > 80 ? String(value.prefix(80)) + "..." : value
+                    line += ": \"\(truncated)\""
+                }
+                lines.append(line)
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Enumeration
+
+    private static func enumerateElement(element: AXUIElement, depth: Int, into elements: inout [ElementSummary]) {
+        guard depth < maxDepth, elements.count < maxElements else { return }
+
+        let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
+
+        // Skip decoration roles
+        if decorationRoles.contains(role) { return }
+
+        let title = getStringAttribute(element, kAXTitleAttribute as CFString)
+            ?? getStringAttribute(element, kAXDescriptionAttribute as CFString)
+        let value = getValueAttribute(element)
+        let hasLabel = title != nil && !title!.isEmpty
+        let hasValue = value != nil && !value!.isEmpty
+
+        // Skip label-required roles that have neither label nor value
+        if labelRequiredRoles.contains(role) && !hasLabel && !hasValue {
+            // Still recurse into children
+        } else if !role.isEmpty && role != "AXWindow" {
+            let cleanedRole = cleanRole(role)
+            elements.append(ElementSummary(
+                role: cleanedRole,
+                label: title,
+                value: value,
+                depth: depth
+            ))
+        }
+
+        // Recurse into children
+        var childrenRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            for child in children {
+                guard elements.count < maxElements else { break }
+                enumerateElement(element: child, depth: depth + 1, into: &elements)
+            }
+        }
+    }
+
+    // MARK: - AX Attribute Helpers
+
+    private static func getStringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private static func getValueAttribute(_ element: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? NSNumber { return num.stringValue }
+        return nil
+    }
+
+    private static func cleanRole(_ role: String) -> String {
+        var cleaned = role
+        if cleaned.hasPrefix("AX") {
+            cleaned = String(cleaned.dropFirst(2))
+        }
+        var result = ""
+        for char in cleaned {
+            if char.isUppercase && !result.isEmpty {
+                result += " "
+            }
+            result += String(char).lowercased()
+        }
+        return result
+    }
+
+    private static func capitalizeFirst(_ str: String) -> String {
+        guard let first = str.first else { return str }
+        return String(first).uppercased() + str.dropFirst()
+    }
+}

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -162,49 +162,81 @@ final class AmbientAgent: ObservableObject {
         cycleCount += 1
         let cycle = cycleCount
 
-        // Tier 0: Capture + OCR + diff
-        let screenshot: Data
-        do {
-            screenshot = try await screenCapture.captureScreen()
-        } catch {
-            log.warning("[\(cycle)] Screenshot failed: \(error.localizedDescription)")
-            return
+        state = .analyzing
+
+        // Try AX capture first
+        let axStart = CFAbsoluteTimeGetCurrent()
+        let snapshot = await AmbientAXCapture.capture()
+        let axElapsed = CFAbsoluteTimeGetCurrent() - axStart
+
+        var screenContent: String
+        var captureMethod: String
+        var appName: String
+        var windowTitle: String
+        var bundleIdentifier: String?
+        var focusedElementDesc: String?
+
+        if let snapshot, AmbientAXCapture.isUseful(snapshot), axElapsed < 0.5 {
+            screenContent = AmbientAXCapture.format(snapshot)
+            captureMethod = "ax-tree"
+            appName = snapshot.focusedAppName
+            windowTitle = snapshot.focusedWindowTitle
+            bundleIdentifier = snapshot.focusedApp
+            if let focused = snapshot.focusedElement {
+                focusedElementDesc = focused.label.map { "\(focused.role) \"\($0)\"" } ?? focused.role
+            }
+        } else {
+            // Fall back to screenshot + OCR
+            if axElapsed >= 0.5 {
+                log.warning("[\(cycle)] AX capture took \(String(format: "%.2f", axElapsed))s, using OCR fallback")
+            } else if snapshot == nil {
+                log.debug("[\(cycle)] AX capture returned nil, using OCR fallback")
+            } else {
+                log.debug("[\(cycle)] AX tree not useful (<3 elements), using OCR fallback")
+            }
+
+            let screenshot: Data
+            do {
+                screenshot = try await screenCapture.captureScreen()
+            } catch {
+                log.warning("[\(cycle)] Screenshot failed: \(error.localizedDescription)")
+                state = .watching
+                return
+            }
+            screenContent = await ocr.recognizeText(from: screenshot)
+            captureMethod = "ocr"
+            appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
+            windowTitle = currentWindowTitle() ?? "Unknown"
         }
 
-        state = .analyzing
-        let ocrText = await ocr.recognizeText(from: screenshot)
-
-        guard !ocrText.isEmpty else {
-            log.debug("[\(cycle)] OCR returned empty text — skipping")
+        guard !screenContent.isEmpty else {
+            log.debug("[\(cycle)] Screen content empty — skipping")
             state = .watching
             return
         }
 
         // Check similarity with previous capture
-        let similarity = ScreenOCR.similarity(previousOCRText, ocrText)
+        let similarity = ScreenOCR.similarity(previousOCRText, screenContent)
         if similarity > 0.85 {
             log.debug("[\(cycle)] Screen unchanged (similarity: \(String(format: "%.2f", similarity))) — skipping")
             state = .watching
             return
         }
-        previousOCRText = ocrText
+        previousOCRText = screenContent
 
-        // Get active app info
-        let appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
-        let windowTitle = currentWindowTitle() ?? "Unknown"
+        log.info("[\(cycle)] Analyzing \(appName) — \"\(windowTitle)\" (\(screenContent.count) chars, \(captureMethod))")
 
-        log.info("[\(cycle)] Tier 1: Analyzing \(appName) — \"\(windowTitle)\" (\(ocrText.count) chars OCR)")
-
-        // Tier 1: Send to Haiku
+        // Send to Haiku
         guard let analyzer = analyzer else { return }
 
         let result: AmbientAnalysisResult
         do {
             result = try await analyzer.analyze(
-                ocrText: ocrText,
+                screenContent: screenContent,
                 appName: appName,
                 windowTitle: windowTitle,
-                knowledgeContext: knowledgeStore.formattedContext()
+                knowledgeContext: knowledgeStore.formattedContext(),
+                captureMethod: captureMethod
             )
         } catch {
             log.warning("[\(cycle)] Analysis failed: \(error.localizedDescription)")
@@ -222,7 +254,11 @@ final class AmbientAgent: ObservableObject {
                     category: "observation",
                     observation: observation,
                     sourceApp: appName,
-                    confidence: result.confidence
+                    confidence: result.confidence,
+                    windowTitle: windowTitle,
+                    focusedElement: focusedElementDesc,
+                    captureMethod: captureMethod,
+                    bundleIdentifier: bundleIdentifier
                 )
                 knowledgeCron?.observationAdded()
             }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAnalyzer.swift
@@ -25,9 +25,14 @@ final class AmbientAnalyzer {
         self.client = AnthropicClient(apiKey: apiKey)
     }
 
-    func analyze(ocrText: String, appName: String, windowTitle: String, knowledgeContext: String) async throws -> AmbientAnalysisResult {
+    func analyze(screenContent: String, appName: String, windowTitle: String, knowledgeContext: String, captureMethod: String = "ocr") async throws -> AmbientAnalysisResult {
+        let captureNote = captureMethod == "ax-tree"
+            ? "Screen content is structured (from accessibility tree) and includes app name, window title, and element roles."
+            : "Screen content is raw text from OCR."
+
         let systemPrompt = """
-        You are a background screen-watching assistant. You observe the user's screen via OCR text and decide what to do.
+        You are a background screen-watching assistant. You observe the user's screen and decide what to do.
+        \(captureNote)
 
         Your goal is to learn about the user over time AND proactively offer help when you spot problems, clutter, or opportunities to make their life easier.
 
@@ -63,8 +68,8 @@ final class AmbientAnalyzer {
         ACTIVE APPLICATION: \(appName)
         WINDOW TITLE: \(windowTitle)
 
-        SCREEN CONTENT (OCR):
-        \(ocrText)
+        SCREEN CONTENT:
+        \(screenContent)
 
         YOUR KNOWLEDGE ABOUT THIS USER:
         \(knowledgeContext)

--- a/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
+++ b/clients/macos/vellum-assistant/Ambient/KnowledgeStore.swift
@@ -10,6 +10,10 @@ struct KnowledgeEntry: Codable, Identifiable {
     let observation: String
     let sourceApp: String
     let confidence: Double
+    var windowTitle: String?
+    var focusedElement: String?
+    var captureMethod: String?
+    var bundleIdentifier: String?
 }
 
 struct KnowledgeFile: Codable {
@@ -52,7 +56,9 @@ final class KnowledgeStore: ObservableObject {
         Array(knowledge.entries.suffix(10))
     }
 
-    func addEntry(category: String, observation: String, sourceApp: String, confidence: Double) {
+    func addEntry(category: String, observation: String, sourceApp: String, confidence: Double,
+                  windowTitle: String? = nil, focusedElement: String? = nil,
+                  captureMethod: String? = nil, bundleIdentifier: String? = nil) {
         // Dedup: skip if a recent entry has a very similar observation
         let recentWindow = knowledge.entries.suffix(20)
         let isDuplicate = recentWindow.contains { existing in
@@ -63,7 +69,7 @@ final class KnowledgeStore: ObservableObject {
             return
         }
 
-        let entry = KnowledgeEntry(
+        var entry = KnowledgeEntry(
             id: UUID(),
             timestamp: Date(),
             category: category,
@@ -71,6 +77,10 @@ final class KnowledgeStore: ObservableObject {
             sourceApp: sourceApp,
             confidence: confidence
         )
+        entry.windowTitle = windowTitle
+        entry.focusedElement = focusedElement
+        entry.captureMethod = captureMethod
+        entry.bundleIdentifier = bundleIdentifier
         knowledge.entries.append(entry)
 
         // Prune oldest entries if over limit


### PR DESCRIPTION
The purpose of this PR is to replace the ambient agent's OCR-based screen capture with structured AX tree enumeration for richer, queryable context.

## Changes Made
- Add `AmbientAXCapture` — lightweight AX capturer optimized for the 30s ambient cycle (shallow depth 4, max 50 elements, skips decoration roles)
- Update `AmbientAgent.runCycle()` to try AX capture first, falling back to screenshot+OCR when the tree is empty, sparse (<3 elements), or slow (>500ms)
- Rename `AmbientAnalyzer.analyze(ocrText:)` to `analyze(screenContent:)` with a `captureMethod` parameter so the prompt adapts to input type
- Add optional metadata fields to `KnowledgeEntry` (`windowTitle`, `focusedElement`, `captureMethod`, `bundleIdentifier`) for richer observations

## Testing
- All 64 existing tests pass
- Manual smoke testing needed: verify AX capture fires on apps like Xcode/Safari/Terminal, OCR fallback triggers on poor AX trees, cycle timing stays under 30s

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
