### PR TITLE
Auto-approve tool permissions for HTTP API sessions

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -469,6 +469,7 @@ export class DaemonServer {
    */
   async processMessage(assistantId: string, conversationId: string, content: string, attachmentIds?: string[]): Promise<void> {
     const session = await this.getOrCreateSession(conversationId);
+    session.setAutoApprove(true);
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -157,6 +157,10 @@ export class Session {
     this.sandboxOverride = enabled;
   }
 
+  setAutoApprove(enabled: boolean): void {
+    this.prompter.setAutoApprove(enabled);
+  }
+
   isProcessing(): boolean {
     return this.processing;
   }

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -16,9 +16,19 @@ interface PendingPrompt {
 export class PermissionPrompter {
   private pending = new Map<string, PendingPrompt>();
   private sendToClient: (msg: ServerMessage) => void;
+  private _autoApprove = false;
 
   constructor(sendToClient: (msg: ServerMessage) => void) {
     this.sendToClient = sendToClient;
+  }
+
+  /**
+   * When enabled, all permission prompts are immediately approved without
+   * waiting for a client response. Used for HTTP API sessions where there
+   * is no IPC client to respond to prompts.
+   */
+  setAutoApprove(enabled: boolean): void {
+    this._autoApprove = enabled;
   }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
@@ -34,6 +44,11 @@ export class PermissionPrompter {
     diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean },
     sandboxed?: boolean,
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
+    if (this._autoApprove) {
+      log.info({ toolName, riskLevel }, 'Auto-approving tool (no IPC client)');
+      return { decision: 'allow' };
+    }
+
     const requestId = uuid();
 
     return new Promise((resolve, reject) => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -322,7 +322,7 @@ export class RuntimeHttpServer {
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(result.conversationId, content);
+        await this.processMessage(assistantId, result.conversationId, content);
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }


### PR DESCRIPTION
## Summary
- HTTP sessions have no IPC client to respond to permission prompts, causing medium/high-risk tools (`bash`, `browser_press_key`, `browser_click`, etc.) to hang for 300 seconds before timing out to deny
- Add `autoApprove` mode to `PermissionPrompter` that immediately allows tool execution
- Enable it for all HTTP API sessions in `DaemonServer.processMessage()`
- Also fix missing `assistantId` argument in channel inbound handler's `processMessage` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
