### PR TITLE
Fix partial updates, form defaults, and panel positioning (#756 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
@@ -128,11 +128,15 @@ struct FormSurfaceView: View {
             guard let defaultValue = field.defaultValue else { continue }
             switch field.type {
             case .text, .textarea, .number:
-                textValues[field.id] = defaultValue
+                textValues[field.id] = defaultValue.stringValue
             case .toggle:
-                toggleValues[field.id] = (defaultValue == "true")
+                if case .boolean(let b) = defaultValue {
+                    toggleValues[field.id] = b
+                } else {
+                    toggleValues[field.id] = (defaultValue.stringValue == "true")
+                }
             case .select:
-                selectValues[field.id] = defaultValue
+                selectValues[field.id] = defaultValue.stringValue
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -19,6 +19,9 @@ final class SurfaceManager: ObservableObject {
 
     private var panels: [String: NSPanel] = [:]
 
+    /// Ordered list of surface IDs for deterministic stacking positions.
+    private var surfaceOrder: [String] = []
+
     /// Vertical offset counter to stack multiple surfaces.
     private let panelWidth: CGFloat = 380
     private let panelMargin: CGFloat = 20
@@ -44,6 +47,7 @@ final class SurfaceManager: ObservableObject {
         }
 
         activeSurfaces[surface.id] = surface
+        surfaceOrder.append(surface.id)
 
         let view = SurfaceContainerView(
             surface: surface,
@@ -71,7 +75,9 @@ final class SurfaceManager: ObservableObject {
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
         // Position bottom-right of screen, stacked above existing panels.
-        positionPanel(panel)
+        // The index is the last position in surfaceOrder (just appended above).
+        let panelIndex = surfaceOrder.count - 1
+        positionPanel(panel, at: panelIndex)
 
         panel.orderFront(nil)
         panels[surface.id] = panel
@@ -118,32 +124,45 @@ final class SurfaceManager: ObservableObject {
     func dismissAll() {
         let ids = Array(panels.keys)
         for id in ids {
-            dismissSurfaceById(id)
+            panels[id]?.close()
+            panels.removeValue(forKey: id)
+            activeSurfaces.removeValue(forKey: id)
+            log.info("Dismissed surface: id=\(id)")
         }
+        surfaceOrder.removeAll()
     }
 
     private func dismissSurfaceById(_ surfaceId: String) {
         panels[surfaceId]?.close()
         panels.removeValue(forKey: surfaceId)
         activeSurfaces.removeValue(forKey: surfaceId)
+        surfaceOrder.removeAll { $0 == surfaceId }
+        repositionAllPanels()
         log.info("Dismissed surface: id=\(surfaceId)")
     }
 
     // MARK: - Positioning
 
-    private func positionPanel(_ panel: NSPanel) {
+    private func positionPanel(_ panel: NSPanel, at index: Int) {
         guard let screen = NSScreen.main else { return }
         let screenFrame = screen.visibleFrame
 
-        // Count existing panels to determine vertical offset for stacking.
-        let existingCount = panels.count
         let estimatedPanelHeight: CGFloat = 140
-        let yOffset = CGFloat(existingCount) * (estimatedPanelHeight + panelSpacing)
+        let yOffset = CGFloat(index) * (estimatedPanelHeight + panelSpacing)
 
         let x = screenFrame.maxX - panelWidth - panelMargin
         let y = screenFrame.minY + panelMargin + yOffset
 
         panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    /// Reposition all visible panels based on their order in `surfaceOrder`.
+    private func repositionAllPanels() {
+        for (index, surfaceId) in surfaceOrder.enumerated() {
+            if let panel = panels[surfaceId] {
+                positionPanel(panel, at: index)
+            }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -43,13 +43,46 @@ enum FormFieldType: String, Sendable {
     case number
 }
 
+/// A form field default value that can be a string, number, or boolean,
+/// matching the `string | number | boolean` union in ipc-protocol.ts.
+enum FormFieldDefault: Sendable, Equatable {
+    case string(String)
+    case number(Double)
+    case boolean(Bool)
+
+    /// Convenience accessor that returns the value as a display string.
+    var stringValue: String {
+        switch self {
+        case .string(let s): return s
+        case .number(let n):
+            // Format integers without a decimal point.
+            if n == n.rounded(.towardZero) && !n.isNaN && !n.isInfinite {
+                return String(Int(n))
+            }
+            return String(n)
+        case .boolean(let b): return b ? "true" : "false"
+        }
+    }
+
+    /// Parse from an untyped Any value coming from IPC JSON.
+    static func from(_ value: Any?) -> FormFieldDefault? {
+        guard let value = value else { return nil }
+        // Check Bool before numeric types because Bool conforms to numeric protocols in Swift.
+        if let b = value as? Bool { return .boolean(b) }
+        if let n = value as? Double { return .number(n) }
+        if let n = value as? Int { return .number(Double(n)) }
+        if let s = value as? String { return .string(s) }
+        return nil
+    }
+}
+
 struct FormField: Identifiable, Sendable {
     let id: String
     let type: FormFieldType
     let label: String
     let placeholder: String?
     let required: Bool
-    let defaultValue: String?
+    let defaultValue: FormFieldDefault?
     let options: [FormFieldOption]?
 }
 
@@ -137,9 +170,12 @@ extension Surface {
     }
 
     /// Update only the data payload of an existing surface from a `UiSurfaceUpdateMessage`.
+    ///
+    /// The update payload is `Partial<SurfaceData>` — only the fields present in the dict are
+    /// applied over the existing data. Missing keys keep their current value.
     func updated(with message: UiSurfaceUpdateMessage) -> Surface? {
         let dict = message.data.value as? [String: Any?] ?? [:]
-        guard let newData = Self.parseSurfaceData(type: self.type, dict: dict) else {
+        guard let mergedData = Self.mergeSurfaceData(existing: self.data, update: dict) else {
             return nil
         }
         return Surface(
@@ -147,7 +183,7 @@ extension Surface {
             sessionId: self.sessionId,
             type: self.type,
             title: self.title,
-            data: newData,
+            data: mergedData,
             actions: self.actions
         )
     }
@@ -166,6 +202,136 @@ extension Surface {
             return parseConfirmationData(dict).map { .confirmation($0) }
         }
     }
+
+    // MARK: - Partial Merge Helpers
+
+    /// Merge a partial update dict into existing `SurfaceData`, keeping fields that are not
+    /// present in the update unchanged. This supports the `Partial<SurfaceData>` contract
+    /// from ipc-protocol.ts.
+    private static func mergeSurfaceData(existing: SurfaceData, update: [String: Any?]) -> SurfaceData? {
+        switch existing {
+        case .card(let card):
+            return .card(mergeCardData(existing: card, update: update))
+        case .form(let form):
+            return .form(mergeFormData(existing: form, update: update))
+        case .list(let list):
+            return .list(mergeListData(existing: list, update: update))
+        case .confirmation(let confirmation):
+            return .confirmation(mergeConfirmationData(existing: confirmation, update: update))
+        }
+    }
+
+    private static func mergeCardData(existing: CardSurfaceData, update: [String: Any?]) -> CardSurfaceData {
+        let title = (update["title"] as? String) ?? existing.title
+        let body = (update["body"] as? String) ?? existing.body
+        let subtitle: String? = update.keys.contains("subtitle") ? (update["subtitle"] as? String) : existing.subtitle
+
+        var metadata = existing.metadata
+        if update.keys.contains("metadata") {
+            if let metaArray = update["metadata"] as? [[String: Any?]] {
+                metadata = metaArray.compactMap { item in
+                    guard let label = item["label"] as? String,
+                          let value = item["value"] as? String else { return nil }
+                    return (label: label, value: value)
+                }
+            } else {
+                metadata = nil
+            }
+        }
+
+        return CardSurfaceData(title: title, subtitle: subtitle, body: body, metadata: metadata)
+    }
+
+    private static func mergeFormData(existing: FormSurfaceData, update: [String: Any?]) -> FormSurfaceData {
+        let description: String? = update.keys.contains("description")
+            ? (update["description"] as? String)
+            : existing.description
+        let submitLabel: String? = update.keys.contains("submitLabel")
+            ? (update["submitLabel"] as? String)
+            : existing.submitLabel
+
+        var fields = existing.fields
+        if let fieldsArray = update["fields"] as? [[String: Any?]] {
+            fields = fieldsArray.compactMap { fieldDict in
+                guard let id = fieldDict["id"] as? String,
+                      let typeStr = fieldDict["type"] as? String,
+                      let fieldType = FormFieldType(rawValue: typeStr),
+                      let label = fieldDict["label"] as? String else {
+                    return nil
+                }
+
+                var options: [FormFieldOption]?
+                if let optionsArray = fieldDict["options"] as? [[String: Any?]] {
+                    options = optionsArray.compactMap { optDict in
+                        guard let label = optDict["label"] as? String,
+                              let value = optDict["value"] as? String else { return nil }
+                        return FormFieldOption(label: label, value: value)
+                    }
+                }
+
+                return FormField(
+                    id: id,
+                    type: fieldType,
+                    label: label,
+                    placeholder: fieldDict["placeholder"] as? String,
+                    required: fieldDict["required"] as? Bool ?? false,
+                    defaultValue: FormFieldDefault.from(fieldDict["defaultValue"] as Any?),
+                    options: options
+                )
+            }
+        }
+
+        return FormSurfaceData(description: description, fields: fields, submitLabel: submitLabel)
+    }
+
+    private static func mergeListData(existing: ListSurfaceData, update: [String: Any?]) -> ListSurfaceData {
+        var items = existing.items
+        if let itemsArray = update["items"] as? [[String: Any?]] {
+            items = itemsArray.compactMap { itemDict in
+                guard let id = itemDict["id"] as? String,
+                      let title = itemDict["title"] as? String else {
+                    return nil
+                }
+                return ListItemData(
+                    id: id,
+                    title: title,
+                    subtitle: itemDict["subtitle"] as? String,
+                    icon: itemDict["icon"] as? String,
+                    selected: itemDict["selected"] as? Bool ?? false
+                )
+            }
+        }
+
+        let selectionMode: SelectionMode
+        if let modeStr = update["selectionMode"] as? String,
+           let mode = SelectionMode(rawValue: modeStr) {
+            selectionMode = mode
+        } else {
+            selectionMode = existing.selectionMode
+        }
+
+        return ListSurfaceData(items: items, selectionMode: selectionMode)
+    }
+
+    private static func mergeConfirmationData(existing: ConfirmationSurfaceData, update: [String: Any?]) -> ConfirmationSurfaceData {
+        let message = (update["message"] as? String) ?? existing.message
+        let detail: String? = update.keys.contains("detail") ? (update["detail"] as? String) : existing.detail
+        let confirmLabel: String? = update.keys.contains("confirmLabel")
+            ? (update["confirmLabel"] as? String) : existing.confirmLabel
+        let cancelLabel: String? = update.keys.contains("cancelLabel")
+            ? (update["cancelLabel"] as? String) : existing.cancelLabel
+        let destructive: Bool = (update["destructive"] as? Bool) ?? existing.destructive
+
+        return ConfirmationSurfaceData(
+            message: message,
+            detail: detail,
+            confirmLabel: confirmLabel,
+            cancelLabel: cancelLabel,
+            destructive: destructive
+        )
+    }
+
+    // MARK: - Full Parse Helpers
 
     private static func parseCardData(_ dict: [String: Any?]) -> CardSurfaceData? {
         guard let title = dict["title"] as? String,
@@ -223,7 +389,7 @@ extension Surface {
                 label: label,
                 placeholder: fieldDict["placeholder"] as? String,
                 required: fieldDict["required"] as? Bool ?? false,
-                defaultValue: fieldDict["defaultValue"] as? String,
+                defaultValue: FormFieldDefault.from(fieldDict["defaultValue"] as Any?),
                 options: options
             )
         }


### PR DESCRIPTION
## Summary
- **Partial surface updates**: `updated(with:)` now does a real field-level merge instead of reparsing the update payload as a complete surface object. Only fields present in the update dict are applied; missing keys keep their existing values. This fixes incremental updates (e.g. body-only card updates) that were being silently dropped.
- **Typed form defaults**: Introduced `FormFieldDefault` enum (`string`/`number`/`boolean`) matching the `string | number | boolean` union in `ipc-protocol.ts`. `parseFormData` now preserves numeric and boolean defaults instead of only keeping strings via `as? String`. Updated `FormSurfaceView.initializeDefaults()` to use the typed values directly.
- **Panel positioning**: Added `surfaceOrder: [String]` array to `SurfaceManager` for deterministic stacking. Panel positions are now derived from each surface's index in this ordered list. After any dismiss, `repositionAllPanels()` reassigns positions to all remaining panels, eliminating overlap caused by count-based y-offset calculation.

## Test plan
- [ ] Verify partial card update with only `{ body: "new body" }` preserves existing title/subtitle/metadata
- [ ] Verify form fields with `defaultValue: 42` or `defaultValue: true` initialize correctly
- [ ] Show 3 surfaces, dismiss the middle one, verify remaining panels restack without overlap
- [ ] Show a surface with same ID as existing one — verify it replaces cleanly at proper position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
