### PR TITLE
Make web API routes mode-agnostic via runtime client

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -1,22 +1,5 @@
-import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq, inArray } from "drizzle-orm";
 
-import {
-  db,
-  getDb,
-} from "@/lib/db";
-import {
-  chatAttachmentsTable,
-  chatMessageAttachmentsTable,
-} from "@/lib/schema";
-import {
-  processAttachmentUpload,
-  sanitizeFilename,
-  type ProcessedAttachment,
-} from "@/lib/attachments";
-import { getStorage, type StorageBucket } from "@/lib/storage";
-import { getAssistantConnectionMode } from "@/lib/assistant-connection";
 import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
 
@@ -24,30 +7,14 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
-const ATTACHMENTS_BUCKET_NAME = process.env.GCS_BUCKET_NAME || "vellum-ai-prod-vellum-assistant";
-const ATTACHMENTS_PREFIX = "vellum-assistant/chat-attachments";
-const MAX_FILES_PER_UPLOAD = 10;
-const MAX_TOTAL_BUFFERED_BYTES = 50 * 1024 * 1024;
-const MAX_TOTAL_BUFFERED_MIB = MAX_TOTAL_BUFFERED_BYTES / (1024 * 1024);
-
 interface UploadResponseAttachment {
   id: string;
   original_filename: string;
   mime_type: string;
   size_bytes: number;
   kind: string;
-  created_at: Date | null;
+  created_at: null;
 }
