### PR TITLE
Emit lifecycle event for missing proxy resolver

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -176,7 +176,22 @@ export class ToolExecutor {
       let execResult: ToolExecutionResult;
       if (tool.executionMode === 'proxy') {
         if (!context.proxyToolResolver) {
-          return { content: 'No proxy resolver configured for proxy tool', isError: true };
+          const msg = 'No proxy resolver configured for proxy tool';
+          const durationMs = Date.now() - startTime;
+          emitLifecycleEvent(context, {
+            type: 'error',
+            toolName: name,
+            input,
+            workingDir: context.workingDir,
+            sessionId: context.sessionId,
+            conversationId: context.conversationId,
+            riskLevel,
+            decision: 'error',
+            durationMs,
+            errorMessage: msg,
+            isExpected: true,
+          });
+          return { content: msg, isError: true };
         }
         execResult = await context.proxyToolResolver(name, input);
       } else {


### PR DESCRIPTION
## Summary
- Fixes a missing terminal lifecycle event when a proxy tool is executed but `context.proxyToolResolver` is not configured.
- Previously, the `start` event was emitted but the early return on the missing-resolver path skipped emitting any terminal event (`error` or `executed`), breaking the observability contract for audit/metrics consumers.
- Adds an `error` lifecycle event emission before the early return, matching the pattern used by the "unknown tool" and `catch` error paths in the same file.

Closes #478

## Test plan
- [ ] Verify type-check passes (`npx tsc --noEmit`) — confirmed locally
- [ ] Inspect the diff to confirm the emitted event shape matches `ToolExecutionErrorEvent`
- [ ] Confirm no other early-return paths are missing terminal lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
