### PR TITLE
Fix timer leak in Chromium auto-install Promise.race

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -85,10 +85,11 @@ class BrowserManager {
             stderr: 'pipe',
           });
           const timeoutMs = 120_000;
+          let timer: ReturnType<typeof setTimeout>;
           const exitCode = await Promise.race([
-            proc.exited,
+            proc.exited.finally(() => clearTimeout(timer)),
             new Promise<never>((_, reject) =>
-              setTimeout(() => {
+              timer = setTimeout(() => {
                 proc.kill();
                 reject(new Error(`Chromium install timed out after ${timeoutMs / 1000}s`));
               }, timeoutMs),


### PR DESCRIPTION
## Summary
- Clear the 120s `setTimeout` timer when `proc.exited` resolves first in the Chromium auto-install flow
- Without this fix, the dangling timer keeps the event loop alive for up to 2 extra minutes after a successful install, preventing clean shutdown
- Uses `.finally()` on `proc.exited` to `clearTimeout(timer)` so the timer is cleaned up regardless of how the promise settles

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm Chromium auto-install still works when browser is missing
- [ ] Confirm process shuts down cleanly after install completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
