### PR TITLE
Guard IPC dispatch map against unknown message types

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -208,11 +208,13 @@ export function handleMessage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const handler = handlers[msg.type] as (
-    msg: ClientMessage,
-    socket: net.Socket,
-    ctx: HandlerContext,
-  ) => void;
+  const handler = handlers[msg.type] as
+    | ((msg: ClientMessage, socket: net.Socket, ctx: HandlerContext) => void)
+    | undefined;
+  if (!handler) {
+    log.warn({ type: msg.type }, 'Unknown message type, ignoring');
+    return;
+  }
   handler(msg, socket, ctx);
 }
 


### PR DESCRIPTION
## Summary
- Adds a guard in `handleMessage` to check if the handler exists before invoking it
- Unknown message types now log a warning and return early instead of crashing the daemon with a `TypeError`
- Addresses review feedback from PR #617 where the switch-to-map refactor removed the implicit ignore behavior for unknown types

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm unknown message types are logged and ignored rather than crashing

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
