### PR TITLE
Fix /do worktree branching and cleanup directory issues

### DIFF
--- a/scripts/commands/do.md
+++ b/scripts/commands/do.md
@@ -17,8 +17,11 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a description of wha
 
 Derive a short branch name slug from the description (e.g. `do/add-login-validation`).
 
+Fetch the latest main and create the worktree based on `origin/main` so the branch doesn't include unrelated commits:
+
 ```bash
-scripts/worktree create do/<slug>
+git fetch origin main
+scripts/worktree create do/<slug> origin/main
 ```
 
 Remember the worktree path printed by the script. ALL work happens in the worktree — do NOT modify files in the main repo.
@@ -80,14 +83,17 @@ gh pr merge <N> --squash
 
 ### 7. Clean up worktree
 
+Change back to the main repo directory first (you may still be inside the worktree from earlier steps), then remove it:
+
 ```bash
+cd <main-repo>
 scripts/worktree remove do/<slug> --delete-branch
 ```
 
 ### 8. Pull main
 
 ```bash
-git checkout main && git pull
+git pull origin main
 ```
 
 ### 9. Report

--- a/scripts/worktree
+++ b/scripts/worktree
@@ -8,7 +8,7 @@ usage() {
   echo "Usage: scripts/worktree <create|remove|list> [args]"
   echo ""
   echo "Commands:"
-  echo "  create <branch-name>                Create a worktree + branch and install deps"
+  echo "  create <branch-name> [start-point]  Create a worktree + branch and install deps"
   echo "  remove <branch-name> [options]      Remove a worktree and optionally delete the branch"
   echo "  list                                List all worktrees"
   echo ""
@@ -25,6 +25,7 @@ usage() {
 
 create() {
   local branch="$1"
+  local start_point="${2:-}"
   local slug="${branch//\//-}"
   local dir="$PARENT_DIR/vellum-wt-${slug}"
 
@@ -34,7 +35,11 @@ create() {
   fi
 
   echo "Creating worktree at $dir on branch $branch..."
-  git -C "$REPO_ROOT" worktree add "$dir" -b "$branch"
+  if [ -n "$start_point" ]; then
+    git -C "$REPO_ROOT" worktree add "$dir" -b "$branch" "$start_point"
+  else
+    git -C "$REPO_ROOT" worktree add "$dir" -b "$branch"
+  fi
 
   echo "Installing assistant dependencies..."
   export PATH="$HOME/.bun/bin:$PATH"
@@ -99,7 +104,7 @@ fi
 case "$1" in
   create)
     [ $# -lt 2 ] && { echo "Error: branch name required"; usage; exit 1; }
-    create "$2"
+    create "$2" "${3:-}"
     ;;
   remove)
     [ $# -lt 2 ] && { echo "Error: branch name required"; usage; exit 1; }


### PR DESCRIPTION
## Summary
- Adds optional `start-point` argument to `scripts/worktree create` so the new branch can be based on a specific commit
- Updates `/do` step 1 to fetch and branch from `origin/main`, preventing unrelated commits from leaking into PRs opened against main
- Updates `/do` step 7 to `cd` back to the main repo before removing the worktree, avoiding `fatal: cannot change to '<worktree>'` errors when the script runs inside the directory being deleted

## Test plan
- [ ] Verify `scripts/worktree create feat/test origin/main` creates a worktree based on origin/main
- [ ] Verify `scripts/worktree create feat/test` (no start-point) still works as before
- [ ] Verify `/do` workflow completes without directory errors during cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
