### PR TITLE
Fix MainWindow activation policy lifecycle

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -103,6 +103,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] notification in
             guard let window = notification.object as? NSWindow,
                   window.title.contains("Settings") || window.title.contains("vellum") else { return }
+            // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
+            guard self?.mainWindow == nil else { return }
             // Revert to accessory (no dock icon) after settings closes
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
@@ -111,6 +113,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            mainWindow?.show()
+        }
+        return true
     }
 
     // MARK: - Menu Bar
@@ -254,7 +263,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             onboarding.close()
             self?.onboardingWindow = nil
-            NSApp.setActivationPolicy(.accessory)
+            self?.showMainWindow()
         }
         onboarding.show()
         onboardingWindow = onboarding


### PR DESCRIPTION
Addresses Devin feedback on #789. Prevents setupWindowObserver from reverting to .accessory while MainWindow exists, adds applicationShouldHandleReopen to restore window from Dock click, and fixes replayOnboarding to show MainWindow after completion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
