### PR TITLE
Remove unused UiSurfaceAction import

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -22,7 +22,6 @@ import type {
   CuSessionCreate,
   CuObservation,
   TaskSubmit,
-  UiSurfaceAction,
 } from './ipc-protocol.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';


### PR DESCRIPTION
## Summary
- Removes the unused `UiSurfaceAction` type import from `handlers.ts`
- Fixes the `@typescript-eslint/no-unused-vars` lint error
- The `ui_surface_action` handler already receives its type from the `MessageOfType` generic in the dispatch map

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
