### PR TITLE
Wire end-to-end integration for JIT UI surfaces

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -6,13 +6,15 @@
  * with the AgentLoop (which runs inference via the Anthropic API with CU tools).
  */
 
+import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
-import type { ServerMessage, CuObservation } from './ipc-protocol.js';
+import type { ServerMessage, CuObservation, SurfaceType, SurfaceData } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { allComputerUseTools } from '../tools/computer-use/definitions.js';
+import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getLogger } from '../util/logger.js';
 
@@ -59,6 +61,10 @@ export class ComputerUseSession {
   private pendingObservation: {
     resolve: (result: ToolExecutionResult) => void;
   } | null = null;
+
+  private pendingSurfaceActions = new Map<string, {
+    resolve: (result: ToolExecutionResult) => void;
+  }>();
 
   // Tracks the agent loop promise so callers can await session completion
   private loopPromise: Promise<void> | null = null;
@@ -142,6 +148,12 @@ export class ComputerUseSession {
       this.pendingObservation = null;
     }
 
+    // Resolve any pending surface actions
+    for (const [, pending] of this.pendingSurfaceActions) {
+      pending.resolve({ content: 'Session aborted', isError: true });
+    }
+    this.pendingSurfaceActions.clear();
+
     this.state = 'error';
     this.sendToClient({
       type: 'cu_error',
@@ -158,13 +170,29 @@ export class ComputerUseSession {
     return this.state;
   }
 
+  handleSurfaceAction(surfaceId: string, actionId: string, data?: Record<string, unknown>): void {
+    const pending = this.pendingSurfaceActions.get(surfaceId);
+    if (!pending) {
+      log.warn({ surfaceId, actionId }, 'No pending surface action found');
+      return;
+    }
+    this.pendingSurfaceActions.delete(surfaceId);
+    pending.resolve({
+      content: JSON.stringify({ actionId, data: data ?? {} }),
+      isError: false,
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Agent loop execution
   // ---------------------------------------------------------------------------
 
   private async runAgentLoop(messages: Message[]): Promise<void> {
     const systemPrompt = buildComputerUseSystemPrompt(this.screenWidth, this.screenHeight);
-    const toolDefs: ToolDefinition[] = allComputerUseTools.map((t) => t.getDefinition());
+    const toolDefs: ToolDefinition[] = [
+      ...allComputerUseTools.map((t) => t.getDefinition()),
+      ...allUiSurfaceTools.map((t) => t.getDefinition()),
+    ];
 
     const prompter = new PermissionPrompter(this.sendToClient);
     const executor = new ToolExecutor(prompter);
@@ -173,6 +201,57 @@ export class ComputerUseSession {
       toolName: string,
       input: Record<string, unknown>,
     ): Promise<ToolExecutionResult> => {
+      // ── Surface tool proxying ──────────────────────────────────────
+      if (toolName === 'ui_show') {
+        const surfaceId = uuid();
+        const surfaceType = input.surface_type as string;
+        const title = typeof input.title === 'string' ? input.title : undefined;
+        const data = input.data as Record<string, unknown>;
+        const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
+        const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+
+        this.sendToClient({
+          type: 'ui_surface_show',
+          sessionId: this.sessionId,
+          surfaceId,
+          surfaceType: surfaceType as SurfaceType,
+          title,
+          data: data as unknown as SurfaceData,
+          actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
+        });
+
+        if (awaitAction) {
+          return new Promise<ToolExecutionResult>((resolve) => {
+            this.pendingSurfaceActions.set(surfaceId, { resolve });
+          });
+        }
+        return { content: JSON.stringify({ surfaceId }), isError: false };
+      }
+
+      if (toolName === 'ui_update') {
+        const surfaceId = input.surface_id as string;
+        const data = input.data as Record<string, unknown>;
+        this.sendToClient({
+          type: 'ui_surface_update',
+          sessionId: this.sessionId,
+          surfaceId,
+          data: data as Partial<SurfaceData>,
+        });
+        return { content: 'Surface updated', isError: false };
+      }
+
+      if (toolName === 'ui_dismiss') {
+        const surfaceId = input.surface_id as string;
+        this.sendToClient({
+          type: 'ui_surface_dismiss',
+          sessionId: this.sessionId,
+          surfaceId,
+        });
+        this.pendingSurfaceActions.delete(surfaceId);
+        return { content: 'Surface dismissed', isError: false };
+      }
+
+      // ── Computer-use tool proxying ─────────────────────────────────
       const reasoning = typeof input.reasoning === 'string' ? input.reasoning : undefined;
 
       // Record action in history

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -210,8 +210,18 @@ const handlers: DispatchMap = {
   ambient_observation: handleAmbientObservation,
   task_submit: handleTaskSubmit,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
-  ui_surface_action: (msg, _socket, _ctx) => {
-    log.info({ surfaceId: msg.surfaceId, actionId: msg.actionId }, 'Surface action received (not yet handled)');
+  ui_surface_action: (msg, _socket, ctx) => {
+    const cuSession = ctx.cuSessions.get(msg.sessionId);
+    if (cuSession) {
+      cuSession.handleSurfaceAction(msg.surfaceId, msg.actionId, msg.data);
+      return;
+    }
+    const session = ctx.sessions.get(msg.sessionId);
+    if (session) {
+      session.handleSurfaceAction(msg.surfaceId, msg.actionId, msg.data);
+      return;
+    }
+    log.warn({ sessionId: msg.sessionId, surfaceId: msg.surfaceId }, 'No session found for surface action');
   },
 };
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -9,8 +9,9 @@ import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
-import type { ToolLifecycleEventHandler } from '../tools/types.js';
+import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/types.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
+import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
@@ -51,6 +52,9 @@ export class Session {
   private contextWindowManager: ContextWindowManager;
   private contextCompactedMessageCount = 0;
   private currentRequestId?: string;
+  private pendingSurfaceActions = new Map<string, {
+    resolve: (result: ToolExecutionResult) => void;
+  }>();
 
   constructor(
     conversationId: string,
@@ -74,7 +78,10 @@ export class Session {
       return publishToolDomainEvent(event);
     };
 
-    const toolDefs = getAllToolDefinitions();
+    const toolDefs = [
+      ...getAllToolDefinitions(),
+      ...allUiSurfaceTools.map((t) => t.getDefinition()),
+    ];
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
       return this.executor.execute(name, input, {
         workingDir: this.workingDir,
@@ -84,6 +91,7 @@ export class Session {
         onOutput,
         sandboxOverride: this.sandboxOverride,
         onToolLifecycleEvent: handleToolLifecycleEvent,
+        proxyToolResolver: this.surfaceProxyResolver.bind(this),
       });
     };
 
@@ -174,6 +182,11 @@ export class Session {
       log.info({ conversationId: this.conversationId }, 'Aborting in-flight processing');
       this.abortController?.abort();
       this.prompter.dispose();
+      // Resolve any pending surface actions
+      for (const [, pending] of this.pendingSurfaceActions) {
+        pending.resolve({ content: 'Session aborted', isError: true });
+      }
+      this.pendingSurfaceActions.clear();
     }
   }
 
@@ -575,6 +588,19 @@ export class Session {
     return userMessageId;
   }
 
+  handleSurfaceAction(surfaceId: string, actionId: string, data?: Record<string, unknown>): void {
+    const pending = this.pendingSurfaceActions.get(surfaceId);
+    if (!pending) {
+      log.warn({ surfaceId, actionId }, 'No pending surface action found');
+      return;
+    }
+    this.pendingSurfaceActions.delete(surfaceId);
+    pending.resolve({
+      content: JSON.stringify({ actionId, data: data ?? {} }),
+      isError: false,
+    });
+  }
+
   getMessages(): Message[] {
     return this.messages;
   }
@@ -607,6 +633,60 @@ export class Session {
     conversationStore.deleteLastExchange(this.conversationId);
 
     return removed;
+  }
+
+  private async surfaceProxyResolver(
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<ToolExecutionResult> {
+    if (toolName === 'ui_show') {
+      const surfaceId = uuid();
+      const surfaceType = input.surface_type as string;
+      const title = typeof input.title === 'string' ? input.title : undefined;
+      const data = input.data as Record<string, unknown>;
+      const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
+      const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+
+      this.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: this.conversationId,
+        surfaceId,
+        surfaceType: surfaceType as SurfaceType,
+        title,
+        data: data as unknown as SurfaceData,
+        actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
+      });
+
+      if (awaitAction) {
+        return new Promise<ToolExecutionResult>((resolve) => {
+          this.pendingSurfaceActions.set(surfaceId, { resolve });
+        });
+      }
+      return { content: JSON.stringify({ surfaceId }), isError: false };
+    }
+
+    if (toolName === 'ui_update') {
+      this.sendToClient({
+        type: 'ui_surface_update',
+        sessionId: this.conversationId,
+        surfaceId: input.surface_id as string,
+        data: input.data as Partial<SurfaceData>,
+      });
+      return { content: 'Surface updated', isError: false };
+    }
+
+    if (toolName === 'ui_dismiss') {
+      const surfaceId = input.surface_id as string;
+      this.sendToClient({
+        type: 'ui_surface_dismiss',
+        sessionId: this.conversationId,
+        surfaceId,
+      });
+      this.pendingSurfaceActions.delete(surfaceId);
+      return { content: 'Surface dismissed', isError: false };
+    }
+
+    return { content: `Unknown proxy tool: ${toolName}`, isError: true };
   }
 
   private recordUsage(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var thinkingWindow: ThinkingIndicatorWindow?
     let ambientAgent = AmbientAgent()
     let daemonClient = DaemonClient()
+    let surfaceManager = SurfaceManager()
 
     private var onboardingWindow: OnboardingWindow?
     private var windowObserver: Any?
@@ -53,6 +54,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupEscapeMonitor()
         setupVoiceInput()
         setupAmbientAgent()
+        setupSurfaceManager()
         setupWindowObserver()
         setupNotifications()
     }
@@ -64,6 +66,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if daemonClient.isConnected {
                 setupAmbientAgent()
             }
+        }
+    }
+
+    private func setupSurfaceManager() {
+        // Wire daemon surface messages to SurfaceManager
+        daemonClient.onSurfaceShow = { [weak self] msg in
+            self?.surfaceManager.showSurface(msg)
+        }
+        daemonClient.onSurfaceUpdate = { [weak self] msg in
+            self?.surfaceManager.updateSurface(msg)
+        }
+        daemonClient.onSurfaceDismiss = { [weak self] msg in
+            self?.surfaceManager.dismissSurface(msg)
+        }
+
+        // Wire SurfaceManager action callback to DaemonClient
+        surfaceManager.onAction = { [weak self] sessionId, surfaceId, actionId, data in
+            guard let self else { return }
+            let codableData: [String: AnyCodable]? = data?.mapValues { AnyCodable($0) }
+            try? self.daemonClient.sendSurfaceAction(
+                sessionId: sessionId,
+                surfaceId: surfaceId,
+                actionId: actionId,
+                data: codableData
+            )
         }
     }
 
@@ -156,6 +183,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.thinkingWindow = nil
                     self?.currentSession?.cancel()
                     self?.currentTextSession?.cancel()
+                    self?.surfaceManager.dismissAll()
                 }
             }
         }
@@ -249,6 +277,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupEscapeMonitor()
             self?.setupVoiceInput()
             self?.setupAmbientAgent()
+            self?.setupSurfaceManager()
             self?.setupWindowObserver()
             self?.setupNotifications()
 
@@ -462,6 +491,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         voiceInput?.stop()
         ambientAgent.stop()
+        surfaceManager.dismissAll()
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds proxy resolution for `ui_show`, `ui_update`, and `ui_dismiss` tools in both `ComputerUseSession` (computer-use sessions) and `Session` (text sessions), enabling model tool calls to flow through IPC to the macOS client
- Routes `ui_surface_action` messages from the client back to the correct session (CU or text) to resolve pending tool results
- Wires `SurfaceManager` callbacks in `AppDelegate.swift` and adds surface cleanup on Escape key and app termination

## Details
When the model calls `ui_show` with actions and `await_action` is true (default when actions are provided), the tool call blocks via a Promise stored in `pendingSurfaceActions`. When the user interacts with the surface, the client sends `ui_surface_action` back through IPC, which resolves the pending Promise with the action ID and any form data. This completes the round-trip: model -> daemon -> client render -> user action -> daemon -> model.

Key changes:
- **`computer-use-session.ts`**: Surface tool handling in proxy resolver (before CU tool handling), `pendingSurfaceActions` map, `handleSurfaceAction()` method, abort cleanup, `allUiSurfaceTools` added to tool definitions
- **`session.ts`**: `surfaceProxyResolver()` method, `pendingSurfaceActions` map, `handleSurfaceAction()` method, abort cleanup, `proxyToolResolver` wired into tool executor, `allUiSurfaceTools` added to tool definitions
- **`handlers.ts`**: Replace stub `ui_surface_action` handler with routing to CU sessions and text sessions
- **`AppDelegate.swift`**: Wire `SurfaceManager` IPC callbacks, dismiss all surfaces on Escape and `applicationWillTerminate`

Closes #752

## Test plan
- [ ] Verify TypeScript type-checks cleanly (`bunx tsc --noEmit`) -- done
- [ ] Verify Swift builds cleanly (`./build.sh`) -- done
- [ ] Test `ui_show` with actions blocks until user clicks an action button
- [ ] Test `ui_show` without actions returns immediately with surfaceId
- [ ] Test `ui_update` sends update to client and returns success
- [ ] Test `ui_dismiss` sends dismiss to client and cleans up pending actions
- [ ] Test Escape key dismisses all surfaces
- [ ] Test session abort resolves pending surface actions with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)