### PR TITLE
fix: guard against non-array JSON in loadFromDb content parsing

### DIFF
--- a/assistant/src/__tests__/session-load-history-repair.test.ts
+++ b/assistant/src/__tests__/session-load-history-repair.test.ts
@@ -161,6 +161,37 @@ describe('loadFromDb history repair', () => {
     expect(messages[0].content[0].type === 'text' && messages[0].content[0].text).toBe('this is not valid json {{{');
   });
 
+  test('non-array JSON content is wrapped in a text block', async () => {
+    mockConversation = {
+      id: 'conv-1',
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      { id: 'm1', role: 'user', content: '"hello"' },
+      { id: 'm2', role: 'assistant', content: '42' },
+      { id: 'm3', role: 'user', content: '{}' },
+      { id: 'm4', role: 'assistant', content: JSON.stringify([{ type: 'text', text: 'Done' }]) },
+    ];
+
+    const session = makeSession();
+    await session.loadFromDb();
+    const messages = session.getMessages();
+
+    expect(messages).toHaveLength(4);
+    // String JSON should be wrapped
+    expect(messages[0].content).toEqual([{ type: 'text', text: '"hello"' }]);
+    // Number JSON should be wrapped
+    expect(messages[1].content).toEqual([{ type: 'text', text: '42' }]);
+    // Object JSON should be wrapped
+    expect(messages[2].content).toEqual([{ type: 'text', text: '{}' }]);
+    // Valid array content should pass through
+    expect(messages[3].content).toEqual([{ type: 'text', text: 'Done' }]);
+  });
+
   test('assistant-role tool_result blocks are stripped during load', async () => {
     mockConversation = {
       id: 'conv-1',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -115,7 +115,8 @@ export class Session {
         const role = m.role as 'user' | 'assistant';
         let content: ContentBlock[];
         try {
-          content = JSON.parse(m.content);
+          const parsed = JSON.parse(m.content);
+          content = Array.isArray(parsed) ? parsed : [{ type: 'text', text: m.content }];
         } catch {
           log.warn({ conversationId: this.conversationId, messageId: m.id }, 'Invalid JSON in persisted message content, replacing with safe text block');
           content = [{ type: 'text', text: m.content }];


### PR DESCRIPTION
## Summary
- Adds `Array.isArray` guard after `JSON.parse` in `Session.loadFromDb()` to handle persisted content that is valid JSON but not an array (e.g. strings `"hello"`, numbers `42`, objects `{}`, `null`)
- Non-array parsed values are wrapped in a safe `[{ type: 'text', text: rawContent }]` block, matching the existing fallback for invalid JSON
- Adds test covering string, number, and object JSON content scenarios

Addresses review feedback from PR #576 (both Devin and Codex reviews flagged the same issue).

## Test plan
- [x] `bun test src/__tests__/session-load-history-repair.test.ts` -- 5 tests pass
- [x] `bunx tsc --noEmit` -- clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
