### PR TITLE
Fix recall marker stripping after deep-repair message merging

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -183,12 +183,16 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   if (recallText.trim().length === 0) return messages;
 
   let targetIndex = -1;
+  let blockIndex = -1;
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
     if (message.role !== 'user' || message.content.length === 0) continue;
-    const firstBlock = message.content[0];
-    if (firstBlock.type === 'text' && firstBlock.text === recallText) {
+    const foundBlock = message.content.findIndex(
+      (block) => block.type === 'text' && block.text === recallText,
+    );
+    if (foundBlock !== -1) {
       targetIndex = index;
+      blockIndex = foundBlock;
       break;
     }
   }
@@ -201,7 +205,10 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
       cleaned.push(message);
       continue;
     }
-    const filteredContent = message.content.slice(1);
+    const filteredContent = [
+      ...message.content.slice(0, blockIndex),
+      ...message.content.slice(blockIndex + 1),
+    ];
     if (filteredContent.length === 0) continue;
     cleaned.push({ ...message, content: filteredContent } as T);
   }


### PR DESCRIPTION
## Summary
- Fixes a bug where `stripMemoryRecallMessages` only checked the first content block (index 0) of each user message for the memory recall marker
- After `deepRepairHistory` merges consecutive same-role messages, the recall block can shift to any position within the merged content array, causing the strip to miss it
- The recall prompt would then persist in `this.messages`, so future turns keep resending retrieval scaffolding as user content

Addresses review feedback on #686.

## Test plan
- [x] Existing `memory-v2-regressions.test.ts` tests pass (18/18)
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify in a session with memory recall enabled: trigger deep repair, then check that the recall marker is stripped from messages after the retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
