### PR TITLE
Fix ASSISTANT_CONNECTION_MODE default in web README

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -22,7 +22,7 @@ Every assistant-facing API route proxies through a single `RuntimeClient` abstra
 
 Environment variables:
 
-- `ASSISTANT_CONNECTION_MODE` — `local` (default) or `cloud`.
+- `ASSISTANT_CONNECTION_MODE` — `cloud` (default) or `local`.
 - `LOCAL_DAEMON_SOCKET_PATH` — Unix socket path for local mode (default: `~/.vellum/vellum.sock`).
 
 ### Assistant Auth


### PR DESCRIPTION
## Summary
- Fixes the documented default for `ASSISTANT_CONNECTION_MODE` in `web/README.md` from `local` to `cloud`, matching the actual code in `web/src/lib/assistant-connection.ts`.
- Addresses review feedback from PR #620.

## Test plan
- [x] Verified `DEFAULT_CONNECTION_MODE` is `"cloud"` in `assistant-connection.ts`
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
