### PR TITLE
Migrate /set-avatar to hashed assistant-token auth

### DIFF
--- a/web/src/app/api/assistants/[id]/set-avatar/route.ts
+++ b/web/src/app/api/assistants/[id]/set-avatar/route.ts
@@ -1,13 +1,40 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { verifyAssistantToken } from "@/lib/auth/assistant-tokens";
 import { Assistant, getDb } from "@/lib/db";
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header?.startsWith("Bearer ")) {
+    return null;
+  }
+  return header.slice(7);
+}
+
+async function authenticateAssistant(
+  request: NextRequest,
+  assistantId: string,
+): Promise<NextResponse | null> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return NextResponse.json(
+      { error: "Missing or invalid Authorization header" },
+      { status: 401 },
+    );
+  }
+  const verified = await verifyAssistantToken(assistantId, token);
+  if (!verified) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+  return null;
+}
 
 /**
  * POST /api/assistants/[id]/set-avatar
- * 
+ *
  * Allows an assistant to set its global avatar.
- * Requires API key authentication via X-API-Key header.
- * 
+ * Requires bearer token authentication via Authorization header.
+ *
  * Body: { avatar_url: string } or { avatar_base64: string, content_type: string }
  */
 export async function POST(
@@ -15,19 +42,13 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: assistantId } = await params;
-  const apiKey = request.headers.get("X-API-Key");
 
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "Missing X-API-Key header" },
-      { status: 401 }
-    );
-  }
+  const authError = await authenticateAssistant(request, assistantId);
+  if (authError) return authError;
 
   try {
     const sql = getDb();
 
-    // Fetch assistant and verify API key
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
     if (result.length === 0) {
       return NextResponse.json(
@@ -37,14 +58,6 @@ export async function POST(
     }
 
     const assistant = result[0] as Assistant;
-    const storedApiKey = (assistant.configuration as Record<string, unknown>)?.apiKey;
-
-    if (!storedApiKey || storedApiKey !== apiKey) {
-      return NextResponse.json(
-        { error: "Invalid API key" },
-        { status: 401 }
-      );
-    }
 
     const body = await request.json();
     const { avatar_url, avatar_base64, content_type } = body;
@@ -71,7 +84,7 @@ export async function POST(
           { status: 400 }
         );
       }
-      
+
       // Validate base64
       try {
         atob(avatar_base64);
@@ -85,7 +98,7 @@ export async function POST(
       // For now, store as data URL (small images only)
       // TODO: Upload to GCS for production
       finalAvatarUrl = `data:${content_type};base64,${avatar_base64}`;
-      
+
       // Limit data URL size (100KB max)
       if (finalAvatarUrl.length > 100000) {
         return NextResponse.json(
@@ -118,7 +131,7 @@ export async function POST(
 
     return NextResponse.json({
       message: "Avatar set successfully",
-      avatar_url: finalAvatarUrl.startsWith("data:") 
+      avatar_url: finalAvatarUrl.startsWith("data:")
         ? `data:${content_type};base64,[BASE64_DATA]` // Don't echo full data URL
         : finalAvatarUrl,
     });
@@ -134,23 +147,18 @@ export async function POST(
 
 /**
  * GET /api/assistants/[id]/set-avatar
- * 
+ *
  * Get the current avatar for an assistant.
- * Requires API key authentication.
+ * Requires bearer token authentication.
  */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: assistantId } = await params;
-  const apiKey = request.headers.get("X-API-Key");
 
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "Missing X-API-Key header" },
-      { status: 401 }
-    );
-  }
+  const authError = await authenticateAssistant(request, assistantId);
+  if (authError) return authError;
 
   try {
     const sql = getDb();
@@ -164,15 +172,6 @@ export async function GET(
     }
 
     const assistant = result[0] as Assistant;
-    const storedApiKey = (assistant.configuration as Record<string, unknown>)?.apiKey;
-
-    if (!storedApiKey || storedApiKey !== apiKey) {
-      return NextResponse.json(
-        { error: "Invalid API key" },
-        { status: 401 }
-      );
-    }
-
     const avatarUrl = (assistant.configuration as Record<string, unknown>)?.avatar_url as string | undefined;
 
     return NextResponse.json({
@@ -190,23 +189,18 @@ export async function GET(
 
 /**
  * DELETE /api/assistants/[id]/set-avatar
- * 
+ *
  * Remove the avatar for an assistant.
- * Requires API key authentication.
+ * Requires bearer token authentication.
  */
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: assistantId } = await params;
-  const apiKey = request.headers.get("X-API-Key");
 
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "Missing X-API-Key header" },
-      { status: 401 }
-    );
-  }
+  const authError = await authenticateAssistant(request, assistantId);
+  if (authError) return authError;
 
   try {
     const sql = getDb();
@@ -220,14 +214,6 @@ export async function DELETE(
     }
 
     const assistant = result[0] as Assistant;
-    const storedApiKey = (assistant.configuration as Record<string, unknown>)?.apiKey;
-
-    if (!storedApiKey || storedApiKey !== apiKey) {
-      return NextResponse.json(
-        { error: "Invalid API key" },
-        { status: 401 }
-      );
-    }
 
     // Remove avatar from configuration
     const currentConfig = assistant.configuration as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Replaces plaintext `X-API-Key` header check with `Authorization: Bearer <token>` verification in POST, GET, and DELETE handlers
- Extracts shared `authenticateAssistant` helper to reduce duplication
- No reference to `configuration.apiKey` remains in this route

PR 5 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
