### PR TITLE
Reinstate assistant existence checks and attachment upload limits

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getAssistantById } from "@/lib/db";
 import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
+
+const MAX_FILES_PER_UPLOAD = 10;
+const MAX_TOTAL_BUFFERED_BYTES = 50 * 1024 * 1024;
+const MAX_TOTAL_BUFFERED_MIB = MAX_TOTAL_BUFFERED_BYTES / (1024 * 1024);
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -41,11 +46,30 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
 
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
     const formData = await request.formData();
     const files = getFilesFromFormData(formData);
     if (files.length === 0) {
       return NextResponse.json(
         { error: "At least one file is required under the 'files' field" },
+        { status: 400 },
+      );
+    }
+    if (files.length > MAX_FILES_PER_UPLOAD) {
+      return NextResponse.json(
+        { error: `A maximum of ${MAX_FILES_PER_UPLOAD} files can be uploaded at once` },
+        { status: 400 },
+      );
+    }
+
+    const declaredTotalBytes = files.reduce((total, file) => total + file.size, 0);
+    if (declaredTotalBytes > MAX_TOTAL_BUFFERED_BYTES) {
+      return NextResponse.json(
+        { error: `Total attachment size cannot exceed ${MAX_TOTAL_BUFFERED_MIB}MB per request` },
         { status: 400 },
       );
     }
@@ -85,6 +109,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
 
     const body = await request.json().catch(() => ({})) as { attachment_ids?: unknown };
     const attachmentIds = normalizeAttachmentIds(body.attachment_ids);

--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { getAssistantById } from "@/lib/db";
 import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
 
@@ -12,6 +13,12 @@ export const runtime = "nodejs";
 export async function GET(_request: Request, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
     const { baseUrl, mode } = resolveRuntime(assistantId);
     const client = createRuntimeClient(baseUrl, assistantId);
 

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getAssistantById } from "@/lib/db";
 import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
 
@@ -31,6 +32,12 @@ function getRuntimeClient(assistantId: string) {
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
     const client = getRuntimeClient(assistantId);
     const conversationKey = assistantId;
 
@@ -53,6 +60,12 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
     const body = await request.json() as PostMessageBody;
     const content = typeof body.content === "string" ? body.content : "";
     const trimmedContent = content.trim();


### PR DESCRIPTION
## Summary
- Restores assistant existence validation (returns 404 for unknown IDs) in the messages, attachments, and health routes that were inadvertently removed in PR #615's mode-agnostic refactor
- Reinstates file upload safeguards in the attachments route: max 10 files per request and 50 MiB total size limit to prevent unbounded memory consumption

## Context
PR #615 ("Make web API routes mode-agnostic via runtime client") removed assistant existence checks and attachment upload limits when simplifying the routes to proxy through the runtime client. This allowed requests against arbitrary/deleted assistant IDs to succeed and removed OOM protections on the attachments upload endpoint.

## Test plan
- [ ] Verify requests with a non-existent assistant ID return 404
- [ ] Verify uploading >10 files returns 400
- [ ] Verify uploading files exceeding 50 MiB total returns 400
- [ ] Verify normal message/attachment/health flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
