### PR TITLE
Add channel inbound idempotency and delivery state to runtime

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -1,0 +1,128 @@
+/**
+ * Channel inbound idempotency + delivery state tracking.
+ *
+ * Ensures duplicate channel messages (e.g. Telegram webhook retries)
+ * don't produce duplicate replies. Tracks delivery acknowledgement
+ * so the runtime owns the full lifecycle instead of web Postgres.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { channelInboundEvents } from './schema.js';
+import { getOrCreateConversation } from './conversation-key-store.js';
+import * as conversationStore from './conversation-store.js';
+
+export interface InboundResult {
+  accepted: boolean;
+  eventId: string;
+  conversationId: string;
+  duplicate: boolean;
+}
+
+/**
+ * Record an inbound channel event. Returns `duplicate: true` if this
+ * exact (assistant, channel, chat, message) combination was already seen.
+ */
+export function recordInbound(
+  assistantId: string,
+  sourceChannel: string,
+  externalChatId: string,
+  externalMessageId: string,
+  content: string,
+): InboundResult {
+  const db = getDb();
+
+  const existing = db
+    .select({
+      id: channelInboundEvents.id,
+      conversationId: channelInboundEvents.conversationId,
+    })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.assistantId, assistantId),
+        eq(channelInboundEvents.sourceChannel, sourceChannel),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        eq(channelInboundEvents.externalMessageId, externalMessageId),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    return {
+      accepted: true,
+      eventId: existing.id,
+      conversationId: existing.conversationId,
+      duplicate: true,
+    };
+  }
+
+  const conversationKey = `${sourceChannel}:${externalChatId}`;
+  const mapping = getOrCreateConversation(assistantId, conversationKey);
+  const now = Date.now();
+  const eventId = uuid();
+
+  // Store the inbound message in the conversation
+  const msg = conversationStore.addMessage(mapping.conversationId, 'user', content);
+
+  db.insert(channelInboundEvents)
+    .values({
+      id: eventId,
+      assistantId,
+      sourceChannel,
+      externalChatId,
+      externalMessageId,
+      conversationId: mapping.conversationId,
+      messageId: msg.id,
+      deliveryStatus: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  return {
+    accepted: true,
+    eventId,
+    conversationId: mapping.conversationId,
+    duplicate: false,
+  };
+}
+
+/**
+ * Acknowledge delivery of an outbound message for a channel event.
+ */
+export function acknowledgeDelivery(
+  assistantId: string,
+  sourceChannel: string,
+  externalChatId: string,
+  externalMessageId: string,
+): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  const existing = db
+    .select({ id: channelInboundEvents.id })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.assistantId, assistantId),
+        eq(channelInboundEvents.sourceChannel, sourceChannel),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        eq(channelInboundEvents.externalMessageId, externalMessageId),
+      ),
+    )
+    .get();
+
+  if (!existing) return false;
+
+  db.update(channelInboundEvents)
+    .set({
+      deliveryStatus: 'delivered',
+      updatedAt: now,
+    })
+    .where(eq(channelInboundEvents.id, existing.id))
+    .run();
+
+  return true;
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -181,6 +181,22 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS channel_inbound_events (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      source_channel TEXT NOT NULL,
+      external_chat_id TEXT NOT NULL,
+      external_message_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
+      delivery_status TEXT NOT NULL DEFAULT 'pending',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (assistant_id, source_channel, external_chat_id, external_message_id)
+    )
+  `);
+
   // FTS table for lexical retrieval over memory_segments.text.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
@@ -251,6 +267,8 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_attachments_assistant_id ON attachments(assistant_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_message_id ON message_attachments(message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_id ON message_attachments(attachment_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_lookup ON channel_inbound_events(assistant_id, source_channel, external_chat_id, external_message_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_conversation ON channel_inbound_events(conversation_id)`);
 
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -146,6 +146,22 @@ export const messageAttachments = sqliteTable('message_attachments', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const channelInboundEvents = sqliteTable('channel_inbound_events', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  sourceChannel: text('source_channel').notNull(),
+  externalChatId: text('external_chat_id').notNull(),
+  externalMessageId: text('external_message_id').notNull(),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  messageId: text('message_id')
+    .references(() => messages.id, { onDelete: 'cascade' }),
+  deliveryStatus: text('delivery_status').notNull().default('pending'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -11,6 +11,7 @@ import {
 } from '../memory/conversation-key-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
+import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 
 const log = getLogger('runtime-http');
 
@@ -85,6 +86,14 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'attachments' && req.method === 'DELETE') {
         return await this.handleDeleteAttachment(assistantId, req);
+      }
+
+      if (endpoint === 'channels/inbound' && req.method === 'POST') {
+        return await this.handleChannelInbound(assistantId, req);
+      }
+
+      if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {
+        return await this.handleChannelDeliveryAck(assistantId, req);
       }
 
       return Response.json({ error: 'Not found' }, { status: 404 });
@@ -226,6 +235,78 @@ export class RuntimeHttpServer {
         { error: 'Attachment not found' },
         { status: 404 },
       );
+    }
+
+    return new Response(null, { status: 204 });
+  }
+
+  private async handleChannelInbound(assistantId: string, req: Request): Promise<Response> {
+    const body = await req.json() as {
+      sourceChannel?: string;
+      externalChatId?: string;
+      externalMessageId?: string;
+      content?: string;
+      senderName?: string;
+    };
+
+    const { sourceChannel, externalChatId, externalMessageId, content } = body;
+
+    if (!sourceChannel || typeof sourceChannel !== 'string') {
+      return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+    }
+    if (!externalChatId || typeof externalChatId !== 'string') {
+      return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+    }
+    if (!externalMessageId || typeof externalMessageId !== 'string') {
+      return Response.json({ error: 'externalMessageId is required' }, { status: 400 });
+    }
+    if (!content || typeof content !== 'string') {
+      return Response.json({ error: 'content is required' }, { status: 400 });
+    }
+
+    const result = channelDeliveryStore.recordInbound(
+      assistantId,
+      sourceChannel,
+      externalChatId,
+      externalMessageId,
+      content,
+    );
+
+    return Response.json({
+      accepted: result.accepted,
+      duplicate: result.duplicate,
+      eventId: result.eventId,
+    });
+  }
+
+  private async handleChannelDeliveryAck(assistantId: string, req: Request): Promise<Response> {
+    const body = await req.json() as {
+      sourceChannel?: string;
+      externalChatId?: string;
+      externalMessageId?: string;
+    };
+
+    const { sourceChannel, externalChatId, externalMessageId } = body;
+
+    if (!sourceChannel || typeof sourceChannel !== 'string') {
+      return Response.json({ error: 'sourceChannel is required' }, { status: 400 });
+    }
+    if (!externalChatId || typeof externalChatId !== 'string') {
+      return Response.json({ error: 'externalChatId is required' }, { status: 400 });
+    }
+    if (!externalMessageId || typeof externalMessageId !== 'string') {
+      return Response.json({ error: 'externalMessageId is required' }, { status: 400 });
+    }
+
+    const acked = channelDeliveryStore.acknowledgeDelivery(
+      assistantId,
+      sourceChannel,
+      externalChatId,
+      externalMessageId,
+    );
+
+    if (!acked) {
+      return Response.json({ error: 'Inbound event not found' }, { status: 404 });
     }
 
     return new Response(null, { status: 204 });


### PR DESCRIPTION
## Summary
- Adds `channel_inbound_events` table with unique constraint on `(assistant_id, source_channel, external_chat_id, external_message_id)` for deduplication
- Creates `channel-delivery-store.ts` with `recordInbound` (idempotent) and `acknowledgeDelivery` helpers
- Implements `POST /channels/inbound` and `POST /channels/delivery-ack` runtime HTTP endpoints
- Runtime now owns channel message lifecycle instead of web Postgres `chat_messages` status fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
