### PR TITLE
Add error handling for missing user table in sessions clear

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -294,6 +294,9 @@ sessions
           console.error('This command is dev-only and will only run against small dev databases.');
           process.exit(1);
         }
+      } catch (err: unknown) {
+        const isUndefinedTable = err instanceof Error && err.message.includes('does not exist');
+        if (!isUndefinedTable) throw err;
       } finally {
         await checkSql.end();
       }


### PR DESCRIPTION
Closes #534

Wraps the user-count safeguard query in a try/catch so that if the `user` table doesn't exist (e.g. migrations not run), the command proceeds instead of crashing. A missing table clearly indicates this isn't a production database. Other errors are re-thrown.

## Changes
- `assistant/src/index.ts`: Added `catch` clause between the existing `try`/`finally` blocks in the `sessions clear` command's user-count safeguard

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Run `vellum sessions clear` against a database without the `user` table — should proceed without crashing
- [ ] Run `vellum sessions clear` against a database with the `user` table — existing behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
