### PR TITLE
Address PR #428 review comments for ambient AX capture

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAXCapture.swift
@@ -6,6 +6,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 struct ElementSummary {
     let role: String
+    let originalRole: String
     let label: String?
     let value: String?
     let depth: Int
@@ -40,9 +41,17 @@ enum AmbientAXCapture {
 
     // MARK: - Public API
 
+    private static let ownBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+
     static func capture() async -> AmbientSnapshot? {
         guard let frontApp = NSWorkspace.shared.frontmostApplication else {
             log.debug("No frontmost app")
+            return nil
+        }
+
+        // Skip capturing our own app to avoid self-referential observations
+        if frontApp.bundleIdentifier == ownBundleId {
+            log.debug("Frontmost app is self — skipping AX capture")
             return nil
         }
 
@@ -91,8 +100,9 @@ enum AmbientAXCapture {
 
     static func isUseful(_ snapshot: AmbientSnapshot) -> Bool {
         let meaningful = snapshot.visibleElements.filter { element in
-            !labelRequiredRoles.contains("AX" + capitalizeFirst(element.role))
+            !labelRequiredRoles.contains(element.originalRole)
             || element.label != nil
+            || element.value != nil
         }
         return meaningful.count >= 3
     }
@@ -152,6 +162,7 @@ enum AmbientAXCapture {
             let cleanedRole = cleanRole(role)
             elements.append(ElementSummary(
                 role: cleanedRole,
+                originalRole: role,
                 label: title,
                 value: value,
                 depth: depth
@@ -200,8 +211,4 @@ enum AmbientAXCapture {
         return result
     }
 
-    private static func capitalizeFirst(_ str: String) -> String {
-        guard let first = str.first else { return str }
-        return String(first).uppercased() + str.dropFirst()
-    }
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -165,6 +165,14 @@ final class AmbientAgent: ObservableObject {
 
         state = .analyzing
 
+        // Skip if frontmost app is Vellum itself to avoid self-referential observations
+        let ownBundleId = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+        if NSWorkspace.shared.frontmostApplication?.bundleIdentifier == ownBundleId {
+            log.debug("[\(cycle)] Frontmost app is self — skipping cycle")
+            state = .watching
+            return
+        }
+
         // Try AX capture first
         let axStart = CFAbsoluteTimeGetCurrent()
         let snapshot = await AmbientAXCapture.capture()

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -51,6 +51,7 @@ final class AmbientAgent: ObservableObject {
     private var syncTask: Task<Void, Never>?
     private var activeSuggestionWindow: AmbientSuggestionWindow?
     private var insightNotificationWindow: InsightNotificationWindow?
+    private var previousAXText: String = ""
     private var previousOCRText: String = ""
     private var knowledgeCancellable: AnyCancellable?
     private var suggestionWindow: AmbientSuggestionWindow?
@@ -215,14 +216,19 @@ final class AmbientAgent: ObservableObject {
             return
         }
 
-        // Check similarity with previous capture
-        let similarity = ScreenOCR.similarity(previousOCRText, screenContent)
+        // Check similarity with previous capture of the same method
+        let previousText = captureMethod == "ax-tree" ? previousAXText : previousOCRText
+        let similarity = ScreenOCR.similarity(previousText, screenContent)
         if similarity > 0.85 {
             log.debug("[\(cycle)] Screen unchanged (similarity: \(String(format: "%.2f", similarity))) — skipping")
             state = .watching
             return
         }
-        previousOCRText = screenContent
+        if captureMethod == "ax-tree" {
+            previousAXText = screenContent
+        } else {
+            previousOCRText = screenContent
+        }
 
         log.info("[\(cycle)] Analyzing \(appName) — \"\(windowTitle)\" (\(screenContent.count) chars, \(captureMethod))")
 


### PR DESCRIPTION
## Summary
- Fix `isUseful` role reconstruction bug by storing `originalRole` in `ElementSummary` instead of trying to reverse the lossy `cleanRole` transformation (multi-word roles like `AXSplitGroup` were never matching)
- Fix `isUseful` to count label-required roles as meaningful when they have a `value` (not just a `label`), matching the behavior in `enumerateElement`
- Track separate previous content per capture method (`ax-tree` vs `ocr`) so the similarity check doesn't produce false negatives when the method alternates between cycles
- Skip AX capture when the frontmost app is Vellum itself to avoid self-referential observations

Addresses review comments from PR #428.

## Test plan
- [x] All 64 existing tests pass
- [ ] Manual: verify `isUseful` correctly filters `AXSplitGroup` elements without labels/values
- [ ] Manual: verify similarity check works correctly when capture method alternates
- [ ] Manual: verify Vellum's own UI is skipped during ambient capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
