### PR TITLE
Add runtime message endpoints for assistant-owned history

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -6,6 +6,10 @@
  */
 
 import { getLogger } from '../util/logger.js';
+import {
+  getOrCreateConversation,
+} from '../memory/conversation-key-store.js';
+import * as conversationStore from '../memory/conversation-store.js';
 
 const log = getLogger('runtime-http');
 
@@ -13,6 +17,14 @@ const DEFAULT_PORT = 7821;
 
 export interface RuntimeHttpServerOptions {
   port?: number;
+}
+
+interface RuntimeMessagePayload {
+  id: string;
+  role: string;
+  content: string;
+  timestamp: string;
+  attachments: unknown[];
 }
 
 export class RuntimeHttpServer {
@@ -44,22 +56,97 @@ export class RuntimeHttpServer {
     const url = new URL(req.url);
     const path = url.pathname;
 
-    // Match /v1/assistants/:assistantId/health
-    const healthMatch = path.match(/^\/v1\/assistants\/([^/]+)\/health$/);
-    if (healthMatch && req.method === 'GET') {
-      return this.handleHealth();
+    // Match /v1/assistants/:assistantId/<endpoint>
+    const match = path.match(/^\/v1\/assistants\/([^/]+)\/(.+)$/);
+    if (!match) {
+      return Response.json({ error: 'Not found' }, { status: 404 });
     }
 
-    return new Response(JSON.stringify({ error: 'Not found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    const assistantId = match[1];
+    const endpoint = match[2];
+
+    try {
+      if (endpoint === 'health' && req.method === 'GET') {
+        return this.handleHealth();
+      }
+
+      if (endpoint === 'messages' && req.method === 'GET') {
+        return this.handleListMessages(assistantId, url);
+      }
+
+      if (endpoint === 'messages' && req.method === 'POST') {
+        return await this.handleSendMessage(assistantId, req);
+      }
+
+      return Response.json({ error: 'Not found' }, { status: 404 });
+    } catch (err) {
+      log.error({ err, endpoint, assistantId }, 'Runtime HTTP handler error');
+      return Response.json({ error: 'Internal server error' }, { status: 500 });
+    }
   }
 
   private handleHealth(): Response {
     return Response.json({
       status: 'healthy',
       timestamp: new Date().toISOString(),
+    });
+  }
+
+  private handleListMessages(assistantId: string, url: URL): Response {
+    const conversationKey = url.searchParams.get('conversationKey');
+    if (!conversationKey) {
+      return Response.json(
+        { error: 'conversationKey query parameter is required' },
+        { status: 400 },
+      );
+    }
+
+    const mapping = getOrCreateConversation(assistantId, conversationKey);
+    const rawMessages = conversationStore.getMessages(mapping.conversationId);
+
+    const messages: RuntimeMessagePayload[] = rawMessages.map((msg) => ({
+      id: msg.id,
+      role: msg.role,
+      content: msg.content,
+      timestamp: new Date(msg.createdAt).toISOString(),
+      attachments: [],
+    }));
+
+    return Response.json({ messages });
+  }
+
+  private async handleSendMessage(assistantId: string, req: Request): Promise<Response> {
+    const body = await req.json() as {
+      conversationKey?: string;
+      content?: string;
+      attachmentIds?: string[];
+    };
+
+    const { conversationKey, content } = body;
+
+    if (!conversationKey) {
+      return Response.json(
+        { error: 'conversationKey is required' },
+        { status: 400 },
+      );
+    }
+
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+      return Response.json(
+        { error: 'content is required' },
+        { status: 400 },
+      );
+    }
+
+    const mapping = getOrCreateConversation(assistantId, conversationKey);
+    const userMessage = conversationStore.addMessage(
+      mapping.conversationId,
+      'user',
+      content,
+    );
+
+    return Response.json({
+      messageId: userMessage.id,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Implements `GET /v1/assistants/:assistantId/messages?conversationKey=<key>` for listing messages
- Implements `POST /v1/assistants/:assistantId/messages` for storing user messages
- Uses conversation-key mapping to resolve opaque keys to internal conversation IDs
- Returns message payloads compatible with the web UI shape

PR 9 of 17 in the Local + Cloud Simplification rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
