### PR TITLE
Fix onboarding window sizing for smaller displays

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -60,7 +60,7 @@ struct OnboardingFlowView: View {
                 Spacer()
             }
         }
-        .frame(width: 1366, height: 849)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.easeOut(duration: 0.8), value: state.currentStep)
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -46,11 +46,19 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
 
-        // Fix the content size so the hosting controller doesn't resize the window after centering
-        let contentSize = NSSize(width: 1366, height: 849)
-        window.contentMinSize = contentSize
-        window.contentMaxSize = contentSize
-        window.setContentSize(contentSize)
+        // Set preferred size, clamped to screen
+        let preferredSize = NSSize(width: 1366, height: 849)
+        let minSize = NSSize(width: 800, height: 600)
+        window.contentMinSize = minSize
+
+        if let screen = NSScreen.main {
+            let visibleFrame = screen.visibleFrame
+            let clampedWidth = min(preferredSize.width, visibleFrame.width)
+            let clampedHeight = min(preferredSize.height, visibleFrame.height)
+            window.setContentSize(NSSize(width: clampedWidth, height: clampedHeight))
+        } else {
+            window.setContentSize(preferredSize)
+        }
         window.center()
 
         // Make the app a regular app so the window gets focus


### PR DESCRIPTION
## Summary
- Addresses Codex P1 feedback on #788
- Removes fixed `contentMaxSize` constraint that made the onboarding window non-resizable
- Clamps window size to the screen's visible frame so it never opens off-screen on smaller displays (e.g. 13" MacBooks)
- Makes `OnboardingFlowView` use flexible sizing (`.frame(maxWidth: .infinity, maxHeight: .infinity)`) so content adapts to any window size

## Test plan
- [ ] On a large display (>=1366x849 visible area), confirm the onboarding window opens at 1366x849 and is centered
- [ ] On a smaller display (or by reducing resolution), confirm the window clamps to the visible frame and all controls remain accessible
- [ ] Verify all onboarding steps render correctly with flexible sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
