### PR TITLE
Add /mainline command for shipping adhoc changes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,9 +16,10 @@ ln -s ../../scripts/commands/check-reviews.md check-reviews.md
 ln -s ../../scripts/commands/brainstorm.md brainstorm.md
 ln -s ../../scripts/commands/swarm.md swarm.md
 ln -s ../../scripts/commands/worktree-plan.md worktree-plan.md
+ln -s ../../scripts/commands/mainline.md mainline.md
 ```
 
-After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, and `/worktree-plan` in Claude Code.
+After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, `/worktree-plan`, and `/mainline` in Claude Code.
 
 ### 2. Enable fast mode
 
@@ -86,6 +87,19 @@ Spawns a pool of agents that work through `.private/TODO.md` in parallel using i
 /swarm       # 3 parallel workers, runs until TODO.md is empty
 /swarm 5     # 5 parallel workers
 /swarm 3 10  # 3 workers, stop after 10 tasks completed
+```
+
+### `/mainline` - Ship current changes to main
+
+Takes all uncommitted changes, creates a branch, commits, opens a PR, merges it via squash, adds the PR to the unreviewed list, and switches back to main. A one-shot command for shipping adhoc work.
+
+**When to use:** When you've been working on something interactively and want to ship it without manually going through the branch/PR/merge dance.
+
+**Frequency:** Whenever you have uncommitted changes to ship.
+
+```
+/mainline                          # infers PR title from the changes
+/mainline Fix login redirect bug   # uses the provided title
 ```
 
 ### `/check-reviews` - Process PR review feedback
@@ -171,6 +185,12 @@ Follow the instructions in scripts/commands/work.md
 
 ```
 Follow the instructions in scripts/commands/check-reviews.md
+```
+
+### Mainline prompt
+
+```
+Follow the instructions in scripts/commands/mainline.md
 ```
 
 ### Brainstorm prompt

--- a/scripts/commands/mainline.md
+++ b/scripts/commands/mainline.md
@@ -1,0 +1,87 @@
+Ship the current uncommitted changes to main via a squash-merged PR.
+
+If the user passed `$ARGUMENTS`, use it as the PR title. Otherwise, infer a concise title from the changes.
+
+## Steps
+
+### 1. Check for changes
+
+```bash
+git status
+git diff
+```
+
+If there are no staged or unstaged changes, stop and tell the user there's nothing to mainline.
+
+### 2. Create a branch (if needed)
+
+If already on a non-main branch, skip this step and use the current branch.
+
+Otherwise, create a new branch from the changes:
+
+```bash
+git checkout -b <user>/<slug-from-title>
+```
+
+### 3. Stage and commit
+
+```bash
+git add -A
+git diff --cached
+```
+
+Review the staged diff. Draft a clear commit message summarizing the changes. Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 4. Push
+
+```bash
+git push -u origin HEAD
+```
+
+### 5. Create the PR
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 6. Add to unreviewed list
+
+Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
+
+### 7. Merge
+
+```bash
+gh pr merge <N> --squash
+```
+
+### 8. Switch back to main and pull
+
+```bash
+git checkout main && git pull
+```
+
+### 9. Report
+
+Output the PR link and a summary of what was shipped.
+
+## Repo-specific gotchas
+
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+
+IMPORTANT: .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing.


### PR DESCRIPTION
## Summary
- Adds `scripts/commands/mainline.md` — a one-shot command that branches, commits, PRs, merges, and returns to main
- Updates `scripts/README.md` with documentation and cross-agent prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
