### PR TITLE
Fix silent message drop and missing messageId in HTTP sendMessage

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -467,8 +467,12 @@ export class DaemonServer {
    * Gets or creates a session and runs the agent loop.
    * Results are saved to the DB for the web UI to poll.
    */
-  async processMessage(assistantId: string, conversationId: string, content: string, attachmentIds?: string[]): Promise<void> {
+  async processMessage(assistantId: string, conversationId: string, content: string, attachmentIds?: string[]): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
+
+    if (session.isProcessing()) {
+      throw new Error('Session is already processing a message');
+    }
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
@@ -480,7 +484,9 @@ export class DaemonServer {
         }))
       : [];
 
-    await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
+    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
+
+    return { messageId };
   }
 
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -191,10 +191,10 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
-  ): Promise<void> {
+  ): Promise<string> {
     if (this.processing) {
       onEvent({ type: 'error', message: 'Already processing a message' });
-      return;
+      return '';
     }
 
     const reqId = requestId ?? uuid();
@@ -202,12 +202,13 @@ export class Session {
     const rlog = log.child({ conversationId: this.conversationId, requestId: reqId });
     this.processing = true;
     this.abortController = new AbortController();
+    let userMessageId = '';
 
     try {
       const isFirstMessage = this.messages.length === 0;
       if (!content.trim() && attachments.length === 0) {
         onEvent({ type: 'error', message: 'Message content or attachments are required' });
-        return;
+        return '';
       }
 
       // Add user message
@@ -224,6 +225,7 @@ export class Session {
         'user',
         JSON.stringify(userMessage.content),
       );
+      userMessageId = persistedUserMessage.id;
 
       const compacted = await this.contextWindowManager.maybeCompact(
         this.messages,
@@ -498,6 +500,8 @@ export class Session {
       this.processing = false;
       this.currentRequestId = undefined;
     }
+
+    return userMessageId;
   }
 
   getMessages(): Message[] {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -26,7 +26,7 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
-) => Promise<void>;
+) => Promise<{ messageId: string }>;
 
 export interface RuntimeHttpServerOptions {
   port?: number;
@@ -290,16 +290,27 @@ export class RuntimeHttpServer {
 
     const mapping = getOrCreateConversation(assistantId, conversationKey);
 
-    // Trigger agent processing in the background. session.processMessage
-    // saves the user message and runs the agent loop; the web UI polls
-    // for results via GET /messages.
-    if (this.processMessage) {
-      this.processMessage(assistantId, mapping.conversationId, content ?? '', hasAttachments ? attachmentIds : undefined).catch((err) => {
-        log.error({ err, conversationId: mapping.conversationId }, 'Failed to process message');
-      });
+    if (!this.processMessage) {
+      return Response.json({ error: 'Message processing not configured' }, { status: 503 });
     }
 
-    return Response.json({ accepted: true });
+    try {
+      const result = await this.processMessage(
+        assistantId,
+        mapping.conversationId,
+        content ?? '',
+        hasAttachments ? attachmentIds : undefined,
+      );
+      return Response.json({ messageId: result.messageId });
+    } catch (err) {
+      if (err instanceof Error && err.message === 'Session is already processing a message') {
+        return Response.json(
+          { error: 'Session is busy processing another message. Please retry.' },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
   }
 
   private async handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
@@ -415,7 +426,7 @@ export class RuntimeHttpServer {
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(result.conversationId, content);
+        await this.processMessage(assistantId, result.conversationId, content);
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }


### PR DESCRIPTION
## Summary
- When the session was already processing, HTTP `POST /messages` silently dropped the user message (never persisted, no error returned). Now returns **409 Conflict** so the client knows to retry.
- `handleSendMessage` now returns `{ messageId }` matching the `SendMessageResponse` contract expected by the web client, instead of `{ accepted: true }`.
- Fixed missing `assistantId` argument in `handleChannelInbound`'s call to `processMessage`.

Addresses review feedback on #651.

## Test plan
- [ ] Send a message via HTTP API while another is processing -- verify 409 response
- [ ] Send a message when session is idle -- verify `{ messageId: "..." }` in response
- [ ] Verify web UI can use the returned messageId for correlation
- [ ] Type-check passes (`bunx tsc --noEmit`)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
