### PR TITLE
Stabilize suggestion effect to avoid re-fetching on poll

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -255,17 +255,18 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const isWaitingForResponse = lastMessage?.role === "user";
 
   const [suggestion, setSuggestion] = useState<string | null>(null);
+  const lastMessageId = lastMessage?.id;
+  const lastMessageRole = lastMessage?.role;
 
   useEffect(() => {
-    if (!shouldShowSuggestion({ input, lastRole: lastMessage?.role, isWaitingForResponse, isAlive })) {
+    if (!shouldShowSuggestion({ input, lastRole: lastMessageRole, isWaitingForResponse, isAlive })) {
       setSuggestion(null);
       return;
     }
 
-    const messageId = lastMessage?.id;
     let cancelled = false;
 
-    fetch(`/api/assistants/${assistantId}/suggestion${messageId ? `?messageId=${messageId}` : ""}`)
+    fetch(`/api/assistants/${assistantId}/suggestion${lastMessageId ? `?messageId=${lastMessageId}` : ""}`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json() as Promise<{ suggestion: string | null; messageId: string | null; stale?: boolean; source: string }>;
@@ -273,7 +274,7 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
       .then((data) => {
         if (cancelled) return;
         if (data.stale) return;
-        if (data.suggestion && data.messageId === messageId) {
+        if (data.suggestion && data.messageId === lastMessageId) {
           setSuggestion(data.suggestion);
         } else {
           setSuggestion(null);
@@ -284,7 +285,7 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
       });
 
     return () => { cancelled = true; };
-  }, [assistantId, input, lastMessage, isWaitingForResponse, isAlive]);
+  }, [assistantId, input, lastMessageId, lastMessageRole, isWaitingForResponse, isAlive]);
 
   const uploadedAttachmentIds = useMemo(
     () => pendingAttachments


### PR DESCRIPTION
## Summary
- Use `lastMessageId` (string primitive) instead of `lastMessage` (object) in `useEffect` deps
- Prevents suggestion fetch from re-firing every 5s poll cycle or on hot-reload during local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
