### PR TITLE
Validate attachment IDs and content type in sendMessage

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -279,6 +279,14 @@ export class RuntimeHttpServer {
       );
     }
 
+    // P2: Reject non-string content values (numbers, objects, etc.)
+    if (content !== undefined && content !== null && typeof content !== 'string') {
+      return Response.json(
+        { error: 'content must be a string' },
+        { status: 400 },
+      );
+    }
+
     const trimmedContent = typeof content === 'string' ? content.trim() : '';
     const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
 
@@ -287,6 +295,19 @@ export class RuntimeHttpServer {
         { error: 'content or attachmentIds is required' },
         { status: 400 },
       );
+    }
+
+    // P1: Validate that all attachment IDs resolve
+    if (hasAttachments) {
+      const resolved = attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds);
+      if (resolved.length !== attachmentIds.length) {
+        const resolvedIds = new Set(resolved.map((a) => a.id));
+        const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
+        return Response.json(
+          { error: `Attachment IDs not found: ${missing.join(', ')}` },
+          { status: 400 },
+        );
+      }
     }
 
     const mapping = getOrCreateConversation(assistantId, conversationKey);


### PR DESCRIPTION
## Summary
- Reject requests with unresolved attachment IDs with a 400 listing the missing IDs, preventing silent acceptance followed by async session failures
- Reject non-string `content` values (numbers, objects, etc.) that would cause `content.trim()` to throw asynchronously in `session.processMessage`

## Test plan
- [ ] Send a message with a stale/invalid attachment ID and verify a 400 response with the missing ID listed
- [ ] Send a message with `content: 123` and verify a 400 response
- [ ] Send a message with valid attachments and string content, verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
