### PR TITLE
Allow JIT surface panels to be dismissed individually

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -67,4 +67,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
 };
 
-export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;
+export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.
+
+IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, forms, lists, confirmations) as floating panels on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text. Call ui_show with a card surface to display it. This is your primary way of presenting information to the user.`;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -240,4 +240,12 @@ export async function runDaemon(): Promise<void> {
 
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    log.error({ err: reason }, 'Unhandled promise rejection');
+  });
+
+  process.on('uncaughtException', (err) => {
+    log.error({ err }, 'Uncaught exception');
+  });
 }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -113,6 +113,19 @@ class BrowserManager {
 
     try {
       this.context = await this.contextCreating;
+
+      // Listen for browser disconnection so we can reset state
+      // instead of leaving a stale context reference.
+      const rawCtx = this.context as unknown as { on?: (event: string, handler: (...args: unknown[]) => void) => void };
+      if (typeof rawCtx.on === 'function') {
+        rawCtx.on('close', () => {
+          log.warn('Browser context closed unexpectedly, resetting state');
+          this.context = null;
+          this.pages.clear();
+          this.snapshotMaps.clear();
+        });
+      }
+
       return this.context;
     } finally {
       this.contextCreating = null;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -67,37 +67,42 @@ async function executeBrowserNavigate(
     // since Playwright follows redirects internally and performs its own DNS resolution.
     if (!allowPrivateNetwork) {
       routeHandler = async (route, request) => {
-        const reqUrl = request.url();
-        let reqParsed: URL;
         try {
-          reqParsed = new URL(reqUrl);
-        } catch {
+          const reqUrl = request.url();
+          let reqParsed: URL;
+          try {
+            reqParsed = new URL(reqUrl);
+          } catch {
+            await route.continue();
+            return;
+          }
+
+          // Check hostname against private/local patterns
+          if (isPrivateOrLocalHost(reqParsed.hostname)) {
+            blockedUrl = sanitizeUrlForOutput(reqParsed);
+            log.warn({ blockedUrl }, 'Blocked navigation to private network target via redirect');
+            await route.abort('blockedbyclient');
+            return;
+          }
+
+          // Resolve DNS and check resolved addresses
+          const resolution = await resolveRequestAddress(
+            reqParsed.hostname,
+            resolveHostAddresses,
+            false,
+          );
+          if (resolution.blockedAddress) {
+            blockedUrl = sanitizeUrlForOutput(reqParsed);
+            log.warn({ blockedUrl, resolvedTo: resolution.blockedAddress }, 'Blocked navigation: DNS resolves to private address');
+            await route.abort('blockedbyclient');
+            return;
+          }
+
           await route.continue();
-          return;
+        } catch (err) {
+          // Route may already be handled if the page navigated or was closed
+          log.debug({ err }, 'Route handler error (route likely already handled)');
         }
-
-        // Check hostname against private/local patterns
-        if (isPrivateOrLocalHost(reqParsed.hostname)) {
-          blockedUrl = sanitizeUrlForOutput(reqParsed);
-          log.warn({ blockedUrl }, 'Blocked navigation to private network target via redirect');
-          await route.abort('blockedbyclient');
-          return;
-        }
-
-        // Resolve DNS and check resolved addresses
-        const resolution = await resolveRequestAddress(
-          reqParsed.hostname,
-          resolveHostAddresses,
-          false,
-        );
-        if (resolution.blockedAddress) {
-          blockedUrl = sanitizeUrlForOutput(reqParsed);
-          log.warn({ blockedUrl, resolvedTo: resolution.blockedAddress }, 'Blocked navigation: DNS resolves to private address');
-          await route.abort('blockedbyclient');
-          return;
-        }
-
-        await route.continue();
       };
       await page.route('**/*', routeHandler);
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -7,11 +7,20 @@ struct SurfaceContainerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Optional title
-            if let title = surface.title {
-                Text(title)
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.textPrimary)
+            // Title row with dismiss button
+            HStack(alignment: .top) {
+                if let title = surface.title {
+                    Text(title)
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+                }
+                Spacer()
+                Button(action: { viewModel.onDismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .buttonStyle(.plain)
             }
 
             // Type-specific content

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -10,10 +10,12 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 final class SurfaceViewModel: ObservableObject {
     @Published var surface: Surface
     let onAction: (String, [String: Any]?) -> Void
+    let onDismiss: () -> Void
 
-    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void) {
+    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void, onDismiss: @escaping () -> Void) {
         self.surface = surface
         self.onAction = onAction
+        self.onDismiss = onDismiss
     }
 }
 
@@ -66,6 +68,10 @@ final class SurfaceManager: ObservableObject {
             surface: surface,
             onAction: { [weak self] actionId, data in
                 self?.onAction?(surface.sessionId, surface.id, actionId, data)
+            },
+            onDismiss: { [weak self] in
+                self?.onAction?(surface.sessionId, surface.id, "dismiss", nil)
+                self?.dismissSurfaceById(surface.id)
             }
         )
         viewModels[surface.id] = viewModel


### PR DESCRIPTION
The purpose of this PR is to let users dismiss individual JIT surface panels and improve daemon stability.

## Changes Made
- Add an X button to the top-right corner of every surface panel (`SurfaceContainerView`)
- Add `onDismiss` closure to `SurfaceViewModel`, sends `"dismiss"` action to daemon via IPC and removes panel locally
- Add global `unhandledRejection`/`uncaughtException` handlers in daemon lifecycle to prevent silent crashes
- Add browser context close listener to reset state on unexpected disconnection
- Wrap Playwright route handler in try/catch to fix `"Route already handled"` crashes during web navigation
- Update default system prompt to instruct model to prefer `ui_show` for structured information display

## Testing
- Build verified (`./build.sh` passes)
- Manual testing: dismiss button appears and works on all surface types
- Daemon stays alive through browser errors that previously caused crashes

---
*This PR was created with Claude Code*