### PR TITLE
Parallelize independent tool executions in the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -420,4 +420,74 @@ describe('AgentLoop', () => {
 
     expect(calls[0].tools).toBeUndefined();
   });
+
+  // 13. Parallel tool execution — multiple tool_use blocks in a single response
+  test('executes multiple tools in parallel', async () => {
+    const { provider, calls } = createMockProvider([
+      // Provider returns 3 tool_use blocks in a single response
+      {
+        content: [
+          { type: 'tool_use' as const, id: 't1', name: 'read_file', input: { path: '/a.txt' } },
+          { type: 'tool_use' as const, id: 't2', name: 'read_file', input: { path: '/b.txt' } },
+          { type: 'tool_use' as const, id: 't3', name: 'read_file', input: { path: '/c.txt' } },
+        ],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'tool_use' as const,
+      },
+      textResponse('Got all three files.'),
+    ]);
+
+    const executionLog: { path: string; start: number; end: number }[] = [];
+    const toolExecutor = async (_name: string, input: Record<string, unknown>) => {
+      const start = Date.now();
+      // Simulate async work — all tools should overlap in time
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const end = Date.now();
+      executionLog.push({ path: (input as { path: string }).path, start, end });
+      return { content: `contents of ${(input as { path: string }).path}`, isError: false };
+    };
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // All 3 tools should have been called
+    expect(executionLog).toHaveLength(3);
+
+    // Verify parallel execution: all tools should start before any finishes
+    // (with 50ms delay each, sequential would take 150ms+, parallel ~50ms)
+    const allStarts = executionLog.map(e => e.start);
+    const allEnds = executionLog.map(e => e.end);
+    const firstEnd = Math.min(...allEnds);
+    const lastStart = Math.max(...allStarts);
+    // In parallel execution, the last tool starts before the first tool ends
+    expect(lastStart).toBeLessThanOrEqual(firstEnd);
+
+    // Provider should have been called twice (tool batch + final text)
+    expect(calls).toHaveLength(2);
+
+    // Second call should contain 3 tool_result blocks in order
+    const secondCallMessages = calls[1].messages;
+    const lastMsg = secondCallMessages[secondCallMessages.length - 1];
+    const toolResultBlocks = lastMsg.content.filter(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(toolResultBlocks).toHaveLength(3);
+    expect(toolResultBlocks[0].tool_use_id).toBe('t1');
+    expect(toolResultBlocks[1].tool_use_id).toBe('t2');
+    expect(toolResultBlocks[2].tool_use_id).toBe('t3');
+
+    // All tool_use events should be emitted before any tool_result events
+    let lastToolUseIdx = -1;
+    let firstToolResultIdx = events.length;
+    events.forEach((e, i) => {
+      if (e.type === 'tool_use') lastToolUseIdx = i;
+      if (e.type === 'tool_result' && i < firstToolResultIdx) firstToolResultIdx = i;
+    });
+    expect(lastToolUseIdx).toBeLessThan(firstToolResultIdx);
+
+    // Final history: user, assistant(3 tool_use), user(3 tool_result), assistant(text)
+    expect(history).toHaveLength(4);
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -153,10 +153,8 @@ export class AgentLoop {
           break;
         }
 
-        // Execute tools and collect results
-        const resultBlocks: ContentBlock[] = [];
+        // Emit all tool_use events upfront, then execute tools in parallel
         for (const toolUse of toolUseBlocks) {
-          if (signal?.aborted) break;
           onEvent({
             type: 'tool_use',
             id: toolUse.id,
@@ -170,60 +168,51 @@ export class AgentLoop {
               input: truncateForLog(JSON.stringify(toolUse.input), 300),
             }, 'Executing tool');
           }
-
-          const toolStart = Date.now();
-
-          const result = await this.toolExecutor(toolUse.name, toolUse.input, (chunk) => {
-            onEvent({ type: 'tool_output_chunk', toolUseId: toolUse.id, chunk });
-          });
-
-          const toolDurationMs = Date.now() - toolStart;
-
-          if (debug) {
-            log.debug({
-              tool: toolUse.name,
-              toolDurationMs,
-              isError: result.isError,
-              output: truncateForLog(result.content, 300),
-            }, 'Tool execution complete');
-          }
-
-          onEvent({
-            type: 'tool_result',
-            toolUseId: toolUse.id,
-            content: result.content,
-            isError: result.isError,
-            diff: result.diff,
-            status: result.status,
-          });
-
-          resultBlocks.push({
-            type: 'tool_result',
-            tool_use_id: toolUse.id,
-            content: result.content,
-            is_error: result.isError,
-          });
         }
 
-        // If cancelled mid-execution, synthesize cancelled results for
-        // any tool_use blocks that weren't executed, so the API contract
-        // (every tool_use must have a matching tool_result) is maintained.
-        if (signal?.aborted) {
-          const completedIds = new Set(
-            resultBlocks
-              .filter((b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result')
-              .map((b) => b.tool_use_id),
-          );
-          for (const toolUse of toolUseBlocks) {
-            if (!completedIds.has(toolUse.id)) {
-              resultBlocks.push({
-                type: 'tool_result',
-                tool_use_id: toolUse.id,
-                content: 'Cancelled by user',
-                is_error: true,
-              });
+        // Execute all tools concurrently for reduced latency
+        const toolResults = await Promise.all(
+          toolUseBlocks.map(async (toolUse) => {
+            const toolStart = Date.now();
+
+            const result = await this.toolExecutor!(toolUse.name, toolUse.input, (chunk) => {
+              onEvent({ type: 'tool_output_chunk', toolUseId: toolUse.id, chunk });
+            });
+
+            const toolDurationMs = Date.now() - toolStart;
+
+            if (debug) {
+              log.debug({
+                tool: toolUse.name,
+                toolDurationMs,
+                isError: result.isError,
+                output: truncateForLog(result.content, 300),
+              }, 'Tool execution complete');
             }
-          }
+
+            onEvent({
+              type: 'tool_result',
+              toolUseId: toolUse.id,
+              content: result.content,
+              isError: result.isError,
+              diff: result.diff,
+              status: result.status,
+            });
+
+            return { toolUse, result };
+          }),
+        );
+
+        // Collect result blocks preserving tool_use order (Promise.all maintains order)
+        const resultBlocks: ContentBlock[] = toolResults.map(({ toolUse, result }) => ({
+          type: 'tool_result' as const,
+          tool_use_id: toolUse.id,
+          content: result.content,
+          is_error: result.isError,
+        }));
+
+        // If cancelled during execution, push completed results and stop
+        if (signal?.aborted) {
           history.push({ role: 'user', content: resultBlocks });
           break;
         }


### PR DESCRIPTION
## Summary
- The agent loop previously executed tool calls sequentially. When the LLM requests multiple independent tool calls in the same response, they now run concurrently via `Promise.all`, significantly reducing latency for multi-tool turns.
- All `tool_use` events are emitted upfront before execution begins, then all tools execute in parallel with results collected in order.
- Adds a test that verifies parallel execution timing (all tools start before any finishes) and correct event ordering (all tool_use events before any tool_result events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
