### PR TITLE
M1: Add surface IPC protocol and type system

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -133,6 +133,18 @@ exports[`IPC message snapshots ClientMessage types task_submit serializes to exp
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types ui_surface_action serializes to expected JSON 1`] = `
+{
+  "actionId": "btn-ok",
+  "data": {
+    "selectedItem": "item-1",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_action",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "text": "Here is some output",
@@ -419,5 +431,45 @@ exports[`IPC message snapshots ServerMessage types ambient_result serializes to 
   "suggestion": "Try running the test with --verbose flag for more details",
   "summary": "User appears to be debugging a test failure",
   "type": "ambient_result",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_show serializes to expected JSON 1`] = `
+{
+  "actions": [
+    {
+      "id": "dismiss",
+      "label": "OK",
+      "style": "primary",
+    },
+  ],
+  "data": {
+    "body": "All tests passed.",
+    "title": "Build Complete",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "surfaceType": "card",
+  "title": "Status Update",
+  "type": "ui_surface_show",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_update serializes to expected JSON 1`] = `
+{
+  "data": {
+    "body": "Updated body text.",
+  },
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_update",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ui_surface_dismiss serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "surfaceId": "surface-001",
+  "type": "ui_surface_dismiss",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -99,6 +99,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     screenWidth: 1920,
     screenHeight: 1080,
   },
+  ui_surface_action: {
+    type: 'ui_surface_action',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    actionId: 'btn-ok',
+    data: { selectedItem: 'item-1' },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -281,6 +288,26 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     decision: 'suggest',
     summary: 'User appears to be debugging a test failure',
     suggestion: 'Try running the test with --verbose flag for more details',
+  },
+  ui_surface_show: {
+    type: 'ui_surface_show',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    surfaceType: 'card',
+    title: 'Status Update',
+    data: { title: 'Build Complete', body: 'All tests passed.' },
+    actions: [{ id: 'dismiss', label: 'OK', style: 'primary' }],
+  },
+  ui_surface_update: {
+    type: 'ui_surface_update',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
+    data: { body: 'Updated body text.' },
+  },
+  ui_surface_dismiss: {
+    type: 'ui_surface_dismiss',
+    sessionId: 'sess-001',
+    surfaceId: 'surface-001',
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -22,6 +22,7 @@ import type {
   CuSessionCreate,
   CuObservation,
   TaskSubmit,
+  UiSurfaceAction,
 } from './ipc-protocol.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
@@ -209,6 +210,9 @@ const handlers: DispatchMap = {
   ambient_observation: handleAmbientObservation,
   task_submit: handleTaskSubmit,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
+  ui_surface_action: (msg, _socket, _ctx) => {
+    log.info({ surfaceId: msg.surfaceId, actionId: msg.actionId }, 'Surface action received (not yet handled)');
+  },
 };
 
 export function handleMessage(

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -120,6 +120,70 @@ export interface AmbientObservation {
   timestamp: number;
 }
 
+// === Surface types ===
+
+export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation';
+
+export interface SurfaceAction {
+  id: string;
+  label: string;
+  style?: 'primary' | 'secondary' | 'destructive';
+}
+
+export interface CardSurfaceData {
+  title: string;
+  subtitle?: string;
+  body: string;
+  metadata?: Array<{ label: string; value: string }>;
+}
+
+export interface FormField {
+  id: string;
+  type: 'text' | 'textarea' | 'select' | 'toggle' | 'number';
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+  defaultValue?: string | number | boolean;
+  options?: Array<{ label: string; value: string }>;
+}
+
+export interface FormSurfaceData {
+  description?: string;
+  fields: FormField[];
+  submitLabel?: string;
+}
+
+export interface ListItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  icon?: string;
+  selected?: boolean;
+}
+
+export interface ListSurfaceData {
+  items: ListItem[];
+  selectionMode: 'single' | 'multiple' | 'none';
+}
+
+export interface ConfirmationSurfaceData {
+  message: string;
+  detail?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData;
+
+export interface UiSurfaceAction {
+  type: 'ui_surface_action';
+  sessionId: string;
+  surfaceId: string;
+  actionId: string;
+  data?: Record<string, unknown>;
+}
+
 export type ClientMessage =
   | UserMessage
   | ConfirmationResponse
@@ -137,7 +201,8 @@ export type ClientMessage =
   | CuSessionCreate
   | CuObservation
   | AmbientObservation
-  | TaskSubmit;
+  | TaskSubmit
+  | UiSurfaceAction;
 
 // === Server → Client messages ===
 
@@ -334,6 +399,29 @@ export interface AmbientResult {
   suggestion?: string;
 }
 
+export interface UiSurfaceShow {
+  type: 'ui_surface_show';
+  sessionId: string;
+  surfaceId: string;
+  surfaceType: SurfaceType;
+  title?: string;
+  data: SurfaceData;
+  actions?: SurfaceAction[];
+}
+
+export interface UiSurfaceUpdate {
+  type: 'ui_surface_update';
+  sessionId: string;
+  surfaceId: string;
+  data: Partial<SurfaceData>;
+}
+
+export interface UiSurfaceDismiss {
+  type: 'ui_surface_dismiss';
+  sessionId: string;
+  surfaceId: string;
+}
+
 export type ServerMessage =
   | AssistantTextDelta
   | AssistantThinkingDelta
@@ -360,7 +448,10 @@ export type ServerMessage =
   | CuComplete
   | CuError
   | TaskRouted
-  | AmbientResult;
+  | AmbientResult
+  | UiSurfaceShow
+  | UiSurfaceUpdate
+  | UiSurfaceDismiss;
 
 // === Serialization ===
 

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -157,6 +157,16 @@ struct PingMessage: Encodable, Sendable {
     let type: String = "ping"
 }
 
+/// Sent when user interacts with a surface.
+/// Wire type: `"ui_surface_action"`
+struct UiSurfaceActionMessage: Encodable, Sendable {
+    let type: String = "ui_surface_action"
+    let sessionId: String
+    let surfaceId: String
+    let actionId: String
+    let data: [String: AnyCodable]?
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -216,6 +226,38 @@ struct AmbientResultMessage: Decodable, Sendable {
     let suggestion: String?
 }
 
+/// Surface show command from daemon.
+/// Wire type: `"ui_surface_show"`
+struct UiSurfaceShowMessage: Decodable, Sendable {
+    let sessionId: String
+    let surfaceId: String
+    let surfaceType: String
+    let title: String?
+    let data: AnyCodable
+    let actions: [SurfaceActionData]?
+}
+
+struct SurfaceActionData: Decodable, Sendable {
+    let id: String
+    let label: String
+    let style: String?
+}
+
+/// Surface update command from daemon.
+/// Wire type: `"ui_surface_update"`
+struct UiSurfaceUpdateMessage: Decodable, Sendable {
+    let sessionId: String
+    let surfaceId: String
+    let data: AnyCodable
+}
+
+/// Surface dismiss command from daemon.
+/// Wire type: `"ui_surface_dismiss"`
+struct UiSurfaceDismissMessage: Decodable, Sendable {
+    let sessionId: String
+    let surfaceId: String
+}
+
 /// Server-level error message.
 struct ErrorMessage: Decodable, Sendable {
     let message: String
@@ -234,6 +276,9 @@ enum ServerMessage: Decodable, Sendable {
     case taskRouted(TaskRoutedMessage)
     case error(ErrorMessage)
     case ambientResult(AmbientResultMessage)
+    case uiSurfaceShow(UiSurfaceShowMessage)
+    case uiSurfaceUpdate(UiSurfaceUpdateMessage)
+    case uiSurfaceDismiss(UiSurfaceDismissMessage)
     case pong
     case unknown(String)
 
@@ -276,6 +321,15 @@ enum ServerMessage: Decodable, Sendable {
         case "ambient_result":
             let message = try AmbientResultMessage(from: decoder)
             self = .ambientResult(message)
+        case "ui_surface_show":
+            let message = try UiSurfaceShowMessage(from: decoder)
+            self = .uiSurfaceShow(message)
+        case "ui_surface_update":
+            let message = try UiSurfaceUpdateMessage(from: decoder)
+            self = .uiSurfaceUpdate(message)
+        case "ui_surface_dismiss":
+            let message = try UiSurfaceDismissMessage(from: decoder)
+            self = .uiSurfaceDismiss(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Defines the surface type system (`SurfaceType`, `SurfaceData`, `SurfaceAction`, etc.) covering card, form, list, and confirmation surface variants
- Adds IPC message types: `ui_surface_show`, `ui_surface_update`, `ui_surface_dismiss` (server-to-client) and `ui_surface_action` (client-to-server)
- Mirrors all types on the Swift side with `Decodable`/`Encodable` structs and `ServerMessage` enum cases
- Updates snapshot tests and handler dispatch map for type completeness

Part of #747.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] Swift build succeeds (`swift build`)
- [x] IPC snapshot tests pass with updated snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
