### PR TITLE
Fix VButton full-width frame ordering

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
@@ -14,6 +14,7 @@ struct VButton: View {
             Text(label)
                 .font(VFont.bodyMedium)
                 .foregroundColor(foregroundColor)
+                .frame(maxWidth: isFullWidth ? .infinity : nil)
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.vertical, VSpacing.lg)
                 .background(backgroundColor)
@@ -22,7 +23,6 @@ struct VButton: View {
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(borderColor, lineWidth: style == .ghost ? 1 : 0)
                 )
-                .frame(maxWidth: isFullWidth ? .infinity : nil)
         }
         .buttonStyle(VButtonPressStyle())
         .disabled(isDisabled)


### PR DESCRIPTION
Move .frame(maxWidth:) before .background so the background fills the full width when isFullWidth is true. Previously the frame was after background/clipShape, which only expanded the layout box while the background stayed at intrinsic text width.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
