### PR TITLE
Fix abort handling and event ordering for parallel tool execution

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -490,4 +490,97 @@ describe('AgentLoop', () => {
     // Final history: user, assistant(3 tool_use), user(3 tool_result), assistant(text)
     expect(history).toHaveLength(4);
   });
+
+  // 14. Abort before parallel tool execution synthesizes cancelled results
+  test('synthesizes cancelled results when aborted before tool execution', async () => {
+    const controller = new AbortController();
+
+    const { provider } = createMockProvider([
+      {
+        content: [
+          { type: 'tool_use' as const, id: 't1', name: 'read_file', input: { path: '/a.txt' } },
+          { type: 'tool_use' as const, id: 't2', name: 'read_file', input: { path: '/b.txt' } },
+        ],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'tool_use' as const,
+      },
+    ]);
+
+    // Abort during the provider call so the signal is already aborted
+    // before tool execution begins
+    const originalSendMessage = provider.sendMessage.bind(provider);
+    provider.sendMessage = async (...args: Parameters<typeof provider.sendMessage>) => {
+      const result = await originalSendMessage(...args);
+      controller.abort();
+      return result;
+    };
+
+    const toolCalls: string[] = [];
+    const toolExecutor = async (_name: string, input: Record<string, unknown>) => {
+      toolCalls.push((input as { path: string }).path);
+      return { content: 'data', isError: false };
+    };
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events), controller.signal);
+
+    // No tools should have been executed
+    expect(toolCalls).toHaveLength(0);
+
+    // History should contain cancelled tool_result blocks
+    const lastMsg = history[history.length - 1];
+    expect(lastMsg.role).toBe('user');
+    const toolResultBlocks = lastMsg.content.filter(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(toolResultBlocks).toHaveLength(2);
+    expect(toolResultBlocks[0].tool_use_id).toBe('t1');
+    expect(toolResultBlocks[0].content).toBe('Cancelled by user');
+    expect(toolResultBlocks[0].is_error).toBe(true);
+    expect(toolResultBlocks[1].tool_use_id).toBe('t2');
+    expect(toolResultBlocks[1].content).toBe('Cancelled by user');
+    expect(toolResultBlocks[1].is_error).toBe(true);
+  });
+
+  // 15. Parallel tool_result events are emitted in deterministic tool_use order
+  test('emits tool_result events in tool_use order regardless of completion timing', async () => {
+    const { provider } = createMockProvider([
+      {
+        content: [
+          { type: 'tool_use' as const, id: 't1', name: 'read_file', input: { path: '/slow.txt' } },
+          { type: 'tool_use' as const, id: 't2', name: 'read_file', input: { path: '/fast.txt' } },
+          { type: 'tool_use' as const, id: 't3', name: 'read_file', input: { path: '/medium.txt' } },
+        ],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'tool_use' as const,
+      },
+      textResponse('Done'),
+    ]);
+
+    // Tools complete in different order than they were called: t2 first, t3 second, t1 last
+    const toolExecutor = async (_name: string, input: Record<string, unknown>) => {
+      const path = (input as { path: string }).path;
+      const delays: Record<string, number> = { '/slow.txt': 80, '/fast.txt': 10, '/medium.txt': 40 };
+      await new Promise(resolve => setTimeout(resolve, delays[path] ?? 10));
+      return { content: `contents of ${path}`, isError: false };
+    };
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const events: AgentEvent[] = [];
+    await loop.run([userMessage], collectEvents(events));
+
+    // Collect tool_result events in order
+    const toolResultEvents = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'tool_result' }> => e.type === 'tool_result',
+    );
+    expect(toolResultEvents).toHaveLength(3);
+
+    // Results must be in tool_use order (t1, t2, t3), NOT completion order (t2, t3, t1)
+    expect(toolResultEvents[0].toolUseId).toBe('t1');
+    expect(toolResultEvents[1].toolUseId).toBe('t2');
+    expect(toolResultEvents[2].toolUseId).toBe('t3');
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -176,6 +176,18 @@ export class AgentLoop {
           }
         }
 
+        // If already cancelled, synthesize cancelled results and stop
+        if (signal?.aborted) {
+          const cancelledBlocks: ContentBlock[] = toolUseBlocks.map((toolUse) => ({
+            type: 'tool_result' as const,
+            tool_use_id: toolUse.id,
+            content: 'Cancelled by user',
+            is_error: true,
+          }));
+          history.push({ role: 'user', content: cancelledBlocks });
+          break;
+        }
+
         // Execute all tools concurrently for reduced latency
         const toolResults = await Promise.all(
           toolUseBlocks.map(async (toolUse) => {
@@ -196,18 +208,21 @@ export class AgentLoop {
               }, 'Tool execution complete');
             }
 
-            onEvent({
-              type: 'tool_result',
-              toolUseId: toolUse.id,
-              content: result.content,
-              isError: result.isError,
-              diff: result.diff,
-              status: result.status,
-            });
-
             return { toolUse, result };
           }),
         );
+
+        // Emit tool_result events in deterministic tool_use order after all complete
+        for (const { toolUse, result } of toolResults) {
+          onEvent({
+            type: 'tool_result',
+            toolUseId: toolUse.id,
+            content: result.content,
+            isError: result.isError,
+            diff: result.diff,
+            status: result.status,
+          });
+        }
 
         // Collect result blocks preserving tool_use order (Promise.all maintains order)
         const resultBlocks: ContentBlock[] = toolResults.map(({ toolUse, result }) => ({


### PR DESCRIPTION
## Summary
- Add abort signal check before `Promise.all` to prevent side-effecting tools from executing after user cancellation (#599 P1 feedback)
- Move `tool_result` event emission to after all parallel tools complete, ensuring deterministic ordering that matches `tool_use` order (#599 P2 feedback)
- Add tests for both abort-before-execution and deterministic event ordering scenarios

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 19 agent-loop tests pass (including 2 new tests)
- [x] New test verifies no tools execute when signal is aborted before `Promise.all`
- [x] New test verifies `tool_result` events arrive in `tool_use` order despite varying completion times
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
