### PR TITLE
M2: Create main app window shell at 1366x849 (#787)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -32,6 +32,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let surfaceManager = SurfaceManager()
 
     private var onboardingWindow: OnboardingWindow?
+    private var mainWindow: MainWindow?
     private var windowObserver: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -57,6 +58,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupSurfaceManager()
         setupWindowObserver()
         setupNotifications()
+        showMainWindow()
     }
 
     private func setupDaemonClient() {
@@ -281,10 +283,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupWindowObserver()
             self?.setupNotifications()
 
-            NSApp.setActivationPolicy(.accessory)
+            self?.showMainWindow()
         }
         onboarding.show()
         onboardingWindow = onboarding
+    }
+
+    private func showMainWindow() {
+        let main = MainWindow()
+        main.show()
+        mainWindow = main
     }
 
     // MARK: - Popover

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MainWindow {
+    private var window: NSWindow?
+
+    func show() {
+        let hostingController = NSHostingController(rootView: MainWindowView())
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = NSSize(width: 800, height: 600)
+
+        window.setContentSize(NSSize(width: 1366, height: 849))
+        window.center()
+
+        // Keep regular activation policy — the main window should appear in Dock and Cmd+Tab
+        NSApp.setActivationPolicy(.regular)
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct MainWindowView: View {
+    var body: some View {
+        ZStack {
+            VColor.background
+                .ignoresSafeArea()
+
+            VStack(spacing: VSpacing.lg) {
+                Text("vellum-assistant")
+                    .font(VFont.display)
+                    .foregroundStyle(VColor.textPrimary)
+
+                Text("Main window — components coming soon")
+                    .font(VFont.body)
+                    .foregroundStyle(VColor.textSecondary)
+            }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+    }
+}


### PR DESCRIPTION
Part of #785. Creates MainWindow + MainWindowView as the primary app interface shell, wired into AppDelegate for both new and returning users.

## Summary
- **MainWindow.swift**: NSWindow wrapper (1366x849, titled, closable, miniaturizable, resizable, fullSizeContentView), transparent titlebar, VColor.background, min size 800x600, regular activation policy
- **MainWindowView.swift**: Placeholder SwiftUI view with design system tokens (VColor, VFont, VSpacing)
- **AppDelegate.swift**: Added `mainWindow` property, `showMainWindow()` method, wired into both the post-onboarding completion path and the returning-user launch path

## Test plan
- [ ] Fresh install: complete onboarding, verify main window appears at 1366x849
- [ ] Returning user: launch app with onboarding already completed, verify main window appears
- [ ] Window is resizable with minimum size 800x600
- [ ] Window shows in Dock and Cmd+Tab
- [ ] Menu bar icon still works alongside main window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
