### PR TITLE
Proxy web attachments route to runtime in local mode

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -16,6 +16,9 @@ import {
   type ProcessedAttachment,
 } from "@/lib/attachments";
 import { getStorage, type StorageBucket } from "@/lib/storage";
+import { getAssistantConnectionMode } from "@/lib/assistant-connection";
+import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
+import { resolveRuntime } from "@/lib/runtime/resolver";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -77,6 +80,43 @@ async function cleanupUploadedObjects(bucket: StorageBucket, storageKeys: string
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+    const connectionMode = getAssistantConnectionMode();
+
+    if (connectionMode === "local") {
+      const formData = await request.formData();
+      const files = getFilesFromFormData(formData);
+      if (files.length === 0) {
+        return NextResponse.json(
+          { error: "At least one file is required under the 'files' field" },
+          { status: 400 },
+        );
+      }
+
+      const { baseUrl } = resolveRuntime(assistantId);
+      const client = createRuntimeClient(baseUrl, assistantId);
+      const createdAttachments: UploadResponseAttachment[] = [];
+
+      for (const file of files) {
+        const arrayBuffer = await file.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString("base64");
+        const result = await client.uploadAttachment({
+          filename: file.name || "attachment",
+          mimeType: file.type || "application/octet-stream",
+          data: base64,
+        });
+        createdAttachments.push({
+          id: result.id,
+          original_filename: result.original_filename,
+          mime_type: result.mime_type,
+          size_bytes: result.size_bytes,
+          kind: result.kind,
+          created_at: null,
+        });
+      }
+
+      return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
+    }
+
     const sql = getDb();
     const assistants = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
     if (assistants.length === 0) {
@@ -205,6 +245,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
   } catch (error) {
     console.error("Error uploading attachments:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to upload attachments to local runtime" },
+        { status: error.status },
+      );
+    }
     const status = error instanceof AttachmentValidationError ? 400 : 500;
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to upload attachments" },
@@ -216,11 +262,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
-    const sql = getDb();
-    const assistants = await sql`SELECT id FROM assistants WHERE id = ${assistantId}`;
-    if (assistants.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    const connectionMode = getAssistantConnectionMode();
 
     const body = await request.json().catch(() => ({})) as { attachment_ids?: unknown };
     const attachmentIds = normalizeAttachmentIds(body.attachment_ids);
@@ -229,6 +271,23 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
         { error: "attachment_ids must contain at least one attachment id" },
         { status: 400 },
       );
+    }
+
+    if (connectionMode === "local") {
+      const { baseUrl } = resolveRuntime(assistantId);
+      const client = createRuntimeClient(baseUrl, assistantId);
+
+      for (const attachmentId of attachmentIds) {
+        await client.deleteAttachment({ attachmentId });
+      }
+
+      return NextResponse.json({ deleted_ids: attachmentIds });
+    }
+
+    const sql = getDb();
+    const assistants = await sql`SELECT id FROM assistants WHERE id = ${assistantId}`;
+    if (assistants.length === 0) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
     }
 
     const attachments = await db
@@ -293,6 +352,12 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ deleted_ids: attachmentIds });
   } catch (error) {
     console.error("Error deleting attachments:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to delete attachments from local runtime" },
+        { status: error.status },
+      );
+    }
     return NextResponse.json(
       { error: "Failed to delete attachments" },
       { status: 500 },


### PR DESCRIPTION
## Summary
- In local connection mode, `POST /api/assistants/[id]/attachments` now converts form data files to base64 and proxies through the runtime client's `uploadAttachment` endpoint
- In local connection mode, `DELETE /api/assistants/[id]/attachments` now proxies through the runtime client's `deleteAttachment` endpoint  
- Cloud mode (GCS + Postgres `chat_attachments`) is unchanged
- Response format stays stable for InteractionTab consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
