### PR TITLE
Fix ESLint no-require-imports error in browser-runtime-check test

### DIFF
--- a/assistant/src/__tests__/browser-runtime-check.test.ts
+++ b/assistant/src/__tests__/browser-runtime-check.test.ts
@@ -17,16 +17,14 @@ mock.module('playwright', () => {
 
 // Mock fs.existsSync for Chromium path checks
 let mockFileExists = true;
-mock.module('node:fs', () => {
-  const actual = require('node:fs');
-  return {
-    ...actual,
-    existsSync: (path: string) => {
-      if (path === mockExecPath) return mockFileExists;
-      return actual.existsSync(path);
-    },
-  };
-});
+const actualFs = await import('node:fs');
+mock.module('node:fs', () => ({
+  ...actualFs,
+  existsSync: (path: string) => {
+    if (path === mockExecPath) return mockFileExists;
+    return actualFs.existsSync(path);
+  },
+}));
 
 // Re-import after mocks
 const { checkBrowserRuntime } = await import('../tools/browser/runtime-check.js');


### PR DESCRIPTION
## Summary
- Replace `require('node:fs')` with top-level `await import('node:fs')` in `browser-runtime-check.test.ts`
- Fixes the `@typescript-eslint/no-require-imports` lint error that was failing CI on all PRs

## Test plan
- [x] `bun run lint` passes
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/browser-runtime-check.test.ts` — 3/3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
