### PR TITLE
Add browser_navigate tool with network safety enforcement

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -14,11 +14,14 @@ mock.module('../util/logger.js', () => ({
 
 import { browserManager, setLaunchFn } from '../tools/browser/browser-manager.js';
 
-function createMockPage(closed = false): { close: () => Promise<void>; isClosed: () => boolean } {
+function createMockPage(closed = false) {
   let _closed = closed;
   return {
     close: async () => { _closed = true; },
     isClosed: () => _closed,
+    goto: async () => ({ status: () => 200, url: () => 'about:blank' }),
+    title: async () => '',
+    url: () => 'about:blank',
   };
 }
 

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/headless-browser-test',
+}));
+
+// Track calls to browserManager and url-safety helpers
+let mockPage: {
+  goto: ReturnType<typeof mock>;
+  title: ReturnType<typeof mock>;
+  url: ReturnType<typeof mock>;
+  close: () => Promise<void>;
+  isClosed: () => boolean;
+};
+
+let getOrCreateSessionPageMock: ReturnType<typeof mock>;
+
+mock.module('../tools/browser/browser-manager.js', () => {
+  getOrCreateSessionPageMock = mock(async () => mockPage);
+  return {
+    browserManager: {
+      getOrCreateSessionPage: getOrCreateSessionPageMock,
+    },
+  };
+});
+
+// Default url-safety: allow everything
+let parseUrlResult: URL | null = null;
+let isPrivateResult = false;
+let resolveResult: { blockedAddress?: string } = {};
+
+mock.module('../tools/network/url-safety.js', () => ({
+  parseUrl: (_input: unknown) => parseUrlResult,
+  isPrivateOrLocalHost: () => isPrivateResult,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => resolveResult,
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+import { executeBrowserNavigate } from '../tools/browser/headless-browser.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+  workingDir: '/tmp',
+};
+
+function resetMockPage() {
+  mockPage = {
+    goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
+    title: mock(async () => 'Example'),
+    url: mock(() => 'https://example.com/'),
+    close: async () => {},
+    isClosed: () => false,
+  };
+}
+
+describe('executeBrowserNavigate', () => {
+  beforeEach(() => {
+    parseUrlResult = null;
+    isPrivateResult = false;
+    resolveResult = {};
+    resetMockPage();
+  });
+
+  // ── Input validation ───────────────────────────────────────────
+
+  test('rejects missing or invalid url', async () => {
+    const result = await executeBrowserNavigate({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('url is required');
+  });
+
+  test('rejects non-http(s) protocols', async () => {
+    parseUrlResult = new URL('ftp://example.com');
+    const result = await executeBrowserNavigate({ url: 'ftp://example.com' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('http or https');
+  });
+
+  // ── Private network blocking ───────────────────────────────────
+
+  test('blocks private/local hosts by default', async () => {
+    parseUrlResult = new URL('http://localhost:3000');
+    isPrivateResult = true;
+    const result = await executeBrowserNavigate({ url: 'http://localhost:3000' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Refusing to navigate');
+    expect(result.content).toContain('localhost');
+  });
+
+  test('allows private hosts with allow_private_network=true', async () => {
+    parseUrlResult = new URL('http://localhost:3000');
+    isPrivateResult = true;
+    const result = await executeBrowserNavigate(
+      { url: 'http://localhost:3000', allow_private_network: true },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Status: 200');
+  });
+
+  test('blocks DNS-resolved private addresses by default', async () => {
+    parseUrlResult = new URL('https://internal.corp.example.com');
+    isPrivateResult = false;
+    resolveResult = { blockedAddress: '10.0.0.1' };
+    const result = await executeBrowserNavigate(
+      { url: 'https://internal.corp.example.com' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('10.0.0.1');
+  });
+
+  test('skips DNS check with allow_private_network=true', async () => {
+    parseUrlResult = new URL('https://internal.corp.example.com');
+    isPrivateResult = false;
+    resolveResult = { blockedAddress: '10.0.0.1' };
+    const result = await executeBrowserNavigate(
+      { url: 'https://internal.corp.example.com', allow_private_network: true },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Status: 200');
+  });
+
+  // ── Successful navigation ──────────────────────────────────────
+
+  test('returns structured result on success', async () => {
+    parseUrlResult = new URL('https://example.com/page');
+    const result = await executeBrowserNavigate({ url: 'https://example.com/page' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Requested URL:');
+    expect(result.content).toContain('Final URL:');
+    expect(result.content).toContain('Status: 200');
+    expect(result.content).toContain('Title: Example');
+  });
+
+  test('notes redirect when final URL differs', async () => {
+    parseUrlResult = new URL('https://example.com/old');
+    mockPage.url = mock(() => 'https://example.com/new');
+    const result = await executeBrowserNavigate({ url: 'https://example.com/old' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('redirected');
+  });
+
+  test('handles null response status', async () => {
+    parseUrlResult = new URL('https://example.com');
+    mockPage.goto = mock(async () => null);
+    const result = await executeBrowserNavigate({ url: 'https://example.com' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Status: unknown');
+  });
+
+  // ── Error handling ─────────────────────────────────────────────
+
+  test('catches navigation errors', async () => {
+    parseUrlResult = new URL('https://example.com');
+    mockPage.goto = mock(async () => { throw new Error('net::ERR_CONNECTION_REFUSED'); });
+    const result = await executeBrowserNavigate({ url: 'https://example.com' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Navigation failed');
+    expect(result.content).toContain('ERR_CONNECTION_REFUSED');
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -69,6 +69,8 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         return `Editing ${input.path ?? ''}...`;
       case 'web_fetch':
         return `Fetching ${sanitizeUrlForDisplay(input.url).slice(0, 80)}...`;
+      case 'browser_navigate':
+        return `Navigating to ${sanitizeUrlForDisplay(input.url).slice(0, 80)}...`;
       default:
         return `Running ${toolName}...`;
     }
@@ -104,6 +106,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
     if (req.toolName === 'web_fetch') {
       return `fetch ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
+    }
+    if (req.toolName === 'browser_navigate') {
+      return `navigate ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
     }
     return `${req.toolName}: ${JSON.stringify(req.input).slice(0, 80)}`;
   }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -143,7 +143,7 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
     return [...new Set(targets)].map((target) => `${toolName}:${target}`);
   }
 
-  if (toolName === 'web_fetch') {
+  if (toolName === 'web_fetch' || toolName === 'browser_navigate') {
     const rawUrl = getStringField(input, 'url').trim();
     const candidates: string[] = [];
 
@@ -173,7 +173,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'file_write') return RiskLevel.Medium;
   if (toolName === 'file_edit') return RiskLevel.Medium;
   if (toolName === 'web_search') return RiskLevel.Low;
-  if (toolName === 'web_fetch') {
+  if (toolName === 'web_fetch' || toolName === 'browser_navigate') {
     return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
   }
   if (toolName === 'skill_load') return RiskLevel.Low;
@@ -332,7 +332,7 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
     return options;
   }
 
-  if (toolName === 'web_fetch') {
+  if (toolName === 'web_fetch' || toolName === 'browser_navigate') {
     const rawUrl = getStringField(input, 'url').trim();
     const normalized = normalizeWebFetchUrl(rawUrl);
     const exact = normalized?.href ?? rawUrl;

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -10,9 +10,17 @@ type BrowserContext = {
   close(): Promise<void>;
 };
 
-type Page = {
+export type PageResponse = {
+  status(): number | null;
+  url(): string;
+};
+
+export type Page = {
   close(): Promise<void>;
   isClosed(): boolean;
+  goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<PageResponse | null>;
+  title(): Promise<string>;
+  url(): string;
 };
 
 type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -1,0 +1,123 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getLogger } from '../../util/logger.js';
+import {
+  parseUrl,
+  isPrivateOrLocalHost,
+  resolveHostAddresses,
+  resolveRequestAddress,
+  sanitizeUrlForOutput,
+} from '../network/url-safety.js';
+import { browserManager } from './browser-manager.js';
+
+const log = getLogger('headless-browser');
+
+const NAVIGATE_TIMEOUT_MS = 30_000;
+
+async function executeBrowserNavigate(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const parsedUrl = parseUrl(input.url);
+  if (!parsedUrl) {
+    return { content: 'Error: url is required and must be a valid HTTP(S) URL', isError: true };
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return { content: 'Error: url must use http or https', isError: true };
+  }
+
+  const allowPrivateNetwork = input.allow_private_network === true;
+  const safeRequestedUrl = sanitizeUrlForOutput(parsedUrl);
+
+  // Block private/local targets by default
+  if (!allowPrivateNetwork && isPrivateOrLocalHost(parsedUrl.hostname)) {
+    return {
+      content: `Error: Refusing to navigate to local/private network target (${parsedUrl.hostname}). Set allow_private_network=true if you explicitly need it.`,
+      isError: true,
+    };
+  }
+
+  // DNS resolution check for non-literal hostnames
+  if (!allowPrivateNetwork) {
+    const resolution = await resolveRequestAddress(
+      parsedUrl.hostname,
+      resolveHostAddresses,
+      allowPrivateNetwork,
+    );
+    if (resolution.blockedAddress) {
+      return {
+        content: `Error: Refusing to navigate to target (${parsedUrl.hostname}) because it resolves to local/private network address ${resolution.blockedAddress}. Set allow_private_network=true if you explicitly need it.`,
+        isError: true,
+      };
+    }
+  }
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    log.debug({ url: safeRequestedUrl, sessionId: context.sessionId }, 'Navigating');
+
+    const response = await page.goto(parsedUrl.href, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAVIGATE_TIMEOUT_MS,
+    });
+
+    const finalUrl = page.url();
+    const title = await page.title();
+    const status = response?.status() ?? null;
+
+    const lines: string[] = [
+      `Requested URL: ${safeRequestedUrl}`,
+      `Final URL: ${finalUrl}`,
+      `Status: ${status ?? 'unknown'}`,
+      `Title: ${title || '(none)'}`,
+    ];
+
+    if (finalUrl !== parsedUrl.href) {
+      lines.push(`Note: Page redirected from the requested URL.`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, url: safeRequestedUrl }, 'Navigation failed');
+    return { content: `Error: Navigation failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserNavigateTool implements Tool {
+  name = 'browser_navigate';
+  description = 'Navigate a headless browser to a URL and return the page title and status. Use this to load web pages for inspection or interaction.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'The URL to navigate to. If scheme is missing, https:// is assumed.',
+          },
+          allow_private_network: {
+            type: 'boolean',
+            description: 'If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety.',
+          },
+        },
+        required: ['url'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserNavigate(input, context);
+  }
+}
+
+registerTool(new BrowserNavigateTool());
+
+export { executeBrowserNavigate };

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -100,6 +100,7 @@ export async function initializeTools(): Promise<void> {
   await import('./network/web-search.js');
   await import('./network/web-fetch.js');
   await import('./skills/load.js');
+  await import('./browser/headless-browser.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded


### PR DESCRIPTION
## Summary
- Adds `browser_navigate` tool that uses Playwright to navigate a headless browser to a URL, returning page title, status, and final URL
- Reuses shared url-safety module for SSRF protection (private network blocking, DNS resolution checks) with `allow_private_network` override
- Extends Page type with `goto`/`title`/`url` methods, registers tool, adds risk classification + allowlist generation in permission checker, and adds CLI progress text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
