### PR TITLE
Fix VButton frame ordering (padding → frame → background)

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
@@ -14,9 +14,9 @@ struct VButton: View {
             Text(label)
                 .font(VFont.bodyMedium)
                 .foregroundColor(foregroundColor)
-                .frame(maxWidth: isFullWidth ? .infinity : nil)
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.vertical, VSpacing.lg)
+                .frame(maxWidth: isFullWidth ? .infinity : nil)
                 .background(backgroundColor)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .overlay(


### PR DESCRIPTION
## Summary
- Moves `.frame(maxWidth:)` **after** `.padding()` and **before** `.background()` in VButton
- Fixes overflow when `isFullWidth` is true: padding is now applied as internal margins first, then the frame expands the padded content, then background fills the full-width area
- Addresses Devin's feedback on PR #763: frame before padding caused total width = availableWidth + 2×padding

## Test plan
- [ ] Build passes (`cd clients/macos && ./build.sh`)
- [ ] VButton with `isFullWidth: true` fills container width without overflow (e.g. FormSurfaceView submit button)
- [ ] VButton with `isFullWidth: false` renders at intrinsic text width with correct padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
