### PR TITLE
Add message_runs persistence for approval flow

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -198,6 +198,23 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS message_runs (
+      id TEXT PRIMARY KEY,
+      assistant_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'running',
+      pending_confirmation TEXT,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      estimated_cost REAL NOT NULL DEFAULT 0,
+      error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS cron_jobs (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -302,6 +319,9 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_id ON message_attachments(attachment_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_lookup ON channel_inbound_events(assistant_id, source_channel, external_chat_id, external_message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_inbound_events_conversation ON channel_inbound_events(conversation_id)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_assistant_status ON message_runs(assistant_id, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_runs_conversation ON message_runs(conversation_id)`);
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id ON cron_runs(job_id)`);

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -1,0 +1,168 @@
+/**
+ * CRUD store for message runs (approval flow state).
+ *
+ * Runs track the lifecycle of an agent loop triggered by a user message:
+ *   running → needs_confirmation → running → completed | failed
+ */
+
+import { eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { messageRuns } from './schema.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RunStatus = 'running' | 'needs_confirmation' | 'completed' | 'failed';
+
+export interface PendingConfirmation {
+  toolName: string;
+  toolUseId: string;
+  input: Record<string, unknown>;
+  riskLevel: string;
+}
+
+export interface Run {
+  id: string;
+  assistantId: string;
+  conversationId: string;
+  messageId: string | null;
+  status: RunStatus;
+  pendingConfirmation: PendingConfirmation | null;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RunUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCost?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToRun(row: typeof messageRuns.$inferSelect): Run {
+  let pendingConfirmation: PendingConfirmation | null = null;
+  if (row.pendingConfirmation) {
+    try { pendingConfirmation = JSON.parse(row.pendingConfirmation); } catch { /* malformed */ }
+  }
+  return {
+    id: row.id,
+    assistantId: row.assistantId,
+    conversationId: row.conversationId,
+    messageId: row.messageId,
+    status: row.status as RunStatus,
+    pendingConfirmation,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    estimatedCost: row.estimatedCost,
+    error: row.error,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export function createRun(
+  assistantId: string,
+  conversationId: string,
+  messageId?: string,
+): Run {
+  const db = getDb();
+  const now = Date.now();
+  const id = uuid();
+
+  const row = {
+    id,
+    assistantId,
+    conversationId,
+    messageId: messageId ?? null,
+    status: 'running' as const,
+    pendingConfirmation: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    estimatedCost: 0,
+    error: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(messageRuns).values(row).run();
+
+  return rowToRun(row);
+}
+
+export function getRun(runId: string): Run | null {
+  const db = getDb();
+  const row = db.select().from(messageRuns).where(eq(messageRuns.id, runId)).get();
+  return row ? rowToRun(row) : null;
+}
+
+export function setRunConfirmation(
+  runId: string,
+  confirmation: PendingConfirmation,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'needs_confirmation',
+      pendingConfirmation: JSON.stringify(confirmation),
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
+export function clearRunConfirmation(runId: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'running',
+      pendingConfirmation: null,
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
+export function completeRun(runId: string, usage?: RunUsage): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'completed',
+      pendingConfirmation: null,
+      ...(usage?.inputTokens != null ? { inputTokens: usage.inputTokens } : {}),
+      ...(usage?.outputTokens != null ? { outputTokens: usage.outputTokens } : {}),
+      ...(usage?.estimatedCost != null ? { estimatedCost: usage.estimatedCost } : {}),
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}
+
+export function failRun(runId: string, error: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(messageRuns)
+    .set({
+      status: 'failed',
+      pendingConfirmation: null,
+      error,
+      updatedAt: now,
+    })
+    .where(eq(messageRuns.id, runId))
+    .run();
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -162,6 +162,26 @@ export const channelInboundEvents = sqliteTable('channel_inbound_events', {
   updatedAt: integer('updated_at').notNull(),
 });
 
+// ── Message Runs (approval flow) ─────────────────────────────────────
+
+export const messageRuns = sqliteTable('message_runs', {
+  id: text('id').primaryKey(),
+  assistantId: text('assistant_id').notNull(),
+  conversationId: text('conversation_id')
+    .notNull()
+    .references(() => conversations.id, { onDelete: 'cascade' }),
+  messageId: text('message_id')
+    .references(() => messages.id, { onDelete: 'cascade' }),
+  status: text('status').notNull().default('running'),          // running | needs_confirmation | completed | failed
+  pendingConfirmation: text('pending_confirmation'),            // JSON when status=needs_confirmation
+  inputTokens: integer('input_tokens').notNull().default(0),
+  outputTokens: integer('output_tokens').notNull().default(0),
+  estimatedCost: real('estimated_cost').notNull().default(0),
+  error: text('error'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const memoryCheckpoints = sqliteTable('memory_checkpoints', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),


### PR DESCRIPTION
## Summary
- New `message_runs` SQLite table tracking agent loop lifecycle (`running` → `needs_confirmation` → `completed`/`failed`)
- New `runs-store.ts` with CRUD operations: `createRun`, `getRun`, `setRunConfirmation`, `clearRunConfirmation`, `completeRun`, `failRun`
- Run state survives daemon restart so pending approvals are preserved across refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
