### PR TITLE
Add /execute-plan command for multi-PR rollout plans

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,9 +17,10 @@ ln -s ../../scripts/commands/brainstorm.md brainstorm.md
 ln -s ../../scripts/commands/swarm.md swarm.md
 ln -s ../../scripts/commands/mainline.md mainline.md
 ln -s ../../scripts/commands/do.md do.md
+ln -s ../../scripts/commands/execute-plan.md execute-plan.md
 ```
 
-After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, `/mainline`, and `/do` in Claude Code.
+After symlinking, the commands are available as `/work`, `/check-reviews`, `/brainstorm`, `/swarm`, `/mainline`, `/do`, and `/execute-plan` in Claude Code.
 
 ### 2. **IMPORTANT** Enable fast mode
 
@@ -118,6 +119,19 @@ Takes a description of changes, creates an isolated git worktree, implements the
 /do Refactor the logger to use structured output
 ```
 
+### `/execute-plan` - Execute a multi-PR rollout plan
+
+Reads a plan file from `.private/plans/`, then sequentially implements and mainlines each PR described in the plan. Automatically detects which PRs have already been completed and picks up where it left off.
+
+**When to use:** When you have a large feature broken into an ordered sequence of PRs (created manually or via brainstorming) and want to execute them one by one.
+
+**Frequency:** Once per plan. Can be re-run to resume after interruption.
+
+```
+/execute-plan BROWSER_PLAN.md    # executes .private/plans/BROWSER_PLAN.md
+/execute-plan AUTH_REFACTOR.md   # executes .private/plans/AUTH_REFACTOR.md
+```
+
 ## Typical workflow
 
 3 shells with Claude Code open, one for each of work/swarm, check-reviews, and brainstorm.
@@ -200,4 +214,10 @@ Follow the instructions in scripts/commands/mainline.md
 
 ```
 Follow the instructions in scripts/commands/do.md
+```
+
+### Execute-plan prompt
+
+```
+Follow the instructions in scripts/commands/execute-plan.md
 ```

--- a/scripts/commands/execute-plan.md
+++ b/scripts/commands/execute-plan.md
@@ -1,0 +1,69 @@
+Execute a multi-PR rollout plan sequentially. Each PR in the plan is implemented and mainlined before moving to the next.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. Example: `/execute-plan BROWSER_PLAN.md`.
+
+## Steps
+
+### 1. Read the plan
+
+Read `.private/plans/$ARGUMENTS`. If the file doesn't exist, stop and tell the user.
+
+Parse the plan to identify the ordered list of PRs. Plans typically have numbered PR sections (e.g. "## PR 1", "## PR 2") each describing: branch name, title, scope, files to modify, implementation steps, tests to run, and acceptance criteria.
+
+### 2. Determine starting point
+
+Check which PRs have already been completed. Look at:
+- The git log for commits/PRs that match earlier PR titles or branch names from the plan.
+- Whether the files/changes described in earlier PRs already exist in the codebase.
+
+Skip any PRs that are already done. Tell the user which PRs you're skipping and why.
+
+### 3. Execute each remaining PR
+
+For each PR in order:
+
+#### 3a. Implement
+
+Read the PR section carefully. Implement all the changes described:
+- Create/modify the listed files according to the steps.
+- Follow the project conventions (Bun + TypeScript, `.js` import extensions, NodeNext resolution).
+- Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+
+#### 3b. Validate
+
+Run the tests and type-checks specified in the PR section. Fix any failures before proceeding.
+
+#### 3c. Mainline
+
+Ship the changes using the same workflow as `/mainline`:
+
+1. Create a branch using the name from the plan (or derive one from the PR title).
+2. Stage and commit with a descriptive message.
+3. Push and create a PR with a title and summary matching the plan.
+4. Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
+5. Merge immediately: `gh pr merge <N> --squash`.
+6. Switch back to main and pull.
+
+#### 3d. Report progress
+
+After each PR is mainlined, tell the user:
+- Which PR was completed (e.g. "PR 3 of 8 done").
+- The PR link.
+- A brief summary of what was shipped.
+
+Then proceed to the next PR.
+
+### 4. Completion
+
+After all PRs are mainlined, tell the user the plan is fully executed. List all the PRs that were created with their links.
+
+## Repo-specific gotchas
+
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- **Imports**: All imports use `.js` extensions (NodeNext module resolution).
+- **Project structure**: Bun + TypeScript project. Code is in `assistant/`.
+
+IMPORTANT: .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing.


### PR DESCRIPTION
## Summary
- Adds `/execute-plan NAME.md` command that reads a plan from `.private/plans/`, then sequentially implements and mainlines each PR
- Automatically detects already-completed PRs and resumes from where it left off
- Updates scripts README with documentation and symlink instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
