### PR TITLE
fix(session): prevent pre-run repair from breaking undo semantics

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -292,7 +292,13 @@ export class Session {
         }
       }
 
-      // Pre-run repair: fix any message ordering issues before sending to provider
+      // Pre-run repair: fix any message ordering issues before sending to provider.
+      // Keep a reference to the original (un-repaired) messages so we can
+      // reconstruct this.messages after the agent loop without leaking synthetic
+      // tool_result blocks that repair may inject.  Leaking those blocks would
+      // break undo semantics (isUndoableUserMessage skips user messages
+      // containing tool_result).
+      const preRepairMessages = runMessages;
       const preRunRepair = repairHistory(runMessages);
       if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
         log.warn({ conversationId: this.conversationId, phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
@@ -424,7 +430,13 @@ export class Session {
         pendingToolResults.clear();
       }
 
-      this.messages = stripMemoryRecallMessages(updatedHistory, recall.injectedText);
+      // Reconstruct history: use the original (un-repaired) prefix so that
+      // synthetic tool_result blocks from pre-run repair don't leak into
+      // this.messages.  Only the new messages appended by the agent loop
+      // (beyond the repaired prefix) are carried forward.
+      const newMessages = updatedHistory.slice(preRunHistoryLength);
+      const restoredHistory = [...preRepairMessages, ...newMessages];
+      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText);
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent);
 


### PR DESCRIPTION
## Summary
- Fixes a bug where `repairHistory()` synthetic `tool_result` blocks injected during pre-run repair leaked into `this.messages`, causing `undo()` to skip the real user message and remove too much history
- Saves a reference to pre-repair messages and reconstructs `this.messages` using the original prefix + only new messages from the agent loop
- Addresses review feedback on PR #577

## Test plan
- [x] `bunx tsc --noEmit` -- clean
- [ ] Manual verification: trigger pre-run repair (e.g. dangling `tool_use` in history), then undo -- should correctly remove only the last exchange

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
