### PR TITLE
Fix screenshot parallelism with Task.detached

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ScreenCapture.swift
@@ -18,7 +18,7 @@ enum CaptureError: LocalizedError {
     }
 }
 
-protocol ScreenCaptureProviding {
+protocol ScreenCaptureProviding: Sendable {
     func captureScreen(maxWidth: Int, maxHeight: Int) async throws -> Data
     func screenSize() -> CGSize
 }
@@ -29,7 +29,7 @@ extension ScreenCaptureProviding {
     }
 }
 
-final class ScreenCapture: ScreenCaptureProviding {
+final class ScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
     func captureScreen(maxWidth: Int = 1280, maxHeight: Int = 720) async throws -> Data {
         let content: SCShareableContent
         do {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -340,8 +340,10 @@ final class ComputerUseSession: ObservableObject {
 
         // Start screenshot capture early (it's async and takes ~100-200ms)
         // This runs in parallel with AX tree enumeration below
-        let screenshotPromise: Task<Data?, Never> = Task {
-            try? await screenCapture.captureScreen()
+        // Use Task.detached so it doesn't inherit @MainActor isolation and can truly run concurrently
+        let screenCap = self.screenCapture
+        let screenshotPromise: Task<Data?, Never> = Task.detached {
+            try? await screenCap.captureScreen()
         }
 
         if let result = enumerator.enumerateCurrentWindow() {

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -60,7 +60,7 @@ final class MockAccessibilityTreeEnumerator: AccessibilityTreeProviding {
     }
 }
 
-final class MockScreenCapture: ScreenCaptureProviding {
+final class MockScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
     var captureCallCount = 0
 
     func captureScreen(maxWidth: Int, maxHeight: Int) async throws -> Data {


### PR DESCRIPTION
Part of #631

## Summary
- Changed `Task { }` to `Task.detached { }` in `buildObservation` so screenshot capture truly runs in parallel with AX tree enumeration, instead of being blocked by `@MainActor` isolation inheritance.
- Added `Sendable` conformance to `ScreenCaptureProviding` protocol and `@unchecked Sendable` to `ScreenCapture` and `MockScreenCapture` classes, required for passing across isolation boundaries in detached tasks.
- Captured `screenCapture` into a local `let` before the detached closure since `self` cannot be implicitly referenced from a non-isolated context.

## Test plan
- [x] `./build.sh test` passes (49 tests, 0 failures)
- [x] Verified the detached task correctly captures `screenCapture` without referencing `self`
- [x] Verified `Sendable` conformance compiles cleanly for protocol + implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->