### PR TITLE
Fix false reply alert on send failure

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -251,14 +251,27 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const lastMessage = messages[messages.length - 1];
   const isWaitingForResponse = lastMessage?.role === "user";
 
+  const lastAssistantMessage = useMemo(
+    () => [...messages].reverse().find((m) => m.role === "assistant"),
+    [messages],
+  );
+  const lastAssistantMessageId = lastAssistantMessage?.id;
+
   const wasWaitingRef = useRef(false);
+  const lastAlertedAssistantIdRef = useRef(lastAssistantMessageId);
   useEffect(() => {
-    if (wasWaitingRef.current && !isWaitingForResponse && !document.hasFocus()) {
+    const hasNewAssistantMessage =
+      lastAssistantMessageId !== undefined &&
+      lastAssistantMessageId !== lastAlertedAssistantIdRef.current;
+    if (wasWaitingRef.current && !isWaitingForResponse && hasNewAssistantMessage && !document.hasFocus()) {
       const audio = new Audio("/wilhelm.mp3");
       audio.play().catch(() => {});
     }
+    if (hasNewAssistantMessage) {
+      lastAlertedAssistantIdRef.current = lastAssistantMessageId;
+    }
     wasWaitingRef.current = isWaitingForResponse;
-  }, [isWaitingForResponse]);
+  }, [isWaitingForResponse, lastAssistantMessageId]);
 
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const lastMessageId = lastMessage?.id;


### PR DESCRIPTION
## Summary
- Fixed a bug where the reply notification (sound when tab is unfocused) would fire on send failures
- The root cause was that `isWaitingForResponse` transitioning `true -> false` (when the optimistic user message was removed on POST failure) was incorrectly treated as a completed response
- Now tracks the last assistant message ID and only triggers the alert when `isWaitingForResponse` transitions to `false` AND a new assistant message actually appeared

## Test plan
- [ ] Send a message with the tab unfocused -- notification should play when assistant replies
- [ ] Disconnect network/cause a send failure with tab unfocused -- notification should NOT play
- [ ] Multiple assistant replies in sequence should each trigger a notification when tab is unfocused

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
