### PR TITLE
Fix user message missing on cached sessions and forward options in lifecycle

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -186,8 +186,8 @@ export async function runDaemon(): Promise<void> {
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({
         port,
-        processMessage: (assistantId, conversationId, content, attachmentIds) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds),
+        processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds, options),
       });
       try {
         await runtimeHttp.start();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -214,11 +214,21 @@ export class Session {
 
       if (options?.userMessageAlreadyPersisted) {
         // The user message was already persisted (e.g. by channel inbound
-        // idempotency logic) and loaded into this.messages via loadFromDb().
-        // Find its ID from the DB for memory-recall exclusion.
+        // idempotency logic). Find its ID from the DB for memory-recall
+        // exclusion, and always add to in-memory array so the LLM sees it
+        // (cached sessions skip loadFromDb on subsequent messages).
         const dbMessages = conversationStore.getMessages(this.conversationId);
         const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
         userMessageId = lastUserMsg?.id ?? '';
+
+        const userMessage = createUserMessage(content, attachments.map((attachment) => ({
+          id: attachment.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          data: attachment.data,
+          extractedText: attachment.extractedText,
+        })));
+        this.messages.push(userMessage);
       } else {
         // Add user message
         const userMessage = createUserMessage(content, attachments.map((attachment) => ({


### PR DESCRIPTION
## Summary

Addresses feedback from Devin and Codex on PR #694:

- **User message missing from in-memory array on cached sessions:** When `userMessageAlreadyPersisted` is true, the code only looked up the message ID from DB but never pushed the user message into `this.messages`. On cached sessions (where `loadFromDb()` is not called again for subsequent messages), the LLM never saw the new user message. Fixed by always pushing the user message into `this.messages` in the `userMessageAlreadyPersisted` branch.

- **Options not forwarded through lifecycle callback:** The `RuntimeHttpServer` callback in `lifecycle.ts` only accepted four parameters and dropped the `options` argument, so `userMessageAlreadyPersisted` was never forwarded to `server.processMessage`. Fixed by adding the fifth `options` parameter to the callback.

## Files modified
- `assistant/src/daemon/session.ts` — Push user message into `this.messages` in the `userMessageAlreadyPersisted` branch
- `assistant/src/daemon/lifecycle.ts` — Forward `options` parameter through the processMessage callback

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify channel inbound flow works for first message in a conversation
- [ ] Verify channel inbound flow works for second+ messages (cached session path)
- [ ] Verify the LLM sees all user messages in multi-turn channel conversations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
