### PR TITLE
Fix stale snapshot eids and escalate browser_close risk

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -177,7 +177,9 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
     return input.allow_private_network === true ? RiskLevel.Medium : RiskLevel.Low;
   }
   if (toolName === 'browser_snapshot') return RiskLevel.Low;
-  if (toolName === 'browser_close') return RiskLevel.Medium;
+  if (toolName === 'browser_close') {
+    return input.close_all_pages === true ? RiskLevel.High : RiskLevel.Medium;
+  }
   if (toolName === 'browser_click') return RiskLevel.Medium;
   if (toolName === 'browser_type') return RiskLevel.Medium;
   if (toolName === 'browser_press_key') return RiskLevel.Medium;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -224,6 +224,8 @@ async function executeBrowserSnapshot(
       (() => {
         const SELECTOR = ${JSON.stringify(INTERACTIVE_SELECTOR)};
         const MAX = ${MAX_SNAPSHOT_ELEMENTS};
+        // Clear stale eid attributes from previous snapshots
+        document.querySelectorAll('[data-vellum-eid]').forEach(el => el.removeAttribute('data-vellum-eid'));
         const els = Array.from(document.querySelectorAll(SELECTOR));
         const visible = els.filter(el => {
           const rect = el.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Clear stale `data-vellum-eid` attributes before assigning new ones in `browser_snapshot`, preventing ambiguous selectors when elements change visibility between snapshots
- Escalate `browser_close` to High risk when `close_all_pages=true`, since global teardown has materially different scope than single-session cleanup and should always prompt

Addresses review feedback on #565.

## Test plan
- [ ] Verify `browser_snapshot` called twice on same page produces unique selectors
- [ ] Verify `browser_close` with `close_all_pages=true` requires approval prompt
- [ ] Verify `browser_close` without the flag remains Medium risk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
