### PR TITLE
Fix uncontrolled-to-controlled input warning in login form

### DIFF
--- a/web/src/app/(app)/login/page.tsx
+++ b/web/src/app/(app)/login/page.tsx
@@ -14,7 +14,12 @@ interface LoginFormValues {
 }
 
 export default function LoginPage() {
-  const { control, handleSubmit, formState: { isSubmitting, errors } } = useForm<LoginFormValues>();
+  const { control, handleSubmit, formState: { isSubmitting, errors } } = useForm<LoginFormValues>({
+    defaultValues: {
+      username: "",
+      password: "",
+    },
+  });
   const { login } = useAuth();
   const router = useRouter();
 


### PR DESCRIPTION
Add defaultValues to useForm hook to prevent React warning about inputs changing from uncontrolled to controlled state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
