### PR TITLE
Fix duplicate user message and stale reply in channel inbound flow

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -467,7 +467,13 @@ export class DaemonServer {
    * Gets or creates a session and runs the agent loop.
    * Results are saved to the DB for the web UI to poll.
    */
-  async processMessage(assistantId: string, conversationId: string, content: string, attachmentIds?: string[]): Promise<{ messageId: string }> {
+  async processMessage(
+    assistantId: string,
+    conversationId: string,
+    content: string,
+    attachmentIds?: string[],
+    options?: { userMessageAlreadyPersisted?: boolean },
+  ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
 
     if (session.isProcessing()) {
@@ -484,7 +490,7 @@ export class DaemonServer {
         }))
       : [];
 
-    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
+    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID(), options);
 
     return { messageId };
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -191,6 +191,7 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
+    options?: { userMessageAlreadyPersisted?: boolean },
   ): Promise<string> {
     if (this.processing) {
       onEvent({ type: 'error', message: 'Already processing a message' });
@@ -211,21 +212,30 @@ export class Session {
         return '';
       }
 
-      // Add user message
-      const userMessage = createUserMessage(content, attachments.map((attachment) => ({
-        id: attachment.id,
-        filename: attachment.filename,
-        mimeType: attachment.mimeType,
-        data: attachment.data,
-        extractedText: attachment.extractedText,
-      })));
-      this.messages.push(userMessage);
-      const persistedUserMessage = conversationStore.addMessage(
-        this.conversationId,
-        'user',
-        JSON.stringify(userMessage.content),
-      );
-      userMessageId = persistedUserMessage.id;
+      if (options?.userMessageAlreadyPersisted) {
+        // The user message was already persisted (e.g. by channel inbound
+        // idempotency logic) and loaded into this.messages via loadFromDb().
+        // Find its ID from the DB for memory-recall exclusion.
+        const dbMessages = conversationStore.getMessages(this.conversationId);
+        const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
+        userMessageId = lastUserMsg?.id ?? '';
+      } else {
+        // Add user message
+        const userMessage = createUserMessage(content, attachments.map((attachment) => ({
+          id: attachment.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          data: attachment.data,
+          extractedText: attachment.extractedText,
+        })));
+        this.messages.push(userMessage);
+        const persistedUserMessage = conversationStore.addMessage(
+          this.conversationId,
+          'user',
+          JSON.stringify(userMessage.content),
+        );
+        userMessageId = persistedUserMessage.id;
+      }
 
       const compacted = await this.contextWindowManager.maybeCompact(
         this.messages,
@@ -270,7 +280,7 @@ export class Session {
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
-        excludeMessageIds: [persistedUserMessage.id],
+        excludeMessageIds: [userMessageId],
         signal: this.abortController.signal,
       });
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -26,6 +26,7 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
+  options?: { userMessageAlreadyPersisted?: boolean },
 ) => Promise<{ messageId: string }>;
 
 export interface RuntimeHttpServerOptions {
@@ -424,32 +425,42 @@ export class RuntimeHttpServer {
     );
 
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
+    // Pass userMessageAlreadyPersisted so the session skips inserting a second
+    // user message (recordInbound already persisted it within its transaction).
+    let processingSucceeded = false;
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(assistantId, result.conversationId, content);
+        await this.processMessage(assistantId, result.conversationId, content, undefined, {
+          userMessageAlreadyPersisted: true,
+        });
+        processingSucceeded = true;
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }
     }
 
-    // Look up the latest assistant message in the conversation to return it.
+    // Only look up the assistant reply when processing succeeded for a new
+    // (non-duplicate) message.  For duplicates or failed processing, returning
+    // a stale assistant message could cause the caller to resend old replies.
     let assistantMessage: RuntimeMessagePayload | undefined;
-    const msgs = conversationStore.getMessages(result.conversationId);
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      if (msgs[i].role === 'assistant') {
-        let parsed: unknown;
-        try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
-        const rendered = renderHistoryContent(parsed);
-        if (rendered.text) {
-          assistantMessage = {
-            id: msgs[i].id,
-            role: 'assistant',
-            content: rendered.text,
-            timestamp: new Date(msgs[i].createdAt).toISOString(),
-            attachments: [],
-          };
+    if (processingSucceeded) {
+      const msgs = conversationStore.getMessages(result.conversationId);
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === 'assistant') {
+          let parsed: unknown;
+          try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
+          const rendered = renderHistoryContent(parsed);
+          if (rendered.text) {
+            assistantMessage = {
+              id: msgs[i].id,
+              role: 'assistant',
+              content: rendered.text,
+              timestamp: new Date(msgs[i].createdAt).toISOString(),
+              attachments: [],
+            };
+          }
+          break;
         }
-        break;
       }
     }
 


### PR DESCRIPTION
## Summary
- **Fixes duplicate user message**: `recordInbound` already persists the user message within its idempotency transaction, but `Session.processMessage` was inserting it again. Added a `userMessageAlreadyPersisted` option that tells Session to skip the second insert when the message is already in the DB (loaded via `loadFromDb()`).
- **Gates assistant message lookup**: The assistant message lookup was unconditional, so webhook retries for duplicate events or failed processing could return stale/unrelated replies. Now only looks up the assistant reply when processing succeeded for a new (non-duplicate) message.

Addresses review feedback on #665 from Devin (duplicate user message) and Codex (duplicate message + stale reply on retries).

## Test plan
- [ ] Send a message via channel inbound endpoint and verify only one user message appears in the conversation history
- [ ] Send a duplicate webhook event and verify no assistant message is returned in the response
- [ ] Verify normal HTTP API `sendMessage` flow is unaffected (does not pass `userMessageAlreadyPersisted`)
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
