### PR TITLE
Fix VTab close button and remove unused VToast duration

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VToast.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VToast.swift
@@ -5,8 +5,6 @@ struct VToast: View {
 
     let message: String
     var style: Style = .info
-    var duration: TimeInterval = 3
-
     var body: some View {
         HStack(spacing: VSpacing.md) {
             Image(systemName: iconName)

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -11,30 +11,34 @@ struct VTab: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: VSpacing.xs) {
-            if let icon = icon {
-                Image(systemName: icon)
-                    .font(.system(size: 10))
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 10))
+                }
+                Text(label)
+                    .font(VFont.caption)
+                    .lineLimit(1)
             }
-            Text(label)
-                .font(VFont.caption)
-                .lineLimit(1)
-            if isCloseable, let onClose = onClose {
+            .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in isHovered = hovering }
+        .overlay(alignment: .trailing) {
+            if isCloseable, let onClose = onClose, isHovered {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: 8, weight: .bold))
                         .foregroundColor(VColor.textMuted)
+                        .padding(.trailing, VSpacing.xs)
                 }
                 .buttonStyle(.plain)
-                .opacity(isHovered ? 1 : 0)
             }
         }
-        .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
-        .background(isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-        .onHover { hovering in isHovered = hovering }
-        .onTapGesture { onSelect() }
     }
 }


### PR DESCRIPTION
Address review feedback on PR #718: fix VTab onTapGesture intercepting close button clicks by restructuring to use Button with overlay, and remove unused VToast duration property.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
