### PR TITLE
fix(session): recompute prefix length after deep-repair retry

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -300,7 +300,7 @@ export class Session {
       // tool_result blocks that repair may inject.  Leaking those blocks would
       // break undo semantics (isUndoableUserMessage skips user messages
       // containing tool_result).
-      const preRepairMessages = runMessages;
+      let preRepairMessages = runMessages;
       const preRunRepair = repairHistory(runMessages);
       if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
         log.warn({ conversationId: this.conversationId, phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
@@ -309,7 +309,7 @@ export class Session {
 
       let orderingErrorDetected = false;
       let deferredOrderingError: string | null = null;
-      const preRunHistoryLength = runMessages.length;
+      let preRunHistoryLength = runMessages.length;
 
       const buildEventHandler = () => (event: import('../agent/loop.js').AgentEvent) => {
         switch (event.type) {
@@ -391,6 +391,8 @@ export class Session {
         log.warn({ conversationId: this.conversationId, phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
         const retryRepair = deepRepairHistory(runMessages);
         runMessages = retryRepair.messages;
+        preRunHistoryLength = runMessages.length;
+        preRepairMessages = runMessages;
         orderingErrorDetected = false;
         deferredOrderingError = null;
 


### PR DESCRIPTION
## Summary
- Updates `preRunHistoryLength` and `preRepairMessages` after `deepRepairHistory` changes the message count in the retry path
- Without this fix, when deep repair merges/removes messages (e.g. consecutive same-role, leading assistant, empty messages), the post-run reconciliation and history reconstruction use stale indices, causing new messages from a successful retry to be lost and the broken prefix to be restored

Addresses review feedback from #593.

## Test plan
- [x] `bunx tsc --noEmit` -- clean

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
