### PR TITLE
Make recordInbound message + event inserts atomic

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -9,9 +9,13 @@
 import { eq, and } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { channelInboundEvents } from './schema.js';
+import { channelInboundEvents, conversations, messages } from './schema.js';
 import { getOrCreateConversation } from './conversation-key-store.js';
-import * as conversationStore from './conversation-store.js';
+import { getConfig } from '../config/loader.js';
+import { indexMessageNow } from './indexer.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('channel-delivery-store');
 
 export interface InboundResult {
   accepted: boolean;
@@ -62,24 +66,47 @@ export function recordInbound(
   const mapping = getOrCreateConversation(assistantId, conversationKey);
   const now = Date.now();
   const eventId = uuid();
+  const messageId = uuid();
 
-  // Store the inbound message in the conversation
-  const msg = conversationStore.addMessage(mapping.conversationId, 'user', content);
+  // Wrap message insert + event insert in a single transaction so a partial
+  // failure doesn't leave an orphaned message without an idempotency record.
+  const message = { id: messageId, conversationId: mapping.conversationId, role: 'user', content, createdAt: now };
 
-  db.insert(channelInboundEvents)
-    .values({
-      id: eventId,
-      assistantId,
-      sourceChannel,
-      externalChatId,
-      externalMessageId,
-      conversationId: mapping.conversationId,
-      messageId: msg.id,
-      deliveryStatus: 'pending',
-      createdAt: now,
-      updatedAt: now,
-    })
-    .run();
+  db.transaction((tx) => {
+    tx.insert(messages).values(message).run();
+    tx.update(conversations)
+      .set({ updatedAt: now })
+      .where(eq(conversations.id, mapping.conversationId))
+      .run();
+    tx.insert(channelInboundEvents)
+      .values({
+        id: eventId,
+        assistantId,
+        sourceChannel,
+        externalChatId,
+        externalMessageId,
+        conversationId: mapping.conversationId,
+        messageId,
+        deliveryStatus: 'pending',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  });
+
+  // Non-critical: index the message for memory retrieval after the transaction commits.
+  try {
+    const config = getConfig();
+    indexMessageNow({
+      messageId: message.id,
+      conversationId: message.conversationId,
+      role: message.role,
+      content: message.content,
+      createdAt: message.createdAt,
+    }, config.memory);
+  } catch (err) {
+    log.warn({ err, conversationId: mapping.conversationId, messageId }, 'Failed to index inbound message for memory');
+  }
 
   return {
     accepted: true,


### PR DESCRIPTION
## Summary
- Wraps the user message insert, conversation `updatedAt` bump, and `channelInboundEvents` insert in a single `db.transaction()` in `recordInbound`
- Previously `addMessage()` ran its own transaction and the event insert was a separate operation -- a partial failure (e.g. disk error on the event insert) would leave an orphaned message with no idempotency record, causing duplicate messages on webhook retry
- Memory indexing (`indexMessageNow`) now runs after the transaction commits as a non-critical side-effect

Addresses review feedback on #616.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Manual: send duplicate webhook payloads and verify only one user message is created
- [ ] Verify that if the event insert fails (e.g. simulated error), no orphaned message remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
