### PR TITLE
Fix Windows fallback when bunx is missing

### DIFF
--- a/web/scripts/run-next.mjs
+++ b/web/scripts/run-next.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
 
 const [nextCommand, ...args] = process.argv.slice(2);
 
@@ -17,15 +19,49 @@ function run(command, commandArgs) {
   });
 }
 
-const bunRun = run("bunx", ["--bun", "next", nextCommand, ...args]);
+function commandExists(command) {
+  const pathValue = process.env.PATH;
+  if (!pathValue) {
+    return false;
+  }
 
-if (!bunRun.error) {
-  process.exit(bunRun.status ?? 0);
+  const directories = pathValue.split(delimiter).filter(Boolean);
+  const extensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean)
+      : [""];
+  const lowerCommand = command.toLowerCase();
+
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const normalizedExtension = extension.toLowerCase();
+      const candidate =
+        process.platform === "win32" &&
+        normalizedExtension &&
+        !lowerCommand.endsWith(normalizedExtension)
+          ? `${command}${extension}`
+          : command;
+
+      if (existsSync(join(directory, candidate))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
-if (bunRun.error.code !== "ENOENT") {
-  console.error(`[run-next] Failed to launch bunx: ${bunRun.error.message}`);
-  process.exit(1);
+if (commandExists("bunx")) {
+  const bunRun = run("bunx", ["--bun", "next", nextCommand, ...args]);
+
+  if (!bunRun.error) {
+    process.exit(bunRun.status ?? 0);
+  }
+
+  if (bunRun.error.code !== "ENOENT") {
+    console.error(`[run-next] Failed to launch bunx: ${bunRun.error.message}`);
+    process.exit(1);
+  }
 }
 
 const nextRun = run("next", [nextCommand, ...args]);


### PR DESCRIPTION
## Summary\n- address review feedback from #413 about missing \ on Windows\n- check PATH for \ before attempting to run it\n- fall back to local \ when \ is unavailable while preserving bun-first behavior when it exists\n\n## Validation\n- node --check web/scripts/run-next.mjs\n- targeted PATH-based script checks for fallback, bunx-first execution, and non-zero exit propagation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
