### PR TITLE
M1: Resize onboarding window to 1366x849 (#786)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/AccessibilityPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AccessibilityPermissionStepView.swift
@@ -153,5 +153,5 @@ struct AccessibilityPermissionStepView: View {
             }())
         }
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
@@ -183,5 +183,5 @@ struct AliveStepView: View {
             onOpenSettings: {}
         )
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -155,5 +155,5 @@ struct FnKeyStepView: View {
             return s
         }())
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
@@ -80,5 +80,5 @@ struct NamingStepView: View {
             return s
         }())
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingBackground.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingBackground.swift
@@ -74,5 +74,5 @@ struct OnboardingBackground: View {
 
 #Preview {
     OnboardingBackground()
-        .frame(width: 600, height: 500)
+        .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -60,7 +60,7 @@ struct OnboardingFlowView: View {
                 Spacer()
             }
         }
-        .frame(width: 600, height: 500)
+        .frame(width: 1366, height: 849)
         .animation(.easeOut(duration: 0.8), value: state.currentStep)
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -33,7 +33,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 500),
+            contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -47,7 +47,7 @@ final class OnboardingWindow {
         window.isReleasedWhenClosed = false
 
         // Fix the content size so the hosting controller doesn't resize the window after centering
-        let contentSize = NSSize(width: 600, height: 500)
+        let contentSize = NSSize(width: 1366, height: 849)
         window.contentMinSize = contentSize
         window.contentMaxSize = contentSize
         window.setContentSize(contentSize)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
@@ -139,5 +139,5 @@ struct ScreenPermissionStepView: View {
             }())
         }
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
@@ -153,5 +153,5 @@ struct SpeechPermissionStepView: View {
             }())
         }
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -60,5 +60,5 @@ struct WakeUpStepView: View {
         OnboardingBackground()
         WakeUpStepView(state: OnboardingState())
     }
-    .frame(width: 600, height: 500)
+    .frame(width: 1366, height: 849)
 }


### PR DESCRIPTION
Part of #785. Updates all onboarding window dimensions from 600x500 to 1366x849.

## Changes

- `OnboardingWindow.swift`: Updated `contentRect`, `contentMinSize`, `contentMaxSize`, and `setContentSize` from 600x500 to 1366x849
- `OnboardingFlowView.swift`: Updated `.frame()` from 600x500 to 1366x849
- All onboarding step preview frames updated from 600x500 to 1366x849:
  - `WakeUpStepView.swift`
  - `NamingStepView.swift`
  - `FnKeyStepView.swift`
  - `SpeechPermissionStepView.swift`
  - `AccessibilityPermissionStepView.swift`
  - `ScreenPermissionStepView.swift`
  - `AliveStepView.swift`
  - `OnboardingBackground.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
