### PR TITLE
Add TextSession class for Q&A interactions

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -1,0 +1,128 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "TextSession")
+
+enum TextSessionState: Equatable {
+    case idle
+    case thinking
+    case streaming(text: String)
+    case completed(text: String)
+    case failed(reason: String)
+    case cancelled
+}
+
+@MainActor
+final class TextSession: ObservableObject {
+    @Published var state: TextSessionState = .idle
+    let task: String
+    let id: String
+
+    private let attachments: [TaskAttachment]
+    private let daemonClient: DaemonClientProtocol
+    private var isCancelled = false
+    private var messageLoopTask: Task<Void, Never>?
+    private var daemonSessionId: String?
+    private var accumulatedText: String = ""
+
+    init(
+        task: String,
+        daemonClient: DaemonClientProtocol,
+        attachments: [TaskAttachment] = []
+    ) {
+        self.id = UUID().uuidString
+        self.task = task
+        self.attachments = attachments
+        self.daemonClient = daemonClient
+    }
+
+    func run() async {
+        isCancelled = false
+        accumulatedText = ""
+        daemonSessionId = nil
+        state = .thinking
+
+        log.info("TextSession starting — task: \(self.task, privacy: .public)")
+
+        // 1. Subscribe before sending
+        let messageStream = daemonClient.subscribe()
+
+        // 2. Send session_create
+        try? daemonClient.send(SessionCreateMessage(title: task))
+
+        // 3. Listen for messages
+        let loopTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            for await message in messageStream {
+                guard !self.isCancelled else { break }
+
+                switch message {
+                case .sessionInfo(let info):
+                    // Accept first session_info as ours (daemon assigns session ID)
+                    if self.daemonSessionId == nil {
+                        self.daemonSessionId = info.sessionId
+                        log.info("Got daemon session ID: \(info.sessionId)")
+
+                        // Now send the user message
+                        let ipcAttachments: [IPCAttachment]? = self.attachments.isEmpty ? nil : self.attachments.map {
+                            IPCAttachment(
+                                filename: $0.fileName,
+                                mimeType: $0.mimeType,
+                                data: $0.data.base64EncodedString(),
+                                extractedText: $0.extractedText
+                            )
+                        }
+                        try? self.daemonClient.send(UserMessageMessage(
+                            sessionId: info.sessionId,
+                            content: self.task,
+                            attachments: ipcAttachments
+                        ))
+                    }
+
+                case .assistantTextDelta(let delta) where delta.sessionId == self.daemonSessionId:
+                    self.accumulatedText += delta.text
+                    self.state = .streaming(text: self.accumulatedText)
+
+                case .assistantThinkingDelta(let delta) where delta.sessionId == self.daemonSessionId:
+                    // Stay in thinking state while receiving thinking deltas
+                    log.debug("Thinking: \(delta.thinking)")
+
+                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId:
+                    if self.accumulatedText.isEmpty {
+                        self.state = .completed(text: "(No response)")
+                    } else {
+                        self.state = .completed(text: self.accumulatedText)
+                    }
+                    return
+
+                case .cuError(let error) where error.sessionId == self.daemonSessionId:
+                    self.state = .failed(reason: error.message)
+                    return
+
+                default:
+                    break
+                }
+            }
+        }
+        messageLoopTask = loopTask
+        await loopTask.value
+
+        // Stream ended or cancelled — ensure terminal state
+        switch state {
+        case .completed, .failed, .cancelled:
+            break
+        default:
+            if isCancelled {
+                state = .cancelled
+            } else {
+                state = .failed(reason: "Connection to daemon lost")
+            }
+        }
+    }
+
+    func cancel() {
+        isCancelled = true
+        messageLoopTask?.cancel()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds new `TextSession` class in `clients/macos/vellum-assistant/ComputerUse/TextSession.swift` that mirrors `ComputerUseSession` but for streamed text Q&A responses
- Uses `session_create` and `user_message` IPC messages (added in #521) to communicate with the daemon
- Handles `assistant_text_delta`, `assistant_thinking_delta`, `message_complete`, and `cu_error` server messages with proper state transitions
- Supports `TextSessionState` enum with idle, thinking, streaming, completed, failed, and cancelled states

Closes #522

## Test plan
- [x] Builds successfully with `swift build` (type-checked against all existing types)
- [ ] Manual test: create a TextSession and verify streaming text arrives correctly
- [ ] Verify cancellation terminates the message loop cleanly
- [ ] Verify daemon disconnect transitions to failed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
