### PR TITLE
Skip await for non-selectable list surfaces (#765 feedback)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -8,7 +8,7 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
-import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
@@ -216,8 +216,11 @@ export class ComputerUseSession {
         const title = typeof input.title === 'string' ? input.title : undefined;
         const data = input.data as SurfaceData;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-        // Interactive surfaces (form, list, confirmation) default to awaiting user action
-        const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+        // Interactive surfaces default to awaiting user action.
+        // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
+        const isInteractive = surfaceType === 'list'
+          ? (data as ListSurfaceData).selectionMode !== 'none'
+          : ['form', 'confirmation'].includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -653,8 +653,11 @@ export class Session {
       const title = typeof input.title === 'string' ? input.title : undefined;
       const data = input.data as SurfaceData;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
-      // Interactive surfaces (form, list, confirmation) default to awaiting user action
-      const isInteractive = ['form', 'list', 'confirmation'].includes(surfaceType);
+      // Interactive surfaces default to awaiting user action.
+      // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
+      const isInteractive = surfaceType === 'list'
+        ? (data as ListSurfaceData).selectionMode !== 'none'
+        : ['form', 'confirmation'].includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
       // Track surface state for ui_update merging


### PR DESCRIPTION
## Summary
- Lists with `selectionMode: "none"` are passive (no selection actions emitted by the macOS client), so defaulting `awaitAction` to `true` would hang the agent loop forever
- Gates the implicit await behavior for list surfaces on selectability (`selectionMode !== 'none'`), matching the fix in both `session.ts` and `computer-use-session.ts`
- Callers can still explicitly pass `await_action: true` to override

## Test plan
- [ ] Verify `ui_show` with `list` + `selectionMode: "none"` returns immediately
- [ ] Verify `ui_show` with `list` + `selectionMode: "single"` still blocks
- [ ] Verify form/confirmation surfaces still default to blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
