### PR TITLE
Make Escape key cancel thinking indicator during classification

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
     private var isStartingSession = false
+    private var startSessionTask: Task<Void, Never>?
     private var textResponseWindow: TextResponseWindow?
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
@@ -147,6 +148,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 { // Escape
                 Task { @MainActor in
+                    self?.startSessionTask?.cancel()
+                    self?.thinkingWindow?.close()
+                    self?.thinkingWindow = nil
                     self?.currentSession?.cancel()
                     self?.currentTextSession?.cancel()
                 }
@@ -278,8 +282,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let effectiveTask = !sessionTask.isEmpty ? sessionTask : "Use the attached files as context."
 
         // Ensure daemon connection before starting any session
-        Task { @MainActor in
-            defer { self.isStartingSession = false }
+        startSessionTask = Task { @MainActor in
+            defer { self.isStartingSession = false; self.startSessionTask = nil }
 
             if !daemonClient.isConnected {
                 log.info("Daemon not connected, attempting to connect before session start")
@@ -301,6 +305,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Classify in background
             let interactionType = await self.classifyInteraction(effectiveTask)
+
+            // Check if cancelled during classification (e.g. user pressed Escape)
+            guard !Task.isCancelled else {
+                thinking.close()
+                self.thinkingWindow = nil
+                return
+            }
 
             // Dismiss thinking indicator
             thinking.close()


### PR DESCRIPTION
Part of #628

## Summary
- Adds `startSessionTask` property to track the Task spawned during session start, so it can be cancelled externally
- Extends the Escape key handler to cancel `startSessionTask` and close the thinking indicator window
- Adds a `Task.isCancelled` guard after `classifyInteraction` returns to bail out cleanly if the user pressed Escape during classification
- The existing `defer` block ensures `isStartingSession` is correctly reset on cancellation

## Test plan
- [ ] Submit a task and immediately press Escape while "Thinking..." indicator is showing -- verify it disappears and no session starts
- [ ] Submit a task and let classification complete normally -- verify existing behavior is unchanged
- [ ] Press Escape during an active computer-use session -- verify it still cancels as before
- [ ] Press Escape during a text Q&A session -- verify it still cancels as before

Fixes feedback from PR #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->