### PR TITLE
Wire channel inbound messages to the AI agent loop

### DIFF
--- a/assistant/src/__tests__/channel-inbound.test.ts
+++ b/assistant/src/__tests__/channel-inbound.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'channel-inbound-test-'));
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+  isDebug: () => false,
+  truncateForLog: (v: string) => v,
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../providers/ratelimit.js', () => ({
+  RateLimitProvider: class {
+    constructor(..._args: unknown[]) {}
+  },
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    systemPrompt: {},
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: {
+      maxRequestsPerMinute: 0,
+      maxTokensPerSession: 0,
+    },
+    auditLog: { retentionDays: 0 },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  loadConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    systemPrompt: {},
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: {
+      maxRequestsPerMinute: 0,
+      maxTokensPerSession: 0,
+    },
+    auditLog: { retentionDays: 0 },
+  }),
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../tools/registry.js', () => ({
+  getAllToolDefinitions: () => [],
+  initializeTools: async () => {},
+}));
+
+// Mock Session to capture processMessage calls and simulate AI response
+let processMessageCalls: Array<{ conversationId: string; content: string }> = [];
+let mockAssistantResponse = 'Hello from the assistant!';
+
+class MockSession {
+  public readonly conversationId: string;
+
+  constructor(conversationId: string) {
+    this.conversationId = conversationId;
+  }
+
+  async loadFromDb(): Promise<void> {}
+  updateClient(): void {}
+  setSandboxOverride(): void {}
+  isProcessing(): boolean { return false; }
+  isStale(): boolean { return false; }
+  markStale(): void {}
+  abort(): void {}
+  handleConfirmationResponse(): void {}
+  undo(): number { return 0; }
+
+  async processMessage(
+    content: string,
+    _attachments: unknown[],
+    onEvent: (msg: Record<string, unknown>) => void,
+  ): Promise<void> {
+    processMessageCalls.push({ conversationId: this.conversationId, content });
+
+    // Simulate assistant text deltas
+    onEvent({ type: 'assistant_text_delta', text: mockAssistantResponse });
+    // Signal completion
+    onEvent({ type: 'message_complete' });
+  }
+}
+
+mock.module('../daemon/session.js', () => ({
+  Session: MockSession,
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { initializeDb, getDb } from '../memory/db.js';
+import * as conversationStore from '../memory/conversation-store.js';
+import { recordInbound } from '../memory/channel-delivery-store.js';
+import { DaemonServer } from '../daemon/server.js';
+
+// Initialize DB
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('recordInbound', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM channel_inbound_events');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversation_keys');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('does not add a user message to the conversation', () => {
+    const result = recordInbound(
+      'assistant-1',
+      'telegram',
+      'chat-123',
+      'msg-1',
+    );
+
+    expect(result.accepted).toBe(true);
+    expect(result.duplicate).toBe(false);
+    expect(result.conversationId).toBeTruthy();
+
+    // Verify no messages were added to the conversation
+    const messages = conversationStore.getMessages(result.conversationId);
+    expect(messages).toHaveLength(0);
+  });
+
+  test('returns duplicate for the same message', () => {
+    const first = recordInbound('assistant-1', 'telegram', 'chat-123', 'msg-1');
+    const second = recordInbound('assistant-1', 'telegram', 'chat-123', 'msg-1');
+
+    expect(first.duplicate).toBe(false);
+    expect(second.duplicate).toBe(true);
+    expect(second.eventId).toBe(first.eventId);
+    expect(second.conversationId).toBe(first.conversationId);
+  });
+
+  test('creates separate conversations for different chats', () => {
+    const a = recordInbound('assistant-1', 'telegram', 'chat-111', 'msg-1');
+    const b = recordInbound('assistant-1', 'telegram', 'chat-222', 'msg-1');
+
+    expect(a.conversationId).not.toBe(b.conversationId);
+  });
+});
+
+describe('DaemonServer.processMessage', () => {
+  beforeEach(() => {
+    processMessageCalls = [];
+    mockAssistantResponse = 'Hello from the assistant!';
+
+    const db = getDb();
+    db.run('DELETE FROM channel_inbound_events');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversation_keys');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('calls processMessage and returns assistant text', async () => {
+    // Create a conversation first
+    const conv = conversationStore.createConversation('test channel');
+
+    const server = new DaemonServer();
+    const result = await server.processMessage(conv.id, 'What is 2+2?');
+
+    expect(result).toBe('Hello from the assistant!');
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].content).toBe('What is 2+2?');
+    expect(processMessageCalls[0].conversationId).toBe(conv.id);
+  });
+
+  test('returns null when assistant produces no text', async () => {
+    mockAssistantResponse = '';
+    const conv = conversationStore.createConversation('test channel');
+
+    const server = new DaemonServer();
+    const result = await server.processMessage(conv.id, 'Hello');
+
+    expect(result).toBeNull();
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -184,7 +184,11 @@ export async function runDaemon(): Promise<void> {
   if (httpPortEnv) {
     const port = parseInt(httpPortEnv, 10);
     if (!isNaN(port) && port > 0) {
-      runtimeHttp = new RuntimeHttpServer({ port });
+      runtimeHttp = new RuntimeHttpServer({
+        port,
+        processMessage: (conversationId, content) =>
+          server.processMessage(conversationId, content),
+      });
       await runtimeHttp.start();
     }
   }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -461,4 +461,38 @@ export class DaemonServer {
     handleMessage(msg, socket, this.handlerContext());
   }
 
+  /**
+   * Process a message through the agent loop and return the assistant's reply.
+   * Used by RuntimeHttpServer to generate AI responses.
+   */
+  async processMessage(conversationId: string, content: string): Promise<string | null> {
+    const session = await this.getOrCreateSession(conversationId, undefined, false);
+
+    return new Promise<string | null>((resolve) => {
+      let assistantText = '';
+      let resolved = false;
+
+      session.processMessage(content, [], (event) => {
+        if (event.type === 'assistant_text_delta') {
+          assistantText += (event as { text: string }).text;
+        }
+        if (event.type === 'message_complete' || event.type === 'generation_cancelled') {
+          if (!resolved) {
+            resolved = true;
+            resolve(assistantText || null);
+          }
+        }
+        if (event.type === 'error' && !resolved) {
+          resolved = true;
+          resolve(assistantText || null);
+        }
+      }).catch(() => {
+        if (!resolved) {
+          resolved = true;
+          resolve(null);
+        }
+      });
+    });
+  }
+
 }

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -11,7 +11,6 @@ import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { channelInboundEvents } from './schema.js';
 import { getOrCreateConversation } from './conversation-key-store.js';
-import * as conversationStore from './conversation-store.js';
 
 export interface InboundResult {
   accepted: boolean;
@@ -29,7 +28,6 @@ export function recordInbound(
   sourceChannel: string,
   externalChatId: string,
   externalMessageId: string,
-  content: string,
 ): InboundResult {
   const db = getDb();
 
@@ -63,8 +61,8 @@ export function recordInbound(
   const now = Date.now();
   const eventId = uuid();
 
-  // Store the inbound message in the conversation
-  const msg = conversationStore.addMessage(mapping.conversationId, 'user', content);
+  // Don't store the user message here — Session.processMessage() will
+  // add it when the runtime processes the inbound through the agent loop.
 
   db.insert(channelInboundEvents)
     .values({
@@ -74,7 +72,7 @@ export function recordInbound(
       externalChatId,
       externalMessageId,
       conversationId: mapping.conversationId,
-      messageId: msg.id,
+      messageId: null,
       deliveryStatus: 'pending',
       createdAt: now,
       updatedAt: now,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -17,8 +17,11 @@ const log = getLogger('runtime-http');
 
 const DEFAULT_PORT = 7821;
 
+export type MessageProcessor = (conversationId: string, content: string) => Promise<string | null>;
+
 export interface RuntimeHttpServerOptions {
   port?: number;
+  processMessage?: MessageProcessor;
 }
 
 interface RuntimeMessagePayload {
@@ -32,9 +35,11 @@ interface RuntimeMessagePayload {
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
+  private processMessage: MessageProcessor | null;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
+    this.processMessage = options.processMessage ?? null;
   }
 
   async start(): Promise<void> {
@@ -269,13 +274,30 @@ export class RuntimeHttpServer {
       sourceChannel,
       externalChatId,
       externalMessageId,
-      content,
     );
+
+    if (result.duplicate) {
+      return Response.json({
+        accepted: result.accepted,
+        duplicate: result.duplicate,
+        eventId: result.eventId,
+      });
+    }
+
+    // Run the agent loop to generate an AI response
+    let assistantMessage: { content: string } | undefined;
+    if (this.processMessage) {
+      const responseText = await this.processMessage(result.conversationId, content);
+      if (responseText) {
+        assistantMessage = { content: responseText };
+      }
+    }
 
     return Response.json({
       accepted: result.accepted,
       duplicate: result.duplicate,
       eventId: result.eventId,
+      assistantMessage,
     });
   }
 


### PR DESCRIPTION
## Summary

- Add `DaemonServer.processMessage()` to run inbound messages through the AI agent loop and collect the assistant's reply
- Add `MessageProcessor` callback type to `RuntimeHttpServer` — decouples HTTP server from daemon internals
- Wire the callback in `lifecycle.ts` (composition root)
- Remove `content` param and `addMessage()` from `recordInbound()` to avoid duplicate user messages (Session.processMessage handles storage)
- Add tests for `recordInbound` idempotency and `DaemonServer.processMessage`

## Architecture

```
lifecycle.ts  (composition root — wires everything)

  ┌─────────────────────┐    ┌────────────────────────┐
  │   DaemonServer      │    │  RuntimeHttpServer     │
  │                     │    │  (port 7821)            │
  │  - IPC socket       │    │                        │
  │  - Session mgmt     │    │  /channels/inbound     │
  │  - processMessage() │◄───│  (+ other endpoints)   │
  │                     │ cb │                        │
  └────────┬────────────┘    └────────────────────────┘
           │
           ▼
  ┌──────────────────────┐
  │   Session            │
  │  - processMessage()  │  ← same for CLI & HTTP
  │  - conversation mgmt │
  │  - LLM agent loop    │
  └──────────────────────┘
```

**CLI flow**: IPC socket → DaemonServer → Session.processMessage() (streaming via bound socket)

**Telegram flow**: ngrok → Next.js webhook → HTTP :7821 /channels/inbound → recordInbound() + callback → DaemonServer.processMessage() → Session.processMessage() (text collected, returned as HTTP response)

Both flows converge on `Session.processMessage()`. The `MessageProcessor` callback is injected via DI so `RuntimeHttpServer` has no dependency on `DaemonServer` or `Session`.

## Test plan
- [x] `recordInbound` does not store user messages (avoids duplication with Session)
- [x] `recordInbound` returns duplicate for repeated messages
- [x] `recordInbound` creates separate conversations for different chats
- [x] `DaemonServer.processMessage` returns assistant text
- [x] `DaemonServer.processMessage` returns null for empty responses
- [ ] Manual: send Telegram message → verify AI response comes back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
