### PR TITLE
Migrate /setup-email to hashed assistant-token auth

### DIFF
--- a/web/src/app/api/assistants/[id]/setup-email/route.ts
+++ b/web/src/app/api/assistants/[id]/setup-email/route.ts
@@ -1,24 +1,41 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { createAssistantMailInbox, registerAssistantMailWebhook } from "@/lib/agentmail";
+import { verifyAssistantToken } from "@/lib/auth/assistant-tokens";
 import { Assistant, getDb } from "@/lib/db";
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header?.startsWith("Bearer ")) {
+    return null;
+  }
+  return header.slice(7);
+}
 
 /**
  * POST /api/assistants/[id]/setup-email
- * 
+ *
  * Allows an assistant to set up its own email inbox.
- * Requires API key authentication via X-API-Key header.
+ * Requires bearer token authentication via Authorization header.
  */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: assistantId } = await params;
-  const apiKey = request.headers.get("X-API-Key");
+  const token = extractBearerToken(request);
 
-  if (!apiKey) {
+  if (!token) {
     return NextResponse.json(
-      { error: "Missing X-API-Key header" },
+      { error: "Missing or invalid Authorization header" },
+      { status: 401 }
+    );
+  }
+
+  const verified = await verifyAssistantToken(assistantId, token);
+  if (!verified) {
+    return NextResponse.json(
+      { error: "Invalid token" },
       { status: 401 }
     );
   }
@@ -26,7 +43,6 @@ export async function POST(
   try {
     const sql = getDb();
 
-    // Fetch assistant and verify API key
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
     if (result.length === 0) {
       return NextResponse.json(
@@ -36,14 +52,6 @@ export async function POST(
     }
 
     const assistant = result[0] as Assistant;
-    const storedApiKey = (assistant.configuration as Record<string, unknown>)?.apiKey;
-
-    if (!storedApiKey || storedApiKey !== apiKey) {
-      return NextResponse.json(
-        { error: "Invalid API key" },
-        { status: 401 }
-      );
-    }
 
     // Check if email is already set up
     const existingMail = (assistant.configuration as Record<string, unknown>)?.agentmail;
@@ -94,20 +102,28 @@ export async function POST(
 
 /**
  * GET /api/assistants/[id]/setup-email
- * 
+ *
  * Check email setup status for an assistant.
- * Requires API key authentication.
+ * Requires bearer token authentication.
  */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: assistantId } = await params;
-  const apiKey = request.headers.get("X-API-Key");
+  const token = extractBearerToken(request);
 
-  if (!apiKey) {
+  if (!token) {
     return NextResponse.json(
-      { error: "Missing X-API-Key header" },
+      { error: "Missing or invalid Authorization header" },
+      { status: 401 }
+    );
+  }
+
+  const verified = await verifyAssistantToken(assistantId, token);
+  if (!verified) {
+    return NextResponse.json(
+      { error: "Invalid token" },
       { status: 401 }
     );
   }
@@ -124,15 +140,6 @@ export async function GET(
     }
 
     const assistant = result[0] as Assistant;
-    const storedApiKey = (assistant.configuration as Record<string, unknown>)?.apiKey;
-
-    if (!storedApiKey || storedApiKey !== apiKey) {
-      return NextResponse.json(
-        { error: "Invalid API key" },
-        { status: 401 }
-      );
-    }
-
     const agentmail = (assistant.configuration as Record<string, unknown>)?.agentmail;
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- Replaces plaintext `X-API-Key` header check with `Authorization: Bearer <token>` verification
- Uses `verifyAssistantToken` from the assistant-tokens helper (prefix + SHA-256 hash lookup)
- Updates `last_used_at` on successful auth
- No reference to `configuration.apiKey` remains in this route

PR 4 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
