### PR TITLE
Wire computer-use into daemon handlers

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,10 +1,12 @@
 import * as net from 'node:net';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
-import { initializeProviders } from '../providers/registry.js';
+import { getProvider, initializeProviders } from '../providers/registry.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
 import { Session } from './session.js';
-import type { ClientMessage, ServerMessage, UserMessageAttachment } from './ipc-protocol.js';
+import { ComputerUseSession } from './computer-use-session.js';
+import type { ClientMessage, ServerMessage, UserMessageAttachment, CuSessionCreate, CuObservation, AmbientObservation } from './ipc-protocol.js';
+import { handleAmbientObservation } from './ambient-handler.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -137,6 +139,8 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 export interface HandlerContext {
   sessions: Map<string, Session>;
   socketToSession: Map<net.Socket, string>;
+  cuSessions: Map<string, ComputerUseSession>;
+  socketToCuSession: Map<net.Socket, string>;
   socketSandboxOverride: Map<net.Socket, boolean>;
   debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
   suppressConfigReload: boolean;
@@ -192,6 +196,15 @@ export function handleMessage(
       break;
     case 'sandbox_set':
       handleSandboxSet(msg.enabled, socket, ctx);
+      break;
+    case 'cu_session_create':
+      handleCuSessionCreate(msg, socket, ctx);
+      break;
+    case 'cu_observation':
+      handleCuObservation(msg, socket, ctx);
+      break;
+    case 'ambient_observation':
+      handleAmbientObservation(msg, socket, ctx);
       break;
     case 'ping':
       ctx.send(socket, { type: 'pong' });
@@ -480,5 +493,55 @@ function handleUsageRequest(
     totalOutputTokens: conversation.totalOutputTokens,
     estimatedCost: conversation.totalEstimatedCost,
     model: config.model,
+  });
+}
+
+// ─── Computer-use handlers ──────────────────────────────────────────────────
+
+function handleCuSessionCreate(
+  msg: CuSessionCreate,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const config = getConfig();
+  const provider = getProvider(config.provider);
+
+  const sendToClient = (serverMsg: ServerMessage) => {
+    ctx.send(socket, serverMsg);
+  };
+
+  const session = new ComputerUseSession(
+    msg.sessionId,
+    msg.task,
+    msg.screenWidth,
+    msg.screenHeight,
+    provider,
+    sendToClient,
+  );
+
+  ctx.cuSessions.set(msg.sessionId, session);
+  ctx.socketToCuSession.set(socket, msg.sessionId);
+
+  log.info({ sessionId: msg.sessionId, task: msg.task }, 'Computer-use session created');
+}
+
+function handleCuObservation(
+  msg: CuObservation,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const session = ctx.cuSessions.get(msg.sessionId);
+  if (!session) {
+    ctx.send(socket, {
+      type: 'cu_error',
+      sessionId: msg.sessionId,
+      message: `No computer-use session found for id ${msg.sessionId}`,
+    });
+    return;
+  }
+
+  // Fire-and-forget: the session sends messages via its sendToClient callback
+  session.handleObservation(msg).catch((err) => {
+    log.error({ err, sessionId: msg.sessionId }, 'Error handling CU observation');
   });
 }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -11,6 +11,7 @@ import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { Session } from './session.js';
+import { ComputerUseSession } from './computer-use-session.js';
 import {
   serialize,
   createMessageParser,
@@ -26,6 +27,8 @@ export class DaemonServer {
   private server: net.Server | null = null;
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
+  private cuSessions = new Map<string, ComputerUseSession>();
+  private socketToCuSession = new Map<net.Socket, string>();
   private connectedSockets = new Set<net.Socket>();
   private socketSandboxOverride = new Map<net.Socket, boolean>();
   // Guards against duplicate session creation when multiple clients connect
@@ -104,6 +107,12 @@ export class DaemonServer {
       session.abort();
     }
     this.sessions.clear();
+
+    for (const cuSession of this.cuSessions.values()) {
+      cuSession.abort();
+    }
+    this.cuSessions.clear();
+    this.socketToCuSession.clear();
 
     for (const socket of this.connectedSockets) {
       socket.destroy();
@@ -323,6 +332,15 @@ export class DaemonServer {
         }
       }
       this.socketToSession.delete(socket);
+      const cuSessionId = this.socketToCuSession.get(socket);
+      if (cuSessionId) {
+        const cuSession = this.cuSessions.get(cuSessionId);
+        if (cuSession) {
+          cuSession.abort();
+          this.cuSessions.delete(cuSessionId);
+        }
+      }
+      this.socketToCuSession.delete(socket);
       log.info('Client disconnected');
     });
 
@@ -424,6 +442,8 @@ export class DaemonServer {
     return {
       sessions: this.sessions,
       socketToSession: this.socketToSession,
+      cuSessions: this.cuSessions,
+      socketToCuSession: this.socketToCuSession,
       socketSandboxOverride: this.socketSandboxOverride,
       debounceTimers: this.debounceTimers,
       suppressConfigReload: this.suppressConfigReload,


### PR DESCRIPTION
## Summary
- Add `cu_session_create` and `cu_observation` handlers to dispatch CU messages from the Swift client to `ComputerUseSession`
- Wire `ambient_observation` handler into the dispatch switch (delegates to existing `handleAmbientObservation`)
- Add `cuSessions` and `socketToCuSession` maps to `DaemonServer` for session lifecycle management
- Clean up CU sessions on socket disconnect and server shutdown

Closes #466

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed)
- [ ] Send `cu_session_create` IPC message → session created in map, logged
- [ ] Send `cu_observation` → routes to correct session, returns `cu_action` via callback
- [ ] Disconnect socket → CU session aborted and cleaned up
- [ ] Server stop → all CU sessions aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
