### PR TITLE
Handle runtime HTTP server startup failure gracefully

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -185,7 +185,12 @@ export async function runDaemon(): Promise<void> {
     const port = parseInt(httpPortEnv, 10);
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({ port });
-      await runtimeHttp.start();
+      try {
+        await runtimeHttp.start();
+      } catch (err) {
+        log.warn({ err, port }, 'Failed to start runtime HTTP server, continuing without it');
+        runtimeHttp = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Wraps `runtimeHttp.start()` in a try/catch so that a port bind failure (port already in use, permission denied, etc.) logs a warning and continues without the HTTP server, instead of crashing the entire daemon.
- Prevents a false-ready state where `startDaemon()` returns success (socket file exists) but the daemon process then exits due to the unhandled HTTP server error.
- Addresses review feedback on PR #609.

## Test plan
- [ ] Set `RUNTIME_HTTP_PORT` to an already-in-use port and verify the daemon starts successfully with a warning log instead of crashing.
- [ ] Set `RUNTIME_HTTP_PORT` to a valid free port and verify the HTTP server starts normally.
- [ ] Omit `RUNTIME_HTTP_PORT` and verify the daemon starts without attempting to create the HTTP server.
- [ ] Verify `bunx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
