### PR TITLE
Move verifyAssistantToken inside try/catch in setup-email route

### DIFF
--- a/web/src/app/api/assistants/[id]/setup-email/route.ts
+++ b/web/src/app/api/assistants/[id]/setup-email/route.ts
@@ -32,15 +32,15 @@ export async function POST(
     );
   }
 
-  const verified = await verifyAssistantToken(assistantId, token);
-  if (!verified) {
-    return NextResponse.json(
-      { error: "Invalid token" },
-      { status: 401 }
-    );
-  }
-
   try {
+    const verified = await verifyAssistantToken(assistantId, token);
+    if (!verified) {
+      return NextResponse.json(
+        { error: "Invalid token" },
+        { status: 401 }
+      );
+    }
+
     const sql = getDb();
 
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
@@ -120,15 +120,15 @@ export async function GET(
     );
   }
 
-  const verified = await verifyAssistantToken(assistantId, token);
-  if (!verified) {
-    return NextResponse.json(
-      { error: "Invalid token" },
-      { status: 401 }
-    );
-  }
-
   try {
+    const verified = await verifyAssistantToken(assistantId, token);
+    if (!verified) {
+      return NextResponse.json(
+        { error: "Invalid token" },
+        { status: 401 }
+      );
+    }
+
     const sql = getDb();
 
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;


### PR DESCRIPTION
## Summary
- Moved `verifyAssistantToken` calls inside the existing `try/catch` blocks in both `POST` and `GET` handlers in the setup-email route
- This ensures DB errors during token verification return clean JSON 500 responses instead of propagating as unhandled exceptions
- Addresses review feedback on PR #606

## Test plan
- [ ] Verify that token verification errors (e.g., DB unreachable) return `{ error: "..." }` JSON with status 500
- [ ] Verify that valid/invalid token auth still works correctly (401 for bad tokens, success for good ones)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
