### PR TITLE
Add pure history-repair module with exhaustive unit tests

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from 'bun:test';
+import { repairHistory } from '../daemon/history-repair.js';
+import type { Message } from '../providers/types.js';
+
+describe('repairHistory', () => {
+  test('no-op for valid histories', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'read', input: { path: '/a' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'file contents' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Here is the file.' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(repaired).toEqual(messages);
+    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.missingToolResultsInserted).toBe(0);
+    expect(stats.orphanToolResultsDowngraded).toBe(0);
+  });
+
+  test('strips tool_result blocks from assistant messages', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Sure' },
+          { type: 'tool_result', tool_use_id: 'tu_x', content: 'stale' },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(repaired).toHaveLength(2);
+    expect(repaired[1].content).toEqual([{ type: 'text', text: 'Sure' }]);
+    expect(stats.assistantToolResultsRemoved).toBe(1);
+  });
+
+  test('inserts missing tool_result when user message lacks it', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Run tool' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+          { type: 'tool_use', id: 'tu_2', name: 'read', input: { path: '/b' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'ok' },
+          // tu_2 is missing
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.missingToolResultsInserted).toBe(1);
+
+    // The user message should now have both tool_results
+    const userMsg = repaired[2];
+    expect(userMsg.role).toBe('user');
+    const trBlocks = userMsg.content.filter((b) => b.type === 'tool_result');
+    expect(trBlocks).toHaveLength(2);
+
+    const synth = trBlocks.find(
+      (b) => b.type === 'tool_result' && b.tool_use_id === 'tu_2',
+    );
+    expect(synth).toBeDefined();
+    expect(synth!.type === 'tool_result' && synth!.is_error).toBe(true);
+  });
+
+  test('injects synthetic user message when assistant tool_use has no following user message', () => {
+    // assistant with tool_use followed by another assistant (no user in between)
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Oops' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.missingToolResultsInserted).toBe(1);
+    expect(repaired).toHaveLength(4);
+    expect(repaired[2].role).toBe('user');
+    expect(repaired[2].content[0].type).toBe('tool_result');
+  });
+
+  test('injects synthetic user message for trailing assistant with tool_use', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.missingToolResultsInserted).toBe(1);
+    expect(repaired).toHaveLength(3);
+    expect(repaired[2].role).toBe('user');
+  });
+
+  test('downgrades orphan tool_result blocks to text', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'ok' },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_unknown',
+            content: 'stale result',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+
+    const userContent = repaired[2].content;
+    expect(userContent).toHaveLength(2);
+    expect(userContent[0].type).toBe('tool_result');
+    expect(userContent[1].type).toBe('text');
+    expect(
+      userContent[1].type === 'text' && userContent[1].text,
+    ).toContain('orphaned tool_result');
+  });
+
+  test('downgrades tool_result in user message when no preceding tool_use', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'hi' },
+          { type: 'tool_result', tool_use_id: 'tu_gone', content: 'wat' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    expect(repaired[0].content[1].type).toBe('text');
+  });
+
+  test('preserves non-tool content unchanged', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'abc' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'hmm', signature: 'sig' },
+          { type: 'text', text: 'World' },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(repaired).toEqual(messages);
+    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.missingToolResultsInserted).toBe(0);
+    expect(stats.orphanToolResultsDowngraded).toBe(0);
+  });
+
+  test('idempotency: running twice produces same output', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+          { type: 'tool_result', tool_use_id: 'tu_x', content: 'bad' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu_orphan', content: 'stale' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      },
+    ];
+
+    const first = repairHistory(messages);
+    const second = repairHistory(first.messages);
+
+    expect(second.messages).toEqual(first.messages);
+    expect(second.stats.assistantToolResultsRemoved).toBe(0);
+    expect(second.stats.missingToolResultsInserted).toBe(0);
+    expect(second.stats.orphanToolResultsDowngraded).toBe(0);
+  });
+
+  test('handles multiple tool_use blocks with all results missing', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Run' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_a', name: 'bash', input: {} },
+          { type: 'tool_use', id: 'tu_b', name: 'read', input: {} },
+          { type: 'tool_use', id: 'tu_c', name: 'write', input: {} },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'next message' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    // The text-only user message should have 3 synthetic tool_results injected
+    expect(stats.missingToolResultsInserted).toBe(3);
+
+    const userMsg = repaired[2];
+    const trBlocks = userMsg.content.filter((b) => b.type === 'tool_result');
+    expect(trBlocks).toHaveLength(3);
+    // Original text content preserved
+    expect(userMsg.content[0]).toEqual({ type: 'text', text: 'next message' });
+  });
+
+  test('handles empty message array', () => {
+    const { messages, stats } = repairHistory([]);
+    expect(messages).toEqual([]);
+    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.missingToolResultsInserted).toBe(0);
+    expect(stats.orphanToolResultsDowngraded).toBe(0);
+  });
+});

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -1,0 +1,135 @@
+import type {
+  Message,
+  ContentBlock,
+  ToolUseContent,
+  ToolResultContent,
+} from '../providers/types.js';
+
+export interface RepairStats {
+  assistantToolResultsRemoved: number;
+  missingToolResultsInserted: number;
+  orphanToolResultsDowngraded: number;
+}
+
+export interface RepairResult {
+  messages: Message[];
+  stats: RepairStats;
+}
+
+const SYNTHETIC_RESULT = '[synthesized: tool result missing from history]';
+
+export function repairHistory(messages: Message[]): RepairResult {
+  const stats: RepairStats = {
+    assistantToolResultsRemoved: 0,
+    missingToolResultsInserted: 0,
+    orphanToolResultsDowngraded: 0,
+  };
+
+  const result: Message[] = [];
+  let pendingToolUseIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant') {
+      // If previous assistant had unfulfilled tool_use, inject synthetic user message
+      if (pendingToolUseIds.size > 0) {
+        result.push(buildSyntheticToolResultMessage(pendingToolUseIds));
+        stats.missingToolResultsInserted += pendingToolUseIds.size;
+        pendingToolUseIds = new Set();
+      }
+
+      // Strip tool_result blocks from assistant messages
+      const cleanedContent: ContentBlock[] = [];
+      for (const block of msg.content) {
+        if (block.type === 'tool_result') {
+          stats.assistantToolResultsRemoved++;
+        } else {
+          cleanedContent.push(block);
+        }
+      }
+
+      result.push({ role: 'assistant', content: cleanedContent });
+
+      // Collect tool_use IDs from this assistant message
+      pendingToolUseIds = new Set(
+        cleanedContent
+          .filter((b): b is ToolUseContent => b.type === 'tool_use')
+          .map((b) => b.id),
+      );
+    } else {
+      // User message
+      if (pendingToolUseIds.size > 0) {
+        const matchedIds = new Set<string>();
+        const newContent: ContentBlock[] = [];
+
+        for (const block of msg.content) {
+          if (block.type === 'tool_result') {
+            const tr = block as ToolResultContent;
+            if (pendingToolUseIds.has(tr.tool_use_id)) {
+              matchedIds.add(tr.tool_use_id);
+              newContent.push(block);
+            } else {
+              stats.orphanToolResultsDowngraded++;
+              newContent.push(downgradeToolResult(tr));
+            }
+          } else {
+            newContent.push(block);
+          }
+        }
+
+        // Inject synthetic tool_result for any unmatched IDs
+        for (const id of pendingToolUseIds) {
+          if (!matchedIds.has(id)) {
+            stats.missingToolResultsInserted++;
+            newContent.push({
+              type: 'tool_result',
+              tool_use_id: id,
+              content: SYNTHETIC_RESULT,
+              is_error: true,
+            });
+          }
+        }
+
+        result.push({ role: 'user', content: newContent });
+        pendingToolUseIds = new Set();
+      } else {
+        // No pending tool_use — any tool_result here is orphaned
+        const newContent: ContentBlock[] = msg.content.map((block) => {
+          if (block.type === 'tool_result') {
+            stats.orphanToolResultsDowngraded++;
+            return downgradeToolResult(block as ToolResultContent);
+          }
+          return block;
+        });
+
+        result.push({ role: 'user', content: newContent });
+      }
+    }
+  }
+
+  // Trailing unfulfilled tool_use at end of history
+  if (pendingToolUseIds.size > 0) {
+    result.push(buildSyntheticToolResultMessage(pendingToolUseIds));
+    stats.missingToolResultsInserted += pendingToolUseIds.size;
+  }
+
+  return { messages: result, stats };
+}
+
+function buildSyntheticToolResultMessage(ids: Set<string>): Message {
+  return {
+    role: 'user',
+    content: Array.from(ids).map((id) => ({
+      type: 'tool_result' as const,
+      tool_use_id: id,
+      content: SYNTHETIC_RESULT,
+      is_error: true,
+    })),
+  };
+}
+
+function downgradeToolResult(tr: ToolResultContent): ContentBlock {
+  return {
+    type: 'text',
+    text: `[orphaned tool_result for ${tr.tool_use_id}]: ${tr.content}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Introduces a deterministic, side-effect-free `repairHistory()` function that fixes invalid message ordering for the Anthropic API
- Strips `tool_result` blocks from assistant messages, injects synthetic results for missing tool_use responses, and downgrades orphan `tool_result` blocks to safe text
- Includes 11 unit tests covering all fix categories plus idempotency

## Test plan
- [x] `bun test src/__tests__/history-repair.test.ts` — all 11 tests pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
