### PR TITLE
Include proxy tools in unknown-tool suggestions when resolver available

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -45,7 +45,7 @@ export class ToolExecutor {
 
     const tool = getTool(name);
     if (!tool) {
-      const available = getAllTools().filter((t) => t.executionMode !== 'proxy').map((t) => t.name).sort().join(', ');
+      const available = getAllTools().filter((t) => t.executionMode !== 'proxy' || context.proxyToolResolver).map((t) => t.name).sort().join(', ');
       const msg = `Unknown tool: ${name}. Available tools: ${available}`;
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent(context, {


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #654 (P2 from Codex)
- When a `proxyToolResolver` is present in the tool context (e.g. computer-use flows), proxy tools are now included in the unknown-tool suggestion list instead of being unconditionally filtered out
- This prevents misleading error messages that omit valid `cu_*` proxy tools when the agent makes a typo in computer-use mode

## Context
PR #654 filtered proxy tools from the unknown-tool suggestion list to avoid suggesting tools the agent can't execute. However, `ToolExecutor.execute` is also called by computer-use flows that provide a `proxyToolResolver` (via `ComputerUseSession.runAgentLoop`). In that context, all valid tools are `cu_*` proxy tools, so filtering them out returns only unrelated local tools and omits the recoverable options.

## Changes
- `assistant/src/tools/executor.ts`: Changed the filter on line 48 from `t.executionMode !== 'proxy'` to `t.executionMode !== 'proxy' || context.proxyToolResolver` — proxy tools are only excluded when no resolver is available

## Test plan
- [ ] Verify unknown tool error in non-proxy context still excludes proxy tools
- [ ] Verify unknown tool error in computer-use context (with proxyToolResolver) includes cu_* tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
