### PR TITLE
Remove dangling test:integration:channels script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,6 @@
     "db:push": "bun run scripts/migrate.mts",
     "db:push:preview": "bun run scripts/migrate.mts --preview",
     "db:studio": "bunx drizzle-kit studio",
-    "test:integration:channels": "bun run scripts/channels-integration-harness.mts",
     "lint": "eslint",
     "pull": "node scripts/pull.mjs",
     "start": "node scripts/run-next.mjs start"


### PR DESCRIPTION
## Summary
- Removes the `test:integration:channels` script entry from `web/package.json` that referenced the deleted `channels-integration-harness.mts` file (removed in PR #619)
- Without this fix, running `bun run test:integration:channels` fails with "Module not found"

## Test plan
- [x] Verify `web/package.json` no longer references `channels-integration-harness.mts`
- [x] Type-check passes (`bunx tsc --noEmit`)

Addresses feedback from PR #619.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
