### PR TITLE
Enforce ownership in /api/vellum/chat

### DIFF
--- a/web/src/app/api/vellum/chat/route.ts
+++ b/web/src/app/api/vellum/chat/route.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { NextResponse } from "next/server";
 
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { getEditorPage, updateEditorPage } from "@/lib/gcp";
 
 interface ChatMessage {
@@ -138,6 +139,14 @@ export async function POST(request: Request) {
     console.log(`[Vellum Chat] 📥 [${requestId}] Parsing request body...`);
     const body: ChatRequest = await request.json();
     const { messages, assistantId, currentPage, username: chatUsername } = body;
+
+    if (assistantId) {
+      try {
+        await requireAssistantOwner(request, assistantId);
+      } catch (error) {
+        return toAuthErrorResponse(error);
+      }
+    }
 
     console.log(`[Vellum Chat] 📋 [${requestId}] Request parsed:`, {
       messageCount: messages?.length,


### PR DESCRIPTION
## Summary
- When `assistantId` is provided in the chat request, require the session user to own the assistant before allowing tool operations
- Non-owner gets `404`, unauthenticated gets `401`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
