### PR TITLE
Use hadPreviousAXTree flag in buildMessages

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -113,7 +113,7 @@ export class ComputerUseSession {
     this.state = 'inferring';
     this.abortController = new AbortController();
 
-    const messages = this.buildMessages(obs);
+    const messages = this.buildMessages(obs, hadPreviousAXTree);
     this.loopPromise = this.runAgentLoop(messages);
 
     // Await the loop; errors are caught inside runAgentLoop
@@ -344,7 +344,7 @@ export class ComputerUseSession {
   // Message building (replicates AnthropicProvider.buildMessages from Swift)
   // ---------------------------------------------------------------------------
 
-  private buildMessages(obs: CuObservation): Message[] {
+  private buildMessages(obs: CuObservation, hadPreviousAXTree: boolean): Message[] {
     const contentBlocks: ContentBlock[] = [];
 
     // Screenshot image block
@@ -373,7 +373,7 @@ export class ComputerUseSession {
     if (obs.axDiff && this.actionHistory.length > 0) {
       textParts.push(obs.axDiff);
       textParts.push('');
-    } else if (this.previousAXTree != null && obs.axTree != null && this.actionHistory.length > 0) {
+    } else if (hadPreviousAXTree && obs.axTree != null && this.actionHistory.length > 0) {
       // AX tree unchanged — tell the model its action had no effect
       const lastAction = this.actionHistory[this.actionHistory.length - 1];
       const wasWait = lastAction?.toolName === 'cu_wait';


### PR DESCRIPTION
Closes #507

## What changed

In `computer-use-session.ts`, `handleObservation` updates `this.previousAXTree` (line 96) *before* calling `buildMessages` (line 116). The `buildMessages` method was checking `this.previousAXTree != null` to decide whether to show an unchanged-UI warning, but this always reflected the post-update state rather than whether a previous AX tree existed before the current observation.

This fix passes the `hadPreviousAXTree` boolean (computed before the update on line 85) into `buildMessages` as a parameter, matching the pattern already used by `buildObservationResultContent`. This makes the code robust against future reuse of `buildMessages` for subsequent observations.

## Changes

- Added `hadPreviousAXTree: boolean` parameter to `buildMessages`
- Pass `hadPreviousAXTree` from `handleObservation` call site
- Use `hadPreviousAXTree` instead of `this.previousAXTree != null` in the unchanged-UI guard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
