### PR TITLE
Filter proxy tools from unknown-tool suggestion list

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -45,7 +45,7 @@ export class ToolExecutor {
 
     const tool = getTool(name);
     if (!tool) {
-      const available = getAllTools().map((t) => t.name).sort().join(', ');
+      const available = getAllTools().filter((t) => t.executionMode !== 'proxy').map((t) => t.name).sort().join(', ');
       const msg = `Unknown tool: ${name}. Available tools: ${available}`;
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent(context, {


### PR DESCRIPTION
## Summary
- The unknown-tool error message in `ToolExecutor` was using `getAllTools()` to build the suggestion list, which included proxy-only `cu_*` computer-use tools
- In normal chat sessions (without a proxy resolver), suggesting those tools would lead to immediate failure with "No proxy resolver configured..."
- Now filters out proxy tools (`executionMode === 'proxy'`), matching the same logic used in `getAllToolDefinitions()`

Addresses feedback on #602.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
