### PR TITLE
Add dev command to zsh shell completion

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -925,6 +925,7 @@ _vellum() {
     local -a commands
     commands=(
         'daemon:Manage the daemon process'
+        'dev:Run daemon in dev mode with auto-restart'
         'sessions:Manage sessions'
         'config:Manage configuration'
         'keys:Manage API keys in secure storage'


### PR DESCRIPTION
## Summary
- Added `dev` command to the hardcoded `commands` array in `generateZshCompletion`
- Bash and fish completions already included `dev`, but zsh was missed in PR #600

## Test plan
- [ ] Run `vellum completions zsh` and verify `dev` appears in the output
- [ ] Verify bash and fish completions are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
