### PR TITLE
Use PostgreSQL error code 42P01 instead of broad string match

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -294,7 +294,7 @@ sessions
           process.exit(1);
         }
       } catch (err: unknown) {
-        const isUndefinedTable = err instanceof Error && err.message.includes('does not exist');
+        const isUndefinedTable = err instanceof Error && 'code' in err && (err as Record<string, unknown>).code === '42P01';
         if (!isUndefinedTable) throw err;
       } finally {
         await checkSql.end();


### PR DESCRIPTION
## Summary
- Replace `err.message.includes('does not exist')` with PostgreSQL error code `42P01` check in the `sessions clear` command
- The broad string match could swallow unrelated errors (e.g. missing database `3D000`, missing schema `3F000`), leading to silent data loss

Closes #552

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Test `sessions clear` against a database with no `user` table (should still skip gracefully)
- [ ] Test `sessions clear` against a non-existent database (should now properly throw instead of being swallowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
