### PR TITLE
Fix undo with tool_result messages leaving orphaned DB rows

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -29,7 +29,15 @@ import {
   addMessage,
   getMessages,
   deleteLastExchange,
+  isLastUserMessageToolResult,
 } from '../memory/conversation-store.js';
+
+// Initialize db once before all tests
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
 
 describe('deleteLastExchange', () => {
   beforeEach(() => {
@@ -37,13 +45,6 @@ describe('deleteLastExchange', () => {
     const db = getDb();
     db.run(`DELETE FROM messages`);
     db.run(`DELETE FROM conversations`);
-  });
-
-  // Initialize db once before all tests
-  initializeDb();
-
-  afterAll(() => {
-    try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
   });
 
   test('deletes last user message and subsequent assistant messages', () => {
@@ -105,5 +106,107 @@ describe('deleteLastExchange', () => {
     expect(remaining).toHaveLength(2);
     expect(remaining[0].content).toBe('first');
     expect(remaining[1].content).toBe('reply1');
+  });
+});
+
+describe('isLastUserMessageToolResult', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test('returns true when last user message is tool_result only', () => {
+    const conv = createConversation('test');
+    addMessage(conv.id, 'user', 'hello');
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'tool_use', id: 'tu1', name: 'bash', input: {} }]));
+    addMessage(conv.id, 'user', JSON.stringify([{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }]));
+
+    expect(isLastUserMessageToolResult(conv.id)).toBe(true);
+  });
+
+  test('returns false when last user message is plain text', () => {
+    const conv = createConversation('test');
+    addMessage(conv.id, 'user', 'hello');
+
+    expect(isLastUserMessageToolResult(conv.id)).toBe(false);
+  });
+
+  test('returns false when no user messages exist', () => {
+    const conv = createConversation('test');
+    expect(isLastUserMessageToolResult(conv.id)).toBe(false);
+  });
+
+  test('returns false when last user message has mixed content types', () => {
+    const conv = createConversation('test');
+    addMessage(conv.id, 'user', JSON.stringify([
+      { type: 'text', text: 'hello' },
+      { type: 'tool_result', tool_use_id: 'tu1', content: 'ok' },
+    ]));
+
+    expect(isLastUserMessageToolResult(conv.id)).toBe(false);
+  });
+});
+
+describe('deleteLastExchange with tool_result messages', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test('looping deleteLastExchange cleans up tool_result user messages', () => {
+    const conv = createConversation('test');
+    // Simulate: user asks question -> assistant uses tool -> tool_result -> assistant responds
+    addMessage(conv.id, 'user', 'What files are in /tmp?');
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'tool_use', id: 'tu1', name: 'bash', input: { command: 'ls /tmp' } }]));
+    addMessage(conv.id, 'user', JSON.stringify([{ type: 'tool_result', tool_use_id: 'tu1', content: 'file1.txt' }]));
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'text', text: 'There is file1.txt in /tmp' }]));
+
+    // First deleteLastExchange removes the tool_result user msg + final assistant msg
+    let deleted = deleteLastExchange(conv.id);
+    expect(deleted).toBe(2);
+
+    // After deleting the tool_result user + assistant, the remaining are:
+    // user: "What files are in /tmp?" and assistant: tool_use
+    let remaining = getMessages(conv.id);
+    expect(remaining).toHaveLength(2);
+
+    // The last user message is the real one, so isLastUserMessageToolResult should be false
+    expect(isLastUserMessageToolResult(conv.id)).toBe(false);
+
+    // Now delete again to remove the real user message + tool_use assistant
+    deleted = deleteLastExchange(conv.id);
+    expect(deleted).toBe(2);
+
+    remaining = getMessages(conv.id);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test('looping pattern handles multiple tool uses in sequence', () => {
+    const conv = createConversation('test');
+    // user -> assistant(tool_use) -> user(tool_result) -> assistant(tool_use) -> user(tool_result) -> assistant(text)
+    addMessage(conv.id, 'user', 'Do two things');
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'tool_use', id: 'tu1', name: 'bash', input: {} }]));
+    addMessage(conv.id, 'user', JSON.stringify([{ type: 'tool_result', tool_use_id: 'tu1', content: 'result1' }]));
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'tool_use', id: 'tu2', name: 'bash', input: {} }]));
+    addMessage(conv.id, 'user', JSON.stringify([{ type: 'tool_result', tool_use_id: 'tu2', content: 'result2' }]));
+    addMessage(conv.id, 'assistant', JSON.stringify([{ type: 'text', text: 'Done both' }]));
+
+    // First delete: removes last tool_result user (row 5) + final assistant (row 6)
+    deleteLastExchange(conv.id);
+    // Last user is now row 3 (tool_result tu1)
+    expect(isLastUserMessageToolResult(conv.id)).toBe(true);
+
+    // Second delete: removes tool_result user (row 3) + assistant tool_use (row 4)
+    deleteLastExchange(conv.id);
+    // Last user is now row 1 (real user message)
+    expect(isLastUserMessageToolResult(conv.id)).toBe(false);
+
+    // Final delete removes the real user message + assistant tool_use
+    deleteLastExchange(conv.id);
+
+    const remaining = getMessages(conv.id);
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -415,7 +415,18 @@ export class Session {
     const removed = this.messages.length - lastUserIdx;
     this.messages = this.messages.slice(0, lastUserIdx);
 
-    // Also remove from DB
+    // Also remove from DB. We may need to call deleteLastExchange multiple
+    // times because the DB stores tool_result user messages as separate rows.
+    // The in-memory findLastUndoableUserMessageIndex skips these, but the DB's
+    // deleteLastExchange only finds the last role='user' row — which may be a
+    // tool_result message, leaving the real user message orphaned.
+    //
+    // Strategy: first peel back any tool_result user messages, then delete
+    // the real user message exchange. This ensures the DB cleanup matches
+    // the in-memory cleanup.
+    while (conversationStore.isLastUserMessageToolResult(this.conversationId)) {
+      conversationStore.deleteLastExchange(this.conversationId);
+    }
     conversationStore.deleteLastExchange(this.conversationId);
 
     return removed;

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -177,6 +177,34 @@ export function clearAll(): { conversations: number; messages: number } {
   return { conversations: convCount, messages: msgCount };
 }
 
+/**
+ * Check whether the last user message in a conversation is a tool_result-only
+ * message (i.e., not a real user-typed message). This is used by undo() to
+ * determine if additional exchanges need to be deleted from the DB.
+ */
+export function isLastUserMessageToolResult(conversationId: string): boolean {
+  const db = getDb();
+  const lastUserMsg = db
+    .select({ content: messages.content })
+    .from(messages)
+    .where(and(eq(messages.conversationId, conversationId), eq(messages.role, 'user')))
+    .orderBy(sql`rowid DESC`)
+    .limit(1)
+    .get();
+
+  if (!lastUserMsg) return false;
+
+  try {
+    const parsed = JSON.parse(lastUserMsg.content);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((block: Record<string, unknown>) => block.type === 'tool_result')) {
+      return true;
+    }
+  } catch {
+    // Not JSON — it's a plain text user message
+  }
+  return false;
+}
+
 export function deleteLastExchange(conversationId: string): number {
   const db = getDb();
 


### PR DESCRIPTION
## Summary
- Fixes `Session.undo()` leaving orphaned DB rows when undoing conversations that involved tool use
- The in-memory cleanup correctly skips `tool_result` user messages to find and remove the original user-typed message, but the DB's `deleteLastExchange` only found the last `role='user'` row (a `tool_result` message), leaving the real user message and its tool-use assistant response orphaned
- After daemon restart, `loadFromDb` would reload those orphaned messages producing a corrupted conversation state
- Added `isLastUserMessageToolResult()` helper to `conversation-store.ts` that inspects the DB's last user message content
- Modified `undo()` to loop `deleteLastExchange`, peeling back `tool_result` user messages before deleting the real user message exchange

Closes #536

## Test plan
- [x] Added tests for `isLastUserMessageToolResult` (4 cases: tool_result-only, plain text, no messages, mixed content)
- [x] Added tests for the looping delete pattern with single and multiple tool uses
- [x] All 10 tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
