### PR TITLE
Fix browser manager race condition and stale snapshot maps

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -49,25 +49,44 @@ function getProfileDir(): string {
 
 class BrowserManager {
   private context: BrowserContext | null = null;
+  private contextCreating: Promise<BrowserContext> | null = null;
   private pages = new Map<string, Page>();
   private snapshotMaps = new Map<string, Map<string, string>>();
 
-  async getOrCreateSessionPage(sessionId: string): Promise<Page> {
-    if (!this.context) {
+  private async ensureContext(): Promise<BrowserContext> {
+    if (this.context) return this.context;
+    if (this.contextCreating) return this.contextCreating;
+
+    this.contextCreating = (async () => {
       const profileDir = getProfileDir();
       mkdirSync(profileDir, { recursive: true });
 
       const launch = launchPersistentContext ?? await getDefaultLaunchFn();
-      this.context = await launch(profileDir, { headless: true });
+      const ctx = await launch(profileDir, { headless: true });
       log.info({ profileDir }, 'Browser context created');
+      return ctx;
+    })();
+
+    try {
+      this.context = await this.contextCreating;
+      return this.context;
+    } finally {
+      this.contextCreating = null;
     }
+  }
+
+  async getOrCreateSessionPage(sessionId: string): Promise<Page> {
+    const context = await this.ensureContext();
 
     const existing = this.pages.get(sessionId);
     if (existing && !existing.isClosed()) {
       return existing;
     }
 
-    const page = await this.context.newPage();
+    // Clear stale snapshot mappings when replacing a closed page
+    this.snapshotMaps.delete(sessionId);
+
+    const page = await context.newPage();
     this.pages.set(sessionId, page);
     log.debug({ sessionId }, 'Session page created');
     return page;


### PR DESCRIPTION
## Summary
- Guard lazy browser context creation with a shared `contextCreating` promise to prevent concurrent calls from spawning duplicate Chromium instances (addresses race condition from PR #559 review)
- Clear stale `snapshotMaps` when replacing a closed session page so `resolveSnapshotSelector` does not return outdated element-id-to-selector mappings

## Test plan
- [x] Existing `browser-manager.test.ts` passes (16/16 tests)
- [x] `bunx tsc --noEmit` passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
