### PR TITLE
Fix base64 size calculation and DELETE attachment error handling

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -33,7 +33,8 @@ export function uploadAttachment(
 ): StoredAttachment {
   const db = getDb();
   const now = Date.now();
-  const sizeBytes = Math.ceil((dataBase64.length * 3) / 4);
+  const padding = dataBase64.endsWith('==') ? 2 : (dataBase64.endsWith('=') ? 1 : 0);
+  const sizeBytes = Math.max(0, Math.floor((dataBase64.length * 3) / 4) - padding);
   const kind = classifyKind(mimeType);
 
   const record = {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -251,9 +251,15 @@ export class RuntimeHttpServer {
   }
 
   private async handleDeleteAttachment(assistantId: string, req: Request): Promise<Response> {
-    const body = await req.json() as {
-      attachmentId?: string;
-    };
+    let body: { attachmentId?: string };
+    try {
+      body = await req.json() as { attachmentId?: string };
+    } catch {
+      return Response.json(
+        { error: 'Invalid or missing JSON body' },
+        { status: 400 },
+      );
+    }
 
     const { attachmentId } = body;
 


### PR DESCRIPTION
## Summary
- Fix base64 size calculation in `attachments-store.ts` to account for padding characters (`=` / `==`), matching the existing correct implementation in `handlers.ts`. Previously overcounted decoded size by up to 2 bytes.
- Wrap `req.json()` in try/catch in the DELETE `/attachments` endpoint so invalid or missing JSON bodies return 400 instead of 500.

Addresses review feedback from PR #613.

## Test plan
- [ ] Verify `uploadAttachment` with padded base64 input (e.g. `YQ==`) returns correct `sizeBytes` (1, not 3)
- [ ] Send a DELETE request to `/attachments` with empty body and confirm 400 response
- [ ] Send a DELETE request with valid JSON and confirm normal 204/404 behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
