### PR TITLE
Optimize CU client pipeline: parallel capture, direct JPEG, tighter delays

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -106,7 +106,6 @@ exports[`IPC message snapshots ClientMessage types cu_observation serializes to 
   "axDiff": "+ new element",
   "axTree": "<ax-tree>...</ax-tree>",
   "executionResult": "click completed",
-  "previousAXTree": "<prev-ax-tree>...</prev-ax-tree>",
   "screenshot": "base64-screenshot-data",
   "secondaryWindows": "Finder, Terminal",
   "sessionId": "cu-sess-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -80,7 +80,6 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'cu_observation',
     sessionId: 'cu-sess-001',
     axTree: '<ax-tree>...</ax-tree>',
-    previousAXTree: '<prev-ax-tree>...</prev-ax-tree>',
     axDiff: '+ new element',
     secondaryWindows: 'Finder, Terminal',
     screenshot: 'base64-screenshot-data',

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -96,7 +96,6 @@ export interface CuObservation {
   type: 'cu_observation';
   sessionId: string;
   axTree?: string;
-  previousAXTree?: string;
   axDiff?: string;
   secondaryWindows?: string;
   screenshot?: string;

--- a/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
@@ -1,6 +1,8 @@
 import ScreenCaptureKit
 import AppKit
 import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
 
 enum CaptureError: LocalizedError {
     case noDisplay
@@ -63,14 +65,18 @@ final class ScreenCapture: ScreenCaptureProviding {
 
         let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
 
-        let nsImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
-        guard let tiffData = nsImage.tiffRepresentation,
-              let bitmapRep = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.6]) else {
+        // Direct CGImage → JPEG via ImageIO (skips NSImage/TIFF intermediate)
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data as CFMutableData, UTType.jpeg.identifier as CFString, 1, nil) else {
+            throw CaptureError.conversionFailed
+        }
+        let options: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: 0.6]
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
             throw CaptureError.conversionFailed
         }
 
-        return jpegData
+        return data as Data
     }
 
     /// Returns the main display size in logical points (same coordinate space as AX tree and CGEvent).

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -51,7 +51,7 @@ final class ComputerUseSession: ObservableObject {
     /// Adaptive delay configuration
     private let adaptiveDelayEnabled: Bool
     private let minDelayMs: UInt64 = 100
-    private let maxDelayMs: UInt64 = 2000
+    private let maxDelayMs: UInt64 = 1200
     private let pollIntervalMs: UInt64 = 100
 
     init(
@@ -338,6 +338,12 @@ final class ComputerUseSession: ObservableObject {
 
         let stepNumber = currentStepNumber + 1
 
+        // Start screenshot capture early (it's async and takes ~100-200ms)
+        // This runs in parallel with AX tree enumeration below
+        let screenshotPromise: Task<Data?, Never> = Task {
+            try? await screenCapture.captureScreen()
+        }
+
         if let result = enumerator.enumerateCurrentWindow() {
             // On first step with Chrome: check if web content is visible.
             if !didChromeAccessibilityCheck,
@@ -350,6 +356,7 @@ final class ComputerUseSession: ObservableObject {
                 if restarted {
                     AccessibilityTreeEnumerator.clearEnhancedAXCache()
                     log.info("Chrome restarted — re-enumerating")
+                    screenshotPromise.cancel()
                     // Re-enumerate after Chrome restart
                     return await buildObservation(executionResult: executionResult, executionError: executionError)
                 } else {
@@ -396,28 +403,26 @@ final class ComputerUseSession: ObservableObject {
                 }
             }
 
+            // Await the pre-started screenshot if we need it; cancel otherwise
             if shouldCaptureScreenshot(stepNumber: stepNumber, flatElements: flat, lastAction: nil) {
-                do {
-                    screenshot = try await screenCapture.captureScreen()
-                    log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
-                } catch {
-                    log.warning("[\(stepNumber)] Screenshot capture failed alongside AX tree: \(error.localizedDescription)")
-                }
+                screenshot = await screenshotPromise.value
+                log.info("[\(stepNumber)] Screenshot captured alongside AX tree (\(screenshot?.count ?? 0) bytes)")
+            } else {
+                screenshotPromise.cancel()
             }
         } else {
-            // No focused window — try screenshot as last resort
+            // No focused window — await pre-started screenshot as last resort
             log.warning("[\(stepNumber)] No AX tree available — falling back to screenshot")
-            do {
-                screenshot = try await screenCapture.captureScreen()
+            screenshot = await screenshotPromise.value
+            if screenshot != nil {
                 log.info("[\(stepNumber)] Screenshot captured (\(screenshot?.count ?? 0) bytes)")
-            } catch {
-                log.error("[\(stepNumber)] Screen capture failed: \(error.localizedDescription)")
+            } else {
+                log.error("[\(stepNumber)] Screen capture failed")
                 return nil
             }
         }
 
         // Save current AX tree for next step's context
-        let prevAXTree = previousAXTreeText
         previousAXTreeText = axTreeText
         previousElements = elements
         previousFlatElements = flatElements
@@ -428,7 +433,6 @@ final class ComputerUseSession: ObservableObject {
         return CuObservationMessage(
             sessionId: id,
             axTree: axTreeText,
-            previousAXTree: prevAXTree,
             axDiff: axDiffText,
             secondaryWindows: secondaryWindowsText,
             screenshot: screenshotBase64,
@@ -526,7 +530,7 @@ final class ComputerUseSession: ObservableObject {
 
         var elapsed = minDelayMs
         var pollCount = 0
-        let maxPollCount = 6
+        let maxPollCount = 5
 
         while elapsed < maxDelayMs && !isCancelled && pollCount < maxPollCount {
             if let result = enumerator.enumerateCurrentWindow() {

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -107,7 +107,6 @@ struct CuObservationMessage: Encodable, Sendable {
     let type: String = "cu_observation"
     let sessionId: String
     let axTree: String?
-    let previousAXTree: String?
     let axDiff: String?
     let secondaryWindows: String?
     let screenshot: String?

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -27,7 +27,7 @@ final class MockDaemonClient: DaemonClientProtocol {
         return continuation
     }
 
-    var messages: AsyncStream<ServerMessage> {
+    func subscribe() -> AsyncStream<ServerMessage> {
         _messages
     }
 
@@ -200,7 +200,8 @@ private func makeCompleteMessage(
     CuCompleteMessage(
         sessionId: sessionId,
         summary: summary,
-        stepCount: stepCount
+        stepCount: stepCount,
+        isResponse: nil
     )
 }
 


### PR DESCRIPTION
Closes #631

## Summary
- **Parallelize AX tree enumeration + screenshot capture** using `Task` — screenshot capture starts immediately and runs concurrently with AX tree enumeration, saving ~100-200ms per step
- **Direct CGImage-to-JPEG conversion** via ImageIO — eliminates the unnecessary CGImage -> NSImage -> TIFF -> NSBitmapImageRep -> JPEG pipeline, using `CGImageDestination` directly
- **Drop unused `previousAXTree` from IPC messages** — the daemon tracks its own `previousAXTree` internally and never reads the field from the client; removes ~2-50KB per message
- **Tighten adaptive delay timings** — maxDelay 2000ms -> 1200ms, maxPollCount 6 -> 5 (most UI updates settle within 500ms)
- **Fix pre-existing test issues** — `MockDaemonClient` now conforms to updated `DaemonClientProtocol` (subscribe() method), `CuCompleteMessage` helper includes `isResponse` parameter

## Test plan
- [x] `./build.sh` compiles successfully
- [x] `./build.sh test` — all 49 tests pass
- [x] `bunx tsc --noEmit` — TypeScript type-checks cleanly
- [x] IPC snapshot tests updated to reflect removed `previousAXTree` field

Part of the responsiveness initiative (#631).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->