### PR TITLE
Fix duplicate tool_result persistence in abort reconciliation

### DIFF
--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -184,6 +184,19 @@ describe('abort tool result persistence', () => {
     // Both tu_1 and tu_2 must be persisted
     expect(persistedToolUseIds.has('tu_1')).toBe(true);
     expect(persistedToolUseIds.has('tu_2')).toBe(true);
+
+    // No tool_use_id should appear more than once (no duplicates)
+    const allToolUseIds: string[] = [];
+    for (const msg of toolResultUserMessages) {
+      const content = JSON.parse(msg.content) as Array<Record<string, unknown>>;
+      for (const block of content) {
+        if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+          allToolUseIds.push(block.tool_use_id);
+        }
+      }
+    }
+    const uniqueIds = new Set(allToolUseIds);
+    expect(allToolUseIds.length).toBe(uniqueIds.size);
   });
 
   test('restart/reload after abort does not reproduce provider ordering errors', async () => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -256,6 +256,7 @@ export class Session {
       let model = '';
       let runMessages = this.messages;
       const pendingToolResults = new Map<string, { content: string; isError: boolean }>();
+      const persistedToolUseIds = new Set<string>();
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
@@ -344,6 +345,9 @@ export class Session {
                 'user',
                 JSON.stringify(toolResultBlocks),
               );
+              for (const id of pendingToolResults.keys()) {
+                persistedToolUseIds.add(id);
+              }
               pendingToolResults.clear();
             }
             // Save assistant message to DB
@@ -396,7 +400,7 @@ export class Session {
         const msg = updatedHistory[i];
         if (msg.role === 'user') {
           for (const block of msg.content) {
-            if (block.type === 'tool_result' && !pendingToolResults.has(block.tool_use_id)) {
+            if (block.type === 'tool_result' && !pendingToolResults.has(block.tool_use_id) && !persistedToolUseIds.has(block.tool_use_id)) {
               pendingToolResults.set(block.tool_use_id, {
                 content: block.content,
                 isError: block.is_error ?? false,


### PR DESCRIPTION
## Summary
- Adds a `persistedToolUseIds` set to track tool_use_ids already flushed to DB inside the `message_complete` handler
- Updates the post-loop reconciliation loop to skip both pending and already-persisted IDs, preventing duplicate `tool_result` rows
- Adds a test assertion verifying no duplicate tool_use_ids are persisted

## Context
PR #578 introduced a reconciliation loop to persist synthesized cancellation tool_results after abort. However, the loop could re-add tool_results from earlier turns that were already persisted and cleared from `pendingToolResults`, creating duplicate DB rows. On session reload, these duplicates would appear as orphan tool_results and get downgraded to text blocks, corrupting history.

Addresses review feedback from Codex and Devin on PR #578.

## Test plan
- [x] `bun test src/__tests__/session-abort-tool-results.test.ts` -- 2 tests pass (8 assertions)
- [x] `bunx tsc --noEmit` -- clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
