### PR TITLE
Add bun-types to web/ for bun:test type resolution

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -41,6 +41,7 @@
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "bun-types": "^1.3.9",
         "drizzle-kit": "^0.31.8",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
@@ -766,6 +767,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -1602,6 +1605,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "bun-types/@types/node": ["@types/node@22.19.8", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",
     "babel-plugin-react-compiler": "^1.0.0",
+    "bun-types": "^1.3.9",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",

--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -27,13 +27,11 @@ function getFilesFromFormData(formData: FormData): File[] {
     return directFiles;
   }
   const files: File[] = [];
-  for (const key of formData.keys()) {
-    for (const value of formData.getAll(key)) {
-      if (value instanceof File) {
-        files.push(value);
-      }
+  formData.forEach((value) => {
+    if (value instanceof File) {
+      files.push(value);
     }
-  }
+  });
   return files;
 }
 

--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -26,7 +26,15 @@ function getFilesFromFormData(formData: FormData): File[] {
   if (directFiles.length > 0) {
     return directFiles;
   }
-  return [...formData.values()].filter((value): value is File => value instanceof File);
+  const files: File[] = [];
+  for (const key of formData.keys()) {
+    for (const value of formData.getAll(key)) {
+      if (value instanceof File) {
+        files.push(value);
+      }
+    }
+  }
+  return files;
 }
 
 function normalizeAttachmentIds(value: unknown): string[] {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["bun-types"],
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
## Summary
- Installs `bun-types` as a dev dependency in `web/`
- Adds `"types": ["bun-types"]` to `web/tsconfig.json` so TypeScript can resolve `bun:test` imports (e.g. in `web/src/lib/chat-suggestion.test.ts`)
- Matches the pattern already used in `assistant/tsconfig.json`

## Test plan
- [x] `bun test web/src/lib/chat-suggestion.test.ts` — all 15 tests pass
- [ ] Verify no new TS errors on `bun:test` imports in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
