### PR TITLE
Extract URL safety helpers for web and browser tools

### DIFF
--- a/assistant/src/__tests__/url-safety.test.ts
+++ b/assistant/src/__tests__/url-safety.test.ts
@@ -1,0 +1,418 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  looksLikeHostPortShorthand,
+  looksLikePathOnlyInput,
+  parseUrl,
+  isIPv4,
+  isPrivateIPv4,
+  unwrapBracketedHostname,
+  extractEmbeddedIPv4FromIPv6,
+  isIPv6,
+  isPrivateIPv6,
+  isPrivateOrLocalHost,
+  resolveRequestAddress,
+  buildHostHeader,
+  stripUrlUserinfo,
+  sanitizeUrlForOutput,
+  sanitizeUrlStringForOutput,
+} from '../tools/network/url-safety.js';
+
+describe('url-safety helpers', () => {
+  // ── looksLikeHostPortShorthand ───────────────────────────────
+
+  describe('looksLikeHostPortShorthand', () => {
+    test('recognizes host:port', () => {
+      expect(looksLikeHostPortShorthand('example.com:8080')).toBe(true);
+      expect(looksLikeHostPortShorthand('example.com:8080/path')).toBe(true);
+    });
+
+    test('recognizes bracketed IPv6 with port', () => {
+      expect(looksLikeHostPortShorthand('[::1]:3000')).toBe(true);
+      expect(looksLikeHostPortShorthand('[2001:db8::1]:443/path')).toBe(true);
+    });
+
+    test('rejects plain hostnames without port', () => {
+      expect(looksLikeHostPortShorthand('example.com')).toBe(false);
+      expect(looksLikeHostPortShorthand('example.com/path')).toBe(false);
+    });
+
+    test('rejects URLs with scheme', () => {
+      expect(looksLikeHostPortShorthand('https://example.com:8080')).toBe(false);
+    });
+  });
+
+  // ── looksLikePathOnlyInput ───────────────────────────────────
+
+  describe('looksLikePathOnlyInput', () => {
+    test('detects absolute paths', () => {
+      expect(looksLikePathOnlyInput('/docs/page')).toBe(true);
+    });
+
+    test('detects relative paths', () => {
+      expect(looksLikePathOnlyInput('./file')).toBe(true);
+      expect(looksLikePathOnlyInput('../parent/file')).toBe(true);
+    });
+
+    test('detects query/fragment-only', () => {
+      expect(looksLikePathOnlyInput('?q=test')).toBe(true);
+      expect(looksLikePathOnlyInput('#section')).toBe(true);
+    });
+
+    test('rejects hostnames', () => {
+      expect(looksLikePathOnlyInput('example.com')).toBe(false);
+    });
+  });
+
+  // ── parseUrl ─────────────────────────────────────────────────
+
+  describe('parseUrl', () => {
+    test('parses full URLs', () => {
+      const url = parseUrl('https://example.com/path');
+      expect(url).not.toBeNull();
+      expect(url!.href).toBe('https://example.com/path');
+    });
+
+    test('adds https:// for bare hostnames', () => {
+      const url = parseUrl('example.com/docs');
+      expect(url).not.toBeNull();
+      expect(url!.href).toBe('https://example.com/docs');
+    });
+
+    test('adds https:// for host:port shorthand', () => {
+      const url = parseUrl('example.com:8443/docs');
+      expect(url).not.toBeNull();
+      expect(url!.href).toBe('https://example.com:8443/docs');
+    });
+
+    test('returns null for non-string input', () => {
+      expect(parseUrl(42)).toBeNull();
+      expect(parseUrl(null)).toBeNull();
+      expect(parseUrl(undefined)).toBeNull();
+    });
+
+    test('returns null for empty/whitespace', () => {
+      expect(parseUrl('')).toBeNull();
+      expect(parseUrl('   ')).toBeNull();
+    });
+
+    test('returns null for path-only input', () => {
+      expect(parseUrl('/docs/page')).toBeNull();
+      expect(parseUrl('./file')).toBeNull();
+    });
+
+    test('returns null for unknown schemes', () => {
+      expect(parseUrl('ftp://example.com')).not.toBeNull(); // URL constructor parses ftp
+      expect(parseUrl('custom-scheme://foo')).not.toBeNull();
+    });
+
+    test('rejects bare hostnames that look like other schemes', () => {
+      // "git:" matches /^[a-zA-Z][a-zA-Z0-9+.-]*:/ but URL constructor parses it
+      // as a valid scheme URI, so parseUrl returns a URL object
+      expect(parseUrl('git:')).not.toBeNull();
+    });
+  });
+
+  // ── isIPv4 ───────────────────────────────────────────────────
+
+  describe('isIPv4', () => {
+    test('recognizes valid IPv4', () => {
+      expect(isIPv4('127.0.0.1')).toBe(true);
+      expect(isIPv4('192.168.1.1')).toBe(true);
+      expect(isIPv4('0.0.0.0')).toBe(true);
+      expect(isIPv4('255.255.255.255')).toBe(true);
+    });
+
+    test('rejects invalid IPv4', () => {
+      expect(isIPv4('256.0.0.1')).toBe(false);
+      expect(isIPv4('1.2.3')).toBe(false);
+      expect(isIPv4('1.2.3.4.5')).toBe(false);
+      expect(isIPv4('localhost')).toBe(false);
+      expect(isIPv4('::1')).toBe(false);
+    });
+  });
+
+  // ── isPrivateIPv4 ────────────────────────────────────────────
+
+  describe('isPrivateIPv4', () => {
+    test('classifies private ranges', () => {
+      expect(isPrivateIPv4('10.0.0.1')).toBe(true);
+      expect(isPrivateIPv4('127.0.0.1')).toBe(true);
+      expect(isPrivateIPv4('192.168.1.1')).toBe(true);
+      expect(isPrivateIPv4('172.16.0.1')).toBe(true);
+      expect(isPrivateIPv4('172.31.255.255')).toBe(true);
+      expect(isPrivateIPv4('169.254.1.1')).toBe(true);
+      expect(isPrivateIPv4('0.0.0.0')).toBe(true);
+    });
+
+    test('classifies public addresses', () => {
+      expect(isPrivateIPv4('93.184.216.34')).toBe(false);
+      expect(isPrivateIPv4('8.8.8.8')).toBe(false);
+      expect(isPrivateIPv4('1.1.1.1')).toBe(false);
+    });
+
+    test('classifies multicast/broadcast', () => {
+      expect(isPrivateIPv4('224.0.0.1')).toBe(true);
+      expect(isPrivateIPv4('255.255.255.255')).toBe(true);
+    });
+
+    test('classifies benchmarking range', () => {
+      expect(isPrivateIPv4('198.18.0.10')).toBe(true);
+      expect(isPrivateIPv4('198.19.255.255')).toBe(true);
+    });
+
+    test('classifies CGNAT range', () => {
+      expect(isPrivateIPv4('100.64.0.1')).toBe(true);
+      expect(isPrivateIPv4('100.127.255.255')).toBe(true);
+    });
+  });
+
+  // ── unwrapBracketedHostname ──────────────────────────────────
+
+  describe('unwrapBracketedHostname', () => {
+    test('removes brackets from IPv6', () => {
+      expect(unwrapBracketedHostname('[::1]')).toBe('::1');
+      expect(unwrapBracketedHostname('[2001:db8::1]')).toBe('2001:db8::1');
+    });
+
+    test('passes through non-bracketed', () => {
+      expect(unwrapBracketedHostname('127.0.0.1')).toBe('127.0.0.1');
+      expect(unwrapBracketedHostname('localhost')).toBe('localhost');
+    });
+  });
+
+  // ── extractEmbeddedIPv4FromIPv6 ──────────────────────────────
+
+  describe('extractEmbeddedIPv4FromIPv6', () => {
+    test('extracts dotted IPv4-mapped IPv6', () => {
+      expect(extractEmbeddedIPv4FromIPv6('::ffff:127.0.0.1')).toBe('127.0.0.1');
+      expect(extractEmbeddedIPv4FromIPv6('[::ffff:192.168.1.1]')).toBe('192.168.1.1');
+    });
+
+    test('extracts hex-encoded IPv4-mapped IPv6', () => {
+      expect(extractEmbeddedIPv4FromIPv6('::ffff:7f00:1')).toBe('127.0.0.1');
+      expect(extractEmbeddedIPv4FromIPv6('::7f00:1')).toBe('127.0.0.1');
+    });
+
+    test('returns null for plain IPv6', () => {
+      expect(extractEmbeddedIPv4FromIPv6('::1')).toBeNull();
+      expect(extractEmbeddedIPv4FromIPv6('2001:db8::1')).toBeNull();
+    });
+
+    test('returns null for non-IPv6', () => {
+      expect(extractEmbeddedIPv4FromIPv6('127.0.0.1')).toBeNull();
+    });
+  });
+
+  // ── isIPv6 ───────────────────────────────────────────────────
+
+  describe('isIPv6', () => {
+    test('recognizes plain IPv6', () => {
+      expect(isIPv6('::1')).toBe(true);
+      expect(isIPv6('2001:db8::1')).toBe(true);
+      expect(isIPv6('::')).toBe(true);
+    });
+
+    test('recognizes bracketed IPv6', () => {
+      expect(isIPv6('[::1]')).toBe(true);
+      expect(isIPv6('[2001:db8::1]')).toBe(true);
+    });
+
+    test('recognizes IPv4-mapped IPv6', () => {
+      expect(isIPv6('::ffff:127.0.0.1')).toBe(true);
+      expect(isIPv6('::ffff:7f00:1')).toBe(true);
+    });
+
+    test('rejects non-IPv6', () => {
+      expect(isIPv6('127.0.0.1')).toBe(false);
+      expect(isIPv6('localhost')).toBe(false);
+    });
+  });
+
+  // ── isPrivateIPv6 ────────────────────────────────────────────
+
+  describe('isPrivateIPv6', () => {
+    test('classifies loopback', () => {
+      expect(isPrivateIPv6('::1')).toBe(true);
+      expect(isPrivateIPv6('::')).toBe(true);
+    });
+
+    test('classifies unique local (fc/fd)', () => {
+      expect(isPrivateIPv6('fc00::1')).toBe(true);
+      expect(isPrivateIPv6('fd12:3456::1')).toBe(true);
+    });
+
+    test('classifies multicast (ff)', () => {
+      expect(isPrivateIPv6('ff02::1')).toBe(true);
+    });
+
+    test('classifies link-local (fe80-febf)', () => {
+      expect(isPrivateIPv6('fe80::1')).toBe(true);
+    });
+
+    test('classifies site-local (fec0-feff)', () => {
+      expect(isPrivateIPv6('fec0::1')).toBe(true);
+    });
+
+    test('classifies IPv4-mapped private', () => {
+      expect(isPrivateIPv6('::ffff:127.0.0.1')).toBe(true);
+      expect(isPrivateIPv6('::ffff:7f00:1')).toBe(true);
+    });
+
+    test('classifies public IPv6 as non-private', () => {
+      expect(isPrivateIPv6('2001:db8::1')).toBe(false);
+    });
+  });
+
+  // ── isPrivateOrLocalHost ─────────────────────────────────────
+
+  describe('isPrivateOrLocalHost', () => {
+    test('detects localhost', () => {
+      expect(isPrivateOrLocalHost('localhost')).toBe(true);
+      expect(isPrivateOrLocalHost('LOCALHOST')).toBe(true);
+      expect(isPrivateOrLocalHost('localhost.localdomain')).toBe(true);
+    });
+
+    test('detects subdomain localhost', () => {
+      expect(isPrivateOrLocalHost('foo.localhost')).toBe(true);
+    });
+
+    test('detects 0.0.0.0', () => {
+      expect(isPrivateOrLocalHost('0.0.0.0')).toBe(true);
+    });
+
+    test('detects metadata.google.internal', () => {
+      expect(isPrivateOrLocalHost('metadata.google.internal')).toBe(true);
+    });
+
+    test('detects private IPs', () => {
+      expect(isPrivateOrLocalHost('127.0.0.1')).toBe(true);
+      expect(isPrivateOrLocalHost('10.0.0.1')).toBe(true);
+      expect(isPrivateOrLocalHost('192.168.1.1')).toBe(true);
+    });
+
+    test('detects private IPv6', () => {
+      expect(isPrivateOrLocalHost('[::1]')).toBe(true);
+      expect(isPrivateOrLocalHost('::1')).toBe(true);
+    });
+
+    test('does not flag public hosts', () => {
+      expect(isPrivateOrLocalHost('example.com')).toBe(false);
+      expect(isPrivateOrLocalHost('93.184.216.34')).toBe(false);
+    });
+  });
+
+  // ── resolveRequestAddress ────────────────────────────────────
+
+  describe('resolveRequestAddress', () => {
+    test('blocks private IP literals when not allowed', async () => {
+      const result = await resolveRequestAddress('127.0.0.1', async () => [], false);
+      expect(result.blockedAddress).toBe('127.0.0.1');
+      expect(result.addresses).toEqual([]);
+    });
+
+    test('allows private IP literals when allowed', async () => {
+      const result = await resolveRequestAddress('127.0.0.1', async () => [], true);
+      expect(result.blockedAddress).toBeUndefined();
+      expect(result.addresses).toEqual(['127.0.0.1']);
+    });
+
+    test('blocks hostname resolving to private address', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['10.0.0.1'],
+        false,
+      );
+      expect(result.blockedAddress).toBe('10.0.0.1');
+    });
+
+    test('allows hostname resolving to public address', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['93.184.216.34'],
+        false,
+      );
+      expect(result.addresses).toEqual(['93.184.216.34']);
+      expect(result.blockedAddress).toBeUndefined();
+    });
+
+    test('returns empty addresses when resolution fails', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => [],
+        false,
+      );
+      expect(result.addresses).toEqual([]);
+      expect(result.blockedAddress).toBeUndefined();
+    });
+
+    test('deduplicates resolved addresses', async () => {
+      const result = await resolveRequestAddress(
+        'example.com',
+        async () => ['93.184.216.34', '93.184.216.34'],
+        false,
+      );
+      expect(result.addresses).toEqual(['93.184.216.34']);
+    });
+  });
+
+  // ── buildHostHeader ──────────────────────────────────────────
+
+  describe('buildHostHeader', () => {
+    test('returns hostname without port for default ports', () => {
+      const url = new URL('https://example.com/path');
+      expect(buildHostHeader(url)).toBe('example.com');
+    });
+
+    test('includes explicit port', () => {
+      const url = new URL('https://example.com:8443/path');
+      expect(buildHostHeader(url)).toBe('example.com:8443');
+    });
+  });
+
+  // ── stripUrlUserinfo ─────────────────────────────────────────
+
+  describe('stripUrlUserinfo', () => {
+    test('removes username and password', () => {
+      const url = new URL('https://user:p%40ss@example.com/path');
+      const stripped = stripUrlUserinfo(url);
+      expect(stripped.username).toBe('');
+      expect(stripped.password).toBe('');
+      expect(stripped.href).toBe('https://example.com/path');
+    });
+
+    test('passes through URLs without userinfo', () => {
+      const url = new URL('https://example.com/path');
+      const stripped = stripUrlUserinfo(url);
+      expect(stripped.href).toBe('https://example.com/path');
+    });
+  });
+
+  // ── sanitizeUrlForOutput ─────────────────────────────────────
+
+  describe('sanitizeUrlForOutput', () => {
+    test('strips userinfo from URL', () => {
+      const url = new URL('https://user:p%40ss@example.com/path');
+      expect(sanitizeUrlForOutput(url)).toBe('https://example.com/path');
+    });
+  });
+
+  // ── sanitizeUrlStringForOutput ───────────────────────────────
+
+  describe('sanitizeUrlStringForOutput', () => {
+    test('strips userinfo from valid URL string', () => {
+      expect(sanitizeUrlStringForOutput('https://user:p%40ss@example.com/path'))
+        .toBe('https://example.com/path');
+    });
+
+    test('redacts credentials in unparseable URL strings', () => {
+      expect(sanitizeUrlStringForOutput('://user@example'))
+        .toContain('[REDACTED]');
+    });
+
+    test('resolves relative URLs with base', () => {
+      const base = new URL('https://example.com');
+      expect(sanitizeUrlStringForOutput('/path', base))
+        .toBe('https://example.com/path');
+    });
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -5,6 +5,7 @@ import { resolveSkillSelector } from '../config/skills.js';
 import { getTool } from '../tools/registry.js';
 import { dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 
 // Low-risk shell programs that are read-only / informational
 const LOW_RISK_PROGRAMS = new Set([
@@ -59,17 +60,6 @@ function getStringField(input: Record<string, unknown>, ...keys: string[]): stri
     if (typeof value === 'string') return value;
   }
   return '';
-}
-
-function looksLikeHostPortShorthand(value: string): boolean {
-  if (/^\[[0-9a-fA-F:.%]+\]:\d+(?:[/?#]|$)/.test(value)) {
-    return true;
-  }
-  return /^[^/?#@\s:]+:\d+(?:[/?#]|$)/.test(value);
-}
-
-function looksLikePathOnlyInput(value: string): boolean {
-  return value.startsWith('/') || value.startsWith('./') || value.startsWith('../') || value.startsWith('?') || value.startsWith('#');
 }
 
 function canonicalizeWebFetchUrl(parsed: URL): URL {

--- a/assistant/src/tools/network/url-safety.ts
+++ b/assistant/src/tools/network/url-safety.ts
@@ -1,0 +1,226 @@
+import { lookup } from 'node:dns/promises';
+
+export type ResolveHostAddresses = (hostname: string) => Promise<string[]>;
+
+export function looksLikeHostPortShorthand(value: string): boolean {
+  if (/^\[[0-9a-fA-F:.%]+\]:\d+(?:[/?#]|$)/.test(value)) {
+    return true;
+  }
+  return /^[^/?#@\s:]+:\d+(?:[/?#]|$)/.test(value);
+}
+
+export function looksLikePathOnlyInput(value: string): boolean {
+  return value.startsWith('/') || value.startsWith('./') || value.startsWith('../') || value.startsWith('?') || value.startsWith('#');
+}
+
+export function parseUrl(input: unknown): URL | null {
+  if (typeof input !== 'string') return null;
+  const value = input.trim();
+  if (!value) return null;
+
+  if (looksLikeHostPortShorthand(value)) {
+    try {
+      return new URL(`https://${value}`);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return new URL(value);
+  } catch {
+    // Allow shorthand like "example.com/docs".
+  }
+
+  if (looksLikePathOnlyInput(value)) {
+    return null;
+  }
+
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value)) {
+    return null;
+  }
+
+  try {
+    return new URL(`https://${value}`);
+  } catch {
+    return null;
+  }
+}
+
+export function isIPv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return false;
+    const value = Number(part);
+    if (value < 0 || value > 255) return false;
+  }
+
+  return true;
+}
+
+export function isPrivateIPv4(hostname: string): boolean {
+  const parts = hostname.split('.').map((part) => Number(part));
+  const [a, b] = parts;
+
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a >= 224) return true;
+
+  return false;
+}
+
+export function unwrapBracketedHostname(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+export function extractEmbeddedIPv4FromIPv6(hostname: string): string | null {
+  const normalized = unwrapBracketedHostname(hostname).split('%')[0].toLowerCase();
+
+  const dottedMatch = normalized.match(/^(?:(?:(?:0:){5}|::)ffff:|(?:(?:0:){6}|::))(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (dottedMatch) {
+    return isIPv4(dottedMatch[1]) ? dottedMatch[1] : null;
+  }
+
+  const hexMatch = normalized.match(/^(?:(?:(?:0:){5}|::)ffff:|(?:(?:0:){6}|::))([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hexMatch) return null;
+
+  const hi = Number.parseInt(hexMatch[1], 16);
+  const lo = Number.parseInt(hexMatch[2], 16);
+  if (Number.isNaN(hi) || Number.isNaN(lo)) return null;
+
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+export function isIPv6(hostname: string): boolean {
+  if (extractEmbeddedIPv4FromIPv6(hostname)) return true;
+
+  const unwrapped = unwrapBracketedHostname(hostname);
+  if (!unwrapped.includes(':')) return false;
+  const stripped = unwrapped.split('%')[0];
+  return /^[0-9a-fA-F:]+$/.test(stripped);
+}
+
+export function isPrivateIPv6(hostname: string): boolean {
+  const normalized = unwrapBracketedHostname(hostname).split('%')[0].toLowerCase();
+
+  if (normalized === '::' || normalized === '::1') return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  if (normalized.startsWith('ff')) return true;
+  if (
+    normalized.startsWith('fe8')
+    || normalized.startsWith('fe9')
+    || normalized.startsWith('fea')
+    || normalized.startsWith('feb')
+    || normalized.startsWith('fec')
+    || normalized.startsWith('fed')
+    || normalized.startsWith('fee')
+    || normalized.startsWith('fef')
+  ) {
+    return true;
+  }
+
+  const mappedIPv4 = extractEmbeddedIPv4FromIPv6(hostname);
+  if (mappedIPv4) {
+    return isPrivateIPv4(mappedIPv4);
+  }
+
+  return false;
+}
+
+export function isPrivateOrLocalHost(hostname: string): boolean {
+  const host = unwrapBracketedHostname(hostname).toLowerCase();
+
+  if (
+    host === 'localhost' ||
+    host === 'localhost.localdomain' ||
+    host === '0.0.0.0' ||
+    host.endsWith('.localhost')
+  ) {
+    return true;
+  }
+  if (host === 'metadata.google.internal') {
+    return true;
+  }
+  if (isIPv4(host)) {
+    return isPrivateIPv4(host);
+  }
+  if (isIPv6(host)) {
+    return isPrivateIPv6(host);
+  }
+  return false;
+}
+
+export async function resolveHostAddresses(hostname: string): Promise<string[]> {
+  try {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    return records.map((record) => record.address);
+  } catch {
+    return [];
+  }
+}
+
+export async function resolveRequestAddress(
+  hostname: string,
+  resolveHost: ResolveHostAddresses,
+  allowPrivateNetwork: boolean,
+): Promise<{ addresses: string[]; blockedAddress?: string }> {
+  const normalizedHost = unwrapBracketedHostname(hostname);
+
+  if (isIPv4(normalizedHost) || isIPv6(normalizedHost)) {
+    if (!allowPrivateNetwork && isPrivateOrLocalHost(normalizedHost)) {
+      return { addresses: [], blockedAddress: normalizedHost };
+    }
+    return { addresses: [normalizedHost] };
+  }
+
+  const addresses = [...new Set((await resolveHost(normalizedHost)).map((address) => unwrapBracketedHostname(address)))];
+  if (addresses.length === 0) {
+    return { addresses: [] };
+  }
+
+  if (!allowPrivateNetwork) {
+    for (const address of addresses) {
+      if (isPrivateOrLocalHost(address)) {
+        return { addresses: [], blockedAddress: address };
+      }
+    }
+  }
+
+  return { addresses };
+}
+
+export function buildHostHeader(url: URL): string {
+  return url.port ? `${url.hostname}:${url.port}` : url.hostname;
+}
+
+export function stripUrlUserinfo(url: URL): URL {
+  const sanitized = new URL(url.href);
+  sanitized.username = '';
+  sanitized.password = '';
+  return sanitized;
+}
+
+export function sanitizeUrlForOutput(url: URL): string {
+  const sanitized = stripUrlUserinfo(url);
+  return sanitized.href;
+}
+
+export function sanitizeUrlStringForOutput(url: string, base?: URL): string {
+  try {
+    const parsed = base ? new URL(url, base) : new URL(url);
+    return sanitizeUrlForOutput(parsed);
+  } catch {
+    return url.replace(/\/\/([^/?#\s@]+)@/g, '//[REDACTED]@');
+  }
+}

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -3,10 +3,23 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getLogger } from '../../util/logger.js';
-import { lookup } from 'node:dns/promises';
 import { request as httpRequest, type IncomingHttpHeaders } from 'node:http';
 import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'node:https';
 import { Readable } from 'node:stream';
+import {
+  type ResolveHostAddresses,
+  parseUrl,
+  isIPv4,
+  isIPv6,
+  isPrivateOrLocalHost,
+  unwrapBracketedHostname,
+  resolveHostAddresses,
+  resolveRequestAddress,
+  buildHostHeader,
+  stripUrlUserinfo,
+  sanitizeUrlForOutput,
+  sanitizeUrlStringForOutput,
+} from './url-safety.js';
 
 const log = getLogger('web-fetch');
 
@@ -38,7 +51,6 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   nbsp: ' ',
 };
 
-type ResolveHostAddresses = (hostname: string) => Promise<string[]>;
 type WebFetchRequestExecutor = (
   url: URL,
   options: {
@@ -67,229 +79,6 @@ function parseMimeType(contentType: string): string {
 function clampInteger(value: unknown, defaultValue: number, min: number, max: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
   return Math.min(max, Math.max(min, Math.round(value)));
-}
-
-function looksLikeHostPortShorthand(value: string): boolean {
-  if (/^\[[0-9a-fA-F:.%]+\]:\d+(?:[/?#]|$)/.test(value)) {
-    return true;
-  }
-  return /^[^/?#@\s:]+:\d+(?:[/?#]|$)/.test(value);
-}
-
-function looksLikePathOnlyInput(value: string): boolean {
-  return value.startsWith('/') || value.startsWith('./') || value.startsWith('../') || value.startsWith('?') || value.startsWith('#');
-}
-
-function parseUrl(input: unknown): URL | null {
-  if (typeof input !== 'string') return null;
-  const value = input.trim();
-  if (!value) return null;
-
-  if (looksLikeHostPortShorthand(value)) {
-    try {
-      return new URL(`https://${value}`);
-    } catch {
-      return null;
-    }
-  }
-
-  try {
-    return new URL(value);
-  } catch {
-    // Allow shorthand like "example.com/docs".
-  }
-
-  if (looksLikePathOnlyInput(value)) {
-    return null;
-  }
-
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value)) {
-    return null;
-  }
-
-  try {
-    return new URL(`https://${value}`);
-  } catch {
-    return null;
-  }
-}
-
-function isIPv4(hostname: string): boolean {
-  const parts = hostname.split('.');
-  if (parts.length !== 4) return false;
-
-  for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return false;
-    const value = Number(part);
-    if (value < 0 || value > 255) return false;
-  }
-
-  return true;
-}
-
-function isPrivateIPv4(hostname: string): boolean {
-  const parts = hostname.split('.').map((part) => Number(part));
-  const [a, b] = parts;
-
-  if (a === 0) return true;
-  if (a === 10) return true;
-  if (a === 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 198 && (b === 18 || b === 19)) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  if (a >= 224) return true;
-
-  return false;
-}
-
-function unwrapBracketedHostname(hostname: string): string {
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    return hostname.slice(1, -1);
-  }
-  return hostname;
-}
-
-function extractEmbeddedIPv4FromIPv6(hostname: string): string | null {
-  const normalized = unwrapBracketedHostname(hostname).split('%')[0].toLowerCase();
-
-  const dottedMatch = normalized.match(/^(?:(?:(?:0:){5}|::)ffff:|(?:(?:0:){6}|::))(\d{1,3}(?:\.\d{1,3}){3})$/);
-  if (dottedMatch) {
-    return isIPv4(dottedMatch[1]) ? dottedMatch[1] : null;
-  }
-
-  const hexMatch = normalized.match(/^(?:(?:(?:0:){5}|::)ffff:|(?:(?:0:){6}|::))([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (!hexMatch) return null;
-
-  const hi = Number.parseInt(hexMatch[1], 16);
-  const lo = Number.parseInt(hexMatch[2], 16);
-  if (Number.isNaN(hi) || Number.isNaN(lo)) return null;
-
-  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
-}
-
-function isIPv6(hostname: string): boolean {
-  if (extractEmbeddedIPv4FromIPv6(hostname)) return true;
-
-  const unwrapped = unwrapBracketedHostname(hostname);
-  if (!unwrapped.includes(':')) return false;
-  const stripped = unwrapped.split('%')[0];
-  return /^[0-9a-fA-F:]+$/.test(stripped);
-}
-
-function isPrivateIPv6(hostname: string): boolean {
-  const normalized = unwrapBracketedHostname(hostname).split('%')[0].toLowerCase();
-
-  if (normalized === '::' || normalized === '::1') return true;
-  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
-  if (normalized.startsWith('ff')) return true;
-  if (
-    normalized.startsWith('fe8')
-    || normalized.startsWith('fe9')
-    || normalized.startsWith('fea')
-    || normalized.startsWith('feb')
-    || normalized.startsWith('fec')
-    || normalized.startsWith('fed')
-    || normalized.startsWith('fee')
-    || normalized.startsWith('fef')
-  ) {
-    return true;
-  }
-
-  const mappedIPv4 = extractEmbeddedIPv4FromIPv6(hostname);
-  if (mappedIPv4) {
-    return isPrivateIPv4(mappedIPv4);
-  }
-
-  return false;
-}
-
-function isPrivateOrLocalHost(hostname: string): boolean {
-  const host = unwrapBracketedHostname(hostname).toLowerCase();
-
-  if (
-    host === 'localhost' ||
-    host === 'localhost.localdomain' ||
-    host === '0.0.0.0' ||
-    host.endsWith('.localhost')
-  ) {
-    return true;
-  }
-  if (host === 'metadata.google.internal') {
-    return true;
-  }
-  if (isIPv4(host)) {
-    return isPrivateIPv4(host);
-  }
-  if (isIPv6(host)) {
-    return isPrivateIPv6(host);
-  }
-  return false;
-}
-
-async function resolveHostAddresses(hostname: string): Promise<string[]> {
-  try {
-    const records = await lookup(hostname, { all: true, verbatim: true });
-    return records.map((record) => record.address);
-  } catch {
-    return [];
-  }
-}
-
-async function resolveRequestAddress(
-  hostname: string,
-  resolveHost: ResolveHostAddresses,
-  allowPrivateNetwork: boolean,
-): Promise<{ addresses: string[]; blockedAddress?: string }> {
-  const normalizedHost = unwrapBracketedHostname(hostname);
-
-  if (isIPv4(normalizedHost) || isIPv6(normalizedHost)) {
-    if (!allowPrivateNetwork && isPrivateOrLocalHost(normalizedHost)) {
-      return { addresses: [], blockedAddress: normalizedHost };
-    }
-    return { addresses: [normalizedHost] };
-  }
-
-  const addresses = [...new Set((await resolveHost(normalizedHost)).map((address) => unwrapBracketedHostname(address)))];
-  if (addresses.length === 0) {
-    return { addresses: [] };
-  }
-
-  if (!allowPrivateNetwork) {
-    for (const address of addresses) {
-      if (isPrivateOrLocalHost(address)) {
-        return { addresses: [], blockedAddress: address };
-      }
-    }
-  }
-
-  return { addresses };
-}
-
-function buildHostHeader(url: URL): string {
-  return url.port ? `${url.hostname}:${url.port}` : url.hostname;
-}
-
-function stripUrlUserinfo(url: URL): URL {
-  const sanitized = new URL(url.href);
-  sanitized.username = '';
-  sanitized.password = '';
-  return sanitized;
-}
-
-function sanitizeUrlForOutput(url: URL): string {
-  const sanitized = stripUrlUserinfo(url);
-  return sanitized.href;
-}
-
-function sanitizeUrlStringForOutput(url: string, base?: URL): string {
-  try {
-    const parsed = base ? new URL(url, base) : new URL(url);
-    return sanitizeUrlForOutput(parsed);
-  } catch {
-    return url.replace(/\/\/([^/?#\s@]+)@/g, '//[REDACTED]@');
-  }
 }
 
 function decodeUrlCredential(value: string): string {


### PR DESCRIPTION
## Summary
- Extracted URL parsing, private-network detection, and sanitization helpers from `web-fetch.ts` into a new shared `url-safety.ts` module
- Replaced duplicated `looksLikeHostPortShorthand` and `looksLikePathOnlyInput` in `checker.ts` with imports from the shared module
- Added 61 focused unit tests for all extracted helpers; no functional behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
