### PR TITLE
Add Auth0 PKCE login integration for macOS client

### DIFF
--- a/clients/macos/Package.resolved
+++ b/clients/macos/Package.resolved
@@ -1,12 +1,39 @@
 {
   "pins" : [
     {
+      "identity" : "auth0.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/auth0/Auth0.swift",
+      "state" : {
+        "revision" : "a817d175ce7fcf9d1c818a880384574a658ce8e5",
+        "version" : "2.17.0"
+      }
+    },
+    {
       "identity" : "hotkey",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soffes/HotKey",
       "state" : {
         "revision" : "a3cf605d7a96f6ff50e04fcb6dea6e2613cfcbe4",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "jwtdecode.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/auth0/JWTDecode.swift.git",
+      "state" : {
+        "revision" : "36a5ce735a61c4bc119593f43ce2c027b4ca7392",
+        "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "simplekeychain",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/auth0/SimpleKeychain.git",
+      "state" : {
+        "revision" : "776c4a6db74d5c6c143974be91c383680d468630",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -14,16 +14,21 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/soffes/HotKey", from: "0.2.1"),
+        .package(url: "https://github.com/auth0/Auth0.swift", from: "2.15.0"),
     ],
     targets: [
         .executableTarget(
             name: "vellum-assistant",
-            dependencies: ["HotKey"],
+            dependencies: [
+                "HotKey",
+                .product(name: "Auth0", package: "Auth0.swift"),
+            ],
             path: "vellum-assistant",
             exclude: ["Resources/Info.plist"],
             resources: [
                 .process("Resources/Assets.xcassets"),
-                .copy("Resources/Recipes")
+                .copy("Resources/Recipes"),
+                .copy("Resources/Auth0.plist")
             ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     let ambientAgent = AmbientAgent()
+    let auth0Manager = Auth0Manager()
 
     private var onboardingWindow: OnboardingWindow?
     private var windowObserver: Any?

--- a/clients/macos/vellum-assistant/App/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant/App/VellumAssistantApp.swift
@@ -6,7 +6,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(ambientAgent: appDelegate.ambientAgent)
+            SettingsView(ambientAgent: appDelegate.ambientAgent, auth0Manager: appDelegate.auth0Manager)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Auth/Auth0Manager.swift
+++ b/clients/macos/vellum-assistant/Auth/Auth0Manager.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Auth0
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "Auth0Manager")
+
+@MainActor
+final class Auth0Manager: ObservableObject {
+    @Published var isAuthenticated = false
+
+    private let credentialsManager: CredentialsManager
+
+    private static let scopes = "openid profile email offline_access"
+
+    init() {
+        self.credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+        self.isAuthenticated = credentialsManager.canRenew()
+    }
+
+    // MARK: - Login
+
+    func login() async throws {
+        let credentials = try await Auth0
+            .webAuth()
+            .scope(Self.scopes)
+            .start()
+
+        _ = credentialsManager.store(credentials: credentials)
+        isAuthenticated = true
+        log.info("Login succeeded")
+    }
+
+    // MARK: - Logout
+
+    func logout() async throws {
+        try await Auth0
+            .webAuth()
+            .clearSession()
+
+        _ = credentialsManager.clear()
+        isAuthenticated = false
+        log.info("Logout succeeded")
+    }
+
+    // MARK: - Token Access
+
+    func getAccessToken() async throws -> String {
+        let credentials = try await credentialsManager.credentials()
+        return credentials.accessToken
+    }
+}

--- a/clients/macos/vellum-assistant/Auth/PlatformAPIClient.swift
+++ b/clients/macos/vellum-assistant/Auth/PlatformAPIClient.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "PlatformAPI")
+
+struct UserProfile: Decodable {
+    let id: String
+    let email: String
+    let name: String?
+}
+
+enum PlatformAPIError: LocalizedError {
+    case notAuthenticated
+    case httpError(statusCode: Int, body: String)
+    case networkError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated: return "Not authenticated"
+        case .httpError(let code, let body): return "HTTP \(code): \(body)"
+        case .networkError(let msg): return "Network error: \(msg)"
+        }
+    }
+}
+
+@MainActor
+final class PlatformAPIClient {
+    private let auth0Manager: Auth0Manager
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(auth0Manager: Auth0Manager, baseURL: URL) {
+        self.auth0Manager = auth0Manager
+        self.baseURL = baseURL
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Generic Request
+
+    func request<T: Decodable>(
+        _ endpoint: String,
+        method: String = "GET",
+        body: (any Encodable)? = nil
+    ) async throws -> T {
+        guard auth0Manager.isAuthenticated else {
+            throw PlatformAPIError.notAuthenticated
+        }
+
+        let accessToken = try await auth0Manager.getAccessToken()
+
+        let url = baseURL.appendingPathComponent(endpoint)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw PlatformAPIError.networkError("Invalid response")
+        }
+
+        if http.statusCode == 401 {
+            log.warning("Received 401 — triggering re-login")
+            try await auth0Manager.login()
+            // Retry once with fresh token
+            return try await retryRequest(endpoint, method: method, body: body)
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw PlatformAPIError.httpError(statusCode: http.statusCode, body: responseBody)
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: - Convenience
+
+    func getMe() async throws -> UserProfile {
+        try await request("api/me")
+    }
+
+    // MARK: - Private
+
+    private func retryRequest<T: Decodable>(
+        _ endpoint: String,
+        method: String,
+        body: (any Encodable)?
+    ) async throws -> T {
+        let accessToken = try await auth0Manager.getAccessToken()
+
+        let url = baseURL.appendingPathComponent(endpoint)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let responseBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw PlatformAPIError.httpError(statusCode: status, body: responseBody)
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/clients/macos/vellum-assistant/Resources/Auth0.plist
+++ b/clients/macos/vellum-assistant/Resources/Auth0.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ClientId</key>
+    <string>YOUR_AUTH0_CLIENT_ID</string>
+    <key>Domain</key>
+    <string>YOUR_AUTH0_DOMAIN</string>
+</dict>
+</plist>

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -10,6 +10,17 @@
     <string>vellum-assistant needs microphone access to transcribe voice commands.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>com.vellum.vellum-assistant</string>
+            </array>
+        </dict>
+    </array>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -14,13 +14,61 @@ struct SettingsView: View {
         let val = UserDefaults.standard.double(forKey: "ambientCaptureInterval")
         return val == 0 ? 30 : val
     }()
+    @State private var authError: String?
     var ambientAgent: AmbientAgent
+    @ObservedObject var auth0Manager: Auth0Manager
 
     // Re-check permissions every 2 seconds while the window is open
     private let permissionTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
     var body: some View {
         Form {
+            Section("Account") {
+                if auth0Manager.isAuthenticated {
+                    HStack {
+                        Image(systemName: "person.crop.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("Signed in")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Sign Out") {
+                            authError = nil
+                            Task {
+                                do {
+                                    try await auth0Manager.logout()
+                                } catch {
+                                    authError = error.localizedDescription
+                                }
+                            }
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    HStack {
+                        Image(systemName: "person.crop.circle")
+                            .foregroundStyle(.secondary)
+                        Text("Not signed in")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Sign In") {
+                            authError = nil
+                            Task {
+                                do {
+                                    try await auth0Manager.login()
+                                } catch {
+                                    authError = error.localizedDescription
+                                }
+                            }
+                        }
+                    }
+                }
+                if let authError {
+                    Text(authError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
             Section("Anthropic API Key") {
                 if hasKey {
                     HStack {
@@ -128,7 +176,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 450, height: 550)
+        .frame(width: 450, height: 620)
         .onAppear {
             checkPermissions()
         }


### PR DESCRIPTION
The purpose of this PR is to add Auth0 authentication to the macOS client so users can sign in via PKCE flow and the app can make authenticated API calls to the platform backend.

## Changes Made
- Add Auth0.swift SDK dependency (v2.15.0+) to `Package.swift`
- Create `Auth0Manager` — login/logout/token lifecycle with Keychain storage via `CredentialsManager`
- Create `PlatformAPIClient` — authenticated HTTP client with auto Bearer token attachment and 401 re-login
- Add `Auth0.plist` with placeholder ClientId/Domain
- Register `com.vellum.vellum-assistant` URL scheme in `Info.plist` for Auth0 callback redirect
- Add "Account" section to Settings with Sign In / Sign Out
- Wire `Auth0Manager` through `AppDelegate` and `VellumAssistantApp`

## Testing
- `swift build` compiles cleanly
- Manual verification needed for login flow (requires real Auth0 credentials in `Auth0.plist`)

## Notes
- `Auth0.plist` has placeholder values — must be replaced with real credentials before testing
- `AnthropicClient` and `AmbientSyncClient` unchanged — will switch to `PlatformAPIClient` in follow-up PRs
- No onboarding login step yet (sign-in is opt-in via Settings)

---
*This PR was created with Claude Code*