### PR TITLE
Add browser_click and browser_type interaction tools

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -23,6 +23,9 @@ function createMockPage(closed = false) {
     title: async () => '',
     url: () => 'about:blank',
     evaluate: async () => null,
+    click: async () => {},
+    fill: async () => {},
+    press: async () => {},
   };
 }
 

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/headless-browser-interactions-test',
+}));
+
+let mockPage: {
+  click: ReturnType<typeof mock>;
+  fill: ReturnType<typeof mock>;
+  press: ReturnType<typeof mock>;
+  evaluate: ReturnType<typeof mock>;
+  title: ReturnType<typeof mock>;
+  url: ReturnType<typeof mock>;
+  goto: ReturnType<typeof mock>;
+  close: () => Promise<void>;
+  isClosed: () => boolean;
+};
+
+let snapshotMaps: Map<string, Map<string, string>>;
+
+mock.module('../tools/browser/browser-manager.js', () => {
+  snapshotMaps = new Map();
+  return {
+    browserManager: {
+      getOrCreateSessionPage: async () => mockPage,
+      closeSessionPage: async () => {},
+      closeAllPages: async () => {},
+      storeSnapshotMap: (sessionId: string, map: Map<string, string>) => {
+        snapshotMaps.set(sessionId, map);
+      },
+      resolveSnapshotSelector: (sessionId: string, elementId: string) => {
+        const map = snapshotMaps.get(sessionId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+    },
+  };
+});
+
+mock.module('../tools/network/url-safety.js', () => ({
+  parseUrl: () => null,
+  isPrivateOrLocalHost: () => false,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => ({}),
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+import {
+  executeBrowserClick,
+  executeBrowserType,
+} from '../tools/browser/headless-browser.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+  workingDir: '/tmp',
+};
+
+function resetMockPage() {
+  mockPage = {
+    click: mock(async () => {}),
+    fill: mock(async () => {}),
+    press: mock(async () => {}),
+    evaluate: mock(async () => ''),
+    title: mock(async () => 'Test Page'),
+    url: mock(() => 'https://example.com/'),
+    goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
+    close: async () => {},
+    isClosed: () => false,
+  };
+}
+
+// ── browser_click ────────────────────────────────────────────────────
+
+describe('executeBrowserClick', () => {
+  beforeEach(() => {
+    resetMockPage();
+    snapshotMaps.clear();
+  });
+
+  test('clicks by element_id via snapshot map', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserClick({ element_id: 'e1' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Clicked element');
+    expect(mockPage.click).toHaveBeenCalledWith('[data-vellum-eid="e1"]');
+  });
+
+  test('clicks by raw selector', async () => {
+    const result = await executeBrowserClick({ selector: '#submit-btn' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(mockPage.click).toHaveBeenCalledWith('#submit-btn');
+  });
+
+  test('prefers element_id over selector', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserClick({ element_id: 'e1', selector: '#other' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(mockPage.click).toHaveBeenCalledWith('[data-vellum-eid="e1"]');
+  });
+
+  test('errors when neither element_id nor selector provided', async () => {
+    const result = await executeBrowserClick({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Either element_id or selector is required');
+  });
+
+  test('errors when element_id not found in snapshot map', async () => {
+    const result = await executeBrowserClick({ element_id: 'e99' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('element_id "e99" not found');
+    expect(result.content).toContain('browser_snapshot');
+  });
+
+  test('errors when snapshot map is missing for session', async () => {
+    const result = await executeBrowserClick({ element_id: 'e1' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('handles click error from page', async () => {
+    mockPage.click = mock(async () => { throw new Error('Element not visible'); });
+    const result = await executeBrowserClick({ selector: '#hidden' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Click failed');
+    expect(result.content).toContain('Element not visible');
+  });
+});
+
+// ── browser_type ─────────────────────────────────────────────────────
+
+describe('executeBrowserType', () => {
+  beforeEach(() => {
+    resetMockPage();
+    snapshotMaps.clear();
+  });
+
+  test('types with element_id and default clear_first=true', async () => {
+    snapshotMaps.set('test-session', new Map([['e3', '[data-vellum-eid="e3"]']]));
+    const result = await executeBrowserType({ element_id: 'e3', text: 'hello' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Typed into element');
+    expect(result.content).toContain('cleared existing content');
+    expect(mockPage.fill).toHaveBeenCalledWith('[data-vellum-eid="e3"]', 'hello');
+  });
+
+  test('types with raw selector', async () => {
+    const result = await executeBrowserType({ selector: 'input[name="email"]', text: 'test' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(mockPage.fill).toHaveBeenCalledWith('input[name="email"]', 'test');
+  });
+
+  test('appends text when clear_first=false', async () => {
+    mockPage.evaluate = mock(async () => 'existing');
+    const result = await executeBrowserType(
+      { selector: '#input', text: ' more', clear_first: false },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(mockPage.evaluate).toHaveBeenCalled();
+    expect(mockPage.fill).toHaveBeenCalledWith('#input', 'existing more');
+    expect(result.content).not.toContain('cleared');
+  });
+
+  test('presses Enter after typing when press_enter=true', async () => {
+    const result = await executeBrowserType(
+      { selector: '#search', text: 'query', press_enter: true },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('pressed Enter');
+    expect(mockPage.fill).toHaveBeenCalledWith('#search', 'query');
+    expect(mockPage.press).toHaveBeenCalledWith('#search', 'Enter');
+  });
+
+  test('errors when text is missing', async () => {
+    const result = await executeBrowserType({ selector: '#input' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('text is required');
+  });
+
+  test('errors when text is empty string', async () => {
+    const result = await executeBrowserType({ selector: '#input', text: '' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('text is required');
+  });
+
+  test('errors when neither element_id nor selector provided', async () => {
+    const result = await executeBrowserType({ text: 'hello' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Either element_id or selector is required');
+  });
+
+  test('errors when element_id not found', async () => {
+    const result = await executeBrowserType({ element_id: 'e99', text: 'hello' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('element_id "e99" not found');
+  });
+
+  test('handles type error from page', async () => {
+    mockPage.fill = mock(async () => { throw new Error('Element is not an input'); });
+    const result = await executeBrowserType({ selector: '#div', text: 'hello' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Type failed');
+    expect(result.content).toContain('Element is not an input');
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -75,6 +75,10 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         return 'Taking page snapshot...';
       case 'browser_close':
         return 'Closing browser...';
+      case 'browser_click':
+        return `Clicking ${String(input.element_id ?? input.selector ?? '').slice(0, 60)}...`;
+      case 'browser_type':
+        return `Typing into ${String(input.element_id ?? input.selector ?? '').slice(0, 60)}...`;
       default:
         return `Running ${toolName}...`;
     }
@@ -116,6 +120,12 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
     if (req.toolName === 'browser_close') {
       return req.input.close_all_pages ? 'close all browser pages' : 'close browser page';
+    }
+    if (req.toolName === 'browser_click') {
+      return `click ${req.input.element_id ?? req.input.selector ?? ''}`;
+    }
+    if (req.toolName === 'browser_type') {
+      return `type into ${req.input.element_id ?? req.input.selector ?? ''}`;
     }
     return `${req.toolName}: ${JSON.stringify(req.input).slice(0, 80)}`;
   }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -178,6 +178,8 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   }
   if (toolName === 'browser_snapshot') return RiskLevel.Low;
   if (toolName === 'browser_close') return RiskLevel.Medium;
+  if (toolName === 'browser_click') return RiskLevel.Medium;
+  if (toolName === 'browser_type') return RiskLevel.Medium;
   if (toolName === 'skill_load') return RiskLevel.Low;
 
   if (toolName === 'bash') {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -22,6 +22,9 @@ export type Page = {
   title(): Promise<string>;
   url(): string;
   evaluate(expression: string): Promise<unknown>;
+  click(selector: string): Promise<void>;
+  fill(selector: string, value: string): Promise<void>;
+  press(selector: string, key: string): Promise<void>;
 };
 
 type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -291,4 +291,180 @@ class BrowserCloseTool implements Tool {
 
 registerTool(new BrowserCloseTool());
 
-export { executeBrowserNavigate, executeBrowserSnapshot, executeBrowserClose };
+// ── shared element resolution ────────────────────────────────────────
+
+function resolveSelector(
+  sessionId: string,
+  input: Record<string, unknown>,
+): { selector: string | null; error: string | null } {
+  const elementId = typeof input.element_id === 'string' ? input.element_id : null;
+  const rawSelector = typeof input.selector === 'string' ? input.selector : null;
+
+  if (!elementId && !rawSelector) {
+    return { selector: null, error: 'Error: Either element_id or selector is required.' };
+  }
+
+  if (elementId) {
+    const resolved = browserManager.resolveSnapshotSelector(sessionId, elementId);
+    if (!resolved) {
+      return {
+        selector: null,
+        error: `Error: element_id "${elementId}" not found. Run browser_snapshot first to get current element IDs.`,
+      };
+    }
+    return { selector: resolved, error: null };
+  }
+
+  return { selector: rawSelector!, error: null };
+}
+
+// ── browser_click ────────────────────────────────────────────────────
+
+async function executeBrowserClick(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const { selector, error } = resolveSelector(context.sessionId, input);
+  if (error) return { content: error, isError: true };
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    await page.click(selector!);
+    return { content: `Clicked element: ${selector}`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, selector }, 'Click failed');
+    return { content: `Error: Click failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserClickTool implements Tool {
+  name = 'browser_click';
+  description = 'Click an element on the page. Target the element by element_id (from browser_snapshot) or a CSS selector.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          element_id: {
+            type: 'string',
+            description: 'The element ID from a previous browser_snapshot result (e.g. "e1").',
+          },
+          selector: {
+            type: 'string',
+            description: 'A CSS selector to target. Used as fallback when element_id is not available.',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserClick(input, context);
+  }
+}
+
+registerTool(new BrowserClickTool());
+
+// ── browser_type ─────────────────────────────────────────────────────
+
+async function executeBrowserType(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const { selector, error } = resolveSelector(context.sessionId, input);
+  if (error) return { content: error, isError: true };
+
+  const text = typeof input.text === 'string' ? input.text : '';
+  if (!text) {
+    return { content: 'Error: text is required.', isError: true };
+  }
+
+  const clearFirst = input.clear_first !== false; // default true
+  const pressEnter = input.press_enter === true;
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+
+    if (clearFirst) {
+      await page.fill(selector!, text);
+    } else {
+      const currentValue = (await page.evaluate(
+        `document.querySelector(${JSON.stringify(selector!)})?.value ?? ''`,
+      )) as string;
+      await page.fill(selector!, currentValue + text);
+    }
+
+    if (pressEnter) {
+      await page.press(selector!, 'Enter');
+    }
+
+    const lines = [`Typed into element: ${selector}`];
+    if (clearFirst) lines.push('(cleared existing content first)');
+    if (pressEnter) lines.push('(pressed Enter after typing)');
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, selector }, 'Type failed');
+    return { content: `Error: Type failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserTypeTool implements Tool {
+  name = 'browser_type';
+  description = 'Type text into an input element. Target by element_id (from browser_snapshot) or CSS selector.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          element_id: {
+            type: 'string',
+            description: 'The element ID from a previous browser_snapshot result (e.g. "e3").',
+          },
+          selector: {
+            type: 'string',
+            description: 'A CSS selector to target. Used as fallback when element_id is not available.',
+          },
+          text: {
+            type: 'string',
+            description: 'The text to type into the element.',
+          },
+          clear_first: {
+            type: 'boolean',
+            description: 'If true (default), clear existing content before typing. Set to false to append.',
+          },
+          press_enter: {
+            type: 'boolean',
+            description: 'If true, press Enter after typing the text.',
+          },
+        },
+        required: ['text'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserType(input, context);
+  }
+}
+
+registerTool(new BrowserTypeTool());
+
+export {
+  executeBrowserNavigate,
+  executeBrowserSnapshot,
+  executeBrowserClose,
+  executeBrowserClick,
+  executeBrowserType,
+};


### PR DESCRIPTION
## Summary
- Adds `browser_click` tool that clicks elements by `element_id` (from snapshot map) or CSS selector, with actionable errors for missing/stale element IDs
- Adds `browser_type` tool that fills text into inputs with `clear_first` (default true) and `press_enter` options; appends to existing value when `clear_first=false`
- Extends Page type with `click`/`fill`/`press` methods, sets both tools to Medium risk, adds CLI progress/preview text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
