### PR TITLE
Repair runtime history immediately before provider call

### DIFF
--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+
+// Capture messages passed to agentLoop.run
+let capturedRunMessages: Message[] = [];
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    systemPrompt: {},
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+// Mock conversation store
+let mockDbMessages: Array<{ id: string; role: string; content: string }> = [];
+let mockConversation: Record<string, unknown> | null = null;
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => mockDbMessages,
+  getConversation: () => mockConversation,
+  createConversation: () => ({ id: 'conv-1' }),
+  listConversations: () => [],
+  addMessage: () => ({ id: 'new-msg' }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+}));
+
+// Mock memory retriever to be no-op
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+// Mock AgentLoop to capture the messages it receives
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(messages: Message[], onEvent: (event: Record<string, unknown>) => void): Promise<Message[]> {
+      capturedRunMessages = messages;
+      // Emit usage event so processMessage doesn't error
+      onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock' });
+      // Return messages with an assistant response appended
+      return [
+        ...messages,
+        { role: 'assistant', content: [{ type: 'text', text: 'response' }] },
+      ];
+    }
+  },
+}));
+
+// Mock context window manager
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return { content: [{ type: 'text', text: 'hi' }], model: 'mock', usage: { inputTokens: 0, outputTokens: 0 }, stopReason: 'end_turn' };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+describe('pre-run history repair', () => {
+  test('broken runtime history gets fixed before provider call', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+
+    // Simulate a corrupt in-memory state: assistant with tool_use but no tool_result follows
+    mockDbMessages = [
+      { id: 'm1', role: 'user', content: JSON.stringify([{ type: 'text', text: 'First' }]) },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: JSON.stringify([
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ]),
+      },
+      // Missing tool_result user message — repaired during loadFromDb
+      // but we want to verify pre-run repair also works independently
+    ];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // loadFromDb already repaired, but let's corrupt the in-memory state
+    // by removing the synthetic user message to simulate a runtime drift
+    const messages = session.getMessages();
+    // After load repair: [user, assistant(tool_use), user(synthetic_tool_result)]
+    // Remove the synthetic user to simulate runtime corruption
+    messages.pop();
+
+    capturedRunMessages = [];
+    const events: Array<Record<string, unknown>> = [];
+    await session.processMessage('Next question', [], (msg) => events.push(msg as unknown as Record<string, unknown>));
+
+    // The messages passed to agentLoop.run should have been repaired
+    // Find all tool_use blocks without matching tool_result
+    const assistantMsgs = capturedRunMessages.filter((m) => m.role === 'assistant');
+    for (const aMsg of assistantMsgs) {
+      const toolUseBlocks = aMsg.content.filter((b) => b.type === 'tool_use');
+      if (toolUseBlocks.length === 0) continue;
+
+      // Find the next user message
+      const aIdx = capturedRunMessages.indexOf(aMsg);
+      const nextMsg = capturedRunMessages[aIdx + 1];
+      expect(nextMsg).toBeDefined();
+      expect(nextMsg.role).toBe('user');
+
+      for (const tu of toolUseBlocks) {
+        if (tu.type !== 'tool_use') continue;
+        const hasResult = nextMsg.content.some(
+          (b) => b.type === 'tool_result' && b.tool_use_id === tu.id,
+        );
+        expect(hasResult).toBe(true);
+      }
+    }
+  });
+
+  test('existing memory-recall injection still works', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    capturedRunMessages = [];
+    await session.processMessage('Hello', [], () => {});
+
+    // Should have a user message in the captured run messages
+    expect(capturedRunMessages.length).toBeGreaterThanOrEqual(1);
+    const userMsg = capturedRunMessages.find((m) => m.role === 'user');
+    expect(userMsg).toBeDefined();
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -292,6 +292,13 @@ export class Session {
         }
       }
 
+      // Pre-run repair: fix any message ordering issues before sending to provider
+      const preRunRepair = repairHistory(runMessages);
+      if (preRunRepair.stats.assistantToolResultsRemoved > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
+        log.warn({ conversationId: this.conversationId, phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
+        runMessages = preRunRepair.messages;
+      }
+
       const updatedHistory = await this.agentLoop.run(
         runMessages,
         (event) => {


### PR DESCRIPTION
## Summary
- Runs `repairHistory()` on `runMessages` right before `agentLoop.run()` to ensure valid message ordering
- Uses repaired messages for the model call only; existing recall/context behavior is unaffected
- Emits `phase=pre_run` structured warning log when runtime repairs are needed

## Test plan
- [x] `bun test src/__tests__/session-pre-run-repair.test.ts` — 2 tests pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
