### PR TITLE
M2: Add daemon surface tools

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -3,6 +3,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { registerComputerUseTools } from './computer-use/registry.js';
+import { registerUiSurfaceTools } from './ui-surface/registry.js';
 
 const log = getLogger('tool-registry');
 
@@ -106,6 +107,11 @@ export async function initializeTools(): Promise<void> {
   // and forward execution to the connected macOS client.  They are excluded
   // from getAllToolDefinitions() since regular chat sessions don't use them.
   registerComputerUseTools();
+
+  // UI surface proxy tools — registered so ToolExecutor can look them up
+  // and forward surface show/update/dismiss to the connected macOS client.
+  // Like CU tools, they are excluded from getAllToolDefinitions().
+  registerUiSurfaceTools();
 
   // The bash tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -1,0 +1,166 @@
+/**
+ * UI surface tool definitions.
+ *
+ * These tools allow the model to show, update, and dismiss just-in-time UI
+ * surfaces (cards, forms, lists, confirmations) on a connected macOS client.
+ * They are proxy tools -- execution is forwarded to the client and never
+ * handled locally by the daemon.
+ */
+
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function proxyExecute(): Promise<ToolExecutionResult> {
+  throw new Error('Proxy tool: execution must be forwarded to the connected client');
+}
+
+// ---------------------------------------------------------------------------
+// ui_show
+// ---------------------------------------------------------------------------
+
+export const uiShowTool: Tool = {
+  name: 'ui_show',
+  description:
+    'Show a UI surface to the user. Supported surface types:\n' +
+    '- card: Informational card with title, subtitle, body text, and optional metadata key-value pairs. ' +
+    'data shape: { title: string, subtitle?: string, body: string, metadata?: Array<{ label: string, value: string }> }\n' +
+    '- form: Input form with typed fields. ' +
+    'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }\n' +
+    '- list: Selectable list of items. ' +
+    'data shape: { items: Array<{ id: string, title: string, subtitle?: string, icon?: string, selected?: boolean }>, selectionMode: "single"|"multiple"|"none" }\n' +
+    '- confirmation: Yes/no confirmation dialog. ' +
+    'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }',
+  category: 'ui-surface',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          surface_type: {
+            type: 'string',
+            enum: ['card', 'form', 'list', 'confirmation'],
+            description: 'The type of surface to display',
+          },
+          title: {
+            type: 'string',
+            description: 'Optional title for the surface window',
+          },
+          data: {
+            type: 'object',
+            description: 'Surface data; structure depends on surface_type (see tool description)',
+          },
+          actions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', description: 'Unique action identifier' },
+                label: { type: 'string', description: 'Button label text' },
+                style: {
+                  type: 'string',
+                  enum: ['primary', 'secondary', 'destructive'],
+                  description: 'Visual style of the button',
+                },
+              },
+              required: ['id', 'label'],
+            },
+            description: 'Optional action buttons to display on the surface',
+          },
+          await_action: {
+            type: 'boolean',
+            description: 'Whether to block until the user interacts with an action. Defaults to true when actions are provided.',
+          },
+        },
+        required: ['surface_type', 'data'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
+// ui_update
+// ---------------------------------------------------------------------------
+
+export const uiUpdateTool: Tool = {
+  name: 'ui_update',
+  description: "Update an existing surface's data. The provided data object is merged into the surface's current data.",
+  category: 'ui-surface',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          surface_id: {
+            type: 'string',
+            description: 'The ID of the surface to update',
+          },
+          data: {
+            type: 'object',
+            description: 'Partial data to merge into the existing surface data',
+          },
+        },
+        required: ['surface_id', 'data'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
+// ui_dismiss
+// ---------------------------------------------------------------------------
+
+export const uiDismissTool: Tool = {
+  name: 'ui_dismiss',
+  description: 'Dismiss a currently displayed surface.',
+  category: 'ui-surface',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          surface_id: {
+            type: 'string',
+            description: 'The ID of the surface to dismiss',
+          },
+        },
+        required: ['surface_id'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
+// All tools exported as array for convenience
+// ---------------------------------------------------------------------------
+
+export const allUiSurfaceTools: Tool[] = [
+  uiShowTool,
+  uiUpdateTool,
+  uiDismissTool,
+];

--- a/assistant/src/tools/ui-surface/registry.ts
+++ b/assistant/src/tools/ui-surface/registry.ts
@@ -1,0 +1,15 @@
+/**
+ * Registers all UI surface proxy tools with the daemon's tool registry.
+ *
+ * Call `registerUiSurfaceTools()` during daemon startup to make the `ui_*`
+ * tools available for inference.
+ */
+
+import { registerTool } from '../registry.js';
+import { allUiSurfaceTools } from './definitions.js';
+
+export function registerUiSurfaceTools(): void {
+  for (const tool of allUiSurfaceTools) {
+    registerTool(tool);
+  }
+}


### PR DESCRIPTION
Part of #747.

## Summary
- Adds `ui_show`, `ui_update`, `ui_dismiss` as proxy tools in the daemon's tool registry
- `ui_show` supports four surface types: card, form, list, and confirmation with optional action buttons
- `ui_update` merges partial data into an existing surface
- `ui_dismiss` removes a displayed surface
- All three tools use `executionMode: 'proxy'` and are automatically excluded from `getAllToolDefinitions()`
- Follows the exact same pattern as the existing `cu_*` computer-use proxy tools

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [ ] Verify tools are registered at daemon startup (logged by tool-registry)
- [ ] Verify tools are excluded from regular chat tool definitions
- [ ] Integration with M5 (explicit inclusion where needed)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
