### PR TITLE
Add IPC message types for user_message sessions

### DIFF
--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -124,6 +124,22 @@ struct AmbientObservationMessage: Encodable, Sendable {
     let timestamp: Double
 }
 
+/// Sent to create a new Q&A session.
+/// Wire type: `"session_create"`
+struct SessionCreateMessage: Encodable, Sendable {
+    let type: String = "session_create"
+    let title: String?
+}
+
+/// Sent to add a user message to an existing Q&A session.
+/// Wire type: `"user_message"`
+struct UserMessageMessage: Encodable, Sendable {
+    let type: String = "user_message"
+    let sessionId: String
+    let content: String
+    let attachments: [IPCAttachment]?
+}
+
 /// Keepalive ping.
 /// Wire type: `"ping"`
 struct PingMessage: Encodable, Sendable {
@@ -154,6 +170,29 @@ struct CuErrorMessage: Decodable, Sendable {
     let message: String
 }
 
+/// Streamed text delta from the assistant's response.
+struct AssistantTextDeltaMessage: Decodable, Sendable {
+    let sessionId: String
+    let text: String
+}
+
+/// Streamed thinking delta from the assistant's reasoning.
+struct AssistantThinkingDeltaMessage: Decodable, Sendable {
+    let sessionId: String
+    let thinking: String
+}
+
+/// Signals that the assistant's message is complete.
+struct MessageCompleteMessage: Decodable, Sendable {
+    let sessionId: String
+}
+
+/// Session metadata from the server (e.g. generated title).
+struct SessionInfoMessage: Decodable, Sendable {
+    let sessionId: String
+    let title: String
+}
+
 /// Result from ambient observation analysis.
 struct AmbientResultMessage: Decodable, Sendable {
     let decision: String
@@ -167,6 +206,10 @@ enum ServerMessage: Decodable, Sendable {
     case cuAction(CuActionMessage)
     case cuComplete(CuCompleteMessage)
     case cuError(CuErrorMessage)
+    case assistantTextDelta(AssistantTextDeltaMessage)
+    case assistantThinkingDelta(AssistantThinkingDeltaMessage)
+    case messageComplete(MessageCompleteMessage)
+    case sessionInfo(SessionInfoMessage)
     case ambientResult(AmbientResultMessage)
     case pong
     case unknown(String)
@@ -189,6 +232,18 @@ enum ServerMessage: Decodable, Sendable {
         case "cu_error":
             let message = try CuErrorMessage(from: decoder)
             self = .cuError(message)
+        case "assistant_text_delta":
+            let message = try AssistantTextDeltaMessage(from: decoder)
+            self = .assistantTextDelta(message)
+        case "assistant_thinking_delta":
+            let message = try AssistantThinkingDeltaMessage(from: decoder)
+            self = .assistantThinkingDelta(message)
+        case "message_complete":
+            let message = try MessageCompleteMessage(from: decoder)
+            self = .messageComplete(message)
+        case "session_info":
+            let message = try SessionInfoMessage(from: decoder)
+            self = .sessionInfo(message)
         case "ambient_result":
             let message = try AmbientResultMessage(from: decoder)
             self = .ambientResult(message)


### PR DESCRIPTION
Closes #521

## Summary
- Add server-to-client message types (`assistant_text_delta`, `assistant_thinking_delta`, `message_complete`, `session_info`) for streaming Q&A responses from the daemon
- Add client-to-server messages (`session_create`, `user_message`) for initiating and continuing Q&A sessions
- Extend `ServerMessage` enum with new cases and decoder logic for all four new wire types

## Test plan
- [x] Swift project builds successfully (`swift build`)
- [ ] Integration test with daemon sending `assistant_text_delta`, `assistant_thinking_delta`, `message_complete`, and `session_info` messages
- [ ] Verify `SessionCreateMessage` and `UserMessageMessage` encode correctly over IPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
