### PR TITLE
Add assistant-owned conversation-key mapping table

### DIFF
--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -1,0 +1,76 @@
+/**
+ * Maps (assistant_id, conversation_key) pairs to internal conversation IDs.
+ *
+ * The web UI identifies conversations by an opaque `conversationKey` (e.g.
+ * a user ID, a channel thread ID).  This store resolves those keys to the
+ * assistant's internal conversation IDs, creating new conversations on
+ * first contact.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { conversationKeys } from './schema.js';
+import { createConversation } from './conversation-store.js';
+
+export interface ConversationKeyMapping {
+  id: string;
+  assistantId: string;
+  conversationKey: string;
+  conversationId: string;
+  createdAt: number;
+}
+
+/**
+ * Look up the conversation ID for a given (assistantId, conversationKey).
+ * Returns `null` if no mapping exists yet.
+ */
+export function getConversationByKey(
+  assistantId: string,
+  conversationKey: string,
+): ConversationKeyMapping | null {
+  const db = getDb();
+  const result = db
+    .select()
+    .from(conversationKeys)
+    .where(
+      and(
+        eq(conversationKeys.assistantId, assistantId),
+        eq(conversationKeys.conversationKey, conversationKey),
+      ),
+    )
+    .get();
+  return result ?? null;
+}
+
+/**
+ * Get or create a conversation for the given (assistantId, conversationKey).
+ *
+ * If a mapping already exists, returns the existing conversation ID.
+ * Otherwise, creates a new conversation and mapping atomically.
+ */
+export function getOrCreateConversation(
+  assistantId: string,
+  conversationKey: string,
+): { conversationId: string; created: boolean } {
+  const existing = getConversationByKey(assistantId, conversationKey);
+  if (existing) {
+    return { conversationId: existing.conversationId, created: false };
+  }
+
+  const conversation = createConversation(`Runtime: ${conversationKey}`);
+  const db = getDb();
+  const now = Date.now();
+
+  db.insert(conversationKeys)
+    .values({
+      id: uuid(),
+      assistantId,
+      conversationKey,
+      conversationId: conversation.id,
+      createdAt: now,
+    })
+    .run();
+
+  return { conversationId: conversation.id, created: true };
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -191,6 +191,17 @@ export function initializeDb(): void {
     END
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversation_keys (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      conversation_key TEXT NOT NULL,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL,
+      UNIQUE (assistant_id, conversation_key)
+    )
+  `);
+
   // Migrations — ALTER TABLE ADD COLUMN throws if column already exists
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE conversations ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
@@ -213,6 +224,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time ON memory_summaries(scope, end_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_keys_assistant_key ON conversation_keys(assistant_id, conversation_key)`);
 
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -113,6 +113,16 @@ export const memoryJobs = sqliteTable('memory_jobs', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+export const conversationKeys = sqliteTable('conversation_keys', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  conversationKey: text('conversation_key').notNull(),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  createdAt: integer('created_at').notNull(),
+});
+
 export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),


### PR DESCRIPTION
## Summary
- Adds `conversation_keys` table to SQLite schema mapping `(assistant_id, conversation_key)` to `conversation_id`
- Adds Drizzle ORM schema definition for the new table
- Adds `conversation-key-store.ts` with `getConversationByKey` and `getOrCreateConversation` helpers

PR 8 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
