### PR TITLE
Show tool call details in chat UI with expandable chips

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { renderHistoryContent } from '../daemon/handlers.js';
+import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 
 describe('renderHistoryContent', () => {
   test('renders text-only content unchanged', () => {
@@ -7,7 +7,8 @@ describe('renderHistoryContent', () => {
       { type: 'text', text: 'hello ' },
       { type: 'text', text: 'world' },
     ]);
-    expect(output).toBe('hello world');
+    expect(output.text).toBe('hello world');
+    expect(output.toolCalls).toEqual([]);
   });
 
   test('renders file attachments for attachment-only turns', () => {
@@ -24,10 +25,10 @@ describe('renderHistoryContent', () => {
       },
     ]);
 
-    expect(output).toContain('[File attachment] spec.pdf');
-    expect(output).toContain('type=application/pdf');
-    expect(output).toContain('size=5 B');
-    expect(output).toContain('Attachment text: Important requirement from the attachment.');
+    expect(output.text).toContain('[File attachment] spec.pdf');
+    expect(output.text).toContain('type=application/pdf');
+    expect(output.text).toContain('size=5 B');
+    expect(output.text).toContain('Attachment text: Important requirement from the attachment.');
   });
 
   test('renders image attachments in history output', () => {
@@ -42,7 +43,7 @@ describe('renderHistoryContent', () => {
       },
     ]);
 
-    expect(output).toContain('[Image attachment] image/png, 5 B');
+    expect(output.text).toContain('[Image attachment] image/png, 5 B');
   });
 
   test('appends attachment lines after text content', () => {
@@ -59,11 +60,164 @@ describe('renderHistoryContent', () => {
       },
     ]);
 
-    expect(output).toContain('please review the file\n[File attachment] notes.txt');
+    expect(output.text).toContain('please review the file\n[File attachment] notes.txt');
   });
 
   test('falls back to string conversion for non-array content', () => {
-    expect(renderHistoryContent('raw string')).toBe('raw string');
-    expect(renderHistoryContent({ foo: 'bar' })).toBe('[object Object]');
+    expect(renderHistoryContent('raw string').text).toBe('raw string');
+    expect(renderHistoryContent({ foo: 'bar' }).text).toBe('[object Object]');
+  });
+
+  test('extracts tool_use blocks into toolCalls', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'web_fetch', input: { url: 'https://example.com' } },
+    ]);
+
+    expect(output.text).toBe('');
+    expect(output.toolCalls).toEqual([
+      { name: 'web_fetch', input: { url: 'https://example.com' } },
+    ]);
+  });
+
+  test('pairs tool_result with matching tool_use by id', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file1.txt\nfile2.txt', is_error: false },
+    ]);
+
+    expect(output.toolCalls).toEqual([
+      { name: 'bash', input: { command: 'ls' }, result: 'file1.txt\nfile2.txt', isError: false },
+    ]);
+  });
+
+  test('marks error tool results', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { command: 'bad' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'command not found', is_error: true },
+    ]);
+
+    expect(output.toolCalls).toEqual([
+      { name: 'bash', input: { command: 'bad' }, result: 'command not found', isError: true },
+    ]);
+  });
+
+  test('handles mixed text and tool blocks', () => {
+    const output = renderHistoryContent([
+      { type: 'text', text: 'Let me look that up.' },
+      { type: 'tool_use', id: 'tu_1', name: 'web_fetch', input: { url: 'https://example.com' } },
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'page content here' },
+    ]);
+
+    expect(output.text).toBe('Let me look that up.');
+    expect(output.toolCalls).toHaveLength(1);
+    expect(output.toolCalls[0].name).toBe('web_fetch');
+    expect(output.toolCalls[0].result).toBe('page content here');
+  });
+
+  test('handles orphan tool_result without matching tool_use', () => {
+    const output = renderHistoryContent([
+      { type: 'tool_result', tool_use_id: 'missing', content: 'some result' },
+    ]);
+
+    expect(output.toolCalls).toEqual([
+      { name: 'unknown', input: {}, result: 'some result', isError: false },
+    ]);
+  });
+});
+
+describe('mergeToolResults', () => {
+  test('merges tool_result user messages into preceding assistant toolCalls', () => {
+    const result = mergeToolResults([
+      { role: 'user', text: 'fetch this page', timestamp: 1, toolCalls: [] },
+      {
+        role: 'assistant', text: '', timestamp: 2,
+        toolCalls: [{ name: 'web_fetch', input: { url: 'https://example.com' } }],
+      },
+      {
+        role: 'user', text: '', timestamp: 3,
+        toolCalls: [{ name: 'unknown', input: {}, result: 'page content', isError: false }],
+      },
+      { role: 'assistant', text: 'Here is what I found.', timestamp: 4, toolCalls: [] },
+    ]);
+
+    expect(result).toHaveLength(3);
+    // The user message with tool_result should be suppressed
+    expect(result[0].role).toBe('user');
+    expect(result[0].text).toBe('fetch this page');
+    // The assistant message should now have the result merged in
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].toolCalls[0].result).toBe('page content');
+    expect(result[1].toolCalls[0].isError).toBe(false);
+    // The final assistant text message is unchanged
+    expect(result[2].text).toBe('Here is what I found.');
+  });
+
+  test('suppresses tool_result-only user messages from visible history', () => {
+    const result = mergeToolResults([
+      { role: 'user', text: 'hello', timestamp: 1, toolCalls: [] },
+      {
+        role: 'assistant', text: '', timestamp: 2,
+        toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
+      },
+      {
+        role: 'user', text: '', timestamp: 3,
+        toolCalls: [{ name: 'unknown', input: {}, result: 'file.txt', isError: false }],
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((m) => !(m.role === 'user' && m.text === ''))).toBe(true);
+  });
+
+  test('preserves user messages that have text content alongside tool_results', () => {
+    const result = mergeToolResults([
+      {
+        role: 'user', text: 'user typed something', timestamp: 1,
+        toolCalls: [{ name: 'unknown', input: {}, result: 'data', isError: false }],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('user typed something');
+  });
+
+  test('handles multiple tool calls merged from a single result message', () => {
+    const result = mergeToolResults([
+      {
+        role: 'assistant', text: '', timestamp: 1,
+        toolCalls: [
+          { name: 'bash', input: { command: 'ls' } },
+          { name: 'bash', input: { command: 'pwd' } },
+        ],
+      },
+      {
+        role: 'user', text: '', timestamp: 2,
+        toolCalls: [
+          { name: 'unknown', input: {}, result: 'file.txt', isError: false },
+          { name: 'unknown', input: {}, result: '/home/user', isError: false },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].toolCalls[0].result).toBe('file.txt');
+    expect(result[0].toolCalls[1].result).toBe('/home/user');
+  });
+
+  test('does not mutate original messages', () => {
+    const original = [
+      {
+        role: 'assistant', text: '', timestamp: 1,
+        toolCalls: [{ name: 'bash', input: { command: 'ls' } }],
+      },
+      {
+        role: 'user', text: '', timestamp: 2,
+        toolCalls: [{ name: 'unknown', input: {}, result: 'output', isError: false }],
+      },
+    ];
+
+    mergeToolResults(original);
+    // Original assistant toolCalls should not have result attached
+    expect((original[0].toolCalls[0] as Record<string, unknown>).result).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -56,13 +56,27 @@ function renderFileBlockForHistory(block: Record<string, unknown>): string {
   return `${summaryParts.join(', ')}\nAttachment text: ${clampAttachmentText(extractedText)}`;
 }
 
-export function renderHistoryContent(content: unknown): string {
+export interface HistoryToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+  isError?: boolean;
+}
+
+export interface RenderedHistoryContent {
+  text: string;
+  toolCalls: HistoryToolCall[];
+}
+
+export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   if (!Array.isArray(content)) {
-    return String(content ?? '');
+    return { text: String(content ?? ''), toolCalls: [] };
   }
 
   const textParts: string[] = [];
   const attachmentParts: string[] = [];
+  const toolCalls: HistoryToolCall[] = [];
+  const pendingToolUses = new Map<string, HistoryToolCall>();
 
   for (const block of content) {
     if (!isRecord(block) || typeof block.type !== 'string') continue;
@@ -79,12 +93,41 @@ export function renderHistoryContent(content: unknown): string {
       attachmentParts.push(renderImageBlockForHistory(block));
       continue;
     }
+    if (block.type === 'tool_use') {
+      const name = typeof block.name === 'string' ? block.name : 'unknown';
+      const input = isRecord(block.input) ? block.input as Record<string, unknown> : {};
+      const id = typeof block.id === 'string' ? block.id : '';
+      const entry: HistoryToolCall = { name, input };
+      toolCalls.push(entry);
+      if (id) pendingToolUses.set(id, entry);
+      continue;
+    }
+    if (block.type === 'tool_result') {
+      const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
+      const resultContent = typeof block.content === 'string' ? block.content : '';
+      const isError = block.is_error === true;
+      const matched = toolUseId ? pendingToolUses.get(toolUseId) : null;
+      if (matched) {
+        matched.result = resultContent;
+        matched.isError = isError;
+      } else {
+        toolCalls.push({ name: 'unknown', input: {}, result: resultContent, isError });
+      }
+      continue;
+    }
   }
 
   const text = textParts.join('');
-  if (attachmentParts.length === 0) return text;
-  if (text.trim().length === 0) return attachmentParts.join('\n');
-  return `${text}\n${attachmentParts.join('\n')}`;
+  let rendered: string;
+  if (attachmentParts.length === 0) {
+    rendered = text;
+  } else if (text.trim().length === 0) {
+    rendered = attachmentParts.join('\n');
+  } else {
+    rendered = `${text}\n${attachmentParts.join('\n')}`;
+  }
+
+  return { text: rendered, toolCalls };
 }
 
 /**
@@ -331,24 +374,79 @@ function handleSandboxSet(
   log.info({ enabled }, 'Sandbox override applied (per-session)');
 }
 
+interface ParsedHistoryMessage {
+  role: string;
+  text: string;
+  timestamp: number;
+  toolCalls: HistoryToolCall[];
+}
+
 function handleHistoryRequest(
   sessionId: string,
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const dbMessages = conversationStore.getMessages(sessionId);
-  const historyMessages = dbMessages.map((m) => {
+  const parsed: ParsedHistoryMessage[] = dbMessages.map((m) => {
     let text = '';
+    let toolCalls: HistoryToolCall[] = [];
     try {
       const content = JSON.parse(m.content);
-      text = renderHistoryContent(content);
+      const rendered = renderHistoryContent(content);
+      text = rendered.text;
+      toolCalls = rendered.toolCalls;
     } catch (err) {
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
       text = m.content;
     }
-    return { role: m.role, text, timestamp: m.createdAt };
+    return { role: m.role, text, timestamp: m.createdAt, toolCalls };
   });
+
+  // Merge tool_result data from user messages into the preceding assistant
+  // message's toolCalls, and suppress user messages that only contain
+  // tool_result blocks (internal agent-loop turns).
+  const merged = mergeToolResults(parsed);
+
+  const historyMessages = merged.map((m) => ({
+    role: m.role,
+    text: m.text,
+    timestamp: m.timestamp,
+    ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
+  }));
   ctx.send(socket, { type: 'history_response', messages: historyMessages });
+}
+
+export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistoryMessage[] {
+  const result: ParsedHistoryMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    // If this is a user message whose only content is tool_result blocks,
+    // merge those results into the preceding assistant message's toolCalls.
+    if (msg.role === 'user' && msg.text.trim() === '' && msg.toolCalls.length > 0) {
+      const prev = result.length > 0 ? result[result.length - 1] : null;
+      if (prev && prev.role === 'assistant' && prev.toolCalls.length > 0) {
+        // Build a lookup from tool name → result for this user message's tool_results
+        for (const resultEntry of msg.toolCalls) {
+          // Match by tool_use_id pairing: tool_results are ordered to match
+          // the tool_uses in the preceding assistant message, so pair by index
+          // of unresolved entries, or fall back to name matching.
+          const unresolved = prev.toolCalls.find(
+            (tc) => tc.result === undefined,
+          );
+          if (unresolved) {
+            unresolved.result = resultEntry.result;
+            unresolved.isError = resultEntry.isError;
+          }
+        }
+      }
+      // Suppress this internal user message from the visible history
+      continue;
+    }
+
+    result.push({ ...msg, toolCalls: msg.toolCalls.map((tc) => ({ ...tc })) });
+  }
+  return result;
 }
 
 function handleUndo(

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -175,9 +175,21 @@ export interface ModelInfo {
   provider: string;
 }
 
+export interface HistoryResponseToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+  isError?: boolean;
+}
+
 export interface HistoryResponse {
   type: 'history_response';
-  messages: Array<{ role: string; text: string; timestamp: number }>;
+  messages: Array<{
+    role: string;
+    text: string;
+    timestamp: number;
+    toolCalls?: HistoryResponseToolCall[];
+  }>;
 }
 
 export interface UndoComplete {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -241,6 +241,8 @@ export class Session {
       let exchangeOutputTokens = 0;
       let model = '';
       let runMessages = this.messages;
+      let lastSavedMessageId: string | null = null;
+      const pendingToolResults = new Map<string, { content: string; isError: boolean }>();
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
@@ -296,18 +298,26 @@ export class Session {
               break;
             case 'tool_result':
               onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status });
+              pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError });
               break;
             case 'error':
               onEvent({ type: 'error', message: event.error.message });
               break;
-            case 'message_complete':
+            case 'message_complete': {
+              // Patch the previously saved assistant message with tool results
+              if (lastSavedMessageId && pendingToolResults.size > 0) {
+                conversationStore.patchToolResults(this.conversationId, lastSavedMessageId, pendingToolResults);
+                pendingToolResults.clear();
+              }
               // Save assistant message to DB
-              conversationStore.addMessage(
+              const saved = conversationStore.addMessage(
                 this.conversationId,
                 'assistant',
                 JSON.stringify(event.message.content),
               );
+              lastSavedMessageId = saved.id;
               break;
+            }
             case 'usage':
               exchangeInputTokens += event.inputTokens;
               exchangeOutputTokens += event.outputTokens;
@@ -317,6 +327,12 @@ export class Session {
         },
         this.abortController.signal,
       );
+
+      // Flush any remaining tool results for the last saved assistant message
+      if (lastSavedMessageId && pendingToolResults.size > 0) {
+        conversationStore.patchToolResults(this.conversationId, lastSavedMessageId, pendingToolResults);
+        pendingToolResults.clear();
+      }
 
       this.messages = stripMemoryRecallMessages(updatedHistory, recall.injectedText);
 

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -142,6 +142,63 @@ export function updateConversationContextWindow(
 }
 
 /**
+ * Patch a saved assistant message's content to inject tool_result data
+ * alongside the corresponding tool_use blocks.
+ *
+ * The pendingResults map is keyed by tool_use_id with value { content, isError }.
+ * For each tool_use block in the saved message whose id matches a key in the map,
+ * a sibling tool_result block is appended immediately after it.
+ */
+export function patchToolResults(
+  conversationId: string,
+  messageId: string,
+  pendingResults: Map<string, { content: string; isError: boolean }>,
+): void {
+  if (pendingResults.size === 0) return;
+
+  const db = getDb();
+  const row = db
+    .select({ content: messages.content })
+    .from(messages)
+    .where(and(eq(messages.id, messageId), eq(messages.conversationId, conversationId)))
+    .get();
+  if (!row) return;
+
+  let blocks: unknown[];
+  try {
+    blocks = JSON.parse(row.content);
+    if (!Array.isArray(blocks)) return;
+  } catch {
+    return;
+  }
+
+  const patched: unknown[] = [];
+  for (const block of blocks) {
+    patched.push(block);
+    if (
+      typeof block === 'object' && block !== null &&
+      (block as Record<string, unknown>).type === 'tool_use'
+    ) {
+      const id = (block as Record<string, unknown>).id;
+      if (typeof id === 'string' && pendingResults.has(id)) {
+        const result = pendingResults.get(id)!;
+        patched.push({
+          type: 'tool_result',
+          tool_use_id: id,
+          content: result.content,
+          is_error: result.isError,
+        });
+      }
+    }
+  }
+
+  db.update(messages)
+    .set({ content: JSON.stringify(patched) })
+    .where(and(eq(messages.id, messageId), eq(messages.conversationId, conversationId)))
+    .run();
+}
+
+/**
  * Delete the last user message and any subsequent assistant messages.
  * Uses rowid comparison instead of timestamps to avoid deleting messages
  * that share the same millisecond timestamp.

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -523,6 +523,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           role: msg.role,
           content: msg.text,
           timestamp: new Date(msg.timestamp).toISOString(),
+          ...(msg.toolCalls && msg.toolCalls.length > 0 ? { toolCalls: msg.toolCalls } : {}),
         }));
 
         return NextResponse.json({
@@ -779,13 +780,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           }
 
           const timestamp = new Date().toISOString();
-          const assistantMessage =
-            localResponse.assistantText.length > 0
+          const hasContent = localResponse.assistantText.length > 0 || localResponse.toolCalls.length > 0;
+          const assistantMessage = hasContent
               ? {
                   id: `local-${sessionId}-${Date.now()}`,
                   role: "assistant" as const,
                   content: localResponse.assistantText,
                   timestamp,
+                  ...(localResponse.toolCalls.length > 0 ? { toolCalls: localResponse.toolCalls } : {}),
                 }
               : null;
 

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -3,6 +3,8 @@
 import {
   AlertTriangle,
   Bot,
+  ChevronDown,
+  ChevronRight,
   FileImage,
   FileText,
   Loader2,
@@ -10,6 +12,7 @@ import {
   Pause,
   Play,
   Send,
+  Terminal,
   User,
   X,
 } from "lucide-react";
@@ -43,12 +46,20 @@ interface MessageAttachment {
   kind: string;
 }
 
+interface ToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+  isError?: boolean;
+}
+
 interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
   timestamp: Date;
   attachments: MessageAttachment[];
+  toolCalls?: ToolCall[];
 }
 
 interface PendingAttachment {
@@ -87,6 +98,57 @@ function inferKindFromMime(mimeType: string): "image" | "document" {
   return mimeType.toLowerCase().startsWith("image/") ? "image" : "document";
 }
 
+function summarizeToolInput(input: Record<string, unknown>): string {
+  const values = Object.values(input);
+  if (values.length === 0) return "";
+  const first = values[0];
+  const str = typeof first === "string" ? first : JSON.stringify(first);
+  return str.length > 80 ? `${str.slice(0, 77)}...` : str;
+}
+
+const TOOL_RESULT_MAX_LENGTH = 2000;
+
+function ToolCallChip({ toolCall }: { toolCall: ToolCall }) {
+  const [expanded, setExpanded] = useState(false);
+  const summary = summarizeToolInput(toolCall.input);
+  const hasResult = typeof toolCall.result === "string";
+
+  return (
+    <div className="my-1">
+      <button
+        type="button"
+        onClick={() => hasResult && setExpanded(!expanded)}
+        className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition-colors ${
+          toolCall.isError
+            ? "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+            : "border-zinc-300 bg-zinc-50 text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
+        } ${hasResult ? "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800" : "cursor-default"}`}
+      >
+        <Terminal className="h-3 w-3 shrink-0" />
+        <span className="font-medium">{toolCall.name}</span>
+        {summary && (
+          <>
+            <span className="opacity-50">&mdash;</span>
+            <span className="max-w-[300px] truncate opacity-75">{summary}</span>
+          </>
+        )}
+        {hasResult && (
+          expanded
+            ? <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+            : <ChevronRight className="h-3 w-3 shrink-0 opacity-50" />
+        )}
+      </button>
+      {expanded && hasResult && (
+        <pre className="mt-1 max-h-60 overflow-auto rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+          {toolCall.result!.length > TOOL_RESULT_MAX_LENGTH
+            ? `${toolCall.result!.slice(0, TOOL_RESULT_MAX_LENGTH)}...[truncated]`
+            : toolCall.result}
+        </pre>
+      )}
+    </div>
+  );
+}
+
 export function InteractionTab({ assistantId, assistantName, assistantCreatedAt }: InteractionTabProps) {
   const [assistantStatus, setAssistantStatus] = useState<AssistantStatus>("checking");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -115,12 +177,14 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
           content: string;
           timestamp: string;
           attachments?: MessageAttachment[];
+          toolCalls?: ToolCall[];
         }) => ({
           id: msg.id,
           role: msg.role,
           content: msg.content,
           timestamp: new Date(msg.timestamp),
           attachments: msg.attachments || [],
+          toolCalls: msg.toolCalls,
         })
       );
 
@@ -687,6 +751,14 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                               </span>
                               <span className="opacity-75">{formatBytes(attachment.size_bytes)}</span>
                             </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {message.toolCalls && message.toolCalls.length > 0 && (
+                        <div className={message.content || message.attachments.length > 0 ? "mt-2" : ""}>
+                          {message.toolCalls.map((tc, idx) => (
+                            <ToolCallChip key={`${tc.name}-${idx}`} toolCall={tc} />
                           ))}
                         </div>
                       )}

--- a/web/src/lib/local-daemon-ipc.ts
+++ b/web/src/lib/local-daemon-ipc.ts
@@ -32,10 +32,18 @@ export interface DaemonSessionInfo {
   title: string;
 }
 
+export interface DaemonToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+  isError?: boolean;
+}
+
 export interface DaemonHistoryMessage {
   role: "user" | "assistant";
   text: string;
   timestamp: number;
+  toolCalls?: DaemonToolCall[];
 }
 
 export interface DaemonUsageUpdate {
@@ -50,6 +58,7 @@ export interface DaemonUsageUpdate {
 export interface DaemonUserMessageResult {
   assistantText: string;
   usage: DaemonUsageUpdate | null;
+  toolCalls: DaemonToolCall[];
 }
 
 export interface DaemonUserMessageAttachment {
@@ -297,10 +306,12 @@ export class LocalDaemonClient {
         ) {
           return null;
         }
+        const toolCalls = parseToolCalls(entry.toolCalls);
         return {
           role,
           text,
           timestamp,
+          ...(toolCalls.length > 0 ? { toolCalls } : {}),
         };
       })
       .filter((entry): entry is DaemonHistoryMessage => entry !== null);
@@ -324,6 +335,8 @@ export class LocalDaemonClient {
 
     let assistantText = "";
     let usage: DaemonUsageUpdate | null = null;
+    const toolCalls: DaemonToolCall[] = [];
+    let currentToolCall: DaemonToolCall | null = null;
 
     while (true) {
       const message = await this.waitFor(() => true, timeoutMs);
@@ -333,6 +346,26 @@ export class LocalDaemonClient {
           if (typeof message.text === "string") {
             assistantText += message.text;
           }
+          break;
+        }
+        case "tool_use_start": {
+          const name = typeof message.toolName === "string" ? message.toolName : "unknown";
+          const input = isObject(message.input) ? message.input as Record<string, unknown> : {};
+          currentToolCall = { name, input };
+          toolCalls.push(currentToolCall);
+          break;
+        }
+        case "tool_result": {
+          const result = typeof message.result === "string" ? message.result : "";
+          const isError = message.isError === true;
+          if (currentToolCall) {
+            currentToolCall.result = result;
+            currentToolCall.isError = isError;
+          } else {
+            const toolName = typeof message.toolName === "string" ? message.toolName : "unknown";
+            toolCalls.push({ name: toolName, input: {}, result, isError });
+          }
+          currentToolCall = null;
           break;
         }
         case "usage_update": {
@@ -346,6 +379,7 @@ export class LocalDaemonClient {
           return {
             assistantText: assistantText.trim(),
             usage,
+            toolCalls,
           };
         case "error": {
           const daemonMessage =
@@ -517,6 +551,21 @@ export class LocalDaemonClient {
       waiter.reject(error);
     }
   }
+}
+
+function parseToolCalls(raw: unknown): DaemonToolCall[] {
+  if (!Array.isArray(raw)) return [];
+  const result: DaemonToolCall[] = [];
+  for (const entry of raw) {
+    if (!isObject(entry)) continue;
+    const name = typeof entry.name === "string" ? entry.name : "unknown";
+    const input = isObject(entry.input) ? entry.input as Record<string, unknown> : {};
+    const tc: DaemonToolCall = { name, input };
+    if (typeof entry.result === "string") tc.result = entry.result;
+    if (typeof entry.isError === "boolean") tc.isError = entry.isError;
+    result.push(tc);
+  }
+  return result;
 }
 
 function parseUsageUpdate(message: DaemonMessage): DaemonUsageUpdate | null {


### PR DESCRIPTION
## Summary
- Replaces empty chat bubbles with collapsible tool call chips showing tool name + input summary
- Persists tool results to SQLite by patching saved assistant messages, enabling click-to-expand on history reload
- Full-stack change: daemon handlers, IPC protocol, web IPC client, API route, and frontend rendering

## Test plan
- [ ] Start daemon (`cd assistant && bun run dev`) and web (`ASSISTANT_CONNECTION_MODE=local vel up`)
- [ ] Send a message that triggers tool use (e.g. web_fetch)
- [ ] Verify tool call chips appear during streaming (not empty bubbles)
- [ ] Verify clicking a chip expands to show the full result
- [ ] Refresh the page and verify history shows expandable tool call chips
- [ ] Run `bun test src/__tests__/server-history-render.test.ts` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
