### PR TITLE
Sanitize error messages in setup-email POST handler

### DIFF
--- a/web/src/app/api/assistants/[id]/setup-email/route.ts
+++ b/web/src/app/api/assistants/[id]/setup-email/route.ts
@@ -92,9 +92,8 @@ export async function POST(
     });
   } catch (error: unknown) {
     console.error("[Setup Email] Error:", error);
-    const message = error instanceof Error ? error.message : "Failed to setup email";
     return NextResponse.json(
-      { error: message },
+      { error: "Failed to setup email" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- Replaces `error.message` with a generic `"Failed to setup email"` string in the POST handler's catch block
- Prevents leaking internal backend details (e.g. DB connection errors from `verifyAssistantToken`) to API clients
- Matches the pattern already used by the GET handler in the same file

Addresses Codex P2 review feedback on PR #650.

## Test plan
- [ ] Verify that POST `/api/assistants/[id]/setup-email` returns generic error message on internal failures
- [ ] Verify that valid/invalid token auth still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
