### PR TITLE
Add remote mode diagnostics to CLI and web runtime

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -24,7 +24,7 @@ import {
 } from './daemon/ipc-protocol.js';
 import { IpcError } from './util/errors.js';
 import { timeAgo } from './util/time.js';
-import { shouldAutoStartDaemon } from './daemon/connection-policy.js';
+import { shouldAutoStartDaemon, hasSocketOverride } from './daemon/connection-policy.js';
 import {
   loadRawConfig,
   saveRawConfig,
@@ -153,6 +153,8 @@ daemon
     } else {
       console.log('Daemon is not running');
     }
+    console.log(`Socket path: ${getSocketPath()}${hasSocketOverride() ? ' (override)' : ''}`);
+    console.log(`Autostart: ${shouldAutoStartDaemon() ? 'enabled' : 'disabled'}`);
   });
 
 // --- Dev command ---
@@ -616,6 +618,13 @@ program
       console.log(`  \u2717 ${label}${detail ? ` — ${detail}` : ''}`);
 
     console.log('Vellum Doctor\n');
+
+    // 0. Connection policy info
+    const socketPath = getSocketPath();
+    const isOverride = hasSocketOverride();
+    const autostart = shouldAutoStartDaemon();
+    console.log(`  Socket:    ${socketPath}${isOverride ? ' (override via VELLUM_DAEMON_SOCKET)' : ''}`);
+    console.log(`  Autostart: ${autostart ? 'enabled' : 'disabled'}\n`);
 
     // 1. Bun installed
     try {

--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -23,6 +23,17 @@ import type {
   ChannelDeliveryAckParams,
 } from "./types";
 
+function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.username = "";
+    parsed.password = "";
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return url.replace(/\/\/[^@]*@/, "//[REDACTED]@");
+  }
+}
+
 export class RuntimeClientError extends Error {
   constructor(
     public readonly status: number,
@@ -49,10 +60,19 @@ export function createRuntimeClient(
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
 
-    const response = await fetch(`${prefix}${path}`, {
-      ...init,
-      headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${prefix}${path}`, {
+        ...init,
+        headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
+      });
+    } catch (err) {
+      const sanitized = sanitizeUrl(baseUrl);
+      throw new RuntimeClientError(
+        0,
+        `Failed to connect to runtime at ${sanitized}${path}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");


### PR DESCRIPTION
## Summary
- Show effective socket path (with override indicator) and autostart policy in `vellum doctor` and `vellum daemon status`
- Web RuntimeClient now catches fetch connection errors and includes sanitized base URL for actionable debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
