### PR TITLE
Fix channel inbound duplicate message (PR #694 follow-up)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -186,8 +186,8 @@ export async function runDaemon(): Promise<void> {
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({
         port,
-        processMessage: (assistantId, conversationId, content, attachmentIds) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds),
+        processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds, options),
       });
       try {
         await runtimeHttp.start();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -214,8 +214,17 @@ export class Session {
 
       if (options?.userMessageAlreadyPersisted) {
         // The user message was already persisted (e.g. by channel inbound
-        // idempotency logic) and loaded into this.messages via loadFromDb().
-        // Find its ID from the DB for memory-recall exclusion.
+        // idempotency logic).  We still need to add it to the in-memory
+        // messages array so the agent loop sees it (loadFromDb only runs
+        // when a session is first created, not on subsequent messages).
+        const userMessage = createUserMessage(content, attachments.map((attachment) => ({
+          id: attachment.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          data: attachment.data,
+          extractedText: attachment.extractedText,
+        })));
+        this.messages.push(userMessage);
         const dbMessages = conversationStore.getMessages(this.conversationId);
         const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
         userMessageId = lastUserMsg?.id ?? '';

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -70,7 +70,8 @@ export function recordInbound(
 
   // Wrap message insert + event insert in a single transaction so a partial
   // failure doesn't leave an orphaned message without an idempotency record.
-  const message = { id: messageId, conversationId: mapping.conversationId, role: 'user', content, createdAt: now };
+  const jsonContent = JSON.stringify([{ type: 'text', text: content }]);
+  const message = { id: messageId, conversationId: mapping.conversationId, role: 'user', content: jsonContent, createdAt: now };
 
   db.transaction((tx) => {
     tx.insert(messages).values(message).run();


### PR DESCRIPTION
## Summary
- **lifecycle.ts**: Forward `options` arg to `server.processMessage` — it was silently dropped, so `userMessageAlreadyPersisted` never reached the session
- **session.ts**: Push user message into `this.messages` even when already persisted, so the agent loop sees it (loadFromDb only runs on session creation, not subsequent messages)
- **channel-delivery-store.ts**: Store user message as JSON content blocks (`[{"type":"text","text":"..."}]`) for consistency with the rest of the system

## Test plan
- [ ] Send a Telegram message → verify only 1 user message row in `messages` table
- [ ] Verify assistant reply is returned and sent back to Telegram
- [ ] Send a second message in the same conversation → verify no duplicate and reply works
- [ ] Restart daemon, send another message → verify loadFromDb path still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
