### PR TITLE
Proxy tool execution in ToolExecutor

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -172,8 +172,16 @@ export class ToolExecutor {
         }
       }
 
-      // Execute the tool
-      const execResult = await tool.execute(input, context);
+      // Execute the tool — proxy tools delegate to an external resolver
+      let execResult: ToolExecutionResult;
+      if (tool.executionMode === 'proxy') {
+        if (!context.proxyToolResolver) {
+          return { content: 'No proxy resolver configured for proxy tool', isError: true };
+        }
+        execResult = await context.proxyToolResolver(name, input);
+      } else {
+        execResult = await tool.execute(input, context);
+      }
 
       // Secret detection on tool output
       const sdConfig = getConfig().secretDetection;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -68,6 +68,11 @@ export type ToolLifecycleEvent =
 
 export type ToolLifecycleEventHandler = (event: ToolLifecycleEvent) => void | Promise<void>;
 
+export type ProxyToolResolver = (
+  toolName: string,
+  input: Record<string, unknown>,
+) => Promise<ToolExecutionResult>;
+
 export interface ToolContext {
   workingDir: string;
   sessionId: string;
@@ -78,6 +83,8 @@ export interface ToolContext {
   sandboxOverride?: boolean;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error/secret_detected). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
+  /** Optional resolver for proxy tools — delegates execution to an external client. */
+  proxyToolResolver?: ProxyToolResolver;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
Closes #461

## Summary
- Added `ProxyToolResolver` type to `types.ts` — a callback that takes a tool name and input, returning a `Promise<ToolExecutionResult>`
- Added optional `proxyToolResolver` field to `ToolContext`, following the same pattern as `PermissionPrompter`
- Modified `ToolExecutor.execute()` to intercept tools with `executionMode === 'proxy'` after permission checks pass, delegating to the proxy resolver instead of calling `tool.execute()` locally
- Secret detection and lifecycle event emission still apply to proxy tool results, preserving the existing security and observability guarantees

## Test plan
- [ ] Verify type-check passes (`npx tsc --noEmit` — only pre-existing `bun-types` error)
- [ ] Confirm proxy tools without a resolver return an error result
- [ ] Confirm proxy tools with a resolver delegate correctly
- [ ] Confirm non-proxy tools continue to execute locally as before
- [ ] Confirm secret detection and lifecycle events still fire on proxy tool results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
