### PR TITLE
Refactor macOS socket resolver for testability

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -100,11 +100,18 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Socket Path
 
     /// Resolves the daemon socket path:
-    /// 1. `VELLUM_DAEMON_SOCKET` environment variable
+    /// 1. `VELLUM_DAEMON_SOCKET` environment variable (or override dictionary)
     /// 2. `~/.vellum/vellum.sock`
-    private static func resolveSocketPath() -> String {
-        if let envPath = ProcessInfo.processInfo.environment["VELLUM_DAEMON_SOCKET"], !envPath.isEmpty {
-            return envPath
+    ///
+    /// Accepts an optional environment dictionary for testability.
+    static func resolveSocketPath(environment: [String: String]? = nil) -> String {
+        let env = environment ?? ProcessInfo.processInfo.environment
+        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespaces).isEmpty {
+            let trimmed = envPath.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("~/") {
+                return NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
+            }
+            return trimmed
         }
         return NSHomeDirectory() + "/.vellum/vellum.sock"
     }

--- a/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import vellum_assistant
+
+@MainActor
+final class DaemonClientSocketPathTests: XCTestCase {
+
+    func testDefaultPath() {
+        let path = DaemonClient.resolveSocketPath(environment: [:])
+        XCTAssertEqual(path, NSHomeDirectory() + "/.vellum/vellum.sock")
+    }
+
+    func testEnvOverride() {
+        let env = ["VELLUM_DAEMON_SOCKET": "/tmp/custom.sock"]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, "/tmp/custom.sock")
+    }
+
+    func testTildeExpansion() {
+        let env = ["VELLUM_DAEMON_SOCKET": "~/my-sockets/vellum.sock"]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, NSHomeDirectory() + "/my-sockets/vellum.sock")
+    }
+
+    func testWhitespaceIsTrimmed() {
+        let env = ["VELLUM_DAEMON_SOCKET": "  /tmp/custom.sock  "]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, "/tmp/custom.sock")
+    }
+
+    func testEmptyStringFallsBackToDefault() {
+        let env = ["VELLUM_DAEMON_SOCKET": ""]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, NSHomeDirectory() + "/.vellum/vellum.sock")
+    }
+
+    func testWhitespaceOnlyFallsBackToDefault() {
+        let env = ["VELLUM_DAEMON_SOCKET": "   "]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, NSHomeDirectory() + "/.vellum/vellum.sock")
+    }
+
+    func testNilEnvironmentUsesProcessInfo() {
+        // When no environment is passed, it uses ProcessInfo.processInfo.environment.
+        // We just verify it returns a non-empty string (the default path).
+        let path = DaemonClient.resolveSocketPath()
+        XCTAssertFalse(path.isEmpty)
+        XCTAssertTrue(path.hasSuffix("vellum.sock"))
+    }
+}


### PR DESCRIPTION
## Summary
- Make `resolveSocketPath()` accept an injectable environment dictionary for testing (previously used `ProcessInfo` directly)
- Add tilde expansion and whitespace trimming to match CLI behavior
- Add 7 unit tests covering override, default, tilde expansion, whitespace, and empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
