### PR TITLE
Clear stale suggestion to prevent outdated display

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -270,7 +270,7 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
       })
       .then((data) => {
         if (cancelled) return;
-        if (data.stale) return;
+        if (data.stale) { setSuggestion(null); return; }
         if (data.suggestion && data.messageId === lastMessageId) {
           setSuggestion(data.suggestion);
         } else {


### PR DESCRIPTION
## Summary
- When the backend returns `{ stale: true }`, the frontend now calls `setSuggestion(null)` before returning, preventing an outdated suggestion from a previous message from remaining visible.

## Test plan
- [ ] Verify that when a stale response is received, no suggestion is shown to the user
- [ ] Verify that non-stale suggestions still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
