### PR TITLE
Protect file/destructive routes with ownership checks

### DIFF
--- a/web/src/app/api/assistants/[id]/cat/route.ts
+++ b/web/src/app/api/assistants/[id]/cat/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { getAssistantConnectionMode } from "@/lib/assistant-connection";
-import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
 
 interface RouteParams {
@@ -11,20 +11,16 @@ interface RouteParams {
 export const runtime = "nodejs";
 
 function obfuscateEnvContent(content: string): string {
-  // Obfuscate values in .env files while preserving keys
   return content
     .split("\n")
     .map((line) => {
-      // Skip comments and empty lines
       if (line.trim().startsWith("#") || !line.trim()) {
         return line;
       }
-      // Find the first = and obfuscate everything after it
       const eqIndex = line.indexOf("=");
       if (eqIndex !== -1) {
         const key = line.substring(0, eqIndex + 1);
         const value = line.substring(eqIndex + 1);
-        // Show first 3 chars if value is long enough, otherwise just show ***
         if (value.length > 6) {
           return `${key}${value.substring(0, 3)}${"*".repeat(Math.min(value.length - 3, 20))}`;
         } else if (value.length > 0) {
@@ -57,8 +53,7 @@ async function fetchFileContentFromAgentServer(
   }
 
   const data = await response.json();
-  
-  // Obfuscate .env file contents
+
   const filename = path.split("/").pop() || "";
   if (filename === ".env" || filename.endsWith(".env")) {
     data.content = obfuscateEnvContent(data.content);
@@ -80,12 +75,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
-
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    const { assistant } = await requireAssistantOwner(request, assistantId);
 
     if (getAssistantConnectionMode() === "local") {
       return NextResponse.json(
@@ -98,7 +88,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const assistant = result[0] as Assistant;
     const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
       | { instanceName?: string; zone?: string }
       | undefined;
@@ -125,6 +114,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const fileData = await fetchFileContentFromAgentServer(externalIp, filePath);
     return NextResponse.json(fileData);
   } catch (error) {
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
     console.error("Error reading file:", error);
     try {
       const parsed = JSON.parse((error as Error).message);

--- a/web/src/app/api/assistants/[id]/editor/route.ts
+++ b/web/src/app/api/assistants/[id]/editor/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getDb } from "@/lib/db";
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import {
   getDefaultEditorTemplate,
   updateEditorPage,
@@ -14,18 +14,11 @@ interface RouteParams {
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const sql = getDb();
-
-    const result = await sql`SELECT * FROM assistants WHERE id = ${id}`;
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    await requireAssistantOwner(request, id);
 
     const url = new URL(request.url);
     const format = url.searchParams.get("format");
 
-    // Always use the default template from disk.
-    // TODO: Corn should coordinate with Brain / Apollo on where we can expect to pull the dynamic editor
     const source = getDefaultEditorTemplate();
 
     if (format === "source") {
@@ -35,6 +28,9 @@ export async function GET(request: Request, { params }: RouteParams) {
     const compiled = transpileEditorSource(source);
     return NextResponse.json({ source, compiled });
   } catch (error) {
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
     console.error("Error fetching editor page:", error);
     return NextResponse.json(
       { error: "Failed to fetch editor page" },
@@ -46,12 +42,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function PUT(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const sql = getDb();
-
-    const result = await sql`SELECT * FROM assistants WHERE id = ${id}`;
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    await requireAssistantOwner(request, id);
 
     const body = await request.json();
     const { source } = body as { source: string };
@@ -87,6 +78,9 @@ export async function PUT(request: Request, { params }: RouteParams) {
     const compiled = transpileEditorSource(source);
     return NextResponse.json({ source, compiled });
   } catch (error) {
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
     console.error("Error updating editor page:", error);
     return NextResponse.json(
       { error: "Failed to update editor page" },

--- a/web/src/app/api/assistants/[id]/kill/route.ts
+++ b/web/src/app/api/assistants/[id]/kill/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { deleteAssistantMailInbox, deleteAssistantMailWebhook } from "@/lib/agentmail";
 import { disconnectTelegramChannel } from "@/lib/channels/service";
-import { Assistant, getDb } from "@/lib/db";
+import { getDb } from "@/lib/db";
 import { deleteInstance } from "@/lib/gcp";
 
 interface RouteParams {
@@ -12,15 +13,9 @@ interface RouteParams {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id: assistantId } = await params;
+    const { assistant } = await requireAssistantOwner(request, assistantId);
 
     const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
-
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
-    const assistant = result[0] as Assistant;
     const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
       | { instanceName?: string; zone?: string }
       | undefined;
@@ -70,6 +65,9 @@ export async function POST(request: Request, { params }: RouteParams) {
       message: "Assistant, compute instance, and email resources deleted",
     });
   } catch (error: unknown) {
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
     console.error("Error killing assistant:", error);
     return NextResponse.json(
       { error: "Failed to kill assistant" },

--- a/web/src/app/api/assistants/[id]/ls/route.ts
+++ b/web/src/app/api/assistants/[id]/ls/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { getAssistantConnectionMode } from "@/lib/assistant-connection";
-import { Assistant, getDb } from "@/lib/db";
 import { getInstanceExternalIp } from "@/lib/gcp";
 
 interface RouteParams {
@@ -42,12 +42,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const searchParams = request.nextUrl.searchParams;
     const path = searchParams.get("path") || "/opt/vellum-agent";
 
-    const sql = getDb();
-    const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
-
-    if (result.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    const { assistant } = await requireAssistantOwner(request, assistantId);
 
     if (getAssistantConnectionMode() === "local") {
       return NextResponse.json(
@@ -62,7 +57,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const assistant = result[0] as Assistant;
     const computeConfig = (assistant.configuration as Record<string, unknown>)?.compute as
       | { instanceName?: string; zone?: string }
       | undefined;
@@ -97,6 +91,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const files = await fetchFilesFromAgentServer(externalIp, path);
     return NextResponse.json({ files, path });
   } catch (error: unknown) {
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
     console.error("Error listing files:", error);
     return NextResponse.json(
       { error: "Failed to list files" },


### PR DESCRIPTION
## Summary
- Apply `requireAssistantOwner` to cat, ls, editor (GET/PUT), and kill routes
- Replaces manual `getAssistantById`/raw SQL lookups with the standard ownership check pattern
- No unauthorized file reads, directory listings, editor modifications, or assistant destruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
