### PR TITLE
Fix uncontrolled-to-controlled input warning in signup form

### DIFF
--- a/web/src/app/(app)/signup/page.tsx
+++ b/web/src/app/(app)/signup/page.tsx
@@ -16,7 +16,14 @@ interface SignupFormValues {
 }
 
 export default function SignupPage() {
-  const { control, handleSubmit, getValues, formState: { isSubmitting, errors } } = useForm<SignupFormValues>();
+  const { control, handleSubmit, getValues, formState: { isSubmitting, errors } } = useForm<SignupFormValues>({
+    defaultValues: {
+      username: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
   const { signup } = useAuth();
   const router = useRouter();
 


### PR DESCRIPTION
## Summary
- Fixes uncontrolled-to-controlled input warning in signup form by adding defaultValues to useForm hook

## Details
The signup form was triggering a React warning because form fields were initialized with `undefined` values and became controlled when users started typing. This PR adds `defaultValues` with empty strings for all fields, ensuring they are controlled from the initial render.

## Test plan
- [ ] Navigate to /signup page
- [ ] Open browser console
- [ ] Start typing in any form field
- [ ] Verify no "uncontrolled-to-controlled" warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
