### PR TITLE
Add semantic token system with theme toggle for Meadow design system

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -20,6 +20,7 @@
         "handlebars": "^4.7.8",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "postgres": "^3.4.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -1170,6 +1171,8 @@
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": "dist/bin/next" }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "handlebars": "^4.7.8",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "postgres": "^3.4.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/web/src/app/(app)/meadow.css
+++ b/web/src/app/(app)/meadow.css
@@ -13,17 +13,17 @@
   --color-sky-800: #0f2b36;
   --color-sky-900: #0a1d24;
 
-  /* Meadow Green (Secondary) */
-  --color-meadow-50: #edf7ed;
-  --color-meadow-100: #d1ecd1;
-  --color-meadow-200: #b1dfb1;
-  --color-meadow-300: #8ed28e;
-  --color-meadow-400: #6ec46e;
-  --color-meadow-500: #5cb85c;
-  --color-meadow-600: #3a7a3a;
-  --color-meadow-700: #2d602d;
-  --color-meadow-800: #1f451f;
-  --color-meadow-900: #142d14;
+  /* Meadow Green (Secondary — sage/teal-green, ~155° hue) */
+  --color-meadow-50:  #ecf5f2;
+  --color-meadow-100: #d0e8e1;
+  --color-meadow-200: #afd8cc;
+  --color-meadow-300: #88c4b3;
+  --color-meadow-400: #63b09c;
+  --color-meadow-500: #4a9a85;
+  --color-meadow-600: #377a69;
+  --color-meadow-700: #2b6053;
+  --color-meadow-800: #1f453c;
+  --color-meadow-900: #142d27;
 
   /* Poppy Orange (Accent / CTA) */
   --color-poppy-50: #fef3ec;
@@ -82,6 +82,28 @@
   --radius-meadow: 14px;
   --radius-meadow-lg: 20px;
 
+  /* Semantic color utilities */
+  --color-app-bg: var(--app-bg);
+  --color-app-surface: var(--app-surface);
+  --color-app-surface-elevated: var(--app-surface-elevated);
+  --color-app-text-primary: var(--app-text-primary);
+  --color-app-text-secondary: var(--app-text-secondary);
+  --color-app-text-muted: var(--app-text-muted);
+  --color-app-border: var(--app-border);
+  --color-app-primary: var(--app-primary);
+  --color-app-primary-hover: var(--app-primary-hover);
+  --color-app-secondary: var(--app-secondary);
+  --color-app-secondary-hover: var(--app-secondary-hover);
+  --color-app-accent: var(--app-accent);
+  --color-app-accent-text: var(--app-accent-text);
+  --color-app-muted: var(--app-muted);
+  --color-app-muted-foreground: var(--app-muted-foreground);
+  --color-app-success: var(--app-success);
+  --color-app-info: var(--app-info);
+  --color-app-danger: var(--app-danger);
+  --color-app-danger-hover: var(--app-danger-hover);
+  --color-app-ring: var(--app-ring);
+
   /* Animation tokens */
   --animate-wobble: wobble 0.3s ease-in-out;
   --animate-bob: bob 3s ease-in-out infinite;
@@ -119,6 +141,14 @@
   --app-success: #6abf5e;       /* dino-400 */
   --app-info: #8da0ce;          /* lavender-400 */
   --app-ring: rgba(106, 191, 94, 0.3); /* dino-400/30% */
+  --app-secondary: #4a9a85;          /* meadow-500 */
+  --app-secondary-hover: #377a69;    /* meadow-600 */
+  --app-accent: #f0913f;             /* poppy-400 */
+  --app-accent-text: #e8834a;        /* poppy-500 */
+  --app-muted: #f5f0ea;              /* cloud-100 — ghost/pill bg */
+  --app-muted-foreground: #c4b894;   /* cloud-500 */
+  --app-danger: #dc2626;             /* red-600 */
+  --app-danger-hover: #b91c1c;       /* red-700 */
 }
 
 /* Dark mode semantic colors */
@@ -135,4 +165,12 @@
   --app-success: #8ed883;       /* dino-300 */
   --app-info: #a3b4d8;          /* lavender-300 */
   --app-ring: rgba(106, 191, 94, 0.3); /* dino-400/30% */
