### PR TITLE
Add browser_press_key, browser_wait_for, and browser_extract tools

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -26,6 +26,9 @@ function createMockPage(closed = false) {
     click: async () => {},
     fill: async () => {},
     press: async () => {},
+    waitForSelector: async () => null,
+    waitForFunction: async () => null,
+    keyboard: { press: async () => {} },
   };
 }
 

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -1,0 +1,261 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/headless-browser-read-tools-test',
+}));
+
+let mockPage: {
+  click: ReturnType<typeof mock>;
+  fill: ReturnType<typeof mock>;
+  press: ReturnType<typeof mock>;
+  evaluate: ReturnType<typeof mock>;
+  title: ReturnType<typeof mock>;
+  url: ReturnType<typeof mock>;
+  goto: ReturnType<typeof mock>;
+  close: () => Promise<void>;
+  isClosed: () => boolean;
+  waitForSelector: ReturnType<typeof mock>;
+  waitForFunction: ReturnType<typeof mock>;
+  keyboard: { press: ReturnType<typeof mock> };
+};
+
+let snapshotMaps: Map<string, Map<string, string>>;
+
+mock.module('../tools/browser/browser-manager.js', () => {
+  snapshotMaps = new Map();
+  return {
+    browserManager: {
+      getOrCreateSessionPage: async () => mockPage,
+      closeSessionPage: async () => {},
+      closeAllPages: async () => {},
+      storeSnapshotMap: (sessionId: string, map: Map<string, string>) => {
+        snapshotMaps.set(sessionId, map);
+      },
+      resolveSnapshotSelector: (sessionId: string, elementId: string) => {
+        const map = snapshotMaps.get(sessionId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+    },
+  };
+});
+
+mock.module('../tools/network/url-safety.js', () => ({
+  parseUrl: () => null,
+  isPrivateOrLocalHost: () => false,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => ({}),
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+import {
+  executeBrowserPressKey,
+  executeBrowserWaitFor,
+  executeBrowserExtract,
+} from '../tools/browser/headless-browser.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+  workingDir: '/tmp',
+};
+
+function resetMockPage() {
+  mockPage = {
+    click: mock(async () => {}),
+    fill: mock(async () => {}),
+    press: mock(async () => {}),
+    evaluate: mock(async () => ''),
+    title: mock(async () => 'Test Page'),
+    url: mock(() => 'https://example.com/'),
+    goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
+    close: async () => {},
+    isClosed: () => false,
+    waitForSelector: mock(async () => null),
+    waitForFunction: mock(async () => null),
+    keyboard: { press: mock(async () => {}) },
+  };
+}
+
+// ── browser_press_key ────────────────────────────────────────────────
+
+describe('executeBrowserPressKey', () => {
+  beforeEach(() => {
+    resetMockPage();
+    snapshotMaps.clear();
+  });
+
+  test('presses key on focused element (no target)', async () => {
+    const result = await executeBrowserPressKey({ key: 'Enter' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Pressed "Enter"');
+    expect(mockPage.keyboard.press).toHaveBeenCalledWith('Enter');
+  });
+
+  test('presses key on targeted element via element_id', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserPressKey({ key: 'Tab', element_id: 'e1' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Pressed "Tab" on element');
+    expect(mockPage.press).toHaveBeenCalledWith('[data-vellum-eid="e1"]', 'Tab');
+  });
+
+  test('presses key on targeted element via selector', async () => {
+    const result = await executeBrowserPressKey({ key: 'Escape', selector: '#modal' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(mockPage.press).toHaveBeenCalledWith('#modal', 'Escape');
+  });
+
+  test('errors when key is missing', async () => {
+    const result = await executeBrowserPressKey({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('key is required');
+  });
+
+  test('errors when element_id not found', async () => {
+    const result = await executeBrowserPressKey({ key: 'Enter', element_id: 'e99' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('element_id "e99" not found');
+  });
+
+  test('handles press error', async () => {
+    mockPage.keyboard.press = mock(async () => { throw new Error('key not recognized'); });
+    const result = await executeBrowserPressKey({ key: 'InvalidKey' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Press key failed');
+  });
+});
+
+// ── browser_wait_for ─────────────────────────────────────────────────
+
+describe('executeBrowserWaitFor', () => {
+  beforeEach(() => {
+    resetMockPage();
+  });
+
+  test('waits for selector', async () => {
+    const result = await executeBrowserWaitFor({ selector: '#loaded' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Element matching "#loaded" appeared');
+    expect(mockPage.waitForSelector).toHaveBeenCalledWith('#loaded', { timeout: 30_000 });
+  });
+
+  test('waits for text', async () => {
+    const result = await executeBrowserWaitFor({ text: 'Success' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Text "Success" appeared');
+    expect(mockPage.waitForFunction).toHaveBeenCalled();
+  });
+
+  test('waits for duration', async () => {
+    const result = await executeBrowserWaitFor({ duration: 10 }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Waited 10ms');
+  });
+
+  test('errors when no mode specified', async () => {
+    const result = await executeBrowserWaitFor({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Exactly one of selector, text, or duration');
+  });
+
+  test('errors when multiple modes specified', async () => {
+    const result = await executeBrowserWaitFor({ selector: '#x', text: 'y' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exactly one');
+  });
+
+  test('respects custom timeout', async () => {
+    const result = await executeBrowserWaitFor({ selector: '#el', timeout: 5000 }, ctx);
+    expect(result.isError).toBe(false);
+    expect(mockPage.waitForSelector).toHaveBeenCalledWith('#el', { timeout: 5000 });
+  });
+
+  test('caps duration at MAX_WAIT_MS', async () => {
+    // Use a small duration to verify the cap logic without actually waiting 30s.
+    // duration=50 is below the cap, so it should wait exactly 50ms.
+    const result = await executeBrowserWaitFor({ duration: 50 }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Waited 50ms');
+  });
+
+  test('handles wait error (timeout)', async () => {
+    mockPage.waitForSelector = mock(async () => { throw new Error('Timeout 30000ms exceeded'); });
+    const result = await executeBrowserWaitFor({ selector: '#missing' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Wait failed');
+    expect(result.content).toContain('Timeout');
+  });
+});
+
+// ── browser_extract ──────────────────────────────────────────────────
+
+describe('executeBrowserExtract', () => {
+  beforeEach(() => {
+    resetMockPage();
+  });
+
+  test('extracts page text content', async () => {
+    mockPage.evaluate = mock(async () => 'Hello World');
+    const result = await executeBrowserExtract({}, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('URL: https://example.com/');
+    expect(result.content).toContain('Title: Test Page');
+    expect(result.content).toContain('Hello World');
+  });
+
+  test('shows (empty page) for empty content', async () => {
+    mockPage.evaluate = mock(async () => '');
+    const result = await executeBrowserExtract({}, ctx);
+    expect(result.content).toContain('(empty page)');
+  });
+
+  test('truncates long content', async () => {
+    const longText = 'x'.repeat(60_000);
+    mockPage.evaluate = mock(async () => longText);
+    const result = await executeBrowserExtract({}, ctx);
+    expect(result.content).toContain('... (truncated)');
+    // Content should be capped
+    expect(result.content.length).toBeLessThan(60_000);
+  });
+
+  test('includes links when requested', async () => {
+    let callCount = 0;
+    mockPage.evaluate = mock(async () => {
+      callCount++;
+      if (callCount === 1) return 'Page text';
+      return [
+        { text: 'About', href: 'https://example.com/about' },
+        { text: 'Contact', href: 'https://example.com/contact' },
+      ];
+    });
+
+    const result = await executeBrowserExtract({ include_links: true }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Links:');
+    expect(result.content).toContain('[About](https://example.com/about)');
+    expect(result.content).toContain('[Contact](https://example.com/contact)');
+  });
+
+  test('does not include links by default', async () => {
+    mockPage.evaluate = mock(async () => 'Page text');
+    const result = await executeBrowserExtract({}, ctx);
+    expect(result.content).not.toContain('Links:');
+  });
+
+  test('handles extract error', async () => {
+    mockPage.evaluate = mock(async () => { throw new Error('page crashed'); });
+    const result = await executeBrowserExtract({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Extract failed');
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -79,6 +79,14 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         return `Clicking ${String(input.element_id ?? input.selector ?? '').slice(0, 60)}...`;
       case 'browser_type':
         return `Typing into ${String(input.element_id ?? input.selector ?? '').slice(0, 60)}...`;
+      case 'browser_press_key':
+        return `Pressing "${String(input.key ?? '')}"...`;
+      case 'browser_wait_for':
+        if (input.selector) return `Waiting for ${String(input.selector).slice(0, 60)}...`;
+        if (input.text) return `Waiting for text "${String(input.text).slice(0, 40)}"...`;
+        return `Waiting ${input.duration ?? 0}ms...`;
+      case 'browser_extract':
+        return 'Extracting page content...';
       default:
         return `Running ${toolName}...`;
     }
@@ -126,6 +134,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
     if (req.toolName === 'browser_type') {
       return `type into ${req.input.element_id ?? req.input.selector ?? ''}`;
+    }
+    if (req.toolName === 'browser_press_key') {
+      return `press "${req.input.key ?? ''}"`;
     }
     return `${req.toolName}: ${JSON.stringify(req.input).slice(0, 80)}`;
   }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -180,6 +180,9 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'browser_close') return RiskLevel.Medium;
   if (toolName === 'browser_click') return RiskLevel.Medium;
   if (toolName === 'browser_type') return RiskLevel.Medium;
+  if (toolName === 'browser_press_key') return RiskLevel.Medium;
+  if (toolName === 'browser_wait_for') return RiskLevel.Low;
+  if (toolName === 'browser_extract') return RiskLevel.Low;
   if (toolName === 'skill_load') return RiskLevel.Low;
 
   if (toolName === 'bash') {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -25,6 +25,9 @@ export type Page = {
   click(selector: string): Promise<void>;
   fill(selector: string, value: string): Promise<void>;
   press(selector: string, key: string): Promise<void>;
+  waitForSelector(selector: string, options?: { timeout?: number }): Promise<unknown>;
+  waitForFunction(expression: string, options?: { timeout?: number }): Promise<unknown>;
+  keyboard: { press(key: string): Promise<void> };
 };
 
 type LaunchFn = (userDataDir: string, options: { headless: boolean }) => Promise<BrowserContext>;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -461,10 +461,266 @@ class BrowserTypeTool implements Tool {
 
 registerTool(new BrowserTypeTool());
 
+// ── browser_press_key ────────────────────────────────────────────────
+
+async function executeBrowserPressKey(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const key = typeof input.key === 'string' ? input.key : '';
+  if (!key) {
+    return { content: 'Error: key is required.', isError: true };
+  }
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+
+    // If element_id or selector is provided, press key on that element
+    const elementId = typeof input.element_id === 'string' ? input.element_id : null;
+    const rawSelector = typeof input.selector === 'string' ? input.selector : null;
+
+    if (elementId || rawSelector) {
+      const { selector, error } = resolveSelector(context.sessionId, input);
+      if (error) return { content: error, isError: true };
+      await page.press(selector!, key);
+      return { content: `Pressed "${key}" on element: ${selector}`, isError: false };
+    }
+
+    // No target → press key on the page (focused element)
+    await page.keyboard.press(key);
+    return { content: `Pressed "${key}"`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, key }, 'Press key failed');
+    return { content: `Error: Press key failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserPressKeyTool implements Tool {
+  name = 'browser_press_key';
+  description = 'Press a keyboard key, optionally targeting a specific element. Use for Enter, Escape, Tab, arrow keys, etc.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          key: {
+            type: 'string',
+            description: 'The key to press (e.g. "Enter", "Escape", "Tab", "ArrowDown", "a").',
+          },
+          element_id: {
+            type: 'string',
+            description: 'Optional element ID from browser_snapshot to target.',
+          },
+          selector: {
+            type: 'string',
+            description: 'Optional CSS selector to target.',
+          },
+        },
+        required: ['key'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserPressKey(input, context);
+  }
+}
+
+registerTool(new BrowserPressKeyTool());
+
+// ── browser_wait_for ─────────────────────────────────────────────────
+
+const MAX_WAIT_MS = 30_000;
+
+async function executeBrowserWaitFor(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const selector = typeof input.selector === 'string' ? input.selector : null;
+  const text = typeof input.text === 'string' ? input.text : null;
+  const duration = typeof input.duration === 'number' ? input.duration : null;
+
+  const modeCount = [selector, text, duration].filter((v) => v !== null).length;
+  if (modeCount === 0) {
+    return { content: 'Error: Exactly one of selector, text, or duration is required.', isError: true };
+  }
+  if (modeCount > 1) {
+    return { content: 'Error: Provide exactly one of selector, text, or duration (not multiple).', isError: true };
+  }
+
+  const timeout = typeof input.timeout === 'number'
+    ? Math.min(input.timeout, MAX_WAIT_MS)
+    : MAX_WAIT_MS;
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+
+    if (selector) {
+      await page.waitForSelector(selector, { timeout });
+      return { content: `Element matching "${selector}" appeared.`, isError: false };
+    }
+
+    if (text) {
+      const escaped = JSON.stringify(text);
+      await page.waitForFunction(
+        `document.body?.innerText?.includes(${escaped})`,
+        { timeout },
+      );
+      return { content: `Text "${text.slice(0, 80)}" appeared on page.`, isError: false };
+    }
+
+    // duration mode (milliseconds)
+    const waitMs = Math.min(duration!, MAX_WAIT_MS);
+    await new Promise((r) => setTimeout(r, waitMs));
+    return { content: `Waited ${waitMs}ms.`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Wait failed');
+    return { content: `Error: Wait failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserWaitForTool implements Tool {
+  name = 'browser_wait_for';
+  description = 'Wait for a condition: a CSS selector to appear, text to appear on the page, or a fixed duration in milliseconds. Provide exactly one mode.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          selector: {
+            type: 'string',
+            description: 'Wait for an element matching this CSS selector to appear.',
+          },
+          text: {
+            type: 'string',
+            description: 'Wait for this text to appear on the page.',
+          },
+          duration: {
+            type: 'number',
+            description: 'Wait for this many milliseconds.',
+          },
+          timeout: {
+            type: 'number',
+            description: 'Maximum wait time in milliseconds (default and max: 30000).',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserWaitFor(input, context);
+  }
+}
+
+registerTool(new BrowserWaitForTool());
+
+// ── browser_extract ──────────────────────────────────────────────────
+
+const MAX_EXTRACT_LENGTH = 50_000;
+
+async function executeBrowserExtract(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const includeLinks = input.include_links === true;
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    const currentUrl = page.url();
+    const title = await page.title();
+
+    let textContent = (await page.evaluate(
+      `document.body?.innerText ?? ''`,
+    )) as string;
+
+    if (textContent.length > MAX_EXTRACT_LENGTH) {
+      textContent = textContent.slice(0, MAX_EXTRACT_LENGTH) + '\n... (truncated)';
+    }
+
+    const lines: string[] = [
+      `URL: ${currentUrl}`,
+      `Title: ${title || '(none)'}`,
+      '',
+      textContent || '(empty page)',
+    ];
+
+    if (includeLinks) {
+      const links = (await page.evaluate(`
+        (() => {
+          const anchors = Array.from(document.querySelectorAll('a[href]'));
+          return anchors.slice(0, 200).map(a => ({
+            text: (a.textContent || '').trim().slice(0, 80),
+            href: a.href,
+          }));
+        })()
+      `)) as Array<{ text: string; href: string }>;
+
+      if (links.length > 0) {
+        lines.push('');
+        lines.push('Links:');
+        for (const link of links) {
+          lines.push(`  [${link.text || '(no text)'}](${link.href})`);
+        }
+      }
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Extract failed');
+    return { content: `Error: Extract failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserExtractTool implements Tool {
+  name = 'browser_extract';
+  description = 'Extract the text content of the current page. Optionally include links. Output is capped to prevent excessive token usage.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          include_links: {
+            type: 'boolean',
+            description: 'If true, include a list of links found on the page (up to 200).',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserExtract(input, context);
+  }
+}
+
+registerTool(new BrowserExtractTool());
+
 export {
   executeBrowserNavigate,
   executeBrowserSnapshot,
   executeBrowserClose,
   executeBrowserClick,
   executeBrowserType,
+  executeBrowserPressKey,
+  executeBrowserWaitFor,
+  executeBrowserExtract,
 };


### PR DESCRIPTION
## Summary
- Adds `browser_press_key` tool for pressing keyboard keys on focused or targeted elements
- Adds `browser_wait_for` tool with three modes: selector appearance, text content, or fixed duration (max 30s)
- Adds `browser_extract` tool for extracting page text content (50k cap) with optional link enumeration (up to 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
