### PR TITLE
Add run endpoints and orchestrator for approval flow

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -190,6 +190,7 @@ export async function runDaemon(): Promise<void> {
           server.processMessage(assistantId, conversationId, content, attachmentIds, options),
         persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds) =>
           server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds),
+        runOrchestrator: server.createRunOrchestrator(),
       });
       try {
         await runtimeHttp.start();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -21,6 +21,7 @@ import {
   type ServerMessage,
 } from './ipc-protocol.js';
 import { handleMessage, type HandlerContext } from './handlers.js';
+import { RunOrchestrator } from '../runtime/run-orchestrator.js';
 
 const log = getLogger('server');
 
@@ -534,6 +535,23 @@ export class DaemonServer {
     }
 
     return { messageId };
+  }
+
+  /**
+   * Create a RunOrchestrator wired to this server's session management.
+   */
+  createRunOrchestrator(): RunOrchestrator {
+    return new RunOrchestrator({
+      getOrCreateSession: (conversationId) =>
+        this.getOrCreateSession(conversationId),
+      resolveAttachments: (assistantId, attachmentIds) =>
+        attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({
+          id: a.id,
+          filename: a.originalFilename,
+          mimeType: a.mimeType,
+          data: a.dataBase64,
+        })),
+    });
   }
 
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -16,6 +16,7 @@ import * as attachmentsStore from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import { getConfig } from '../config/loader.js';
+import type { RunOrchestrator } from './run-orchestrator.js';
 
 const log = getLogger('runtime-http');
 
