### PR TITLE
Add VELLUM_DAEMON_SOCKET override to CLI

### DIFF
--- a/assistant/src/__tests__/platform-socket-path.test.ts
+++ b/assistant/src/__tests__/platform-socket-path.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+describe('getSocketPath', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.VELLUM_DAEMON_SOCKET;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VELLUM_DAEMON_SOCKET;
+    } else {
+      process.env.VELLUM_DAEMON_SOCKET = originalEnv;
+    }
+  });
+
+  test('returns default path when no override is set', async () => {
+    delete process.env.VELLUM_DAEMON_SOCKET;
+    // Re-import to pick up env changes
+    const { getSocketPath } = await import('../util/platform.js');
+    expect(getSocketPath()).toBe(join(homedir(), '.vellum', 'vellum.sock'));
+  });
+
+  test('uses VELLUM_DAEMON_SOCKET when set', async () => {
+    process.env.VELLUM_DAEMON_SOCKET = '/tmp/custom.sock';
+    const { getSocketPath } = await import('../util/platform.js');
+    expect(getSocketPath()).toBe('/tmp/custom.sock');
+  });
+
+  test('expands ~ in VELLUM_DAEMON_SOCKET', async () => {
+    process.env.VELLUM_DAEMON_SOCKET = '~/my-sockets/vellum.sock';
+    const { getSocketPath } = await import('../util/platform.js');
+    expect(getSocketPath()).toBe(join(homedir(), 'my-sockets', 'vellum.sock'));
+  });
+
+  test('trims whitespace from VELLUM_DAEMON_SOCKET', async () => {
+    process.env.VELLUM_DAEMON_SOCKET = '  /tmp/custom.sock  ';
+    const { getSocketPath } = await import('../util/platform.js');
+    expect(getSocketPath()).toBe('/tmp/custom.sock');
+  });
+
+  test('ignores empty VELLUM_DAEMON_SOCKET', async () => {
+    process.env.VELLUM_DAEMON_SOCKET = '   ';
+    const { getSocketPath } = await import('../util/platform.js');
+    expect(getSocketPath()).toBe(join(homedir(), '.vellum', 'vellum.sock'));
+  });
+});

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -38,7 +38,17 @@ export function getDataDir(): string {
 }
 
 export function getSocketPath(): string {
+  const override = process.env.VELLUM_DAEMON_SOCKET?.trim();
+  if (override) {
+    return expandHomePath(override);
+  }
   return join(getDataDir(), 'vellum.sock');
+}
+
+function expandHomePath(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
 }
 
 export function getPidPath(): string {


### PR DESCRIPTION
## Summary
- Add `VELLUM_DAEMON_SOCKET` env var support to `getSocketPath()` in `platform.ts` with `~` expansion
- Default path (`~/.vellum/vellum.sock`) unchanged when env var is not set
- Add tests for override, tilde expansion, whitespace trimming, and empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
