### PR TITLE
M3: Add macOS surface infrastructure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -1,0 +1,212 @@
+import AppKit
+import SwiftUI
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SurfaceManager")
+
+/// Manages the lifecycle of surface windows (NSPanel) shown in response to daemon IPC messages.
+///
+/// Each surface is displayed in a floating, non-activating panel positioned at the bottom-right
+/// of the screen, following the same window pattern as `AmbientSuggestionWindow`.
+@MainActor
+final class SurfaceManager: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published var activeSurfaces: [String: Surface] = [:]
+
+    // MARK: - Private State
+
+    private var panels: [String: NSPanel] = [:]
+
+    /// Vertical offset counter to stack multiple surfaces.
+    private let panelWidth: CGFloat = 380
+    private let panelMargin: CGFloat = 20
+    private let panelSpacing: CGFloat = 10
+
+    // MARK: - Action Callback
+
+    /// Called when a user interacts with a surface action button.
+    /// Parameters: sessionId, surfaceId, actionId, optional data dictionary.
+    var onAction: ((String, String, String, [String: Any]?) -> Void)?
+
+    // MARK: - Show
+
+    func showSurface(_ message: UiSurfaceShowMessage) {
+        guard let surface = Surface.from(message) else {
+            log.error("Failed to parse surface from message: surfaceId=\(message.surfaceId), type=\(message.surfaceType)")
+            return
+        }
+
+        // Dismiss any existing surface with the same ID first.
+        if panels[surface.id] != nil {
+            dismissSurfaceById(surface.id)
+        }
+
+        activeSurfaces[surface.id] = surface
+
+        let view = SurfacePlaceholderView(
+            surface: surface,
+            onAction: { [weak self] actionId, data in
+                self?.onAction?(surface.sessionId, surface.id, actionId, data)
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 140),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Position bottom-right of screen, stacked above existing panels.
+        positionPanel(panel)
+
+        panel.orderFront(nil)
+        panels[surface.id] = panel
+
+        log.info("Showing surface: id=\(surface.id), type=\(surface.type.rawValue)")
+    }
+
+    // MARK: - Update
+
+    func updateSurface(_ message: UiSurfaceUpdateMessage) {
+        guard let existing = activeSurfaces[message.surfaceId] else {
+            log.warning("Cannot update unknown surface: \(message.surfaceId)")
+            return
+        }
+
+        guard let updated = existing.updated(with: message) else {
+            log.error("Failed to parse updated data for surface: \(message.surfaceId)")
+            return
+        }
+
+        activeSurfaces[message.surfaceId] = updated
+
+        // Rebuild the view in the existing panel.
+        guard let panel = panels[message.surfaceId] else { return }
+
+        let view = SurfacePlaceholderView(
+            surface: updated,
+            onAction: { [weak self] actionId, data in
+                self?.onAction?(updated.sessionId, updated.id, actionId, data)
+            }
+        )
+
+        panel.contentViewController = NSHostingController(rootView: view)
+
+        log.info("Updated surface: id=\(message.surfaceId)")
+    }
+
+    // MARK: - Dismiss
+
+    func dismissSurface(_ message: UiSurfaceDismissMessage) {
+        dismissSurfaceById(message.surfaceId)
+    }
+
+    func dismissAll() {
+        let ids = Array(panels.keys)
+        for id in ids {
+            dismissSurfaceById(id)
+        }
+    }
+
+    private func dismissSurfaceById(_ surfaceId: String) {
+        panels[surfaceId]?.close()
+        panels.removeValue(forKey: surfaceId)
+        activeSurfaces.removeValue(forKey: surfaceId)
+        log.info("Dismissed surface: id=\(surfaceId)")
+    }
+
+    // MARK: - Positioning
+
+    private func positionPanel(_ panel: NSPanel) {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+
+        // Count existing panels to determine vertical offset for stacking.
+        let existingCount = panels.count
+        let estimatedPanelHeight: CGFloat = 140
+        let yOffset = CGFloat(existingCount) * (estimatedPanelHeight + panelSpacing)
+
+        let x = screenFrame.maxX - panelWidth - panelMargin
+        let y = screenFrame.minY + panelMargin + yOffset
+
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+}
+
+// MARK: - Placeholder View
+
+/// Temporary placeholder view for surfaces. The actual type-specific renderers will be
+/// added in M4. This view displays the surface title, type, and action buttons using
+/// the project's design system.
+private struct SurfacePlaceholderView: View {
+    let surface: Surface
+    let onAction: (String, [String: Any]?) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: iconName)
+                    .foregroundStyle(VColor.accent)
+                Text(surface.title ?? surface.type.rawValue.capitalized)
+                    .font(VFont.heading)
+                    .foregroundStyle(VColor.textPrimary)
+                Spacer()
+            }
+
+            // Type badge
+            Text(surface.type.rawValue.uppercased())
+                .font(VFont.small)
+                .foregroundStyle(VColor.textMuted)
+
+            // Actions
+            if !surface.actions.isEmpty {
+                HStack(spacing: VSpacing.md) {
+                    Spacer()
+                    ForEach(surface.actions) { action in
+                        VButton(
+                            label: action.label,
+                            style: buttonStyle(for: action.style)
+                        ) {
+                            onAction(action.id, nil)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.xl)
+        .frame(width: 380)
+        .vPanelBackground()
+    }
+
+    private var iconName: String {
+        switch surface.type {
+        case .card: return "rectangle.portrait"
+        case .form: return "doc.text"
+        case .list: return "list.bullet"
+        case .confirmation: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func buttonStyle(for style: SurfaceActionStyle) -> VButton.Style {
+        switch style {
+        case .primary: return .primary
+        case .secondary: return .ghost
+        case .destructive: return .danger
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+// MARK: - Surface Enums
+
+enum SurfaceType: String, Codable, Sendable {
+    case card
+    case form
+    case list
+    case confirmation
+}
+
+enum SurfaceActionStyle: String, Codable, Sendable {
+    case primary
+    case secondary
+    case destructive
+}
+
+enum SelectionMode: String, Sendable {
+    case single
+    case multiple
+    case none
+}
+
+// MARK: - Surface Data Models
+
+struct CardSurfaceData: Sendable {
+    let title: String
+    let subtitle: String?
+    let body: String
+    let metadata: [(label: String, value: String)]?
+}
+
+struct FormFieldOption: Sendable {
+    let label: String
+    let value: String
+}
+
+enum FormFieldType: String, Sendable {
+    case text
+    case textarea
+    case select
+    case toggle
+    case number
+}
+
+struct FormField: Identifiable, Sendable {
+    let id: String
+    let type: FormFieldType
+    let label: String
+    let placeholder: String?
+    let required: Bool
+    let defaultValue: String?
+    let options: [FormFieldOption]?
+}
+
+struct FormSurfaceData: Sendable {
+    let description: String?
+    let fields: [FormField]
+    let submitLabel: String?
+}
+
+struct ListItemData: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let subtitle: String?
+    let icon: String?
+    let selected: Bool
+}
+
+struct ListSurfaceData: Sendable {
+    let items: [ListItemData]
+    let selectionMode: SelectionMode
+}
+
+struct ConfirmationSurfaceData: Sendable {
+    let message: String
+    let detail: String?
+    let confirmLabel: String?
+    let cancelLabel: String?
+    let destructive: Bool
+}
+
+enum SurfaceData: Sendable {
+    case card(CardSurfaceData)
+    case form(FormSurfaceData)
+    case list(ListSurfaceData)
+    case confirmation(ConfirmationSurfaceData)
+}
+
+struct SurfaceActionButton: Identifiable, Sendable {
+    let id: String
+    let label: String
+    let style: SurfaceActionStyle
+}
+
+struct Surface: Identifiable, Sendable {
+    let id: String
+    let sessionId: String
+    let type: SurfaceType
+    let title: String?
+    let data: SurfaceData
+    let actions: [SurfaceActionButton]
+}
+
+// MARK: - Parsing from IPC Messages
+
+extension Surface {
+    /// Parse a `Surface` from a `UiSurfaceShowMessage` received over IPC.
+    /// The message carries an `AnyCodable` data payload whose shape depends on `surfaceType`.
+    static func from(_ message: UiSurfaceShowMessage) -> Surface? {
+        guard let surfaceType = SurfaceType(rawValue: message.surfaceType) else {
+            return nil
+        }
+
+        let dict = message.data.value as? [String: Any?] ?? [:]
+
+        guard let surfaceData = parseSurfaceData(type: surfaceType, dict: dict) else {
+            return nil
+        }
+
+        let actions = (message.actions ?? []).map { action in
+            SurfaceActionButton(
+                id: action.id,
+                label: action.label,
+                style: SurfaceActionStyle(rawValue: action.style ?? "secondary") ?? .secondary
+            )
+        }
+
+        return Surface(
+            id: message.surfaceId,
+            sessionId: message.sessionId,
+            type: surfaceType,
+            title: message.title,
+            data: surfaceData,
+            actions: actions
+        )
+    }
+
+    /// Update only the data payload of an existing surface from a `UiSurfaceUpdateMessage`.
+    func updated(with message: UiSurfaceUpdateMessage) -> Surface? {
+        let dict = message.data.value as? [String: Any?] ?? [:]
+        guard let newData = Self.parseSurfaceData(type: self.type, dict: dict) else {
+            return nil
+        }
+        return Surface(
+            id: self.id,
+            sessionId: self.sessionId,
+            type: self.type,
+            title: self.title,
+            data: newData,
+            actions: self.actions
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    private static func parseSurfaceData(type: SurfaceType, dict: [String: Any?]) -> SurfaceData? {
+        switch type {
+        case .card:
+            return parseCardData(dict).map { .card($0) }
+        case .form:
+            return parseFormData(dict).map { .form($0) }
+        case .list:
+            return parseListData(dict).map { .list($0) }
+        case .confirmation:
+            return parseConfirmationData(dict).map { .confirmation($0) }
+        }
+    }
+
+    private static func parseCardData(_ dict: [String: Any?]) -> CardSurfaceData? {
+        guard let title = dict["title"] as? String,
+              let body = dict["body"] as? String else {
+            return nil
+        }
+
+        let subtitle = dict["subtitle"] as? String
+
+        var metadata: [(label: String, value: String)]?
+        if let metaArray = dict["metadata"] as? [[String: Any?]] {
+            metadata = metaArray.compactMap { item in
+                guard let label = item["label"] as? String,
+                      let value = item["value"] as? String else { return nil }
+                return (label: label, value: value)
+            }
+        }
+
+        return CardSurfaceData(
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            metadata: metadata
+        )
+    }
+
+    private static func parseFormData(_ dict: [String: Any?]) -> FormSurfaceData? {
+        guard let fieldsArray = dict["fields"] as? [[String: Any?]] else {
+            return nil
+        }
+
+        let description = dict["description"] as? String
+        let submitLabel = dict["submitLabel"] as? String
+
+        let fields: [FormField] = fieldsArray.compactMap { fieldDict in
+            guard let id = fieldDict["id"] as? String,
+                  let typeStr = fieldDict["type"] as? String,
+                  let fieldType = FormFieldType(rawValue: typeStr),
+                  let label = fieldDict["label"] as? String else {
+                return nil
+            }
+
+            var options: [FormFieldOption]?
+            if let optionsArray = fieldDict["options"] as? [[String: Any?]] {
+                options = optionsArray.compactMap { optDict in
+                    guard let label = optDict["label"] as? String,
+                          let value = optDict["value"] as? String else { return nil }
+                    return FormFieldOption(label: label, value: value)
+                }
+            }
+
+            return FormField(
+                id: id,
+                type: fieldType,
+                label: label,
+                placeholder: fieldDict["placeholder"] as? String,
+                required: fieldDict["required"] as? Bool ?? false,
+                defaultValue: fieldDict["defaultValue"] as? String,
+                options: options
+            )
+        }
+
+        return FormSurfaceData(
+            description: description,
+            fields: fields,
+            submitLabel: submitLabel
+        )
+    }
+
+    private static func parseListData(_ dict: [String: Any?]) -> ListSurfaceData? {
+        guard let itemsArray = dict["items"] as? [[String: Any?]] else {
+            return nil
+        }
+
+        let selectionModeStr = dict["selectionMode"] as? String ?? "none"
+        let selectionMode = SelectionMode(rawValue: selectionModeStr) ?? .none
+
+        let items: [ListItemData] = itemsArray.compactMap { itemDict in
+            guard let id = itemDict["id"] as? String,
+                  let title = itemDict["title"] as? String else {
+                return nil
+            }
+            return ListItemData(
+                id: id,
+                title: title,
+                subtitle: itemDict["subtitle"] as? String,
+                icon: itemDict["icon"] as? String,
+                selected: itemDict["selected"] as? Bool ?? false
+            )
+        }
+
+        return ListSurfaceData(items: items, selectionMode: selectionMode)
+    }
+
+    private static func parseConfirmationData(_ dict: [String: Any?]) -> ConfirmationSurfaceData? {
+        guard let message = dict["message"] as? String else {
+            return nil
+        }
+
+        return ConfirmationSurfaceData(
+            message: message,
+            detail: dict["detail"] as? String,
+            confirmLabel: dict["confirmLabel"] as? String,
+            cancelLabel: dict["cancelLabel"] as? String,
+            destructive: dict["destructive"] as? Bool ?? false
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -26,6 +26,18 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published var isConnected: Bool = false
 
+    // MARK: - Surface Event Callbacks
+
+    /// Called when the daemon sends a `ui_surface_show` message.
+    /// Set by the app layer to forward to SurfaceManager without coupling DaemonClient to it.
+    var onSurfaceShow: ((UiSurfaceShowMessage) -> Void)?
+
+    /// Called when the daemon sends a `ui_surface_update` message.
+    var onSurfaceUpdate: ((UiSurfaceUpdateMessage) -> Void)?
+
+    /// Called when the daemon sends a `ui_surface_dismiss` message.
+    var onSurfaceDismiss: ((UiSurfaceDismissMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -231,6 +243,20 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         })
     }
 
+    // MARK: - Surface Actions
+
+    /// Convenience method for sending a surface action response to the daemon.
+    /// Keeps the IPC message construction co-located with the client.
+    func sendSurfaceAction(sessionId: String, surfaceId: String, actionId: String, data: [String: AnyCodable]?) throws {
+        let message = UiSurfaceActionMessage(
+            sessionId: sessionId,
+            surfaceId: surfaceId,
+            actionId: actionId,
+            data: data
+        )
+        try send(message)
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -332,6 +358,18 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             awaitingPong = false
             pongTimeoutTask?.cancel()
             pongTimeoutTask = nil
+        }
+
+        // Forward surface messages to registered callbacks.
+        switch message {
+        case .uiSurfaceShow(let msg):
+            onSurfaceShow?(msg)
+        case .uiSurfaceUpdate(let msg):
+            onSurfaceUpdate?(msg)
+        case .uiSurfaceDismiss(let msg):
+            onSurfaceDismiss?(msg)
+        default:
+            break
         }
 
         // Broadcast to all subscribers.


### PR DESCRIPTION
## Summary
- **SurfaceTypes.swift** — Swift data models for all surface types (card, form, list, confirmation), including a `Surface.from(_:)` factory that parses `UiSurfaceShowMessage`'s `AnyCodable` data payload into typed structs, and `updated(with:)` for surface updates
- **SurfaceManager.swift** — `@MainActor` manager that creates floating `NSPanel` windows following the `AmbientSuggestionWindow` pattern (non-activating, HUD-style, bottom-right positioned with stacking), with show/update/dismiss lifecycle and action callbacks
- **DaemonClient.swift** — Added decoupled surface event callbacks (`onSurfaceShow`, `onSurfaceUpdate`, `onSurfaceDismiss`) forwarded from `handleServerMessage`, plus `sendSurfaceAction(sessionId:surfaceId:actionId:data:)` convenience method

Part of #747.

## Test plan
- [x] `swift build` succeeds with no warnings
- [ ] Verify surface windows appear when daemon sends `ui_surface_show` messages
- [ ] Verify surfaces update in-place when `ui_surface_update` is received
- [ ] Verify surfaces dismiss when `ui_surface_dismiss` is received
- [ ] Verify action callbacks fire correctly on button press

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
