### PR TITLE
Fix /do step 8 to checkout main before pulling

### DIFF
--- a/scripts/commands/do.md
+++ b/scripts/commands/do.md
@@ -93,7 +93,7 @@ scripts/worktree remove do/<slug> --delete-branch
 ### 8. Pull main
 
 ```bash
-git pull origin main
+git checkout main && git pull origin main
 ```
 
 ### 9. Report


### PR DESCRIPTION
## Summary
- Fixes PR #584 review feedback: step 8 now runs `git checkout main && git pull origin main` instead of just `git pull origin main`
- Without the checkout, `git pull origin main` would merge origin/main into whatever branch is currently checked out, potentially corrupting an unrelated branch

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
