### PR TITLE
Couple surface payload type to surfaceType discriminator (#754 feedback)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -8,7 +8,7 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
-import type { ServerMessage, CuObservation, SurfaceType, SurfaceData } from './ipc-protocol.js';
+import type { ServerMessage, CuObservation, UiSurfaceShow, SurfaceData } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
@@ -214,11 +214,11 @@ export class ComputerUseSession {
           type: 'ui_surface_show',
           sessionId: this.sessionId,
           surfaceId,
-          surfaceType: surfaceType as SurfaceType,
+          surfaceType,
           title,
-          data: data as unknown as SurfaceData,
+          data,
           actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
-        });
+        } as unknown as UiSurfaceShow);
 
         if (awaitAction) {
           return new Promise<ToolExecutionResult>((resolve) => {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -399,15 +399,40 @@ export interface AmbientResult {
   suggestion?: string;
 }
 
-export interface UiSurfaceShow {
+/** Common fields shared by all UiSurfaceShow variants. */
+interface UiSurfaceShowBase {
   type: 'ui_surface_show';
   sessionId: string;
   surfaceId: string;
-  surfaceType: SurfaceType;
   title?: string;
-  data: SurfaceData;
   actions?: SurfaceAction[];
 }
+
+export interface UiSurfaceShowCard extends UiSurfaceShowBase {
+  surfaceType: 'card';
+  data: CardSurfaceData;
+}
+
+export interface UiSurfaceShowForm extends UiSurfaceShowBase {
+  surfaceType: 'form';
+  data: FormSurfaceData;
+}
+
+export interface UiSurfaceShowList extends UiSurfaceShowBase {
+  surfaceType: 'list';
+  data: ListSurfaceData;
+}
+
+export interface UiSurfaceShowConfirmation extends UiSurfaceShowBase {
+  surfaceType: 'confirmation';
+  data: ConfirmationSurfaceData;
+}
+
+export type UiSurfaceShow =
+  | UiSurfaceShowCard
+  | UiSurfaceShowForm
+  | UiSurfaceShowList
+  | UiSurfaceShowConfirmation;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, UiSurfaceShow, SurfaceData } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -651,11 +651,11 @@ export class Session {
         type: 'ui_surface_show',
         sessionId: this.conversationId,
         surfaceId,
-        surfaceType: surfaceType as SurfaceType,
+        surfaceType,
         title,
-        data: data as unknown as SurfaceData,
+        data,
         actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
-      });
+      } as unknown as UiSurfaceShow);
 
       if (awaitAction) {
         return new Promise<ToolExecutionResult>((resolve) => {


### PR DESCRIPTION
## Summary
- Refactors `UiSurfaceShow` from a single interface with independent `surfaceType` and `data` fields into a discriminated union that binds each `surfaceType` literal (`'card'`, `'form'`, `'list'`, `'confirmation'`) to its matching data interface (`CardSurfaceData`, `FormSurfaceData`, `ListSurfaceData`, `ConfirmationSurfaceData`).
- Prevents invalid combinations (e.g. `surfaceType: 'card'` paired with `ListSurfaceData`) at compile time rather than runtime.
- Updates consumer call sites in `session.ts` and `computer-use-session.ts` to cast through `unknown` at the dynamic tool-input boundary.

## Test plan
- [x] `bunx tsc --noEmit` passes with zero errors
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — all 49 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
