### PR TITLE
Show thinking indicator immediately on task submit

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var textResponseWindow: TextResponseWindow?
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
+    private var thinkingWindow: ThinkingIndicatorWindow?
     let ambientAgent = AmbientAgent()
     let daemonClient = DaemonClient()
 
@@ -293,7 +294,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
+            // Show thinking indicator IMMEDIATELY
+            let thinking = ThinkingIndicatorWindow()
+            thinking.show()
+            self.thinkingWindow = thinking
+
+            // Classify in background
             let interactionType = await self.classifyInteraction(effectiveTask)
+
+            // Dismiss thinking indicator
+            thinking.close()
+            self.thinkingWindow = nil
 
             switch interactionType {
             case .computerUse:

--- a/clients/macos/vellum-assistant/UI/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/UI/ThinkingIndicatorWindow.swift
@@ -1,0 +1,61 @@
+import AppKit
+import SwiftUI
+
+struct ThinkingIndicatorView: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Thinking...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+}
+
+@MainActor
+final class ThinkingIndicatorWindow {
+    private var panel: NSPanel?
+
+    func show() {
+        let hostingView = NSHostingView(rootView: ThinkingIndicatorView())
+        hostingView.setFrameSize(hostingView.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: hostingView.fittingSize),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = hostingView
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.hasShadow = true
+        panel.backgroundColor = NSColor.clear
+        panel.isOpaque = false
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+
+        // Position at bottom-right of screen (same as SessionOverlayWindow)
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let windowSize = hostingView.fittingSize
+            let x = screenFrame.maxX - windowSize.width - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panel.orderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.close()
+        panel = nil
+    }
+}


### PR DESCRIPTION
Closes #628

## Summary
- Adds a floating `ThinkingIndicatorWindow` (NSPanel with HUD styling) that shows a spinner + "Thinking..." immediately when the user submits a task
- Eliminates the ~0.5-1.5s dead zone between popover close and session UI appearing while Haiku classification runs
- Indicator automatically dismisses when classification completes and the CU overlay or text response window appears

## Test plan
- [ ] Submit a task and verify the "Thinking..." indicator appears immediately after the popover closes
- [ ] Verify the indicator dismisses when the session overlay or text response window appears
- [ ] Verify the indicator is positioned at bottom-right of screen, matching SessionOverlayWindow placement
- [ ] Verify pressing Escape during the thinking phase still cancels properly
- [ ] Build passes: `./build.sh`

Part of the responsiveness initiative (#628).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->