### PR TITLE
Start ambient agent after session-time daemon reconnect

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -285,6 +285,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 log.info("Daemon not connected, attempting to connect before session start")
                 do {
                     try await daemonClient.connect()
+                    // Start ambient agent if it was deferred due to missing daemon connection
+                    self.setupAmbientAgent()
                 } catch {
                     log.error("Failed to connect to daemon: \(error.localizedDescription)")
                     self.showDaemonConnectionError()


### PR DESCRIPTION
Closes #556

## Summary
- After a successful daemon reconnect in `startSession`, call `setupAmbientAgent()` so ambient monitoring resumes when the daemon becomes available through a session-triggered reconnect, not just through the initial startup path.
- `setupAmbientAgent()` is idempotent — it sets `appDelegate`/`daemonClient` and only calls `start()` if enabled and connected.

## Test plan
- [ ] Verify build passes (`swift build`)
- [ ] Start app with daemon offline, confirm ambient agent doesn't start
- [ ] Trigger a session (which reconnects to daemon), confirm ambient agent starts after reconnect
- [ ] Start app with daemon online, confirm ambient agent starts normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
