### PR TITLE
Add chat suggestion utility functions and tests

### DIFF
--- a/web/src/lib/chat-suggestion.test.ts
+++ b/web/src/lib/chat-suggestion.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildHeuristicSuggestion,
+  extractSuggestibleAssistantText,
+  sanitizeSuggestion,
+  shouldShowSuggestion,
+  type SuggestionMessage,
+} from "./chat-suggestion";
+
+// ---------------------------------------------------------------------------
+// sanitizeSuggestion
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSuggestion", () => {
+  test("trims whitespace", () => {
+    expect(sanitizeSuggestion("  hello  ")).toBe("hello");
+  });
+
+  test("returns first line only", () => {
+    expect(sanitizeSuggestion("line one\nline two\nline three")).toBe("line one");
+  });
+
+  test("returns null for empty string", () => {
+    expect(sanitizeSuggestion("")).toBeNull();
+  });
+
+  test("returns null for whitespace-only string", () => {
+    expect(sanitizeSuggestion("   \n\n  ")).toBeNull();
+  });
+
+  test("truncates to default maxLen (200)", () => {
+    const long = "a".repeat(300);
+    const result = sanitizeSuggestion(long);
+    expect(result).toHaveLength(200);
+  });
+
+  test("truncates to custom maxLen", () => {
+    const result = sanitizeSuggestion("hello world", 5);
+    expect(result).toBe("hello");
+  });
+
+  test("returns full string when under maxLen", () => {
+    expect(sanitizeSuggestion("short", 200)).toBe("short");
+  });
+
+  test("handles quoted text at end of line", () => {
+    expect(sanitizeSuggestion('  "hello"  ')).toBe('"hello"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSuggestibleAssistantText
+// ---------------------------------------------------------------------------
+
+describe("extractSuggestibleAssistantText", () => {
+  test("returns text from assistant message", () => {
+    const msg: SuggestionMessage = { role: "assistant", content: "Hello there!" };
+    expect(extractSuggestibleAssistantText(msg)).toBe("Hello there!");
+  });
+
+  test("returns null for user message", () => {
+    const msg: SuggestionMessage = { role: "user", content: "Hi" };
+    expect(extractSuggestibleAssistantText(msg)).toBeNull();
+  });
+
+  test("returns null for empty assistant content", () => {
+    const msg: SuggestionMessage = { role: "assistant", content: "" };
+    expect(extractSuggestibleAssistantText(msg)).toBeNull();
+  });
+
+  test("returns null for whitespace-only assistant content", () => {
+    const msg: SuggestionMessage = { role: "assistant", content: "   \n  " };
+    expect(extractSuggestibleAssistantText(msg)).toBeNull();
+  });
+
+  test("returns text even when toolCalls are present", () => {
+    const msg: SuggestionMessage = {
+      role: "assistant",
+      content: "Here's the result",
+      toolCalls: [{ name: "search", input: { q: "test" } }],
+    };
+    expect(extractSuggestibleAssistantText(msg)).toBe("Here's the result");
+  });
+
+  test("returns null for tool-only message (no text)", () => {
+    const msg: SuggestionMessage = {
+      role: "assistant",
+      content: "",
+      toolCalls: [{ name: "search", input: { q: "test" } }],
+    };
+    expect(extractSuggestibleAssistantText(msg)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHeuristicSuggestion
+// ---------------------------------------------------------------------------
+
+describe("buildHeuristicSuggestion", () => {
+  test('returns "Yes" when assistant text ends with a question mark', () => {
+    expect(buildHeuristicSuggestion("Would you like to continue?")).toBe("Yes");
+  });
+
+  test("detects question mark followed by trailing punctuation/quotes", () => {
+    expect(buildHeuristicSuggestion('Is this correct?"')).toBe("Yes");
+    expect(buildHeuristicSuggestion("Ready to go?)")).toBe("Yes");
+    expect(buildHeuristicSuggestion("Want to proceed?`")).toBe("Yes");
+  });
+
+  test('returns "Tell me more" for non-question text', () => {
+    expect(buildHeuristicSuggestion("I've completed the task.")).toBe("Tell me more");
+  });
+
+  test('returns "Tell me more" for statements', () => {
+    expect(buildHeuristicSuggestion("Here is the result")).toBe("Tell me more");
+  });
+
+  test("returns null for empty text", () => {
+    expect(buildHeuristicSuggestion("")).toBeNull();
+  });
+
+  test("returns null for whitespace-only text", () => {
+    expect(buildHeuristicSuggestion("   ")).toBeNull();
+  });
+
+  test("handles multiline text — checks last line for question", () => {
+    const text = "Here is some info.\nDo you want more details?";
+    expect(buildHeuristicSuggestion(text)).toBe("Yes");
+  });
+
+  test("handles multiline text — last line is not a question", () => {
+    const text = "Do you want details?\nHere they are.";
+    expect(buildHeuristicSuggestion(text)).toBe("Tell me more");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldShowSuggestion
+// ---------------------------------------------------------------------------
+
+describe("shouldShowSuggestion", () => {
+  const base = {
+    input: "",
+    lastRole: "assistant" as const,
+    isWaitingForResponse: false,
+    isAlive: true,
+  };
+
+  test("returns true when all conditions met", () => {
+    expect(shouldShowSuggestion(base)).toBe(true);
+  });
+
+  test("returns false when input is non-empty", () => {
+    expect(shouldShowSuggestion({ ...base, input: "hello" })).toBe(false);
+  });
+
+  test("returns false when input is whitespace-only", () => {
+    expect(shouldShowSuggestion({ ...base, input: "  " })).toBe(false);
+  });
+
+  test("returns false when last role is user", () => {
+    expect(shouldShowSuggestion({ ...base, lastRole: "user" })).toBe(false);
+  });
+
+  test("returns false when last role is undefined", () => {
+    expect(shouldShowSuggestion({ ...base, lastRole: undefined })).toBe(false);
+  });
+
+  test("returns false when waiting for response", () => {
+    expect(shouldShowSuggestion({ ...base, isWaitingForResponse: true })).toBe(false);
+  });
+
+  test("returns false when assistant is not alive", () => {
+    expect(shouldShowSuggestion({ ...base, isAlive: false })).toBe(false);
+  });
+});

--- a/web/src/lib/chat-suggestion.ts
+++ b/web/src/lib/chat-suggestion.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure utility functions for chat autocomplete suggestions.
+ *
+ * These are intentionally framework-agnostic — no React, no fetch, no DOM.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SuggestionMessage {
+  role: "user" | "assistant";
+  content: string;
+  toolCalls?: { name: string; input: Record<string, unknown>; result?: string; isError?: boolean }[];
+}
+
+export interface ShouldShowSuggestionParams {
+  input: string;
+  lastRole: "user" | "assistant" | undefined;
+  isWaitingForResponse: boolean;
+  isAlive: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeSuggestion
+// ---------------------------------------------------------------------------
+
+/**
+ * Clean and truncate a raw suggestion string.
+ *
+ * - Trims surrounding whitespace.
+ * - Keeps only the first line (single-line suggestion).
+ * - Truncates to `maxLen` characters.
+ * - Returns `null` for empty / whitespace-only input.
+ */
+export function sanitizeSuggestion(raw: string, maxLen = 200): string | null {
+  const firstLine = raw.split("\n")[0].trim();
+  if (firstLine.length === 0) return null;
+  return firstLine.length <= maxLen ? firstLine : firstLine.slice(0, maxLen);
+}
+
+// ---------------------------------------------------------------------------
+// extractSuggestibleAssistantText
+// ---------------------------------------------------------------------------
+
+/**
+ * Given the last message, extract the text portion that is suitable for
+ * deriving a suggestion. Returns `null` when:
+ * - The message is not from the assistant.
+ * - The assistant message has no text content (e.g. tool-only).
+ */
+export function extractSuggestibleAssistantText(message: SuggestionMessage): string | null {
+  if (message.role !== "assistant") return null;
+
+  const text = message.content.trim();
+  if (text.length === 0) return null;
+
+  return text;
+}
+
+// ---------------------------------------------------------------------------
+// buildHeuristicSuggestion
+// ---------------------------------------------------------------------------
+
+const QUESTION_RE = /\?[\s"'`)*\]]*$/;
+
+/**
+ * Build a short heuristic follow-up suggestion from the assistant's last text.
+ *
+ * Strategy (v1 — intentionally simple):
+ * 1. If the text ends with a question → "Yes"
+ * 2. Otherwise → "Tell me more"
+ */
+export function buildHeuristicSuggestion(lastAssistantText: string): string | null {
+  const sanitized = sanitizeSuggestion(lastAssistantText);
+  if (!sanitized) return null;
+
+  // Use the full (non-sanitized) text for question detection since the
+  // question mark may be beyond the truncation boundary.
+  const trimmed = lastAssistantText.trim();
+  if (QUESTION_RE.test(trimmed)) {
+    return "Yes";
+  }
+
+  return "Tell me more";
+}
+
+// ---------------------------------------------------------------------------
+// shouldShowSuggestion
+// ---------------------------------------------------------------------------
+
+/**
+ * Gate whether the suggestion UI should be visible.
+ *
+ * All four conditions must hold:
+ * 1. Composer input is empty.
+ * 2. The most recent message is from the assistant.
+ * 3. We are NOT currently waiting for an assistant response.
+ * 4. The assistant is alive (healthy).
+ */
+export function shouldShowSuggestion({
+  input,
+  lastRole,
+  isWaitingForResponse,
+  isAlive,
+}: ShouldShowSuggestionParams): boolean {
+  if (input.length > 0) return false;
+  if (lastRole !== "assistant") return false;
+  if (isWaitingForResponse) return false;
+  if (!isAlive) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- New `web/src/lib/chat-suggestion.ts` with pure utility functions: `sanitizeSuggestion`, `extractSuggestibleAssistantText`, `buildHeuristicSuggestion`, `shouldShowSuggestion`
- Comprehensive test suite (29 tests) covering multiline, quoted, empty, too-long, and edge cases
- No UI or backend changes — pure utilities for upcoming suggestion feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
