### PR TITLE
Fix stale delivery cutoff date serialization

### DIFF
--- a/web/src/lib/channels/service.ts
+++ b/web/src/lib/channels/service.ts
@@ -424,7 +424,7 @@ async function persistAssistantReplyStatus(
 
 async function claimAssistantReplyDelivery(messageId: string) {
   const sql = getDb();
-  const staleDeliveryCutoff = new Date(Date.now() - DELIVERY_IN_PROGRESS_STALE_MS);
+  const staleDeliveryCutoff = new Date(Date.now() - DELIVERY_IN_PROGRESS_STALE_MS).toISOString();
   const claimed = await sql`
     UPDATE chat_messages
     SET status = ${ASSISTANT_REPLY_STATUS_DELIVERY_IN_PROGRESS},


### PR DESCRIPTION
## Summary
- Convert `staleDeliveryCutoff` from a `Date` object to an ISO string via `.toISOString()` in `claimAssistantReplyDelivery`
- Ensures the date value serializes correctly when interpolated into the postgres SQL query

## Test plan
- [ ] Verify assistant reply delivery claiming works correctly with the ISO string format
- [ ] Confirm stale deliveries are properly reclaimed after the cutoff period

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
