### PR TITLE
Default await_action for interactive surfaces and merge ui_update patches (#760 feedback)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -65,6 +65,7 @@ export class ComputerUseSession {
   private pendingSurfaceActions = new Map<string, {
     resolve: (result: ToolExecutionResult) => void;
   }>();
+  private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
 
   // Tracks the agent loop promise so callers can await session completion
   private loopPromise: Promise<void> | null = null;
@@ -153,6 +154,7 @@ export class ComputerUseSession {
       pending.resolve({ content: 'Session aborted', isError: true });
     }
     this.pendingSurfaceActions.clear();
+    this.surfaceState.clear();
 
     this.state = 'error';
     this.sendToClient({
@@ -204,19 +206,24 @@ export class ComputerUseSession {
       // ── Surface tool proxying ──────────────────────────────────────
       if (toolName === 'ui_show') {
         const surfaceId = uuid();
-        const surfaceType = input.surface_type as string;
+        const surfaceType = input.surface_type as SurfaceType;
         const title = typeof input.title === 'string' ? input.title : undefined;
-        const data = input.data as Record<string, unknown>;
+        const data = input.data as SurfaceData;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-        const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+        // Interactive surfaces (form, list, confirmation) default to awaiting user action
+        const isInteractive = surfaceType === 'form' || surfaceType === 'list' || surfaceType === 'confirmation';
+        const awaitAction = input.await_action !== false && (input.await_action === true || isInteractive || (actions && actions.length > 0));
+
+        // Track surface state for ui_update merging
+        this.surfaceState.set(surfaceId, { surfaceType, data });
 
         this.sendToClient({
           type: 'ui_surface_show',
           sessionId: this.sessionId,
           surfaceId,
-          surfaceType: surfaceType as SurfaceType,
+          surfaceType,
           title,
-          data: data as unknown as SurfaceData,
+          data,
           actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
         });
 
@@ -230,12 +237,23 @@ export class ComputerUseSession {
 
       if (toolName === 'ui_update') {
         const surfaceId = input.surface_id as string;
-        const data = input.data as Record<string, unknown>;
+        const patch = input.data as Record<string, unknown>;
+
+        // Merge the partial patch into the stored full surface data
+        const stored = this.surfaceState.get(surfaceId);
+        let mergedData: SurfaceData;
+        if (stored) {
+          mergedData = { ...stored.data, ...patch } as SurfaceData;
+          stored.data = mergedData;
+        } else {
+          mergedData = patch as unknown as SurfaceData;
+        }
+
         this.sendToClient({
           type: 'ui_surface_update',
           sessionId: this.sessionId,
           surfaceId,
-          data: data as Partial<SurfaceData>,
+          data: mergedData,
         });
         return { content: 'Surface updated', isError: false };
       }
@@ -248,6 +266,7 @@ export class ComputerUseSession {
           surfaceId,
         });
         this.pendingSurfaceActions.delete(surfaceId);
+        this.surfaceState.delete(surfaceId);
         return { content: 'Surface dismissed', isError: false };
       }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -55,6 +55,7 @@ export class Session {
   private pendingSurfaceActions = new Map<string, {
     resolve: (result: ToolExecutionResult) => void;
   }>();
+  private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
 
   constructor(
     conversationId: string,
@@ -187,6 +188,7 @@ export class Session {
         pending.resolve({ content: 'Session aborted', isError: true });
       }
       this.pendingSurfaceActions.clear();
+      this.surfaceState.clear();
     }
   }
 
@@ -641,19 +643,24 @@ export class Session {
   ): Promise<ToolExecutionResult> {
     if (toolName === 'ui_show') {
       const surfaceId = uuid();
-      const surfaceType = input.surface_type as string;
+      const surfaceType = input.surface_type as SurfaceType;
       const title = typeof input.title === 'string' ? input.title : undefined;
-      const data = input.data as Record<string, unknown>;
+      const data = input.data as SurfaceData;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-      const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+      // Interactive surfaces (form, list, confirmation) default to awaiting user action
+      const isInteractive = surfaceType === 'form' || surfaceType === 'list' || surfaceType === 'confirmation';
+      const awaitAction = input.await_action !== false && (input.await_action === true || isInteractive || (actions && actions.length > 0));
+
+      // Track surface state for ui_update merging
+      this.surfaceState.set(surfaceId, { surfaceType, data });
 
       this.sendToClient({
         type: 'ui_surface_show',
         sessionId: this.conversationId,
         surfaceId,
-        surfaceType: surfaceType as SurfaceType,
+        surfaceType,
         title,
-        data: data as unknown as SurfaceData,
+        data,
         actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
       });
 
@@ -666,11 +673,24 @@ export class Session {
     }
 
     if (toolName === 'ui_update') {
+      const surfaceId = input.surface_id as string;
+      const patch = input.data as Record<string, unknown>;
+
+      // Merge the partial patch into the stored full surface data
+      const stored = this.surfaceState.get(surfaceId);
+      let mergedData: SurfaceData;
+      if (stored) {
+        mergedData = { ...stored.data, ...patch } as SurfaceData;
+        stored.data = mergedData;
+      } else {
+        mergedData = patch as unknown as SurfaceData;
+      }
+
       this.sendToClient({
         type: 'ui_surface_update',
         sessionId: this.conversationId,
-        surfaceId: input.surface_id as string,
-        data: input.data as Partial<SurfaceData>,
+        surfaceId,
+        data: mergedData,
       });
       return { content: 'Surface updated', isError: false };
     }
@@ -683,6 +703,7 @@ export class Session {
         surfaceId,
       });
       this.pendingSurfaceActions.delete(surfaceId);
+      this.surfaceState.delete(surfaceId);
       return { content: 'Surface dismissed', isError: false };
     }
 


### PR DESCRIPTION
## Summary
- **Interactive surfaces default to `await_action=true`**: Form, list, and confirmation surfaces now block and wait for user input by default, even when no explicit actions are provided. The macOS client emits user actions (submit, select, confirm/cancel) for these surface types from `SurfaceContainerView`, so previously `ui_show` would return immediately and later `ui_surface_action` messages were dropped with "No pending surface action found."
- **`ui_update` merges patches before forwarding**: A `Map<surfaceId, SurfaceData>` now tracks the full surface state. When `ui_update` is called with a partial patch, the daemon merges it into the stored full state and sends the merged result to the client. Previously, partial patches were forwarded as-is, causing the macOS client's `Surface.updated(with:)` to fail silently when required fields were missing.
- Both fixes applied consistently to `session.ts` and `computer-use-session.ts`.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass (49/49)
- [ ] Manual: show a form surface without explicit actions, verify it blocks until user submits
- [ ] Manual: call `ui_update` with a partial patch (e.g., only `description`), verify the macOS client receives all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
