### PR TITLE
Fix suggestion cache race with in-flight promise deduplication

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -50,6 +50,7 @@ export class RuntimeHttpServer {
   private port: number;
   private processMessage?: MessageProcessor;
   private suggestionCache = new Map<string, string>();
+  private suggestionInFlight = new Map<string, Promise<string | null>>();
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
@@ -235,12 +236,22 @@ export class RuntimeHttpServer {
         });
       }
 
-
       // Try LLM suggestion if an Anthropic API key is configured
       const apiKey = getConfig().apiKeys.anthropic;
       if (apiKey) {
         try {
-          const llmSuggestion = await this.generateLlmSuggestion(apiKey, text);
+          // Deduplicate concurrent requests: if an LLM call is already
+          // in-flight for this messageId, await the same promise instead
+          // of starting a duplicate call.
+          let promise = this.suggestionInFlight.get(msg.id);
+          if (!promise) {
+            promise = this.generateLlmSuggestion(apiKey, text);
+            this.suggestionInFlight.set(msg.id, promise);
+          }
+
+          const llmSuggestion = await promise;
+          this.suggestionInFlight.delete(msg.id);
+
           if (llmSuggestion) {
             // Evict oldest entries if cache is at capacity
             if (this.suggestionCache.size >= SUGGESTION_CACHE_MAX) {
@@ -256,6 +267,7 @@ export class RuntimeHttpServer {
             });
           }
         } catch (err) {
+          this.suggestionInFlight.delete(msg.id);
           log.warn({ err }, 'LLM suggestion failed');
         }
       }


### PR DESCRIPTION
## Summary
- Adds `suggestionInFlight: Map<string, Promise<string | null>>` to deduplicate concurrent LLM suggestion requests
- On cache miss, stores the LLM promise immediately (before `await`), so subsequent requests for the same `messageId` await the same promise instead of starting a duplicate LLM call
- Cleans up the in-flight entry on both success and error paths

## Why
The existing `suggestionCache` only stored resolved results. Because the cache check and cache write were separated by an `await` on the LLM API call (which can take 2-5+ seconds), concurrent polling requests would each see a cache miss and fire duplicate LLM calls -- exactly the scenario the cache was supposed to prevent. Addresses feedback from Devin on #697.

## Test plan
- [ ] First `/suggestion` request for a message triggers a single LLM call
- [ ] A second request arriving while the first is still in-flight awaits the same promise (no duplicate LLM call)
- [ ] After the promise resolves, the result is moved to `suggestionCache` for future requests
- [ ] If the LLM call fails, the in-flight entry is cleaned up so retries are possible
- [ ] Type-check passes (`bunx tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
