### PR TITLE
Handle .responded state in RecipeExecutor

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -119,6 +119,16 @@ final class RecipeExecutor {
             ))
             return RecipeResult(success: true, credentials: credentials, error: nil)
 
+        case .responded(let answer, let steps):
+            log.info("Recipe '\(recipeName)' responded in \(steps) steps: \(answer)")
+            let credentials = extractCredentials(from: answer)
+            onProgress(RecipeProgress(
+                currentStep: recipe.totalSteps,
+                totalSteps: recipe.totalSteps,
+                description: "Done!"
+            ))
+            return RecipeResult(success: true, credentials: credentials, error: nil)
+
         case .failed(let reason):
             log.error("Recipe '\(recipeName)' failed: \(reason)")
             return RecipeResult(success: false, credentials: [:], error: reason)


### PR DESCRIPTION
Closes #532

## Summary
- Adds a `case .responded(let answer, let steps)` to the switch on `session.state` in `RecipeExecutor.execute`, modeled after the existing `.completed` case
- Recipe sessions that end with a `cu_respond` action are now correctly reported as successful (`RecipeResult(success: true, ...)`) instead of falling through to the default "Unexpected session state" failure
- Credential extraction is performed on the `answer` string, same as it is on `summary` for completed sessions

## Test plan
- [ ] Verify the project builds cleanly (`swift build`)
- [ ] Confirm that a recipe session ending in `.responded` returns a successful `RecipeResult`
- [ ] Confirm that credentials are correctly extracted from the response answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
