### PR TITLE
Register UI surface tools lazily in session contexts

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -15,6 +15,7 @@ import { ToolExecutor } from '../tools/executor.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
+import { registerUiSurfaceTools } from '../tools/ui-surface/registry.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getLogger } from '../util/logger.js';
 
@@ -188,6 +189,11 @@ export class ComputerUseSession {
   // ---------------------------------------------------------------------------
 
   private async runAgentLoop(messages: Message[]): Promise<void> {
+    // Ensure UI surface tools are registered so ToolExecutor can resolve them.
+    // Registration is done here (not at daemon startup) so that surface tools
+    // are only available in sessions that have surface proxy infrastructure.
+    registerUiSurfaceTools();
+
     const systemPrompt = buildComputerUseSystemPrompt(this.screenWidth, this.screenHeight);
     const toolDefs: ToolDefinition[] = [
       ...allComputerUseTools.map((t) => t.getDefinition()),

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -12,6 +12,7 @@ import { ToolExecutor } from '../tools/executor.js';
 import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/types.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
+import { registerUiSurfaceTools } from '../tools/ui-surface/registry.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
@@ -77,6 +78,11 @@ export class Session {
       auditToolLifecycleEvent(event);
       return publishToolDomainEvent(event);
     };
+
+    // Ensure UI surface tools are registered so ToolExecutor can resolve them.
+    // Registration is done here (not at daemon startup) so that surface tools
+    // are only available in sessions that have surface proxy infrastructure.
+    registerUiSurfaceTools();
 
     const toolDefs = [
       ...getAllToolDefinitions(),

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -3,7 +3,6 @@ import type { Tool, ToolContext, ToolExecutionResult } from './types.js';
 import type { ToolDefinition } from '../providers/types.js';
 import { getLogger } from '../util/logger.js';
 import { registerComputerUseTools } from './computer-use/registry.js';
-import { registerUiSurfaceTools } from './ui-surface/registry.js';
 
 const log = getLogger('tool-registry');
 
@@ -108,10 +107,13 @@ export async function initializeTools(): Promise<void> {
   // from getAllToolDefinitions() since regular chat sessions don't use them.
   registerComputerUseTools();
 
-  // UI surface proxy tools — registered so ToolExecutor can look them up
-  // and forward surface show/update/dismiss to the connected macOS client.
-  // Like CU tools, they are excluded from getAllToolDefinitions().
-  registerUiSurfaceTools();
+  // NOTE: UI surface proxy tools (ui_show, ui_update, ui_dismiss) are NOT
+  // registered here.  They are registered lazily by sessions that have the
+  // surface proxy infrastructure wired up (ComputerUseSession and Session).
+  // Registering them globally would make them executable in any context with
+  // a proxyToolResolver, but the CU proxy resolver forwards unknown tool
+  // names as cu_action and blocks waiting for cu_observation — which would
+  // never arrive for surface tools, causing the turn to stall indefinitely.
 
   // The bash tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.


### PR DESCRIPTION
## Summary
- Removed `registerUiSurfaceTools()` from global `initializeTools()` in `registry.ts` to prevent UI surface proxy tools from being executable in contexts without surface proxy routing
- Added `registerUiSurfaceTools()` calls to `ComputerUseSession.runAgentLoop()` and `Session` constructor, which both have proper surface proxy infrastructure wired up
- Without this fix, if a UI surface tool was invoked in a context where the proxy resolver forwards unknown tool names as `cu_action`, the turn would stall indefinitely waiting for a `cu_observation` that never arrives

Addresses review feedback on #755.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass (`bun test src/__tests__/ipc-snapshot.test.ts` — 49 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
