### PR TITLE
Add web proxy suggestion route with stale handling

### DIFF
--- a/web/src/app/api/assistants/[id]/suggestion/route.ts
+++ b/web/src/app/api/assistants/[id]/suggestion/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAssistantById } from "@/lib/db";
+import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
+import { resolveRuntime } from "@/lib/runtime/resolver";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: assistantId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    const { baseUrl } = resolveRuntime(assistantId);
+    const client = createRuntimeClient(baseUrl, assistantId);
+    const conversationKey = assistantId;
+
+    const messageId = request.nextUrl.searchParams.get("messageId") ?? undefined;
+
+    const result = await client.getSuggestion({ conversationKey, messageId });
+
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { suggestion: null, messageId: null, source: "none" as const },
+        { status: error.status },
+      );
+    }
+    console.error("Error fetching suggestion:", error);
+    return NextResponse.json(
+      { suggestion: null, messageId: null, source: "none" as const },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -256,14 +256,49 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const lastMessage = messages[messages.length - 1];
   const isWaitingForResponse = lastMessage?.role === "user";
 
-  const suggestion = useMemo(() => {
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const suggestionMessageIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
     if (!shouldShowSuggestion({ input, lastRole: lastMessage?.role, isWaitingForResponse, isAlive })) {
-      return null;
+      setSuggestion(null);
+      return;
     }
+
     const text = extractSuggestibleAssistantText(lastMessage);
-    if (!text) return null;
-    return buildHeuristicSuggestion(text);
-  }, [input, lastMessage, isWaitingForResponse, isAlive]);
+    if (!text) {
+      setSuggestion(null);
+      return;
+    }
+
+    // Set heuristic immediately as fallback
+    const heuristic = buildHeuristicSuggestion(text);
+    setSuggestion(heuristic);
+    suggestionMessageIdRef.current = lastMessage?.id ?? null;
+
+    // Try backend endpoint for potentially better suggestion
+    const messageId = lastMessage?.id;
+    let cancelled = false;
+
+    fetch(`/api/assistants/${assistantId}/suggestion${messageId ? `?messageId=${messageId}` : ""}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<{ suggestion: string | null; messageId: string | null; stale?: boolean; source: string }>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        // Ignore stale responses (latest message changed since request)
+        if (data.stale) return;
+        if (data.suggestion && data.messageId === messageId) {
+          setSuggestion(data.suggestion);
+        }
+      })
+      .catch(() => {
+        // Silently fall back to heuristic (already set above)
+      });
+
+    return () => { cancelled = true; };
+  }, [assistantId, input, lastMessage, isWaitingForResponse, isAlive]);
 
   const uploadedAttachmentIds = useMemo(
     () => pendingAttachments


### PR DESCRIPTION
## Summary
- New `/api/assistants/[id]/suggestion` Next.js proxy route that forwards to the runtime suggestion endpoint
- InteractionTab now fetches backend suggestions asynchronously, with stale response detection (ignores if latest message has changed)
- Graceful fallback to client-side heuristic if backend is unavailable (404/500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
