### PR TITLE
Add get_weather tool with Open-Meteo integration (#794)

### DIFF
--- a/assistant/src/__tests__/get-weather.test.ts
+++ b/assistant/src/__tests__/get-weather.test.ts
@@ -1,0 +1,294 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect } from 'bun:test';
+import { weatherCodeToDescription, executeGetWeather } from '../tools/weather/get-weather.js';
+
+// ---------------------------------------------------------------------------
+// Helper: build a mock fetch that returns predefined geocoding & weather data
+// ---------------------------------------------------------------------------
+
+function createMockFetch(options?: {
+  geoResults?: unknown[];
+  geoStatus?: number;
+  geoError?: Error;
+  forecastData?: unknown;
+  forecastStatus?: number;
+  forecastError?: Error;
+}): typeof globalThis.fetch {
+  const {
+    geoResults,
+    geoStatus = 200,
+    geoError,
+    forecastData,
+    forecastStatus = 200,
+    forecastError,
+  } = options ?? {};
+
+  const defaultGeoResults = [
+    { name: 'San Francisco', latitude: 37.7749, longitude: -122.4194, country: 'United States', admin1: 'California' },
+  ];
+
+  const defaultForecastData = {
+    current: {
+      temperature_2m: 15.0,
+      relative_humidity_2m: 72,
+      apparent_temperature: 13.5,
+      weather_code: 2,
+      wind_speed_10m: 18.0,
+      wind_direction_10m: 270,
+    },
+    current_units: {
+      temperature_2m: '\u00B0C',
+      relative_humidity_2m: '%',
+      apparent_temperature: '\u00B0C',
+      wind_speed_10m: 'km/h',
+      wind_direction_10m: '\u00B0',
+    },
+    daily: {
+      time: ['2025-01-15', '2025-01-16', '2025-01-17', '2025-01-18', '2025-01-19'],
+      weather_code: [2, 61, 3, 0, 1],
+      temperature_2m_max: [17.0, 14.0, 16.0, 19.0, 20.0],
+      temperature_2m_min: [10.0, 8.0, 9.0, 11.0, 12.0],
+      precipitation_probability_max: [10, 80, 30, 0, 5],
+    },
+    daily_units: {
+      temperature_2m_max: '\u00B0C',
+      temperature_2m_min: '\u00B0C',
+      precipitation_probability_max: '%',
+    },
+  };
+
+  return (async (url: string | URL | Request) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+
+    if (urlStr.includes('geocoding-api.open-meteo.com')) {
+      if (geoError) throw geoError;
+      return new Response(JSON.stringify({ results: geoResults ?? defaultGeoResults }), {
+        status: geoStatus,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    if (urlStr.includes('api.open-meteo.com')) {
+      if (forecastError) throw forecastError;
+      return new Response(JSON.stringify(forecastData ?? defaultForecastData), {
+        status: forecastStatus,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return new Response('Not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Weather code mapping
+// ---------------------------------------------------------------------------
+
+describe('weatherCodeToDescription', () => {
+  test('maps clear sky (code 0)', () => {
+    expect(weatherCodeToDescription(0)).toBe('Clear sky');
+  });
+
+  test('maps partly cloudy (code 2)', () => {
+    expect(weatherCodeToDescription(2)).toBe('Partly cloudy');
+  });
+
+  test('maps moderate rain (code 63)', () => {
+    expect(weatherCodeToDescription(63)).toBe('Moderate rain');
+  });
+
+  test('maps heavy snowfall (code 75)', () => {
+    expect(weatherCodeToDescription(75)).toBe('Heavy snowfall');
+  });
+
+  test('maps thunderstorm (code 95)', () => {
+    expect(weatherCodeToDescription(95)).toBe('Thunderstorm');
+  });
+
+  test('maps thunderstorm with heavy hail (code 99)', () => {
+    expect(weatherCodeToDescription(99)).toBe('Thunderstorm with heavy hail');
+  });
+
+  test('returns Unknown for unrecognized codes', () => {
+    expect(weatherCodeToDescription(42)).toBe('Unknown');
+    expect(weatherCodeToDescription(100)).toBe('Unknown');
+    expect(weatherCodeToDescription(-1)).toBe('Unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Geocoding parsing
+// ---------------------------------------------------------------------------
+
+describe('geocoding parsing', () => {
+  test('extracts location name, admin1, and country from geocoding results', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('San Francisco, California, United States');
+    expect(result.content).toContain('37.7749');
+    expect(result.content).toContain('-122.4194');
+  });
+
+  test('handles location without admin1', async () => {
+    const mockFetch = createMockFetch({
+      geoResults: [{ name: 'Tokyo', latitude: 35.6762, longitude: 139.6503, country: 'Japan' }],
+    });
+    const result = await executeGetWeather({ location: 'Tokyo' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Tokyo, Japan');
+  });
+
+  test('handles location without country', async () => {
+    const mockFetch = createMockFetch({
+      geoResults: [{ name: 'Somewhere', latitude: 0, longitude: 0 }],
+    });
+    const result = await executeGetWeather({ location: 'Somewhere' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Weather for Somewhere');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weather output formatting
+// ---------------------------------------------------------------------------
+
+describe('weather output formatting', () => {
+  test('returns current conditions in fahrenheit by default', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    // 15C = 59F
+    expect(result.content).toContain('59\u00B0F');
+    expect(result.content).toContain('Humidity: 72%');
+    expect(result.content).toContain('Partly cloudy');
+  });
+
+  test('returns current conditions in celsius when requested', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco', units: 'celsius' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('15\u00B0C');
+    expect(result.content).toContain('Humidity: 72%');
+  });
+
+  test('includes 5-day forecast', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('5-Day Forecast');
+    expect(result.content).toContain('2025-01-15');
+    expect(result.content).toContain('2025-01-19');
+    expect(result.content).toContain('Precip');
+  });
+
+  test('wind speed is converted to mph in fahrenheit mode', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    // 18 km/h ~= 11 mph
+    expect(result.content).toContain('11 mph');
+    expect(result.content).toContain('W');
+  });
+
+  test('wind speed stays in km/h in celsius mode', async () => {
+    const mockFetch = createMockFetch();
+    const result = await executeGetWeather({ location: 'San Francisco', units: 'celsius' }, mockFetch);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('18 km/h');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+  test('returns error for missing location', async () => {
+    const result = await executeGetWeather({});
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('location is required');
+  });
+
+  test('returns error for empty location', async () => {
+    const result = await executeGetWeather({ location: '' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('location is required');
+  });
+
+  test('returns error for whitespace-only location', async () => {
+    const result = await executeGetWeather({ location: '   ' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('location is required');
+  });
+
+  test('returns error for invalid units', async () => {
+    const result = await executeGetWeather({ location: 'NYC', units: 'kelvin' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('units must be "celsius" or "fahrenheit"');
+  });
+
+  test('returns error when location is not found', async () => {
+    const mockFetch = createMockFetch({ geoResults: [] });
+    const result = await executeGetWeather({ location: 'xyznonexistent' }, mockFetch);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Could not find location');
+  });
+
+  test('returns error when geocoding returns no results array', async () => {
+    // Return empty object with no results key
+    const emptyGeoFetch = (async () => {
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await executeGetWeather({ location: 'unknown' }, emptyGeoFetch);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Could not find location');
+  });
+
+  test('returns error when geocoding API returns non-200', async () => {
+    const mockFetch = createMockFetch({ geoStatus: 500 });
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Geocoding API returned HTTP 500');
+  });
+
+  test('returns error when weather API returns non-200', async () => {
+    const mockFetch = createMockFetch({ forecastStatus: 503 });
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Weather API returned HTTP 503');
+  });
+
+  test('returns error when geocoding fetch throws', async () => {
+    const mockFetch = createMockFetch({ geoError: new Error('Network error') });
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Geocoding request failed');
+    expect(result.content).toContain('Network error');
+  });
+
+  test('returns error when weather fetch throws', async () => {
+    const mockFetch = createMockFetch({ forecastError: new Error('Connection refused') });
+    const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Weather forecast request failed');
+    expect(result.content).toContain('Connection refused');
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -101,6 +101,7 @@ export async function initializeTools(): Promise<void> {
   await import('./network/web-fetch.js');
   await import('./skills/load.js');
   await import('./browser/headless-browser.js');
+  await import('./weather/get-weather.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -1,0 +1,230 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('get-weather');
+
+const GEOCODING_API = 'https://geocoding-api.open-meteo.com/v1/search';
+const FORECAST_API = 'https://api.open-meteo.com/v1/forecast';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Maps WMO weather codes (0-99) to human-readable descriptions.
+ * See: https://www.noaa.gov/weather/codes
+ */
+export function weatherCodeToDescription(code: number): string {
+  if (code === 0) return 'Clear sky';
+  if (code === 1) return 'Mainly clear';
+  if (code === 2) return 'Partly cloudy';
+  if (code === 3) return 'Overcast';
+  if (code === 45) return 'Foggy';
+  if (code === 48) return 'Depositing rime fog';
+  if (code === 51) return 'Light drizzle';
+  if (code === 53) return 'Moderate drizzle';
+  if (code === 55) return 'Dense drizzle';
+  if (code === 56) return 'Light freezing drizzle';
+  if (code === 57) return 'Dense freezing drizzle';
+  if (code === 61) return 'Slight rain';
+  if (code === 63) return 'Moderate rain';
+  if (code === 65) return 'Heavy rain';
+  if (code === 66) return 'Light freezing rain';
+  if (code === 67) return 'Heavy freezing rain';
+  if (code === 71) return 'Slight snowfall';
+  if (code === 73) return 'Moderate snowfall';
+  if (code === 75) return 'Heavy snowfall';
+  if (code === 77) return 'Snow grains';
+  if (code === 80) return 'Slight rain showers';
+  if (code === 81) return 'Moderate rain showers';
+  if (code === 82) return 'Violent rain showers';
+  if (code === 85) return 'Slight snow showers';
+  if (code === 86) return 'Heavy snow showers';
+  if (code === 95) return 'Thunderstorm';
+  if (code === 96) return 'Thunderstorm with slight hail';
+  if (code === 99) return 'Thunderstorm with heavy hail';
+  return 'Unknown';
+}
+
+interface GeocodingResult {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country?: string;
+  admin1?: string;
+}
+
+interface CurrentWeather {
+  temperature_2m: number;
+  relative_humidity_2m: number;
+  apparent_temperature: number;
+  weather_code: number;
+  wind_speed_10m: number;
+  wind_direction_10m: number;
+}
+
+interface DailyForecast {
+  time: string[];
+  weather_code: number[];
+  temperature_2m_max: number[];
+  temperature_2m_min: number[];
+  precipitation_probability_max: number[];
+}
+
+interface ForecastResponse {
+  current: CurrentWeather;
+  current_units: Record<string, string>;
+  daily: DailyForecast;
+  daily_units: Record<string, string>;
+}
+
+function windDirectionToCompass(degrees: number): string {
+  const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW'];
+  const index = Math.round(degrees / 22.5) % 16;
+  return directions[index];
+}
+
+function celsiusToFahrenheit(celsius: number): number {
+  return Math.round((celsius * 9) / 5 + 32);
+}
+
+function kphToMph(kph: number): number {
+  return Math.round(kph * 0.621371);
+}
+
+type FetchFn = typeof globalThis.fetch;
+
+export async function executeGetWeather(
+  input: Record<string, unknown>,
+  fetchFn: FetchFn = globalThis.fetch,
+): Promise<ToolExecutionResult> {
+  const location = input.location;
+  if (typeof location !== 'string' || location.trim() === '') {
+    return { content: 'Error: location is required and must be a non-empty string', isError: true };
+  }
+
+  const units = (input.units as string) ?? 'fahrenheit';
+  if (units !== 'celsius' && units !== 'fahrenheit') {
+    return { content: 'Error: units must be "celsius" or "fahrenheit"', isError: true };
+  }
+
+  const useFahrenheit = units === 'fahrenheit';
+
+  // Step 1: Geocode the location
+  let geo: GeocodingResult;
+  try {
+    const geoUrl = `${GEOCODING_API}?name=${encodeURIComponent(location.trim())}&count=1`;
+    log.debug({ url: geoUrl }, 'Geocoding location');
+
+    const geoResponse = await fetchFn(geoUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+    if (!geoResponse.ok) {
+      return { content: `Error: Geocoding API returned HTTP ${geoResponse.status}`, isError: true };
+    }
+
+    const geoData = (await geoResponse.json()) as { results?: GeocodingResult[] };
+    if (!geoData.results || geoData.results.length === 0) {
+      return { content: `Error: Could not find location "${location}". Please try a different search term.`, isError: true };
+    }
+
+    geo = geoData.results[0];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, location }, 'Geocoding request failed');
+    return { content: `Error: Geocoding request failed: ${msg}`, isError: true };
+  }
+
+  // Step 2: Fetch the weather forecast
+  let forecast: ForecastResponse;
+  try {
+    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=5`;
+    log.debug({ url: weatherUrl }, 'Fetching weather forecast');
+
+    const weatherResponse = await fetchFn(weatherUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+    if (!weatherResponse.ok) {
+      return { content: `Error: Weather API returned HTTP ${weatherResponse.status}`, isError: true };
+    }
+
+    forecast = (await weatherResponse.json()) as ForecastResponse;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, location }, 'Weather forecast request failed');
+    return { content: `Error: Weather forecast request failed: ${msg}`, isError: true };
+  }
+
+  // Step 3: Format the output
+  const locationParts = [geo.name];
+  if (geo.admin1) locationParts.push(geo.admin1);
+  if (geo.country) locationParts.push(geo.country);
+  const locationDisplay = locationParts.join(', ');
+
+  const current = forecast.current;
+  const tempUnit = useFahrenheit ? 'F' : 'C';
+  const speedUnit = useFahrenheit ? 'mph' : 'km/h';
+
+  const currentTemp = useFahrenheit ? celsiusToFahrenheit(current.temperature_2m) : Math.round(current.temperature_2m);
+  const currentFeelsLike = useFahrenheit ? celsiusToFahrenheit(current.apparent_temperature) : Math.round(current.apparent_temperature);
+  const currentWind = useFahrenheit ? kphToMph(current.wind_speed_10m) : Math.round(current.wind_speed_10m);
+  const windDir = windDirectionToCompass(current.wind_direction_10m);
+  const currentDescription = weatherCodeToDescription(current.weather_code);
+
+  const lines: string[] = [
+    `Weather for ${locationDisplay}`,
+    `Coordinates: ${geo.latitude}, ${geo.longitude}`,
+    '',
+    '--- Current Conditions ---',
+    `Temperature: ${currentTemp}\u00B0${tempUnit}`,
+    `Feels like: ${currentFeelsLike}\u00B0${tempUnit}`,
+    `Humidity: ${current.relative_humidity_2m}%`,
+    `Wind: ${currentWind} ${speedUnit} ${windDir}`,
+    `Conditions: ${currentDescription}`,
+    '',
+    '--- 5-Day Forecast ---',
+  ];
+
+  const daily = forecast.daily;
+  for (let i = 0; i < daily.time.length; i++) {
+    const date = daily.time[i];
+    const high = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_max[i]) : Math.round(daily.temperature_2m_max[i]);
+    const low = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_min[i]) : Math.round(daily.temperature_2m_min[i]);
+    const precip = daily.precipitation_probability_max[i];
+    const desc = weatherCodeToDescription(daily.weather_code[i]);
+    lines.push(`${date}: High ${high}\u00B0${tempUnit}, Low ${low}\u00B0${tempUnit}, Precip ${precip}%, ${desc}`);
+  }
+
+  return { content: lines.join('\n'), isError: false };
+}
+
+class GetWeatherTool implements Tool {
+  name = 'get_weather';
+  description = 'Get current weather conditions and forecast for a location';
+  category = 'weather';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          location: {
+            type: 'string',
+            description: 'The location to get weather for (city name, address, etc.)',
+          },
+          units: {
+            type: 'string',
+            enum: ['celsius', 'fahrenheit'],
+            description: 'Temperature units to use (default: fahrenheit)',
+          },
+        },
+        required: ['location'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executeGetWeather(input);
+  }
+}
+
+registerTool(new GetWeatherTool());


### PR DESCRIPTION
## Summary
- Add `get_weather` tool that fetches current weather conditions and a 5-day forecast for any location using the Open-Meteo API (free, no API key required)
- Two-step flow: geocoding (location name to lat/lon) then weather forecast retrieval, with WMO weather code mapping, unit conversion (celsius/fahrenheit), and wind direction compass display
- Register the tool in `initializeTools()` in registry.ts and add comprehensive test coverage (25 tests) covering geocoding parsing, weather code mapping, output formatting, and error handling

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 25 tests pass (`bun test src/__tests__/get-weather.test.ts`)
- [x] Tests cover: weather code mapping for all major WMO codes, geocoding result parsing (with/without admin1/country), fahrenheit and celsius output, wind unit conversion, missing/empty/whitespace location, invalid units, location not found, API HTTP errors, network failures

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
