### PR TITLE
Auto-install Chromium when browser tools are first used

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -1,7 +1,9 @@
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { getDataDir } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
+import { checkBrowserRuntime } from './runtime-check.js';
 
 const log = getLogger('browser-manager');
 
@@ -73,6 +75,24 @@ class BrowserManager {
     this.contextCreating = (async () => {
       const profileDir = getProfileDir();
       mkdirSync(profileDir, { recursive: true });
+
+      // Auto-install Chromium if missing
+      if (!launchPersistentContext) {
+        const status = await checkBrowserRuntime();
+        if (status.playwrightAvailable && !status.chromiumInstalled) {
+          log.info('Chromium not installed, installing via playwright...');
+          const result = spawnSync('bunx', ['playwright', 'install', 'chromium'], {
+            stdio: 'pipe',
+            timeout: 120_000,
+          });
+          if (result.status === 0) {
+            log.info('Chromium installed successfully');
+          } else {
+            const stderr = result.stderr?.toString().trim();
+            log.error({ exitCode: result.status, stderr }, 'Failed to install Chromium');
+          }
+        }
+      }
 
       const launch = launchPersistentContext ?? await getDefaultLaunchFn();
       const ctx = await launch(profileDir, { headless: true });


### PR DESCRIPTION
## Summary
- Before launching the Playwright browser context, check if Chromium is installed using the existing `checkBrowserRuntime()` function
- If missing, automatically run `bunx playwright install chromium` (with 2min timeout)
- Prevents users from hitting "Executable doesn't exist" errors when using browser tools for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
