### PR TITLE
Fix missing assistantId in channel inbound processMessage call

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -415,7 +415,7 @@ export class RuntimeHttpServer {
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(result.conversationId, content);
+        await this.processMessage(assistantId, result.conversationId, content);
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }


### PR DESCRIPTION
## Summary
- Restores the missing `assistantId` first argument in the `handleChannelInbound` call to `processMessage` in `http-server.ts`
- The revert in PR #668 accidentally dropped this argument, shifting all subsequent parameters and breaking the entire channel inbound flow (e.g. Telegram integration)
- Addresses review feedback from both Devin (critical) and Codex (P1) on PR #668

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed)
- [ ] Verify channel inbound messages (e.g. Telegram) are processed correctly with the right `assistantId`, `conversationId`, and `content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
