### PR TITLE
Fix CU session socket lifecycle and rate limiting

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
+import { RateLimitProvider } from '../providers/ratelimit.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
 import { Session } from './session.js';
@@ -140,8 +141,9 @@ export interface HandlerContext {
   sessions: Map<string, Session>;
   socketToSession: Map<net.Socket, string>;
   cuSessions: Map<string, ComputerUseSession>;
-  socketToCuSession: Map<net.Socket, string>;
+  socketToCuSession: Map<net.Socket, Set<string>>;
   socketSandboxOverride: Map<net.Socket, boolean>;
+  sharedRequestTimestamps: number[];
   debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
   suppressConfigReload: boolean;
   setSuppressConfigReload(value: boolean): void;
@@ -503,8 +505,18 @@ function handleCuSessionCreate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  // Abort any existing session with the same ID to prevent zombies
+  const existingSession = ctx.cuSessions.get(msg.sessionId);
+  if (existingSession) {
+    existingSession.abort();
+  }
+
   const config = getConfig();
-  const provider = getProvider(config.provider);
+  let provider = getProvider(config.provider);
+  const { rateLimit } = config;
+  if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
+    provider = new RateLimitProvider(provider, rateLimit, ctx.sharedRequestTimestamps);
+  }
 
   const sendToClient = (serverMsg: ServerMessage) => {
     ctx.send(socket, serverMsg);
@@ -520,7 +532,14 @@ function handleCuSessionCreate(
   );
 
   ctx.cuSessions.set(msg.sessionId, session);
-  ctx.socketToCuSession.set(socket, msg.sessionId);
+
+  // Track all CU sessions per socket so disconnect cleans up all of them
+  let sessionIds = ctx.socketToCuSession.get(socket);
+  if (!sessionIds) {
+    sessionIds = new Set();
+    ctx.socketToCuSession.set(socket, sessionIds);
+  }
+  sessionIds.add(msg.sessionId);
 
   log.info({ sessionId: msg.sessionId, task: msg.task }, 'Computer-use session created');
 }

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -6,7 +6,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
 import { Session } from './session.js';
 import { ComputerUseSession } from './computer-use-session.js';
-import type { ClientMessage, ServerMessage, UserMessageAttachment, CuSessionCreate, CuObservation, AmbientObservation } from './ipc-protocol.js';
+import type { ClientMessage, ServerMessage, UserMessageAttachment, CuSessionCreate, CuObservation } from './ipc-protocol.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 
 const log = getLogger('handlers');

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -505,10 +505,18 @@ function handleCuSessionCreate(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  // Abort any existing session with the same ID to prevent zombies
+  // Abort any existing session with the same ID to prevent zombies,
+  // and remove it from the previous owner's socket set so disconnect
+  // cleanup doesn't accidentally abort the replacement session.
   const existingSession = ctx.cuSessions.get(msg.sessionId);
   if (existingSession) {
     existingSession.abort();
+    for (const [otherSocket, ids] of ctx.socketToCuSession) {
+      if (ids.delete(msg.sessionId)) {
+        if (ids.size === 0) ctx.socketToCuSession.delete(otherSocket);
+        break;
+      }
+    }
   }
 
   const config = getConfig();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -28,7 +28,7 @@ export class DaemonServer {
   private sessions = new Map<string, Session>();
   private socketToSession = new Map<net.Socket, string>();
   private cuSessions = new Map<string, ComputerUseSession>();
-  private socketToCuSession = new Map<net.Socket, string>();
+  private socketToCuSession = new Map<net.Socket, Set<string>>();
   private connectedSockets = new Set<net.Socket>();
   private socketSandboxOverride = new Map<net.Socket, boolean>();
   // Guards against duplicate session creation when multiple clients connect
@@ -332,12 +332,14 @@ export class DaemonServer {
         }
       }
       this.socketToSession.delete(socket);
-      const cuSessionId = this.socketToCuSession.get(socket);
-      if (cuSessionId) {
-        const cuSession = this.cuSessions.get(cuSessionId);
-        if (cuSession) {
-          cuSession.abort();
-          this.cuSessions.delete(cuSessionId);
+      const cuSessionIds = this.socketToCuSession.get(socket);
+      if (cuSessionIds) {
+        for (const cuSessionId of cuSessionIds) {
+          const cuSession = this.cuSessions.get(cuSessionId);
+          if (cuSession) {
+            cuSession.abort();
+            this.cuSessions.delete(cuSessionId);
+          }
         }
       }
       this.socketToCuSession.delete(socket);
@@ -445,6 +447,7 @@ export class DaemonServer {
       cuSessions: this.cuSessions,
       socketToCuSession: this.socketToCuSession,
       socketSandboxOverride: this.socketSandboxOverride,
+      sharedRequestTimestamps: this.sharedRequestTimestamps,
       debounceTimers: this.debounceTimers,
       suppressConfigReload: this.suppressConfigReload,
       setSuppressConfigReload: (value: boolean) => { this.suppressConfigReload = value; },

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -8,7 +8,7 @@
  */
 
 import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { Tool, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Change `socketToCuSession` from `Map<Socket, string>` to `Map<Socket, Set<string>>` so all CU sessions on a socket are cleaned up on disconnect (prevents orphaned sessions)
- Abort existing CU session when a new one is created with the same ID (prevents zombie agent loops)
- Wrap CU provider with `RateLimitProvider` to respect configured rate limits (parity with regular sessions)

Closes #487

## Test plan
- [ ] Create multiple CU sessions on the same socket, verify all are cleaned up on disconnect
- [ ] Create a CU session with a duplicate ID, verify the old one is aborted
- [ ] Configure rate limits and verify CU sessions respect them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
