### PR TITLE
Fix tool call rendering in runtime HTTP API

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -392,7 +392,8 @@ function handleSandboxSet(
   log.info({ enabled: msg.enabled }, 'Sandbox override applied (per-session)');
 }
 
-interface ParsedHistoryMessage {
+export interface ParsedHistoryMessage {
+  id?: string;
   role: string;
   text: string;
   timestamp: number;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -12,29 +12,11 @@ import {
 import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
+import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 
 const log = getLogger('runtime-http');
 
 const DEFAULT_PORT = 7821;
-
-/**
- * Extract plain text from a DB content field.
- * Content is stored as JSON (Anthropic content block array) or plain text.
- */
-function extractTextContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: { type?: string }) => b.type === 'text')
-        .map((b: { text?: string }) => b.text ?? '')
-        .join('');
-    }
-    return raw;
-  } catch {
-    return raw;
-  }
-}
 
 export type MessageProcessor = (
   conversationId: string,
@@ -52,6 +34,7 @@ interface RuntimeMessagePayload {
   content: string;
   timestamp: string;
   attachments: unknown[];
+  toolCalls?: Array<{ name: string; input: Record<string, unknown>; result?: string; isError?: boolean }>;
 }
 
 export class RuntimeHttpServer {
@@ -149,12 +132,32 @@ export class RuntimeHttpServer {
     const mapping = getOrCreateConversation(assistantId, conversationKey);
     const rawMessages = conversationStore.getMessages(mapping.conversationId);
 
-    const messages: RuntimeMessagePayload[] = rawMessages.map((msg) => ({
-      id: msg.id,
-      role: msg.role,
-      content: extractTextContent(msg.content),
-      timestamp: new Date(msg.createdAt).toISOString(),
+    // Parse content blocks and extract text + tool calls
+    const parsed = rawMessages.map((msg) => {
+      let content: unknown;
+      try { content = JSON.parse(msg.content); } catch { content = msg.content; }
+      const rendered = renderHistoryContent(content);
+      return {
+        role: msg.role,
+        text: rendered.text,
+        timestamp: msg.createdAt,
+        toolCalls: rendered.toolCalls,
+        id: msg.id,
+      };
+    });
+
+    // Merge tool_result data from internal user messages into the
+    // preceding assistant message's toolCalls, and suppress those
+    // internal user messages from the visible history.
+    const merged = mergeToolResults(parsed);
+
+    const messages: RuntimeMessagePayload[] = merged.map((m) => ({
+      id: m.id ?? '',
+      role: m.role,
+      content: m.text,
+      timestamp: new Date(m.timestamp).toISOString(),
       attachments: [],
+      ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
     }));
 
     return Response.json({ messages });


### PR DESCRIPTION
## Summary
- Replace `extractTextContent()` with `renderHistoryContent()` + `mergeToolResults()` in the HTTP messages endpoint
- Tool calls now return structured data (name, input, result) instead of being stripped to blank content
- Internal `tool_result` user messages are suppressed from the visible history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
