### PR TITLE
Add unified remote access runbook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,61 @@ bun install
 bun run src/index.ts daemon start
 ```
 
+## Remote Access
+
+Access a remote assistant daemon from your local machine via SSH.
+
+### Web (runtime HTTP tunnel)
+
+The web app connects to the runtime via HTTP. Use the tunnel helper to forward the runtime port:
+
+```bash
+# On your local machine — forward remote runtime port
+scripts/vellum-runtime-tunnel.sh start user@remote-host
+
+# Print env vars for web local mode
+scripts/vellum-runtime-tunnel.sh print-env
+# Output:
+#   ASSISTANT_CONNECTION_MODE=local
+#   LOCAL_RUNTIME_URL=http://127.0.0.1:7821
+
+# On the remote host, start the daemon with HTTP enabled
+RUNTIME_HTTP_PORT=7821 bun run src/index.ts daemon start
+```
+
+### CLI (socket forwarding)
+
+The CLI connects via Unix socket. Forward the socket with SSH:
+
+```bash
+ssh -L ~/.vellum/remote.sock:/home/user/.vellum/vellum.sock user@remote-host -N &
+VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock vellum
+```
+
+When `VELLUM_DAEMON_SOCKET` is set, autostart is disabled by default. Set `VELLUM_DAEMON_AUTOSTART=1` to override.
+
+### macOS app (socket forwarding)
+
+The macOS app also supports `VELLUM_DAEMON_SOCKET`. Launch it from the terminal:
+
+```bash
+ssh -L ~/.vellum/remote.sock:/home/user/.vellum/vellum.sock user@remote-host -N &
+VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a vellum-assistant
+```
+
+### Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Web: "Failed to connect to runtime" | Is the tunnel running? (`scripts/vellum-runtime-tunnel.sh status`) |
+| Web: "CLOUD_RUNTIME_URL must be set" | Set `ASSISTANT_CONNECTION_MODE=local` |
+| CLI: "could not connect to daemon socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
+| CLI: daemon starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
+| macOS: not connecting | Verify socket path in `VELLUM_DAEMON_SOCKET` exists and is writable |
+| Any: "connection refused" | Is the remote daemon running? (`vellum daemon status` on remote) |
+
+Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
+
 ## License
 
 Proprietary - Vellum AI

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -6,3 +6,17 @@ GEMINI_API_KEY=...
 OLLAMA_API_KEY=
 # Optional override (defaults to http://127.0.0.1:11434/v1)
 OLLAMA_BASE_URL=
+
+# --- Remote Access ---
+
+# Override the daemon socket path (default: ~/.vellum/vellum.sock).
+# Use this to target a forwarded or remote socket.
+# VELLUM_DAEMON_SOCKET=~/.vellum/vellum.sock
+
+# Control daemon autostart behavior.
+# When VELLUM_DAEMON_SOCKET is set, autostart is disabled by default.
+# Set to 1 to force autostart even with a custom socket path.
+# VELLUM_DAEMON_AUTOSTART=1
+
+# Enable the runtime HTTP server (required for web local mode).
+# RUNTIME_HTTP_PORT=7821

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -105,6 +105,10 @@ UI/                   SwiftUI views + overlay windows
 Logging/              Session recording to JSON
 ```
 
+## Remote Daemon
+
+The app supports connecting to a remote daemon via SSH socket forwarding. Set `VELLUM_DAEMON_SOCKET` to the forwarded socket path. See the [Remote Access](../../README.md#remote-access) section in the root README.
+
 ## Safety
 
 - Credit cards, SSNs, and passwords are blocked at the verifier level

--- a/web/README.md
+++ b/web/README.md
@@ -26,6 +26,8 @@ Environment variables:
 - `CLOUD_RUNTIME_URL` — Base URL for the hosted cloud runtime (required in cloud mode).
 - `LOCAL_RUNTIME_URL` — Override the default local runtime URL (default: `http://127.0.0.1:7821`).
 
+For remote runtime access via SSH, see the [Remote Access](../README.md#remote-access) section in the root README.
+
 ### Assistant Auth
 
 Assistant-initiated routes (e.g. `/api/assistants/[id]/setup-email`, `/api/assistants/[id]/set-avatar`) authenticate with hashed bearer tokens stored in the `assistant_auth_tokens` table. Plaintext keys are never stored.


### PR DESCRIPTION
## Summary
- Add Remote Access section to root README with web, CLI, and macOS runbooks
- Add troubleshooting matrix for common connection issues
- Add remote access env vars to `assistant/.env.example`
- Cross-link from web and macOS READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
