### PR TITLE
Add runtime HTTP server skeleton in assistant package

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -16,6 +16,7 @@ import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
 import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
+import { RuntimeHttpServer } from '../runtime/http-server.js';
 
 const log = getLogger('lifecycle');
 
@@ -177,6 +178,17 @@ export async function runDaemon(): Promise<void> {
   await server.start();
   const memoryWorker = startMemoryJobsWorker();
 
+  // Start optional runtime HTTP server when RUNTIME_HTTP_PORT is set
+  let runtimeHttp: RuntimeHttpServer | null = null;
+  const httpPortEnv = process.env.RUNTIME_HTTP_PORT;
+  if (httpPortEnv) {
+    const port = parseInt(httpPortEnv, 10);
+    if (!isNaN(port) && port > 0) {
+      runtimeHttp = new RuntimeHttpServer({ port });
+      await runtimeHttp.start();
+    }
+  }
+
   writePid(process.pid);
   log.info({ pid: process.pid }, 'Daemon started');
 
@@ -207,6 +219,7 @@ export async function runDaemon(): Promise<void> {
     forceTimer.unref();
 
     await server.stop();
+    if (runtimeHttp) await runtimeHttp.stop();
     await browserManager.closeAllPages();
     memoryWorker.stop();
     cleanupPidFile();

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1,0 +1,65 @@
+/**
+ * Optional HTTP server that exposes the canonical runtime API.
+ *
+ * Runs in the same process as the daemon. Started only when
+ * `RUNTIME_HTTP_PORT` is set (default: disabled).
+ */
+
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('runtime-http');
+
+const DEFAULT_PORT = 7821;
+
+export interface RuntimeHttpServerOptions {
+  port?: number;
+}
+
+export class RuntimeHttpServer {
+  private server: ReturnType<typeof Bun.serve> | null = null;
+  private port: number;
+
+  constructor(options: RuntimeHttpServerOptions = {}) {
+    this.port = options.port ?? DEFAULT_PORT;
+  }
+
+  async start(): Promise<void> {
+    this.server = Bun.serve({
+      port: this.port,
+      fetch: (req) => this.handleRequest(req),
+    });
+
+    log.info({ port: this.port }, 'Runtime HTTP server listening');
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      this.server.stop(true);
+      this.server = null;
+      log.info('Runtime HTTP server stopped');
+    }
+  }
+
+  private async handleRequest(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    // Match /v1/assistants/:assistantId/health
+    const healthMatch = path.match(/^\/v1\/assistants\/([^/]+)\/health$/);
+    if (healthMatch && req.method === 'GET') {
+      return this.handleHealth();
+    }
+
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  private handleHealth(): Response {
+    return Response.json({
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `RuntimeHttpServer` class using `Bun.serve()` for the canonical runtime API
- Implements `GET /v1/assistants/:assistantId/health` as the first endpoint
- Opt-in via `RUNTIME_HTTP_PORT` env var (disabled by default)
- Graceful shutdown integrated into daemon lifecycle

PR 7 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
