### PR TITLE
Fix context-summary marker classification and undo targeting

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -237,4 +237,12 @@ describe('ContextWindowManager', () => {
     };
     expect(getSummaryFromContextMessage(legacySummary)).toContain('legacy');
   });
+
+  test('does not parse user-authored summary marker text as internal summary', () => {
+    const userMessage: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: `${CONTEXT_SUMMARY_MARKER}\nI typed this prefix myself` }],
+    };
+    expect(getSummaryFromContextMessage(userMessage)).toBeNull();
+  });
 });

--- a/assistant/src/__tests__/session-undo.test.ts
+++ b/assistant/src/__tests__/session-undo.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { CONTEXT_SUMMARY_MARKER, createContextSummaryMessage } from '../context/window-manager.js';
+import { findLastUndoableUserMessageIndex } from '../daemon/session.js';
+import type { Message } from '../providers/types.js';
+
+function textMessage(role: 'user' | 'assistant', text: string): Message {
+  return { role, content: [{ type: 'text', text }] };
+}
+
+describe('findLastUndoableUserMessageIndex', () => {
+  test('returns -1 when only an internal context summary exists', () => {
+    const messages = [createContextSummaryMessage('## Goals\n- remembered context')];
+    expect(findLastUndoableUserMessageIndex(messages)).toBe(-1);
+  });
+
+  test('skips context summaries and tool-result user turns', () => {
+    const messages: Message[] = [
+      createContextSummaryMessage('## Goals\n- remembered context'),
+      textMessage('assistant', 'older assistant reply'),
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+          { type: 'text', text: '[System: progress reminder]' },
+        ],
+      },
+      textMessage('assistant', 'tool follow-up'),
+      textMessage('user', 'actual user prompt'),
+      textMessage('assistant', 'actual assistant response'),
+    ];
+
+    expect(findLastUndoableUserMessageIndex(messages)).toBe(4);
+  });
+
+  test('treats user-authored summary marker text as a normal user turn', () => {
+    const spoofMessage = textMessage(
+      'user',
+      `${CONTEXT_SUMMARY_MARKER}\nThis is ordinary user text, not internal summary state.`,
+    );
+    expect(findLastUndoableUserMessageIndex([spoofMessage])).toBe(0);
+  });
+});

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -11,6 +11,7 @@ const CHUNK_MIN_TOKENS = 1000;
 const MAX_BLOCK_PREVIEW_CHARS = 3000;
 const MAX_FALLBACK_SUMMARY_CHARS = 12000;
 const MAX_CONTEXT_SUMMARY_CHARS = 16000;
+const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 const SUMMARY_SYSTEM_PROMPT = [
   'You compress long assistant conversations into durable working memory.',
@@ -302,14 +303,23 @@ export function getSummaryFromContextMessage(message: Message | undefined): stri
   if (!message) return null;
   const text = extractText(message.content).trim();
   if (!text.startsWith(CONTEXT_SUMMARY_MARKER)) return null;
-  return text.slice(CONTEXT_SUMMARY_MARKER.length).trim();
+  if (INTERNAL_CONTEXT_SUMMARY_MESSAGES.has(message)) {
+    return text.slice(CONTEXT_SUMMARY_MARKER.length).trim();
+  }
+  // Backward compatibility for older in-memory sessions that used assistant-role summaries.
+  if (message.role === 'assistant') {
+    return text.slice(CONTEXT_SUMMARY_MARKER.length).trim();
+  }
+  return null;
 }
 
 export function createContextSummaryMessage(summary: string): Message {
-  return {
+  const message: Message = {
     role: 'user',
     content: [{ type: 'text', text: `${CONTEXT_SUMMARY_MARKER}\n${clampSummary(summary)}` }],
   };
+  INTERNAL_CONTEXT_SUMMARY_MESSAGES.add(message);
+  return message;
 }
 
 function buildSummaryPrompt(currentSummary: string, chunk: string): string {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -22,6 +22,7 @@ import { createToolAuditListener } from '../events/tool-audit-listener.js';
 import {
   ContextWindowManager,
   createContextSummaryMessage,
+  getSummaryFromContextMessage,
 } from '../context/window-manager.js';
 import {
   buildMemoryRecall,
@@ -360,14 +361,7 @@ export class Session {
   undo(): number {
     if (this.processing) return 0;
 
-    // Find last user message in memory
-    let lastUserIdx = -1;
-    for (let i = this.messages.length - 1; i >= 0; i--) {
-      if (this.messages[i].role === 'user') {
-        lastUserIdx = i;
-        break;
-      }
-    }
+    const lastUserIdx = findLastUndoableUserMessageIndex(this.messages);
     if (lastUserIdx === -1) return 0;
 
     const removed = this.messages.length - lastUserIdx;
@@ -434,17 +428,26 @@ export class Session {
   }
 }
 
+function isUndoableUserMessage(message: Message): boolean {
+  if (message.role !== 'user') return false;
+  if (getSummaryFromContextMessage(message) !== null) return false;
+  if (message.content.some((block) => block.type === 'tool_result')) return false;
+  return true;
+}
+
+export function findLastUndoableUserMessageIndex(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isUndoableUserMessage(messages[i])) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 function buildMemoryQuery(content: string, messages: Message[]): string {
-  const summaryMessage = messages.find((message) =>
-    message.role === 'assistant'
-    && message.content.some((block) => block.type === 'text' && block.text.includes('[Context Summary v1]')),
-  );
-  const summaryText = summaryMessage
-    ? summaryMessage.content
-      .filter((block): block is Extract<typeof summaryMessage.content[number], { type: 'text' }> => block.type === 'text')
-      .map((block) => block.text)
-      .join('\n')
-    : '';
+  const summaryText = messages
+    .map((message) => getSummaryFromContextMessage(message))
+    .find((summary): summary is string => summary !== null) ?? '';
   const compactSummary = summaryText.slice(0, 1200);
   return compactSummary.length > 0
     ? `${content}\n\nContext summary:\n${compactSummary}`


### PR DESCRIPTION
## Summary
- address feedback from #414 about synthetic context summary turns being undoable
- make context-summary parsing strict: only internal placeholders and legacy assistant-role summaries are recognized
- prevent `/undo` from targeting synthetic summary turns or tool-result user turns
- keep memory query summary injection working by reading summary via `getSummaryFromContextMessage`
- add focused regression tests for marker spoofing and undo selection

## Validation
- export PATH="$HOME/.bun/bin:$PATH"
- bun test src/__tests__/context-window-manager.test.ts
- bun test src/__tests__/session-undo.test.ts