### PR TITLE
Extract IPC message handlers into separate module

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -124,7 +124,7 @@ import { DaemonServer } from '../daemon/server.js';
 
 type DaemonServerTestAccess = {
   sendInitialSession: (socket: net.Socket) => Promise<void>;
-  handleUndo: (sessionId: string, socket: net.Socket) => void;
+  dispatchMessage: (msg: { type: string; [key: string]: unknown }, socket: net.Socket) => void;
   sessions: Map<string, MockSession>;
   socketToSession: Map<net.Socket, string>;
 };
@@ -164,7 +164,7 @@ describe('DaemonServer initial session hydration', () => {
     const { socket, writes } = createFakeSocket();
 
     await internal.sendInitialSession(socket);
-    internal.handleUndo(conversation.id, socket);
+    internal.dispatchMessage({ type: 'undo', sessionId: conversation.id }, socket);
 
     const messages = decodeMessages(writes);
     const sessionInfo = messages.find((msg) => msg.type === 'session_info');

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,0 +1,313 @@
+import * as net from 'node:net';
+import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
+import { initializeProviders } from '../providers/registry.js';
+import * as conversationStore from '../memory/conversation-store.js';
+import { getLogger } from '../util/logger.js';
+import { Session } from './session.js';
+import type { ClientMessage, ServerMessage } from './ipc-protocol.js';
+
+const log = getLogger('handlers');
+
+/**
+ * Shared context that handlers need from the DaemonServer.
+ * Keeps handlers decoupled from the server class itself.
+ */
+export interface HandlerContext {
+  sessions: Map<string, Session>;
+  socketToSession: Map<net.Socket, string>;
+  socketSandboxOverride: Map<net.Socket, boolean>;
+  debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
+  suppressConfigReload: boolean;
+  setSuppressConfigReload(value: boolean): void;
+  send(socket: net.Socket, msg: ServerMessage): void;
+  getOrCreateSession(
+    conversationId: string,
+    socket?: net.Socket,
+    rebindClient?: boolean,
+  ): Promise<Session>;
+}
+
+// ─── Dispatch ────────────────────────────────────────────────────────────────
+
+export function handleMessage(
+  msg: ClientMessage,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  switch (msg.type) {
+    case 'user_message':
+      handleUserMessage(msg.sessionId, msg.content, socket, ctx);
+      break;
+    case 'confirmation_response':
+      handleConfirmationResponse(msg, socket, ctx);
+      break;
+    case 'session_list':
+      handleSessionList(socket, ctx);
+      break;
+    case 'session_create':
+      handleSessionCreate(msg.title, socket, ctx);
+      break;
+    case 'session_switch':
+      handleSessionSwitch(msg.sessionId, socket, ctx);
+      break;
+    case 'cancel':
+      handleCancel(socket, ctx);
+      break;
+    case 'model_get':
+      handleModelGet(socket, ctx);
+      break;
+    case 'model_set':
+      handleModelSet(msg.model, socket, ctx);
+      break;
+    case 'history_request':
+      handleHistoryRequest(msg.sessionId, socket, ctx);
+      break;
+    case 'undo':
+      handleUndo(msg.sessionId, socket, ctx);
+      break;
+    case 'usage_request':
+      handleUsageRequest(msg.sessionId, socket, ctx);
+      break;
+    case 'sandbox_set':
+      handleSandboxSet(msg.enabled, socket, ctx);
+      break;
+    case 'ping':
+      ctx.send(socket, { type: 'pong' });
+      break;
+  }
+}
+
+// ─── Individual handlers ─────────────────────────────────────────────────────
+
+async function handleUserMessage(
+  sessionId: string,
+  content: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    ctx.socketToSession.set(socket, sessionId);
+    const session = await ctx.getOrCreateSession(sessionId, socket, true);
+    await session.processMessage(content, (event) => {
+      ctx.send(socket, event);
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, sessionId }, 'Error processing user message');
+    ctx.send(socket, { type: 'error', message });
+  }
+}
+
+function handleConfirmationResponse(
+  msg: ClientMessage & { type: 'confirmation_response' },
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const sessionId = ctx.socketToSession.get(socket);
+  if (sessionId) {
+    const session = ctx.sessions.get(sessionId);
+    if (session) {
+      session.handleConfirmationResponse(
+        msg.requestId,
+        msg.decision as 'allow' | 'always_allow' | 'deny',
+        msg.selectedPattern,
+        msg.selectedScope,
+      );
+    }
+  }
+}
+
+function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
+  const conversations = conversationStore.listConversations(50);
+  ctx.send(socket, {
+    type: 'session_list_response',
+    sessions: conversations.map((c) => ({
+      id: c.id,
+      title: c.title ?? 'Untitled',
+      updatedAt: c.updatedAt,
+    })),
+  });
+}
+
+async function handleSessionCreate(
+  title: string | undefined,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const conversation = conversationStore.createConversation(
+    title ?? 'New Conversation',
+  );
+  await ctx.getOrCreateSession(conversation.id, socket, true);
+  ctx.send(socket, {
+    type: 'session_info',
+    sessionId: conversation.id,
+    title: conversation.title ?? 'New Conversation',
+  });
+}
+
+async function handleSessionSwitch(
+  sessionId: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const conversation = conversationStore.getConversation(sessionId);
+  if (!conversation) {
+    ctx.send(socket, { type: 'error', message: `Session ${sessionId} not found` });
+    return;
+  }
+  ctx.socketToSession.set(socket, sessionId);
+  await ctx.getOrCreateSession(sessionId, socket, true);
+  ctx.send(socket, {
+    type: 'session_info',
+    sessionId: conversation.id,
+    title: conversation.title ?? 'Untitled',
+  });
+}
+
+function handleCancel(socket: net.Socket, ctx: HandlerContext): void {
+  const sessionId = ctx.socketToSession.get(socket);
+  if (sessionId) {
+    const session = ctx.sessions.get(sessionId);
+    if (session) {
+      session.abort();
+    }
+  }
+}
+
+function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
+  const config = getConfig();
+  ctx.send(socket, {
+    type: 'model_info',
+    model: config.model,
+    provider: config.provider,
+  });
+}
+
+function handleModelSet(
+  model: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    // Use raw config to avoid persisting env-var API keys to disk
+    const raw = loadRawConfig();
+    raw.model = model;
+
+    // Suppress the file watcher callback — handleModelSet already does
+    // the full reload sequence; a redundant watcher-triggered reload
+    // would incorrectly evict sessions created after this method returns.
+    ctx.setSuppressConfigReload(true);
+    try {
+      saveRawConfig(raw);
+    } catch (err) {
+      ctx.setSuppressConfigReload(false);
+      throw err;
+    }
+    const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
+    if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+
+    // Re-initialize provider with the new model so LLM calls use it
+    const config = getConfig();
+    initializeProviders(config);
+
+    // Evict idle sessions immediately; mark busy ones as stale so they
+    // get recreated with the new provider once they finish processing.
+    for (const [id, session] of ctx.sessions) {
+      if (!session.isProcessing()) {
+        ctx.sessions.delete(id);
+      } else {
+        session.markStale();
+      }
+    }
+
+    ctx.send(socket, {
+      type: 'model_info',
+      model: config.model,
+      provider: config.provider,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.send(socket, { type: 'error', message: `Failed to set model: ${message}` });
+  }
+}
+
+function handleSandboxSet(
+  enabled: boolean,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  // Per-socket override: store the sandbox preference for this client only.
+  // The override is applied to the session so it doesn't affect other clients.
+  ctx.socketSandboxOverride.set(socket, enabled);
+  const sessionId = ctx.socketToSession.get(socket);
+  if (sessionId) {
+    const session = ctx.sessions.get(sessionId);
+    if (session) {
+      session.setSandboxOverride(enabled);
+    }
+  }
+  log.info({ enabled }, 'Sandbox override applied (per-session)');
+}
+
+function handleHistoryRequest(
+  sessionId: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const dbMessages = conversationStore.getMessages(sessionId);
+  const historyMessages = dbMessages.map((m) => {
+    let text = '';
+    try {
+      const content = JSON.parse(m.content);
+      if (Array.isArray(content)) {
+        text = content
+          .filter((b: { type: string }) => b.type === 'text')
+          .map((b: { text: string }) => b.text)
+          .join('');
+      } else {
+        text = String(content);
+      }
+    } catch (err) {
+      log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
+      text = m.content;
+    }
+    return { role: m.role, text, timestamp: m.createdAt };
+  });
+  ctx.send(socket, { type: 'history_response', messages: historyMessages });
+}
+
+function handleUndo(
+  sessionId: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const session = ctx.sessions.get(sessionId);
+  if (!session) {
+    ctx.send(socket, { type: 'error', message: 'No active session' });
+    return;
+  }
+  const removedCount = session.undo();
+  ctx.send(socket, { type: 'undo_complete', removedCount });
+}
+
+function handleUsageRequest(
+  sessionId: string,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const conversation = conversationStore.getConversation(sessionId);
+  if (!conversation) {
+    ctx.send(socket, { type: 'error', message: 'No active session' });
+    return;
+  }
+  const config = getConfig();
+  ctx.send(socket, {
+    type: 'usage_response',
+    totalInputTokens: conversation.totalInputTokens,
+    totalOutputTokens: conversation.totalOutputTokens,
+    estimatedCost: conversation.totalEstimatedCost,
+    model: config.model,
+  });
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -5,7 +5,7 @@ import { getSocketPath, getDataDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
-import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
+import { getConfig, invalidateConfigCache } from '../config/loader.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
@@ -18,6 +18,7 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './ipc-protocol.js';
+import { handleMessage, type HandlerContext } from './handlers.js';
 
 const log = getLogger('server');
 
@@ -307,7 +308,7 @@ export class DaemonServer {
         return;
       }
       for (const msg of messages) {
-        this.handleMessage(msg as ClientMessage, socket);
+        this.dispatchMessage(msg as ClientMessage, socket);
       }
     });
 
@@ -419,248 +420,22 @@ export class DaemonServer {
     return session;
   }
 
-  private handleMessage(msg: ClientMessage, socket: net.Socket): void {
-    switch (msg.type) {
-      case 'user_message':
-        this.handleUserMessage(msg.sessionId, msg.content, socket);
-        break;
-      case 'confirmation_response': {
-        const sessionId = this.socketToSession.get(socket);
-        if (sessionId) {
-          const session = this.sessions.get(sessionId);
-          if (session) {
-            session.handleConfirmationResponse(
-              msg.requestId,
-              msg.decision as 'allow' | 'always_allow' | 'deny',
-              msg.selectedPattern,
-              msg.selectedScope,
-            );
-          }
-        }
-        break;
-      }
-      case 'session_list':
-        this.handleSessionList(socket);
-        break;
-      case 'session_create':
-        this.handleSessionCreate(msg.title, socket);
-        break;
-      case 'session_switch':
-        this.handleSessionSwitch(msg.sessionId, socket);
-        break;
-      case 'cancel': {
-        const cancelSessionId = this.socketToSession.get(socket);
-        if (cancelSessionId) {
-          const session = this.sessions.get(cancelSessionId);
-          if (session) {
-            session.abort();
-          }
-        }
-        break;
-      }
-      case 'model_get':
-        this.handleModelGet(socket);
-        break;
-      case 'model_set':
-        this.handleModelSet(msg.model, socket);
-        break;
-      case 'history_request':
-        this.handleHistoryRequest(msg.sessionId, socket);
-        break;
-      case 'undo':
-        this.handleUndo(msg.sessionId, socket);
-        break;
-      case 'usage_request':
-        this.handleUsageRequest(msg.sessionId, socket);
-        break;
-      case 'sandbox_set':
-        this.handleSandboxSet(msg.enabled, socket);
-        break;
-      case 'ping':
-        this.send(socket, { type: 'pong' });
-        break;
-    }
+  private handlerContext(): HandlerContext {
+    return {
+      sessions: this.sessions,
+      socketToSession: this.socketToSession,
+      socketSandboxOverride: this.socketSandboxOverride,
+      debounceTimers: this.debounceTimers,
+      suppressConfigReload: this.suppressConfigReload,
+      setSuppressConfigReload: (value: boolean) => { this.suppressConfigReload = value; },
+      send: (socket, msg) => this.send(socket, msg),
+      getOrCreateSession: (id, socket?, rebind?) =>
+        this.getOrCreateSession(id, socket, rebind),
+    };
   }
 
-  private async handleUserMessage(
-    sessionId: string,
-    content: string,
-    socket: net.Socket,
-  ): Promise<void> {
-    try {
-      this.socketToSession.set(socket, sessionId);
-      const session = await this.getOrCreateSession(sessionId, socket, true);
-      await session.processMessage(content, (event) => {
-        this.send(socket, event);
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error({ err, sessionId }, 'Error processing user message');
-      this.send(socket, { type: 'error', message });
-    }
-  }
-
-  private handleSessionList(socket: net.Socket): void {
-    const conversations = conversationStore.listConversations(50);
-    this.send(socket, {
-      type: 'session_list_response',
-      sessions: conversations.map((c) => ({
-        id: c.id,
-        title: c.title ?? 'Untitled',
-        updatedAt: c.updatedAt,
-      })),
-    });
-  }
-
-  private async handleSessionCreate(
-    title: string | undefined,
-    socket: net.Socket,
-  ): Promise<void> {
-    const conversation = conversationStore.createConversation(
-      title ?? 'New Conversation',
-    );
-    await this.getOrCreateSession(conversation.id, socket, true);
-    this.send(socket, {
-      type: 'session_info',
-      sessionId: conversation.id,
-      title: conversation.title ?? 'New Conversation',
-    });
-  }
-
-  private async handleSessionSwitch(
-    sessionId: string,
-    socket: net.Socket,
-  ): Promise<void> {
-    const conversation = conversationStore.getConversation(sessionId);
-    if (!conversation) {
-      this.send(socket, { type: 'error', message: `Session ${sessionId} not found` });
-      return;
-    }
-    this.socketToSession.set(socket, sessionId);
-    await this.getOrCreateSession(sessionId, socket, true);
-    this.send(socket, {
-      type: 'session_info',
-      sessionId: conversation.id,
-      title: conversation.title ?? 'Untitled',
-    });
-  }
-
-  private handleModelGet(socket: net.Socket): void {
-    const config = getConfig();
-    this.send(socket, {
-      type: 'model_info',
-      model: config.model,
-      provider: config.provider,
-    });
-  }
-
-  private handleModelSet(model: string, socket: net.Socket): void {
-    try {
-      // Use raw config to avoid persisting env-var API keys to disk
-      const raw = loadRawConfig();
-      raw.model = model;
-
-      // Suppress the file watcher callback — handleModelSet already does
-      // the full reload sequence; a redundant watcher-triggered reload
-      // would incorrectly evict sessions created after this method returns.
-      this.suppressConfigReload = true;
-      try {
-        saveRawConfig(raw);
-      } catch (err) {
-        this.suppressConfigReload = false;
-        throw err;
-      }
-      const existingSuppressTimer = this.debounceTimers.get('__suppress_reset__');
-      if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
-      const resetTimer = setTimeout(() => { this.suppressConfigReload = false; }, 300);
-      this.debounceTimers.set('__suppress_reset__', resetTimer);
-
-      // Re-initialize provider with the new model so LLM calls use it
-      const config = getConfig();
-      initializeProviders(config);
-
-      // Evict idle sessions immediately; mark busy ones as stale so they
-      // get recreated with the new provider once they finish processing.
-      for (const [id, session] of this.sessions) {
-        if (!session.isProcessing()) {
-          this.sessions.delete(id);
-        } else {
-          session.markStale();
-        }
-      }
-
-      this.send(socket, {
-        type: 'model_info',
-        model: config.model,
-        provider: config.provider,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.send(socket, { type: 'error', message: `Failed to set model: ${message}` });
-    }
-  }
-
-  private handleSandboxSet(enabled: boolean, socket: net.Socket): void {
-    // Per-socket override: store the sandbox preference for this client only.
-    // The override is applied to the session so it doesn't affect other clients.
-    this.socketSandboxOverride.set(socket, enabled);
-    const sessionId = this.socketToSession.get(socket);
-    if (sessionId) {
-      const session = this.sessions.get(sessionId);
-      if (session) {
-        session.setSandboxOverride(enabled);
-      }
-    }
-    log.info({ enabled }, 'Sandbox override applied (per-session)');
-  }
-
-  private handleHistoryRequest(sessionId: string, socket: net.Socket): void {
-    const dbMessages = conversationStore.getMessages(sessionId);
-    const historyMessages = dbMessages.map((m) => {
-      let text = '';
-      try {
-        const content = JSON.parse(m.content);
-        if (Array.isArray(content)) {
-          text = content
-            .filter((b: { type: string }) => b.type === 'text')
-            .map((b: { text: string }) => b.text)
-            .join('');
-        } else {
-          text = String(content);
-        }
-      } catch (err) {
-        log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
-        text = m.content;
-      }
-      return { role: m.role, text, timestamp: m.createdAt };
-    });
-    this.send(socket, { type: 'history_response', messages: historyMessages });
-  }
-
-  private handleUndo(sessionId: string, socket: net.Socket): void {
-    const session = this.sessions.get(sessionId);
-    if (!session) {
-      this.send(socket, { type: 'error', message: 'No active session' });
-      return;
-    }
-    const removedCount = session.undo();
-    this.send(socket, { type: 'undo_complete', removedCount });
-  }
-
-  private handleUsageRequest(sessionId: string, socket: net.Socket): void {
-    const conversation = conversationStore.getConversation(sessionId);
-    if (!conversation) {
-      this.send(socket, { type: 'error', message: 'No active session' });
-      return;
-    }
-    const config = getConfig();
-    this.send(socket, {
-      type: 'usage_response',
-      totalInputTokens: conversation.totalInputTokens,
-      totalOutputTokens: conversation.totalOutputTokens,
-      estimatedCost: conversation.totalEstimatedCost,
-      model: config.model,
-    });
+  private dispatchMessage(msg: ClientMessage, socket: net.Socket): void {
+    handleMessage(msg, socket, this.handlerContext());
   }
 
 }


### PR DESCRIPTION
## Summary
- Extracts all 13 IPC message handlers from `DaemonServer` class in `server.ts` into a new `handlers.ts` module
- Introduces `HandlerContext` interface to decouple handlers from the server instance, providing access to sessions, socket maps, and server methods
- Reduces `server.ts` from 666 to 441 lines — now focused on server lifecycle (start/stop, connections, file watching)
- Updates test to use `dispatchMessage` instead of directly accessing removed private methods

## Test plan
- [x] `bun tsc --noEmit` passes with no errors
- [x] `daemon-server-session-init.test.ts` passes (both tests)
- [x] All pre-existing test failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
