### PR TITLE
Fix piped reply handling in worktree remove

### DIFF
--- a/scripts/worktree
+++ b/scripts/worktree
@@ -77,7 +77,7 @@ remove() {
     echo
   else
     # Non-TTY: try to read piped input, default to "y" on EOF
-    read -r REPLY 2>/dev/null || REPLY="y"
+    read -r REPLY 2>/dev/null || { [ -z "$REPLY" ] && REPLY="y"; }
     REPLY="${REPLY:=y}"
   fi
   if [[ $REPLY =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
Closes #554

## Summary
- Fix `read -r REPLY || REPLY="y"` overwriting valid piped responses (like `n`) when input lacks a trailing newline
- `read` returns non-zero at EOF even when it captured data, so the fallback now only triggers when REPLY is truly empty: `read -r REPLY 2>/dev/null || { [ -z "$REPLY" ] && REPLY="y"; }`

## Test plan
- [ ] `printf 'y' | scripts/worktree remove <branch>` deletes the branch
- [ ] `printf 'n' | scripts/worktree remove <branch>` keeps the branch (was broken before)
- [ ] `echo 'y' | scripts/worktree remove <branch>` deletes the branch (newline-terminated, already worked)
- [ ] `echo 'n' | scripts/worktree remove <branch>` keeps the branch (newline-terminated, already worked)
- [ ] `scripts/worktree remove <branch>` with no pipe defaults to prompting (TTY path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
