### PR TITLE
Fix POST /messages blocking and empty messageId on error

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -186,8 +186,10 @@ export async function runDaemon(): Promise<void> {
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({
         port,
-        processMessage: (assistantId, conversationId, content, attachmentIds) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds),
+        processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds, options),
+        persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds) =>
+          server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds),
       });
       try {
         await runtimeHttp.start();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -463,9 +463,46 @@ export class DaemonServer {
   }
 
   /**
-   * Process a message from the HTTP runtime API.
-   * Gets or creates a session and runs the agent loop.
-   * Results are saved to the DB for the web UI to poll.
+   * Persist a user message and start the agent loop in the background.
+   * Returns the messageId immediately without waiting for the agent loop
+   * to complete. Used by the HTTP sendMessage endpoint so the response
+   * is not blocked for the duration of the agent loop.
+   */
+  async persistAndProcessMessage(
+    assistantId: string,
+    conversationId: string,
+    content: string,
+    attachmentIds?: string[],
+  ): Promise<{ messageId: string }> {
+    const session = await this.getOrCreateSession(conversationId);
+
+    // Resolve attachment IDs to full attachment data for the session
+    const attachments = attachmentIds
+      ? attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+          id: a.id,
+          filename: a.originalFilename,
+          mimeType: a.mimeType,
+          data: a.dataBase64,
+        }))
+      : [];
+
+    // persistUserMessage throws if the session is busy or persistence fails
+    const requestId = crypto.randomUUID();
+    const messageId = session.persistUserMessage(content, attachments, requestId);
+
+    // Fire-and-forget the agent loop. Errors are logged but do not
+    // affect the HTTP response (the client polls GET /messages).
+    session.runAgentLoop(content, messageId, () => {}).catch((err) => {
+      log.error({ err, conversationId }, 'Background agent loop failed');
+    });
+
+    return { messageId };
+  }
+
+  /**
+   * Process a message from the HTTP runtime API (blocking).
+   * Gets or creates a session and runs the full agent loop before returning.
+   * Used by the channel inbound endpoint which needs the assistant reply.
    */
   async processMessage(
     assistantId: string,
@@ -491,6 +528,10 @@ export class DaemonServer {
       : [];
 
     const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID(), options);
+
+    if (!messageId) {
+      throw new Error('Failed to persist user message');
+    }
 
     return { messageId };
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -186,60 +186,85 @@ export class Session {
     this.prompter.resolveConfirmation(requestId, decision, selectedPattern, selectedScope);
   }
 
-  async processMessage(
+  /**
+   * Persist a user message and mark the session as processing.
+   * Returns the messageId immediately without running the agent loop.
+   * After calling this, call `runAgentLoop` to continue processing.
+   */
+  persistUserMessage(
     content: string,
     attachments: UserMessageAttachment[],
-    onEvent: (msg: ServerMessage) => void,
     requestId?: string,
     options?: { userMessageAlreadyPersisted?: boolean },
-  ): Promise<string> {
+  ): string {
     if (this.processing) {
-      onEvent({ type: 'error', message: 'Already processing a message' });
-      return '';
+      throw new Error('Session is already processing a message');
+    }
+
+    if (!content.trim() && attachments.length === 0) {
+      throw new Error('Message content or attachments are required');
     }
 
     const reqId = requestId ?? uuid();
     this.currentRequestId = reqId;
-    const rlog = log.child({ conversationId: this.conversationId, requestId: reqId });
     this.processing = true;
     this.abortController = new AbortController();
+
     let userMessageId = '';
 
-    try {
-      const isFirstMessage = this.messages.length === 0;
-      if (!content.trim() && attachments.length === 0) {
-        onEvent({ type: 'error', message: 'Message content or attachments are required' });
-        return '';
-      }
+    if (options?.userMessageAlreadyPersisted) {
+      const dbMessages = conversationStore.getMessages(this.conversationId);
+      const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
+      userMessageId = lastUserMsg?.id ?? '';
+    } else {
+      const userMessage = createUserMessage(content, attachments.map((attachment) => ({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        data: attachment.data,
+        extractedText: attachment.extractedText,
+      })));
+      this.messages.push(userMessage);
+      const persistedUserMessage = conversationStore.addMessage(
+        this.conversationId,
+        'user',
+        JSON.stringify(userMessage.content),
+      );
+      userMessageId = persistedUserMessage.id;
+    }
 
-      if (options?.userMessageAlreadyPersisted) {
-        // The user message was already persisted (e.g. by channel inbound
-        // idempotency logic) and loaded into this.messages via loadFromDb().
-        // Find its ID from the DB for memory-recall exclusion.
-        const dbMessages = conversationStore.getMessages(this.conversationId);
-        const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
-        userMessageId = lastUserMsg?.id ?? '';
-      } else {
-        // Add user message
-        const userMessage = createUserMessage(content, attachments.map((attachment) => ({
-          id: attachment.id,
-          filename: attachment.filename,
-          mimeType: attachment.mimeType,
-          data: attachment.data,
-          extractedText: attachment.extractedText,
-        })));
-        this.messages.push(userMessage);
-        const persistedUserMessage = conversationStore.addMessage(
-          this.conversationId,
-          'user',
-          JSON.stringify(userMessage.content),
-        );
-        userMessageId = persistedUserMessage.id;
-      }
+    if (!userMessageId) {
+      this.processing = false;
+      this.abortController = null;
+      this.currentRequestId = undefined;
+      throw new Error('Failed to persist user message');
+    }
+
+    return userMessageId;
+  }
+
+  /**
+   * Run the agent loop after a user message has been persisted via
+   * `persistUserMessage`. Clears the `processing` flag when done.
+   */
+  async runAgentLoop(
+    content: string,
+    userMessageId: string,
+    onEvent: (msg: ServerMessage) => void,
+  ): Promise<void> {
+    if (!this.abortController) {
+      throw new Error('runAgentLoop called without prior persistUserMessage');
+    }
+    const abortController = this.abortController;
+    const reqId = this.currentRequestId ?? uuid();
+    const rlog = log.child({ conversationId: this.conversationId, requestId: reqId });
+
+    try {
+      const isFirstMessage = this.messages.length === 1;
 
       const compacted = await this.contextWindowManager.maybeCompact(
         this.messages,
-        this.abortController.signal,
+        abortController.signal,
       );
       if (compacted.compacted) {
         this.messages = compacted.messages;
@@ -281,7 +306,7 @@ export class Session {
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
         excludeMessageIds: [userMessageId],
-        signal: this.abortController.signal,
+        signal: abortController.signal,
       });
 
       onEvent({
@@ -399,7 +424,7 @@ export class Session {
       let updatedHistory = await this.agentLoop.run(
         runMessages,
         buildEventHandler(),
-        this.abortController.signal,
+        abortController.signal,
         reqId,
       );
 
@@ -423,7 +448,7 @@ export class Session {
         updatedHistory = await this.agentLoop.run(
           runMessages,
           buildEventHandler(),
-          this.abortController.signal,
+          abortController.signal,
           reqId,
         );
 
@@ -483,7 +508,7 @@ export class Session {
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent);
 
-      if (this.abortController?.signal.aborted) {
+      if (abortController.signal.aborted) {
         onEvent({ type: 'generation_cancelled' });
       } else {
         onEvent({ type: 'message_complete' });
@@ -497,7 +522,7 @@ export class Session {
       }
     } catch (err) {
       // AbortError is expected when user cancels — don't treat as an error
-      if (this.abortController?.signal.aborted) {
+      if (abortController.signal.aborted) {
         rlog.info('Generation cancelled by user');
         onEvent({ type: 'generation_cancelled' });
       } else {
@@ -510,7 +535,29 @@ export class Session {
       this.processing = false;
       this.currentRequestId = undefined;
     }
+  }
 
+  /**
+   * Convenience method that persists a user message and runs the agent loop
+   * in a single call. Used by the IPC path where blocking is expected.
+   */
+  async processMessage(
+    content: string,
+    attachments: UserMessageAttachment[],
+    onEvent: (msg: ServerMessage) => void,
+    requestId?: string,
+    options?: { userMessageAlreadyPersisted?: boolean },
+  ): Promise<string> {
+    let userMessageId: string;
+    try {
+      userMessageId = this.persistUserMessage(content, attachments, requestId, options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      onEvent({ type: 'error', message });
+      return '';
+    }
+
+    await this.runAgentLoop(content, userMessageId, onEvent);
     return userMessageId;
   }
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -29,9 +29,23 @@ export type MessageProcessor = (
   options?: { userMessageAlreadyPersisted?: boolean },
 ) => Promise<{ messageId: string }>;
 
+/**
+ * Non-blocking message processor that persists the user message and
+ * starts the agent loop in the background, returning the messageId
+ * immediately.
+ */
+export type NonBlockingMessageProcessor = (
+  assistantId: string,
+  conversationId: string,
+  content: string,
+  attachmentIds?: string[],
+) => Promise<{ messageId: string }>;
+
 export interface RuntimeHttpServerOptions {
   port?: number;
   processMessage?: MessageProcessor;
+  /** Non-blocking processor for POST /messages (persists + fires agent loop). */
+  persistAndProcessMessage?: NonBlockingMessageProcessor;
 }
 
 interface RuntimeMessagePayload {
@@ -49,12 +63,14 @@ export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
   private processMessage?: MessageProcessor;
+  private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
     this.processMessage = options.processMessage;
+    this.persistAndProcessMessage = options.persistAndProcessMessage;
   }
 
   async start(): Promise<void> {
@@ -355,12 +371,13 @@ export class RuntimeHttpServer {
 
     const mapping = getOrCreateConversation(assistantId, conversationKey);
 
-    if (!this.processMessage) {
+    const processor = this.persistAndProcessMessage ?? this.processMessage;
+    if (!processor) {
       return Response.json({ error: 'Message processing not configured' }, { status: 503 });
     }
 
     try {
-      const result = await this.processMessage(
+      const result = await processor(
         assistantId,
         mapping.conversationId,
         content ?? '',


### PR DESCRIPTION
## Summary
- **Non-blocking POST /messages**: Split `session.processMessage` into `persistUserMessage` (returns messageId immediately) and `runAgentLoop` (runs in background). The HTTP `POST /messages` handler now only awaits message persistence, returning the messageId without blocking for the full agent loop. Clients continue to use `GET /messages` polling for results.
- **Empty messageId guard**: `persistUserMessage` throws if the messageId is empty after persistence, and `DaemonServer.processMessage` also validates the returned messageId. These errors propagate as 500 responses instead of silently returning `{"messageId":""}`.
- Channel inbound endpoint (`POST /channels/inbound`) still blocks for the full agent loop since it needs the assistant reply in the response.

Addresses review feedback on #693.

## Test plan
- [ ] POST /messages returns `{ messageId }` immediately without waiting for agent loop
- [ ] GET /messages returns the assistant reply after the agent loop completes
- [ ] POST /messages while session is processing returns 409
- [ ] Internal persistence failure returns 500 (not 200 with empty messageId)
- [ ] Channel inbound still blocks and returns assistant reply
- [ ] Type-check passes (`bunx tsc --noEmit`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
