### PR TITLE
Protect assistant CRUD route with ownership checks

### DIFF
--- a/web/src/app/api/assistants/[id]/route.ts
+++ b/web/src/app/api/assistants/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { Assistant, getDb, UpdateAssistantInput } from "@/lib/db";
 
 interface RouteParams {
@@ -8,37 +9,27 @@ interface RouteParams {
 
 export async function GET(request: Request, { params }: RouteParams) {
   try {
-    const sql = getDb();
     const { id } = await params;
+    const { assistant } = await requireAssistantOwner(request, id);
 
-    const result = await sql`SELECT * FROM assistants WHERE id = ${id}`;
-
-    if (result.length === 0) {
-      return NextResponse.json(
-        { error: "Assistant not found" },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json(result[0] as Assistant);
+    return NextResponse.json(assistant as Assistant);
   } catch (error) {
     console.error("Error fetching assistant:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch assistant" },
-      { status: 500 }
-    );
+    return toAuthErrorResponse(error);
   }
 }
 
 export async function PUT(request: Request, { params }: RouteParams) {
   try {
-    const sql = getDb();
     const { id } = await params;
+    await requireAssistantOwner(request, id);
+
+    const sql = getDb();
     const body: UpdateAssistantInput = await request.json();
 
     const result = await sql`
       UPDATE assistants
-      SET 
+      SET
         name = COALESCE(${body.name || null}, name),
         description = COALESCE(${body.description || null}, description),
         configuration = COALESCE(${body.configuration ? JSON.stringify(body.configuration) : null}::jsonb, configuration),
@@ -57,18 +48,16 @@ export async function PUT(request: Request, { params }: RouteParams) {
     return NextResponse.json(result[0] as Assistant);
   } catch (error) {
     console.error("Error updating assistant:", error);
-    return NextResponse.json(
-      { error: "Failed to update assistant" },
-      { status: 500 }
-    );
+    return toAuthErrorResponse(error);
   }
 }
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
-    const sql = getDb();
     const { id } = await params;
+    await requireAssistantOwner(request, id);
 
+    const sql = getDb();
     const result = await sql`DELETE FROM assistants WHERE id = ${id} RETURNING id`;
 
     if (result.length === 0) {
@@ -81,9 +70,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error deleting assistant:", error);
-    return NextResponse.json(
-      { error: "Failed to delete assistant" },
-      { status: 500 }
-    );
+    return toAuthErrorResponse(error);
   }
 }


### PR DESCRIPTION
## Summary
- Apply `requireAssistantOwner` to GET/PUT/DELETE on `/api/assistants/[id]`
- Owner gets normal response, non-owner gets `404`, unauthenticated gets `401`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
