### PR TITLE
Fix CU session state machine and permissions

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -82,8 +82,9 @@ export class ComputerUseSession {
     }
 
     // Track consecutive unchanged steps
+    const hadPreviousAXTree = this.previousAXTree != null;
     if (this.stepCount > 0) {
-      if (obs.axDiff == null && this.previousAXTree != null && obs.axTree != null) {
+      if (obs.axDiff == null && hadPreviousAXTree && obs.axTree != null) {
         this.consecutiveUnchangedSteps++;
       } else if (obs.axDiff != null) {
         this.consecutiveUnchangedSteps = 0;
@@ -97,7 +98,7 @@ export class ComputerUseSession {
 
     if (this.state === 'awaiting_observation' && this.pendingObservation) {
       // Resolve the pending proxy tool result with updated screen context
-      const content = this.buildObservationResultContent(obs);
+      const content = this.buildObservationResultContent(obs, hadPreviousAXTree);
       const result: ToolExecutionResult = obs.executionError
         ? { content: `Action failed: ${obs.executionError}\n\n${content}`, isError: true }
         : { content, isError: false };
@@ -304,7 +305,7 @@ export class ComputerUseSession {
   // updated screen state on each turn (not just "Action executed").
   // ---------------------------------------------------------------------------
 
-  private buildObservationResultContent(obs: CuObservation): string {
+  private buildObservationResultContent(obs: CuObservation, hadPreviousAXTree: boolean): string {
     const parts: string[] = [];
 
     if (obs.executionResult) {
@@ -316,7 +317,7 @@ export class ComputerUseSession {
     if (obs.axDiff) {
       parts.push(obs.axDiff);
       parts.push('');
-    } else if (this.previousAXTree != null && obs.axTree != null) {
+    } else if (hadPreviousAXTree && obs.axTree != null) {
       const lastAction = this.actionHistory[this.actionHistory.length - 1];
       const wasWait = lastAction?.toolName === 'cu_wait';
       if (this.consecutiveUnchangedSteps >= CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD) {

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -96,10 +96,12 @@ export class ComputerUseSession {
     }
 
     if (this.state === 'awaiting_observation' && this.pendingObservation) {
-      // Resolve the pending proxy tool result with a summary
+      // Resolve the pending proxy tool result with updated screen context
+      const content = this.buildObservationResultContent(obs);
       const result: ToolExecutionResult = obs.executionError
-        ? { content: `Action failed: ${obs.executionError}`, isError: true }
-        : { content: obs.executionResult ?? 'Action executed', isError: false };
+        ? { content: `Action failed: ${obs.executionError}\n\n${content}`, isError: true }
+        : { content, isError: false };
+      this.state = 'inferring';
       this.pendingObservation.resolve(result);
       this.pendingObservation = null;
       // The agent loop continues automatically after resolution
@@ -298,6 +300,45 @@ export class ComputerUseSession {
   }
 
   // ---------------------------------------------------------------------------
+  // Build rich tool-result content from an observation so the model sees
+  // updated screen state on each turn (not just "Action executed").
+  // ---------------------------------------------------------------------------
+
+  private buildObservationResultContent(obs: CuObservation): string {
+    const parts: string[] = [];
+
+    if (obs.executionResult) {
+      parts.push(obs.executionResult);
+      parts.push('');
+    }
+
+    // AX tree diff
+    if (obs.axDiff) {
+      parts.push(obs.axDiff);
+      parts.push('');
+    } else if (this.previousAXTree != null && obs.axTree != null) {
+      const lastAction = this.actionHistory[this.actionHistory.length - 1];
+      const wasWait = lastAction?.toolName === 'cu_wait';
+      if (this.consecutiveUnchangedSteps >= CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD) {
+        parts.push(
+          `WARNING: ${this.consecutiveUnchangedSteps} consecutive actions had NO VISIBLE EFFECT on the UI. You MUST try a completely different approach.`,
+        );
+      } else if (!wasWait) {
+        parts.push('Your last action had NO VISIBLE EFFECT on the UI. Try something different.');
+      }
+      parts.push('');
+    }
+
+    // Current screen state
+    if (obs.axTree) {
+      parts.push('CURRENT SCREEN STATE:');
+      parts.push(obs.axTree);
+    }
+
+    return parts.join('\n').trim() || 'Action executed';
+  }
+
+  // ---------------------------------------------------------------------------
   // Message building (replicates AnthropicProvider.buildMessages from Swift)
   // ---------------------------------------------------------------------------
 
@@ -330,7 +371,7 @@ export class ComputerUseSession {
     if (obs.axDiff && this.actionHistory.length > 0) {
       textParts.push(obs.axDiff);
       textParts.push('');
-    } else if (obs.previousAXTree != null && obs.axTree != null && this.actionHistory.length > 0) {
+    } else if (this.previousAXTree != null && obs.axTree != null && this.actionHistory.length > 0) {
       // AX tree unchanged — tell the model its action had no effect
       const lastAction = this.actionHistory[this.actionHistory.length - 1];
       const wasWait = lastAction?.toolName === 'cu_wait';

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -5,7 +5,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import { getLogger } from '../util/logger.js';
 import { Session } from './session.js';
 import { ComputerUseSession } from './computer-use-session.js';
-import type { ClientMessage, ServerMessage, UserMessageAttachment, CuSessionCreate, CuObservation, AmbientObservation } from './ipc-protocol.js';
+import type { ClientMessage, ServerMessage, UserMessageAttachment, CuSessionCreate, CuObservation } from './ipc-protocol.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 
 const log = getLogger('handlers');

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -2,6 +2,7 @@ import { RiskLevel, type PermissionCheckResult, type AllowlistOption, type Scope
 import { findMatchingRule, findDenyRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
 import { resolveSkillSelector } from '../config/skills.js';
+import { getTool } from '../tools/registry.js';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -244,6 +245,10 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
 
     return maxRisk;
   }
+
+  // Check the tool registry for a declared default risk level
+  const tool = getTool(toolName);
+  if (tool) return tool.defaultRiskLevel;
 
   // Unknown tool → Medium
   return RiskLevel.Medium;

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -8,7 +8,7 @@
  */
 
 import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { Tool, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add missing `state = 'inferring'` transition after resolving pending observation — prevents duplicate agent loops from spurious observations
- Include updated screen state (AX tree, diff, unchanged warnings) in proxy tool results so the model sees fresh context each turn instead of just "Action executed"
- Use session-tracked `previousAXTree` instead of `obs.previousAXTree` for unchanged-UI detection (the obs field is optional)
- Check registered tool's `defaultRiskLevel` in `classifyRisk` before falling back to Medium — `cu_*` tools (declared Low) now auto-allow instead of triggering permission prompts that stall the headless CU session

Closes #488

## Test plan
- [ ] Verify CU session state transitions correctly through observation/inference cycles
- [ ] Confirm model receives updated screen state in tool results after each action
- [ ] Verify `cu_*` tools are auto-allowed without permission prompts
- [ ] Test unchanged-UI warnings fire correctly using session-tracked AX tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
