### PR TITLE
Fix DaemonClient broadcast and reconnect backoff

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -258,6 +258,9 @@ final class AmbientAgent: ObservableObject {
             return
         }
 
+        // Subscribe before sending so we don't miss a fast daemon response
+        let messageStream = daemonClient.subscribe()
+
         do {
             try daemonClient.send(AmbientObservationMessage(
                 ocrText: screenContent,
@@ -272,7 +275,7 @@ final class AmbientAgent: ObservableObject {
         }
 
         // Wait for ambient_result from daemon
-        guard let ambientResult = await waitForAmbientResult(timeout: 30) else {
+        guard let ambientResult = await waitForAmbientResult(stream: messageStream, timeout: 30) else {
             log.warning("[\(cycle)] Timed out waiting for ambient result from daemon")
             state = .watching
             return
@@ -332,9 +335,7 @@ final class AmbientAgent: ObservableObject {
         state = .watching
     }
 
-    private func waitForAmbientResult(timeout: TimeInterval = 30) async -> AmbientResultMessage? {
-        guard let daemonClient = daemonClient else { return nil }
-        let messageStream = daemonClient.subscribe()
+    private func waitForAmbientResult(stream messageStream: AsyncStream<ServerMessage>, timeout: TimeInterval = 30) async -> AmbientResultMessage? {
         return await withTaskGroup(of: AmbientResultMessage?.self) { group in
             group.addTask {
                 for await message in messageStream {

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -334,7 +334,7 @@ final class AmbientAgent: ObservableObject {
 
     private func waitForAmbientResult(timeout: TimeInterval = 30) async -> AmbientResultMessage? {
         guard let daemonClient = daemonClient else { return nil }
-        let messageStream = daemonClient.messages
+        let messageStream = daemonClient.subscribe()
         return await withTaskGroup(of: AmbientResultMessage?.self) { group in
             group.addTask {
                 for await message in messageStream {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -131,7 +131,7 @@ final class ComputerUseSession: ObservableObject {
         // Wrap in a cancellable task so cancel() can interrupt the stream await.
         let loopTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            for await message in daemonClient.messages {
+            for await message in daemonClient.subscribe() {
                 guard !self.isCancelled else { break }
 
                 // Wait while paused

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -98,7 +98,10 @@ final class ComputerUseSession: ObservableObject {
             try? await Task.sleep(nanoseconds: initialDelayMs * 1_000_000)
         }
 
-        // 1. Send session create message
+        // 1. Subscribe before sending so we don't miss fast daemon responses
+        let messageStream = daemonClient.subscribe()
+
+        // 2. Send session create message
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(
                 filename: $0.fileName,
@@ -115,7 +118,7 @@ final class ComputerUseSession: ObservableObject {
             attachments: ipcAttachments
         ))
 
-        // 2. Initial perceive + send first observation
+        // 3. Initial perceive + send first observation
         let obs = await buildObservation(executionResult: nil, executionError: nil)
         if let obs {
             try? daemonClient.send(obs)
@@ -127,11 +130,11 @@ final class ComputerUseSession: ObservableObject {
 
         state = .thinking(step: 1, maxSteps: maxSteps)
 
-        // 3. Listen for daemon messages (filter by sessionId)
+        // 4. Listen for daemon messages (filter by sessionId)
         // Wrap in a cancellable task so cancel() can interrupt the stream await.
         let loopTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            for await message in daemonClient.subscribe() {
+            for await message in messageStream {
                 guard !self.isCancelled else { break }
 
                 // Wait while paused

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -7,7 +7,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Protocol for daemon client communication, enabling dependency injection and testing.
 @MainActor
 protocol DaemonClientProtocol {
-    var messages: AsyncStream<ServerMessage> { get }
+    func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
 }
 
@@ -16,8 +16,9 @@ protocol DaemonClientProtocol {
 /// Connects to the daemon's socket at `~/.vellum/vellum.sock` (or `VELLUM_DAEMON_SOCKET` env override),
 /// sends and receives newline-delimited JSON messages.
 ///
-/// This is a long-lived singleton. The `messages` stream stays open for the app's lifetime.
-/// Consumers (ComputerUseSession, AmbientAgent) filter for messages relevant to them.
+/// This is a long-lived singleton. Consumers call `subscribe()` to get an independent message
+/// stream, enabling multiple consumers (ComputerUseSession, AmbientAgent) to each receive all
+/// messages and filter for the ones relevant to them.
 @MainActor
 final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
@@ -25,11 +26,21 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published var isConnected: Bool = false
 
-    // MARK: - Message Stream
+    // MARK: - Broadcast Subscribers
 
-    /// Stream of incoming server messages. Stays open for the lifetime of the client.
-    var messages: AsyncStream<ServerMessage> {
-        stream
+    /// Creates a new message stream for the caller. Each subscriber receives all messages
+    /// independently, enabling multiple consumers (ComputerUseSession, AmbientAgent) to
+    /// filter for messages relevant to them without competing for elements.
+    func subscribe() -> AsyncStream<ServerMessage> {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        subscribers[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.subscribers.removeValue(forKey: id)
+            }
+        }
+        return stream
     }
 
     // MARK: - Private State
@@ -37,8 +48,7 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     private var connection: NWConnection?
     private let queue = DispatchQueue(label: "com.vellum.vellum-assistant.daemon-client", qos: .userInitiated)
 
-    private let stream: AsyncStream<ServerMessage>
-    private let continuation: AsyncStream<ServerMessage>.Continuation
+    private var subscribers: [UUID: AsyncStream<ServerMessage>.Continuation] = [:]
 
     /// Buffer for accumulating incoming data until we have complete newline-delimited messages.
     private var receiveBuffer = Data()
@@ -72,11 +82,7 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Init
 
-    init() {
-        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
-        self.stream = stream
-        self.continuation = continuation
-    }
+    init() {}
 
     deinit {
         // Cancel everything without triggering reconnect.
@@ -85,7 +91,10 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         pingTask?.cancel()
         pongTimeoutTask?.cancel()
         connection?.cancel()
-        continuation.finish()
+        for continuation in subscribers.values {
+            continuation.finish()
+        }
+        subscribers.removeAll()
     }
 
     // MARK: - Socket Path
@@ -108,7 +117,6 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         disconnectInternal(triggerReconnect: false)
 
         shouldReconnect = true
-        reconnectDelay = 1.0
 
         let socketPath = Self.resolveSocketPath()
         log.info("Connecting to daemon socket at \(socketPath)")
@@ -289,8 +297,10 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             pongTimeoutTask = nil
         }
 
-        // Yield all messages (including pong) to stream consumers.
-        continuation.yield(message)
+        // Broadcast to all subscribers.
+        for continuation in subscribers.values {
+            continuation.yield(message)
+        }
     }
 
     // MARK: - Reconnect


### PR DESCRIPTION
## Summary
- Replace single `AsyncStream` with a `subscribe()` broadcast pattern using `[UUID: Continuation]` registry, so multiple consumers (ComputerUseSession, AmbientAgent) each receive all messages independently instead of competing for elements
- Remove `reconnectDelay = 1.0` from `connect()` which was defeating exponential backoff by overwriting the doubled delay on every reconnect attempt (the reset in the `.ready` handler is sufficient)
- Update all callers (`AmbientAgent.swift`, `Session.swift`) from `.messages` to `.subscribe()`

Closes #502

## Test plan
- [ ] Verify AmbientAgent receives ambient_result messages while ComputerUseSession simultaneously receives cu_action messages
- [ ] Verify reconnect backoff increases (1s → 2s → 4s → ...) when daemon is unavailable, rather than hammering every 1s
- [ ] Verify backoff resets to 1s after a successful connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
