### PR TITLE
Remove heuristic suggestion fallback

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -223,19 +223,11 @@ export class RuntimeHttpServer {
             });
           }
         } catch (err) {
-          log.warn({ err }, 'LLM suggestion failed, falling back to heuristic');
+          log.warn({ err }, 'LLM suggestion failed');
         }
       }
 
-      // Heuristic fallback
-      const questionRe = /\?[\s"'`)*\]]*$/;
-      const suggestion = questionRe.test(text) ? 'Yes' : 'Tell me more';
-
-      return Response.json({
-        suggestion,
-        messageId: msg.id,
-        source: 'heuristic' as const,
-      });
+      return Response.json({ suggestion: null, messageId: null, source: 'none' as const });
     }
 
     return Response.json({ suggestion: null, messageId: null, source: 'none' as const });

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -31,8 +31,6 @@ import {
 
 import { Button } from "@/components/app/core/Button";
 import {
-  buildHeuristicSuggestion,
-  extractSuggestibleAssistantText,
   shouldShowSuggestion,
 } from "@/lib/chat-suggestion";
 
@@ -257,7 +255,6 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const isWaitingForResponse = lastMessage?.role === "user";
 
   const [suggestion, setSuggestion] = useState<string | null>(null);
-  const suggestionMessageIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!shouldShowSuggestion({ input, lastRole: lastMessage?.role, isWaitingForResponse, isAlive })) {
@@ -265,18 +262,6 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
       return;
     }
 
-    const text = extractSuggestibleAssistantText(lastMessage);
-    if (!text) {
-      setSuggestion(null);
-      return;
-    }
-
-    // Set heuristic immediately as fallback
-    const heuristic = buildHeuristicSuggestion(text);
-    setSuggestion(heuristic);
-    suggestionMessageIdRef.current = lastMessage?.id ?? null;
-
-    // Try backend endpoint for potentially better suggestion
     const messageId = lastMessage?.id;
     let cancelled = false;
 
@@ -287,14 +272,15 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
       })
       .then((data) => {
         if (cancelled) return;
-        // Ignore stale responses (latest message changed since request)
         if (data.stale) return;
         if (data.suggestion && data.messageId === messageId) {
           setSuggestion(data.suggestion);
+        } else {
+          setSuggestion(null);
         }
       })
       .catch(() => {
-        // Silently fall back to heuristic (already set above)
+        setSuggestion(null);
       });
 
     return () => { cancelled = true; };

--- a/web/src/lib/chat-suggestion.test.ts
+++ b/web/src/lib/chat-suggestion.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  buildHeuristicSuggestion,
-  extractSuggestibleAssistantText,
   sanitizeSuggestion,
   shouldShowSuggestion,
-  type SuggestionMessage,
 } from "./chat-suggestion";
 
 // ---------------------------------------------------------------------------
