### PR TITLE
Runtime client interface in web (no behavior change)

### DIFF
--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -1,0 +1,114 @@
+/**
+ * HTTP-based RuntimeClient implementation.
+ *
+ * Talks to any runtime that implements the canonical
+ * `/v1/assistants/:assistantId/*` HTTP contract, whether that's a local
+ * daemon HTTP server or a hosted cloud runtime.
+ */
+
+import type {
+  RuntimeClient,
+  RuntimeHealthResponse,
+  ListMessagesParams,
+  ListMessagesResponse,
+  SendMessageParams,
+  SendMessageResponse,
+  UploadAttachmentParams,
+  UploadAttachmentResponse,
+  DeleteAttachmentParams,
+  ChannelInboundParams,
+  ChannelInboundResponse,
+  ChannelDeliveryAckParams,
+} from "./types";
+
+export class RuntimeClientError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RuntimeClientError";
+  }
+}
+
+export function createRuntimeClient(
+  baseUrl: string,
+  assistantId: string,
+  token?: string,
+): RuntimeClient {
+  const prefix = `${baseUrl}/v1/assistants/${assistantId}`;
+
+  async function request<T>(
+    path: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+
+    const response = await fetch(`${prefix}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new RuntimeClientError(response.status, body || `HTTP ${response.status}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  return {
+    health() {
+      return request<RuntimeHealthResponse>("/health");
+    },
+
+    listMessages(params: ListMessagesParams) {
+      const qs = new URLSearchParams({ conversationKey: params.conversationKey });
+      if (params.cursor) qs.set("cursor", params.cursor);
+      if (params.limit != null) qs.set("limit", String(params.limit));
+      return request<ListMessagesResponse>(`/messages?${qs.toString()}`);
+    },
+
+    sendMessage(params: SendMessageParams) {
+      return request<SendMessageResponse>("/messages", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    },
+
+    uploadAttachment(params: UploadAttachmentParams) {
+      return request<UploadAttachmentResponse>("/attachments", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    },
+
+    deleteAttachment(params: DeleteAttachmentParams) {
+      return request<void>(`/attachments`, {
+        method: "DELETE",
+        body: JSON.stringify({ attachmentId: params.attachmentId }),
+      });
+    },
+
+    channelInbound(params: ChannelInboundParams) {
+      return request<ChannelInboundResponse>("/channels/inbound", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    },
+
+    channelDeliveryAck(params: ChannelDeliveryAckParams) {
+      return request<void>("/channels/delivery-ack", {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    },
+  };
+}

--- a/web/src/lib/runtime/resolver.ts
+++ b/web/src/lib/runtime/resolver.ts
@@ -1,0 +1,55 @@
+/**
+ * Resolves the runtime base URL for an assistant.
+ *
+ * In local mode the runtime is the daemon's HTTP server running on the
+ * same machine.  In cloud mode it's a hosted runtime endpoint.
+ *
+ * This module is intentionally kept simple — it reads environment config
+ * and returns a URL string.  The RuntimeClient in `client.ts` handles
+ * the actual HTTP calls.
+ */
+
+import {
+  getAssistantConnectionMode,
+  type AssistantConnectionMode,
+} from "@/lib/assistant-connection";
+
+const DEFAULT_LOCAL_RUNTIME_PORT = 7821;
+
+export interface ResolvedRuntime {
+  baseUrl: string;
+  mode: AssistantConnectionMode;
+}
+
+/**
+ * Resolve the runtime base URL for a given assistant.
+ *
+ * Environment variables:
+ *   - `LOCAL_RUNTIME_URL`  — override the default local runtime URL
+ *   - `CLOUD_RUNTIME_URL`  — base URL for the hosted cloud runtime
+ */
+export function resolveRuntime(_assistantId: string): ResolvedRuntime {
+  const mode = getAssistantConnectionMode();
+
+  if (mode === "local") {
+    const override = process.env.LOCAL_RUNTIME_URL?.trim();
+    const baseUrl = override || `http://127.0.0.1:${DEFAULT_LOCAL_RUNTIME_PORT}`;
+    return { baseUrl: normalizeBaseUrl(baseUrl), mode };
+  }
+
+  const cloudBase = process.env.CLOUD_RUNTIME_URL?.trim();
+  if (!cloudBase) {
+    throw new Error(
+      "CLOUD_RUNTIME_URL must be set when running in cloud mode",
+    );
+  }
+
+  return { baseUrl: normalizeBaseUrl(cloudBase), mode };
+}
+
+/**
+ * Strip trailing slashes so callers can append paths directly.
+ */
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}

--- a/web/src/lib/runtime/types.ts
+++ b/web/src/lib/runtime/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Runtime client contract — same interface for local and cloud runtimes.
+ *
+ * All assistant-owned operations (messages, attachments, channels) flow
+ * through this interface so web routes never branch on deployment mode.
+ */
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+export interface RuntimeHealthResponse {
+  status: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export interface RuntimeMessageAttachment {
+  id: string;
+  original_filename: string;
+  mime_type: string;
+  size_bytes: number;
+  kind: string;
+}
+
+export interface RuntimeMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  attachments: RuntimeMessageAttachment[];
+  toolCalls?: unknown[];
+}
+
+export interface ListMessagesParams {
+  conversationKey: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListMessagesResponse {
+  messages: RuntimeMessage[];
+  nextCursor?: string;
+}
+
+export interface SendMessageParams {
+  conversationKey: string;
+  content: string;
+  attachmentIds?: string[];
+}
+
+export interface SendMessageResponse {
+  messageId: string;
+  assistantMessage?: RuntimeMessage;
+}
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+export interface UploadAttachmentParams {
+  filename: string;
+  mimeType: string;
+  data: string; // base64-encoded
+}
+
+export interface UploadAttachmentResponse {
+  id: string;
+  original_filename: string;
+  mime_type: string;
+  size_bytes: number;
+  kind: string;
+}
+
+export interface DeleteAttachmentParams {
+  attachmentId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Channels
+// ---------------------------------------------------------------------------
+
+export interface ChannelInboundParams {
+  sourceChannel: string;
+  externalChatId: string;
+  externalMessageId: string;
+  content: string;
+  senderName?: string;
+}
+
+export interface ChannelInboundResponse {
+  accepted: boolean;
+  assistantMessage?: RuntimeMessage;
+}
+
+export interface ChannelDeliveryAckParams {
+  sourceChannel: string;
+  externalChatId: string;
+  externalMessageId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client interface
+// ---------------------------------------------------------------------------
+
+export interface RuntimeClient {
+  health(): Promise<RuntimeHealthResponse>;
+
+  listMessages(params: ListMessagesParams): Promise<ListMessagesResponse>;
+  sendMessage(params: SendMessageParams): Promise<SendMessageResponse>;
+
+  uploadAttachment(params: UploadAttachmentParams): Promise<UploadAttachmentResponse>;
+  deleteAttachment(params: DeleteAttachmentParams): Promise<void>;
+
+  channelInbound(params: ChannelInboundParams): Promise<ChannelInboundResponse>;
+  channelDeliveryAck(params: ChannelDeliveryAckParams): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- Introduces `RuntimeClient` typed interface with methods for health, messages, attachments, and channels
- Adds HTTP-based `createRuntimeClient` factory that talks to the `/v1/assistants/:assistantId/*` contract
- Adds `resolveRuntime` resolver that picks local vs cloud base URL from environment config
- No routes use this yet — purely additive, no behavior changes

PR 1 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
