### PR TITLE
Add rejection-aware suggestion filtering to ambient agent

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -313,8 +313,10 @@ final class AmbientAgent: ObservableObject {
             return
         }
         guard let syncClient else { return }
-        cachedRejections = await syncClient.fetchRejections()
-        lastRejectionFetchDate = Date()
+        if let fetched = await syncClient.fetchRejections() {
+            cachedRejections = fetched
+            lastRejectionFetchDate = Date()
+        }
     }
 
     private func isSimilarToRejection(_ suggestion: String) -> Bool {
@@ -351,6 +353,14 @@ final class AmbientAgent: ObservableObject {
                     source: "alexs-macbook-pro-2"
                 )
                 Task { await self?.syncClient?.sendDecision(decision) }
+                self?.cachedRejections.append(RejectionEntry(
+                    insightId: "",
+                    title: suggestion,
+                    description: suggestion,
+                    reason: nil,
+                    source: "alexs-macbook-pro-2",
+                    receivedAt: ISO8601DateFormatter().string(from: Date())
+                ))
             }
         )
         activeSuggestionWindow = window

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -55,6 +55,9 @@ final class AmbientAgent: ObservableObject {
     private var previousOCRText: String = ""
     private var knowledgeCancellable: AnyCancellable?
     private var suggestionWindow: AmbientSuggestionWindow?
+    private var cachedRejections: [RejectionEntry] = []
+    private var lastRejectionFetchDate: Date?
+    private let rejectionRefreshInterval: TimeInterval = 600
 
     weak var appDelegate: AppDelegate?
 
@@ -94,6 +97,10 @@ final class AmbientAgent: ObservableObject {
         }
         cron.onInsightsAdded = { [weak sync] insights in
             Task { await sync?.sendInsights(insights) }
+        }
+
+        Task { [weak self] in
+            await self?.refreshRejectionsIfNeeded()
         }
 
         syncTask = Task.detached { [weak self] in
@@ -279,9 +286,14 @@ final class AmbientAgent: ObservableObject {
 
         case .suggest:
             if let suggestion = result.suggestion, result.confidence > 0.8 {
-                log.info("[\(cycle)] Suggestion: \(suggestion)")
-                lastSuggestion = suggestion
-                showSuggestion(suggestion)
+                await refreshRejectionsIfNeeded()
+                if isSimilarToRejection(suggestion) {
+                    log.info("[\(cycle)] Suggestion suppressed (similar to previous rejection): \(suggestion)")
+                } else {
+                    log.info("[\(cycle)] Suggestion: \(suggestion)")
+                    lastSuggestion = suggestion
+                    showSuggestion(suggestion)
+                }
             } else {
                 log.debug("[\(cycle)] Suggestion below confidence threshold (\(String(format: "%.2f", result.confidence)))")
             }
@@ -294,6 +306,25 @@ final class AmbientAgent: ObservableObject {
         await syncClient?.flushQueue()
 
         state = .watching
+    }
+
+    private func refreshRejectionsIfNeeded() async {
+        if let lastFetch = lastRejectionFetchDate, Date().timeIntervalSince(lastFetch) < rejectionRefreshInterval {
+            return
+        }
+        guard let syncClient else { return }
+        cachedRejections = await syncClient.fetchRejections()
+        lastRejectionFetchDate = Date()
+    }
+
+    private func isSimilarToRejection(_ suggestion: String) -> Bool {
+        for rejection in cachedRejections {
+            let rejectionText = "\(rejection.title) \(rejection.description)"
+            if ScreenOCR.similarity(suggestion, rejectionText) > 0.5 {
+                return true
+            }
+        }
+        return false
     }
 
     private func showSuggestion(_ suggestion: String) {
@@ -310,6 +341,16 @@ final class AmbientAgent: ObservableObject {
                 self?.activeSuggestionWindow = nil
                 self?.lastSuggestion = nil
                 self?.suggestionWindow = nil
+                let decision = AutomationDecision(
+                    insightId: "",
+                    insightTitle: suggestion,
+                    description: suggestion,
+                    schedule: "",
+                    approved: false,
+                    reason: nil,
+                    source: "alexs-macbook-pro-2"
+                )
+                Task { await self?.syncClient?.sendDecision(decision) }
             }
         )
         activeSuggestionWindow = window

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -56,6 +56,7 @@ final class AmbientAgent: ObservableObject {
     private var knowledgeCancellable: AnyCancellable?
     private var suggestionWindow: AmbientSuggestionWindow?
     private var cachedRejections: [RejectionEntry] = []
+    private var localRejections: [RejectionEntry] = []
     private var lastRejectionFetchDate: Date?
     private let rejectionRefreshInterval: TimeInterval = 600
 
@@ -314,15 +315,18 @@ final class AmbientAgent: ObservableObject {
         }
         guard let syncClient else { return }
         if let fetched = await syncClient.fetchRejections() {
-            cachedRejections = fetched
+            // Remove local rejections that now appear on the server
+            let fetchedTitles = Set(fetched.map(\.title))
+            localRejections.removeAll { fetchedTitles.contains($0.title) }
+            cachedRejections = fetched + localRejections
             lastRejectionFetchDate = Date()
         }
     }
 
     private func isSimilarToRejection(_ suggestion: String) -> Bool {
         for rejection in cachedRejections {
-            let rejectionText = "\(rejection.title) \(rejection.description)"
-            if ScreenOCR.similarity(suggestion, rejectionText) > 0.5 {
+            if ScreenOCR.similarity(suggestion, rejection.title) > 0.5 ||
+               ScreenOCR.similarity(suggestion, rejection.description) > 0.5 {
                 return true
             }
         }
@@ -353,14 +357,16 @@ final class AmbientAgent: ObservableObject {
                     source: "alexs-macbook-pro-2"
                 )
                 Task { await self?.syncClient?.sendDecision(decision) }
-                self?.cachedRejections.append(RejectionEntry(
+                let entry = RejectionEntry(
                     insightId: "",
                     title: suggestion,
                     description: suggestion,
                     reason: nil,
                     source: "alexs-macbook-pro-2",
                     receivedAt: ISO8601DateFormatter().string(from: Date())
-                ))
+                )
+                self?.cachedRejections.append(entry)
+                self?.localRejections.append(entry)
             }
         )
         activeSuggestionWindow = window

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -41,6 +41,28 @@ actor AmbientSyncClient {
         }
     }
 
+    // MARK: - Fetch Methods
+
+    func fetchRejections(limit: Int = 100) async -> [RejectionEntry] {
+        let url = baseURL.appendingPathComponent("api/rejections")
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "limit", value: "\(limit)")]
+        guard let requestURL = components.url else { return [] }
+        do {
+            let (data, response) = try await session.data(from: requestURL)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                log.warning("fetchRejections: HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+                return []
+            }
+            let rejections = try JSONDecoder().decode([RejectionEntry].self, from: data)
+            log.info("Fetched \(rejections.count) rejections")
+            return rejections
+        } catch {
+            log.warning("fetchRejections failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
     // MARK: - Send Methods
 
     func sendObservation(_ entry: KnowledgeEntry) {
@@ -154,5 +176,15 @@ struct AutomationDecision: Encodable {
     let description: String
     let schedule: String
     let approved: Bool
+    let reason: String?
     let source: String
+}
+
+struct RejectionEntry: Decodable {
+    let insightId: String
+    let title: String
+    let description: String
+    let reason: String?
+    let source: String
+    let receivedAt: String
 }

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -43,23 +43,23 @@ actor AmbientSyncClient {
 
     // MARK: - Fetch Methods
 
-    func fetchRejections(limit: Int = 100) async -> [RejectionEntry] {
+    func fetchRejections(limit: Int = 100) async -> [RejectionEntry]? {
         let url = baseURL.appendingPathComponent("api/rejections")
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "limit", value: "\(limit)")]
-        guard let requestURL = components.url else { return [] }
+        guard let requestURL = components.url else { return nil }
         do {
             let (data, response) = try await session.data(from: requestURL)
             guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
                 log.warning("fetchRejections: HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)")
-                return []
+                return nil
             }
             let rejections = try JSONDecoder().decode([RejectionEntry].self, from: data)
             log.info("Fetched \(rejections.count) rejections")
             return rejections
         } catch {
             log.warning("fetchRejections failed: \(error.localizedDescription)")
-            return []
+            return nil
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -341,6 +341,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             description: description,
             schedule: schedule,
             approved: approved,
+            reason: nil,
             source: "alexs-macbook-pro-2"
         )
 


### PR DESCRIPTION
## Summary
- Add `RejectionEntry` model and `fetchRejections()` GET endpoint to `AmbientSyncClient` (fail-open on server errors)
- Add rejection cache with 10-minute TTL to `AmbientAgent`, warm on launch
- Filter suggestions against cached rejections using word-overlap similarity (0.5 threshold) before surfacing
- Send rejection decision via sync client when users dismiss a suggestion
- Add `reason: String?` field to `AutomationDecision` for future use

### Review feedback addressed (from #402)
- **Local cache update on dismiss**: Dismissed suggestions are immediately appended to both `cachedRejections` and a separate `localRejections` array, preventing re-display within the TTL window
- **TTL skip on failed fetch**: `refreshRejectionsIfNeeded()` only updates `lastRejectionFetchDate` on successful fetch (uses `if let` guard), so transient failures don't block retries for 10 minutes
- **Jaccard similarity dilution fix**: `isSimilarToRejection` now checks `title` and `description` separately (OR logic) instead of concatenating them, which diluted the score when description was much longer
- **Server refresh preserves local rejections**: `refreshRejectionsIfNeeded()` merges server-fetched rejections with locally-appended ones instead of replacing the entire cache, so un-synced dismissals survive a cache refresh

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (64/64 tests)
- [ ] Manual: dismiss a suggestion and verify it doesn't reappear within 10 minutes
- [ ] Manual: verify suggestions matching previously rejected items are suppressed on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
