### PR TITLE
fix(session): persist deep-repair structural fixes in restored history

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -399,6 +399,11 @@ export class Session {
         rlog.warn({ phase: 'retry' }, 'Provider ordering error detected, attempting one-shot deep-repair retry');
         const retryRepair = deepRepairHistory(runMessages);
         runMessages = retryRepair.messages;
+        // Update preRepairMessages so that structural fixes from deep repair
+        // (e.g., stripping leading assistant messages, merging same-role runs)
+        // persist in this.messages after the run.  Without this, the original
+        // malformed prefix would be restored and trigger the same error next turn.
+        preRepairMessages = retryRepair.messages;
         preRunHistoryLength = runMessages.length;
         orderingErrorDetected = false;
         deferredOrderingError = null;


### PR DESCRIPTION
## Summary
- After a successful deep-repair retry, `preRepairMessages` was still pointing to the original (malformed) prefix, so structural fixes from `deepRepairHistory` (e.g., stripping leading assistant messages, merging same-role runs) were discarded when reconstructing `this.messages`
- This caused the same provider ordering error to recur on the next user turn, adding avoidable latency and token cost
- Fix: update `preRepairMessages` to the deep-repaired messages after a successful retry so the fixes persist in memory

Addresses Codex P2 feedback on #648.

## Test plan
- [ ] Verify type-check passes (pre-existing error in `http-server.ts` is unrelated)
- [ ] Confirm that after a deep-repair retry, `this.messages` reflects the repaired prefix rather than the original malformed one
- [ ] Validate that subsequent user turns do not re-trigger the ordering error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
