### PR TITLE
Add toolChoice support to AgentLoop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -6,6 +6,7 @@ const log = getLogger('agent-loop');
 export interface AgentLoopConfig {
   maxTokens: number;
   thinking?: { enabled: boolean; budgetTokens: number };
+  toolChoice?: { type: 'auto' | 'any' | 'tool'; name?: string };
 }
 
 export type AgentEvent =
@@ -72,6 +73,10 @@ export class AgentLoop {
             type: 'enabled',
             budget_tokens: budgetTokens,
           };
+        }
+
+        if (this.config.toolChoice) {
+          providerConfig.tool_choice = this.config.toolChoice;
         }
 
         if (debug) {


### PR DESCRIPTION
Closes #462

## Summary
- Add optional `toolChoice` field to `AgentLoopConfig` supporting `auto`, `any`, and `tool` types
- Pass `tool_choice` through to provider config in the agent loop's `run()` method
- Existing behavior is unchanged when `toolChoice` is not set (field is optional, not included in `DEFAULT_CONFIG`)

The Anthropic provider already spreads `...config` into API params, so `tool_choice` flows through automatically. This enables the macOS client to force exactly one tool call per turn via `{ type: "any" }`.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit` — only pre-existing `bun-types` error)
- [x] No behavioral change when `toolChoice` is omitted (default path unchanged)
- [x] Verified Anthropic provider spreads config into API params at `client.ts:37`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
