### PR TITLE
Persist onboarding progress across forced restarts

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -194,6 +194,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let onboarding = OnboardingWindow()
         onboarding.onComplete = { [weak self] state in
+            OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
 
@@ -210,6 +211,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func showOnboarding() {
         let onboarding = OnboardingWindow()
         onboarding.onComplete = { [weak self] state in
+            OnboardingState.clearPersistedState()
             UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
             UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")

--- a/clients/macos/vellum-assistant/UI/Onboarding/AccessibilityPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/AccessibilityPermissionStepView.swift
@@ -92,6 +92,13 @@ struct AccessibilityPermissionStepView: View {
                 }
                 return
             }
+            // Auto-advance if permission was already granted (e.g. after restart)
+            if PermissionManager.accessibilityStatus(prompt: false) == .granted {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    grantPermission()
+                }
+                return
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showContent = true

--- a/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/OnboardingState.swift
@@ -38,9 +38,39 @@ final class OnboardingState {
         !speechGranted || !accessibilityGranted || !screenGranted
     }
 
+    /// Restore onboarding progress from a previous session (e.g. after macOS
+    /// kills the app when toggling screen-recording permission).
+    init() {
+        let saved = UserDefaults.standard.integer(forKey: "onboarding.step")
+        if saved > 0 {
+            currentStep = saved
+            assistantName = UserDefaults.standard.string(forKey: "onboarding.name") ?? ""
+            if let raw = UserDefaults.standard.string(forKey: "onboarding.key"),
+               let key = ActivationKey(rawValue: raw) {
+                chosenKey = key
+            }
+            hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
+        }
+    }
+
     func advance() {
         withAnimation(.easeOut(duration: 0.8)) {
             currentStep += 1
+        }
+        persist()
+    }
+
+    /// Persist progress so we can resume after a forced restart.
+    private func persist() {
+        UserDefaults.standard.set(currentStep, forKey: "onboarding.step")
+        UserDefaults.standard.set(assistantName, forKey: "onboarding.name")
+        UserDefaults.standard.set(chosenKey.rawValue, forKey: "onboarding.key")
+        UserDefaults.standard.set(hasHatched, forKey: "onboarding.hatched")
+    }
+
+    static func clearPersistedState() {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched"] {
+            UserDefaults.standard.removeObject(forKey: key)
         }
     }
 }

--- a/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/ScreenPermissionStepView.swift
@@ -74,9 +74,17 @@ struct ScreenPermissionStepView: View {
                 }
                 return
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                withAnimation(.easeOut(duration: 0.5)) {
-                    showContent = true
+            // Auto-advance if permission was already granted (e.g. after restart)
+            Task {
+                let status = await PermissionManager.screenRecordingStatus()
+                if status == .granted {
+                    grantPermission()
+                    return
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        showContent = true
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/UI/Onboarding/SpeechPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/UI/Onboarding/SpeechPermissionStepView.swift
@@ -82,6 +82,13 @@ struct SpeechPermissionStepView: View {
                 }
                 return
             }
+            // Auto-advance if permission was already granted (e.g. after restart)
+            if SFSpeechRecognizer.authorizationStatus() == .authorized {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    grantPermission()
+                }
+                return
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showCard = true


### PR DESCRIPTION
The purpose of this PR is to fix onboarding getting bricked when macOS kills and restarts the app after toggling screen recording permission.

## Changes Made
- Persist onboarding step progress (`currentStep`, `assistantName`, `chosenKey`, `hasHatched`) to UserDefaults so state survives forced restarts
- Add auto-advance on appear for all three permission steps (speech, accessibility, screen recording) when permission is already granted
- Clear persisted onboarding state on completion in both `showOnboarding` and `replayOnboarding` flows

## Testing
- Built and verified compilation
- Manual testing: grant screen recording permission during onboarding, app restarts and resumes at the correct step

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
