### PR TITLE
Add TextResponseView and TextResponseWindow for Q&A UI

### DIFF
--- a/clients/macos/vellum-assistant/UI/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/UI/TextResponseView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct TextResponseView: View {
+    @ObservedObject var session: TextSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header
+            HStack(spacing: 6) {
+                Image(systemName: "text.bubble.fill")
+                    .foregroundStyle(.blue)
+                Text("vellum-assistant")
+                    .font(.headline)
+                    .lineLimit(1)
+            }
+
+            // Task text
+            Text(session.task)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            Divider()
+
+            // State-dependent content
+            stateContent
+
+            // Controls
+            controlButtons
+        }
+        .padding(14)
+        .frame(width: 400, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch session.state {
+        case .idle:
+            Text("Initializing...")
+                .foregroundStyle(.secondary)
+
+        case .thinking:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Thinking...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .streaming(let text):
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Text(text)
+                        .font(.system(.caption, design: .default))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .id("streamingText")
+                }
+                .frame(maxHeight: 300)
+                .onChange(of: text) {
+                    proxy.scrollTo("streamingText", anchor: .bottom)
+                }
+            }
+
+        case .completed(let text):
+            ScrollView {
+                Text(text)
+                    .font(.system(.caption, design: .default))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: 300)
+
+        case .failed(let reason):
+            HStack(spacing: 6) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+
+        case .cancelled:
+            Text("Cancelled")
+                .font(.caption.bold())
+                .foregroundStyle(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private var controlButtons: some View {
+        switch session.state {
+        case .thinking, .streaming:
+            HStack {
+                Spacer()
+                Button("Stop") {
+                    session.cancel()
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .controlSize(.small)
+            }
+
+        case .completed(let text):
+            HStack {
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                Spacer()
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/UI/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/UI/TextResponseWindow.swift
@@ -1,0 +1,67 @@
+import AppKit
+import Combine
+import SwiftUI
+
+@MainActor
+final class TextResponseWindow {
+    private var panel: NSPanel?
+    private let session: TextSession
+    private var stateCancellable: AnyCancellable?
+
+    init(session: TextSession) {
+        self.session = session
+    }
+
+    func show() {
+        let view = TextResponseView(session: session)
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.9
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Size window to fit SwiftUI content and resize on every state change
+        sizeAndPosition(panel)
+        stateCancellable = session.$state
+            .sink { [weak self, weak panel] _ in
+                guard let self, let panel else { return }
+                self.sizeAndPosition(panel)
+            }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        stateCancellable?.cancel()
+        stateCancellable = nil
+        panel?.close()
+        panel = nil
+    }
+
+    private func sizeAndPosition(_ panel: NSPanel) {
+        if let fittingSize = panel.contentView?.fittingSize {
+            panel.setContentSize(fittingSize)
+        }
+        // Pin to bottom-right of screen
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let panelFrame = panel.frame
+            let x = screenFrame.maxX - panelFrame.width - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+    }
+}


### PR DESCRIPTION
Closes #523

## Summary
- Add `TextResponseView` SwiftUI view that observes a `TextSession` and renders state-dependent content: idle, thinking spinner, live-streaming text with auto-scroll, completed text with copy button, error, and cancellation states
- Add `TextResponseWindow` NSPanel wrapper that hosts the view in a floating HUD-style panel pinned to the bottom-right of the screen, mirroring the existing `SessionOverlayWindow` pattern
- Both files follow existing codebase conventions (macOS 14+ `onChange`, `.nonactivatingPanel` style, `sizeAndPosition` on state change)

## Test plan
- [ ] Build succeeds (`swift build` passes with no errors)
- [ ] Launch app with a Q&A task and verify the TextResponseWindow appears
- [ ] Verify streaming text auto-scrolls to bottom
- [ ] Verify completed state shows copy button that copies to clipboard
- [ ] Verify stop button cancels an in-progress session
- [ ] Verify error state renders with red icon and reason text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
