### PR TITLE
Fix tool_result blocks corrupting assistant messages in DB

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -110,10 +110,19 @@ export class Session {
 
     this.messages = dbMessages
       .slice(this.contextCompactedMessageCount)
-      .map((m) => ({
-        role: m.role as 'user' | 'assistant',
-        content: JSON.parse(m.content),
-      }));
+      .map((m) => {
+        const role = m.role as 'user' | 'assistant';
+        const content = JSON.parse(m.content);
+        // Strip tool_result blocks from assistant messages (legacy data from
+        // patchToolResults which injected them in the wrong role).
+        if (role === 'assistant' && Array.isArray(content)) {
+          const cleaned = content.filter(
+            (block: Record<string, unknown>) => block.type !== 'tool_result',
+          );
+          return { role, content: cleaned };
+        }
+        return { role, content };
+      });
 
     if (contextSummary) {
       this.messages.unshift(createContextSummaryMessage(contextSummary));
@@ -241,7 +250,6 @@ export class Session {
       let exchangeOutputTokens = 0;
       let model = '';
       let runMessages = this.messages;
-      let lastSavedMessageId: string | null = null;
       const pendingToolResults = new Map<string, { content: string; isError: boolean }>();
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
@@ -304,18 +312,30 @@ export class Session {
               onEvent({ type: 'error', message: event.error.message });
               break;
             case 'message_complete': {
-              // Patch the previously saved assistant message with tool results
-              if (lastSavedMessageId && pendingToolResults.size > 0) {
-                conversationStore.patchToolResults(this.conversationId, lastSavedMessageId, pendingToolResults);
+              // Save pending tool results as a user message before the next assistant message.
+              // tool_result blocks belong in user messages per the Anthropic API spec.
+              if (pendingToolResults.size > 0) {
+                const toolResultBlocks = Array.from(pendingToolResults.entries()).map(
+                  ([toolUseId, result]) => ({
+                    type: 'tool_result',
+                    tool_use_id: toolUseId,
+                    content: result.content,
+                    is_error: result.isError,
+                  }),
+                );
+                conversationStore.addMessage(
+                  this.conversationId,
+                  'user',
+                  JSON.stringify(toolResultBlocks),
+                );
                 pendingToolResults.clear();
               }
               // Save assistant message to DB
-              const saved = conversationStore.addMessage(
+              conversationStore.addMessage(
                 this.conversationId,
                 'assistant',
                 JSON.stringify(event.message.content),
               );
-              lastSavedMessageId = saved.id;
               break;
             }
             case 'usage':
@@ -328,9 +348,21 @@ export class Session {
         this.abortController.signal,
       );
 
-      // Flush any remaining tool results for the last saved assistant message
-      if (lastSavedMessageId && pendingToolResults.size > 0) {
-        conversationStore.patchToolResults(this.conversationId, lastSavedMessageId, pendingToolResults);
+      // Flush any remaining tool results as a user message
+      if (pendingToolResults.size > 0) {
+        const toolResultBlocks = Array.from(pendingToolResults.entries()).map(
+          ([toolUseId, result]) => ({
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: result.content,
+            is_error: result.isError,
+          }),
+        );
+        conversationStore.addMessage(
+          this.conversationId,
+          'user',
+          JSON.stringify(toolResultBlocks),
+        );
         pendingToolResults.clear();
       }
 

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -142,63 +142,6 @@ export function updateConversationContextWindow(
 }
 
 /**
- * Patch a saved assistant message's content to inject tool_result data
- * alongside the corresponding tool_use blocks.
- *
- * The pendingResults map is keyed by tool_use_id with value { content, isError }.
- * For each tool_use block in the saved message whose id matches a key in the map,
- * a sibling tool_result block is appended immediately after it.
- */
-export function patchToolResults(
-  conversationId: string,
-  messageId: string,
-  pendingResults: Map<string, { content: string; isError: boolean }>,
-): void {
-  if (pendingResults.size === 0) return;
-
-  const db = getDb();
-  const row = db
-    .select({ content: messages.content })
-    .from(messages)
-    .where(and(eq(messages.id, messageId), eq(messages.conversationId, conversationId)))
-    .get();
-  if (!row) return;
-
-  let blocks: unknown[];
-  try {
-    blocks = JSON.parse(row.content);
-    if (!Array.isArray(blocks)) return;
-  } catch {
-    return;
-  }
-
-  const patched: unknown[] = [];
-  for (const block of blocks) {
-    patched.push(block);
-    if (
-      typeof block === 'object' && block !== null &&
-      (block as Record<string, unknown>).type === 'tool_use'
-    ) {
-      const id = (block as Record<string, unknown>).id;
-      if (typeof id === 'string' && pendingResults.has(id)) {
-        const result = pendingResults.get(id)!;
-        patched.push({
-          type: 'tool_result',
-          tool_use_id: id,
-          content: result.content,
-          is_error: result.isError,
-        });
-      }
-    }
-  }
-
-  db.update(messages)
-    .set({ content: JSON.stringify(patched) })
-    .where(and(eq(messages.id, messageId), eq(messages.conversationId, conversationId)))
-    .run();
-}
-
-/**
  * Delete the last user message and any subsequent assistant messages.
  * Uses rowid comparison instead of timestamps to avoid deleting messages
  * that share the same millisecond timestamp.


### PR DESCRIPTION
## Summary

- **Bug**: `patchToolResults` was injecting `tool_result` blocks into saved assistant messages in the DB, violating the Anthropic API spec (tool_result must only appear in user messages). After daemon restart, `loadFromDb` would send these corrupted messages to the API, breaking any conversation that used tools.
- **Fix**: Save tool results as separate user messages in the DB (matching the API's expected alternating user/assistant structure) instead of patching them into assistant messages.
- **Legacy data**: Added defensive stripping of `tool_result` blocks from assistant messages in `loadFromDb` to handle old corrupted data gracefully.

## Test plan

- [x] Existing `server-history-render.test.ts` tests pass (15/15) — `mergeToolResults` correctly pairs tool results from user messages into assistant toolCalls for display
- [x] `conversation-store.test.ts` tests pass (4/4)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Manual: Start a conversation with tool use, restart daemon, send a follow-up message — should work without API validation errors
- [ ] Manual: Load an old conversation that had patched assistant messages — legacy data should be cleaned up on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
