### PR TITLE
Respect piped responses in worktree remove

### DIFF
--- a/scripts/worktree
+++ b/scripts/worktree
@@ -8,13 +8,18 @@ usage() {
   echo "Usage: scripts/worktree <create|remove|list> [args]"
   echo ""
   echo "Commands:"
-  echo "  create <branch-name>   Create a worktree + branch and install deps"
-  echo "  remove <branch-name>   Remove a worktree and optionally delete the branch"
-  echo "  list                   List all worktrees"
+  echo "  create <branch-name>                Create a worktree + branch and install deps"
+  echo "  remove <branch-name> [options]      Remove a worktree and optionally delete the branch"
+  echo "  list                                List all worktrees"
+  echo ""
+  echo "Remove options:"
+  echo "  --delete-branch      Always delete the branch (no prompt)"
+  echo "  --no-delete-branch   Never delete the branch (no prompt)"
   echo ""
   echo "Examples:"
   echo "  scripts/worktree create feat/streaming"
   echo "  scripts/worktree remove feat/streaming"
+  echo "  scripts/worktree remove feat/streaming --delete-branch"
   echo "  scripts/worktree list"
 }
 
@@ -42,6 +47,16 @@ create() {
 
 remove() {
   local branch="$1"
+  local delete_branch=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --delete-branch) delete_branch="yes"; shift ;;
+      --no-delete-branch) delete_branch="no"; shift ;;
+      *) echo "Error: unknown option $1"; usage; exit 1 ;;
+    esac
+  done
+
   local slug="${branch//\//-}"
   local dir="$PARENT_DIR/vellum-wt-${slug}"
 
@@ -53,11 +68,17 @@ remove() {
   echo "Removing worktree at $dir..."
   git -C "$REPO_ROOT" worktree remove "$dir"
 
-  if [[ -t 0 ]]; then
+  if [[ "$delete_branch" == "yes" ]]; then
+    REPLY="y"
+  elif [[ "$delete_branch" == "no" ]]; then
+    REPLY="n"
+  elif [[ -t 0 ]]; then
     read -p "Delete branch $branch? [y/N] " -n 1 -r
     echo
   else
-    REPLY="y"
+    # Non-TTY: try to read piped input, default to "y" on EOF
+    read -r REPLY 2>/dev/null || REPLY="y"
+    REPLY="${REPLY:=y}"
   fi
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     git -C "$REPO_ROOT" branch -d "$branch" 2>/dev/null || \
@@ -82,7 +103,8 @@ case "$1" in
     ;;
   remove)
     [ $# -lt 2 ] && { echo "Error: branch name required"; usage; exit 1; }
-    remove "$2"
+    shift
+    remove "$@"
     ;;
   list)
     list


### PR DESCRIPTION
Closes #538

## Summary
- Instead of forcing `REPLY="y"` when stdin is not a TTY, the script now reads from stdin first and only defaults to "y" on EOF. This means `echo n | scripts/worktree remove <branch>` correctly preserves the branch.
- Adds `--delete-branch` and `--no-delete-branch` flags for explicit control without any prompt or stdin dependency.
- Updates usage text and examples to document the new options.

## Test plan
- [ ] `echo n | scripts/worktree remove <branch>` should skip branch deletion
- [ ] `echo y | scripts/worktree remove <branch>` should delete the branch
- [ ] `true | scripts/worktree remove <branch>` (empty stdin) should default to deleting (backward compat)
- [ ] `scripts/worktree remove <branch> --delete-branch` should always delete
- [ ] `scripts/worktree remove <branch> --no-delete-branch` should never delete
- [ ] Interactive TTY usage still prompts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
