### PR TITLE
Add Playwright runtime dependency and diagnostics

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -13,6 +13,7 @@
         "openai": "^6.18.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.1.3",
+        "playwright": "^1.58.2",
         "postgres": "^3.4.8",
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
@@ -318,6 +319,8 @@
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
@@ -447,6 +450,10 @@
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -21,6 +21,7 @@
     "openai": "^6.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.1.3",
+    "playwright": "^1.58.2",
     "postgres": "^3.4.8",
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",

--- a/assistant/src/__tests__/browser-runtime-check.test.ts
+++ b/assistant/src/__tests__/browser-runtime-check.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// Mock playwright before importing runtime-check
+let mockExecPath = '/fake/chromium';
+let mockExecThrows = false;
+
+mock.module('playwright', () => {
+  return {
+    chromium: {
+      executablePath: () => {
+        if (mockExecThrows) throw new Error('Browser not found');
+        return mockExecPath;
+      },
+    },
+  };
+});
+
+// Mock fs.existsSync for Chromium path checks
+let mockFileExists = true;
+mock.module('node:fs', () => {
+  const actual = require('node:fs');
+  return {
+    ...actual,
+    existsSync: (path: string) => {
+      if (path === mockExecPath) return mockFileExists;
+      return actual.existsSync(path);
+    },
+  };
+});
+
+// Re-import after mocks
+const { checkBrowserRuntime } = await import('../tools/browser/runtime-check.js');
+
+describe('browser runtime check', () => {
+  beforeEach(() => {
+    mockExecPath = '/fake/chromium';
+    mockExecThrows = false;
+    mockFileExists = true;
+  });
+
+  test('reports success when playwright and chromium are available', async () => {
+    const status = await checkBrowserRuntime();
+    expect(status.playwrightAvailable).toBe(true);
+    expect(status.chromiumInstalled).toBe(true);
+    expect(status.chromiumPath).toBe('/fake/chromium');
+    expect(status.error).toBeNull();
+  });
+
+  test('reports chromium not installed when executable is missing', async () => {
+    mockFileExists = false;
+    const status = await checkBrowserRuntime();
+    expect(status.playwrightAvailable).toBe(true);
+    expect(status.chromiumInstalled).toBe(false);
+    expect(status.chromiumPath).toBeNull();
+    expect(status.error).toContain('Chromium not found');
+    expect(status.error).toContain('bunx playwright install chromium');
+  });
+
+  test('handles executablePath throwing an error', async () => {
+    mockExecThrows = true;
+    const status = await checkBrowserRuntime();
+    expect(status.playwrightAvailable).toBe(true);
+    expect(status.chromiumInstalled).toBe(false);
+    expect(status.chromiumPath).toBeNull();
+    expect(status.error).toBe('Browser not found');
+  });
+});

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -863,6 +863,17 @@ program
     } else {
       fail('WASM files', missingWasm.join(', '));
     }
+
+    // 12. Browser runtime (Playwright + Chromium)
+    const { checkBrowserRuntime } = await import('./tools/browser/runtime-check.js');
+    const browserStatus = await checkBrowserRuntime();
+    if (browserStatus.playwrightAvailable && browserStatus.chromiumInstalled) {
+      pass('Browser runtime (Playwright + Chromium)');
+    } else if (!browserStatus.playwrightAvailable) {
+      fail('Browser runtime', 'playwright not available');
+    } else {
+      fail('Browser runtime', browserStatus.error ?? 'Chromium not installed');
+    }
   });
 
 // --- Completions command ---

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs';
+
+export interface BrowserRuntimeStatus {
+  playwrightAvailable: boolean;
+  chromiumInstalled: boolean;
+  chromiumPath: string | null;
+  error: string | null;
+}
+
+export async function checkBrowserRuntime(): Promise<BrowserRuntimeStatus> {
+  // Check if playwright can be imported
+  let chromium: { executablePath: () => string };
+  try {
+    const pw = await import('playwright');
+    chromium = pw.chromium;
+  } catch {
+    return {
+      playwrightAvailable: false,
+      chromiumInstalled: false,
+      chromiumPath: null,
+      error: 'playwright package not available',
+    };
+  }
+
+  // Check if Chromium browser is installed
+  try {
+    const execPath = chromium.executablePath();
+    const installed = existsSync(execPath);
+    return {
+      playwrightAvailable: true,
+      chromiumInstalled: installed,
+      chromiumPath: installed ? execPath : null,
+      error: installed ? null : `Chromium not found at ${execPath}. Run: bunx playwright install chromium`,
+    };
+  } catch (err) {
+    return {
+      playwrightAvailable: true,
+      chromiumInstalled: false,
+      chromiumPath: null,
+      error: err instanceof Error ? err.message : 'Failed to check Chromium install',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Added `playwright` as a dependency in the assistant package
- Created `runtime-check.ts` helper that detects Playwright availability and Chromium install readiness
- Wired the check into `vellum doctor` as diagnostic check #12 (Browser runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
