### PR TITLE
Add Tab key to accept suggestion into composer

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -563,12 +563,17 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Tab" && suggestion && input.length === 0) {
+        e.preventDefault();
+        setInput(suggestion);
+        return;
+      }
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         handleSubmit(e as unknown as FormEvent);
       }
     },
-    [handleSubmit]
+    [handleSubmit, suggestion, input]
   );
 
   const getStatusDisplay = () => {


### PR DESCRIPTION
## Summary
- In `handleKeyDown`, intercept `Tab` when a suggestion is visible and composer is empty
- `Tab` fills the composer with the suggestion text (does not submit)
- `Enter` behavior unchanged — still required to send

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