-
-interface PreparedUpload {
-  attachmentId: string;
-  fileName: string;
-  processed: ProcessedAttachment;
-  buffer: Buffer;
-  storageKey: string;
-}
-
-class AttachmentValidationError extends Error {}
 
 function getFilesFromFormData(formData: FormData): File[] {
   const directFiles = formData.getAll("files").filter((value): value is File => value instanceof File);
@@ -65,63 +32,14 @@ function normalizeAttachmentIds(value: unknown): string[] {
   return [...new Set(ids)];
 }
 
-async function cleanupUploadedObjects(bucket: StorageBucket, storageKeys: string[]): Promise<void> {
-  await Promise.all(
-    storageKeys.map(async (storageKey) => {
-      try {
-        await bucket.file(storageKey).delete();
-      } catch (error) {
-        console.warn(`[attachments] Failed to clean up object "${storageKey}"`, error);
-      }
-    }),
-  );
+function getRuntimeClient(assistantId: string) {
+  const { baseUrl } = resolveRuntime(assistantId);
+  return createRuntimeClient(baseUrl, assistantId);
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
-    const connectionMode = getAssistantConnectionMode();
-
-    if (connectionMode === "local") {
-      const formData = await request.formData();
-      const files = getFilesFromFormData(formData);
-      if (files.length === 0) {
-        return NextResponse.json(
-          { error: "At least one file is required under the 'files' field" },
-          { status: 400 },
-        );
-      }
-
-      const { baseUrl } = resolveRuntime(assistantId);
-      const client = createRuntimeClient(baseUrl, assistantId);
-      const createdAttachments: UploadResponseAttachment[] = [];
-
-      for (const file of files) {
-        const arrayBuffer = await file.arrayBuffer();
-        const base64 = Buffer.from(arrayBuffer).toString("base64");
-        const result = await client.uploadAttachment({
-          filename: file.name || "attachment",
-          mimeType: file.type || "application/octet-stream",
-          data: base64,
-        });
-        createdAttachments.push({
-          id: result.id,
-          original_filename: result.original_filename,
-          mime_type: result.mime_type,
-          size_bytes: result.size_bytes,
-          kind: result.kind,
-          created_at: null,
-        });
-      }
-
-      return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
-    }
-
-    const sql = getDb();
-    const assistants = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
-    if (assistants.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
 
     const formData = await request.formData();
     const files = getFilesFromFormData(formData);
@@ -131,127 +49,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { status: 400 },
       );
     }
-    if (files.length > MAX_FILES_PER_UPLOAD) {
-      return NextResponse.json(
-        { error: `A maximum of ${MAX_FILES_PER_UPLOAD} files can be uploaded at once` },
-        { status: 400 },
-      );
-    }
 
-    const declaredTotalBytes = files.reduce((total, file) => total + file.size, 0);
-    if (declaredTotalBytes > MAX_TOTAL_BUFFERED_BYTES) {
-      return NextResponse.json(
-        { error: `Total attachment size cannot exceed ${MAX_TOTAL_BUFFERED_MIB}MB per request` },
-        { status: 400 },
-      );
-    }
-
-    const storage = getStorage();
-    const bucket = storage.bucket(ATTACHMENTS_BUCKET_NAME);
-    const preparedUploads: PreparedUpload[] = [];
-    let totalBufferedBytes = 0;
+    const client = getRuntimeClient(assistantId);
+    const createdAttachments: UploadResponseAttachment[] = [];
 
     for (const file of files) {
-      const fileName = file.name || "attachment";
       const arrayBuffer = await file.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      totalBufferedBytes += buffer.byteLength;
-      if (totalBufferedBytes > MAX_TOTAL_BUFFERED_BYTES) {
-        throw new AttachmentValidationError(
-          `Total attachment size cannot exceed ${MAX_TOTAL_BUFFERED_MIB}MB per request`,
-        );
-      }
-
-      const attachmentId = randomUUID();
-      let processed: ProcessedAttachment;
-      try {
-        processed = await processAttachmentUpload(fileName, file.type, buffer);
-      } catch (error) {
-        throw new AttachmentValidationError(
-          error instanceof Error ? error.message : `Failed to process "${fileName}"`,
-        );
-      }
-      const storageKey = `${ATTACHMENTS_PREFIX}/${assistantId}/${attachmentId}/${sanitizeFilename(fileName)}`;
-
-      preparedUploads.push({
-        attachmentId,
-        fileName,
-        processed,
-        buffer,
-        storageKey,
+      const base64 = Buffer.from(arrayBuffer).toString("base64");
+      const result = await client.uploadAttachment({
+        filename: file.name || "attachment",
+        mimeType: file.type || "application/octet-stream",
+        data: base64,
       });
-    }
-
-    const uploadedStorageKeys: string[] = [];
-    try {
-      for (const upload of preparedUploads) {
-        await bucket.file(upload.storageKey).save(upload.buffer, {
-          contentType: upload.processed.mimeType,
-          metadata: {
-            assistantId,
-            attachmentId: upload.attachmentId,
-            originalFilename: upload.processed.fileName,
-            mimeType: upload.processed.mimeType,
-            sizeBytes: String(upload.processed.sizeBytes),
-            sha256: upload.processed.sha256,
-            kind: upload.processed.kind,
-            createdAt: new Date().toISOString(),
-          },
-        });
-        uploadedStorageKeys.push(upload.storageKey);
-      }
-    } catch (error) {
-      await cleanupUploadedObjects(bucket, uploadedStorageKeys);
-      throw error;
-    }
-
-    let createdAttachments: UploadResponseAttachment[] = [];
-    try {
-      const insertedRows = await db
-        .insert(chatAttachmentsTable)
-        .values(preparedUploads.map((upload) => ({
-          id: upload.attachmentId,
-          assistantId,
-          originalFilename: upload.processed.fileName,
-          mimeType: upload.processed.mimeType,
-          sizeBytes: upload.processed.sizeBytes,
-          storageKey: upload.storageKey,
-          sha256: upload.processed.sha256,
-          kind: upload.processed.kind,
-          extractedText: upload.processed.extractedText,
-        })))
-        .returning();
-
-      const insertedById = new Map(insertedRows.map((row) => [row.id, row]));
-      createdAttachments = preparedUploads.map((upload) => {
-        const saved = insertedById.get(upload.attachmentId);
-        if (!saved) {
-          throw new Error(`Missing inserted attachment row for ${upload.attachmentId}`);
-        }
-        return {
-          id: saved.id,
-          original_filename: saved.originalFilename,
-          mime_type: saved.mimeType,
-          size_bytes: saved.sizeBytes,
-          kind: saved.kind,
-          created_at: saved.createdAt ?? null,
-        };
+      createdAttachments.push({
+        id: result.id,
+        original_filename: result.original_filename,
+        mime_type: result.mime_type,
+        size_bytes: result.size_bytes,
+        kind: result.kind,
+        created_at: null,
       });
-    } catch (error) {
-      await cleanupUploadedObjects(bucket, uploadedStorageKeys);
-      throw error;
     }
 
     return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
   } catch (error) {
     console.error("Error uploading attachments:", error);
-    if (error instanceof RuntimeClientError) {
-      return NextResponse.json(
-        { error: "Failed to upload attachments to local runtime" },
-        { status: error.status },
-      );
-    }
-    const status = error instanceof AttachmentValidationError ? 400 : 500;
+    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to upload attachments" },
       { status },
@@ -262,7 +85,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
-    const connectionMode = getAssistantConnectionMode();
 
     const body = await request.json().catch(() => ({})) as { attachment_ids?: unknown };
     const attachmentIds = normalizeAttachmentIds(body.attachment_ids);
@@ -273,94 +95,19 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    if (connectionMode === "local") {
-      const { baseUrl } = resolveRuntime(assistantId);
-      const client = createRuntimeClient(baseUrl, assistantId);
+    const client = getRuntimeClient(assistantId);
 
-      for (const attachmentId of attachmentIds) {
-        await client.deleteAttachment({ attachmentId });
-      }
-
-      return NextResponse.json({ deleted_ids: attachmentIds });
+    for (const attachmentId of attachmentIds) {
+      await client.deleteAttachment({ attachmentId });
     }
-
-    const sql = getDb();
-    const assistants = await sql`SELECT id FROM assistants WHERE id = ${assistantId}`;
-    if (assistants.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
-    const attachments = await db
-      .select({
-        id: chatAttachmentsTable.id,
-        storageKey: chatAttachmentsTable.storageKey,
-      })
-      .from(chatAttachmentsTable)
-      .where(and(
-        eq(chatAttachmentsTable.assistantId, assistantId),
-        inArray(chatAttachmentsTable.id, attachmentIds),
-      ));
-
-    if (attachments.length !== attachmentIds.length) {
-      return NextResponse.json(
-        { error: "One or more attachment_ids are invalid for this assistant" },
-        { status: 400 },
-      );
-    }
-
-    const linkedRows = await db
-      .selectDistinct({
-        attachmentId: chatMessageAttachmentsTable.attachmentId,
-      })
-      .from(chatMessageAttachmentsTable)
-      .where(inArray(chatMessageAttachmentsTable.attachmentId, attachmentIds));
-
-    if (linkedRows.length > 0) {
-      return NextResponse.json(
-        { error: "Cannot delete attachments that are already linked to messages" },
-        { status: 409 },
-      );
-    }
-
-    const storage = getStorage();
-    const bucket = storage.bucket(ATTACHMENTS_BUCKET_NAME);
-    const deletionResults = await Promise.allSettled(
-      attachments.map((attachment) => bucket.file(attachment.storageKey).delete()),
-    );
-
-    const failedKeys = deletionResults
-      .map((result, index) => ({ result, storageKey: attachments[index]?.storageKey }))
-      .filter((entry) => entry.result.status === "rejected" && typeof entry.storageKey === "string")
-      .map((entry) => entry.storageKey as string);
-
-    if (failedKeys.length > 0) {
-      const preview = failedKeys.slice(0, 3).join(", ");
-      const suffix = failedKeys.length > 3 ? ", ..." : "";
-      return NextResponse.json(
-        { error: `Failed to delete ${failedKeys.length} attachment object(s): ${preview}${suffix}` },
-        { status: 500 },
-      );
-    }
-
-    await db
-      .delete(chatAttachmentsTable)
-      .where(and(
-        eq(chatAttachmentsTable.assistantId, assistantId),
-        inArray(chatAttachmentsTable.id, attachmentIds),
-      ));
 
     return NextResponse.json({ deleted_ids: attachmentIds });
   } catch (error) {
     console.error("Error deleting attachments:", error);
-    if (error instanceof RuntimeClientError) {
-      return NextResponse.json(
-        { error: "Failed to delete attachments from local runtime" },
-        { status: error.status },
-      );
-    }
+    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to delete attachments" },
-      { status: 500 },
+      { status },
     );
   }
 }

--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -1,15 +1,7 @@
 import { NextResponse } from "next/server";
 
-import {
-  getAssistantConnectionMode,
-  getLocalDaemonSocketPath,
-} from "@/lib/assistant-connection";
-import { Assistant, getDb } from "@/lib/db";
-import { getInstanceExternalIp, getInstanceStatus } from "@/lib/gcp";
-import {
-  LocalDaemonClient,
-  describeLocalDaemonError,
-} from "@/lib/local-daemon-ipc";
+import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
+import { resolveRuntime } from "@/lib/runtime/resolver";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -17,176 +9,37 @@ interface RouteParams {
 
 export const runtime = "nodejs";
 
-function cloudResponse(payload: Record<string, unknown>) {
-  return NextResponse.json({
-    connectionMode: "cloud",
-    ...payload,
-  });
-}
-
-export async function GET(request: Request, { params }: RouteParams) {
+export async function GET(_request: Request, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+    const { baseUrl, mode } = resolveRuntime(assistantId);
+    const client = createRuntimeClient(baseUrl, assistantId);
 
-    const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
+    const healthData = await client.health();
 
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
-    const connectionMode = getAssistantConnectionMode();
-    if (connectionMode === "local") {
-      const socketPath = getLocalDaemonSocketPath();
-      let daemon: LocalDaemonClient | null = null;
-      let reachable = false;
-      let errorDetail: string | null = null;
-
-      try {
-        daemon = await LocalDaemonClient.connect(socketPath);
-        await daemon.ping(3000);
-        reachable = true;
-      } catch (error: unknown) {
-        reachable = false;
-        errorDetail = describeLocalDaemonError(error);
-      } finally {
-        daemon?.close();
-      }
-
-      return NextResponse.json({
-        status: reachable ? "healthy" : "unreachable",
-        message: reachable
-          ? "Connected to local daemon"
-          : "Local daemon is not reachable",
-        connectionMode: "local",
-        daemon: {
-          socketPath,
-          reachable,
-          ...(errorDetail ? { error: errorDetail } : {}),
-        },
-      });
-    }
-
-    const assistant = result[0] as Assistant;
-    const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
-      | { instanceName?: string; zone?: string }
-      | undefined;
-
-    // If no compute instance is configured, report as healthy so the chat UI is usable
-    // TODO: Remove this once we have a way to reproduce our production environment kubernetes locally
-    if (!computeConfig?.instanceName || !computeConfig?.zone) {
-      return cloudResponse({
-        status: "healthy",
-        message: "Running in demo mode",
-      });
-    }
-
-    const provisioningError = (assistant.configuration as Record<string, unknown>)?.provisioningError as string | undefined;
-    if (provisioningError) {
-      return cloudResponse({
-        status: "provisioning_failed",
-        message: provisioningError,
-      });
-    }
-
-    const externalIp = await getInstanceExternalIp(
-      computeConfig.instanceName,
-      computeConfig.zone
-    );
-
-    if (!externalIp) {
-      const instanceStatus = await getInstanceStatus(
-        computeConfig.instanceName,
-        computeConfig.zone
-      );
-
-      if (
-        instanceStatus === "STAGING" ||
-        instanceStatus === "PROVISIONING" ||
-        instanceStatus === "RUNNING"
-      ) {
-        return cloudResponse({
-          status: "starting",
-          message: "Agent instance is starting up",
-        });
-      }
-
-      return cloudResponse({
-        status: "stopped",
-        message: "Instance has no external IP (likely stopped)",
-      });
-    }
-
-    try {
-      const healthUrl = `http://${externalIp}:8080/health`;
-      const response = await fetch(healthUrl, {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-        signal: AbortSignal.timeout(5000),
-      });
-
-      if (!response.ok) {
-        return cloudResponse({
-          status: "unhealthy",
-          message: `Health check returned ${response.status}`,
-          ip: externalIp,
-        });
-      }
-
-      const healthData = await response.json();
-
-      if (healthData.status === "setting_up") {
-        return cloudResponse({
-          status: "setting_up",
-          progress: healthData.progress || null,
-          ip: externalIp,
-        });
-      }
-
-      if (healthData.status === "error") {
-        return cloudResponse({
-          status: "provisioning_failed",
-          message: healthData.error || healthData.progress || "Setup failed",
-          ip: externalIp,
-        });
-      }
-
-      // Also fetch system stats
-      let stats = null;
-      try {
-        const statsUrl = `http://${externalIp}:8080/stats`;
-        const statsResponse = await fetch(statsUrl, {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-          signal: AbortSignal.timeout(3000),
-        });
-        if (statsResponse.ok) {
-          stats = await statsResponse.json();
-        }
-      } catch {
-        // Stats fetch failed, continue without them
-      }
-
-      return cloudResponse({
-        status: "healthy",
-        data: healthData,
-        ip: externalIp,
-        stats,
-      });
-    } catch (fetchError: unknown) {
-      console.log("Health check failed:", fetchError);
-      const errorDetail = fetchError instanceof Error ? fetchError.message : "Unknown error";
-      return cloudResponse({
-        status: "unreachable",
-        message: `Health check failed: ${errorDetail}`,
-        ip: externalIp,
-      });
-    }
+    return NextResponse.json({
+      ...healthData,
+      connectionMode: mode,
+    });
   } catch (error: unknown) {
     console.error("Error checking assistant health:", error);
+
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        {
+          status: "unhealthy",
+          message: `Runtime health check returned ${error.status}`,
+        },
+        { status: error.status },
+      );
+    }
+
     return NextResponse.json(
-      { error: "Failed to check assistant health" },
-      { status: 500 }
+      {
+        status: "unreachable",
+        message: error instanceof Error ? error.message : "Failed to check assistant health",
+      },
+      { status: 502 },
     );
   }
 }

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -1,22 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import {
-  getAssistantConnectionMode,
-} from "@/lib/assistant-connection";
-import {
-  Assistant,
-  ChatAttachment,
-  ChatMessage,
-  createChatMessage,
-  getAttachmentsForMessages,
-  getChatAttachmentsByIdsAndAssistant,
-  getDb,
-  getChatMessages,
-  getMessageByGcsId,
-  linkAttachmentsToMessage,
-} from "@/lib/db";
-import { buildAttachmentFallbackText } from "@/lib/attachments";
-import { getInstanceExternalIp } from "@/lib/gcp";
 import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
 
@@ -26,98 +9,10 @@ interface RouteParams {
 
 export const runtime = "nodejs";
 
-interface OutboxMessage {
-  id: string;
-  content: string;
-  status: string;
-  createdAt: string;
-  sender: string;
-}
-
-interface AssistantError {
-  timestamp: string;
-  message: string;
-}
-
 interface PostMessageBody {
   content?: unknown;
   attachment_ids?: unknown;
-  sourceChannel?: unknown;
-}
-
-interface MessageAttachmentPayload {
-  id: string;
-  original_filename: string;
-  mime_type: string;
-  size_bytes: number;
-  kind: string;
-}
-
-interface MessagePayload {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  timestamp: Date | null;
-  attachments: MessageAttachmentPayload[];
-}
-
-const GREETING_MESSAGE = "Hey there! I just hatched 🐣\n\nWhat's your name? And while we're at it — what should I call myself?";
-const GITHUB_APP_HTML = `<div style="border:1px solid #d0d7de;border-radius:12px;overflow:hidden;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:600px;background:#fff">
-  <div style="background:#24292f;padding:16px 24px;display:flex;align-items:center;gap:12px">
-    <svg height="32" viewBox="0 0 16 16" width="32" fill="#fff"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-    <span style="color:#fff;font-size:18px;font-weight:600">GitHub Apps</span>
-  </div>
-  <div style="padding:32px 24px;text-align:center">
-    <div style="width:80px;height:80px;border-radius:16px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);margin:0 auto 16px;display:flex;align-items:center;justify-content:center">
-      <span style="font-size:36px;color:#fff;font-weight:700">VJ</span>
-    </div>
-    <h2 style="margin:0 0 4px;font-size:24px;color:#24292f">Vargas JR</h2>
-    <p style="margin:0 0 20px;color:#57606a;font-size:14px">by vellum-ai</p>
-    <div style="display:inline-block;background:#2da44e;color:#fff;padding:8px 24px;border-radius:6px;font-size:14px;font-weight:600;margin-bottom:20px">✓ Installed</div>
-    <div style="border-top:1px solid #d0d7de;padding-top:20px;margin-top:8px">
-      <div style="display:flex;justify-content:center;gap:32px;color:#57606a;font-size:13px">
-        <div><strong style="color:#24292f;display:block;font-size:18px">1</strong>repository</div>
-        <div><strong style="color:#24292f;display:block;font-size:18px">12</strong>permissions</div>
-        <div><strong style="color:#24292f;display:block;font-size:18px">3</strong>events</div>
-      </div>
-    </div>
-    <div style="margin-top:20px;padding:12px 16px;background:#dafbe1;border-radius:6px;text-align:left;font-size:13px;color:#1a7f37">
-      <strong>Active</strong> — This app is installed on <strong>vellum-ai/vellum-assistant</strong> with read &amp; write access to code, pull requests, and issues.
-    </div>
-  </div>
-</div>`;
-
-
-function getCannedResponse(assistantMessageCount: number): { content: string; action?: string } {
-  switch (assistantMessageCount) {
-    case 0:
-      return {
-        content: "I love it — Vargas JR it is! Nice to meet you. 😎\n\nSo, what would you like me to do first?",
-        action: "rename",
-      };
-    case 1:
-      return {
-        content: "Done! I just made the background red for you. 🔴\n\nWhat else would you like me to do?",
-        action: "background",
-      };
-    case 2:
-      return {
-        content: `On it! I just registered myself as a GitHub App and installed it on your repo.\n\nHere's the proof:\n\n${GITHUB_APP_HTML}\n\nI now have access to open PRs, review code, and respond to issues on your behalf. What should I work on first?`,
-        action: "github",
-      };
-    default:
-      return { content: "Got it! What's next?" };
-  }
-}
-
-function toAttachmentPayload(attachment: ChatAttachment): MessageAttachmentPayload {
-  return {
-    id: attachment.id,
-    original_filename: attachment.originalFilename,
-    mime_type: attachment.mimeType,
-    size_bytes: attachment.sizeBytes,
-    kind: attachment.kind,
-  };
+  conversationKey?: unknown;
 }
 
 function normalizeAttachmentIds(value: unknown): string[] {
@@ -128,191 +23,29 @@ function normalizeAttachmentIds(value: unknown): string[] {
   return [...new Set(ids)];
 }
 
-function buildForwardedContent(
-  content: string,
-  attachments: ChatAttachment[],
-): string {
-  if (attachments.length === 0) {
-    return content;
-  }
-
-  const fallbackText = buildAttachmentFallbackText(
-    attachments.map((attachment) => ({
-      fileName: attachment.originalFilename,
-      mimeType: attachment.mimeType,
-      sizeBytes: attachment.sizeBytes,
-      kind: attachment.kind === "image" ? "image" : "document",
-      extractedText: attachment.extractedText,
-    })),
-  );
-
-  if (!content) {
-    return fallbackText;
-  }
-  return `${fallbackText}\n\n${content}`;
+function getRuntimeClient(assistantId: string) {
+  const { baseUrl } = resolveRuntime(assistantId);
+  return createRuntimeClient(baseUrl, assistantId);
 }
 
-async function buildMessagePayloads(messages: ChatMessage[]): Promise<MessagePayload[]> {
-  const attachmentsByMessageId = await getAttachmentsForMessages(messages.map((msg) => msg.id));
-  return messages.map((msg) => ({
-    id: msg.id,
-    role: msg.role as "user" | "assistant",
-    content: msg.content,
-    timestamp: msg.createdAt,
-    attachments: (attachmentsByMessageId.get(msg.id) ?? []).map(toAttachmentPayload),
-  }));
-}
-
-
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+    const client = getRuntimeClient(assistantId);
+    const conversationKey = assistantId;
 
-    const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
+    const result = await client.listMessages({ conversationKey });
 
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
-    const assistant = result[0] as Assistant;
-    const connectionMode = getAssistantConnectionMode();
-
-    if (connectionMode === "local") {
-      try {
-        const { baseUrl } = resolveRuntime(assistantId);
-        const client = createRuntimeClient(baseUrl, assistantId);
-        const conversationKey = assistantId; // use assistant ID as default conversation key
-        const result = await client.listMessages({ conversationKey });
-
-        return NextResponse.json({
-          messages: result.messages,
-          errors: [],
-          connectionMode: "local",
-        });
-      } catch (error: unknown) {
-        console.error("Error fetching local runtime messages:", error);
-        const status = error instanceof RuntimeClientError ? error.status : 502;
-        return NextResponse.json(
-          { error: "Failed to fetch messages from local runtime", connectionMode: "local" },
-          { status },
-        );
-      }
-    }
-
-    // In local dev, return a hardcoded greeting if no messages exist yet
-    if (process.env.NODE_ENV !== "production") {
-      const localMessages = await getChatMessages(assistantId);
-      const formattedMessages = await buildMessagePayloads(localMessages);
-
-      if (formattedMessages.length === 0) {
-        formattedMessages.push({
-          id: "local-greeting",
-          role: "assistant" as const,
-          content: `Hey there! I just hatched 🐣\n\nWhat's your name? And while we're at it — what should I call myself?`,
-          timestamp: new Date(),
-          attachments: [],
-        });
-      }
-
-      return NextResponse.json({ messages: formattedMessages, errors: [] });
-    }
-
-    const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
-      | { instanceName?: string; zone?: string }
-      | undefined;
-
-    // Sync messages from compute instance outbox if available
-    if (computeConfig?.instanceName && computeConfig?.zone) {
-      try {
-        const externalIp = await getInstanceExternalIp(
-          computeConfig.instanceName,
-          computeConfig.zone
-        );
-
-        if (externalIp) {
-          const outboxResponse = await fetch(
-            `http://${externalIp}:8080/outbox`
-          );
-
-          if (outboxResponse.ok) {
-            const outboxData = await outboxResponse.json();
-            const outboxMessages: OutboxMessage[] = outboxData.messages || [];
-
-            for (const outboxMsg of outboxMessages) {
-              if (
-                outboxMsg.status === "queued" ||
-                outboxMsg.status === "sent"
-              ) {
-                const existingMsg = await getMessageByGcsId(outboxMsg.id);
-                if (!existingMsg) {
-                  await createChatMessage({
-                    assistantId: assistantId,
-                    role: "assistant",
-                    content: outboxMsg.content,
-                    status: "delivered",
-                    gcsMessageId: outboxMsg.id,
-                  });
-                }
-              }
-            }
-          }
-        }
-      } catch (error: unknown) {
-        console.error("Failed to sync messages from assistant outbox:", error);
-      }
-    }
-
-    const dbMessages = await getChatMessages(assistantId);
-    const formattedMessages = await buildMessagePayloads(dbMessages);
-
-    // If no messages exist yet, persist and show a greeting
-    if (formattedMessages.length === 0) {
-      const greeting = await createChatMessage({
-        assistantId,
-        role: "assistant",
-        content: GREETING_MESSAGE,
-        status: "delivered",
-      });
-      formattedMessages.push({
-        id: greeting.id,
-        role: "assistant" as const,
-        content: GREETING_MESSAGE,
-        timestamp: greeting.createdAt,
-        attachments: [],
-      });
-    }
-
-    // Fetch recent errors from the assistant (only if compute is configured)
-    let recentErrors: AssistantError[] = [];
-    if (computeConfig?.instanceName && computeConfig?.zone) {
-      try {
-        const externalIp = await getInstanceExternalIp(
-          computeConfig.instanceName,
-          computeConfig.zone
-        );
-
-        if (externalIp) {
-          const errorsResponse = await fetch(
-            `http://${externalIp}:8080/errors?limit=5`
-          );
-
-          if (errorsResponse.ok) {
-            const errorsData = await errorsResponse.json();
-            recentErrors = errorsData.errors || [];
-          }
-        }
-      } catch (error: unknown) {
-        console.error("Failed to fetch errors from assistant:", error);
-      }
-    }
-
-    return NextResponse.json({ messages: formattedMessages, errors: recentErrors });
+    return NextResponse.json({
+      messages: result.messages,
+      errors: [],
+    });
   } catch (error: unknown) {
     console.error("Error fetching messages:", error);
+    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to fetch messages" },
-      { status: 500 }
+      { status },
     );
   }
 }
@@ -321,198 +54,37 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
     const body = await request.json() as PostMessageBody;
-    const sourceChannel =
-      typeof body.sourceChannel === "string" ? body.sourceChannel : "web";
     const content = typeof body.content === "string" ? body.content : "";
     const trimmedContent = content.trim();
     const attachmentIds = normalizeAttachmentIds(body.attachment_ids);
 
-    if (sourceChannel !== "web") {
-      return NextResponse.json({
-        error: "Unsupported source channel for this endpoint",
-      }, { status: 400 });
-    }
-
-    const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
-
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
-    const assistant = result[0] as Assistant;
-    const fetchedAttachments = attachmentIds.length > 0
-      ? await getChatAttachmentsByIdsAndAssistant(attachmentIds, assistantId)
-      : [];
-
-    const attachmentsById = new Map(fetchedAttachments.map((attachment) => [attachment.id, attachment]));
-    const attachments = attachmentIds
-      .map((attachmentId) => attachmentsById.get(attachmentId))
-      .filter((attachment): attachment is ChatAttachment => Boolean(attachment));
-
     if (!trimmedContent && attachmentIds.length === 0) {
       return NextResponse.json(
         { error: "Either content or attachment_ids is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    if (attachments.length !== attachmentIds.length) {
-      return NextResponse.json(
-        { error: "One or more attachment_ids are invalid for this assistant" },
-        { status: 400 }
-      );
-    }
+    const client = getRuntimeClient(assistantId);
+    const conversationKey = assistantId;
 
-    const connectionMode = getAssistantConnectionMode();
-
-    if (connectionMode === "local") {
-      try {
-        const { baseUrl } = resolveRuntime(assistantId);
-        const client = createRuntimeClient(baseUrl, assistantId);
-        const conversationKey = assistantId; // use assistant ID as default conversation key
-
-        const result = await client.sendMessage({
-          conversationKey,
-          content,
-          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        });
-
-        return NextResponse.json({
-          success: true,
-          connectionMode: "local",
-          messageId: result.messageId,
-          ...(result.assistantMessage ? { assistantMessage: result.assistantMessage } : {}),
-          message: "Message processed by local runtime",
-        });
-      } catch (error: unknown) {
-        console.error("Error sending local runtime message:", error);
-        const status = error instanceof RuntimeClientError ? error.status : 502;
-        return NextResponse.json(
-          { error: "Failed to send message to local runtime", connectionMode: "local" },
-          { status },
-        );
-      }
-    }
-
-    const forwardedContent = buildForwardedContent(content, attachments);
-    const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
-      | { instanceName?: string; zone?: string }
-      | undefined;
-
-    // If no compute instance, use canned responses (demo mode)
-    if (!computeConfig?.instanceName) {
-      const userMessage = await createChatMessage({
-        assistantId,
-        role: "user",
-        content,
-        status: "sent",
-      });
-      if (attachmentIds.length > 0) {
-        await linkAttachmentsToMessage(userMessage.id, attachmentIds);
-      }
-
-      // Count user messages to determine which canned response to give
-      const existingMessages = await getChatMessages(assistantId);
-      const userMessageCount = existingMessages.filter(
-        (m: ChatMessage) => m.role === "user"
-      ).length;
-
-      const { content: responseContent, action } = getCannedResponse(userMessageCount - 1);
-
-      if (action === "rename") {
-        await sql`UPDATE assistants SET name = 'Vargas JR', updated_at = NOW() WHERE id = ${assistantId}`;
-      } else if (action === "background") {
-        const config = (assistant.configuration as Record<string, unknown>) || {};
-        await sql`
-          UPDATE assistants
-          SET configuration = ${JSON.stringify({ ...config, ui: { backgroundColor: "#dc2626" } })},
-              updated_at = NOW()
-          WHERE id = ${assistantId}
-        `;
-      }
-
-      // Simulate a slight delay before the assistant "responds"
-      await new Promise(resolve => setTimeout(resolve, 1500));
-
-      const assistantMsg = await createChatMessage({
-        assistantId,
-        role: "assistant",
-        content: responseContent,
-        status: "delivered",
-      });
-
-      return NextResponse.json({
-        success: true,
-        assistantMessage: {
-          id: assistantMsg.id,
-          role: "assistant",
-          content: responseContent,
-          timestamp: assistantMsg.createdAt,
-        },
-      });
-    }
-
-    // Forward to compute instance
-    const externalIp = await getInstanceExternalIp(
-      computeConfig.instanceName,
-      computeConfig.zone!
-    );
-
-    if (!externalIp) {
-      return NextResponse.json(
-        { error: "Agent instance not reachable - no external IP" },
-        { status: 503 }
-      );
-    }
-
-    const assistantResponse = await fetch(`http://${externalIp}:8080/messages`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: forwardedContent }),
-    });
-
-    if (!assistantResponse.ok) {
-      const errorData = await assistantResponse.json().catch(() => ({}));
-      return NextResponse.json(
-        { error: errorData.error || "Failed to send message to assistant" },
-        { status: assistantResponse.status }
-      );
-    }
-
-    const assistantData = await assistantResponse.json();
-
-    const dbMessage = await createChatMessage({
-      assistantId: assistantId,
-      role: "user",
+    const result = await client.sendMessage({
+      conversationKey,
       content,
-      status: "sent",
-      sourceChannel,
-      gcsMessageId: assistantData.messageId,
+      attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
     });
-    if (attachmentIds.length > 0) {
-      await linkAttachmentsToMessage(dbMessage.id, attachmentIds);
-    }
 
     return NextResponse.json({
       success: true,
-      messageId: dbMessage.id,
-      message: "Message sent to assistant inbox",
+      messageId: result.messageId,
+      ...(result.assistantMessage ? { assistantMessage: result.assistantMessage } : {}),
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Failed to send message";
     console.error("Error sending message:", error);
-
-    if (message === "Assistant not found" || message === "Agent not found") {
-      return NextResponse.json({ error: message }, { status: 404 });
-    }
-    if (message === "Message content is required") {
-      return NextResponse.json({ error: message }, { status: 400 });
-    }
-
+    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to send message" },
-      { status: 500 }
+      { status },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites messages, attachments, and health routes to always proxy through the runtime client — no more local/cloud branching
- Removes ~900 lines: Postgres chat reads, GCS upload/delete, compute instance outbox sync, canned demo responses, and LocalDaemonClient IPC
- `ASSISTANT_CONNECTION_MODE` now only affects which runtime URL the resolver returns, not the route logic itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
