### PR TITLE
Fix SSRF block message in catch path of browser_navigate

### DIFF
--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -30,6 +30,7 @@ mock.module('../tools/browser/browser-manager.js', () => {
   return {
     browserManager: {
       getOrCreateSessionPage: getOrCreateSessionPageMock,
+      clearSnapshotMap: mock(() => {}),
     },
   };
 });
@@ -174,5 +175,36 @@ describe('executeBrowserNavigate', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Navigation failed');
     expect(result.content).toContain('ERR_CONNECTION_REFUSED');
+  });
+
+  test('returns security message when route handler blocks a redirect and goto throws', async () => {
+    parseUrlResult = new URL('https://public.example.com');
+    isPrivateResult = false;
+
+    // Capture the route handler when page.route is called
+    let capturedHandler: ((route: unknown, request: unknown) => Promise<void>) | null = null;
+    mockPage.route = mock(async (_pattern: string, handler: (route: unknown, request: unknown) => Promise<void>) => {
+      capturedHandler = handler;
+    });
+
+    // Make goto invoke the captured handler with a private redirect target, then throw
+    mockPage.goto = mock(async () => {
+      if (capturedHandler) {
+        // Temporarily make isPrivateOrLocalHost return true for the redirect target
+        isPrivateResult = true;
+        const mockRoute = { abort: mock(async () => {}), continue: mock(async () => {}) };
+        const mockRequest = { url: () => 'http://169.254.169.254/metadata' };
+        await capturedHandler(mockRoute, mockRequest);
+        isPrivateResult = false;
+      }
+      throw new Error('net::ERR_BLOCKED_BY_CLIENT');
+    });
+
+    const result = await executeBrowserNavigate({ url: 'https://public.example.com' }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Navigation blocked');
+    expect(result.content).toContain('allow_private_network=true');
+    // Should NOT contain the raw Playwright error
+    expect(result.content).not.toContain('ERR_BLOCKED_BY_CLIENT');
   });
 });

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -56,6 +56,7 @@ async function executeBrowserNavigate(
   }
 
   let routeHandler: RouteHandler | null = null;
+  let blockedUrl: string | null = null;
 
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
@@ -64,7 +65,6 @@ async function executeBrowserNavigate(
     // Install request interception to block redirects/sub-requests to private networks.
     // This prevents SSRF bypass via server-side redirects and DNS rebinding attacks,
     // since Playwright follows redirects internally and performs its own DNS resolution.
-    let blockedUrl: string | null = null;
     if (!allowPrivateNetwork) {
       routeHandler = async (route, request) => {
         const reqUrl = request.url();
@@ -151,6 +151,17 @@ async function executeBrowserNavigate(
         await page.unroute('**/*', routeHandler);
       } catch { /* ignore cleanup errors */ }
     }
+
+    // If the route handler blocked a redirect to a private network address,
+    // page.goto() throws. Return the clear security message instead of the
+    // raw Playwright error (which could leak credentials from the URL).
+    if (blockedUrl) {
+      return {
+        content: `Error: Navigation blocked. A request targeted a local/private network address (${blockedUrl}). Set allow_private_network=true if you explicitly need it.`,
+        isError: true,
+      };
+    }
+
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, url: safeRequestedUrl }, 'Navigation failed');
     return { content: `Error: Navigation failed: ${msg}`, isError: true };


### PR DESCRIPTION
## Summary
- Fixes the catch block in `executeBrowserNavigate` to check `blockedUrl` and return the clear security message ("Navigation blocked...") instead of the raw Playwright error when the route handler blocks a redirect to a private network address
- Prevents credential leakage: the raw Playwright error message can include the rejected URL (which may contain userinfo), so returning the sanitized `blockedUrl` instead avoids this
- Moves `blockedUrl` declaration outside the `try` block so it's accessible in `catch`
- Adds test covering the redirect-blocked-then-goto-throws scenario
- Fixes incomplete `browserManager` mock by adding `clearSnapshotMap`

Addresses review feedback on #586.

## Test plan
- [x] All 11 navigate tests pass (including new redirect-block test)
- [x] Type-check passes with `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
