### PR TITLE
Normalize async message contract with accepted flag and runId

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -383,7 +383,7 @@ export class RuntimeHttpServer {
         content ?? '',
         hasAttachments ? attachmentIds : undefined,
       );
-      return Response.json({ messageId: result.messageId });
+      return Response.json({ accepted: true, messageId: result.messageId });
     } catch (err) {
       if (err instanceof Error && err.message === 'Session is already processing a message') {
         return Response.json(

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -88,8 +88,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
 
     return NextResponse.json({
-      success: true,
+      accepted: result.accepted,
       messageId: result.messageId,
+      ...(result.runId ? { runId: result.runId } : {}),
       ...(result.assistantMessage ? { assistantMessage: result.assistantMessage } : {}),
     });
   } catch (error: unknown) {

--- a/web/src/lib/runtime/types.ts
+++ b/web/src/lib/runtime/types.ts
@@ -54,7 +54,9 @@ export interface SendMessageParams {
 }
 
 export interface SendMessageResponse {
+  accepted: boolean;
   messageId: string;
+  runId?: string;
   assistantMessage?: RuntimeMessage;
 }
 


### PR DESCRIPTION
## Summary
- Runtime `POST /messages` now returns `{ accepted: true, messageId }` making the async fire-and-forget nature explicit
- Added optional `runId` field to `SendMessageResponse` to prepare for the run-based approval flow
- Web types and proxy route updated to match the runtime contract (replaced `success` with `accepted`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
