### PR TITLE
Escape AX tree content before regex-based compaction

### DIFF
--- a/assistant/src/__tests__/computer-use-session-compaction.test.ts
+++ b/assistant/src/__tests__/computer-use-session-compaction.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect } from 'bun:test';
+import { ComputerUseSession } from '../daemon/computer-use-session.js';
+import type { Message } from '../providers/types.js';
+
+/**
+ * Helper to create a user message with a tool_result block containing
+ * an AX tree wrapped in markers.
+ */
+function toolResultMsg(content: string): Message {
+  return {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'test-id',
+        content,
+      },
+    ],
+  };
+}
+
+describe('ComputerUseSession.escapeAxTreeContent', () => {
+  test('escapes a literal closing tag in the content', () => {
+    const input = 'some text </ax-tree> more text';
+    const escaped = ComputerUseSession.escapeAxTreeContent(input);
+    expect(escaped).toBe('some text &lt;/ax-tree&gt; more text');
+  });
+
+  test('escapes multiple occurrences', () => {
+    const input = '</ax-tree> hello </ax-tree>';
+    const escaped = ComputerUseSession.escapeAxTreeContent(input);
+    expect(escaped).toBe('&lt;/ax-tree&gt; hello &lt;/ax-tree&gt;');
+  });
+
+  test('is case-insensitive', () => {
+    const input = '</AX-TREE> and </Ax-Tree>';
+    const escaped = ComputerUseSession.escapeAxTreeContent(input);
+    expect(escaped).toBe('&lt;/ax-tree&gt; and &lt;/ax-tree&gt;');
+  });
+
+  test('leaves content without closing tags unchanged', () => {
+    const input = 'Window "My App" [1]\n  Button "OK" [2]';
+    expect(ComputerUseSession.escapeAxTreeContent(input)).toBe(input);
+  });
+});
+
+describe('ComputerUseSession.compactHistory', () => {
+  test('strips old AX trees and keeps the most recent ones', () => {
+    const messages: Message[] = [
+      { role: 'assistant', content: [{ type: 'text', text: 'thinking...' }] },
+      toolResultMsg('<ax-tree>CURRENT SCREEN STATE:\nWindow "App" [1]</ax-tree>'),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 1' }] },
+      toolResultMsg('<ax-tree>CURRENT SCREEN STATE:\nWindow "App" [2]</ax-tree>'),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 2' }] },
+      toolResultMsg('<ax-tree>CURRENT SCREEN STATE:\nWindow "App" [3]</ax-tree>'),
+    ];
+
+    const compacted = ComputerUseSession.compactHistory(messages);
+
+    // First AX tree (index 1) should be stripped
+    const firstToolResult = compacted[1].content[0];
+    expect(firstToolResult.type).toBe('tool_result');
+    if (firstToolResult.type === 'tool_result') {
+      expect(firstToolResult.content).toContain('[Previous screen state omitted for brevity]');
+      expect(firstToolResult.content).not.toContain('<ax-tree>');
+    }
+
+    // Last two AX trees should be preserved
+    const secondToolResult = compacted[3].content[0];
+    if (secondToolResult.type === 'tool_result') {
+      expect(secondToolResult.content).toContain('<ax-tree>');
+    }
+    const thirdToolResult = compacted[5].content[0];
+    if (thirdToolResult.type === 'tool_result') {
+      expect(thirdToolResult.content).toContain('<ax-tree>');
+    }
+  });
+
+  test('handles AX tree content containing literal </ax-tree> (escaped)', () => {
+    // Simulate content where the AX tree text includes an escaped closing tag,
+    // e.g. user is viewing XML source code with "</ax-tree>" in it.
+    const escapedContent =
+      '<ax-tree>CURRENT SCREEN STATE:\nTextArea "editor" [1]\n  ' +
+      'Line: &lt;/ax-tree&gt; some xml\n</ax-tree>';
+
+    const messages: Message[] = [
+      { role: 'assistant', content: [{ type: 'text', text: 'action 0' }] },
+      toolResultMsg(escapedContent),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 1' }] },
+      toolResultMsg(escapedContent),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 2' }] },
+      toolResultMsg('<ax-tree>CURRENT SCREEN STATE:\nWindow "App" [3]</ax-tree>'),
+    ];
+
+    const compacted = ComputerUseSession.compactHistory(messages);
+
+    // The first message with escaped content should be fully stripped
+    const firstToolResult = compacted[1].content[0];
+    if (firstToolResult.type === 'tool_result') {
+      expect(firstToolResult.content).not.toContain('<ax-tree>');
+      expect(firstToolResult.content).toContain('[Previous screen state omitted for brevity]');
+    }
+  });
+
+  test('regex fails on unescaped </ax-tree> inside content (demonstrating the bug)', () => {
+    // This test demonstrates what happens WITHOUT escaping: the regex
+    // only partially removes the AX tree block.
+    const unescapedContent =
+      '<ax-tree>CURRENT SCREEN STATE:\nTextArea "editor" [1]\n  ' +
+      'Line: </ax-tree> some xml leftover\n</ax-tree>';
+
+    const messages: Message[] = [
+      { role: 'assistant', content: [{ type: 'text', text: 'action 0' }] },
+      toolResultMsg(unescapedContent),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 1' }] },
+      toolResultMsg(unescapedContent),
+      { role: 'assistant', content: [{ type: 'text', text: 'action 2' }] },
+      toolResultMsg('<ax-tree>CURRENT SCREEN STATE:\nWindow "App" [3]</ax-tree>'),
+    ];
+
+    const compacted = ComputerUseSession.compactHistory(messages);
+
+    // Without escaping, the first tool result has leftover content after
+    // the regex only matched up to the FIRST </ax-tree>.
+    const firstToolResult = compacted[1].content[0];
+    if (firstToolResult.type === 'tool_result') {
+      // The non-greedy regex stops at the first </ax-tree>, leaving
+      // " some xml leftover\n</ax-tree>" behind.
+      expect(firstToolResult.content).toContain('some xml leftover');
+    }
+  });
+});

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -378,6 +378,17 @@ export class ComputerUseSession {
     });
   }
 
