### PR TITLE
Sanitize plan filename in /execute-plan archive step

### DIFF
--- a/scripts/commands/execute-plan.md
+++ b/scripts/commands/execute-plan.md
@@ -8,7 +8,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. E
 
 ### 1. Read the plan
 
-Read `.private/plans/$ARGUMENTS`. If the file doesn't exist, stop and tell the user.
+Sanitize `$ARGUMENTS` by stripping any path separators (use only the basename). Then read `.private/plans/<sanitized name>`. If the file doesn't exist, stop and tell the user.
 
 Parse the plan to identify the ordered list of PRs. Plans typically have numbered PR sections (e.g. "## PR 1", "## PR 2") each describing: branch name, title, scope, files to modify, implementation steps, tests to run, and acceptance criteria.
 
@@ -57,11 +57,14 @@ Then proceed to the next PR.
 
 ### 4. Archive the plan
 
-After all PRs are mainlined, move the plan file to `.private/plans/archived/`:
+After all PRs are mainlined, move the plan file to `.private/plans/archived/`.
+
+Strip any path separators from `$ARGUMENTS` to use only the basename, and quote it to prevent word splitting or glob expansion:
 
 ```bash
+PLAN_FILE="$(basename "$ARGUMENTS")"
 mkdir -p .private/plans/archived
-mv .private/plans/$ARGUMENTS .private/plans/archived/$ARGUMENTS
+mv ".private/plans/$PLAN_FILE" ".private/plans/archived/$PLAN_FILE"
 ```
 
 ### 5. Completion


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #581
- Uses `basename` to strip path traversal components from `$ARGUMENTS` before using it in file paths
- Quotes all variable interpolations to prevent word splitting and glob expansion
- Also sanitizes `$ARGUMENTS` in step 1 (reading the plan) for consistency

## Test plan
- [ ] Verify `/execute-plan BROWSER_PLAN.md` still works correctly
- [ ] Verify `/execute-plan ../../../etc/passwd` cannot escape `.private/plans/`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