@@ -46,6 +47,8 @@ export interface RuntimeHttpServerOptions {
   processMessage?: MessageProcessor;
   /** Non-blocking processor for POST /messages (persists + fires agent loop). */
   persistAndProcessMessage?: NonBlockingMessageProcessor;
+  /** Run orchestrator for the approval-flow run endpoints. */
+  runOrchestrator?: RunOrchestrator;
 }
 
 interface RuntimeMessagePayload {
@@ -64,6 +67,7 @@ export class RuntimeHttpServer {
   private port: number;
   private processMessage?: MessageProcessor;
   private persistAndProcessMessage?: NonBlockingMessageProcessor;
+  private runOrchestrator?: RunOrchestrator;
   private suggestionCache = new Map<string, string>();
   private suggestionInFlight = new Map<string, Promise<string | null>>();
 
@@ -71,6 +75,7 @@ export class RuntimeHttpServer {
     this.port = options.port ?? DEFAULT_PORT;
     this.processMessage = options.processMessage;
     this.persistAndProcessMessage = options.persistAndProcessMessage;
+    this.runOrchestrator = options.runOrchestrator;
   }
 
   async start(): Promise<void> {
@@ -126,6 +131,22 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'suggestion' && req.method === 'GET') {
         return await this.handleGetSuggestion(assistantId, url);
+      }
+
+      if (endpoint === 'runs' && req.method === 'POST') {
+        return await this.handleCreateRun(assistantId, req);
+      }
+
+      // Match runs/:runId and runs/:runId/decision
+      const runsMatch = endpoint.match(/^runs\/([^/]+)(\/decision)?$/);
+      if (runsMatch) {
+        const runId = runsMatch[1];
+        if (runsMatch[2] === '/decision' && req.method === 'POST') {
+          return await this.handleRunDecision(assistantId, runId, req);
+        }
+        if (req.method === 'GET') {
+          return this.handleGetRun(assistantId, runId);
+        }
       }
 
       if (endpoint === 'channels/inbound' && req.method === 'POST') {
@@ -394,6 +415,123 @@ export class RuntimeHttpServer {
       throw err;
     }
   }
+
+  // ── Run endpoints ────────────────────────────────────────────────────
+
+  private async handleCreateRun(assistantId: string, req: Request): Promise<Response> {
+    if (!this.runOrchestrator) {
+      return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
+    }
+
+    const body = await req.json() as {
+      conversationKey?: string;
+      content?: string;
+      attachmentIds?: string[];
+    };
+
+    const { conversationKey, content, attachmentIds } = body;
+
+    if (!conversationKey) {
+      return Response.json({ error: 'conversationKey is required' }, { status: 400 });
+    }
+
+    if (content !== undefined && content !== null && typeof content !== 'string') {
+      return Response.json({ error: 'content must be a string' }, { status: 400 });
+    }
+
+    const trimmedContent = typeof content === 'string' ? content.trim() : '';
+    const hasAttachments = Array.isArray(attachmentIds) && attachmentIds.length > 0;
+
+    if (trimmedContent.length === 0 && !hasAttachments) {
+      return Response.json({ error: 'content or attachmentIds is required' }, { status: 400 });
+    }
+
+    if (hasAttachments) {
+      const resolved = attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds);
+      if (resolved.length !== attachmentIds.length) {
+        const resolvedIds = new Set(resolved.map((a) => a.id));
+        const missing = attachmentIds.filter((id) => !resolvedIds.has(id));
+        return Response.json(
+          { error: `Attachment IDs not found: ${missing.join(', ')}` },
+          { status: 400 },
+        );
+      }
+    }
+
+    const mapping = getOrCreateConversation(assistantId, conversationKey);
+
+    try {
+      const run = await this.runOrchestrator.startRun(
+        assistantId,
+        mapping.conversationId,
+        content ?? '',
+        hasAttachments ? attachmentIds : undefined,
+      );
+      return Response.json({
+        id: run.id,
+        status: run.status,
+        messageId: run.messageId,
+        createdAt: new Date(run.createdAt).toISOString(),
+      }, { status: 201 });
+    } catch (err) {
+      if (err instanceof Error && err.message === 'Session is already processing a message') {
+        return Response.json(
+          { error: 'Session is busy processing another message. Please retry.' },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
+  }
+
+  private handleGetRun(_assistantId: string, runId: string): Response {
+    if (!this.runOrchestrator) {
+      return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
+    }
+
+    const run = this.runOrchestrator.getRun(runId);
+    if (!run) {
+      return Response.json({ error: 'Run not found' }, { status: 404 });
+    }
+
+    return Response.json({
+      id: run.id,
+      status: run.status,
+      messageId: run.messageId,
+      pendingConfirmation: run.pendingConfirmation,
+      error: run.error,
+      createdAt: new Date(run.createdAt).toISOString(),
+      updatedAt: new Date(run.updatedAt).toISOString(),
+    });
+  }
+
+  private async handleRunDecision(_assistantId: string, runId: string, req: Request): Promise<Response> {
+    if (!this.runOrchestrator) {
+      return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
+    }
+
+    const body = await req.json() as { decision?: string };
+    const { decision } = body;
+
+    if (decision !== 'allow' && decision !== 'deny') {
+      return Response.json(
+        { error: 'decision must be "allow" or "deny"' },
+        { status: 400 },
+      );
+    }
+
+    const applied = this.runOrchestrator.submitDecision(runId, decision);
+    if (!applied) {
+      return Response.json(
+        { error: 'No pending confirmation for this run' },
+        { status: 409 },
+      );
+    }
+
+    return Response.json({ accepted: true });
+  }
+
+  // ── Attachment endpoints ────────────────────────────────────────────
 
   private async handleUploadAttachment(assistantId: string, req: Request): Promise<Response> {
     const body = await req.json() as {

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -1,0 +1,131 @@
+/**
+ * Orchestrates run lifecycle for the HTTP runtime API.
+ *
+ * A "run" wraps a single agent-loop execution, tracking its state through:
+ *   running → needs_confirmation → running → completed | failed
+ *
+ * When a tool needs permission, the orchestrator intercepts the
+ * confirmation_request from the session's prompter and records it in
+ * the run store.  The web UI can then poll the run status and submit
+ * a decision via the /decision endpoint.
+ */
+
+import * as runsStore from '../memory/runs-store.js';
+import type { Run } from '../memory/runs-store.js';
+import type { Session } from '../daemon/session.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { UserDecision } from '../permissions/types.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('run-orchestrator');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PendingRunState {
+  prompterRequestId: string;
+  session: Session;
+}
+
+export interface RunOrchestratorDeps {
+  getOrCreateSession: (conversationId: string) => Promise<Session>;
+  resolveAttachments: (assistantId: string, attachmentIds: string[]) => Array<{
+    id: string;
+    filename: string;
+    mimeType: string;
+    data: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export class RunOrchestrator {
+  private pending = new Map<string, PendingRunState>();
+  private deps: RunOrchestratorDeps;
+
+  constructor(deps: RunOrchestratorDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Start a new run: persist the user message, create a run record,
+   * and fire the agent loop in the background.
+   */
+  async startRun(
+    assistantId: string,
+    conversationId: string,
+    content: string,
+    attachmentIds?: string[],
+  ): Promise<Run> {
+    const session = await this.deps.getOrCreateSession(conversationId);
+
+    if (session.isProcessing()) {
+      throw new Error('Session is already processing a message');
+    }
+
+    const attachments = attachmentIds
+      ? this.deps.resolveAttachments(assistantId, attachmentIds)
+      : [];
+
+    const requestId = crypto.randomUUID();
+    const messageId = session.persistUserMessage(content, attachments, requestId);
+    const run = runsStore.createRun(assistantId, conversationId, messageId);
+
+    // Hook into session to intercept confirmation_request events.
+    // When the prompter sends one, we record it in the run store so
+    // the web UI can poll and submit a decision.
+    session.updateClient((msg: ServerMessage) => {
+      if (msg.type === 'confirmation_request') {
+        runsStore.setRunConfirmation(run.id, {
+          toolName: msg.toolName,
+          toolUseId: msg.requestId,
+          input: msg.input,
+          riskLevel: msg.riskLevel,
+        });
+        this.pending.set(run.id, {
+          prompterRequestId: msg.requestId,
+          session,
+        });
+      }
+    });
+
+    // Fire-and-forget the agent loop
+    session.runAgentLoop(content, messageId, () => {}).then(() => {
+      runsStore.completeRun(run.id);
+      this.pending.delete(run.id);
+    }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ err, runId: run.id }, 'Run failed');
+      runsStore.failRun(run.id, message);
+      this.pending.delete(run.id);
+    });
+
+    return run;
+  }
+
+  /** Read current run state from the store. */
+  getRun(runId: string): Run | null {
+    return runsStore.getRun(runId);
+  }
+
+  /**
+   * Submit a permission decision for a pending confirmation.
+   * Returns true if the decision was applied, false if no pending
+   * confirmation exists for this run.
+   */
+  submitDecision(runId: string, decision: UserDecision): boolean {
+    const pendingState = this.pending.get(runId);
+    if (!pendingState) return false;
+
+    runsStore.clearRunConfirmation(runId);
+    pendingState.session.handleConfirmationResponse(
+      pendingState.prompterRequestId,
+      decision,
+    );
+    this.pending.delete(runId);
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- New `RunOrchestrator` wraps agent loop with run lifecycle tracking (`running` → `needs_confirmation` → `completed`/`failed`)
- Three new HTTP endpoints: `POST /runs`, `GET /runs/:runId`, `POST /runs/:runId/decision`
- Orchestrator intercepts session confirmation requests to bridge IPC-based permission prompts to HTTP polling
- Wired into daemon lifecycle alongside existing message processor callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
