### PR TITLE
Always create fresh branch in /mainline command

### DIFF
--- a/scripts/commands/mainline.md
+++ b/scripts/commands/mainline.md
@@ -13,14 +13,15 @@ git diff
 
 If there are no staged or unstaged changes, stop and tell the user there's nothing to mainline.
 
-### 2. Create a branch (if needed)
+### 2. Create a fresh branch
 
-If already on a non-main branch, skip this step and use the current branch.
-
-Otherwise, create a new branch from the changes:
+Always create a fresh branch from main so the PR only contains the uncommitted changes — never reuse an existing non-main branch, which could include unrelated commits.
 
 ```bash
+git stash --include-untracked
+git checkout main && git pull
 git checkout -b <user>/<slug-from-title>
+git stash pop
 ```
 
 ### 3. Stage and commit


### PR DESCRIPTION
## Summary

- When `/mainline` was run on an existing non-main branch, it reused that branch and included all prior commits in the PR, potentially shipping unrelated work to main
- Fix: always stash uncommitted changes, switch to main, create a fresh branch, then pop the stash — ensuring the PR only contains the intended uncommitted changes

## Test plan

- [ ] Run `/mainline` while on main with uncommitted changes — should work as before
- [ ] Run `/mainline` while on a feature branch with uncommitted changes — should stash, create fresh branch from main, and only include the uncommitted changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
