### PR TITLE
Fix cu_respond never triggering .responded state

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -185,6 +185,7 @@ export class ComputerUseSession {
           sessionId: this.sessionId,
           summary,
           stepCount: this.stepCount,
+          isResponse: toolName === 'cu_respond' ? true : undefined,
         });
         this.state = 'complete';
         return { content: 'Session complete', isError: false };

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -301,6 +301,7 @@ export interface CuComplete {
   sessionId: string;
   summary: string;
   stepCount: number;
+  isResponse?: boolean;
 }
 
 export interface CuError {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -40,7 +40,6 @@ final class ComputerUseSession: ObservableObject {
     private let verifier: ActionVerifier
     private let logger: SessionLogger
     private let initialDelayMs: UInt64
-    private var pendingResponseAnswer: String?
     private var didChromeAccessibilityCheck = false
     private var previousAXTreeText: String?
     private var previousElements: [AXElement]?
@@ -83,7 +82,6 @@ final class ComputerUseSession: ObservableObject {
         verifier.reset()
         isCancelled = false
         isPaused = false
-        pendingResponseAnswer = nil
         previousAXTreeText = nil
         previousElements = nil
         previousFlatElements = nil
@@ -153,9 +151,8 @@ final class ComputerUseSession: ObservableObject {
                     if self.isCancelled { return }
 
                 case .cuComplete(let complete) where complete.sessionId == self.id:
-                    if let answer = self.pendingResponseAnswer {
-                        self.state = .responded(answer: answer, steps: complete.stepCount)
-                        self.pendingResponseAnswer = nil
+                    if complete.isResponse == true {
+                        self.state = .responded(answer: complete.summary, steps: complete.stepCount)
                     } else {
                         self.state = .completed(summary: complete.summary, steps: complete.stepCount)
                     }
@@ -216,12 +213,7 @@ final class ComputerUseSession: ObservableObject {
         log.info("[\(action.stepNumber)] Daemon action: \(agentAction.displayDescription) — reasoning: \(action.reasoning ?? "")")
 
         // Handle done/respond completion actions — don't execute, wait for cu_complete
-        if agentAction.type == .done {
-            return
-        }
-        if agentAction.type == .respond {
-            pendingResponseAnswer = action.input["answer"]?.value as? String
-                ?? action.input["text"]?.value as? String
+        if agentAction.type == .done || agentAction.type == .respond {
             return
         }
 

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -162,6 +162,7 @@ struct CuCompleteMessage: Decodable, Sendable {
     let sessionId: String
     let summary: String
     let stepCount: Int
+    let isResponse: Bool?
 }
 
 /// Session-level error from the server.


### PR DESCRIPTION
Closes #533

## Summary
- Added `isResponse?: boolean` to the `CuComplete` IPC message interface so the Swift client can distinguish `cu_respond` completions from `cu_done` completions
- Set `isResponse: true` in the daemon's `cu_complete` message when the terminal tool is `cu_respond`
- Updated the Swift `.cuComplete` handler to check `complete.isResponse == true` instead of relying on `pendingResponseAnswer`
- Removed the broken `pendingResponseAnswer` property and all its usages, since `handleAction` was never called for terminal tools (they return early before `cu_action` is sent)

## Test plan
- [ ] Trigger a computer-use session that ends with `cu_respond` and verify the `.responded` overlay appears
- [ ] Trigger a computer-use session that ends with `cu_done` and verify the `.completed` overlay still appears
- [ ] Verify both Swift and TypeScript type-check cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
