### PR TITLE
Make getOrCreateConversation atomic with db.transaction()

### DIFF
--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -10,8 +10,7 @@
 import { eq, and } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversationKeys } from './schema.js';
-import { createConversation } from './conversation-store.js';
+import { conversations, conversationKeys } from './schema.js';
 
 export interface ConversationKeyMapping {
   id: string;
@@ -47,30 +46,59 @@ export function getConversationByKey(
  * Get or create a conversation for the given (assistantId, conversationKey).
  *
  * If a mapping already exists, returns the existing conversation ID.
- * Otherwise, creates a new conversation and mapping atomically.
+ * Otherwise, creates a new conversation and mapping atomically within a
+ * single transaction to prevent race conditions and orphaned rows.
  */
 export function getOrCreateConversation(
   assistantId: string,
   conversationKey: string,
 ): { conversationId: string; created: boolean } {
-  const existing = getConversationByKey(assistantId, conversationKey);
-  if (existing) {
-    return { conversationId: existing.conversationId, created: false };
-  }
-
-  const conversation = createConversation(`Runtime: ${conversationKey}`);
   const db = getDb();
-  const now = Date.now();
 
-  db.insert(conversationKeys)
-    .values({
-      id: uuid(),
-      assistantId,
-      conversationKey,
-      conversationId: conversation.id,
-      createdAt: now,
-    })
-    .run();
+  return db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(conversationKeys)
+      .where(
+        and(
+          eq(conversationKeys.assistantId, assistantId),
+          eq(conversationKeys.conversationKey, conversationKey),
+        ),
+      )
+      .get();
 
-  return { conversationId: conversation.id, created: true };
+    if (existing) {
+      return { conversationId: existing.conversationId, created: false };
+    }
+
+    const now = Date.now();
+    const conversationId = uuid();
+
+    tx.insert(conversations)
+      .values({
+        id: conversationId,
+        title: `Runtime: ${conversationKey}`,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      })
+      .run();
+
+    tx.insert(conversationKeys)
+      .values({
+        id: uuid(),
+        assistantId,
+        conversationKey,
+        conversationId,
+        createdAt: now,
+      })
+      .run();
+
+    return { conversationId, created: true };
+  });
 }


### PR DESCRIPTION
## Summary
- Wraps the entire `getOrCreateConversation` flow (read-check, conversation insert, key mapping insert) in a single `db.transaction()` call
- Prevents race conditions where concurrent callers could create orphaned conversation rows
- Removes the dependency on `createConversation` from `conversation-store.ts`, inlining the conversation insert within the transaction

Addresses review feedback on PR #610.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify existing conversation key lookups still work
- [ ] Verify new conversation creation via key mapping still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
