### PR TITLE
Default to safe non-interactive worktree branch deletion

### DIFF
--- a/scripts/commands/swarm.md
+++ b/scripts/commands/swarm.md
@@ -92,7 +92,7 @@ For "Address the feedback on <PR URL>" tasks:
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
 5. Send the agent a shutdown request.
-6. Remove the worktree: `scripts/worktree remove swarm/task-<counter>`.
+6. Remove the worktree: `scripts/worktree remove swarm/task-<counter> --delete-branch`.
 7. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate — give enough detail that the user understands what happened without clicking the PR.
 8. Remove the item from the in-flight list.
 9. Pull the latest main branch to ensure the worktree is up to date.

--- a/scripts/worktree
+++ b/scripts/worktree
@@ -76,9 +76,9 @@ remove() {
     read -p "Delete branch $branch? [y/N] " -n 1 -r
     echo
   else
-    # Non-TTY: try to read piped input, default to "y" on EOF
-    read -r REPLY 2>/dev/null || { [ -z "$REPLY" ] && REPLY="y"; }
-    REPLY="${REPLY:=y}"
+    # Non-TTY: read piped input if available, default to "n" (safe)
+    read -r REPLY 2>/dev/null || REPLY=""
+    REPLY="${REPLY:-n}"
   fi
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     git -C "$REPO_ROOT" branch -d "$branch" 2>/dev/null || \


### PR DESCRIPTION
## Summary

- Addresses review feedback on PR #516: non-interactive `worktree remove` now defaults to keeping the branch ("n") instead of deleting it ("y")
- Piped input is still respected (e.g., `echo y | scripts/worktree remove <branch>` works)
- Non-interactive callers (like swarm agents) should use `--delete-branch` for explicit branch cleanup
- Updates `swarm.md` to pass `--delete-branch` so swarm agents continue to get automatic cleanup

## Test plan

- [ ] `scripts/worktree create test/foo && scripts/worktree remove test/foo` -- interactive prompt still appears
- [ ] `echo n | scripts/worktree remove test/bar` -- branch is preserved
- [ ] `echo y | scripts/worktree remove test/baz` -- branch is deleted
- [ ] `scripts/worktree remove test/qux` with non-TTY stdin (no pipe) -- branch is preserved (safe default)
- [ ] `scripts/worktree remove test/quux --delete-branch` -- branch is always deleted

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
