### PR TITLE
Add created_by backfill script and schema hardening

### DIFF
--- a/web/scripts/backfill-created-by.ts
+++ b/web/scripts/backfill-created-by.ts
@@ -1,0 +1,95 @@
+/**
+ * Backfill script: canonicalize assistants.created_by to user IDs.
+ *
+ * Legacy assistants may have created_by set to a username or display name
+ * instead of the canonical user.id. This script resolves those values and
+ * updates them in place.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx scripts/backfill-created-by.ts [--dry-run]
+ */
+
+import postgres from "postgres";
+
+const dryRun = process.argv.includes("--dry-run");
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  const sql = postgres(connectionString);
+
+  try {
+    // Find assistants whose created_by is not already a user.id
+    const nonCanonical = await sql`
+      SELECT a.id, a.created_by
+      FROM assistants a
+      WHERE a.created_by IS NOT NULL
+        AND a.created_by != ''
+        AND NOT EXISTS (
+          SELECT 1 FROM "user" u WHERE u.id = a.created_by
+        )
+    `;
+
+    if (nonCanonical.length === 0) {
+      console.log("All assistants already have canonical created_by values.");
+      return;
+    }
+
+    console.log(`Found ${nonCanonical.length} assistant(s) with non-canonical created_by values.\n`);
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const row of nonCanonical) {
+      const createdBy = (row.created_by as string).trim();
+
+      // Try matching by username
+      const byUsername = await sql`
+        SELECT id FROM "user" WHERE username = ${createdBy} LIMIT 1
+      `;
+      if (byUsername.length === 1) {
+        const userId = byUsername[0].id as string;
+        if (dryRun) {
+          console.log(`[DRY RUN] assistant ${row.id}: "${createdBy}" -> "${userId}" (matched by username)`);
+        } else {
+          await sql`UPDATE assistants SET created_by = ${userId} WHERE id = ${row.id}`;
+          console.log(`Updated assistant ${row.id}: "${createdBy}" -> "${userId}" (matched by username)`);
+        }
+        updated++;
+        continue;
+      }
+
+      // Try matching by display name (only if unique)
+      const byName = await sql`
+        SELECT id FROM "user" WHERE name = ${createdBy} LIMIT 2
+      `;
+      if (byName.length === 1) {
+        const userId = byName[0].id as string;
+        if (dryRun) {
+          console.log(`[DRY RUN] assistant ${row.id}: "${createdBy}" -> "${userId}" (matched by name)`);
+        } else {
+          await sql`UPDATE assistants SET created_by = ${userId} WHERE id = ${row.id}`;
+          console.log(`Updated assistant ${row.id}: "${createdBy}" -> "${userId}" (matched by name)`);
+        }
+        updated++;
+        continue;
+      }
+
+      console.warn(`Skipped assistant ${row.id}: "${createdBy}" could not be resolved to a user`);
+      skipped++;
+    }
+
+    console.log(`\nDone. Updated: ${updated}, Skipped: ${skipped}${dryRun ? " (dry run)" : ""}`);
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/web/src/lib/schema.ts
+++ b/web/src/lib/schema.ts
@@ -16,7 +16,7 @@ export const assistantsTable = pgTable("assistants", {
   name: varchar("name", { length: 255 }).notNull(),
   description: text("description"),
   configuration: jsonb("configuration").default({}),
-  createdBy: varchar("created_by", { length: 255 }),
+  createdBy: varchar("created_by", { length: 255 }).notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
 });


### PR DESCRIPTION
## Summary
- Add `web/scripts/backfill-created-by.ts` script that canonicalizes legacy `created_by` values (usernames, display names) to user IDs
- Supports `--dry-run` mode for safe previewing
- Mark `created_by` as `NOT NULL` in Drizzle schema (all creation paths now set it from session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
