### PR TITLE
Add correlation IDs to ambient observation/result messages

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -118,6 +118,7 @@ exports[`IPC message snapshots ClientMessage types ambient_observation serialize
 {
   "appName": "Safari",
   "ocrText": "Hello world visible on screen",
+  "requestId": "req-amb-001",
   "timestamp": 1700000000,
   "type": "ambient_observation",
   "windowTitle": "Google",
@@ -398,6 +399,7 @@ exports[`IPC message snapshots ServerMessage types cu_error serializes to expect
 exports[`IPC message snapshots ServerMessage types ambient_result serializes to expected JSON 1`] = `
 {
   "decision": "suggest",
+  "requestId": "req-amb-001",
   "suggestion": "Try running the test with --verbose flag for more details",
   "summary": "User appears to be debugging a test failure",
   "type": "ambient_result",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -88,6 +88,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   ambient_observation: {
     type: 'ambient_observation',
+    requestId: 'req-amb-001',
     ocrText: 'Hello world visible on screen',
     appName: 'Safari',
     windowTitle: 'Google',
@@ -266,6 +267,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   ambient_result: {
     type: 'ambient_result',
+    requestId: 'req-amb-001',
     decision: 'suggest',
     summary: 'User appears to be debugging a test failure',
     suggestion: 'Try running the test with --verbose flag for more details',

--- a/assistant/src/daemon/ambient-handler.ts
+++ b/assistant/src/daemon/ambient-handler.ts
@@ -20,6 +20,7 @@ export async function handleAmbientObservation(
 
     ctx.send(socket, {
       type: 'ambient_result',
+      requestId: msg.requestId,
       decision: result.decision,
       summary: result.summary,
       suggestion: result.suggestion,
@@ -28,6 +29,7 @@ export async function handleAmbientObservation(
     log.error({ err }, 'Error processing ambient observation');
     ctx.send(socket, {
       type: 'ambient_result',
+      requestId: msg.requestId,
       decision: 'ignore',
     });
   }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -105,6 +105,7 @@ export interface CuObservation {
 
 export interface AmbientObservation {
   type: 'ambient_observation';
+  requestId: string;
   ocrText: string;
   appName?: string;
   windowTitle?: string;
@@ -312,6 +313,7 @@ export interface CuError {
 
 export interface AmbientResult {
   type: 'ambient_result';
+  requestId: string;
   decision: 'ignore' | 'observe' | 'suggest';
   summary?: string;
   suggestion?: string;

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -260,9 +260,11 @@ final class AmbientAgent: ObservableObject {
 
         // Subscribe before sending so we don't miss a fast daemon response
         let messageStream = daemonClient.subscribe()
+        let requestId = UUID().uuidString
 
         do {
             try daemonClient.send(AmbientObservationMessage(
+                requestId: requestId,
                 ocrText: screenContent,
                 appName: appName,
                 windowTitle: windowTitle,
@@ -274,8 +276,8 @@ final class AmbientAgent: ObservableObject {
             return
         }
 
-        // Wait for ambient_result from daemon
-        guard let ambientResult = await waitForAmbientResult(stream: messageStream, timeout: 30) else {
+        // Wait for ambient_result from daemon matching our requestId
+        guard let ambientResult = await waitForAmbientResult(stream: messageStream, requestId: requestId, timeout: 30) else {
             log.warning("[\(cycle)] Timed out waiting for ambient result from daemon")
             state = .watching
             return
@@ -335,11 +337,11 @@ final class AmbientAgent: ObservableObject {
         state = .watching
     }
 
-    private func waitForAmbientResult(stream messageStream: AsyncStream<ServerMessage>, timeout: TimeInterval = 30) async -> AmbientResultMessage? {
+    private func waitForAmbientResult(stream messageStream: AsyncStream<ServerMessage>, requestId: String, timeout: TimeInterval = 30) async -> AmbientResultMessage? {
         return await withTaskGroup(of: AmbientResultMessage?.self) { group in
             group.addTask {
                 for await message in messageStream {
-                    if case .ambientResult(let result) = message {
+                    if case .ambientResult(let result) = message, result.requestId == requestId {
                         return result
                     }
                 }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -118,6 +118,7 @@ struct CuObservationMessage: Encodable, Sendable {
 /// Wire type: `"ambient_observation"`
 struct AmbientObservationMessage: Encodable, Sendable {
     let type: String = "ambient_observation"
+    let requestId: String
     let ocrText: String
     let appName: String?
     let windowTitle: String?
@@ -193,6 +194,7 @@ struct SessionInfoMessage: Decodable, Sendable {
 
 /// Result from ambient observation analysis.
 struct AmbientResultMessage: Decodable, Sendable {
+    let requestId: String
     let decision: String
     let summary: String?
     let suggestion: String?


### PR DESCRIPTION
Closes #509

## Summary
- Added `requestId: String` field to both `AmbientObservation` and `AmbientResult` IPC message types (TypeScript and Swift)
- Generate a UUID per ambient cycle in `AmbientAgent.runCycle()` and include it in the observation message
- Filter `waitForAmbientResult` to only accept results matching the current cycle's `requestId`
- Echo back `requestId` from the observation in the daemon's ambient handler response (both success and error paths)

This prevents stale daemon responses from timed-out cycles being consumed by subsequent cycles, which would apply the wrong summary/suggestion to the current screen context.

## Test plan
- [ ] Verify `swift build` passes (confirmed locally)
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] IPC snapshot tests updated to include `requestId` field
- [ ] Manual: start ambient agent, confirm observations still flow end-to-end with the new requestId field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
