### PR TITLE
Show suggestion as ghost placeholder text in composer

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -904,8 +904,9 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
+                placeholder={suggestion ?? undefined}
                 rows={1}
-                className="flex-1 resize-none rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-900 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white"
+                className="flex-1 resize-none rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white dark:placeholder-zinc-500"
               />
               <Button
                 type="submit"
@@ -915,16 +916,6 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                 className="bg-green-600 text-white hover:bg-green-700"
               />
             </div>
-            {suggestion && (
-              <div className="mt-2 flex items-center gap-2 text-xs text-zinc-400 dark:text-zinc-500">
-                <span className="truncate">
-                  Suggestion: <span className="text-zinc-600 dark:text-zinc-300">{suggestion}</span>
-                </span>
-                <kbd className="shrink-0 rounded border border-zinc-200 bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
-                  Tab
-                </kbd>
-              </div>
-            )}
             {hasUploadingAttachments && (
               <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
                 Uploading attachments...


### PR DESCRIPTION
## Summary
- Move suggestion into the textarea as native placeholder text (ghost text)
- Remove the separate "Suggestion: ..." hint row and Tab badge below the composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
