### PR TITLE
Fix DATABASE_URL parsing in sessions clear command

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -261,7 +261,7 @@ sessions
       try {
         const envContent = readFileSync(envLocalPath, 'utf-8');
         const match = envContent.match(/^DATABASE_URL=(.+)$/m);
-        if (match) databaseUrl = match[1].trim();
+        if (match) databaseUrl = match[1].trim().replace(/^['"]|['"]$/g, '');
       } catch {
         // .env.local not found — will warn below
       }
@@ -270,8 +270,7 @@ sessions
     // ── Safety: only allow localhost ──────────────────────────────────
     let pgAvailable = false;
     if (databaseUrl) {
-      const hostMatch = databaseUrl.match(/@([^:/]+)/);
-      const host = hostMatch?.[1] ?? '';
+      const host = new URL(databaseUrl).hostname;
       const allowedHosts = ['localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal'];
       if (!allowedHosts.includes(host)) {
         console.error(`Error: DATABASE_URL points to '${host}' — refusing to run.`);


### PR DESCRIPTION
Closes #535

Fixes three bugs in DATABASE_URL parsing for the `sessions clear` command:

1. **Strip surrounding quotes from .env.local values** — the regex `^DATABASE_URL=(.+)$` captures surrounding quotes (single or double) from `.env.local`, but `.trim()` only removes whitespace, causing the Postgres connection to fail with a malformed URL. Added `.replace(/^['"]|['"]$/g, '')` after `.trim()`.

2. **Use URL API for host extraction instead of regex** — the old regex `/@([^:/]+)/` matched the first `@`, but RFC 3986 says the last `@` separates userinfo from host. A password containing `@` could bypass the safety check.

3. **URLs without credentials now work correctly** — URLs like `postgresql://localhost:5432/vellum` (no `user:pass@`) don't contain `@`, so the old regex returned no match, `host` was empty, and the command would exit. `new URL(databaseUrl).hostname` handles all URL formats correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
