### PR TITLE
Add runtime suggestion endpoint and client support

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -101,6 +101,10 @@ export class RuntimeHttpServer {
         return await this.handleDeleteAttachment(assistantId, req);
       }
 
+      if (endpoint === 'suggestion' && req.method === 'GET') {
+        return this.handleGetSuggestion(assistantId, url);
+      }
+
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
         return await this.handleChannelInbound(assistantId, req);
       }
@@ -167,6 +171,56 @@ export class RuntimeHttpServer {
     }));
 
     return Response.json({ messages });
+  }
+
+  private handleGetSuggestion(assistantId: string, url: URL): Response {
+    const conversationKey = url.searchParams.get('conversationKey');
+    if (!conversationKey) {
+      return Response.json(
+        { error: 'conversationKey query parameter is required' },
+        { status: 400 },
+      );
+    }
+
+    const mapping = getConversationByKey(assistantId, conversationKey);
+    if (!mapping) {
+      return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+    }
+
+    const rawMessages = conversationStore.getMessages(mapping.conversationId);
+    if (rawMessages.length === 0) {
+      return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
+    }
+
+    // Walk backwards to find the last assistant message with text content
+    for (let i = rawMessages.length - 1; i >= 0; i--) {
+      const msg = rawMessages[i];
+      if (msg.role !== 'assistant') continue;
+
+      let content: unknown;
+      try { content = JSON.parse(msg.content); } catch { content = msg.content; }
+      const rendered = renderHistoryContent(content);
+      const text = rendered.text.trim();
+      if (!text) continue;
+
+      // Optional: skip if a specific messageId was requested and doesn't match
+      const requestedMessageId = url.searchParams.get('messageId');
+      if (requestedMessageId && msg.id !== requestedMessageId) {
+        return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
+      }
+
+      // Heuristic: if last text ends with a question, suggest "Yes", else "Tell me more"
+      const questionRe = /\?[\s"'`)*\]]*$/;
+      const suggestion = questionRe.test(text) ? 'Yes' : 'Tell me more';
+
+      return Response.json({
+        suggestion,
+        messageId: msg.id,
+        source: 'heuristic' as const,
+      });
+    }
+
+    return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
   }
 
   private async handleSendMessage(assistantId: string, req: Request): Promise<Response> {

--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -13,6 +13,8 @@ import type {
   ListMessagesResponse,
   SendMessageParams,
   SendMessageResponse,
+  GetSuggestionParams,
+  GetSuggestionResponse,
   UploadAttachmentParams,
   UploadAttachmentResponse,
   DeleteAttachmentParams,
@@ -81,6 +83,12 @@ export function createRuntimeClient(
         method: "POST",
         body: JSON.stringify(params),
       });
+    },
+
+    getSuggestion(params: GetSuggestionParams) {
+      const qs = new URLSearchParams({ conversationKey: params.conversationKey });
+      if (params.messageId) qs.set("messageId", params.messageId);
+      return request<GetSuggestionResponse>(`/suggestion?${qs.toString()}`);
     },
 
     uploadAttachment(params: UploadAttachmentParams) {

--- a/web/src/lib/runtime/types.ts
+++ b/web/src/lib/runtime/types.ts
@@ -81,6 +81,22 @@ export interface DeleteAttachmentParams {
 }
 
 // ---------------------------------------------------------------------------
+// Suggestion
+// ---------------------------------------------------------------------------
+
+export interface GetSuggestionParams {
+  conversationKey: string;
+  messageId?: string;
+}
+
+export interface GetSuggestionResponse {
+  suggestion: string | null;
+  messageId: string | null;
+  source: "heuristic" | "llm" | "none";
+  stale?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Channels
 // ---------------------------------------------------------------------------
 
@@ -112,6 +128,8 @@ export interface RuntimeClient {
 
   listMessages(params: ListMessagesParams): Promise<ListMessagesResponse>;
   sendMessage(params: SendMessageParams): Promise<SendMessageResponse>;
+
+  getSuggestion(params: GetSuggestionParams): Promise<GetSuggestionResponse>;
 
   uploadAttachment(params: UploadAttachmentParams): Promise<UploadAttachmentResponse>;
   deleteAttachment(params: DeleteAttachmentParams): Promise<void>;


### PR DESCRIPTION
## Summary
- New `GET /v1/assistants/:assistantId/suggestion` runtime endpoint with heuristic suggestion logic
- Add `GetSuggestionParams`/`GetSuggestionResponse` types to runtime contract
- Add `getSuggestion()` to `RuntimeClient` interface and HTTP client implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
