### PR TITLE
Fix missing assistantId arg in channel inbound processMessage call

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -415,7 +415,7 @@ export class RuntimeHttpServer {
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(result.conversationId, content);
+        await this.processMessage(assistantId, result.conversationId, content);
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }


### PR DESCRIPTION
## Summary
- `handleChannelInbound` called `processMessage(result.conversationId, content)` but the signature expects `(assistantId, conversationId, content, attachmentIds?)`
- This caused `conversationId` to be passed as `assistantId` and `content` as `conversationId`, so the agent loop ran with the wrong conversation and the user's message was never processed correctly
- Fix: add `assistantId` as the first argument

## Test plan
- [x] Send a Telegram message and verify the AI responds with contextually relevant content (not a generic greeting)
- [x] Query `messages` table to verify the correct conversation ID is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)