### PR TITLE
Fix interactive surface await default and merge ui_update patches

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -66,6 +66,9 @@ export class ComputerUseSession {
     resolve: (result: ToolExecutionResult) => void;
   }>();
 
+  /** Tracks active surface data so ui_update can merge patches before forwarding. */
+  private activeSurfaces = new Map<string, { type: SurfaceType; data: Record<string, unknown> }>();
+
   // Tracks the agent loop promise so callers can await session completion
   private loopPromise: Promise<void> | null = null;
 
@@ -153,6 +156,7 @@ export class ComputerUseSession {
       pending.resolve({ content: 'Session aborted', isError: true });
     }
     this.pendingSurfaceActions.clear();
+    this.activeSurfaces.clear();
 
     this.state = 'error';
     this.sendToClient({
@@ -208,7 +212,11 @@ export class ComputerUseSession {
         const title = typeof input.title === 'string' ? input.title : undefined;
         const data = input.data as Record<string, unknown>;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-        const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+        const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+        const awaitAction = (input.await_action as boolean) ?? isInteractive;
+
+        // Track active surface data for patch merging in ui_update
+        this.activeSurfaces.set(surfaceId, { type: surfaceType as SurfaceType, data: { ...data } });
 
         this.sendToClient({
           type: 'ui_surface_show',
@@ -231,11 +239,17 @@ export class ComputerUseSession {
       if (toolName === 'ui_update') {
         const surfaceId = input.surface_id as string;
         const data = input.data as Record<string, unknown>;
+        // Merge the patch with existing surface data before forwarding
+        const existing = this.activeSurfaces.get(surfaceId);
+        const mergedData = { ...existing?.data, ...data };
+        if (existing) {
+          this.activeSurfaces.set(surfaceId, { type: existing.type, data: mergedData });
+        }
         this.sendToClient({
           type: 'ui_surface_update',
           sessionId: this.sessionId,
           surfaceId,
-          data: data as Partial<SurfaceData>,
+          data: mergedData as Partial<SurfaceData>,
         });
         return { content: 'Surface updated', isError: false };
       }
@@ -248,6 +262,7 @@ export class ComputerUseSession {
           surfaceId,
         });
         this.pendingSurfaceActions.delete(surfaceId);
+        this.activeSurfaces.delete(surfaceId);
         return { content: 'Surface dismissed', isError: false };
       }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -56,6 +56,9 @@ export class Session {
     resolve: (result: ToolExecutionResult) => void;
   }>();
 
+  /** Tracks active surface data so ui_update can merge patches before forwarding. */
+  private activeSurfaces = new Map<string, { type: SurfaceType; data: Record<string, unknown> }>();
+
   constructor(
     conversationId: string,
     provider: Provider,
@@ -187,6 +190,7 @@ export class Session {
         pending.resolve({ content: 'Session aborted', isError: true });
       }
       this.pendingSurfaceActions.clear();
+      this.activeSurfaces.clear();
     }
   }
 
@@ -645,7 +649,11 @@ export class Session {
       const title = typeof input.title === 'string' ? input.title : undefined;
       const data = input.data as Record<string, unknown>;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-      const awaitAction = input.await_action !== false && (input.await_action === true || (actions && actions.length > 0));
+      const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+      const awaitAction = (input.await_action as boolean) ?? isInteractive;
+
+      // Track active surface data for patch merging in ui_update
+      this.activeSurfaces.set(surfaceId, { type: surfaceType as SurfaceType, data: { ...data } });
 
       this.sendToClient({
         type: 'ui_surface_show',
@@ -666,11 +674,19 @@ export class Session {
     }
 
     if (toolName === 'ui_update') {
+      const surfaceId = input.surface_id as string;
+      const data = input.data as Record<string, unknown>;
+      // Merge the patch with existing surface data before forwarding
+      const existing = this.activeSurfaces.get(surfaceId);
+      const mergedData = { ...existing?.data, ...data };
+      if (existing) {
+        this.activeSurfaces.set(surfaceId, { type: existing.type, data: mergedData });
+      }
       this.sendToClient({
         type: 'ui_surface_update',
         sessionId: this.conversationId,
-        surfaceId: input.surface_id as string,
-        data: input.data as Partial<SurfaceData>,
+        surfaceId,
+        data: mergedData as Partial<SurfaceData>,
       });
       return { content: 'Surface updated', isError: false };
     }
@@ -683,6 +699,7 @@ export class Session {
         surfaceId,
       });
       this.pendingSurfaceActions.delete(surfaceId);
+      this.activeSurfaces.delete(surfaceId);
       return { content: 'Surface dismissed', isError: false };
     }
 


### PR DESCRIPTION
## Summary
- **Default `awaitAction` to `true` for interactive surfaces:** Form, list, and confirmation surfaces now block by default (even without explicit `actions`), so hardcoded client-side actions (submit, select, confirm/cancel from `SurfaceContainerView`) are properly awaited rather than dropped.
- **Merge `ui_update` patches before forwarding:** Both session classes now track active surface data in an `activeSurfaces` map. When `ui_update` is called, the incoming partial patch is merged with the stored full data before being sent to the client, preventing `Surface.updated(with:)` from returning `nil` when required fields are missing.
- **Cleanup on dismiss/abort:** The `activeSurfaces` map is cleaned up when surfaces are dismissed or sessions are aborted.

Addresses PR #760 review feedback.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — all 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
