### PR TITLE
Use stable ID for ambient conversation instead of title match

### DIFF
--- a/assistant/src/memory/ambient-indexer.ts
+++ b/assistant/src/memory/ambient-indexer.ts
@@ -8,6 +8,9 @@ import { getLogger } from '../util/logger.js';
 
 const log = getLogger('ambient-indexer');
 
+/** Deterministic well-known ID for the ambient conversation so we never
+ *  select the wrong conversation by mutable title. */
+const AMBIENT_CONVERSATION_ID = '00000000-0000-4000-a000-000000000001';
 const AMBIENT_CONVERSATION_TITLE = 'Ambient Observations';
 
 const ANALYSIS_PROMPT = `You are an ambient screen observer for a macOS assistant. You receive OCR text captured from the user's screen along with the app name and window title.
@@ -97,7 +100,7 @@ function getOrCreateAmbientConversation(): string {
   const existing = db
     .select({ id: conversations.id })
     .from(conversations)
-    .where(eq(conversations.title, AMBIENT_CONVERSATION_TITLE))
+    .where(eq(conversations.id, AMBIENT_CONVERSATION_ID))
     .limit(1)
     .get();
 
@@ -105,7 +108,20 @@ function getOrCreateAmbientConversation(): string {
     return existing.id;
   }
 
-  const conv = conversationStore.createConversation(AMBIENT_CONVERSATION_TITLE);
-  log.info({ conversationId: conv.id }, 'Created ambient observations conversation');
-  return conv.id;
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id: AMBIENT_CONVERSATION_ID,
+      title: AMBIENT_CONVERSATION_TITLE,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextCompactedMessageCount: 0,
+    })
+    .run();
+
+  log.info({ conversationId: AMBIENT_CONVERSATION_ID }, 'Created ambient observations conversation');
+  return AMBIENT_CONVERSATION_ID;
 }


### PR DESCRIPTION
## Summary
- Replaces the mutable-title lookup (`where title = 'Ambient Observations'`) in `ambient-indexer.ts` with a deterministic well-known UUID (`AMBIENT_CONVERSATION_ID`), so a user-renamed conversation or a normal chat with the same title can never be mistakenly selected as the ambient sink.
- No schema migration needed -- the `id` column is already a text primary key, so we simply use a fixed constant UUID when creating the ambient conversation.

Closes #480

## Test plan
- [ ] Verify type-check passes (`npx tsc --noEmit`)
- [ ] On a fresh DB, ambient observations create the conversation with the fixed ID
- [ ] On an existing DB where the ambient conversation was previously created by title, the old conversation remains but a new one with the fixed ID is created on next observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
