### PR TITLE
Fix race condition in startSession with isStartingSession guard

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
+    private var isStartingSession = false
     private var textResponseWindow: TextResponseWindow?
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
@@ -268,7 +269,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func startSession(submission: TaskSubmission) {
-        guard currentSession == nil && currentTextSession == nil else { return }
+        guard currentSession == nil && currentTextSession == nil && !isStartingSession else { return }
+        isStartingSession = true
         popover.performClose(nil)
 
         let sessionTask = submission.task.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -277,6 +279,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Ensure daemon connection before starting any session
         Task { @MainActor in
+            defer { self.isStartingSession = false }
+
             if !daemonClient.isConnected {
                 log.info("Daemon not connected, attempting to connect before session start")
                 do {


### PR DESCRIPTION
Closes #555

## Summary
- Add `private var isStartingSession = false` flag to `AppDelegate`
- Check `!isStartingSession` in the guard at the top of `startSession(submission:)`
- Set `isStartingSession = true` synchronously **before** the `Task` block
- Reset `isStartingSession = false` via `defer` inside the `Task` block, covering all exit paths (daemon connection failure, accessibility permission denial, normal completion)

This prevents two rapid calls to `startSession` from both passing the guard while `await daemonClient.connect()` is in progress, which would lead to two concurrent sessions.

## Test plan
- [ ] Verify build succeeds (`swift build`)
- [ ] Rapid double-click on submit does not create two concurrent sessions
- [ ] Single session start still works normally
- [ ] Session can be started again after a previous session completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
