### PR TITLE
Add request IDs to structured logging for cross-boundary tracing

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -51,10 +51,12 @@ export class AgentLoop {
     messages: Message[],
     onEvent: (event: AgentEvent) => void,
     signal?: AbortSignal,
+    requestId?: string,
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
     const debug = isDebug();
+    const rlog = requestId ? log.child({ requestId }) : log;
 
     while (true) {
       if (signal?.aborted) break;
@@ -80,7 +82,7 @@ export class AgentLoop {
         }
 
         if (debug) {
-          log.debug({
+          rlog.debug({
             systemPrompt: truncateForLog(this.systemPrompt, 200),
             messageCount: history.length,
             lastMessage: history.length > 0
@@ -113,7 +115,7 @@ export class AgentLoop {
         const providerDurationMs = Date.now() - providerStart;
 
         if (debug) {
-          log.debug({
+          rlog.debug({
             providerDurationMs,
             model: response.model,
             stopReason: response.stopReason,
@@ -163,7 +165,7 @@ export class AgentLoop {
           });
 
           if (debug) {
-            log.debug({
+            rlog.debug({
               tool: toolUse.name,
               input: truncateForLog(JSON.stringify(toolUse.input), 300),
             }, 'Executing tool');
@@ -182,7 +184,7 @@ export class AgentLoop {
             const toolDurationMs = Date.now() - toolStart;
 
             if (debug) {
-              log.debug({
+              rlog.debug({
                 tool: toolUse.name,
                 toolDurationMs,
                 isError: result.isError,
@@ -231,7 +233,7 @@ export class AgentLoop {
 
         if (debug) {
           const turnDurationMs = Date.now() - turnStart;
-          log.debug({
+          rlog.debug({
             turnDurationMs,
             providerDurationMs,
             toolCount: toolUseBlocks.length,
@@ -242,7 +244,7 @@ export class AgentLoop {
         // Abort errors are expected when user cancels — don't emit as errors
         if (signal?.aborted) break;
         const err = error instanceof Error ? error : new Error(String(error));
-        log.error({ err }, 'Agent loop error');
+        rlog.error({ err }, 'Agent loop error');
         onEvent({ type: 'error', error: err });
         break;
       }

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,4 +1,5 @@
 import * as net from 'node:net';
+import { v4 as uuid } from 'uuid';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -223,15 +224,18 @@ async function handleUserMessage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  const requestId = uuid();
+  const rlog = log.child({ sessionId, requestId });
   try {
     ctx.socketToSession.set(socket, sessionId);
     const session = await ctx.getOrCreateSession(sessionId, socket, true);
+    rlog.info('Processing user message');
     await session.processMessage(content ?? '', attachments ?? [], (event) => {
       ctx.send(socket, event);
-    });
+    }, requestId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log.error({ err, sessionId }, 'Error processing user message');
+    rlog.error({ err }, 'Error processing user message');
     ctx.send(socket, { type: 'error', message });
   }
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
@@ -49,6 +50,7 @@ export class Session {
   private usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
   private contextWindowManager: ContextWindowManager;
   private contextCompactedMessageCount = 0;
+  private currentRequestId?: string;
 
   constructor(
     conversationId: string,
@@ -78,6 +80,7 @@ export class Session {
         workingDir: this.workingDir,
         sessionId: this.conversationId,
         conversationId: this.conversationId,
+        requestId: this.currentRequestId,
         onOutput,
         sandboxOverride: this.sandboxOverride,
         onToolLifecycleEvent: handleToolLifecycleEvent,
@@ -187,12 +190,16 @@ export class Session {
     content: string,
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
+    requestId?: string,
   ): Promise<void> {
     if (this.processing) {
       onEvent({ type: 'error', message: 'Already processing a message' });
       return;
     }
 
+    const reqId = requestId ?? uuid();
+    this.currentRequestId = reqId;
+    const rlog = log.child({ conversationId: this.conversationId, requestId: reqId });
     this.processing = true;
     this.abortController = new AbortController();
 
@@ -303,7 +310,7 @@ export class Session {
       let preRepairMessages = runMessages;
       const preRunRepair = repairHistory(runMessages);
       if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
-        log.warn({ conversationId: this.conversationId, phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
+        rlog.warn({ phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
         runMessages = preRunRepair.messages;
       }
 
@@ -381,6 +388,7 @@ export class Session {
         runMessages,
         buildEventHandler(),
         this.abortController.signal,
+        reqId,
       );
 
       // One-shot self-heal retry: if the provider returned a strict ordering
@@ -388,7 +396,7 @@ export class Session {
       // deep repair (handles additional edge cases like consecutive same-role
       // messages) and retry exactly once.
       if (orderingErrorDetected && updatedHistory.length === preRunHistoryLength) {
-        log.warn({ conversationId: this.conversationId, phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
+        rlog.warn({ phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
         const retryRepair = deepRepairHistory(runMessages);
         runMessages = retryRepair.messages;
         preRunHistoryLength = runMessages.length;
@@ -400,10 +408,11 @@ export class Session {
           runMessages,
           buildEventHandler(),
           this.abortController.signal,
+          reqId,
         );
 
         if (orderingErrorDetected) {
-          log.error({ conversationId: this.conversationId, phase: 'retry' }, 'Deep-repair retry also failed with ordering error');
+          rlog.error({ phase: 'retry' }, 'Deep-repair retry also failed with ordering error');
         }
       }
 
@@ -473,16 +482,17 @@ export class Session {
     } catch (err) {
       // AbortError is expected when user cancels — don't treat as an error
       if (this.abortController?.signal.aborted) {
-        log.info({ conversationId: this.conversationId }, 'Generation cancelled by user');
+        rlog.info('Generation cancelled by user');
         onEvent({ type: 'generation_cancelled' });
       } else {
         const message = err instanceof Error ? err.message : String(err);
-        log.error({ err }, 'Session processing error');
+        rlog.error({ err }, 'Session processing error');
         onEvent({ type: 'error', message });
       }
     } finally {
       this.abortController = null;
       this.processing = false;
+      this.currentRequestId = undefined;
     }
   }
 

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -2,6 +2,7 @@ export interface ToolDomainEvents {
   'tool.execution.started': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     input: Record<string, unknown>;
     startedAtMs: number;
@@ -9,6 +10,7 @@ export interface ToolDomainEvents {
   'tool.permission.requested': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     riskLevel: string;
     requestedAtMs: number;
@@ -16,6 +18,7 @@ export interface ToolDomainEvents {
   'tool.permission.decided': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     decision: 'allow' | 'always_allow' | 'deny' | 'always_deny';
     riskLevel: string;
@@ -24,6 +27,7 @@ export interface ToolDomainEvents {
   'tool.secret.detected': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     action: 'redact' | 'warn' | 'block';
     matches: Array<{ type: string; redactedValue: string }>;
@@ -32,6 +36,7 @@ export interface ToolDomainEvents {
   'tool.execution.finished': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     decision: string;
     riskLevel: string;
@@ -42,6 +47,7 @@ export interface ToolDomainEvents {
   'tool.execution.failed': {
     conversationId: string;
     sessionId: string;
+    requestId?: string;
     toolName: string;
     decision: string;
     riskLevel: string;

--- a/assistant/src/events/tool-domain-event-publisher.ts
+++ b/assistant/src/events/tool-domain-event-publisher.ts
@@ -17,6 +17,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.execution.started', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           input: event.input,
           startedAtMs: event.startedAtMs,
@@ -26,6 +27,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.permission.requested', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           riskLevel: event.riskLevel,
           requestedAtMs: Date.now(),
@@ -35,6 +37,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.permission.decided', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           decision: event.decision,
           riskLevel: event.riskLevel,
@@ -46,6 +49,7 @@ export function createToolDomainEventPublisher(
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,
+            requestId: event.requestId,
             toolName: event.toolName,
             decision: event.decision,
             riskLevel: event.riskLevel,
@@ -55,6 +59,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.execution.finished', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           decision: event.decision,
           riskLevel: event.riskLevel,
@@ -68,6 +73,7 @@ export function createToolDomainEventPublisher(
           await eventBus.emit('tool.permission.decided', {
             conversationId: event.conversationId,
             sessionId: event.sessionId,
+            requestId: event.requestId,
             toolName: event.toolName,
             decision: event.decision,
             riskLevel: event.riskLevel,
@@ -77,6 +83,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.execution.failed', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           decision: event.decision,
           riskLevel: event.riskLevel,
@@ -92,6 +99,7 @@ export function createToolDomainEventPublisher(
         await eventBus.emit('tool.secret.detected', {
           conversationId: event.conversationId,
           sessionId: event.sessionId,
+          requestId: event.requestId,
           toolName: event.toolName,
           action: event.action,
           matches: event.matches,

--- a/assistant/src/events/tool-metrics-listener.ts
+++ b/assistant/src/events/tool-metrics-listener.ts
@@ -36,6 +36,7 @@ export function registerToolMetricsLoggingListener(
             input: formatInputForLog(event.payload.input, truncate),
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
+            requestId: event.payload.requestId,
           },
           'Tool execute start',
         );
@@ -47,6 +48,7 @@ export function registerToolMetricsLoggingListener(
             riskLevel: event.payload.riskLevel,
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
+            requestId: event.payload.requestId,
           },
           'Tool permission requested',
         );
@@ -58,6 +60,7 @@ export function registerToolMetricsLoggingListener(
           riskLevel: event.payload.riskLevel,
           sessionId: event.payload.sessionId,
           conversationId: event.payload.conversationId,
+          requestId: event.payload.requestId,
         };
 
         if (event.payload.decision === 'deny' || event.payload.decision === 'always_deny') {
@@ -79,6 +82,7 @@ export function registerToolMetricsLoggingListener(
             action: event.payload.action,
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
+            requestId: event.payload.requestId,
           },
           'Secrets detected in tool output',
         );
@@ -95,6 +99,7 @@ export function registerToolMetricsLoggingListener(
             isError: event.payload.isError,
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
+            requestId: event.payload.requestId,
           },
           'Tool execute result',
         );
@@ -113,6 +118,7 @@ export function registerToolMetricsLoggingListener(
               isExpected: event.payload.isExpected,
               sessionId: event.payload.sessionId,
               conversationId: event.payload.conversationId,
+              requestId: event.payload.requestId,
             },
             'Tool execution failed (expected)',
           );
@@ -130,6 +136,7 @@ export function registerToolMetricsLoggingListener(
             isExpected: event.payload.isExpected,
             sessionId: event.payload.sessionId,
             conversationId: event.payload.conversationId,
+            requestId: event.payload.requestId,
           },
           'Tool execution error',
         );

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -39,6 +39,7 @@ export class ToolExecutor {
       workingDir: context.workingDir,
       sessionId: context.sessionId,
       conversationId: context.conversationId,
+      requestId: context.requestId,
       startedAtMs: startTime,
     });
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -7,6 +7,7 @@ interface ToolLifecycleEventBase {
   workingDir: string;
   sessionId: string;
   conversationId: string;
+  requestId?: string;
 }
 
 export interface ToolExecutionStartEvent extends ToolLifecycleEventBase {
@@ -77,6 +78,8 @@ export interface ToolContext {
   workingDir: string;
   sessionId: string;
   conversationId: string;
+  /** Per-message request ID for log correlation across session/connection boundaries. */
+  requestId?: string;
   /** Optional callback for streaming incremental output to the client. */
   onOutput?: (chunk: string) => void;
   /** Per-session sandbox override. When set, takes precedence over the global config. */


### PR DESCRIPTION
## Summary
- Generate a UUID `requestId` per user message and thread it through the entire request lifecycle: handlers → session → agent loop → tool executor → lifecycle events → domain events → metrics listener
- Use pino child loggers (`log.child({ conversationId, requestId })`) so all log lines within a request automatically include the request ID without manual plumbing at each call site
- Add `requestId` to `ToolContext`, `ToolLifecycleEventBase`, and all `ToolDomainEvents` interfaces for end-to-end traceability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
