### PR TITLE
Fix worktree remove failing in non-interactive contexts

### DIFF
--- a/scripts/worktree
+++ b/scripts/worktree
@@ -53,8 +53,12 @@ remove() {
   echo "Removing worktree at $dir..."
   git -C "$REPO_ROOT" worktree remove "$dir"
 
-  read -p "Delete branch $branch? [y/N] " -n 1 -r
-  echo
+  if [[ -t 0 ]]; then
+    read -p "Delete branch $branch? [y/N] " -n 1 -r
+    echo
+  else
+    REPLY="y"
+  fi
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     git -C "$REPO_ROOT" branch -d "$branch" 2>/dev/null || \
       git -C "$REPO_ROOT" branch -D "$branch"


### PR DESCRIPTION
## Summary

- `read -p` in `remove()` fails with exit code 1 when stdin is not a TTY (e.g., swarm agents calling `scripts/worktree remove`), causing the script to abort due to `set -euo pipefail`
- The worktree gets removed but the branch is never cleaned up, accumulating orphaned branches
- Fix: check `[[ -t 0 ]]` before prompting; auto-delete the branch when running non-interactively

## Test plan

- [ ] Manual: `scripts/worktree create test/foo && scripts/worktree remove test/foo` — interactive prompt should still appear
- [ ] Manual: `echo "" | scripts/worktree remove test/bar` — should auto-delete branch without prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
