### PR TITLE
Archive executed plan files after /execute-plan completes

### DIFF
--- a/scripts/commands/execute-plan.md
+++ b/scripts/commands/execute-plan.md
@@ -55,7 +55,16 @@ After each PR is mainlined, tell the user:
 
 Then proceed to the next PR.
 
-### 4. Completion
+### 4. Archive the plan
+
+After all PRs are mainlined, move the plan file to `.private/plans/archived/`:
+
+```bash
+mkdir -p .private/plans/archived
+mv .private/plans/$ARGUMENTS .private/plans/archived/$ARGUMENTS
+```
+
+### 5. Completion
 
 After all PRs are mainlined, tell the user the plan is fully executed. List all the PRs that were created with their links.
 


### PR DESCRIPTION
## Summary
- Adds a new step to `/execute-plan` that moves the plan file to `.private/plans/archived/` after all PRs are mainlined
- Keeps completed plans out of the active plans directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
