### PR TITLE
Simplify channel inbound dedup: single insert path + update_id

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -186,8 +186,8 @@ export async function runDaemon(): Promise<void> {
     if (!isNaN(port) && port > 0) {
       runtimeHttp = new RuntimeHttpServer({
         port,
-        processMessage: (assistantId, conversationId, content, attachmentIds, options) =>
-          server.processMessage(assistantId, conversationId, content, attachmentIds, options),
+        processMessage: (assistantId, conversationId, content, attachmentIds) =>
+          server.processMessage(assistantId, conversationId, content, attachmentIds),
         persistAndProcessMessage: (assistantId, conversationId, content, attachmentIds) =>
           server.persistAndProcessMessage(assistantId, conversationId, content, attachmentIds),
         runOrchestrator: server.createRunOrchestrator(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -510,7 +510,6 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds?: string[],
-    options?: { userMessageAlreadyPersisted?: boolean },
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
 
@@ -528,7 +527,7 @@ export class DaemonServer {
         }))
       : [];
 
-    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID(), options);
+    const messageId = await session.processMessage(content, attachments, () => {}, crypto.randomUUID());
 
     if (!messageId) {
       throw new Error('Failed to persist user message');

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -216,7 +216,6 @@ export class Session {
     content: string,
     attachments: UserMessageAttachment[],
     requestId?: string,
-    options?: { userMessageAlreadyPersisted?: boolean },
   ): string {
     if (this.processing) {
       throw new Error('Session is already processing a message');
@@ -233,40 +232,20 @@ export class Session {
 
     let userMessageId = '';
 
-    if (options?.userMessageAlreadyPersisted) {
-      // The user message was already persisted (e.g. by channel inbound
-      // idempotency logic). Find its ID from the DB for memory-recall
-      // exclusion, and always add to in-memory array so the LLM sees it
-      // (cached sessions skip loadFromDb on subsequent messages).
-      const dbMessages = conversationStore.getMessages(this.conversationId);
-      const lastUserMsg = dbMessages.filter((m) => m.role === 'user').pop();
-      userMessageId = lastUserMsg?.id ?? '';
-
-      const userMessage = createUserMessage(content, attachments.map((attachment) => ({
-        id: attachment.id,
-        filename: attachment.filename,
-        mimeType: attachment.mimeType,
-        data: attachment.data,
-        extractedText: attachment.extractedText,
-      })));
-      this.messages.push(userMessage);
-    } else {
-      // Add user message
-      const userMessage = createUserMessage(content, attachments.map((attachment) => ({
-        id: attachment.id,
-        filename: attachment.filename,
-        mimeType: attachment.mimeType,
-        data: attachment.data,
-        extractedText: attachment.extractedText,
-      })));
-      this.messages.push(userMessage);
-      const persistedUserMessage = conversationStore.addMessage(
-        this.conversationId,
-        'user',
-        JSON.stringify(userMessage.content),
-      );
-      userMessageId = persistedUserMessage.id;
-    }
+    const userMessage = createUserMessage(content, attachments.map((attachment) => ({
+      id: attachment.id,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      data: attachment.data,
+      extractedText: attachment.extractedText,
+    })));
+    this.messages.push(userMessage);
+    const persistedUserMessage = conversationStore.addMessage(
+      this.conversationId,
+      'user',
+      JSON.stringify(userMessage.content),
+    );
+    userMessageId = persistedUserMessage.id;
 
     if (!userMessageId) {
       this.processing = false;
@@ -581,11 +560,10 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
-    options?: { userMessageAlreadyPersisted?: boolean },
   ): Promise<string> {
     let userMessageId: string;
     try {
-      userMessageId = this.persistUserMessage(content, attachments, requestId, options);
+      userMessageId = this.persistUserMessage(content, attachments, requestId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       onEvent({ type: 'error', message });

--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -9,13 +9,8 @@
 import { eq, and } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { channelInboundEvents, conversations, messages } from './schema.js';
+import { channelInboundEvents, conversations } from './schema.js';
 import { getOrCreateConversation } from './conversation-key-store.js';
-import { getConfig } from '../config/loader.js';
-import { indexMessageNow } from './indexer.js';
-import { getLogger } from '../util/logger.js';
-
-const log = getLogger('channel-delivery-store');
 
 export interface InboundResult {
   accepted: boolean;
@@ -33,7 +28,6 @@ export function recordInbound(
   sourceChannel: string,
   externalChatId: string,
   externalMessageId: string,
-  content: string,
 ): InboundResult {
   const db = getDb();
 
@@ -66,14 +60,8 @@ export function recordInbound(
   const mapping = getOrCreateConversation(assistantId, conversationKey);
   const now = Date.now();
   const eventId = uuid();
-  const messageId = uuid();
-
-  // Wrap message insert + event insert in a single transaction so a partial
-  // failure doesn't leave an orphaned message without an idempotency record.
-  const message = { id: messageId, conversationId: mapping.conversationId, role: 'user', content, createdAt: now };
 
   db.transaction((tx) => {
-    tx.insert(messages).values(message).run();
     tx.update(conversations)
       .set({ updatedAt: now })
       .where(eq(conversations.id, mapping.conversationId))
@@ -86,27 +74,12 @@ export function recordInbound(
         externalChatId,
         externalMessageId,
         conversationId: mapping.conversationId,
-        messageId,
         deliveryStatus: 'pending',
         createdAt: now,
         updatedAt: now,
       })
       .run();
   });
-
-  // Non-critical: index the message for memory retrieval after the transaction commits.
-  try {
-    const config = getConfig();
-    indexMessageNow({
-      messageId: message.id,
-      conversationId: message.conversationId,
-      role: message.role,
-      content: message.content,
-      createdAt: message.createdAt,
-    }, config.memory);
-  } catch (err) {
-    log.warn({ err, conversationId: mapping.conversationId, messageId }, 'Failed to index inbound message for memory');
-  }
 
   return {
     accepted: true,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -27,7 +27,6 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
-  options?: { userMessageAlreadyPersisted?: boolean },
 ) => Promise<{ messageId: string }>;
 
 /**
@@ -640,18 +639,13 @@ export class RuntimeHttpServer {
       sourceChannel,
       externalChatId,
       externalMessageId,
-      content,
     );
 
     // For new (non-duplicate) messages, run the agent loop to generate a reply.
-    // Pass userMessageAlreadyPersisted so the session skips inserting a second
-    // user message (recordInbound already persisted it within its transaction).
     let processingSucceeded = false;
     if (!result.duplicate && this.processMessage) {
       try {
-        await this.processMessage(assistantId, result.conversationId, content, undefined, {
-          userMessageAlreadyPersisted: true,
-        });
+        await this.processMessage(assistantId, result.conversationId, content);
         processingSucceeded = true;
       } catch (err) {
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');

--- a/web/src/lib/channels/plugins/telegram.ts
+++ b/web/src/lib/channels/plugins/telegram.ts
@@ -68,7 +68,8 @@ function parseTelegramInbound(payload: Record<string, unknown>): NormalizedInbou
       }
     | undefined;
 
-  if (!message?.text || !message.chat?.id || !message.message_id) {
+  const updateId = payload.update_id as number | undefined;
+  if (!message?.text || !message.chat?.id || !updateId) {
     return null;
   }
 
@@ -86,7 +87,7 @@ function parseTelegramInbound(payload: Record<string, unknown>): NormalizedInbou
   return {
     text: message.text,
     externalChatId: String(message.chat.id),
-    externalMessageId: String(message.message_id),
+    externalMessageId: String(updateId),
     sender: {
       externalUserId,
       username: message.from?.username,


### PR DESCRIPTION
## Summary
- Remove user message persistence from `recordInbound` — it now only records the idempotency event
- Remove `userMessageAlreadyPersisted` flag from `session.ts`, `server.ts`, `http-server.ts`, `lifecycle.ts`, and `MessageProcessor` type
- User messages are always persisted through `session.processMessage` — one path, no branching, no edge cases
- Use Telegram `update_id` (globally unique, sequential) instead of `message_id` (only unique per chat) for webhook idempotency, per [Telegram's recommendation](https://core.telegram.org/bots/api#update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
