### PR TITLE
Add collectionBehavior to ThinkingIndicatorWindow

### DIFF
--- a/clients/macos/vellum-assistant/UI/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/UI/ThinkingIndicatorWindow.swift
@@ -40,6 +40,7 @@ final class ThinkingIndicatorWindow {
         panel.isOpaque = false
         panel.alphaValue = 0.95
         panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
         // Position at bottom-right of screen (same as SessionOverlayWindow)
         if let screen = NSScreen.main {


### PR DESCRIPTION
Part of #628

## Summary
- Adds `panel.collectionBehavior = [.canJoinAllSpaces, .stationary]` to `ThinkingIndicatorWindow`, matching the pattern used by all other floating panels in the app (SessionOverlayWindow, TextResponseWindow, etc.)
- Without this, the thinking indicator won't appear in fullscreen or multi-Space workflows

## Test plan
- [x] Build succeeds
- [ ] Verify thinking indicator appears when in a fullscreen app or on a secondary Space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->