### PR TITLE
Update ui_surface tool registration comments (#755 feedback)

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -108,12 +108,13 @@ export async function initializeTools(): Promise<void> {
   registerComputerUseTools();
 
   // NOTE: UI surface proxy tools (ui_show, ui_update, ui_dismiss) are NOT
-  // registered here.  They are registered lazily by sessions that have the
-  // surface proxy infrastructure wired up (ComputerUseSession and Session).
-  // Registering them globally would make them executable in any context with
-  // a proxyToolResolver, but the CU proxy resolver forwards unknown tool
-  // names as cu_action and blocks waiting for cu_observation — which would
-  // never arrive for surface tools, causing the turn to stall indefinitely.
+  // registered here.  They are registered per-session by Session and
+  // ComputerUseSession, which both wire up a surfaceProxyResolver that
+  // explicitly handles ui_show/ui_update/ui_dismiss BEFORE falling through
+  // to CU tool handling.  This ensures surface tools never reach the
+  // cu_action dispatch path and cannot stall waiting for a cu_observation
+  // that would never arrive.  See surfaceProxyResolver in session.ts and
+  // the proxyResolver in computer-use-session.ts.
 
   // The bash tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.

--- a/assistant/src/tools/ui-surface/registry.ts
+++ b/assistant/src/tools/ui-surface/registry.ts
@@ -1,8 +1,10 @@
 /**
  * Registers all UI surface proxy tools with the daemon's tool registry.
  *
- * Call `registerUiSurfaceTools()` during daemon startup to make the `ui_*`
- * tools available for inference.
+ * Called per-session by Session and ComputerUseSession (not at daemon startup)
+ * so that ui_* tools are only available in contexts where a surfaceProxyResolver
+ * is wired up to handle them.  The proxy resolver intercepts ui_show/ui_update/
+ * ui_dismiss before they can fall through to CU tool dispatch, preventing stalls.
  */
 
 import { registerTool } from '../registry.js';


### PR DESCRIPTION
## Summary
- Updates comments in `registry.ts` and `ui-surface/registry.ts` to accurately reflect the current architecture after PR #760 resolved the stalling concern raised in PR #755 review feedback.
- The original comments warned that registering ui_surface tools globally could cause stalls because the CU proxy resolver would forward unknown tool names as `cu_action`. PR #760 added explicit `ui_show`/`ui_update`/`ui_dismiss` handling in both `Session.surfaceProxyResolver` and `ComputerUseSession.proxyResolver` **before** the CU fallthrough path, making this safe.
- No behavioral changes -- comments only.

## Test plan
- [x] Verified `bunx tsc --noEmit` passes (pre-existing `SurfaceType` errors unrelated to this change)
- [x] Confirmed changes are comment-only with no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
