### PR TITLE
Preserve @State on surface update and use server action IDs (#757 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -2,7 +2,26 @@ import SwiftUI
 
 struct ConfirmationSurfaceView: View {
     let data: ConfirmationSurfaceData
+    let actions: [SurfaceActionButton]
     let onAction: (String) -> Void
+
+    /// The action ID to emit when the user cancels.
+    /// Uses the first server-provided action ID if exactly 2 actions are defined, otherwise defaults to "cancel".
+    private var cancelActionId: String {
+        if actions.count == 2 {
+            return actions[0].id
+        }
+        return "cancel"
+    }
+
+    /// The action ID to emit when the user confirms.
+    /// Uses the second server-provided action ID if exactly 2 actions are defined, otherwise defaults to "confirm".
+    private var confirmActionId: String {
+        if actions.count == 2 {
+            return actions[1].id
+        }
+        return "confirm"
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -31,14 +50,14 @@ struct ConfirmationSurfaceView: View {
                     label: data.cancelLabel ?? "Cancel",
                     style: .ghost
                 ) {
-                    onAction("cancel")
+                    onAction(cancelActionId)
                 }
 
                 VButton(
                     label: data.confirmLabel ?? "Confirm",
                     style: data.destructive ? .danger : .primary
                 ) {
-                    onAction("confirm")
+                    onAction(confirmActionId)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 struct SurfaceContainerView: View {
-    let surface: Surface
-    let onAction: (String, [String: Any]?) -> Void
+    @ObservedObject var viewModel: SurfaceViewModel
+
+    private var surface: Surface { viewModel.surface }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -19,16 +20,21 @@ struct SurfaceContainerView: View {
                 CardSurfaceView(data: data)
             case .form(let data):
                 FormSurfaceView(data: data, onSubmit: { values in
-                    onAction("submit", values)
+                    let actionId = surface.actions.first?.id ?? "submit"
+                    viewModel.onAction(actionId, values)
                 })
             case .list(let data):
                 ListSurfaceView(data: data, onSelect: { selectedIds in
-                    onAction("select", ["selectedIds": selectedIds])
+                    viewModel.onAction("select", ["selectedIds": selectedIds])
                 })
             case .confirmation(let data):
-                ConfirmationSurfaceView(data: data, onAction: { actionId in
-                    onAction(actionId, nil)
-                })
+                ConfirmationSurfaceView(
+                    data: data,
+                    actions: surface.actions,
+                    onAction: { actionId in
+                        viewModel.onAction(actionId, nil)
+                    }
+                )
             }
 
             // Action buttons for card/list surfaces
@@ -60,7 +66,7 @@ struct SurfaceContainerView: View {
                     label: action.label,
                     style: buttonStyle(for: action.style)
                 ) {
-                    onAction(action.id, nil)
+                    viewModel.onAction(action.id, nil)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -4,6 +4,19 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SurfaceManager")
 
+/// Observable view model that holds the current surface state.
+/// Kept alive across updates so that child SwiftUI views preserve their @State (e.g. form inputs).
+@MainActor
+final class SurfaceViewModel: ObservableObject {
+    @Published var surface: Surface
+    let onAction: (String, [String: Any]?) -> Void
+
+    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void) {
+        self.surface = surface
+        self.onAction = onAction
+    }
+}
+
 /// Manages the lifecycle of surface windows (NSPanel) shown in response to daemon IPC messages.
 ///
 /// Each surface is displayed in a floating, non-activating panel positioned at the bottom-right
@@ -18,6 +31,7 @@ final class SurfaceManager: ObservableObject {
     // MARK: - Private State
 
     private var panels: [String: NSPanel] = [:]
+    private var viewModels: [String: SurfaceViewModel] = [:]
 
     /// Ordered list of surface IDs for deterministic stacking positions.
     private var surfaceOrder: [String] = []
@@ -49,12 +63,15 @@ final class SurfaceManager: ObservableObject {
         activeSurfaces[surface.id] = surface
         surfaceOrder.append(surface.id)
 
-        let view = SurfaceContainerView(
+        let viewModel = SurfaceViewModel(
             surface: surface,
             onAction: { [weak self] actionId, data in
                 self?.onAction?(surface.sessionId, surface.id, actionId, data)
             }
         )
+        viewModels[surface.id] = viewModel
+
+        let view = SurfaceContainerView(viewModel: viewModel)
 
         let hostingController = NSHostingController(rootView: view)
 
@@ -100,17 +117,8 @@ final class SurfaceManager: ObservableObject {
 
         activeSurfaces[message.surfaceId] = updated
 
-        // Rebuild the view in the existing panel.
-        guard let panel = panels[message.surfaceId] else { return }
-
-        let view = SurfaceContainerView(
-            surface: updated,
-            onAction: { [weak self] actionId, data in
-                self?.onAction?(updated.sessionId, updated.id, actionId, data)
-            }
-        )
-
-        panel.contentViewController = NSHostingController(rootView: view)
+        // Update the existing view model so child views preserve their @State.
+        viewModels[message.surfaceId]?.surface = updated
 
         log.info("Updated surface: id=\(message.surfaceId)")
     }
@@ -126,6 +134,7 @@ final class SurfaceManager: ObservableObject {
         for id in ids {
             panels[id]?.close()
             panels.removeValue(forKey: id)
+            viewModels.removeValue(forKey: id)
             activeSurfaces.removeValue(forKey: id)
             log.info("Dismissed surface: id=\(id)")
         }
@@ -135,6 +144,7 @@ final class SurfaceManager: ObservableObject {
     private func dismissSurfaceById(_ surfaceId: String) {
         panels[surfaceId]?.close()
         panels.removeValue(forKey: surfaceId)
+        viewModels.removeValue(forKey: surfaceId)
         activeSurfaces.removeValue(forKey: surfaceId)
         surfaceOrder.removeAll { $0 == surfaceId }
         repositionAllPanels()


### PR DESCRIPTION
## Summary
- Introduce `SurfaceViewModel` (`ObservableObject`) so `updateSurface` mutates a `@Published` property instead of replacing the `NSHostingController`, preserving `@State` in `FormSurfaceView` and `ListSurfaceView` across updates.
- Use server-provided action IDs for form submits (first action's ID from `surface.actions`, falling back to `"submit"`).
- Use server-provided action IDs for confirmation surfaces (`actions[0]` for cancel, `actions[1]` for confirm when exactly 2 actions are defined, falling back to `"cancel"`/`"confirm"` defaults).

## Test plan
- [ ] Show a form surface, type into fields, trigger an update via `ui_update` -- verify form input values are preserved
- [ ] Show a confirmation surface with custom action IDs -- verify the emitted action ID matches the server-provided IDs, not hardcoded "cancel"/"confirm"
- [ ] Show a form surface with a custom action ID -- verify the submit emits that action ID instead of "submit"
- [ ] Show a confirmation surface with no actions defined -- verify it falls back to "cancel"/"confirm" defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
