### PR TITLE
Fix stale snapshot mappings and contenteditable append mode

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -143,6 +143,10 @@ class BrowserManager {
     this.snapshotMaps.set(sessionId, map);
   }
 
+  clearSnapshotMap(sessionId: string): void {
+    this.snapshotMaps.delete(sessionId);
+  }
+
   resolveSnapshotSelector(sessionId: string, elementId: string): string | null {
     const map = this.snapshotMaps.get(sessionId);
     if (!map) return null;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -120,6 +120,12 @@ async function executeBrowserNavigate(
       };
     }
 
+    // Navigation changed the page content, so clear stale snapshot mappings.
+    // Without this, element IDs from a previous page could resolve and cause
+    // confusing Playwright timeout errors instead of the actionable
+    // "run browser_snapshot first" message.
+    browserManager.clearSnapshotMap(context.sessionId);
+
     const finalUrl = page.url();
     const safeFinalUrl = sanitizeUrlForOutput(new URL(finalUrl));
     const title = await page.title();
@@ -461,8 +467,10 @@ async function executeBrowserType(
     if (clearFirst) {
       await page.fill(selector!, text);
     } else {
+      // Read existing content before appending. Use .value for form inputs,
+      // with fallback to .textContent for contenteditable elements.
       const currentValue = (await page.evaluate(
-        `document.querySelector(${JSON.stringify(selector!)})?.value ?? ''`,
+        `(() => { const el = document.querySelector(${JSON.stringify(selector!)}); if (!el) return ''; if (typeof el.value === 'string') return el.value; return el.textContent ?? ''; })()`,
       )) as string;
       await page.fill(selector!, currentValue + text);
     }


### PR DESCRIPTION
## Summary
- Clear snapshot element ID mappings after `browser_navigate` so stale IDs from a previous page produce actionable "run browser_snapshot first" errors instead of Playwright timeout failures
- Fix `browser_type` append mode (`clear_first=false`) to fall back to `textContent` for contenteditable elements where `.value` is undefined, preventing silent content overwrites

Addresses review feedback on PR #567.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing browser-manager tests pass (16/16)
- [ ] Manual: navigate to page A, snapshot, navigate to page B, try clicking old element ID -- should get "run browser_snapshot first" error
- [ ] Manual: type into a contenteditable element with `clear_first=false` -- should append, not overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