+  --app-secondary: #63b09c;          /* meadow-400 */
+  --app-secondary-hover: #4a9a85;    /* meadow-500 */
+  --app-accent: #f0913f;             /* poppy-400 */
+  --app-accent-text: #f4a261;        /* poppy-300 */
+  --app-muted: #153d4e;              /* sky-700 */
+  --app-muted-foreground: #9ac5d2;   /* sky-200 */
+  --app-danger: #ef4444;             /* red-500 */
+  --app-danger-hover: #dc2626;       /* red-600 */
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -13,11 +13,9 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${nunito.variable} ${quicksand.variable} antialiased`}
       >

--- a/web/src/components/app/core/Button/Button.tsx
+++ b/web/src/components/app/core/Button/Button.tsx
@@ -13,16 +13,15 @@ const iconSizeMap = {
 } as const;
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-display font-semibold rounded-meadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dino-400/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-display font-semibold rounded-meadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        primary: "bg-poppy-400 text-white hover:bg-poppy-500",
-        secondary: "bg-meadow-500 text-white hover:bg-meadow-600",
-        ghost: "hover:bg-cloud-100 dark:hover:bg-sky-700",
-        outline:
-          "border border-cloud-300 hover:bg-cloud-50 dark:border-sky-600 dark:hover:bg-sky-700",
-        danger: "bg-red-600 text-white hover:bg-red-700",
+        primary: "bg-app-primary text-white hover:bg-app-primary-hover",
+        secondary: "bg-app-secondary text-white hover:bg-app-secondary-hover",
+        ghost: "hover:bg-app-muted",
+        outline: "border border-app-border hover:bg-app-muted",
+        danger: "bg-app-danger text-white hover:bg-app-danger-hover",
       },
       size: {
         sm: "h-8 px-3 text-sm",

--- a/web/src/components/app/core/Tabs/Tabs.tsx
+++ b/web/src/components/app/core/Tabs/Tabs.tsx
@@ -15,8 +15,8 @@ const Tabs = TabsPrimitive.Root;
 const tabsListVariants = cva("flex items-center", {
   variants: {
     variant: {
-      underline: "border-b border-cloud-200 dark:border-sky-700",
-      pill: "rounded-meadow bg-cloud-100 p-1 dark:bg-sky-800",
+      underline: "border-b border-app-border",
+      pill: "rounded-meadow bg-app-muted p-1",
     },
   },
   defaultVariants: {
@@ -44,13 +44,13 @@ TabsList.displayName = TabsPrimitive.List.displayName;
 /* ───────────── TabsTrigger ───────────── */
 
 const tabsTriggerVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap font-display text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dino-400/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap font-display text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         underline:
-          "border-b-2 border-transparent px-4 py-2 text-cloud-500 hover:text-sky-900 dark:text-sky-400 dark:hover:text-white data-[state=active]:border-poppy-400 data-[state=active]:text-poppy-500",
-        pill: "rounded-meadow px-3 py-1.5 text-cloud-500 dark:text-sky-400 data-[state=active]:bg-white data-[state=active]:text-sky-900 data-[state=active]:shadow-sm dark:data-[state=active]:bg-sky-700 dark:data-[state=active]:text-white",
+          "border-b-2 border-transparent px-4 py-2 text-app-muted-foreground hover:text-app-text-primary data-[state=active]:border-app-accent data-[state=active]:text-app-accent-text",
+        pill: "rounded-meadow px-3 py-1.5 text-app-muted-foreground data-[state=active]:bg-app-surface data-[state=active]:text-app-text-primary data-[state=active]:shadow-sm",
       },
     },
     defaultVariants: {

--- a/web/src/components/app/core/Toast/Toast.tsx
+++ b/web/src/components/app/core/Toast/Toast.tsx
@@ -26,8 +26,8 @@ const VARIANT_STYLES: Record<
 > = {
   default: {
     container:
-      "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-white",
-    icon: "text-zinc-500 dark:text-zinc-400",
+      "bg-app-surface border-app-border text-app-text-primary",
+    icon: "text-app-text-muted",
     iconElement: null,
   },
   info: {

--- a/web/src/components/app/pages/AssistantEditor/_AppView.tsx
+++ b/web/src/components/app/pages/AssistantEditor/_AppView.tsx
@@ -57,7 +57,7 @@ export function AppView({ assistantId }: AppViewProps) {
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-cloud-200 px-4 dark:border-sky-700">
+      <div className="flex items-center justify-between border-b border-app-border px-4">
         <TabsList variant="underline" className="border-b-0">
           <TabsTrigger value="chat" variant="underline">
             Chat

--- a/web/src/components/shared/Providers/Providers.tsx
+++ b/web/src/components/shared/Providers/Providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ThemeProvider } from "next-themes";
 import { ReactNode } from "react";
 
 import { AuthProvider } from "@/lib/auth";
@@ -11,7 +12,9 @@ interface ProvidersProps {
 export function Providers({ children }: ProvidersProps) {
   return (
     <AuthProvider>
-      {children}
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
     </AuthProvider>
   );
 }

--- a/web/src/components/shared/UserMenu/UserMenu.tsx
+++ b/web/src/components/shared/UserMenu/UserMenu.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { Home, LogOut, Settings, User } from "lucide-react";
+import { Home, LogOut, Monitor, Moon, Settings, Sun, User } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
+import { Button } from "@/components/app/core/Button";
 import { useAuth } from "@/lib/auth";
+
+const emptySubscribe = () => () => {};
 
 export function UserMenu() {
   const { isLoggedIn, username, logout } = useAuth();
+  const { setTheme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -67,6 +73,38 @@ export function UserMenu() {
             <Settings className="h-4 w-4" />
             Settings
           </Link>
+
+          {mounted && (
+            <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-2 dark:border-zinc-700">
+              <span className="text-sm text-zinc-600 dark:text-zinc-400">Theme</span>
+              <div className="flex gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Sun}
+                  onClick={() => setTheme("light")}
+                  aria-label="Light mode"
+                  className="h-8 w-8 px-0"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Moon}
+                  onClick={() => setTheme("dark")}
+                  aria-label="Dark mode"
+                  className="h-8 w-8 px-0"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={Monitor}
+                  onClick={() => setTheme("system")}
+                  aria-label="System theme"
+                  className="h-8 w-8 px-0"
+                />
+              </div>
+            </div>
+          )}
 
           <div className="border-t border-zinc-200 dark:border-zinc-700">
             <button


### PR DESCRIPTION
Expand meadow.css with semantic color tokens (secondary, accent, muted, danger) and register them as Tailwind @theme colors. Update Button, Tabs, Toast, and _AppView to use semantic classes, removing all manual dark: overrides. Add next-themes for theme switching with light/dark/system toggle in UserMenu.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
