### PR TITLE
Replace blocking spawnSync with async Bun.spawn for Chromium install

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
 import { getDataDir } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
 import { checkBrowserRuntime } from './runtime-check.js';
@@ -81,15 +80,26 @@ class BrowserManager {
         const status = await checkBrowserRuntime();
         if (status.playwrightAvailable && !status.chromiumInstalled) {
           log.info('Chromium not installed, installing via playwright...');
-          const result = spawnSync('bunx', ['playwright', 'install', 'chromium'], {
-            stdio: 'pipe',
-            timeout: 120_000,
+          const proc = Bun.spawn(['bunx', 'playwright', 'install', 'chromium'], {
+            stdout: 'pipe',
+            stderr: 'pipe',
           });
-          if (result.status === 0) {
+          const timeoutMs = 120_000;
+          const exitCode = await Promise.race([
+            proc.exited,
+            new Promise<never>((_, reject) =>
+              setTimeout(() => {
+                proc.kill();
+                reject(new Error(`Chromium install timed out after ${timeoutMs / 1000}s`));
+              }, timeoutMs),
+            ),
+          ]);
+          if (exitCode === 0) {
             log.info('Chromium installed successfully');
           } else {
-            const stderr = result.stderr?.toString().trim();
-            log.error({ exitCode: result.status, stderr }, 'Failed to install Chromium');
+            const stderr = await new Response(proc.stderr).text();
+            const msg = stderr.trim() || `exited with code ${exitCode}`;
+            throw new Error(`Failed to install Chromium: ${msg}`);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Replaced `spawnSync` with async `Bun.spawn` in browser-manager.ts to prevent blocking the event loop for up to 2 minutes during Chromium installation
- Added proper timeout handling via `Promise.race` that kills the subprocess on timeout and surfaces a clear error
- Changed failure behavior from log-and-continue to throw, preventing repeated multi-minute install-then-fail cycles

Addresses review feedback on #657 from Devin and Codex.

## Test plan
- [x] All 16 existing browser-manager tests pass
- [x] Type-check passes (only pre-existing unrelated error in http-server.ts)
- [ ] Manual: verify Chromium auto-install still works when Chromium is missing
- [ ] Manual: verify timeout produces a clear error message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
