### PR TITLE
Fix Optional comparison bug in ambient decision sync

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -317,9 +317,9 @@ final class AmbientAgent: ObservableObject {
         }
 
         // Sync non-ignore analysis results and flush retry queue
-        if decision != .ignore {
+        if let decision, decision != .ignore {
             let result = AmbientAnalysisResult(
-                decision: decision ?? .ignore,
+                decision: decision,
                 observation: ambientResult.summary,
                 suggestion: ambientResult.suggestion,
                 confidence: 1.0,


### PR DESCRIPTION
## Summary
- Fix `if decision != .ignore` guard that incorrectly passes when `decision` is `nil` (unknown daemon decision string), causing unknown decisions to be synced as `.ignore`
- Use `if let decision, decision != .ignore` to properly unwrap the Optional first

Closes #510

## Test plan
- [ ] Send an unrecognized decision string from daemon — verify it is not synced (no `sendAnalysis` call)
- [ ] Send a valid non-ignore decision — verify it is synced normally
- [ ] Send `.ignore` decision — verify it is still skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
