### PR TITLE
Add idempotency and recovery hardening for runs

### DIFF
--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -5,7 +5,7 @@
  *   running → needs_confirmation → running → completed | failed
  */
 
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
 import { messageRuns } from './schema.js';
@@ -165,4 +165,36 @@ export function failRun(runId: string, error: string): void {
     })
     .where(eq(messageRuns.id, runId))
     .run();
+}
+
+/**
+ * Mark all non-terminal runs as failed.
+ * Called on startup to recover from daemon restarts that left runs
+ * in running/needs_confirmation with no in-memory state to resolve them.
+ * Returns the number of rows affected.
+ */
+export function failOrphanedRuns(): number {
+  const db = getDb();
+  const now = Date.now();
+  const activeStatuses = ['running', 'needs_confirmation'];
+
+  // Count first so we can report how many were recovered.
+  const active = db.select({ id: messageRuns.id })
+    .from(messageRuns)
+    .where(inArray(messageRuns.status, activeStatuses))
+    .all();
+
+  if (active.length === 0) return 0;
+
+  db.update(messageRuns)
+    .set({
+      status: 'failed',
+      pendingConfirmation: null,
+      error: 'Run was interrupted (daemon restart)',
+      updatedAt: now,
+    })
+    .where(inArray(messageRuns.status, activeStatuses))
+    .run();
+
+  return active.length;
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -523,8 +523,8 @@ export class RuntimeHttpServer {
     const applied = this.runOrchestrator.submitDecision(runId, decision);
     if (!applied) {
       return Response.json(
-        { error: 'No pending confirmation for this run' },
-        { status: 409 },
+        { error: 'Run not found' },
+        { status: 404 },
       );
     }
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -48,6 +48,13 @@ export class RunOrchestrator {
 
   constructor(deps: RunOrchestratorDeps) {
     this.deps = deps;
+
+    // On startup, mark any runs left in non-terminal states as failed.
+    // These are orphans from a previous daemon process that was interrupted.
+    const recovered = runsStore.failOrphanedRuns();
+    if (recovered > 0) {
+      log.info({ count: recovered }, 'Recovered orphaned runs from previous session');
+    }
   }
 
   /**
@@ -113,19 +120,35 @@ export class RunOrchestrator {
 
   /**
    * Submit a permission decision for a pending confirmation.
-   * Returns true if the decision was applied, false if no pending
-   * confirmation exists for this run.
+   * Returns true if the decision was applied or was already handled
+   * (idempotent). Returns false only if the run doesn't exist.
    */
   submitDecision(runId: string, decision: UserDecision): boolean {
     const pendingState = this.pending.get(runId);
-    if (!pendingState) return false;
+    if (pendingState) {
+      runsStore.clearRunConfirmation(runId);
+      pendingState.session.handleConfirmationResponse(
+        pendingState.prompterRequestId,
+        decision,
+      );
+      this.pending.delete(runId);
+      return true;
+    }
 
-    runsStore.clearRunConfirmation(runId);
-    pendingState.session.handleConfirmationResponse(
-      pendingState.prompterRequestId,
-      decision,
-    );
-    this.pending.delete(runId);
+    // No in-memory pending state — check if the run exists.
+    // If it's in a terminal or running state, the decision was already
+    // handled (double-submit) or the prompter timed out. Either way,
+    // treat as idempotent success.
+    const run = runsStore.getRun(runId);
+    if (!run) return false;
+
+    // If the run is still needs_confirmation but there's no in-memory
+    // state, the prompter already timed out and auto-denied. Clear the
+    // stale confirmation to keep the stored state consistent.
+    if (run.status === 'needs_confirmation') {
+      runsStore.clearRunConfirmation(runId);
+    }
+
     return true;
   }
 }

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -173,6 +173,7 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const uploadedPendingAttachmentIdsRef = useRef<string[]>([]);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingRunConfirmation | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
 
   const fetchMessages = useCallback(async () => {
     try {
@@ -336,6 +337,13 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
     uploadedPendingAttachmentIdsRef.current = uploadedAttachmentIds;
   }, [uploadedAttachmentIds]);
 
+  // Auto-dismiss run error after 8 seconds
+  useEffect(() => {
+    if (!runError) return;
+    const timer = setTimeout(() => setRunError(null), 8000);
+    return () => clearTimeout(timer);
+  }, [runError]);
+
   useEffect(() => {
     if (!activeRunId) return;
 
@@ -357,6 +365,9 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
           setActiveRunId(null);
           setPendingConfirmation(null);
           setIsLoading(false);
+          if (run.status === "failed" && run.error) {
+            setRunError(run.error);
+          }
           await fetchMessages();
         } else {
           setPendingConfirmation(null);
@@ -918,6 +929,24 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                         <div className="h-2 w-2 animate-bounce rounded-full bg-zinc-400 [animation-delay:0.1s]" />
                         <div className="h-2 w-2 animate-bounce rounded-full bg-zinc-400 [animation-delay:0.2s]" />
                       </div>
+                    </div>
+                  </div>
+                )}
+                {runError && (
+                  <div className="flex gap-3">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-950">
+                      <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400" />
+                    </div>
+                    <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-950/50">
+                      <p className="text-sm text-red-700 dark:text-red-300">{runError}</p>
+                      <button
+                        type="button"
+                        onClick={() => setRunError(null)}
+                        className="ml-1 rounded p-0.5 text-red-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900"
+                        aria-label="Dismiss error"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Make duplicate run decision submissions idempotent (200 instead of 409 on double-submit, stale `needs_confirmation` state cleaned up when prompter already timed out)
- Recover orphaned runs on daemon startup — runs stuck in `running`/`needs_confirmation` from a previous process are marked as failed
- Show run error messages inline in InteractionTab with auto-dismiss after 8s and manual dismiss button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
