### PR TITLE
Align web env contract and docs with runtime resolution

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -23,7 +23,8 @@ Every assistant-facing API route proxies through a single `RuntimeClient` abstra
 Environment variables:
 
 - `ASSISTANT_CONNECTION_MODE` — `cloud` (default) or `local`.
-- `LOCAL_DAEMON_SOCKET_PATH` — Unix socket path for local mode (default: `~/.vellum/vellum.sock`).
+- `CLOUD_RUNTIME_URL` — Base URL for the hosted cloud runtime (required in cloud mode).
+- `LOCAL_RUNTIME_URL` — Override the default local runtime URL (default: `http://127.0.0.1:7821`).
 
 ### Assistant Auth
 

--- a/web/src/lib/assistant-connection.ts
+++ b/web/src/lib/assistant-connection.ts
@@ -1,6 +1,3 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 export type AssistantConnectionMode = "cloud" | "local";
 
 const DEFAULT_CONNECTION_MODE: AssistantConnectionMode = "cloud";
@@ -15,28 +12,10 @@ function normalizeConnectionMode(
   return DEFAULT_CONNECTION_MODE;
 }
 
-function expandHomePath(pathValue: string): string {
-  if (pathValue === "~") {
-    return homedir();
-  }
-  if (pathValue.startsWith("~/")) {
-    return join(homedir(), pathValue.slice(2));
-  }
-  return pathValue;
-}
-
 export function getAssistantConnectionMode(): AssistantConnectionMode {
   return normalizeConnectionMode(process.env.ASSISTANT_CONNECTION_MODE);
 }
 
 export function isLocalDaemonMode(): boolean {
   return getAssistantConnectionMode() === "local";
-}
-
-export function getLocalDaemonSocketPath(): string {
-  const configuredPath = process.env.LOCAL_DAEMON_SOCKET_PATH?.trim();
-  if (!configuredPath) {
-    return join(homedir(), ".vellum", "vellum.sock");
-  }
-  return expandHomePath(configuredPath);
 }


### PR DESCRIPTION
## Summary
- Replace stale `LOCAL_DAEMON_SOCKET_PATH` docs with actual env vars (`CLOUD_RUNTIME_URL`, `LOCAL_RUNTIME_URL`) in web README
- Remove dead `getLocalDaemonSocketPath()` and `expandHomePath()` from `assistant-connection.ts` (unused by runtime URL resolver)
- Default connection mode (`cloud`) remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
