### PR TITLE
fix(history-repair): preserve tool_result content during migration

### DIFF
--- a/assistant/docs/history-repair.md
+++ b/assistant/docs/history-repair.md
@@ -15,7 +15,7 @@ The history-repair system provides a multi-layered defense.
 
 | Rule | Trigger | Action |
 |------|---------|--------|
-| Strip assistant tool_result | `tool_result` block inside an assistant message | Remove the block |
+| Migrate assistant tool_result | `tool_result` block inside an assistant message | Strip from assistant, migrate to the next user message as a proper `tool_result` if it matches a pending `tool_use` ID |
 | Inject missing tool_result | `tool_use` in assistant with no matching `tool_result` in the next user message | Append a synthetic `tool_result` (is_error=true, content: `[synthesized: tool result missing from history]`) |
 | Downgrade orphan tool_result | `tool_result` in a user message whose `tool_use_id` doesn't match any pending `tool_use` | Convert to a `text` block: `[orphaned tool_result for <id>]: <content>` |
 
@@ -59,7 +59,7 @@ All repair activity is logged as structured JSON via the `session` logger module
 | Field | Type | Description |
 |-------|------|-------------|
 | `phase` | `load` / `pre_run` / `retry` | Which repair phase triggered the log |
-| `assistantToolResultsRemoved` | number | tool_result blocks stripped from assistant messages |
+| `assistantToolResultsMigrated` | number | tool_result blocks migrated from assistant to user messages |
 | `missingToolResultsInserted` | number | Synthetic tool_result blocks injected |
 | `orphanToolResultsDowngraded` | number | Orphan tool_result blocks converted to text |
 
@@ -71,7 +71,7 @@ All repair activity is logged as structured JSON via the `session` logger module
   "module": "session",
   "conversationId": "abc-123",
   "phase": "load",
-  "assistantToolResultsRemoved": 0,
+  "assistantToolResultsMigrated": 0,
   "missingToolResultsInserted": 2,
   "orphanToolResultsDowngraded": 0,
   "msg": "Repaired persisted history"
@@ -82,7 +82,7 @@ All repair activity is logged as structured JSON via the `session` logger module
 
 - **Healthy system**: All counters stay at 0 — no repair logs emitted.
 - **Post-crash recovery**: `missingToolResultsInserted > 0` during `phase=load`. Expected after daemon kill.
-- **Legacy data migration**: `assistantToolResultsRemoved > 0` during `phase=load`. Expected for sessions created before the tool_result fix.
+- **Legacy data migration**: `assistantToolResultsMigrated > 0` during `phase=load`. Expected for sessions with legacy tool_result blocks in assistant messages; content is preserved during migration.
 - **Runtime drift**: Any counter > 0 during `phase=pre_run`. Rare; indicates an in-memory corruption path that should be investigated.
 - **Retry triggered**: `phase=retry` log entry. The provider rejected the history despite pre-run repair. If the retry also fails, an error-level log follows.
 

--- a/assistant/src/__tests__/history-repair-observability.test.ts
+++ b/assistant/src/__tests__/history-repair-observability.test.ts
@@ -11,7 +11,7 @@ describe('history-repair observability', () => {
 
     const { stats } = repairHistory(messages);
 
-    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
   });
