### PR TITLE
Move authenticateAssistant inside try-catch in set-avatar route

### DIFF
--- a/web/src/app/api/assistants/[id]/set-avatar/route.ts
+++ b/web/src/app/api/assistants/[id]/set-avatar/route.ts
@@ -43,10 +43,10 @@ export async function POST(
 ) {
   const { id: assistantId } = await params;
 
-  const authError = await authenticateAssistant(request, assistantId);
-  if (authError) return authError;
-
   try {
+    const authError = await authenticateAssistant(request, assistantId);
+    if (authError) return authError;
+
     const sql = getDb();
 
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
@@ -157,10 +157,10 @@ export async function GET(
 ) {
   const { id: assistantId } = await params;
 
-  const authError = await authenticateAssistant(request, assistantId);
-  if (authError) return authError;
-
   try {
+    const authError = await authenticateAssistant(request, assistantId);
+    if (authError) return authError;
+
     const sql = getDb();
 
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
@@ -199,10 +199,10 @@ export async function DELETE(
 ) {
   const { id: assistantId } = await params;
 
-  const authError = await authenticateAssistant(request, assistantId);
-  if (authError) return authError;
-
   try {
+    const authError = await authenticateAssistant(request, assistantId);
+    if (authError) return authError;
+
     const sql = getDb();
 
     const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #607.

- Moved the `authenticateAssistant` call inside the existing `try-catch` block in all three handlers (POST, GET, DELETE) in the set-avatar route
- `verifyAssistantToken` performs a database query that can throw on transient DB/network failures; previously this call was outside the `try-catch`, meaning errors would propagate as unhandled exceptions and produce raw 500 responses instead of clean JSON error responses

## Test plan

- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm all three handlers (POST, GET, DELETE) now have `authenticateAssistant` inside their `try-catch` blocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
