### PR TITLE
Add screen-reader support for ghost suggestion autocomplete

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -923,13 +923,18 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                 />
                 {ghostSuffix && (
                   <div
-                    aria-hidden
+                    aria-hidden="true"
                     className="pointer-events-none absolute inset-0 overflow-hidden rounded-lg border border-transparent bg-white px-4 py-2 text-sm dark:bg-zinc-900"
                   >
                     <span className="invisible whitespace-pre">{input}</span>
                     <span className="text-zinc-400 dark:text-zinc-500">{ghostSuffix}</span>
                   </div>
                 )}
+                <span className="sr-only" aria-live="polite">
+                  {ghostSuffix
+                    ? `Suggestion available: ${suggestion}. Press Tab to accept.`
+                    : ""}
+                </span>
               </div>
               <Button
                 type="submit"


### PR DESCRIPTION
## Summary
- The ghost suggestion overlay uses `aria-hidden`, making Tab-complete invisible to screen readers
- Added a visually-hidden `aria-live="polite"` region that announces "Suggestion available: {text}. Press Tab to accept." when a ghost suggestion is shown
- Uses Tailwind's `sr-only` utility for visual hiding while remaining accessible

## Test plan
- [ ] Verify ghost suggestion still renders visually as before
- [ ] Enable VoiceOver/NVDA and confirm the suggestion is announced when it appears
- [ ] Confirm announcement clears when the suggestion is dismissed (e.g., typing diverges from suggestion)
- [ ] Verify Tab still accepts the suggestion as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
