### PR TITLE
Add rejection fetch backoff and ambient sync disclosure

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -58,6 +58,7 @@ final class AmbientAgent: ObservableObject {
     private var cachedRejections: [RejectionEntry] = []
     private var lastRejectionFetchDate: Date?
     private let rejectionRefreshInterval: TimeInterval = 600
+    private let rejectionFailureRetryInterval: TimeInterval = 60
 
     weak var appDelegate: AppDelegate?
 
@@ -316,6 +317,10 @@ final class AmbientAgent: ObservableObject {
         if let fetched = await syncClient.fetchRejections() {
             cachedRejections = fetched
             lastRejectionFetchDate = Date()
+        } else {
+            // Back off on failure to avoid hammering a flapping endpoint.
+            // Use a shorter interval than the normal TTL so recovery is still prompt.
+            lastRejectionFetchDate = Date().addingTimeInterval(-(rejectionRefreshInterval - rejectionFailureRetryInterval))
         }
     }
 

--- a/clients/macos/vellum-assistant/UI/SettingsView.swift
+++ b/clients/macos/vellum-assistant/UI/SettingsView.swift
@@ -354,7 +354,7 @@ private struct PrivacyDetailView: View {
                         title: "What Data Leaves Your Mac",
                         items: [
                             "When you run a task: screenshots (compressed, max 1280x720) and UI element data (window titles, button labels, text field values) are sent to the Anthropic API over HTTPS.",
-                            "When ambient mode is on: extracted on-screen text (via on-device OCR) and the active app name are sent to Anthropic for analysis.",
+                            "When ambient mode is on: extracted on-screen text (via on-device OCR) and the active app name are sent to Anthropic for analysis. If sync is enabled, ambient observations and insights are also sent to the Velly backend.",
                             "Voice input: speech is transcribed on-device using Apple Speech Recognition. Only the final text is sent to Anthropic as part of the task.",
                         ]
                     )


### PR DESCRIPTION
## Summary
- **Rejection fetch backoff**: On `fetchRejections()` failure, back off for 60s instead of retrying every call. Prevents hammering a flapping endpoint while still recovering within ~1 minute.
- **Privacy copy**: Disclose that ambient observations and insights are sent to the Velly backend when sync is enabled.

Stacked on #443 — merge that first.

## Test plan
- [ ] Verify build compiles cleanly
- [ ] Simulate network failure during rejection fetch and confirm retries are spaced ~60s apart (not immediate)
- [ ] Check "What Data Leaves Your Mac" section in Settings > Privacy & Security > Learn More mentions sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
