### PR TITLE
Simplify awaitAction logic for interactive surfaces

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -217,8 +217,8 @@ export class ComputerUseSession {
         const data = input.data as SurfaceData;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
         // Interactive surfaces (form, list, confirmation) default to awaiting user action
-        const isInteractive = surfaceType === 'form' || surfaceType === 'list' || surfaceType === 'confirmation';
-        const awaitAction = input.await_action !== false && (input.await_action === true || isInteractive || (actions && actions.length > 0));
+        const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+        const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging
         this.surfaceState.set(surfaceId, { surfaceType, data });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -654,8 +654,8 @@ export class Session {
       const data = input.data as SurfaceData;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
       // Interactive surfaces (form, list, confirmation) default to awaiting user action
-      const isInteractive = surfaceType === 'form' || surfaceType === 'list' || surfaceType === 'confirmation';
-      const awaitAction = input.await_action !== false && (input.await_action === true || isInteractive || (actions && actions.length > 0));
+      const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+      const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
       // Track surface state for ui_update merging
       this.surfaceState.set(surfaceId, { surfaceType, data });


### PR DESCRIPTION
## Summary
- Simplify `awaitAction` expression in both `computer-use-session.ts` and `session.ts` to use nullish coalescing (`??`) instead of a complex boolean chain
- When `await_action` is explicitly provided (true/false), that value is used directly
- When `await_action` is not provided, interactive surface types (form, list, confirmation) default to blocking, cards default to non-blocking
- Also adds missing `SurfaceType` import needed by the `surfaceState` map added in #765

Addresses review feedback on PR #760.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` — all 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
