### PR TITLE
Fix thinking hang: finish subscriber streams on daemon disconnect

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -245,6 +245,13 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         receiveBuffer = Data()
         isConnected = false
+
+        // Finish all subscriber streams so `for await` loops terminate
+        // instead of hanging forever on disconnect.
+        for continuation in subscribers.values {
+            continuation.finish()
+        }
+        subscribers.removeAll()
     }
 
     // MARK: - Receive Loop


### PR DESCRIPTION
The purpose of this PR is to fix the thinking indicator hanging indefinitely when the daemon connection drops during task classification.

## Changes Made
- Finish all `AsyncStream` subscriber continuations in `DaemonClient.disconnectInternal()` so `for await` loops terminate on disconnect instead of blocking forever

## Context
After #643 moved interaction classification to the daemon, a new `for await` loop in `startSession()` waits for the `task_routed` response. If the daemon becomes unavailable during this wait, `disconnectInternal()` was called but never finished the subscriber streams — the `for await` blocked forever and the thinking indicator stayed up permanently. This also affects `ComputerUseSession` and `TextSession` message loops.

## Testing
- All 52 macOS tests pass
- All daemon tests pass

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
