### PR TITLE
Fix Shift+Tab accessibility regression in suggestion acceptance

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -589,7 +589,7 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Tab" && ghostSuffix) {
+      if (e.key === "Tab" && !e.shiftKey && ghostSuffix) {
         e.preventDefault();
         setInput(input + ghostSuffix);
         return;


### PR DESCRIPTION
## Summary
- Adds `!e.shiftKey` guard to the Tab key condition in `handleKeyDown` so that `Shift+Tab` still allows reverse keyboard navigation when a ghost suggestion is visible
- Addresses P2 review feedback on PR #673 (accessibility regression for keyboard-only flows)

## Files changed
- `web/src/components/app/pages/RightPanel/InteractionTab.tsx`

## Test plan
- [ ] With a ghost suggestion visible, press Tab -- suggestion is accepted (unchanged behavior)
- [ ] With a ghost suggestion visible, press Shift+Tab -- focus moves backward instead of inserting suggestion text (fixed behavior)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
