### PR TITLE
Model toolChoice as discriminated union

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -6,7 +6,7 @@ const log = getLogger('agent-loop');
 export interface AgentLoopConfig {
   maxTokens: number;
   thinking?: { enabled: boolean; budgetTokens: number };
-  toolChoice?: { type: 'auto' | 'any' | 'tool'; name?: string };
+  toolChoice?: { type: 'auto' } | { type: 'any' } | { type: 'tool'; name: string };
 }
 
 export type AgentEvent =


### PR DESCRIPTION
## Summary
- Refactors `toolChoice` in `AgentLoopConfig` from a loose object type (`{ type: 'auto' | 'any' | 'tool'; name?: string }`) into a proper discriminated union that prevents invalid combinations at compile time
- `{ type: 'tool' }` without a `name` and `{ type: 'auto', name: '...' }` are now type errors, preventing runtime 4xx errors from the Anthropic API

Closes #475

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] Existing caller in `computer-use-session.ts` (`{ type: 'any' }`) is compatible with the new type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
