### PR TITLE
Handle existing branch name in /mainline command

### DIFF
--- a/scripts/commands/mainline.md
+++ b/scripts/commands/mainline.md
@@ -20,7 +20,7 @@ Always create a fresh branch from main so the PR only contains the uncommitted c
 ```bash
 git stash --include-untracked
 git checkout main && git pull
-git checkout -b <user>/<slug-from-title>
+git checkout -B <user>/<slug-from-title>
 git stash pop
 ```
 


### PR DESCRIPTION
Closes #537

Uses `git checkout -B` instead of `-b` so that if the branch name already exists locally, it resets it to the current HEAD instead of failing. Prevents stash loss when the same PR title slug is used across attempts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
