### PR TITLE
Wire runtime HTTP server to daemon session processing

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -184,7 +184,11 @@ export async function runDaemon(): Promise<void> {
   if (httpPortEnv) {
     const port = parseInt(httpPortEnv, 10);
     if (!isNaN(port) && port > 0) {
-      runtimeHttp = new RuntimeHttpServer({ port });
+      runtimeHttp = new RuntimeHttpServer({
+        port,
+        processMessage: (conversationId, content) =>
+          server.processMessage(conversationId, content),
+      });
       try {
         await runtimeHttp.start();
       } catch (err) {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -461,4 +461,14 @@ export class DaemonServer {
     handleMessage(msg, socket, this.handlerContext());
   }
 
+  /**
+   * Process a message from the HTTP runtime API.
+   * Gets or creates a session and runs the agent loop.
+   * Results are saved to the DB for the web UI to poll.
+   */
+  async processMessage(conversationId: string, content: string): Promise<void> {
+    const session = await this.getOrCreateSession(conversationId);
+    await session.processMessage(content, [], () => {}, crypto.randomUUID());
+  }
+
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -17,8 +17,33 @@ const log = getLogger('runtime-http');
 
 const DEFAULT_PORT = 7821;
 
+/**
+ * Extract plain text from a DB content field.
+ * Content is stored as JSON (Anthropic content block array) or plain text.
+ */
+function extractTextContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((b: { type?: string }) => b.type === 'text')
+        .map((b: { text?: string }) => b.text ?? '')
+        .join('');
+    }
+    return raw;
+  } catch {
+    return raw;
+  }
+}
+
+export type MessageProcessor = (
+  conversationId: string,
+  content: string,
+) => Promise<void>;
+
 export interface RuntimeHttpServerOptions {
   port?: number;
+  processMessage?: MessageProcessor;
 }
 
 interface RuntimeMessagePayload {
@@ -32,9 +57,11 @@ interface RuntimeMessagePayload {
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
+  private processMessage?: MessageProcessor;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
+    this.processMessage = options.processMessage;
   }
 
   async start(): Promise<void> {
@@ -125,7 +152,7 @@ export class RuntimeHttpServer {
     const messages: RuntimeMessagePayload[] = rawMessages.map((msg) => ({
       id: msg.id,
       role: msg.role,
-      content: msg.content,
+      content: extractTextContent(msg.content),
       timestamp: new Date(msg.createdAt).toISOString(),
       attachments: [],
     }));
@@ -157,15 +184,17 @@ export class RuntimeHttpServer {
     }
 
     const mapping = getOrCreateConversation(assistantId, conversationKey);
-    const userMessage = conversationStore.addMessage(
-      mapping.conversationId,
-      'user',
-      content,
-    );
 
-    return Response.json({
-      messageId: userMessage.id,
-    });
+    // Trigger agent processing in the background. session.processMessage
+    // saves the user message and runs the agent loop; the web UI polls
+    // for results via GET /messages.
+    if (this.processMessage) {
+      this.processMessage(mapping.conversationId, content).catch((err) => {
+        log.error({ err, conversationId: mapping.conversationId }, 'Failed to process message');
+      });
+    }
+
+    return Response.json({ accepted: true });
   }
 
   private async handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {


### PR DESCRIPTION
## Summary
- Fix web UI chat hanging forever: `RuntimeHttpServer.handleSendMessage` now delegates to `DaemonServer.processMessage` which runs the agent loop in the background, instead of just saving the message to the DB and returning
- Fix messages displaying as raw JSON: `handleListMessages` now extracts plain text from Anthropic content block format before returning to the web UI
- Add `processMessage` public method to `DaemonServer` that creates/reuses sessions for HTTP-originated messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
