### PR TITLE
Unignore .private/commands for shared use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ dist
 .DS_Store
 *.pem
 .claude/
-.private/
+.private/*.md
 temp.sh
 context.md
 .codex

--- a/.private/commands/brainstorm.md
+++ b/.private/commands/brainstorm.md
@@ -1,0 +1,27 @@
+Carefully read through the codebase and the exising .private/TODO.md and come up with a list of ideas for changes we should make to the codebase in order to make this project fucking amazing.
+
+Can include but not limited to:
+
+- new features
+- improvements to existing features
+- security improvements
+- tooling improvements
+- bug fixes
+- performance improvements
+- documentation improvements
+- testing improvements
+- refactoring / code architecture improvements
+- deduplicating code
+- simplifying complicated code
+- removing dead code
+- code cleanup
+- code style/readability improvements
+
+This is just meant to be a starting point for brainstorming, don't limit yourself to these ideas.
+Ultrathink about this and go wild.
+We're going to make this the best assistant on the planet.
+
+Once you've done your absolute best, share the changes you plan on making with me, and once I approve them, update .private/TODO.md.
+.private/TODO.md should be a single bulleted list of items organized by descending priority, don't organize by category. Keep the "Address the feedback on <PR URL>" items at the top of the list.
+
+IMPORTANT: .private/TODO.md is written to by other processes so make sure you read it before writing to it and after writing to it. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md is gitignored.

--- a/.private/commands/check-reviews.md
+++ b/.private/commands/check-reviews.md
@@ -1,0 +1,62 @@
+You are running a single iteration of a cronjob that runs periodically for task scheduling.
+
+<instructions>
+
+Look at every item in .private/UNREVIEWED_PRS.md. Each line is a PR URL like `https://github.com/vellum-ai/vellum-assistant/pull/123`.
+
+Check each PR to see if **both** chatgpt-codex-connector and devin-ai-integration have reviewed it and whether they have feedback.
+
+## How to fetch PR data
+
+For each PR, run these commands in parallel:
+
+1. **Reviews, comments, and creation time:** `gh pr view <number> --json comments,reviews,createdAt`
+2. **PR description reactions:** `gh api repos/vellum-ai/vellum-assistant/issues/<number>/reactions --jq '[.[] | {user: .user.login, content: .content}]'`
+
+Note: PR description reactions use the **issues** API endpoint (not pulls). The `reactionGroups` field from `gh pr view` doesn't include user info.
+
+Also fetch inline review comments if needed: `gh api repos/vellum-ai/vellum-assistant/pulls/<number>/comments --jq '[.[] | {user: .user.login, body: .body}]'`
+
+## How to determine review status
+
+### chatgpt-codex-connector (appears as `chatgpt-codex-connector[bot]`)
+
+- **Approved:** Left a `+1` reaction on the PR description (check the issues reactions endpoint)
+- **Requested changes:** Left a PR review or inline review comment with suggestions/issues (look for reviews or comments by `chatgpt-codex-connector[bot]`)
+- **Pending:** Neither of the above
+
+### devin-ai-integration (appears as `devin-ai-integration[bot]`)
+
+- **Approved:** Left a PR review containing "No Issues Found" (typically "✅ Devin Review: No Issues Found")
+- **Requested changes:** Left a PR review or inline comment with issues/findings (any review that does NOT say "No Issues Found")
+- **Pending:** No review from this user
+
+## Skipping slow reviewers (30-minute timeout)
+
+If a PR was created **30 or more minutes ago** (based on `createdAt`) and only **one** of Codex or Devin has reviewed it while the other is still pending, treat the pending reviewer as **skipped**. A skipped review counts as an implicit approval. If **neither** has reviewed after 30 minutes, do NOT skip — keep waiting (both still pending).
+
+When a reviewer is skipped:
+- The PR is considered "fully reviewed" (just like if both had responded).
+- The skipped reviewer's status should display as "Skipped" in the output table.
+- Apply the normal actions logic using the one real review plus the implicit approval from the skip.
+
+## Actions
+
+- If either reviewer hasn't reviewed yet **and** the PR is less than 30 minutes old, keep the PR in UNREVIEWED_PRS.md for next time.
+- If the PR is 30+ minutes old and at least one reviewer has responded, treat any missing reviewer as skipped (implicit approval) and proceed as fully reviewed.
+- If both have reviewed (or one reviewed + one skipped) and either **real** review requested changes, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
+- If fully reviewed (both reviewed, or one reviewed + one skipped), remove the PR from .private/UNREVIEWED_PRS.md.
+
+## Output
+
+Display a table with these columns:
+
+| PR  | Age | Codex | Devin | Fully Reviewed | Added to TODO | Removed from Unreviewed |
+| --- | --- | ----- | ----- | -------------- | ------------- | ----------------------- |
+
+- **Age**: How long ago the PR was created (e.g., "2h 15m", "45m"). Include a ⏰ marker if the 30-minute timeout triggered a skip.
+- **Codex/Devin columns**: Show "Approved", "Changes requested", "Pending", or "Skipped" (when the 30-min timeout applied).
+
+</instructions>
+
+IMPORTANT: .private/TODO.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md and .private/UNREVIEWED_PRS.md are gitignored.

--- a/.private/commands/swarm.md
+++ b/.private/commands/swarm.md
@@ -1,0 +1,122 @@
+Work through .private/TODO.md using a pool of parallel agents. One task per agent. As agents finish, spawn new ones for the next items. Keep going until the user says to stop or TODO.md is empty.
+
+Arguments (optional): $ARGUMENTS
+
+Parse positional arguments:
+
+- **First argument** (optional): number of parallel workers (default: 3). Example: `/swarm 5` runs 5 workers.
+- **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 3 10` runs 3 workers and stops after completing 10 tasks.
+
+If no arguments are provided, default to 3 workers with no task limit (run until TODO.md is empty or the user says to stop).
+
+## Repo-specific gotchas (include these in every agent prompt)
+
+- **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **No piping to tail/head**: `tail` and `head` may not be available in the shell. Avoid `cmd | tail -N`. Instead, run the command directly and let output truncate naturally, or use the Read tool on output files.
+
+## Phase 1: Setup
+
+1. Read .private/TODO.md. Keep an internal list of which items are currently in-flight.
+2. Parse the arguments: note the worker count (default: 3) and max-tasks limit (if provided). Track a **completed count** starting at 0.
+3. Create a team with `TeamCreate` (team name: `swarm`).
+
+## Phase 2: Pick the next task
+
+When choosing which item to hand to the next available agent:
+
+- Don't just always pop from the top. Be smart about **conflict avoidance**: look at what's currently in-flight and avoid scheduling a task that's likely to touch the same files or subsystems. For example, don't run two security-related tasks or two IPC tasks at the same time if they'll both modify overlapping files.
+- If the top item would conflict with in-flight work, skip it and pick the next non-conflicting item instead. Come back to skipped items when the conflicting work finishes.
+
+### Handling "Address the feedback" items
+
+These are tasks to read review comments on an already-merged PR, then create a NEW PR with the requested fixes. Before handing one off:
+
+- Check if the referenced PR is merged. If not, merge it first (the review system only reviews on initial push, so PRs are never updated after opening).
+- Then hand the task to an agent like any other item.
+
+## Phase 3: Spawn an agent
+
+For each task being handed off:
+
+1. Create a worktree: `.claude/worktree create swarm/task-<counter>`.
+2. Create a `TaskCreate` entry for tracking.
+3. Spawn a `general-purpose` agent via the `Task` tool with `team_name: "swarm"`. The prompt must include:
+
+```
+You are working on a single task in an isolated git worktree.
+
+## Project context
+- Bun + TypeScript project. Code is in `assistant/`.
+- Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- All imports use `.js` extensions (NodeNext module resolution).
+
+## Repo-specific gotchas
+- `gh pr view` does NOT support a `merged` --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
+- This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- `tail` and `head` may not be available in the shell. Don't pipe to them.
+
+## Your worktree
+<absolute path to worktree>
+ALL work happens here. Do NOT touch the main repo.
+
+## Your task
+<the TODO item, plus relevant context: file paths, function names, existing patterns>
+
+## Workflow
+1. Make the changes in your worktree.
+2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
+3. Commit with a descriptive message.
+4. Push and create a PR:
+   gh pr create --base main --title "<concise title>" --body "<what changed and why>"
+5. Merge immediately: gh pr merge <number> --squash
+6. Send a message to "lead" with:
+   - The PR link
+   - A summary of what you changed and why
+   - Which files were modified
+   - Any issues or concerns
+
+For "Address the feedback on <PR URL>" tasks:
+- Read the review comments on the referenced PR to understand what changes are requested.
+- Implement the requested fixes in your worktree (on a new branch — this will become a new PR).
+- Follow the same PR creation and merge workflow above.
+```
+
+## Phase 4: When an agent finishes
+
+1. Read its completion message.
+2. Update tracking files (read fresh each time, write back carefully):
+   - Remove the completed item from .private/TODO.md.
+   - Append a deatiled description of what was done to the end of .private/DONE.md, separated by a horizontal rule.
+   - Append the PR link to .private/UNREVIEWED_PRS.md.
+3. Mark the TaskCreate entry as completed.
+4. Increment the **completed count**.
+5. Send the agent a shutdown request.
+6. Remove the worktree: `.claude/worktree remove swarm/task-<counter>`.
+7. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate — give enough detail that the user understands what happened without clicking the PR.
+8. Remove the item from the in-flight list.
+9. Pull the latest main branch to ensure the worktree is up to date.
+10. **If the user has NOT signaled stop AND the max-tasks limit has NOT been reached**: pick the next task (Phase 2) and spawn a new agent (Phase 3).
+11. **If the user HAS signaled stop OR the max-tasks limit has been reached**: don't spawn. Once all in-flight agents finish, proceed to shutdown.
+
+## Phase 5: Shutdown
+
+When the user says to stop, the max-tasks limit is reached, or TODO.md is empty (and all agents have finished):
+
+1. Let all in-progress agents finish their current task. Do NOT interrupt them.
+2. Process all remaining results (update TODO.md, DONE.md, UNREVIEWED_PRS.md, clean up worktrees).
+3. Delete the team with `TeamDelete`.
+4. Print a final summary table:
+
+   | #   | Item                               | PR   | Status |
+   | --- | ---------------------------------- | ---- | ------ |
+   | 1   | Fix quadratic string concat        | #210 | merged |
+   | 2   | Add foreign key on toolInvocations | #211 | merged |
+   | 3   | IPC message size limits            | —    | failed |
+
+## Important
+
+- Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
+- .private/TODO.md, .private/DONE.md, and .private/UNREVIEWED_PRS.md are written to by other processes. Always read before writing, verify after writing. These files are gitignored.
+- If an agent reports failure, put the item back in TODO.md at its original priority position and note the failure in the summary.
+- If an agent hits merge conflicts after another agent's PR landed, tell it to rebase: `git pull --rebase origin main`.

--- a/.private/commands/work.md
+++ b/.private/commands/work.md
@@ -1,0 +1,39 @@
+Handle one task using this selection rule:
+
+- If the user passed `$ARGUMENTS`, treat that as the task to handle.
+- Otherwise, handle the first item in `.private/TODO.md`.
+
+IMPORTANT: If the task is "Address the feedback on <PR URL>", first check if the PR has been merged already. If not, merge it immediately and continue with the task.
+
+## Repo-specific gotchas
+
+- **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt` instead: `gh pr view <N> --json state,mergedAt,title,url`
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **No piping to tail/head**: `tail` and `head` may not be available in the shell. Avoid `cmd | tail -N`. Instead, run the command directly and let output truncate naturally, or use the Read tool on output files.
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+
+If it requires code changes:
+
+- Check the codebase to make sure it's still relevant. It may have been addressed already by someone else, or the codebase may have changed so it's no longer relevant, in which case remove it from the .private/TODO.md list and provide a detailed explanation of why it can be removed.
+
+If it's still relevant:
+
+- Decide if it can be implemented in a single PR or if it's large and complex enough that you need to break it down into multiple PRs to keep it manageable.
+
+If you need to break it down into multiple PRs:
+
+- Replace the item in .private/TODO.md in-place with one item per sub-task you need to complete to implement the feature, and let me know that you've done this and wait for more instructions.
+
+If you can implement it in a single PR:
+
+- Create a PR for it (output a link to the PR)
+- Append the link to only this new PR to .private/UNREVIEWED_PRS.md
+- CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
+
+After you've handled the item:
+
+- Append a deatiled description of what was done to the end of .private/DONE.md, separated by a horizontal rule.
+- If the handled task exists in `.private/TODO.md`, remove that exact item from the list. Be very careful to not accidentally overwrite other changes or remove other items unless you're absolutely sure you're doing the right thing.
+- Provide a detailed description of what you did.
+
+IMPORTANT: .private/TODO.md, .private/DONE.md and .private/UNREVIEWED_PRS.md are written to by other processes so make sure you read them before writing to them and after writing to them. Don't be alarmed if you see changes that you didn't make, but make sure your changes are persisted and you're not overwriting other changes. .private/TODO.md, .private/DONE.md and .private/UNREVIEWED_PRS.md are gitignored.

--- a/.private/commands/worktree-plan.md
+++ b/.private/commands/worktree-plan.md
@@ -1,0 +1,13 @@
+Read the IDEAS.md file at .claude/IDEAS.md. The user wants to work on a batch of items in parallel using git worktrees.
+
+Based on the items the user selects (or suggest a good batch if they don't specify), do the following:
+
+1. Group the selected items into non-conflicting batches (items that touch the same files should be in the same batch, done sequentially within that batch).
+2. For each batch, draft a detailed kickoff message that a fresh Claude Code session can use to implement the items autonomously. The message should include:
+   - The reminder that this is a Bun + TypeScript project with code in `assistant/`, that `export PATH="$HOME/.bun/bin:$PATH"` is needed, and that imports use `.js` extensions (NodeNext resolution).
+   - A numbered list of tasks in the order they should be done.
+   - Enough context about the existing code (file paths, relevant APIs) that the session doesn't need to explore from scratch.
+   - The instruction to commit each task separately and type-check after each change.
+3. Tell the user the `scripts/worktree create <branch>` command to run for each batch.
+
+Keep the kickoff messages practical and specific — not vague. Reference actual file paths and function names.


### PR DESCRIPTION
## Summary
- Changed `.gitignore` from ignoring all of `.private/` to only ignoring `.private/*.md`
- This tracks `.private/commands/` so teammates can use the shared command files
- Data files (TODO.md, DONE.md, etc.) remain gitignored

## Test plan
- [x] Verified `git check-ignore` correctly ignores `.md` files and allows `commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
