### PR TITLE
fix(session): preserve original prefix in deep-repair retry path

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -400,7 +400,6 @@ export class Session {
         const retryRepair = deepRepairHistory(runMessages);
         runMessages = retryRepair.messages;
         preRunHistoryLength = runMessages.length;
-        preRepairMessages = runMessages;
         orderingErrorDetected = false;
         deferredOrderingError = null;
 


### PR DESCRIPTION
## Summary
- Removes the `preRepairMessages = runMessages` assignment in the deep-repair retry path (line 403 of session.ts)
- This addresses feedback from PR #595 where overwriting `preRepairMessages` with deep-repaired messages caused repair artifacts (synthesized/rewritten `tool_result` blocks) to leak into `this.messages` via `restoredHistory`
- The original un-repaired prefix is now always preserved when reconstructing `this.messages`, preventing broken undo semantics (`isUndoableUserMessage` treats user messages with `tool_result` as non-undoable)

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify undo still works correctly after a deep-repair retry triggers during a session
- [ ] Verify `this.messages` does not contain synthesized `tool_result` blocks from repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
