### PR TITLE
Cache LLM suggestions by messageId to avoid duplicate API calls

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -43,10 +43,13 @@ interface RuntimeMessagePayload {
   toolCalls?: Array<{ name: string; input: Record<string, unknown>; result?: string; isError?: boolean }>;
 }
 
+const SUGGESTION_CACHE_MAX = 100;
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
   private processMessage?: MessageProcessor;
+  private suggestionCache = new Map<string, string>();
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -212,12 +215,29 @@ export class RuntimeHttpServer {
         return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
       }
 
+      // Return cached suggestion if we already generated one for this message
+      const cached = this.suggestionCache.get(msg.id);
+      if (cached !== undefined) {
+        return Response.json({
+          suggestion: cached,
+          messageId: msg.id,
+          source: 'llm' as const,
+        });
+      }
+
       // Try LLM suggestion if an Anthropic API key is configured
       const apiKey = getConfig().apiKeys.anthropic;
       if (apiKey) {
         try {
           const llmSuggestion = await this.generateLlmSuggestion(apiKey, text);
           if (llmSuggestion) {
+            // Evict oldest entries if cache is at capacity
+            if (this.suggestionCache.size >= SUGGESTION_CACHE_MAX) {
+              const oldest = this.suggestionCache.keys().next().value!;
+              this.suggestionCache.delete(oldest);
+            }
+            this.suggestionCache.set(msg.id, llmSuggestion);
+
             return Response.json({
               suggestion: llmSuggestion,
               messageId: msg.id,


### PR DESCRIPTION
## Summary
- Adds a `Map<string, string>` suggestion cache keyed by `messageId` to `RuntimeHttpServer`
- Before calling `generateLlmSuggestion`, checks the cache and returns immediately if a suggestion already exists for that message
- After generating a new suggestion, stores it in the cache
- Cache is capped at 100 entries with oldest-first (FIFO) eviction to prevent unbounded growth

## Why
The UI polls `/suggestion` every 5 seconds. Without caching, each poll triggers a new LLM call for the same message, wasting ~12 API calls/minute per open tab.

## Test plan
- [ ] Verify that the first `/suggestion` request for a message triggers an LLM call and returns the result
- [ ] Verify that subsequent `/suggestion` requests for the same `messageId` return the cached result without an LLM call
- [ ] Verify that after 100 cached entries, the oldest entry is evicted
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
