### PR TITLE
Add assistant-owned attachment storage with runtime endpoints

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1,0 +1,100 @@
+/**
+ * Assistant-owned attachment storage.
+ *
+ * Stores attachments in the local SQLite database with base64-encoded
+ * data. Provides upload, delete, and message-linkage operations.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { attachments, messageAttachments } from './schema.js';
+
+export interface StoredAttachment {
+  id: string;
+  assistantId: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  createdAt: number;
+}
+
+function classifyKind(mimeType: string): string {
+  if (mimeType.startsWith('image/')) return 'image';
+  return 'document';
+}
+
+export function uploadAttachment(
+  assistantId: string,
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+): StoredAttachment {
+  const db = getDb();
+  const now = Date.now();
+  const sizeBytes = Math.ceil((dataBase64.length * 3) / 4);
+  const kind = classifyKind(mimeType);
+
+  const record = {
+    id: uuid(),
+    assistantId,
+    originalFilename: filename,
+    mimeType,
+    sizeBytes,
+    kind,
+    dataBase64,
+    createdAt: now,
+  };
+
+  db.insert(attachments).values(record).run();
+
+  return {
+    id: record.id,
+    assistantId,
+    originalFilename: filename,
+    mimeType,
+    sizeBytes,
+    kind,
+    createdAt: now,
+  };
+}
+
+export function deleteAttachment(assistantId: string, attachmentId: string): boolean {
+  const db = getDb();
+  const existing = db
+    .select({ id: attachments.id })
+    .from(attachments)
+    .where(
+      and(
+        eq(attachments.id, attachmentId),
+        eq(attachments.assistantId, assistantId),
+      ),
+    )
+    .get();
+
+  if (!existing) return false;
+
+  db.delete(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .run();
+
+  return true;
+}
+
+export function linkAttachmentToMessage(
+  messageId: string,
+  attachmentId: string,
+  position: number,
+): void {
+  const db = getDb();
+  db.insert(messageAttachments)
+    .values({
+      id: uuid(),
+      messageId,
+      attachmentId,
+      position,
+      createdAt: Date.now(),
+    })
+    .run();
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -158,6 +158,29 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS attachments (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      original_filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      data_base64 TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS message_attachments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      attachment_id TEXT NOT NULL REFERENCES attachments(id) ON DELETE CASCADE,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
   // FTS table for lexical retrieval over memory_segments.text.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
@@ -225,6 +248,9 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time ON memory_summaries(scope, end_at DESC)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_keys_assistant_key ON conversation_keys(assistant_id, conversation_key)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_attachments_assistant_id ON attachments(assistant_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_message_id ON message_attachments(message_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_id ON message_attachments(attachment_id)`);
 
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -123,6 +123,29 @@ export const conversationKeys = sqliteTable('conversation_keys', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const attachments = sqliteTable('attachments', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  originalFilename: text('original_filename').notNull(),
+  mimeType: text('mime_type').notNull(),
+  sizeBytes: integer('size_bytes').notNull(),
+  kind: text('kind').notNull(),
+  dataBase64: text('data_base64').notNull(),
+  createdAt: integer('created_at').notNull(),
+});
+
+export const messageAttachments = sqliteTable('message_attachments', {
+  id: text('id').primaryKey(),
+  messageId: text('message_id')
+    .notNull()
+    .references(() => messages.id, { onDelete: 'cascade' }),
+  attachmentId: text('attachment_id')
+    .notNull()
+    .references(() => attachments.id, { onDelete: 'cascade' }),
+  position: integer('position').notNull().default(0),
+  createdAt: integer('created_at').notNull(),
+});
+
 export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -10,6 +10,7 @@ import {
   getOrCreateConversation,
 } from '../memory/conversation-key-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import * as attachmentsStore from '../memory/attachments-store.js';
 
 const log = getLogger('runtime-http');
 
@@ -76,6 +77,14 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'messages' && req.method === 'POST') {
         return await this.handleSendMessage(assistantId, req);
+      }
+
+      if (endpoint === 'attachments' && req.method === 'POST') {
+        return await this.handleUploadAttachment(assistantId, req);
+      }
+
+      if (endpoint === 'attachments' && req.method === 'DELETE') {
+        return await this.handleDeleteAttachment(assistantId, req);
       }
 
       return Response.json({ error: 'Not found' }, { status: 404 });
@@ -148,5 +157,77 @@ export class RuntimeHttpServer {
     return Response.json({
       messageId: userMessage.id,
     });
+  }
+
+  private async handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
+    const body = await req.json() as {
+      filename?: string;
+      mimeType?: string;
+      data?: string;
+    };
+
+    const { filename, mimeType, data } = body;
+
+    if (!filename || typeof filename !== 'string') {
+      return Response.json(
+        { error: 'filename is required' },
+        { status: 400 },
+      );
+    }
+
+    if (!mimeType || typeof mimeType !== 'string') {
+      return Response.json(
+        { error: 'mimeType is required' },
+        { status: 400 },
+      );
+    }
+
+    if (!data || typeof data !== 'string') {
+      return Response.json(
+        { error: 'data (base64) is required' },
+        { status: 400 },
+      );
+    }
+
+    const attachment = attachmentsStore.uploadAttachment(
+      assistantId,
+      filename,
+      mimeType,
+      data,
+    );
+
+    return Response.json({
+      id: attachment.id,
+      original_filename: attachment.originalFilename,
+      mime_type: attachment.mimeType,
+      size_bytes: attachment.sizeBytes,
+      kind: attachment.kind,
+    });
+  }
+
+  private async handleDeleteAttachment(assistantId: string, req: Request): Promise<Response> {
+    const body = await req.json() as {
+      attachmentId?: string;
+    };
+
+    const { attachmentId } = body;
+
+    if (!attachmentId || typeof attachmentId !== 'string') {
+      return Response.json(
+        { error: 'attachmentId is required' },
+        { status: 400 },
+      );
+    }
+
+    const deleted = attachmentsStore.deleteAttachment(assistantId, attachmentId);
+
+    if (!deleted) {
+      return Response.json(
+        { error: 'Attachment not found' },
+        { status: 404 },
+      );
+    }
+
+    return new Response(null, { status: 204 });
   }
 }


### PR DESCRIPTION
## Summary
- Adds `attachments` and `message_attachments` tables to the assistant SQLite database (Drizzle schema + raw DDL init)
- Creates `attachments-store.ts` with upload, delete, and message-linkage helpers
- Implements `POST /v1/assistants/:id/attachments` (upload) and `DELETE /v1/assistants/:id/attachments` (delete) on the runtime HTTP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
