### PR TITLE
Add persistent browser manager for daemon sessions

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// Mock platform so we don't touch real ~/.vellum
+const testDataDir = '/tmp/browser-manager-test';
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDataDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { browserManager, setLaunchFn } from '../tools/browser/browser-manager.js';
+
+function createMockPage(closed = false): { close: () => Promise<void>; isClosed: () => boolean } {
+  let _closed = closed;
+  return {
+    close: async () => { _closed = true; },
+    isClosed: () => _closed,
+  };
+}
+
+function createMockContext() {
+  const pages: ReturnType<typeof createMockPage>[] = [];
+  let closed = false;
+  return {
+    context: {
+      newPage: async () => {
+        const page = createMockPage();
+        pages.push(page);
+        return page;
+      },
+      close: async () => { closed = true; },
+    },
+    get pages() { return pages; },
+    get closed() { return closed; },
+  };
+}
+
+describe('BrowserManager', () => {
+  let mockCtx: ReturnType<typeof createMockContext>;
+
+  beforeEach(async () => {
+    // Close any existing context from prior tests
+    await browserManager.closeAllPages();
+
+    mockCtx = createMockContext();
+    setLaunchFn(async () => mockCtx.context);
+  });
+
+  // ── getOrCreateSessionPage ───────────────────────────────────
+
+  describe('getOrCreateSessionPage', () => {
+    test('creates a new page for a new session', async () => {
+      const page = await browserManager.getOrCreateSessionPage('s1');
+      expect(page).toBeDefined();
+      expect(page.isClosed()).toBe(false);
+      expect(mockCtx.pages).toHaveLength(1);
+    });
+
+    test('returns same page for same session', async () => {
+      const page1 = await browserManager.getOrCreateSessionPage('s1');
+      const page2 = await browserManager.getOrCreateSessionPage('s1');
+      expect(page1).toBe(page2);
+      expect(mockCtx.pages).toHaveLength(1);
+    });
+
+    test('creates different pages for different sessions', async () => {
+      const page1 = await browserManager.getOrCreateSessionPage('s1');
+      const page2 = await browserManager.getOrCreateSessionPage('s2');
+      expect(page1).not.toBe(page2);
+      expect(mockCtx.pages).toHaveLength(2);
+    });
+
+    test('replaces closed page with new one', async () => {
+      const page1 = await browserManager.getOrCreateSessionPage('s1');
+      await page1.close();
+      expect(page1.isClosed()).toBe(true);
+
+      const page2 = await browserManager.getOrCreateSessionPage('s1');
+      expect(page2).not.toBe(page1);
+      expect(page2.isClosed()).toBe(false);
+      expect(mockCtx.pages).toHaveLength(2);
+    });
+
+    test('lazily creates browser context on first page request', async () => {
+      expect(browserManager.hasContext()).toBe(false);
+      await browserManager.getOrCreateSessionPage('s1');
+      expect(browserManager.hasContext()).toBe(true);
+    });
+
+    test('reuses browser context across sessions', async () => {
+      await browserManager.getOrCreateSessionPage('s1');
+      await browserManager.getOrCreateSessionPage('s2');
+      // Only one context was created (launchFn called once)
+      expect(browserManager.hasContext()).toBe(true);
+    });
+  });
+
+  // ── closeSessionPage ─────────────────────────────────────────
+
+  describe('closeSessionPage', () => {
+    test('closes an open session page', async () => {
+      const page = await browserManager.getOrCreateSessionPage('s1');
+      await browserManager.closeSessionPage('s1');
+      expect(page.isClosed()).toBe(true);
+    });
+
+    test('is safe to call for non-existent session', async () => {
+      await browserManager.closeSessionPage('nonexistent');
+      // Should not throw
+    });
+
+    test('clears snapshot map for the session', async () => {
+      await browserManager.getOrCreateSessionPage('s1');
+      browserManager.storeSnapshotMap('s1', new Map([['e1', '#btn']]));
+      expect(browserManager.resolveSnapshotSelector('s1', 'e1')).toBe('#btn');
+
+      await browserManager.closeSessionPage('s1');
+      expect(browserManager.resolveSnapshotSelector('s1', 'e1')).toBeNull();
+    });
+  });
+
+  // ── closeAllPages ────────────────────────────────────────────
+
+  describe('closeAllPages', () => {
+    test('closes all session pages and browser context', async () => {
+      const page1 = await browserManager.getOrCreateSessionPage('s1');
+      const page2 = await browserManager.getOrCreateSessionPage('s2');
+
+      await browserManager.closeAllPages();
+
+      expect(page1.isClosed()).toBe(true);
+      expect(page2.isClosed()).toBe(true);
+      expect(mockCtx.closed).toBe(true);
+      expect(browserManager.hasContext()).toBe(false);
+    });
+
+    test('is safe to call when no pages or context exist', async () => {
+      await browserManager.closeAllPages();
+      // Should not throw
+    });
+
+    test('clears all snapshot maps', async () => {
+      await browserManager.getOrCreateSessionPage('s1');
+      await browserManager.getOrCreateSessionPage('s2');
+      browserManager.storeSnapshotMap('s1', new Map([['e1', '#a']]));
+      browserManager.storeSnapshotMap('s2', new Map([['e2', '#b']]));
+
+      await browserManager.closeAllPages();
+
+      expect(browserManager.resolveSnapshotSelector('s1', 'e1')).toBeNull();
+      expect(browserManager.resolveSnapshotSelector('s2', 'e2')).toBeNull();
+    });
+  });
+
+  // ── snapshot map ─────────────────────────────────────────────
+
+  describe('snapshot map', () => {
+    test('stores and resolves element selectors', () => {
+      const map = new Map([
+        ['e1', '#submit-btn'],
+        ['e2', 'input[name="email"]'],
+      ]);
+      browserManager.storeSnapshotMap('s1', map);
+
+      expect(browserManager.resolveSnapshotSelector('s1', 'e1')).toBe('#submit-btn');
+      expect(browserManager.resolveSnapshotSelector('s1', 'e2')).toBe('input[name="email"]');
+    });
+
+    test('returns null for unknown element id', () => {
+      browserManager.storeSnapshotMap('s1', new Map([['e1', '#btn']]));
+      expect(browserManager.resolveSnapshotSelector('s1', 'e999')).toBeNull();
+    });
+
+    test('returns null for unknown session', () => {
+      expect(browserManager.resolveSnapshotSelector('unknown', 'e1')).toBeNull();
+    });
+
+    test('overwrites previous snapshot map for same session', () => {
+      browserManager.storeSnapshotMap('s1', new Map([['e1', '#old']]));
+      browserManager.storeSnapshotMap('s1', new Map([['e1', '#new']]));
+      expect(browserManager.resolveSnapshotSelector('s1', 'e1')).toBe('#new');
+    });
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -15,6 +15,7 @@ import { DaemonServer } from './server.js';
 import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
 import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
+import { browserManager } from '../tools/browser/browser-manager.js';
 
 const log = getLogger('lifecycle');
 
@@ -206,6 +207,7 @@ export async function runDaemon(): Promise<void> {
     forceTimer.unref();
 
     await server.stop();
+    await browserManager.closeAllPages();
     memoryWorker.stop();
     cleanupPidFile();
     process.exit(0);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -1,0 +1,110 @@
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { getDataDir } from '../../util/platform.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('browser-manager');
+
+type BrowserContext = {
+  newPage(): Promise<Page>;
+  close(): Promise<void>;
+};
+
+type Page = {
+  close(): Promise<void>;
+  isClosed(): boolean;
+};
+
+type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;
+
+let launchPersistentContext: LaunchFn | null = null;
+
+export function setLaunchFn(fn: LaunchFn | null): void {
+  launchPersistentContext = fn;
+}
+
+async function getDefaultLaunchFn(): Promise<LaunchFn> {
+  const pw = await import('playwright');
+  return pw.chromium.launchPersistentContext.bind(pw.chromium);
+}
+
+function getProfileDir(): string {
+  return join(getDataDir(), 'browser-profile');
+}
+
+class BrowserManager {
+  private context: BrowserContext | null = null;
+  private pages = new Map<string, Page>();
+  private snapshotMaps = new Map<string, Map<string, string>>();
+
+  async getOrCreateSessionPage(sessionId: string): Promise<Page> {
+    if (!this.context) {
+      const profileDir = getProfileDir();
+      mkdirSync(profileDir, { recursive: true });
+
+      const launch = launchPersistentContext ?? await getDefaultLaunchFn();
+      this.context = await launch(profileDir, { headless: true });
+      log.info({ profileDir }, 'Browser context created');
+    }
+
+    const existing = this.pages.get(sessionId);
+    if (existing && !existing.isClosed()) {
+      return existing;
+    }
+
+    const page = await this.context.newPage();
+    this.pages.set(sessionId, page);
+    log.debug({ sessionId }, 'Session page created');
+    return page;
+  }
+
+  async closeSessionPage(sessionId: string): Promise<void> {
+    const page = this.pages.get(sessionId);
+    if (page && !page.isClosed()) {
+      await page.close();
+    }
+    this.pages.delete(sessionId);
+    this.snapshotMaps.delete(sessionId);
+    log.debug({ sessionId }, 'Session page closed');
+  }
+
+  async closeAllPages(): Promise<void> {
+    for (const [sessionId, page] of this.pages) {
+      if (!page.isClosed()) {
+        try {
+          await page.close();
+        } catch (err) {
+          log.warn({ err, sessionId }, 'Failed to close page');
+        }
+      }
+    }
+    this.pages.clear();
+    this.snapshotMaps.clear();
+
+    if (this.context) {
+      try {
+        await this.context.close();
+      } catch (err) {
+        log.warn({ err }, 'Failed to close browser context');
+      }
+      this.context = null;
+      log.info('Browser context closed');
+    }
+  }
+
+  storeSnapshotMap(sessionId: string, map: Map<string, string>): void {
+    this.snapshotMaps.set(sessionId, map);
+  }
+
+  resolveSnapshotSelector(sessionId: string, elementId: string): string | null {
+    const map = this.snapshotMaps.get(sessionId);
+    if (!map) return null;
+    return map.get(elementId) ?? null;
+  }
+
+  hasContext(): boolean {
+    return this.context !== null;
+  }
+}
+
+export const browserManager = new BrowserManager();


### PR DESCRIPTION
## Summary
- Implemented singleton `BrowserManager` with lazy Chromium context creation and persistent profile at `~/.vellum/browser-profile`
- Provides per-session page management (`getOrCreateSessionPage`, `closeSessionPage`, `closeAllPages`) and snapshot element-id-to-selector mapping
- Wired `closeAllPages()` into daemon shutdown in `lifecycle.ts` for clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
