### PR TITLE
Add vellum sessions clear command for dev database reset

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -13,6 +13,7 @@
         "openai": "^6.18.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.1.3",
+        "postgres": "^3.4.8",
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
         "web-tree-sitter": "0.26.5",
@@ -446,6 +447,8 @@
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -21,6 +21,7 @@
     "openai": "^6.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.1.3",
+    "postgres": "^3.4.8",
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",
     "web-tree-sitter": "0.26.5",

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -41,6 +41,7 @@ import {
   getConversation,
   getMessages,
   listConversations,
+  clearAll as clearAllConversations,
 } from './memory/conversation-store.js';
 import { initializeDb } from './memory/db.js';
 import { formatMarkdown, formatJson } from './export/formatter.js';
@@ -246,6 +247,77 @@ sessions
     } else {
       process.stdout.write(output);
     }
+  });
+
+sessions
+  .command('clear')
+  .description('Clear all chat messages from both the daemon DB and the web Postgres DB (dev only)')
+  .action(async () => {
+    // ── Resolve DATABASE_URL ──────────────────────────────────────────
+    let databaseUrl = process.env.DATABASE_URL;
+    if (!databaseUrl) {
+      const { resolve } = await import('node:path');
+      const envLocalPath = resolve(import.meta.dirname, '../../web/.env.local');
+      try {
+        const envContent = readFileSync(envLocalPath, 'utf-8');
+        const match = envContent.match(/^DATABASE_URL=(.+)$/m);
+        if (match) databaseUrl = match[1].trim();
+      } catch {
+        // .env.local not found — will warn below
+      }
+    }
+
+    // ── Safety: only allow localhost ──────────────────────────────────
+    let pgAvailable = false;
+    if (databaseUrl) {
+      const hostMatch = databaseUrl.match(/@([^:/]+)/);
+      const host = hostMatch?.[1] ?? '';
+      const allowedHosts = ['localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal'];
+      if (!allowedHosts.includes(host)) {
+        console.error(`Error: DATABASE_URL points to '${host}' — refusing to run.`);
+        console.error('This command is dev-only and will only run against localhost databases.');
+        process.exit(1);
+      }
+      pgAvailable = true;
+    } else {
+      console.log('Warning: DATABASE_URL not set — will only clear daemon DB.');
+    }
+
+    // ── Confirmation prompt ──────────────────────────────────────────
+    const parts: string[] = ['daemon SQLite database'];
+    if (pgAvailable) parts.push('web Postgres database');
+    console.log(`This will permanently delete all conversations and messages from: ${parts.join(', ')}.`);
+
+    const readline = await import('node:readline');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>((resolve) => {
+      rl.question('Are you sure? (y/N) ', resolve);
+    });
+    rl.close();
+    if (answer.toLowerCase() !== 'y') {
+      console.log('Cancelled');
+      return;
+    }
+
+    // ── Clear daemon SQLite ──────────────────────────────────────────
+    initializeDb();
+    const result = clearAllConversations();
+    console.log(`Daemon DB: cleared ${result.conversations} conversations, ${result.messages} messages`);
+
+    // ── Clear web Postgres ───────────────────────────────────────────
+    if (pgAvailable && databaseUrl) {
+      const postgres = (await import('postgres')).default;
+      const sql = postgres(databaseUrl, { max: 1 });
+      try {
+        const msgs = await sql`DELETE FROM chat_messages`;
+        const attachments = await sql`DELETE FROM chat_attachments`;
+        console.log(`Postgres: cleared ${msgs.count} messages, ${attachments.count} attachments`);
+      } finally {
+        await sql.end();
+      }
+    }
+
+    console.log('Done.');
   });
 
 // --- Config commands ---
@@ -783,7 +855,7 @@ program
   .action((shell: string) => {
     const subcommands: Record<string, string[]> = {
       daemon: ['start', 'stop', 'restart', 'status'],
-      sessions: ['list', 'new', 'export'],
+      sessions: ['list', 'new', 'export', 'clear'],
       config: ['set', 'get', 'list'],
       keys: ['list', 'set', 'delete'],
       trust: ['list', 'remove', 'clear'],

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -147,6 +147,36 @@ export function updateConversationContextWindow(
  * that share the same millisecond timestamp.
  * Returns the number of messages deleted.
  */
+/**
+ * Delete all conversations, messages, and related data (tool invocations,
+ * memory segments, etc.) from the daemon database.
+ * Returns { conversations, messages } counts.
+ */
+export function clearAll(): { conversations: number; messages: number } {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+
+  const msgCount = (raw.query('SELECT COUNT(*) AS c FROM messages').get() as { c: number }).c;
+  const convCount = (raw.query('SELECT COUNT(*) AS c FROM conversations').get() as { c: number }).c;
+
+  // Delete in dependency order. Cascades handle memory_segments,
+  // memory_item_sources, and tool_invocations, but we explicitly
+  // clear non-cascading memory tables too.
+  raw.exec('DELETE FROM memory_segment_fts');
+  raw.exec('DELETE FROM memory_item_sources');
+  raw.exec('DELETE FROM memory_segments');
+  raw.exec('DELETE FROM memory_items');
+  raw.exec('DELETE FROM memory_summaries');
+  raw.exec('DELETE FROM memory_embeddings');
+  raw.exec('DELETE FROM memory_jobs');
+  raw.exec('DELETE FROM memory_checkpoints');
+  raw.exec('DELETE FROM tool_invocations');
+  raw.exec('DELETE FROM messages');
+  raw.exec('DELETE FROM conversations');
+
+  return { conversations: convCount, messages: msgCount };
+}
+
 export function deleteLastExchange(conversationId: string): number {
   const db = getDb();
 


### PR DESCRIPTION
## Summary

- Adds `vellum sessions clear` subcommand that clears all chat messages from both the daemon's SQLite database and the web app's Postgres database
- **Safety**: refuses to run if `DATABASE_URL` points to a non-localhost host; prompts for interactive confirmation before deleting
- Loads `DATABASE_URL` from `web/.env.local` if not set in the environment
- Clears: conversations, messages, tool invocations, memory segments/items/summaries/embeddings/jobs/checkpoints (daemon), chat_messages, chat_attachments (web)

## Test plan

- [x] TypeScript compilation clean
- [x] Existing tests pass (conversation-store, server-history-render)
- [ ] Manual: `vellum sessions clear` with localhost DATABASE_URL — should clear both DBs
- [ ] Manual: `DATABASE_URL=postgresql://u:p@prod.example.com/db vellum sessions clear` — should refuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
