### PR TITLE
Mint hashed assistant token on creation instead of plaintext apiKey

### DIFF
--- a/web/src/app/api/assistants/route.ts
+++ b/web/src/app/api/assistants/route.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 
 import { Assistant, CreateAssistantInput, getDb } from "@/lib/db";
@@ -6,10 +5,7 @@ import {
   getDefaultEditorTemplate,
   uploadEditorPage,
 } from "@/lib/gcp";
-
-function generateApiKey(): string {
-  return `vellum_${randomBytes(32).toString("hex")}`;
-}
+import { createAssistantToken } from "@/lib/auth/assistant-tokens";
 
 export async function GET() {
   try {
@@ -44,12 +40,7 @@ export async function POST(request: Request) {
           body.name = "New Assistant";
         }
 
-        const apiKey = generateApiKey();
-        
-        const initialConfig = { 
-          ...body.configuration, 
-          apiKey,
-        };
+        const initialConfig = body.configuration ?? {};
 
         controller.enqueue(sseEvent("progress", { step: "database", message: "Creating assistant record..." }));
         const result = await sql`
@@ -58,6 +49,9 @@ export async function POST(request: Request) {
           RETURNING *
         `;
         const assistant = result[0] as Assistant;
+
+        const { plaintext: assistantToken } = await createAssistantToken(assistant.id);
+        controller.enqueue(sseEvent("token", { token: assistantToken }));
 
         controller.enqueue(sseEvent("progress", { step: "editor", message: "Setting up editor..." }));
         try {


### PR DESCRIPTION
## Summary
- Replaces plaintext `configuration.apiKey` with a hashed token in `assistant_auth_tokens` table
- Plaintext token is emitted once via SSE `token` event during assistant creation
- Assistant configuration no longer contains any secrets

PR 3 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
