### PR TITLE
Fix app not appearing in System Settings for permissions

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -164,7 +164,8 @@ if [ "$CMD" = "run" ]; then
     # Kill existing instance if running
     pkill -x "$APP_NAME" 2>/dev/null || true
     sleep 0.3
-    # Use absolute path to avoid Launch Services opening a stale copy
-    "$MACOS_DIR/$APP_NAME" &
-    disown
+    # Launch via `open` so Launch Services registers the bundle —
+    # this is required for macOS TCC to associate the app with its
+    # bundle ID and show it in System Settings > Privacy & Security.
+    open "$APP_DIR"
 fi


### PR DESCRIPTION
The purpose of this PR is to fix the app not appearing in System Settings > Privacy & Security after being launched via `./build.sh run`.

## Changes Made
- Replace direct binary execution (`"$MACOS_DIR/$APP_NAME" &`) with `open "$APP_DIR"` in the run command
- This ensures Launch Services registers the `.app` bundle, which is required for macOS TCC to associate the process with its bundle ID and show it in Privacy & Security settings (Accessibility, Screen Recording, Microphone)

## Context
PR #430 replaced `xcodebuild` + `run-dev.sh` with a single `build.sh` script. The old script launched the app via `open "$APP_PATH"`, but the new script ran the binary directly, bypassing Launch Services registration. Without that registration, TCC cannot track the app for permission grants.

## Testing
- Build and launch with `./build.sh run`, verify the app appears in System Settings > Privacy & Security

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
