### PR TITLE
Preserve attachment context in runtime sendMessage endpoint

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -186,8 +186,8 @@ export async function runDaemon(): Promise<void> {
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({
         port,
-        processMessage: (conversationId, content) =>
-          server.processMessage(conversationId, content),
+        processMessage: (assistantId, conversationId, content, attachmentIds) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds),
       });
       try {
         await runtimeHttp.start();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -10,6 +10,7 @@ import { buildSystemPrompt } from '../config/system-prompt.js';
 import { clearCache as clearTrustCache } from '../permissions/trust-store.js';
 import { resetAllowlist } from '../security/secret-allowlist.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import * as attachmentsStore from '../memory/attachments-store.js';
 import { Session } from './session.js';
 import { ComputerUseSession } from './computer-use-session.js';
 import {
@@ -466,9 +467,20 @@ export class DaemonServer {
    * Gets or creates a session and runs the agent loop.
    * Results are saved to the DB for the web UI to poll.
    */
-  async processMessage(conversationId: string, content: string): Promise<void> {
+  async processMessage(assistantId: string, conversationId: string, content: string, attachmentIds?: string[]): Promise<void> {
     const session = await this.getOrCreateSession(conversationId);
-    await session.processMessage(content, [], () => {}, crypto.randomUUID());
+
+    // Resolve attachment IDs to full attachment data for the session
+    const attachments = attachmentIds
+      ? attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+          id: a.id,
+          filename: a.originalFilename,
+          mimeType: a.mimeType,
+          data: a.dataBase64,
+        }))
+      : [];
+
+    await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
   }
 
 }

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -82,6 +82,40 @@ export function deleteAttachment(assistantId: string, attachmentId: string): boo
   return true;
 }
 
+export function getAttachmentsByIds(
+  assistantId: string,
+  ids: string[],
+): Array<StoredAttachment & { dataBase64: string }> {
+  if (ids.length === 0) return [];
+  const db = getDb();
+  const results: Array<StoredAttachment & { dataBase64: string }> = [];
+  for (const id of ids) {
+    const row = db
+      .select()
+      .from(attachments)
+      .where(
+        and(
+          eq(attachments.id, id),
+          eq(attachments.assistantId, assistantId),
+        ),
+      )
+      .get();
+    if (row) {
+      results.push({
+        id: row.id,
+        assistantId: row.assistantId,
+        originalFilename: row.originalFilename,
+        mimeType: row.mimeType,
+        sizeBytes: row.sizeBytes,
+        kind: row.kind,
+        dataBase64: row.dataBase64,
+        createdAt: row.createdAt,
+      });
+    }
+  }
+  return results;
+}
+
 export function linkAttachmentToMessage(
   messageId: string,
   attachmentId: string,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -20,8 +20,10 @@ const log = getLogger('runtime-http');
 const DEFAULT_PORT = 7821;
 
 export type MessageProcessor = (
+  assistantId: string,
   conversationId: string,
   content: string,
+  attachmentIds?: string[],
 ) => Promise<void>;
 
 export interface RuntimeHttpServerOptions {
@@ -174,7 +176,7 @@ export class RuntimeHttpServer {
       attachmentIds?: string[];
     };
 
-    const { conversationKey, content } = body;
+    const { conversationKey, content, attachmentIds } = body;
 
     if (!conversationKey) {
       return Response.json(
@@ -183,9 +185,12 @@ export class RuntimeHttpServer {
       );
     }
 
-    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+    const trimmedContent = typeof content === 'string' ? content.trim() : '';
+    const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
+
+    if (trimmedContent.length === 0 && !hasAttachments) {
       return Response.json(
-        { error: 'content is required' },
+        { error: 'content or attachmentIds is required' },
         { status: 400 },
       );
     }
@@ -196,7 +201,7 @@ export class RuntimeHttpServer {
     // saves the user message and runs the agent loop; the web UI polls
     // for results via GET /messages.
     if (this.processMessage) {
-      this.processMessage(mapping.conversationId, content).catch((err) => {
+      this.processMessage(assistantId, mapping.conversationId, content ?? '', hasAttachments ? attachmentIds : undefined).catch((err) => {
         log.error({ err, conversationId: mapping.conversationId }, 'Failed to process message');
       });
     }


### PR DESCRIPTION
## Summary
- Fixed `handleSendMessage` in the runtime HTTP server to allow empty content when `attachmentIds` are provided (previously rejected with 400)
- Plumbed `attachmentIds` through the `MessageProcessor` callback to `DaemonServer.processMessage`, which resolves them to full attachment data via a new `getAttachmentsByIds` helper
- This ensures local-mode attachment-only sends work and text+attachment sends preserve attachment context in assistant replies

Addresses review feedback from PR #612.

## Test plan
- [ ] Verify text-only messages still work as before
- [ ] Verify attachment-only sends (empty content + attachmentIds) are accepted and processed
- [ ] Verify text+attachment sends include attachment data in the agent session
- [ ] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
