### PR TITLE
Add browser_snapshot and browser_close tools

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -22,6 +22,7 @@ function createMockPage(closed = false) {
     goto: async () => ({ status: () => 200, url: () => 'about:blank' }),
     title: async () => '',
     url: () => 'about:blank',
+    evaluate: async () => null,
   };
 }
 

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/headless-browser-snapshot-test',
+}));
+
+let mockPage: {
+  evaluate: ReturnType<typeof mock>;
+  title: ReturnType<typeof mock>;
+  url: ReturnType<typeof mock>;
+  goto: ReturnType<typeof mock>;
+  close: ReturnType<typeof mock>;
+  isClosed: () => boolean;
+};
+
+let closeSessionPageMock: ReturnType<typeof mock>;
+let closeAllPagesMock: ReturnType<typeof mock>;
+let storeSnapshotMapMock: ReturnType<typeof mock>;
+let storedMaps: Map<string, Map<string, string>>;
+
+mock.module('../tools/browser/browser-manager.js', () => {
+  storedMaps = new Map();
+  closeSessionPageMock = mock(async () => {});
+  closeAllPagesMock = mock(async () => {});
+  storeSnapshotMapMock = mock((sessionId: string, map: Map<string, string>) => {
+    storedMaps.set(sessionId, map);
+  });
+  return {
+    browserManager: {
+      getOrCreateSessionPage: async () => mockPage,
+      closeSessionPage: closeSessionPageMock,
+      closeAllPages: closeAllPagesMock,
+      storeSnapshotMap: storeSnapshotMapMock,
+      resolveSnapshotSelector: (sessionId: string, elementId: string) => {
+        const map = storedMaps.get(sessionId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+    },
+  };
+});
+
+mock.module('../tools/network/url-safety.js', () => ({
+  parseUrl: () => null,
+  isPrivateOrLocalHost: () => false,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => ({}),
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+import {
+  executeBrowserSnapshot,
+  executeBrowserClose,
+} from '../tools/browser/headless-browser.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+  workingDir: '/tmp',
+};
+
+function resetMockPage() {
+  mockPage = {
+    evaluate: mock(async () => []),
+    title: mock(async () => 'Test Page'),
+    url: mock(() => 'https://example.com/'),
+    goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
+    close: mock(async () => {}),
+    isClosed: () => false,
+  };
+}
+
+// ── browser_snapshot ─────────────────────────────────────────────────
+
+describe('executeBrowserSnapshot', () => {
+  beforeEach(() => {
+    resetMockPage();
+    storedMaps.clear();
+    storeSnapshotMapMock.mockClear();
+  });
+
+  test('returns page URL and title with no elements', async () => {
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('URL: https://example.com/');
+    expect(result.content).toContain('Title: Test Page');
+    expect(result.content).toContain('(no interactive elements found)');
+  });
+
+  test('lists interactive elements with element IDs', async () => {
+    mockPage.evaluate = mock(async () => [
+      { eid: 'e1', tag: 'a', attrs: { href: '/about' }, text: 'About Us' },
+      { eid: 'e2', tag: 'button', attrs: {}, text: 'Submit' },
+      { eid: 'e3', tag: 'input', attrs: { type: 'text', name: 'email', placeholder: 'Email' }, text: '' },
+    ]);
+
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('[e1] <a href="/about"> About Us');
+    expect(result.content).toContain('[e2] <button> Submit');
+    expect(result.content).toContain('[e3] <input type="text" name="email" placeholder="Email">');
+    expect(result.content).toContain('3 interactive elements found.');
+  });
+
+  test('stores selector map in browser manager', async () => {
+    mockPage.evaluate = mock(async () => [
+      { eid: 'e1', tag: 'a', attrs: { href: '/' }, text: 'Home' },
+      { eid: 'e2', tag: 'button', attrs: {}, text: 'OK' },
+    ]);
+
+    await executeBrowserSnapshot({}, ctx);
+    expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
+
+    const stored = storedMaps.get('test-session');
+    expect(stored).toBeDefined();
+    expect(stored!.get('e1')).toBe('[data-vellum-eid="e1"]');
+    expect(stored!.get('e2')).toBe('[data-vellum-eid="e2"]');
+  });
+
+  test('handles single element with singular count', async () => {
+    mockPage.evaluate = mock(async () => [
+      { eid: 'e1', tag: 'button', attrs: {}, text: 'Click' },
+    ]);
+
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.content).toContain('1 interactive element found.');
+  });
+
+  test('handles evaluate error', async () => {
+    mockPage.evaluate = mock(async () => { throw new Error('page crashed'); });
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Snapshot failed');
+    expect(result.content).toContain('page crashed');
+  });
+
+  test('shows (none) for empty title', async () => {
+    mockPage.title = mock(async () => '');
+    const result = await executeBrowserSnapshot({}, ctx);
+    expect(result.content).toContain('Title: (none)');
+  });
+});
+
+// ── browser_close ────────────────────────────────────────────────────
+
+describe('executeBrowserClose', () => {
+  beforeEach(() => {
+    resetMockPage();
+    closeSessionPageMock.mockClear();
+    closeAllPagesMock.mockClear();
+  });
+
+  test('closes session page by default', async () => {
+    const result = await executeBrowserClose({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Browser page closed for this session.');
+    expect(closeSessionPageMock).toHaveBeenCalledWith('test-session');
+    expect(closeAllPagesMock).not.toHaveBeenCalled();
+  });
+
+  test('closes all pages with close_all_pages=true', async () => {
+    const result = await executeBrowserClose({ close_all_pages: true }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('All browser pages and context closed.');
+    expect(closeAllPagesMock).toHaveBeenCalledTimes(1);
+    expect(closeSessionPageMock).not.toHaveBeenCalled();
+  });
+
+  test('handles close error', async () => {
+    closeSessionPageMock.mockImplementation(async () => { throw new Error('close failed'); });
+    const result = await executeBrowserClose({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Close failed');
+    expect(result.content).toContain('close failed');
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -71,6 +71,10 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         return `Fetching ${sanitizeUrlForDisplay(input.url).slice(0, 80)}...`;
       case 'browser_navigate':
         return `Navigating to ${sanitizeUrlForDisplay(input.url).slice(0, 80)}...`;
+      case 'browser_snapshot':
+        return 'Taking page snapshot...';
+      case 'browser_close':
+        return 'Closing browser...';
       default:
         return `Running ${toolName}...`;
     }
@@ -109,6 +113,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
     if (req.toolName === 'browser_navigate') {
       return `navigate ${sanitizeUrlForDisplay(req.input.url ?? '')}`;
+    }
+    if (req.toolName === 'browser_close') {
+      return req.input.close_all_pages ? 'close all browser pages' : 'close browser page';
     }
     return `${req.toolName}: ${JSON.stringify(req.input).slice(0, 80)}`;
   }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -176,6 +176,8 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'web_fetch' || toolName === 'browser_navigate') {
     return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
   }
+  if (toolName === 'browser_snapshot') return RiskLevel.Low;
+  if (toolName === 'browser_close') return RiskLevel.Medium;
   if (toolName === 'skill_load') return RiskLevel.Low;
 
   if (toolName === 'bash') {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -21,6 +21,7 @@ export type Page = {
   goto(url: string, options?: { waitUntil?: string; timeout?: number }): Promise<PageResponse | null>;
   title(): Promise<string>;
   url(): string;
+  evaluate(expression: string): Promise<unknown>;
 };
 
 type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -120,4 +120,175 @@ class BrowserNavigateTool implements Tool {
 
 registerTool(new BrowserNavigateTool());
 
-export { executeBrowserNavigate };
+// ── browser_snapshot ─────────────────────────────────────────────────
+
+const MAX_SNAPSHOT_ELEMENTS = 500;
+
+const INTERACTIVE_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="tab"]',
+  '[role="menuitem"]',
+  '[contenteditable="true"]',
+].join(', ');
+
+type SnapshotElement = {
+  eid: string;
+  tag: string;
+  attrs: Record<string, string>;
+  text: string;
+};
+
+async function executeBrowserSnapshot(
+  _input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    const currentUrl = page.url();
+    const title = await page.title();
+
+    const elements = (await page.evaluate(`
+      (() => {
+        const SELECTOR = ${JSON.stringify(INTERACTIVE_SELECTOR)};
+        const MAX = ${MAX_SNAPSHOT_ELEMENTS};
+        const els = Array.from(document.querySelectorAll(SELECTOR));
+        const visible = els.filter(el => {
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        });
+        return visible.slice(0, MAX).map((el, i) => {
+          const eid = 'e' + (i + 1);
+          el.setAttribute('data-vellum-eid', eid);
+          const tag = el.tagName.toLowerCase();
+          const attrs = {};
+          for (const attr of ['type', 'name', 'placeholder', 'href', 'value', 'role', 'aria-label', 'id']) {
+            if (el.hasAttribute(attr)) attrs[attr] = el.getAttribute(attr);
+          }
+          const text = (el.textContent || '').trim().slice(0, 80);
+          return { eid, tag, attrs, text };
+        });
+      })()
+    `)) as SnapshotElement[];
+
+    // Build and store selector map
+    const selectorMap = new Map<string, string>();
+    for (const el of elements) {
+      selectorMap.set(el.eid, `[data-vellum-eid="${el.eid}"]`);
+    }
+    browserManager.storeSnapshotMap(context.sessionId, selectorMap);
+
+    // Format output
+    const lines: string[] = [
+      `URL: ${currentUrl}`,
+      `Title: ${title || '(none)'}`,
+      '',
+    ];
+
+    if (elements.length === 0) {
+      lines.push('(no interactive elements found)');
+    } else {
+      for (const el of elements) {
+        let desc = `<${el.tag}`;
+        for (const [key, val] of Object.entries(el.attrs)) {
+          desc += ` ${key}="${val}"`;
+        }
+        desc += '>';
+        if (el.text) {
+          desc += ` ${el.text}`;
+        }
+        lines.push(`[${el.eid}] ${desc}`);
+      }
+      lines.push('');
+      lines.push(`${elements.length} interactive element${elements.length === 1 ? '' : 's'} found.`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Snapshot failed');
+    return { content: `Error: Snapshot failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserSnapshotTool implements Tool {
+  name = 'browser_snapshot';
+  description = 'List interactive elements on the current page. Returns elements with unique IDs that can be used with browser_click and browser_type.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {},
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserSnapshot(input, context);
+  }
+}
+
+registerTool(new BrowserSnapshotTool());
+
+// ── browser_close ────────────────────────────────────────────────────
+
+async function executeBrowserClose(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  try {
+    if (input.close_all_pages === true) {
+      await browserManager.closeAllPages();
+      return { content: 'All browser pages and context closed.', isError: false };
+    }
+    await browserManager.closeSessionPage(context.sessionId);
+    return { content: 'Browser page closed for this session.', isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Close failed');
+    return { content: `Error: Close failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserCloseTool implements Tool {
+  name = 'browser_close';
+  description = 'Close the browser page for the current session, or all pages if close_all_pages is true.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          close_all_pages: {
+            type: 'boolean',
+            description: 'If true, close all browser pages and the browser context. Default: false (close only the current session page).',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserClose(input, context);
+  }
+}
+
+registerTool(new BrowserCloseTool());
+
+export { executeBrowserNavigate, executeBrowserSnapshot, executeBrowserClose };


### PR DESCRIPTION
## Summary
- Adds `browser_snapshot` tool that enumerates interactive elements (links, buttons, inputs, etc.) with deterministic element IDs, persists element_id -> selector map per session for use by future click/type tools
- Adds `browser_close` tool for session page cleanup, with `close_all_pages` flag for full context teardown
- Extends Page type with `evaluate()`, sets `browser_snapshot` as Low risk and `browser_close` as Medium risk, adds CLI progress/preview text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
