### PR TITLE
fix(browser): use innerText for contenteditable append mode

### DIFF
--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -479,9 +479,10 @@ async function executeBrowserType(
       await page.fill(selector!, text);
     } else {
       // Read existing content before appending. Use .value for form inputs,
-      // with fallback to .textContent for contenteditable elements.
+      // with fallback to .innerText for contenteditable elements (preserves
+      // visual line breaks from <br> and block elements, unlike textContent).
       const currentValue = (await page.evaluate(
-        `(() => { const el = document.querySelector(${JSON.stringify(selector!)}); if (!el) return ''; if (typeof el.value === 'string') return el.value; return el.textContent ?? ''; })()`,
+        `(() => { const el = document.querySelector(${JSON.stringify(selector!)}); if (!el) return ''; if (typeof el.value === 'string') return el.value; return el.innerText ?? ''; })()`,
       )) as string;
       await page.fill(selector!, currentValue + text);
     }


### PR DESCRIPTION
## Summary
- Use `innerText` instead of `textContent` when reading existing content from contenteditable elements in `browser_type` append mode (`clear_first=false`)
- `textContent` concatenates raw text nodes and drops visual line breaks from `<br>` and block-level elements, silently corrupting multi-line content
- `innerText` respects rendered layout and preserves newlines, matching what the user sees

Addresses review feedback on PR #589.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Manual: type into a contenteditable element containing `<br>` tags with `clear_first=false` -- line breaks should be preserved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
