### PR TITLE
Remove required sessionId from IPC stream message types

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -80,15 +80,15 @@ final class TextSession: ObservableObject {
                         ))
                     }
 
-                case .assistantTextDelta(let delta) where delta.sessionId == self.daemonSessionId:
+                case .assistantTextDelta(let delta) where self.daemonSessionId != nil:
                     self.accumulatedText += delta.text
                     self.state = .streaming(text: self.accumulatedText)
 
-                case .assistantThinkingDelta(let delta) where delta.sessionId == self.daemonSessionId:
+                case .assistantThinkingDelta(let delta) where self.daemonSessionId != nil:
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId:
+                case .messageComplete(_) where self.daemonSessionId != nil:
                     if self.accumulatedText.isEmpty {
                         self.state = .completed(text: "(No response)")
                     } else {

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -172,19 +172,16 @@ struct CuErrorMessage: Decodable, Sendable {
 
 /// Streamed text delta from the assistant's response.
 struct AssistantTextDeltaMessage: Decodable, Sendable {
-    let sessionId: String
     let text: String
 }
 
 /// Streamed thinking delta from the assistant's reasoning.
 struct AssistantThinkingDeltaMessage: Decodable, Sendable {
-    let sessionId: String
     let thinking: String
 }
 
 /// Signals that the assistant's message is complete.
 struct MessageCompleteMessage: Decodable, Sendable {
-    let sessionId: String
 }
 
 /// Session metadata from the server (e.g. generated title).


### PR DESCRIPTION
Closes #531

## Summary
- Removed the required `sessionId` field from `AssistantTextDeltaMessage`, `AssistantThinkingDeltaMessage`, and `MessageCompleteMessage` in `IPCMessages.swift`
- Updated `TextSession.swift` where-clause filters to guard on `daemonSessionId != nil` instead of comparing against the removed field
- The daemon never sends `sessionId` on these wire types, so `JSONDecoder` was throwing `keyNotFound` for every message, silently breaking Q&A streaming

## Test plan
- [ ] Verify Q&A sessions now receive streamed text, thinking deltas, and message_complete events
- [ ] Verify computer-use sessions are unaffected (their message types still have sessionId)
- [ ] Swift build succeeds: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
