### PR TITLE
Differentiate cu_respond from cu_done in session overlay

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -12,6 +12,7 @@ enum SessionState: Equatable {
     case paused(step: Int, maxSteps: Int)
     case awaitingConfirmation(reason: String)
     case completed(summary: String, steps: Int)
+    case responded(answer: String, steps: Int)
     case failed(reason: String)
     case cancelled
 }
@@ -39,6 +40,7 @@ final class ComputerUseSession: ObservableObject {
     private let verifier: ActionVerifier
     private let logger: SessionLogger
     private let initialDelayMs: UInt64
+    private var pendingResponseAnswer: String?
     private var didChromeAccessibilityCheck = false
     private var previousAXTreeText: String?
     private var previousElements: [AXElement]?
@@ -81,6 +83,7 @@ final class ComputerUseSession: ObservableObject {
         verifier.reset()
         isCancelled = false
         isPaused = false
+        pendingResponseAnswer = nil
         previousAXTreeText = nil
         previousElements = nil
         previousFlatElements = nil
@@ -150,7 +153,12 @@ final class ComputerUseSession: ObservableObject {
                     if self.isCancelled { return }
 
                 case .cuComplete(let complete) where complete.sessionId == self.id:
-                    self.state = .completed(summary: complete.summary, steps: complete.stepCount)
+                    if let answer = self.pendingResponseAnswer {
+                        self.state = .responded(answer: answer, steps: complete.stepCount)
+                        self.pendingResponseAnswer = nil
+                    } else {
+                        self.state = .completed(summary: complete.summary, steps: complete.stepCount)
+                    }
                     self.logger.finishSession(result: "completed: \(complete.summary)")
                     return
 
@@ -169,7 +177,7 @@ final class ComputerUseSession: ObservableObject {
 
         // Stream ended or cancelled — ensure terminal state is set
         switch state {
-        case .completed, .failed, .cancelled:
+        case .completed, .responded, .failed, .cancelled:
             break // already in terminal state
         default:
             if isCancelled {
@@ -208,7 +216,12 @@ final class ComputerUseSession: ObservableObject {
         log.info("[\(action.stepNumber)] Daemon action: \(agentAction.displayDescription) — reasoning: \(action.reasoning ?? "")")
 
         // Handle done/respond completion actions — don't execute, wait for cu_complete
-        if agentAction.type == .done || agentAction.type == .respond {
+        if agentAction.type == .done {
+            return
+        }
+        if agentAction.type == .respond {
+            pendingResponseAnswer = action.input["answer"]?.value as? String
+                ?? action.input["text"]?.value as? String
             return
         }
 

--- a/clients/macos/vellum-assistant/UI/SessionOverlayView.swift
+++ b/clients/macos/vellum-assistant/UI/SessionOverlayView.swift
@@ -129,6 +129,24 @@ struct SessionOverlayView: View {
                 }
             }
 
+        case .responded(let answer, _):
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "text.bubble.fill")
+                        .foregroundStyle(.blue)
+                    Text("Response")
+                        .font(.caption.bold())
+                }
+                ScrollView {
+                    Text(answer)
+                        .font(.caption)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 200)
+            }
+            .frame(width: 380)
+
         case .failed(let reason):
             HStack(spacing: 6) {
                 Image(systemName: "xmark.circle.fill")
@@ -184,7 +202,7 @@ struct SessionOverlayView: View {
                 .controlSize(.small)
             }
 
-        case .completed, .failed, .cancelled:
+        case .completed, .failed, .cancelled, .responded:
             HStack(spacing: 8) {
                 undoButton
                 Spacer()


### PR DESCRIPTION
Closes #525

## Summary
- Add new `SessionState.responded(answer:steps:)` case to differentiate when the model uses `cu_respond` (answering a question) vs `cu_done` (completing a task)
- Capture the response answer from the `cu_respond` action input and use it to set the `.responded` state when `cu_complete` arrives
- Show a distinct blue text-bubble UI with selectable, scrollable answer text instead of the generic green-checkmark completion state

## Test plan
- [ ] Trigger a CU session that ends with `cu_respond` (e.g., ask a question about what's on screen) and verify the blue "Response" bubble appears with the answer text
- [ ] Trigger a CU session that ends with `cu_done` and verify the existing green checkmark completion UI still appears
- [ ] Verify the response text is selectable and scrollable for long answers
- [ ] Verify the undo button still appears in the responded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
