### PR TITLE
Add prompt caching for system prompt and tool definitions

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -17,7 +17,7 @@ export type AgentEvent =
   | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
   | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }
   | { type: 'error'; error: Error }
-  | { type: 'usage'; inputTokens: number; outputTokens: number; model: string };
+  | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 64000,
@@ -121,6 +121,8 @@ export class AgentLoop {
             stopReason: response.stopReason,
             inputTokens: response.usage.inputTokens,
             outputTokens: response.usage.outputTokens,
+            cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
+            cacheReadInputTokens: response.usage.cacheReadInputTokens,
             contentBlocks: response.content.map((b) => ({
               type: b.type,
               ...(b.type === 'text' ? { text: truncateForLog(b.text, 200) } : {}),
@@ -133,6 +135,8 @@ export class AgentLoop {
           type: 'usage',
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
+          cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
+          cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
         });
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -38,14 +38,23 @@ export class AnthropicProvider implements Provider {
       };
 
       if (systemPrompt) {
-        params.system = systemPrompt;
+        params.system = [
+          {
+            type: 'text' as const,
+            text: systemPrompt,
+            cache_control: { type: 'ephemeral' as const },
+          },
+        ];
       }
 
       if (tools && tools.length > 0) {
-        params.tools = tools.map((t) => ({
+        params.tools = tools.map((t, i) => ({
           name: t.name,
           description: t.description,
           input_schema: t.input_schema as Anthropic.Tool["input_schema"],
+          ...(i === tools.length - 1
+            ? { cache_control: { type: 'ephemeral' as const } }
+            : {}),
         }));
       }
 
@@ -69,6 +78,8 @@ export class AnthropicProvider implements Provider {
         usage: {
           inputTokens: response.usage.input_tokens,
           outputTokens: response.usage.output_tokens,
+          cacheCreationInputTokens: (response.usage as any).cache_creation_input_tokens,
+          cacheReadInputTokens: (response.usage as any).cache_read_input_tokens,
         },
         stopReason: response.stop_reason ?? "unknown",
       };

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -74,6 +74,8 @@ export interface ProviderResponse {
   usage: {
     inputTokens: number;
     outputTokens: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
   };
   stopReason: string;
 }


### PR DESCRIPTION
Closes #629

## Summary
- System prompt sent as content block array with `cache_control: { type: 'ephemeral' }` so it is cached across turns
- Last tool definition gets `cache_control` marker so the entire tool list prefix is cached
- Cache hit metrics (`cache_creation_input_tokens`, `cache_read_input_tokens`) surfaced in usage reporting through `ProviderResponse`, `AgentEvent`, and debug logging

## Why
The system prompt and tool definitions are identical across turns in a conversation. Adding cache breakpoints gives ~10x faster prefix processing for multi-turn conversations.

Part of the responsiveness initiative (#629).

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify cache metrics appear in debug logs during multi-turn conversation
- [ ] Confirm second turn shows `cache_read_input_tokens > 0` indicating cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->