### PR TITLE
Fix SSRF bypass and credential leak in browser_navigate

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -28,6 +28,8 @@ function createMockPage(closed = false) {
     press: async () => {},
     waitForSelector: async () => null,
     waitForFunction: async () => null,
+    route: async () => {},
+    unroute: async () => {},
     keyboard: { press: async () => {} },
   };
 }

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -17,6 +17,8 @@ let mockPage: {
   goto: ReturnType<typeof mock>;
   title: ReturnType<typeof mock>;
   url: ReturnType<typeof mock>;
+  route: ReturnType<typeof mock>;
+  unroute: ReturnType<typeof mock>;
   close: () => Promise<void>;
   isClosed: () => boolean;
 };
@@ -59,6 +61,8 @@ function resetMockPage() {
     goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
     title: mock(async () => 'Example'),
     url: mock(() => 'https://example.com/'),
+    route: mock(async () => {}),
+    unroute: mock(async () => {}),
     close: async () => {},
     isClosed: () => false,
   };

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -15,6 +15,17 @@ export type PageResponse = {
   url(): string;
 };
 
+export type RouteHandler = (route: PageRoute, request: PageRequest) => Promise<void> | void;
+
+export type PageRoute = {
+  abort(errorCode?: string): Promise<void>;
+  continue(options?: Record<string, unknown>): Promise<void>;
+};
+
+export type PageRequest = {
+  url(): string;
+};
+
 export type Page = {
   close(): Promise<void>;
   isClosed(): boolean;
@@ -27,6 +38,8 @@ export type Page = {
   press(selector: string, key: string): Promise<void>;
   waitForSelector(selector: string, options?: { timeout?: number }): Promise<unknown>;
   waitForFunction(expression: string, options?: { timeout?: number }): Promise<unknown>;
+  route(pattern: string, handler: RouteHandler): Promise<void>;
+  unroute(pattern: string, handler?: RouteHandler): Promise<void>;
   keyboard: { press(key: string): Promise<void> };
 };
 

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -11,6 +11,7 @@ import {
   sanitizeUrlForOutput,
 } from '../network/url-safety.js';
 import { browserManager } from './browser-manager.js';
+import type { RouteHandler } from './browser-manager.js';
 
 const log = getLogger('headless-browser');
 
@@ -54,22 +55,79 @@ async function executeBrowserNavigate(
     }
   }
 
+  let routeHandler: RouteHandler | null = null;
+
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
     log.debug({ url: safeRequestedUrl, sessionId: context.sessionId }, 'Navigating');
+
+    // Install request interception to block redirects/sub-requests to private networks.
+    // This prevents SSRF bypass via server-side redirects and DNS rebinding attacks,
+    // since Playwright follows redirects internally and performs its own DNS resolution.
+    let blockedUrl: string | null = null;
+    if (!allowPrivateNetwork) {
+      routeHandler = async (route, request) => {
+        const reqUrl = request.url();
+        let reqParsed: URL;
+        try {
+          reqParsed = new URL(reqUrl);
+        } catch {
+          await route.continue();
+          return;
+        }
+
+        // Check hostname against private/local patterns
+        if (isPrivateOrLocalHost(reqParsed.hostname)) {
+          blockedUrl = sanitizeUrlForOutput(reqParsed);
+          log.warn({ blockedUrl }, 'Blocked navigation to private network target via redirect');
+          await route.abort('blockedbyclient');
+          return;
+        }
+
+        // Resolve DNS and check resolved addresses
+        const resolution = await resolveRequestAddress(
+          reqParsed.hostname,
+          resolveHostAddresses,
+          false,
+        );
+        if (resolution.blockedAddress) {
+          blockedUrl = sanitizeUrlForOutput(reqParsed);
+          log.warn({ blockedUrl, resolvedTo: resolution.blockedAddress }, 'Blocked navigation: DNS resolves to private address');
+          await route.abort('blockedbyclient');
+          return;
+        }
+
+        await route.continue();
+      };
+      await page.route('**/*', routeHandler);
+    }
 
     const response = await page.goto(parsedUrl.href, {
       waitUntil: 'domcontentloaded',
       timeout: NAVIGATE_TIMEOUT_MS,
     });
 
+    // Remove the route handler now that navigation is complete
+    if (routeHandler) {
+      await page.unroute('**/*', routeHandler);
+      routeHandler = null;
+    }
+
+    if (blockedUrl) {
+      return {
+        content: `Error: Navigation blocked. A request targeted a local/private network address (${blockedUrl}). Set allow_private_network=true if you explicitly need it.`,
+        isError: true,
+      };
+    }
+
     const finalUrl = page.url();
+    const safeFinalUrl = sanitizeUrlForOutput(new URL(finalUrl));
     const title = await page.title();
     const status = response?.status() ?? null;
 
     const lines: string[] = [
       `Requested URL: ${safeRequestedUrl}`,
-      `Final URL: ${finalUrl}`,
+      `Final URL: ${safeFinalUrl}`,
       `Status: ${status ?? 'unknown'}`,
       `Title: ${title || '(none)'}`,
     ];
@@ -80,6 +138,13 @@ async function executeBrowserNavigate(
 
     return { content: lines.join('\n'), isError: false };
   } catch (err) {
+    // Best-effort cleanup of route handler on error
+    if (routeHandler) {
+      try {
+        const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+        await page.unroute('**/*', routeHandler);
+      } catch { /* ignore cleanup errors */ }
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, url: safeRequestedUrl }, 'Navigation failed');
     return { content: `Error: Navigation failed: ${msg}`, isError: true };


### PR DESCRIPTION
## Summary
- Adds Playwright request interception (`page.route`) in `browser_navigate` to validate all request URLs -- including redirect targets -- against private network rules, closing SSRF bypass via server-side redirects and DNS rebinding attacks
- Sanitizes the final URL through `sanitizeUrlForOutput()` to prevent credential leakage when redirect targets contain userinfo
- Extends the `Page` type with `route`/`unroute` methods and updates test mocks accordingly

Addresses review feedback on #563.

## Test plan
- [x] All 61 existing browser tests pass (navigate, snapshot, interactions, read-tools, browser-manager)
- [x] Type-check passes with `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
