### PR TITLE
Add /blitz slash command for end-to-end feature execution

### DIFF
--- a/scripts/commands/swarm.md
+++ b/scripts/commands/swarm.md
@@ -67,8 +67,9 @@ ALL work happens here. Do NOT touch the main repo.
 1. Make the changes in your worktree.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
 3. Commit with a descriptive message.
-4. Push and create a PR:
-   gh pr create --base main --title "<concise title>" --body "<what changed and why>"
+4. Push and create a PR (assign to current GitHub user):
+   GH_USERNAME=$(gh api user --jq '.login')
+   gh pr create --base main --title "<concise title>" --body "<what changed and why>" --assignee "$GH_USERNAME"
 5. Merge immediately: gh pr merge <number> --squash
 6. Send a message to "lead" with:
    - The PR link


### PR DESCRIPTION
The purpose of this PR is to add a `/blitz` slash command that codifies the end-to-end feature execution workflow into a single command.

## Changes Made
- Add `scripts/commands/blitz.md` — a 6-phase slash command that orchestrates: GH project setup, planning & issue creation, TODO population, parallel swarm execution, review sweep, and final reporting
- Supports `--auto`, `--workers N`, and `--skip-plan` flags
- Delegates to existing `/swarm` and `/check-reviews` commands rather than duplicating their logic
- Integrates with GH Projects v2 via GraphQL for issue tracking and status updates

## Testing
- Verified symlink at `.claude/commands/blitz.md` resolves correctly
- Confirmed referenced files (`scripts/commands/swarm.md`, `scripts/commands/check-reviews.md`) exist at expected paths

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
