### PR TITLE
Run agent loop in channelInbound so Telegram users receive replies

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -308,10 +308,41 @@ export class RuntimeHttpServer {
       content,
     );
 
+    // For new (non-duplicate) messages, run the agent loop to generate a reply.
+    if (!result.duplicate && this.processMessage) {
+      try {
+        await this.processMessage(result.conversationId, content);
+      } catch (err) {
+        log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
+      }
+    }
+
+    // Look up the latest assistant message in the conversation to return it.
+    let assistantMessage: RuntimeMessagePayload | undefined;
+    const msgs = conversationStore.getMessages(result.conversationId);
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].role === 'assistant') {
+        let parsed: unknown;
+        try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
+        const rendered = renderHistoryContent(parsed);
+        if (rendered.text) {
+          assistantMessage = {
+            id: msgs[i].id,
+            role: 'assistant',
+            content: rendered.text,
+            timestamp: new Date(msgs[i].createdAt).toISOString(),
+            attachments: [],
+          };
+        }
+        break;
+      }
+    }
+
     return Response.json({
       accepted: result.accepted,
       duplicate: result.duplicate,
       eventId: result.eventId,
+      ...(assistantMessage ? { assistantMessage } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary
- The `handleChannelInbound` endpoint was only recording the inbound message without invoking the agent loop, so the response never included an `assistantMessage` and Telegram users never received replies.
- After recording the inbound event, the handler now awaits `processMessage` to run the agent loop, then looks up the latest assistant message and includes it in the response JSON.
- Also parses content blocks via `renderHistoryContent` so the returned text is properly extracted.

## Test plan
- [ ] Send a Telegram message to an assistant with channel configured and verify the assistant replies
- [ ] Verify duplicate messages (webhook retries) still return `duplicate: true` and don't re-run the agent loop
- [ ] Verify type-check passes (`bunx tsc --noEmit`)

Addresses feedback from PR #618.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
