### PR TITLE
Fix JSON object coercion in renderHistoryContent

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -65,7 +65,13 @@ describe('renderHistoryContent', () => {
 
   test('falls back to string conversion for non-array content', () => {
     expect(renderHistoryContent('raw string').text).toBe('raw string');
-    expect(renderHistoryContent({ foo: 'bar' }).text).toBe('[object Object]');
+    expect(renderHistoryContent(null).text).toBe('');
+    expect(renderHistoryContent(undefined).text).toBe('');
+    expect(renderHistoryContent(42).text).toBe('42');
+  });
+
+  test('preserves JSON object content as JSON string', () => {
+    expect(renderHistoryContent({ foo: 'bar' }).text).toBe('{"foo":"bar"}');
   });
 
   test('extracts tool_use blocks into toolCalls', () => {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -90,7 +90,15 @@ export interface RenderedHistoryContent {
 
 export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   if (!Array.isArray(content)) {
-    return { text: String(content ?? ''), toolCalls: [] };
+    let text: string;
+    if (content == null) {
+      text = '';
+    } else if (typeof content === 'object') {
+      text = JSON.stringify(content);
+    } else {
+      text = String(content);
+    }
+    return { text, toolCalls: [] };
   }
 
   const textParts: string[] = [];


### PR DESCRIPTION
## Summary
- Fixes `renderHistoryContent` coercing non-array JSON objects to `"[object Object]"` via the `String()` fallback
- Non-array objects (e.g. inbound messages stored as raw JSON by `recordInbound`) are now serialized with `JSON.stringify` to preserve the original content
- Primitives and null/undefined retain their existing behavior

Addresses review feedback on PR #653.

## Test plan
- [x] Updated existing test to verify `null`, `undefined`, and numeric fallback behavior
- [x] Added new test case verifying `{ foo: 'bar' }` renders as `'{"foo":"bar"}'` instead of `'[object Object]'`
- [x] All 16 tests in `server-history-render.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
