### PR TITLE
Add db:studio script for Drizzle Kit Studio

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "build": "node scripts/run-next.mjs build",
     "db:push": "bun run scripts/migrate.mts",
     "db:push:preview": "bun run scripts/migrate.mts --preview",
+    "db:studio": "bunx drizzle-kit studio",
     "test:integration:channels": "bun run scripts/channels-integration-harness.mts",
     "lint": "eslint",
     "pull": "node scripts/pull.mjs",


### PR DESCRIPTION
## Summary
- Add `db:studio` npm script to `web/package.json`
- Runs `bunx drizzle-kit studio` for launching the Drizzle database GUI

## Test plan
- [ ] Run `npm run db:studio` from the `web/` directory and verify Drizzle Kit Studio launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
