### PR TITLE
Register computer-use tools during daemon initialization

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -2,6 +2,7 @@ import { RiskLevel } from '../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
+import { registerComputerUseTools } from './computer-use/registry.js';
 
 const log = getLogger('tool-registry');
 
@@ -83,7 +84,11 @@ export function getAllTools(): Tool[] {
 }
 
 export function getAllToolDefinitions(): ToolDefinition[] {
-  return getAllTools().map((t) => t.getDefinition());
+  // Exclude proxy tools (e.g. cu_* computer-use tools) — they are only used
+  // by ComputerUseSession which builds its own tool definitions list.
+  return getAllTools()
+    .filter((t) => t.executionMode !== 'proxy')
+    .map((t) => t.getDefinition());
 }
 
 export async function initializeTools(): Promise<void> {
@@ -95,6 +100,11 @@ export async function initializeTools(): Promise<void> {
   await import('./network/web-search.js');
   await import('./network/web-fetch.js');
   await import('./skills/load.js');
+
+  // Computer-use proxy tools — registered so ToolExecutor can look them up
+  // and forward execution to the connected macOS client.  They are excluded
+  // from getAllToolDefinitions() since regular chat sessions don't use them.
+  registerComputerUseTools();
 
   // The bash tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.


### PR DESCRIPTION
## Summary
- Call `registerComputerUseTools()` from `initializeTools()` so the 12 `cu_*` proxy tools are registered in the global tool map at daemon startup
- Filter `executionMode: 'proxy'` tools out of `getAllToolDefinitions()` so they are not exposed to regular chat sessions
- Without this fix, `ToolExecutor.execute()` returned "Unknown tool" for any `cu_*` tool because `getTool()` could not find them in the registry, making computer-use effectively disabled

Closes #477

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed)
- [ ] Verify `cu_*` tools are findable via `getTool()` after `initializeTools()` runs
- [ ] Verify `getAllToolDefinitions()` does NOT include `cu_*` tools (regular sessions unaffected)
- [ ] Verify `ComputerUseSession` still works — it imports `allComputerUseTools` directly and builds its own tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
