### PR TITLE
Add autostart policy for remote socket mode

### DIFF
--- a/assistant/src/__tests__/connection-policy.test.ts
+++ b/assistant/src/__tests__/connection-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from 'bun:test';
+import { hasSocketOverride, shouldAutoStartDaemon } from '../daemon/connection-policy.js';
+
+describe('hasSocketOverride', () => {
+  test('returns false when VELLUM_DAEMON_SOCKET is not set', () => {
+    expect(hasSocketOverride({})).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_SOCKET is empty', () => {
+    expect(hasSocketOverride({ VELLUM_DAEMON_SOCKET: '' })).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_SOCKET is whitespace', () => {
+    expect(hasSocketOverride({ VELLUM_DAEMON_SOCKET: '   ' })).toBe(false);
+  });
+
+  test('returns true when VELLUM_DAEMON_SOCKET is set', () => {
+    expect(hasSocketOverride({ VELLUM_DAEMON_SOCKET: '/tmp/custom.sock' })).toBe(true);
+  });
+});
+
+describe('shouldAutoStartDaemon', () => {
+  test('returns true by default (no env vars set)', () => {
+    expect(shouldAutoStartDaemon({})).toBe(true);
+  });
+
+  test('returns false when socket override is set', () => {
+    expect(shouldAutoStartDaemon({ VELLUM_DAEMON_SOCKET: '/tmp/custom.sock' })).toBe(false);
+  });
+
+  test('returns true when socket override + VELLUM_DAEMON_AUTOSTART=1', () => {
+    expect(shouldAutoStartDaemon({
+      VELLUM_DAEMON_SOCKET: '/tmp/custom.sock',
+      VELLUM_DAEMON_AUTOSTART: '1',
+    })).toBe(true);
+  });
+
+  test('returns true when VELLUM_DAEMON_AUTOSTART=true', () => {
+    expect(shouldAutoStartDaemon({
+      VELLUM_DAEMON_SOCKET: '/tmp/custom.sock',
+      VELLUM_DAEMON_AUTOSTART: 'true',
+    })).toBe(true);
+  });
+
+  test('returns false when VELLUM_DAEMON_AUTOSTART=0', () => {
+    expect(shouldAutoStartDaemon({ VELLUM_DAEMON_AUTOSTART: '0' })).toBe(false);
+  });
+
+  test('returns false when VELLUM_DAEMON_AUTOSTART=false', () => {
+    expect(shouldAutoStartDaemon({ VELLUM_DAEMON_AUTOSTART: 'false' })).toBe(false);
+  });
+
+  test('autostart flag takes precedence over socket override', () => {
+    // Explicit autostart=0 disables even without socket override
+    expect(shouldAutoStartDaemon({ VELLUM_DAEMON_AUTOSTART: '0' })).toBe(false);
+    // Explicit autostart=1 enables even with socket override
+    expect(shouldAutoStartDaemon({
+      VELLUM_DAEMON_SOCKET: '/tmp/custom.sock',
+      VELLUM_DAEMON_AUTOSTART: '1',
+    })).toBe(true);
+  });
+});

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -13,6 +13,7 @@ import { Spinner } from './util/spinner.js';
 import { copyToClipboard, extractLastCodeBlock, formatSessionForExport } from './util/clipboard.js';
 import { timeAgo } from './util/time.js';
 import { ensureDaemonRunning } from './daemon/lifecycle.js';
+import { shouldAutoStartDaemon } from './daemon/connection-policy.js';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 10_000;
@@ -587,7 +588,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
 
       try {
-        await ensureDaemonRunning();
+        if (shouldAutoStartDaemon()) await ensureDaemonRunning();
         await connect();
         if (options.noSandbox) {
           send({ type: 'sandbox_set', enabled: false });

--- a/assistant/src/daemon/connection-policy.ts
+++ b/assistant/src/daemon/connection-policy.ts
@@ -1,0 +1,25 @@
+/**
+ * Connection policy helpers for daemon autostart behavior.
+ *
+ * When the user targets a remote/forwarded socket via VELLUM_DAEMON_SOCKET,
+ * autostart should be disabled by default to avoid accidentally spawning
+ * a local daemon. VELLUM_DAEMON_AUTOSTART=1 forces autostart regardless.
+ */
+
+export function hasSocketOverride(env: Record<string, string | undefined> = process.env): boolean {
+  const override = env.VELLUM_DAEMON_SOCKET?.trim();
+  return !!override;
+}
+
+export function shouldAutoStartDaemon(env: Record<string, string | undefined> = process.env): boolean {
+  // Explicit autostart flag takes precedence
+  const autostart = env.VELLUM_DAEMON_AUTOSTART?.trim();
+  if (autostart === '1' || autostart === 'true') return true;
+  if (autostart === '0' || autostart === 'false') return false;
+
+  // No explicit flag: disable autostart when using a remote/custom socket
+  if (hasSocketOverride(env)) return false;
+
+  // Default: autostart enabled
+  return true;
+}

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { IpcError } from './util/errors.js';
 import { timeAgo } from './util/time.js';
+import { shouldAutoStartDaemon } from './daemon/connection-policy.js';
 import {
   loadRawConfig,
   saveRawConfig,
@@ -98,7 +99,9 @@ program
   .version(version)
   .option('--no-sandbox', 'Disable sandbox for this session (runtime override, not persisted)')
   .action(async (opts: { sandbox?: boolean }) => {
-    await ensureDaemonRunning();
+    if (shouldAutoStartDaemon()) {
+      await ensureDaemonRunning();
+    }
     await startCli({ noSandbox: opts.sandbox === false });
   });
 
@@ -194,7 +197,7 @@ sessions
   .command('list')
   .description('List all sessions')
   .action(async () => {
-    await ensureDaemonRunning();
+    if (shouldAutoStartDaemon()) await ensureDaemonRunning();
     const response = await sendOneMessage({ type: 'session_list' });
     if (response.type === 'session_list_response') {
       if (response.sessions.length === 0) {
@@ -213,7 +216,7 @@ sessions
   .command('new [title]')
   .description('Create a new session')
   .action(async (title?: string) => {
-    await ensureDaemonRunning();
+    if (shouldAutoStartDaemon()) await ensureDaemonRunning();
     const response = await sendOneMessage({
       type: 'session_create',
       title,


### PR DESCRIPTION
## Summary
- Add `connection-policy.ts` with `hasSocketOverride()` and `shouldAutoStartDaemon()` helpers
- Disable autostart by default when `VELLUM_DAEMON_SOCKET` is set (external socket mode)
- `VELLUM_DAEMON_AUTOSTART=1` forces autostart regardless
- Integrate into CLI default action, session commands, and reconnect logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
