### PR TITLE
Lock down /api/assistants and remove x-username

### DIFF
--- a/web/src/app/(app)/assistant/page.tsx
+++ b/web/src/app/(app)/assistant/page.tsx
@@ -60,14 +60,9 @@ export default function AssistantPage() {
     setHatchError(null);
 
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      headers["x-username"] = username;
-
       const response = await fetch("/api/assistants", {
         method: "POST",
-        headers,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
 

--- a/web/src/app/(app)/assistants/page.tsx
+++ b/web/src/app/(app)/assistants/page.tsx
@@ -11,7 +11,7 @@ import { Assistant } from "@/lib/db";
 
 export default function AssistantsPage() {
   const router = useRouter();
-  const { isLoggedIn, isLoading: isAuthLoading, username, email } = useAuth();
+  const { isLoggedIn, isLoading: isAuthLoading, email } = useAuth();
   const [assistants, setAssistants] = useState<Assistant[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
@@ -46,13 +46,9 @@ export default function AssistantsPage() {
     setProgressMessage("Initializing...");
     setError(null);
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (username) {
-        headers["x-username"] = username;
-      }
       const response = await fetch("/api/assistants", {
         method: "POST",
-        headers,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
 

--- a/web/src/app/api/assistants/route.ts
+++ b/web/src/app/api/assistants/route.ts
@@ -6,11 +6,17 @@ import {
   uploadEditorPage,
 } from "@/lib/gcp";
 import { createAssistantToken } from "@/lib/auth/assistant-tokens";
+import { getRequestUser } from "@/lib/auth/server-session";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const user = await getRequestUser(request);
+    if (!user.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const sql = getDb();
-    const assistants = await sql`SELECT * FROM assistants ORDER BY created_at DESC`;
+    const assistants = await sql`SELECT * FROM assistants WHERE created_by = ${user.id} ORDER BY created_at DESC`;
     return NextResponse.json(assistants as unknown as Assistant[]);
   } catch (error: unknown) {
     console.error("Error fetching assistants:", error);
@@ -28,8 +34,13 @@ export async function POST(request: Request) {
     return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
   }
 
+  const user = await getRequestUser(request);
+  if (!user.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const body: CreateAssistantInput = await request.json();
-  const createdBy = request.headers.get("x-username") || null;
+  const createdBy = user.id;
 
   const stream = new ReadableStream({
     async start(controller) {


### PR DESCRIPTION
## Summary
- `GET /api/assistants` now requires authenticated session and returns only the current user's assistants
- `POST /api/assistants` sets `created_by` from session user id — no longer trusts `x-username` header
- Removed `x-username` header usage from `/assistant` and `/assistants` client pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
