### PR TITLE
Fix ordering error retry: defer error event and use deep repair

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { repairHistory } from '../daemon/history-repair.js';
+import { repairHistory, deepRepairHistory } from '../daemon/history-repair.js';
 import type { Message } from '../providers/types.js';
 
 describe('repairHistory', () => {
@@ -357,6 +357,90 @@ describe('repairHistory', () => {
   test('handles empty message array', () => {
     const { messages, stats } = repairHistory([]);
     expect(messages).toEqual([]);
+    expect(stats.assistantToolResultsMigrated).toBe(0);
+    expect(stats.missingToolResultsInserted).toBe(0);
+    expect(stats.orphanToolResultsDowngraded).toBe(0);
+  });
+});
+
+describe('deepRepairHistory', () => {
+  test('merges consecutive same-role messages', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'user', content: [{ type: 'text', text: 'World' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+
+    const { messages: repaired } = deepRepairHistory(messages);
+
+    expect(repaired).toHaveLength(2);
+    expect(repaired[0].role).toBe('user');
+    expect(repaired[0].content).toHaveLength(2);
+    expect(repaired[1].role).toBe('assistant');
+  });
+
+  test('strips leading assistant messages', () => {
+    const messages: Message[] = [
+      { role: 'assistant', content: [{ type: 'text', text: 'Stale' }] },
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+
+    const { messages: repaired } = deepRepairHistory(messages);
+
+    expect(repaired).toHaveLength(2);
+    expect(repaired[0].role).toBe('user');
+  });
+
+  test('removes empty messages', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+
+    const { messages: repaired } = deepRepairHistory(messages);
+
+    expect(repaired).toHaveLength(2);
+    expect(repaired[0].role).toBe('user');
+    expect(repaired[1].role).toBe('assistant');
+    expect(repaired[1].content[0]).toEqual({ type: 'text', text: 'Hi' });
+  });
+
+  test('applies standard repair after deep pass', () => {
+    // Consecutive assistant messages with tool_use but missing tool_result
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Go' }] },
+      { role: 'user', content: [{ type: 'text', text: 'more context' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = deepRepairHistory(messages);
+
+    // User messages merged, then tool_result inserted between assistants
+    expect(repaired[0].role).toBe('user');
+    expect(repaired[0].content).toHaveLength(2);
+    expect(stats.missingToolResultsInserted).toBe(1);
+  });
+
+  test('no-op for already-valid history', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+
+    const { messages: repaired, stats } = deepRepairHistory(messages);
+
+    expect(repaired).toEqual(messages);
     expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -152,7 +152,7 @@ describe('provider ordering error retry', () => {
     expect(agentLoopRunCount).toBe(2);
   });
 
-  test('retry succeeds with repaired history', async () => {
+  test('retry succeeds with repaired history and no spurious error event', async () => {
     agentLoopRunCount = 0;
     shouldEmitOrderingError = true;
 
@@ -165,6 +165,10 @@ describe('provider ordering error retry', () => {
     // Should have a message_complete event (from successful retry)
     const messageComplete = events.find((e) => e.type === 'message_complete');
     expect(messageComplete).toBeDefined();
+
+    // Ordering error should be suppressed when retry succeeds — no error events
+    const errorEvents = events.filter((e) => e.type === 'error');
+    expect(errorEvents.length).toBe(0);
 
     // Should also have the assistant response in memory
     const messages = session.getMessages();

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -155,6 +155,37 @@ function buildResultMessage(
   };
 }
 
+/**
+ * Aggressive repair pass that handles edge cases beyond repairHistory:
+ * - Merges consecutive same-role messages
+ * - Ensures the first message is from the user
+ * - Removes empty messages
+ * Then applies the standard repairHistory on top.
+ */
+export function deepRepairHistory(messages: Message[]): RepairResult {
+  // 1. Remove messages with no content blocks
+  let cleaned = messages.filter((m) => m.content.length > 0);
+
+  // 2. Strip leading assistant messages (provider requires user-first)
+  while (cleaned.length > 0 && cleaned[0].role === 'assistant') {
+    cleaned = cleaned.slice(1);
+  }
+
+  // 3. Merge consecutive same-role messages
+  const merged: Message[] = [];
+  for (const msg of cleaned) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.role === msg.role) {
+      prev.content = [...prev.content, ...msg.content];
+    } else {
+      merged.push({ role: msg.role, content: [...msg.content] });
+    }
+  }
+
+  // 4. Apply standard tool-use/tool-result repair on top
+  return repairHistory(merged);
+}
+
 function downgradeToolResult(tr: ToolResultContent): ContentBlock {
   return {
     type: 'text',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { Message, ContentBlock } from '../providers/types.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment } from './ipc-protocol.js';
-import { repairHistory } from './history-repair.js';
+import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { createUserMessage } from '../agent/message-types.js';
@@ -308,6 +308,7 @@ export class Session {
       }
 
       let orderingErrorDetected = false;
+      let deferredOrderingError: string | null = null;
       const preRunHistoryLength = runMessages.length;
 
       const buildEventHandler = () => (event: import('../agent/loop.js').AgentEvent) => {
@@ -332,8 +333,11 @@ export class Session {
           case 'error':
             if (isProviderOrderingError(event.error.message)) {
               orderingErrorDetected = true;
+              // Defer the error event — only forward if retry also fails
+              deferredOrderingError = event.error.message;
+            } else {
+              onEvent({ type: 'error', message: event.error.message });
             }
-            onEvent({ type: 'error', message: event.error.message });
             break;
           case 'message_complete': {
             // Save pending tool results as a user message before the next assistant message.
@@ -380,13 +384,15 @@ export class Session {
       );
 
       // One-shot self-heal retry: if the provider returned a strict ordering
-      // error and no messages were appended (error on first call), repair
-      // the history and retry exactly once.
+      // error and no messages were appended (error on first call), apply a
+      // deep repair (handles additional edge cases like consecutive same-role
+      // messages) and retry exactly once.
       if (orderingErrorDetected && updatedHistory.length === preRunHistoryLength) {
-        log.warn({ conversationId: this.conversationId, phase: 'retry' }, 'Provider ordering error detected, attempting one-shot repair retry');
-        const retryRepair = repairHistory(runMessages);
+        log.warn({ conversationId: this.conversationId, phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
+        const retryRepair = deepRepairHistory(runMessages);
         runMessages = retryRepair.messages;
         orderingErrorDetected = false;
+        deferredOrderingError = null;
 
         updatedHistory = await this.agentLoop.run(
           runMessages,
@@ -395,8 +401,13 @@ export class Session {
         );
 
         if (orderingErrorDetected) {
-          log.error({ conversationId: this.conversationId, phase: 'retry' }, 'Repair retry also failed with ordering error');
+          log.error({ conversationId: this.conversationId, phase: 'retry' }, 'Deep-repair retry also failed with ordering error');
         }
+      }
+
+      // Forward the deferred ordering error to the client if retry failed or was not attempted
+      if (deferredOrderingError) {
+        onEvent({ type: 'error', message: deferredOrderingError });
       }
 
       // Reconcile synthesized cancellation tool_results from history tail.


### PR DESCRIPTION
## Summary
- Defers ordering error events to the client instead of emitting them immediately, suppressing spurious errors when the retry succeeds
- Replaces idempotent `repairHistory` call in retry path with new `deepRepairHistory` that handles additional edge cases (consecutive same-role messages, leading assistant messages, empty messages)
- Adds tests for `deepRepairHistory` and verifies no error events leak to clients on successful retry

Addresses review feedback from #579.

## Test plan
- [x] `bun test src/__tests__/history-repair.test.ts` — 18 tests pass (5 new for deepRepairHistory)
- [x] `bun test src/__tests__/session-provider-retry-repair.test.ts` — 3 tests pass (updated to verify no spurious errors)
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
