### PR TITLE
Fix GET /messages creating conversations as side effect

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -7,6 +7,7 @@
 
 import { getLogger } from '../util/logger.js';
 import {
+  getConversationByKey,
   getOrCreateConversation,
 } from '../memory/conversation-key-store.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -129,7 +130,10 @@ export class RuntimeHttpServer {
       );
     }
 
-    const mapping = getOrCreateConversation(assistantId, conversationKey);
+    const mapping = getConversationByKey(assistantId, conversationKey);
+    if (!mapping) {
+      return Response.json({ messages: [] });
+    }
     const rawMessages = conversationStore.getMessages(mapping.conversationId);
 
     // Parse content blocks and extract text + tool calls


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #611: the `GET /messages` endpoint was using `getOrCreateConversation`, which creates a new conversation row in the database when none exists. This means any GET request with an arbitrary `conversationKey` would pollute the database with orphan empty conversations.
- Switched to the read-only `getConversationByKey` and returns an empty `{ messages: [] }` response when no conversation is found.

## Test plan
- [ ] Verify `GET /messages?conversationKey=nonexistent` returns `{ messages: [] }` without creating a DB row
- [ ] Verify `GET /messages?conversationKey=existing` still returns messages as before
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
