### PR TITLE
Add /do command for worktree-isolated task execution

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,9 +16,10 @@ ln -s ../../scripts/commands/check-reviews.md check-reviews.md
 ln -s ../../scripts/commands/brainstorm.md brainstorm.md
 ln -s ../../scripts/commands/swarm.md swarm.md
 ln -s ../../scripts/commands/mainline.md mainline.md
+ln -s ../../scripts/commands/do.md do.md
 ```
 
-After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, and `/mainline` in Claude Code.
+After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, `/mainline`, and `/do` in Claude Code.
 
 ### 2. **IMPORTANT** Enable fast mode
 
@@ -104,6 +105,19 @@ Takes all uncommitted changes, creates a branch, commits, opens a PR, merges it 
 /mainline Fix login redirect bug   # uses the provided title
 ```
 
+### `/do` - Implement and ship a one-off task
+
+Takes a description of changes, creates an isolated git worktree, implements the changes, creates a PR, merges it, and cleans up the worktree. Like `/work` but for ad-hoc tasks that aren't in the backlog, and isolated in a worktree so it doesn't interfere with your working tree.
+
+**When to use:** When you want to describe a change and have it implemented and shipped end-to-end without touching your current working directory.
+
+**Frequency:** Whenever you have a self-contained task to ship.
+
+```
+/do Add input validation to the login form
+/do Refactor the logger to use structured output
+```
+
 ## Typical workflow
 
 3 shells with Claude Code open, one for each of work/swarm, check-reviews, and brainstorm.
@@ -180,4 +194,10 @@ Follow the instructions in scripts/commands/brainstorm.md
 
 ```
 Follow the instructions in scripts/commands/mainline.md
+```
+
+### Do prompt
+
+```
+Follow the instructions in scripts/commands/do.md
 ```

--- a/scripts/commands/do.md
+++ b/scripts/commands/do.md
@@ -1,0 +1,97 @@
+Implement the requested changes in an isolated worktree, then ship them to main via a squash-merged PR.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, stop and tell the user to provide a description of what to do. Example: `/do Add input validation to the login form`.
+
+## Repo-specific gotchas
+
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- **Imports**: All imports use `.js` extensions (NodeNext module resolution).
+- **Project structure**: Bun + TypeScript project. Code is in `assistant/`.
+
+## Steps
+
+### 1. Create worktree
+
+Derive a short branch name slug from the description (e.g. `do/add-login-validation`).
+
+```bash
+scripts/worktree create do/<slug>
+```
+
+Remember the worktree path printed by the script. ALL work happens in the worktree — do NOT modify files in the main repo.
+
+### 2. Implement the changes
+
+Working entirely inside the worktree directory, implement what was requested. Explore the codebase, make changes, add tests if appropriate, and type-check:
+
+```bash
+cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
+```
+
+### 3. Stage and commit
+
+```bash
+cd <worktree>
+git add -A
+git diff --cached
+```
+
+Review the staged diff. Draft a clear commit message. Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 4. Push and create PR
+
+```bash
+git push -u origin HEAD
+```
+
+Infer a concise PR title from the changes.
+
+```bash
+gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 5. Add to unreviewed list
+
+Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
+
+### 6. Merge
+
+```bash
+gh pr merge <N> --squash
+```
+
+### 7. Clean up worktree
+
+```bash
+scripts/worktree remove do/<slug> --delete-branch
+```
+
+### 8. Pull main
+
+```bash
+git checkout main && git pull
+```
+
+### 9. Report
+
+Output the PR link and a summary of what was shipped. End your message with "Done."
+
+IMPORTANT: .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing.


### PR DESCRIPTION
## Summary
- Adds `/do <description>` slash command that implements changes in an isolated git worktree, then ships via squash-merged PR
- Like `/work` for ad-hoc tasks not in the backlog, isolated so it doesn't touch the working tree
- Updates scripts README with documentation and symlink instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
