### PR TITLE
Add respond tool for voice Q&A with stub calendar data

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionExecutor.swift
@@ -234,7 +234,7 @@ final class ActionExecutor: ActionExecuting {
         case .wait:
             let ms = action.waitDuration ?? 500
             try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
-        case .done:
+        case .done, .respond:
             break
         }
         return nil

--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -13,6 +13,7 @@ enum ActionType: String, Codable {
     case drag
     case openApp = "open_app"
     case runAppleScript = "run_applescript"
+    case respond
 }
 
 struct AgentAction: Codable {
@@ -137,6 +138,12 @@ struct AgentAction: Codable {
                 return "Done: \(preview)"
             }
             return "Done"
+        case .respond:
+            if let summary = summary {
+                let preview = summary.count > 60 ? String(summary.prefix(60)) + "..." : summary
+                return "Response: \(preview)"
+            }
+            return "Response"
         }
     }
 }

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -236,7 +236,7 @@ final class ComputerUseSession: ObservableObject {
             logger.logTurn(step: stepNumber, axTree: axTreeText, screenshot: screenshot, action: action, usedVision: usedVision, usage: tokenUsage)
 
             // 3. CHECK COMPLETION
-            if action.type == .done {
+            if action.type == .done || action.type == .respond {
                 let summary = action.summary ?? "Task completed"
                 let record = ActionRecord(step: stepNumber, action: action, result: "executed", timestamp: Date())
                 actionHistory.append(record)

--- a/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
+++ b/clients/macos/vellum-assistant/Inference/AnthropicProvider.swift
@@ -47,6 +47,12 @@ final class AnthropicProvider: ActionInferenceProvider {
 
     // MARK: - System Prompt
 
+    private static func currentDateString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, MMMM d, yyyy h:mm a"
+        return formatter.string(from: Date())
+    }
+
     private func buildSystemPrompt(screenSize: CGSize) -> String {
         """
         You are vellum-assistant's computer use agent. You control the user's Mac to accomplish tasks by interacting with UI elements one action at a time.
@@ -55,7 +61,7 @@ final class AnthropicProvider: ActionInferenceProvider {
 
         You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements — this is much more reliable than pixel coordinates.
 
-        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, open_app, run_applescript, done.
+        YOUR ONLY AVAILABLE TOOLS ARE: click, double_click, right_click, type_text, key, scroll, drag, wait, open_app, run_applescript, done, respond.
         You MUST only call one of these tools each turn. Do NOT attempt to call any other tool.
 
         RULES:
@@ -92,6 +98,15 @@ final class AnthropicProvider: ActionInferenceProvider {
         - NEVER use "do shell script" inside AppleScript — it is blocked for security.
         - Keep scripts short and focused on a single operation.
         - Examples of good use: `tell application "Safari" to set URL of current tab of front window to "https://example.com"`, `tell application "Finder" to open POSIX file "/Users/me/Documents"`.
+
+        CALENDAR / SCHEDULE DATA:
+        Today is \(Self.currentDateString()).
+        Here are the user's upcoming meetings for today:
+        - 10:00 AM — Team Standup (30 min, Google Meet)
+        - 2:00 PM — 1:1 with Sarah (30 min, Zoom)
+        - 4:00 PM — Sprint Planning (1 hour, Conference Room B)
+
+        If the user is asking a question about their schedule or meetings, use the `respond` tool to answer directly. Do NOT use computer-control tools to open the Calendar app.
         """
     }
 
@@ -308,6 +323,10 @@ final class AnthropicProvider: ActionInferenceProvider {
         case "done":
             let summary = input["summary"] as? String ?? "Task completed"
             return AgentAction(type: .done, reasoning: reasoning, summary: summary)
+
+        case "respond":
+            let answer = input["answer"] as? String ?? "No answer provided"
+            return AgentAction(type: .respond, reasoning: reasoning, summary: answer)
 
         default:
             throw InferenceError.parseError("Unknown tool: \(name)")

--- a/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
+++ b/clients/macos/vellum-assistant/Inference/ToolDefinitions.swift
@@ -218,6 +218,24 @@ enum ToolDefinitions {
                 ],
                 "required": ["summary"]
             ] as [String: Any]
+        ],
+        [
+            "name": "respond",
+            "description": "Respond directly to the user with a text answer. Use this when the user is asking a question (about their schedule, meetings, calendar, etc.) rather than asking you to control the computer.",
+            "input_schema": [
+                "type": "object",
+                "properties": [
+                    "answer": [
+                        "type": "string",
+                        "description": "The text answer to display to the user"
+                    ],
+                    "reasoning": [
+                        "type": "string",
+                        "description": "Explanation of how you determined the answer"
+                    ]
+                ],
+                "required": ["answer", "reasoning"]
+            ] as [String: Any]
         ]
     ]
 }

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ToolDefinitionsTests: XCTestCase {
 
     func testToolCount() {
-        XCTAssertEqual(ToolDefinitions.tools.count, 11, "Should have 11 tools defined")
+        XCTAssertEqual(ToolDefinitions.tools.count, 12, "Should have 12 tools defined")
     }
 
     func testToolNames() {
@@ -20,6 +20,7 @@ final class ToolDefinitionsTests: XCTestCase {
         XCTAssertTrue(names.contains("open_app"))
         XCTAssertTrue(names.contains("run_applescript"))
         XCTAssertTrue(names.contains("done"))
+        XCTAssertTrue(names.contains("respond"))
     }
 
     func testToolsHaveInputSchema() {


### PR DESCRIPTION
The purpose of this PR is to add a `respond` tool so the assistant can answer voice questions (e.g. "When is my next meeting?") directly instead of controlling the computer.

## Changes Made
- Add `respond` action type to `ActionType` enum with display description
- Add `respond` tool definition with `answer` and `reasoning` input fields
- Inject stub calendar data and current date/time into the system prompt
- Handle `respond` in tool call parsing (`AnthropicProvider`) and session completion (`Session`)
- Add `.respond` case to `ActionExecutor` switch for exhaustiveness

## Testing
- All 64 existing tests pass
- Updated `ToolDefinitionsTests` to expect 12 tools and assert `respond` is present
- Manual test: hold Fn, say "When is my next meeting?", expect overlay showing answer from stub data

## Notes
- Calendar data is currently stubbed in the system prompt (hardcoded meetings). Future work: EventKit integration for real calendar data.
- Response displays in the existing `.completed` overlay — no new UI needed for MVP.

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
