### PR TITLE
Add SSH runtime tunnel helper script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,35 @@
-# Automation Commands
+# Scripts
 
-This directory contains slash commands for Claude Code that automate development workflows. They manage a shared task list (`.private/TODO.md`), create PRs, merge them, and track review status.
+This directory contains automation commands for Claude Code and helper scripts for development workflows.
+
+## Utility Scripts
+
+### `vellum-runtime-tunnel.sh` — SSH tunnel for remote runtime access
+
+Forwards a local TCP port to a remote Vellum runtime HTTP server via SSH. Use this when running the web app in local mode against a remote assistant daemon.
+
+```bash
+# Start a tunnel to a remote host
+scripts/vellum-runtime-tunnel.sh start user@remote-host
+
+# Check tunnel status
+scripts/vellum-runtime-tunnel.sh status
+
+# Print env vars for web local mode
+scripts/vellum-runtime-tunnel.sh print-env
+# Output:
+#   ASSISTANT_CONNECTION_MODE=local
+#   LOCAL_RUNTIME_URL=http://127.0.0.1:7821
+
+# Stop the tunnel
+scripts/vellum-runtime-tunnel.sh stop
+```
+
+Options: `--local-port PORT` and `--remote-port PORT` (both default to 7821).
+
+## Automation Commands
+
+Slash commands for Claude Code that automate development workflows. They manage a shared task list (`.private/TODO.md`), create PRs, merge them, and track review status.
 
 ## Setup
 

--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# vellum-runtime-tunnel.sh — SSH tunnel helper for remote runtime HTTP access.
+#
+# Forwards a local TCP port to a remote Vellum runtime HTTP server via SSH.
+# Designed for web local mode: set LOCAL_RUNTIME_URL to the forwarded port.
+#
+# Usage:
+#   vellum-runtime-tunnel.sh start <ssh-host> [options]
+#   vellum-runtime-tunnel.sh stop
+#   vellum-runtime-tunnel.sh status
+#   vellum-runtime-tunnel.sh print-env
+#
+# Options:
+#   --local-port PORT    Local port to bind (default: 7821)
+#   --remote-port PORT   Remote runtime HTTP port (default: 7821)
+
+set -euo pipefail
+
+DEFAULT_PORT=7821
+PID_FILE="${HOME}/.vellum/runtime-tunnel.pid"
+INFO_FILE="${HOME}/.vellum/runtime-tunnel.info"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+ensure_dir() {
+  mkdir -p "${HOME}/.vellum"
+}
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    cat "$PID_FILE"
+  fi
+}
+
+is_running() {
+  local pid
+  pid=$(read_pid)
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+cmd_start() {
+  local ssh_host=""
+  local local_port="$DEFAULT_PORT"
+  local remote_port="$DEFAULT_PORT"
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --local-port)
+        local_port="$2"; shift 2 ;;
+      --remote-port)
+        remote_port="$2"; shift 2 ;;
+      -*)
+        die "unknown option: $1" ;;
+      *)
+        if [[ -z "$ssh_host" ]]; then
+          ssh_host="$1"; shift
+        else
+          die "unexpected argument: $1"
+        fi
+        ;;
+    esac
+  done
+
+  [[ -n "$ssh_host" ]] || die "usage: $0 start <ssh-host> [--local-port PORT] [--remote-port PORT]"
+
+  if is_running; then
+    echo "Tunnel already running (PID $(read_pid))"
+    return 0
+  fi
+
+  ensure_dir
+
+  echo "Starting SSH tunnel: localhost:${local_port} -> ${ssh_host}:${remote_port} ..."
+  ssh -f -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host"
+
+  # Find the ssh process we just spawned
+  local pid
+  pid=$(pgrep -f "ssh.*-L.*127.0.0.1:${local_port}:127.0.0.1:${remote_port}.*${ssh_host}" | tail -1)
+  if [[ -z "$pid" ]]; then
+    die "failed to find SSH tunnel process"
+  fi
+
+  echo "$pid" > "$PID_FILE"
+  cat > "$INFO_FILE" <<EOINFO
+LOCAL_PORT=${local_port}
+REMOTE_PORT=${remote_port}
+SSH_HOST=${ssh_host}
+EOINFO
+
+  echo "Tunnel running (PID ${pid})"
+  echo "Set LOCAL_RUNTIME_URL=http://127.0.0.1:${local_port} for web local mode."
+}
+
+cmd_stop() {
+  if ! is_running; then
+    echo "No tunnel running."
+    rm -f "$PID_FILE" "$INFO_FILE"
+    return 0
+  fi
+
+  local pid
+  pid=$(read_pid)
+  echo "Stopping tunnel (PID ${pid}) ..."
+  kill "$pid" 2>/dev/null || true
+  rm -f "$PID_FILE" "$INFO_FILE"
+  echo "Tunnel stopped."
+}
+
+cmd_status() {
+  if is_running; then
+    local pid
+    pid=$(read_pid)
+    echo "Tunnel running (PID ${pid})"
+    if [[ -f "$INFO_FILE" ]]; then
+      cat "$INFO_FILE"
+    fi
+  else
+    echo "No tunnel running."
+    rm -f "$PID_FILE" "$INFO_FILE"
+  fi
+}
+
+cmd_print_env() {
+  if ! is_running; then
+    die "no tunnel running — start one first"
+  fi
+
+  if [[ ! -f "$INFO_FILE" ]]; then
+    die "tunnel info file missing"
+  fi
+
+  # shellcheck source=/dev/null
+  source "$INFO_FILE"
+  echo "ASSISTANT_CONNECTION_MODE=local"
+  echo "LOCAL_RUNTIME_URL=http://127.0.0.1:${LOCAL_PORT}"
+}
+
+case "${1:-}" in
+  start)     shift; cmd_start "$@" ;;
+  stop)      cmd_stop ;;
+  status)    cmd_status ;;
+  print-env) cmd_print_env ;;
+  *)
+    echo "Usage: $0 {start|stop|status|print-env}"
+    echo ""
+    echo "Commands:"
+    echo "  start <ssh-host> [--local-port PORT] [--remote-port PORT]"
+    echo "      Start an SSH tunnel to a remote Vellum runtime."
+    echo "  stop"
+    echo "      Stop the running tunnel."
+    echo "  status"
+    echo "      Check if a tunnel is running."
+    echo "  print-env"
+    echo "      Print env vars for web local mode."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `scripts/vellum-runtime-tunnel.sh` with `start|stop|status|print-env` commands for SSH local TCP forwarding to a remote runtime HTTP server
- `print-env` outputs `ASSISTANT_CONNECTION_MODE=local` and `LOCAL_RUNTIME_URL` for web local mode
- Update `scripts/README.md` with usage documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