@@ -36,8 +36,8 @@ describe('history-repair observability', () => {
 
     const { stats } = repairHistory(messages);
 
-    // assistantToolResultsRemoved: 1 (tu_bad in assistant message)
-    expect(stats.assistantToolResultsRemoved).toBe(1);
+    // assistantToolResultsMigrated: 1 (tu_bad migrated from assistant message)
+    expect(stats.assistantToolResultsMigrated).toBe(1);
     // missingToolResultsInserted: 1 (tu_1 had no matching result in next user msg)
     // but actually the orphan tu_orphan is downgraded, and tu_1 is injected
     expect(stats.missingToolResultsInserted).toBe(1);
@@ -46,7 +46,7 @@ describe('history-repair observability', () => {
 
     // All counters > 0 → log would be emitted
     const shouldLog =
-      stats.assistantToolResultsRemoved > 0 ||
+      stats.assistantToolResultsMigrated > 0 ||
       stats.missingToolResultsInserted > 0 ||
       stats.orphanToolResultsDowngraded > 0;
     expect(shouldLog).toBe(true);

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -27,7 +27,7 @@ describe('repairHistory', () => {
     const { messages: repaired, stats } = repairHistory(messages);
 
     expect(repaired).toEqual(messages);
-    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
   });
@@ -48,7 +48,7 @@ describe('repairHistory', () => {
 
     expect(repaired).toHaveLength(2);
     expect(repaired[1].content).toEqual([{ type: 'text', text: 'Sure' }]);
-    expect(stats.assistantToolResultsRemoved).toBe(1);
+    expect(stats.assistantToolResultsMigrated).toBe(1);
   });
 
   test('inserts missing tool_result when user message lacks it', () => {
@@ -217,7 +217,7 @@ describe('repairHistory', () => {
     const { messages: repaired, stats } = repairHistory(messages);
 
     expect(repaired).toEqual(messages);
-    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
   });
@@ -248,7 +248,7 @@ describe('repairHistory', () => {
     const second = repairHistory(first.messages);
 
     expect(second.messages).toEqual(first.messages);
-    expect(second.stats.assistantToolResultsRemoved).toBe(0);
+    expect(second.stats.assistantToolResultsMigrated).toBe(0);
     expect(second.stats.missingToolResultsInserted).toBe(0);
     expect(second.stats.orphanToolResultsDowngraded).toBe(0);
   });
@@ -282,10 +282,82 @@ describe('repairHistory', () => {
     expect(userMsg.content[0]).toEqual({ type: 'text', text: 'next message' });
   });
 
+  test('migrates tool_result from assistant message to user message preserving content', () => {
+    // Legacy corruption: assistant has both tool_use and its own tool_result
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'file1\nfile2' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Here are the files.' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.assistantToolResultsMigrated).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(0);
+
+    // assistant message should have tool_use only
+    expect(repaired[1].content).toEqual([
+      { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+    ]);
+
+    // injected user message should carry the original result, not a synthetic error
+    expect(repaired[2].role).toBe('user');
+    expect(repaired[2].content).toEqual([
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file1\nfile2' },
+    ]);
+
+    // original second assistant message follows
+    expect(repaired[3].content).toEqual([
+      { type: 'text', text: 'Here are the files.' },
+    ]);
+  });
+
+  test('migrates tool_result from assistant to following user message filling gap', () => {
+    // assistant has tool_use(tu_1) + tool_result(tu_1), user message has no tool_result
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'success data' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'thanks' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.assistantToolResultsMigrated).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(0);
+
+    // user message should now have both original text and the migrated tool_result
+    const userMsg = repaired[2];
+    expect(userMsg.content).toHaveLength(2);
+    expect(userMsg.content[0]).toEqual({ type: 'text', text: 'thanks' });
+    expect(userMsg.content[1]).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: 'success data',
+    });
+  });
+
   test('handles empty message array', () => {
     const { messages, stats } = repairHistory([]);
     expect(messages).toEqual([]);
-    expect(stats.assistantToolResultsRemoved).toBe(0);
+    expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
   });

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -6,7 +6,7 @@ import type {
 } from '../providers/types.js';
 
 export interface RepairStats {
-  assistantToolResultsRemoved: number;
+  assistantToolResultsMigrated: number;
   missingToolResultsInserted: number;
   orphanToolResultsDowngraded: number;
 }
@@ -20,28 +20,37 @@ const SYNTHETIC_RESULT = '[synthesized: tool result missing from history]';
 
 export function repairHistory(messages: Message[]): RepairResult {
   const stats: RepairStats = {
-    assistantToolResultsRemoved: 0,
+    assistantToolResultsMigrated: 0,
     missingToolResultsInserted: 0,
     orphanToolResultsDowngraded: 0,
   };
 
   const result: Message[] = [];
   let pendingToolUseIds = new Set<string>();
+  // tool_result blocks stripped from assistant messages, keyed by tool_use_id
+  let recoveredResults = new Map<string, ToolResultContent>();
 
   for (const msg of messages) {
     if (msg.role === 'assistant') {
-      // If previous assistant had unfulfilled tool_use, inject synthetic user message
+      // If previous assistant had unfulfilled tool_use, inject user message
+      // using recovered results where available, synthetic for the rest
       if (pendingToolUseIds.size > 0) {
-        result.push(buildSyntheticToolResultMessage(pendingToolUseIds));
-        stats.missingToolResultsInserted += pendingToolUseIds.size;
+        result.push(
+          buildResultMessage(pendingToolUseIds, recoveredResults, stats),
+        );
         pendingToolUseIds = new Set();
+        recoveredResults = new Map();
       }
 
-      // Strip tool_result blocks from assistant messages
+      // Strip tool_result blocks from assistant messages, preserving them
+      // so they can be migrated to the correct user message position
       const cleanedContent: ContentBlock[] = [];
+      const newRecovered = new Map<string, ToolResultContent>();
       for (const block of msg.content) {
         if (block.type === 'tool_result') {
-          stats.assistantToolResultsRemoved++;
+          const tr = block as ToolResultContent;
+          newRecovered.set(tr.tool_use_id, tr);
+          stats.assistantToolResultsMigrated++;
         } else {
           cleanedContent.push(block);
         }
@@ -55,6 +64,7 @@ export function repairHistory(messages: Message[]): RepairResult {
           .filter((b): b is ToolUseContent => b.type === 'tool_use')
           .map((b) => b.id),
       );
+      recoveredResults = newRecovered;
     } else {
       // User message
       if (pendingToolUseIds.size > 0) {
@@ -76,21 +86,28 @@ export function repairHistory(messages: Message[]): RepairResult {
           }
         }
 
-        // Inject synthetic tool_result for any unmatched IDs
+        // Fill unmatched IDs: use recovered results if available, otherwise synthesize
         for (const id of pendingToolUseIds) {
           if (!matchedIds.has(id)) {
-            stats.missingToolResultsInserted++;
-            newContent.push({
-              type: 'tool_result',
-              tool_use_id: id,
-              content: SYNTHETIC_RESULT,
-              is_error: true,
-            });
+            const recovered = recoveredResults.get(id);
+            if (recovered) {
+              newContent.push(recovered);
+              // Already counted in assistantToolResultsMigrated
+            } else {
+              stats.missingToolResultsInserted++;
+              newContent.push({
+                type: 'tool_result',
+                tool_use_id: id,
+                content: SYNTHETIC_RESULT,
+                is_error: true,
+              });
+            }
           }
         }
 
         result.push({ role: 'user', content: newContent });
         pendingToolUseIds = new Set();
+        recoveredResults = new Map();
       } else {
         // No pending tool_use — any tool_result here is orphaned
         const newContent: ContentBlock[] = msg.content.map((block) => {
@@ -108,22 +125,33 @@ export function repairHistory(messages: Message[]): RepairResult {
 
   // Trailing unfulfilled tool_use at end of history
   if (pendingToolUseIds.size > 0) {
-    result.push(buildSyntheticToolResultMessage(pendingToolUseIds));
-    stats.missingToolResultsInserted += pendingToolUseIds.size;
+    result.push(buildResultMessage(pendingToolUseIds, recoveredResults, stats));
   }
 
   return { messages: result, stats };
 }
 
-function buildSyntheticToolResultMessage(ids: Set<string>): Message {
+function buildResultMessage(
+  ids: Set<string>,
+  recovered: Map<string, ToolResultContent>,
+  stats: RepairStats,
+): Message {
   return {
     role: 'user',
-    content: Array.from(ids).map((id) => ({
-      type: 'tool_result' as const,
-      tool_use_id: id,
-      content: SYNTHETIC_RESULT,
-      is_error: true,
-    })),
+    content: Array.from(ids).map((id) => {
+      const rec = recovered.get(id);
+      if (rec) {
+        // Already counted in assistantToolResultsMigrated
+        return rec;
+      }
+      stats.missingToolResultsInserted++;
+      return {
+        type: 'tool_result' as const,
+        tool_use_id: id,
+        content: SYNTHETIC_RESULT,
+        is_error: true,
+      };
+    }),
   };
 }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -124,7 +124,7 @@ export class Session {
       });
 
     const { messages: repairedMessages, stats } = repairHistory(parsedMessages);
-    if (stats.assistantToolResultsRemoved > 0 || stats.missingToolResultsInserted > 0 || stats.orphanToolResultsDowngraded > 0) {
+    if (stats.assistantToolResultsMigrated > 0 || stats.missingToolResultsInserted > 0 || stats.orphanToolResultsDowngraded > 0) {
       log.warn({ conversationId: this.conversationId, phase: 'load', ...stats }, 'Repaired persisted history');
     }
     this.messages = repairedMessages;
@@ -294,7 +294,7 @@ export class Session {
 
       // Pre-run repair: fix any message ordering issues before sending to provider
       const preRunRepair = repairHistory(runMessages);
-      if (preRunRepair.stats.assistantToolResultsRemoved > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
+      if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
         log.warn({ conversationId: this.conversationId, phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
         runMessages = preRunRepair.messages;
       }


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #575: when assistant messages contain both `tool_use` and `tool_result` blocks (legacy corruption), the `tool_result` content is now preserved and migrated to the correct user message position instead of being discarded and replaced with synthetic error results
- Renames `assistantToolResultsRemoved` stat to `assistantToolResultsMigrated` to reflect the new behavior
- Adds 2 new test cases covering the migration path (assistant-to-user and assistant-to-injected-user)

## Test plan
- [x] `bun test src/__tests__/history-repair.test.ts` -- all 13 tests pass
- [x] `bun test src/__tests__/history-repair-observability.test.ts` -- all 2 tests pass
- [x] `bunx tsc --noEmit` -- clean

## Files modified
- `assistant/src/daemon/history-repair.ts` -- core logic change
- `assistant/src/__tests__/history-repair.test.ts` -- 2 new tests
- `assistant/src/__tests__/history-repair-observability.test.ts` -- stat rename
- `assistant/src/daemon/session.ts` -- stat rename in log checks
- `assistant/docs/history-repair.md` -- updated docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
