### PR TITLE
Add IPC protocol extensions for computer-use

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -69,6 +69,30 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'sandbox_set',
     enabled: true,
   },
+  cu_session_create: {
+    type: 'cu_session_create',
+    sessionId: 'cu-sess-001',
+    task: 'Open Safari and search for weather',
+    screenWidth: 1920,
+    screenHeight: 1080,
+  },
+  cu_observation: {
+    type: 'cu_observation',
+    sessionId: 'cu-sess-001',
+    axTree: '<ax-tree>...</ax-tree>',
+    previousAXTree: '<prev-ax-tree>...</prev-ax-tree>',
+    axDiff: '+ new element',
+    secondaryWindows: 'Finder, Terminal',
+    screenshot: 'base64-screenshot-data',
+    executionResult: 'click completed',
+  },
+  ambient_observation: {
+    type: 'ambient_observation',
+    ocrText: 'Hello world visible on screen',
+    appName: 'Safari',
+    windowTitle: 'Google',
+    timestamp: 1700000000,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -220,6 +244,31 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     degraded: false,
     provider: 'openai',
     model: 'text-embedding-3-small',
+  },
+  cu_action: {
+    type: 'cu_action',
+    sessionId: 'cu-sess-001',
+    toolName: 'click',
+    input: { x: 100, y: 200 },
+    reasoning: 'Clicking the search button',
+    stepNumber: 1,
+  },
+  cu_complete: {
+    type: 'cu_complete',
+    sessionId: 'cu-sess-001',
+    summary: 'Successfully opened Safari and searched for weather',
+    stepCount: 5,
+  },
+  cu_error: {
+    type: 'cu_error',
+    sessionId: 'cu-sess-001',
+    message: 'Session timed out after 30 steps',
+  },
+  ambient_result: {
+    type: 'ambient_result',
+    decision: 'suggest',
+    summary: 'User appears to be debugging a test failure',
+    suggestion: 'Try running the test with --verbose flag for more details',
   },
 };
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -82,6 +82,35 @@ export interface SandboxSetRequest {
   enabled: boolean;
 }
 
+export interface CuSessionCreate {
+  type: 'cu_session_create';
+  sessionId: string;
+  task: string;
+  screenWidth: number;
+  screenHeight: number;
+  attachments?: UserMessageAttachment[];
+}
+
+export interface CuObservation {
+  type: 'cu_observation';
+  sessionId: string;
+  axTree?: string;
+  previousAXTree?: string;
+  axDiff?: string;
+  secondaryWindows?: string;
+  screenshot?: string;
+  executionResult?: string;
+  executionError?: string;
+}
+
+export interface AmbientObservation {
+  type: 'ambient_observation';
+  ocrText: string;
+  appName?: string;
+  windowTitle?: string;
+  timestamp: number;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -95,7 +124,10 @@ export type ClientMessage =
   | HistoryRequest
   | UndoRequest
   | UsageRequest
-  | SandboxSetRequest;
+  | SandboxSetRequest
+  | CuSessionCreate
+  | CuObservation
+  | AmbientObservation;
 
 // === Server → Client messages ===
 
@@ -255,6 +287,35 @@ export interface MemoryStatus {
   model?: string;
 }
 
+export interface CuAction {
+  type: 'cu_action';
+  sessionId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  reasoning?: string;
+  stepNumber: number;
+}
+
+export interface CuComplete {
+  type: 'cu_complete';
+  sessionId: string;
+  summary: string;
+  stepCount: number;
+}
+
+export interface CuError {
+  type: 'cu_error';
+  sessionId: string;
+  message: string;
+}
+
+export interface AmbientResult {
+  type: 'ambient_result';
+  decision: 'ignore' | 'observe' | 'suggest';
+  summary?: string;
+  suggestion?: string;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | AssistantThinkingDelta
@@ -276,7 +337,11 @@ export type ServerMessage =
   | ContextCompacted
   | SecretDetected
   | MemoryRecalled
-  | MemoryStatus;
+  | MemoryStatus
+  | CuAction
+  | CuComplete
+  | CuError
+  | AmbientResult;
 
 // === Serialization ===
 


### PR DESCRIPTION
Closes #463

## Summary
- Add 3 new client-to-server message types: `CuSessionCreate`, `CuObservation`, `AmbientObservation`
- Add 4 new server-to-client message types: `CuAction`, `CuComplete`, `CuError`, `AmbientResult`
- Update `ClientMessage` and `ServerMessage` union types to include the new variants
- Update IPC snapshot tests with representative examples for all 7 new types

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] All new types are pure additions — no existing interfaces modified
- [ ] Snapshot tests pass (requires bun test runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
