### PR TITLE
Use configured API key for suggestions

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -15,6 +15,7 @@ import * as conversationStore from '../memory/conversation-store.js';
 import * as attachmentsStore from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
+import { getConfig } from '../config/loader.js';
 
 const log = getLogger('runtime-http');
 
@@ -210,8 +211,8 @@ export class RuntimeHttpServer {
         return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
       }
 
-      // Try LLM suggestion if ANTHROPIC_API_KEY is available
-      const apiKey = process.env.ANTHROPIC_API_KEY;
+      // Try LLM suggestion if an Anthropic API key is configured
+      const apiKey = getConfig().apiKeys.anthropic;
       if (apiKey) {
         try {
           const llmSuggestion = await this.generateLlmSuggestion(apiKey, text);


### PR DESCRIPTION
## Summary
- Replace `process.env.ANTHROPIC_API_KEY` with `getConfig().apiKeys.anthropic` in the suggestion handler
- Suggestions now use the same API key resolution as regular LLM calls (secure storage / env var / config file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