@@ -46,92 +43,6 @@ describe("sanitizeSuggestion", () => {
 
   test("handles quoted text at end of line", () => {
     expect(sanitizeSuggestion('  "hello"  ')).toBe('"hello"');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractSuggestibleAssistantText
-// ---------------------------------------------------------------------------
-
-describe("extractSuggestibleAssistantText", () => {
-  test("returns text from assistant message", () => {
-    const msg: SuggestionMessage = { role: "assistant", content: "Hello there!" };
-    expect(extractSuggestibleAssistantText(msg)).toBe("Hello there!");
-  });
-
-  test("returns null for user message", () => {
-    const msg: SuggestionMessage = { role: "user", content: "Hi" };
-    expect(extractSuggestibleAssistantText(msg)).toBeNull();
-  });
-
-  test("returns null for empty assistant content", () => {
-    const msg: SuggestionMessage = { role: "assistant", content: "" };
-    expect(extractSuggestibleAssistantText(msg)).toBeNull();
-  });
-
-  test("returns null for whitespace-only assistant content", () => {
-    const msg: SuggestionMessage = { role: "assistant", content: "   \n  " };
-    expect(extractSuggestibleAssistantText(msg)).toBeNull();
-  });
-
-  test("returns text even when toolCalls are present", () => {
-    const msg: SuggestionMessage = {
-      role: "assistant",
-      content: "Here's the result",
-      toolCalls: [{ name: "search", input: { q: "test" } }],
-    };
-    expect(extractSuggestibleAssistantText(msg)).toBe("Here's the result");
-  });
-
-  test("returns null for tool-only message (no text)", () => {
-    const msg: SuggestionMessage = {
-      role: "assistant",
-      content: "",
-      toolCalls: [{ name: "search", input: { q: "test" } }],
-    };
-    expect(extractSuggestibleAssistantText(msg)).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildHeuristicSuggestion
-// ---------------------------------------------------------------------------
-
-describe("buildHeuristicSuggestion", () => {
-  test('returns "Yes" when assistant text ends with a question mark', () => {
-    expect(buildHeuristicSuggestion("Would you like to continue?")).toBe("Yes");
-  });
-
-  test("detects question mark followed by trailing punctuation/quotes", () => {
-    expect(buildHeuristicSuggestion('Is this correct?"')).toBe("Yes");
-    expect(buildHeuristicSuggestion("Ready to go?)")).toBe("Yes");
-    expect(buildHeuristicSuggestion("Want to proceed?`")).toBe("Yes");
-  });
-
-  test('returns "Tell me more" for non-question text', () => {
-    expect(buildHeuristicSuggestion("I've completed the task.")).toBe("Tell me more");
-  });
-
-  test('returns "Tell me more" for statements', () => {
-    expect(buildHeuristicSuggestion("Here is the result")).toBe("Tell me more");
-  });
-
-  test("returns null for empty text", () => {
-    expect(buildHeuristicSuggestion("")).toBeNull();
-  });
-
-  test("returns null for whitespace-only text", () => {
-    expect(buildHeuristicSuggestion("   ")).toBeNull();
-  });
-
-  test("handles multiline text — checks last line for question", () => {
-    const text = "Here is some info.\nDo you want more details?";
-    expect(buildHeuristicSuggestion(text)).toBe("Yes");
-  });
-
-  test("handles multiline text — last line is not a question", () => {
-    const text = "Do you want details?\nHere they are.";
-    expect(buildHeuristicSuggestion(text)).toBe("Tell me more");
   });
 });
 

--- a/web/src/lib/chat-suggestion.ts
+++ b/web/src/lib/chat-suggestion.ts
@@ -8,12 +8,6 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export interface SuggestionMessage {
-  role: "user" | "assistant";
-  content: string;
-  toolCalls?: { name: string; input: Record<string, unknown>; result?: string; isError?: boolean }[];
-}
-
 export interface ShouldShowSuggestionParams {
   input: string;
   lastRole: "user" | "assistant" | undefined;
@@ -37,52 +31,6 @@ export function sanitizeSuggestion(raw: string, maxLen = 200): string | null {
   const firstLine = raw.split("\n")[0].trim();
   if (firstLine.length === 0) return null;
   return firstLine.length <= maxLen ? firstLine : firstLine.slice(0, maxLen);
-}
-
-// ---------------------------------------------------------------------------
-// extractSuggestibleAssistantText
-// ---------------------------------------------------------------------------
-
-/**
- * Given the last message, extract the text portion that is suitable for
- * deriving a suggestion. Returns `null` when:
- * - The message is not from the assistant.
- * - The assistant message has no text content (e.g. tool-only).
- */
-export function extractSuggestibleAssistantText(message: SuggestionMessage): string | null {
-  if (message.role !== "assistant") return null;
-
-  const text = message.content.trim();
-  if (text.length === 0) return null;
-
-  return text;
-}
-
-// ---------------------------------------------------------------------------
-// buildHeuristicSuggestion
-// ---------------------------------------------------------------------------
-
-const QUESTION_RE = /\?[\s"'`)*\]]*$/;
-
-/**
- * Build a short heuristic follow-up suggestion from the assistant's last text.
- *
- * Strategy (v1 — intentionally simple):
- * 1. If the text ends with a question → "Yes"
- * 2. Otherwise → "Tell me more"
- */
-export function buildHeuristicSuggestion(lastAssistantText: string): string | null {
-  const sanitized = sanitizeSuggestion(lastAssistantText);
-  if (!sanitized) return null;
-
-  // Use the full (non-sanitized) text for question detection since the
-  // question mark may be beyond the truncation boundary.
-  const trimmed = lastAssistantText.trim();
-  if (QUESTION_RE.test(trimmed)) {
-    return "Yes";
-  }
-
-  return "Tell me more";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove default "Yes" / "Tell me more" heuristic from both backend and frontend
- Suggestions now only appear when LLM endpoint returns one (requires `ANTHROPIC_API_KEY`)
- Remove `buildHeuristicSuggestion`, `extractSuggestibleAssistantText`, and their tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