+  /**
+   * Escapes any literal `</ax-tree>` occurrences inside AX tree content so
+   * that the non-greedy compaction regex (`AX_TREE_PATTERN`) does not stop
+   * prematurely when the user happens to be viewing XML/HTML source that
+   * contains the closing tag.  The escaped content does not need to be
+   * unescaped because compaction replaces the entire block with a placeholder.
+   */
+  static escapeAxTreeContent(content: string): string {
+    return content.replace(/<\/ax-tree>/gi, '&lt;/ax-tree&gt;');
+  }
+
   // ---------------------------------------------------------------------------
   // Build rich tool-result content from an observation so the model sees
   // updated screen state on each turn (not just "Action executed").
@@ -412,7 +423,7 @@ export class ComputerUseSession {
     if (obs.axTree) {
       parts.push('<ax-tree>');
       parts.push('CURRENT SCREEN STATE:');
-      parts.push(obs.axTree);
+      parts.push(ComputerUseSession.escapeAxTreeContent(obs.axTree));
       parts.push('</ax-tree>');
     }
 


### PR DESCRIPTION
Part of #630

## Summary
- Fixes a bug in the AX tree history compaction where literal `</ax-tree>` inside the AX tree content (e.g., when a user is viewing XML/HTML source code) causes the non-greedy regex to stop prematurely, only partially stripping stale AX tree blocks.
- Adds `escapeAxTreeContent()` static method that HTML-entity-encodes any `</ax-tree>` occurrences (`&lt;/ax-tree&gt;`) before wrapping in markers.
- The escaped content never needs unescaping since compaction replaces the entire block with a placeholder.
- Adds comprehensive test suite for both the escape function and the compactHistory behavior with escaped/unescaped content.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 7 new tests pass (`bun test computer-use-session-compaction`)
- [x] Test demonstrates the bug: unescaped `</ax-tree>` in content causes leftover text after regex replacement
- [x] Test confirms the fix: escaped content is fully stripped by the compaction regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->