### PR TITLE
Fix browser_wait_for empty string mode validation

### DIFF
--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -607,8 +607,8 @@ async function executeBrowserWaitFor(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const selector = typeof input.selector === 'string' ? input.selector : null;
-  const text = typeof input.text === 'string' ? input.text : null;
+  const selector = typeof input.selector === 'string' && input.selector ? input.selector : null;
+  const text = typeof input.text === 'string' && input.text ? input.text : null;
   const duration = typeof input.duration === 'number' ? input.duration : null;
 
   const modeCount = [selector, text, duration].filter((v) => v !== null).length;


### PR DESCRIPTION
## Summary
- Fixes a bug where empty string inputs (e.g. `{"selector": ""}` or `{"text": ""}`) to `browser_wait_for` would pass mode validation but silently fall through to the duration branch, returning `Waited 0ms` instead of an error
- Empty strings are now treated as null during mode parsing, so they properly trigger the "exactly one mode required" validation error

Addresses review feedback on #568.

## Test plan
- [ ] Call `browser_wait_for` with `{"selector": ""}` — should return error instead of `Waited 0ms`
- [ ] Call `browser_wait_for` with `{"text": ""}` — should return error instead of `Waited 0ms`
- [ ] Call `browser_wait_for` with valid selector/text/duration — should work as before

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
