### PR TITLE
Include cache tokens in total inputTokens

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -76,10 +76,12 @@ export class AnthropicProvider implements Provider {
         ),
         model: response.model,
         usage: {
-          inputTokens: response.usage.input_tokens,
+          inputTokens: response.usage.input_tokens
+            + (response.usage.cache_creation_input_tokens ?? 0)
+            + (response.usage.cache_read_input_tokens ?? 0),
           outputTokens: response.usage.output_tokens,
-          cacheCreationInputTokens: (response.usage as any).cache_creation_input_tokens,
-          cacheReadInputTokens: (response.usage as any).cache_read_input_tokens,
+          cacheCreationInputTokens: response.usage.cache_creation_input_tokens ?? undefined,
+          cacheReadInputTokens: response.usage.cache_read_input_tokens ?? undefined,
         },
         stopReason: response.stop_reason ?? "unknown",
       };

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -72,6 +72,7 @@ export interface ProviderResponse {
   content: ContentBlock[];
   model: string;
   usage: {
+    /** Total input tokens (input_tokens + cache_creation + cache_read). */
     inputTokens: number;
     outputTokens: number;
     cacheCreationInputTokens?: number;


### PR DESCRIPTION
Part of #629

## Summary
- **Fixed `inputTokens` under-reporting**: The Anthropic API's `input_tokens` field only counts tokens after the last cache breakpoint, not the total. `inputTokens` now sums `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` to report true total usage.
- **Removed `as any` casts**: The Anthropic SDK exports `cache_creation_input_tokens` and `cache_read_input_tokens` as first-class fields on the `Usage` type (`number | null`), so the unsafe casts are unnecessary. Replaced with null-coalescing (`?? 0` for the sum, `?? undefined` to convert `null` to `undefined` for the optional fields).
- **Added JSDoc**: Documented that `inputTokens` in the `ProviderResponse` type is the total (including cache tokens).

Addresses feedback from PR #632.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All related tests pass (`bun test` on agent-loop, ratelimit, context-window-manager, agent-loop-thinking -- 45 tests)
- [x] Verified downstream consumers (`estimateCost`, `recordUsage`, CLI display, rate limiter) all benefit from receiving the true total

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->