### PR TITLE
Handle malformed DATABASE_URL gracefully in sessions clear

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -270,7 +270,13 @@ sessions
     // ── Safety: only allow localhost ──────────────────────────────────
     let pgAvailable = false;
     if (databaseUrl) {
-      const host = new URL(databaseUrl).hostname;
+      let host: string;
+      try {
+        host = new URL(databaseUrl).hostname;
+      } catch {
+        console.error(`Error: DATABASE_URL is not a valid URL: ${databaseUrl}`);
+        process.exit(1);
+      }
       const allowedHosts = ['localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal'];
       if (!allowedHosts.includes(host)) {
         console.error(`Error: DATABASE_URL points to '${host}' — refusing to run.`);


### PR DESCRIPTION
Closes #553

## Summary
- Wrap `new URL(databaseUrl)` in try/catch in the `sessions clear` command so malformed DATABASE_URL values produce a clear error message (`Error: DATABASE_URL is not a valid URL: ...`) instead of crashing with an unhelpful TypeError stack trace.

## Test plan
- [ ] Set `DATABASE_URL` to a malformed value (e.g. `postgressql:localhost/db`) and run `vellum sessions clear` — should see a clear error message and exit cleanly
- [ ] Set `DATABASE_URL` to a valid localhost URL — should work as before
- [ ] Unset `DATABASE_URL` — should warn and continue with daemon DB only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
