### PR TITLE
Wire shared DaemonClient into AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -31,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        setupDaemonClient()
         setupMenuBar()
         setupHotKey()
         setupEscapeMonitor()
@@ -38,6 +39,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupAmbientAgent()
         setupWindowObserver()
         setupNotifications()
+    }
+
+    private func setupDaemonClient() {
+        Task {
+            try? await daemonClient.connect()
+        }
     }
 
     private func setupWindowObserver() {
@@ -164,12 +171,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupAmbientAgent() {
         ambientAgent.appDelegate = self
-
-        let client = DaemonClient()
-        ambientAgent.daemonClient = client
-        Task {
-            try? await client.connect()
-        }
+        ambientAgent.daemonClient = daemonClient
 
         if ambientAgent.isEnabled {
             ambientAgent.start()
@@ -215,6 +217,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onboarding.close()
             self?.onboardingWindow = nil
 
+            self?.setupDaemonClient()
             self?.setupMenuBar()
             self?.setupHotKey()
             self?.setupEscapeMonitor()


### PR DESCRIPTION
Closes #497

## Summary
- Remove duplicate `DaemonClient()` creation in `setupAmbientAgent()` — now uses the shared `daemonClient` property already on `AppDelegate`
- Add `setupDaemonClient()` method that connects the shared client on app launch
- Call `setupDaemonClient()` in both the normal `applicationDidFinishLaunching` path and the post-onboarding completion handler

## Test plan
- [x] `swift build` succeeds
- [x] `swift build --build-tests` succeeds
- [ ] Verify ambient agent receives daemon messages through the shared client
- [ ] Verify CU session still works with the shared daemon client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
