### PR TITLE
Terminate basename option parsing in /execute-plan

### DIFF
--- a/scripts/commands/execute-plan.md
+++ b/scripts/commands/execute-plan.md
@@ -8,7 +8,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. E
 
 ### 1. Read the plan
 
-Sanitize `$ARGUMENTS` by stripping any path separators (use only the basename). Then read `.private/plans/<sanitized name>`. If the file doesn't exist, stop and tell the user.
+Sanitize `$ARGUMENTS` by stripping any path separators (use `basename -- "$ARGUMENTS"` to handle names starting with `-`). Then read `.private/plans/<sanitized name>`. If the file doesn't exist, stop and tell the user.
 
 Parse the plan to identify the ordered list of PRs. Plans typically have numbered PR sections (e.g. "## PR 1", "## PR 2") each describing: branch name, title, scope, files to modify, implementation steps, tests to run, and acceptance criteria.
 
@@ -62,7 +62,7 @@ After all PRs are mainlined, move the plan file to `.private/plans/archived/`.
 Strip any path separators from `$ARGUMENTS` to use only the basename, and quote it to prevent word splitting or glob expansion:
 
 ```bash
-PLAN_FILE="$(basename "$ARGUMENTS")"
+PLAN_FILE="$(basename -- "$ARGUMENTS")"
 mkdir -p .private/plans/archived
 mv ".private/plans/$PLAN_FILE" ".private/plans/archived/$PLAN_FILE"
 ```


### PR DESCRIPTION
## Summary
- Adds `--` to `basename` calls in `scripts/commands/execute-plan.md` so filenames starting with `-` (e.g. `-plan.md`, `--help`) are always treated as filenames, not flags
- Addresses review feedback from PR #594

## Changes
- Step 1 (Read the plan): Updated prose instruction to use `basename -- "$ARGUMENTS"`
- Step 4 (Archive the plan): Updated code block to use `basename -- "$ARGUMENTS"`

## Test plan
- [x] Verified the markdown renders correctly
- [x] No TypeScript changes, so no type-check needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
