### PR TITLE
Default missing selectionMode to none for list await (#774 feedback)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -219,7 +219,7 @@ export class ComputerUseSession {
         // Interactive surfaces default to awaiting user action.
         // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
         const isInteractive = surfaceType === 'list'
-          ? (data as ListSurfaceData).selectionMode !== 'none'
+          ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
           : ['form', 'confirmation'].includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -656,7 +656,7 @@ export class Session {
       // Interactive surfaces default to awaiting user action.
       // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
       const isInteractive = surfaceType === 'list'
-        ? (data as ListSurfaceData).selectionMode !== 'none'
+        ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
         : ['form', 'confirmation'].includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 


### PR DESCRIPTION
## Summary
- When the LLM omits `selectionMode` from list surface data, the field is `undefined`
- `undefined !== 'none'` evaluates to `true`, causing the agent to block on a passive list
- The macOS client defaults missing `selectionMode` to `"none"`, so we match that behavior with nullish coalescing: `(data.selectionMode ?? 'none') !== 'none'`

## Test plan
- [ ] `ui_show` with list data missing `selectionMode` returns immediately (non-blocking)
- [ ] `ui_show` with `selectionMode: "single"` still blocks
- [ ] `ui_show` with `selectionMode: "none"` still returns immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
