### PR TITLE
Add user count safeguard to sessions clear command

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -283,6 +283,22 @@ sessions
       console.log('Warning: DATABASE_URL not set — will only clear daemon DB.');
     }
 
+    // ── Safety: reject databases with many users ─────────────────────
+    if (pgAvailable && databaseUrl) {
+      const postgres = (await import('postgres')).default;
+      const checkSql = postgres(databaseUrl, { max: 1 });
+      try {
+        const [{ count: userCount }] = await checkSql`SELECT COUNT(*)::int AS count FROM "user"`;
+        if (userCount >= 10) {
+          console.error(`Error: database has ${userCount} users — this looks like a production database.`);
+          console.error('This command is dev-only and will only run against small dev databases.');
+          process.exit(1);
+        }
+      } finally {
+        await checkSql.end();
+      }
+    }
+
     // ── Confirmation prompt ──────────────────────────────────────────
     const parts: string[] = ['daemon SQLite database'];
     if (pgAvailable) parts.push('web Postgres database');


### PR DESCRIPTION
## Summary

- Adds an early check before `vellum sessions clear` proceeds: if the Postgres database has >= 10 users, the command errors out
- This prevents accidental use against production databases that happen to be on localhost (e.g., via SSH tunnel)

## Test plan

- [ ] Manual: `vellum sessions clear` on dev DB with < 10 users — should proceed normally
- [ ] Manual: DB with >= 10 users — should refuse with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
