### PR TITLE
Add pomodoro timer tool with start/pause/resume/cancel (#796)

### DIFF
--- a/assistant/src/__tests__/pomodoro.test.ts
+++ b/assistant/src/__tests__/pomodoro.test.ts
@@ -1,0 +1,351 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { executePomodoro, timers } from '../tools/timer/pomodoro.js';
+
+describe('pomodoro tool', () => {
+  beforeEach(() => {
+    timers.clear();
+  });
+
+  afterEach(() => {
+    // Clear any lingering timeouts
+    for (const timer of timers.values()) {
+      if (timer.timeoutHandle) {
+        clearTimeout(timer.timeoutHandle);
+      }
+    }
+    timers.clear();
+  });
+
+  // ── action validation ────────────────────────────────────────────
+
+  test('rejects missing action', () => {
+    const result = executePomodoro({});
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('action is required');
+  });
+
+  test('rejects unknown action', () => {
+    const result = executePomodoro({ action: 'destroy' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action');
+    expect(result.content).toContain('destroy');
+  });
+
+  // ── start ────────────────────────────────────────────────────────
+
+  test('start creates a timer with default duration', () => {
+    const result = executePomodoro({ action: 'start' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('started');
+    expect(result.content).toContain('25 minutes');
+    expect(result.content).toContain('Pomodoro');
+    expect(timers.size).toBe(1);
+
+    const timer = timers.values().next().value!;
+    expect(timer.status).toBe('running');
+    expect(timer.durationMinutes).toBe(25);
+    expect(timer.label).toBe('Pomodoro');
+  });
+
+  test('start creates a timer with custom duration and label', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: 10, label: 'Deep Work' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Deep Work');
+    expect(result.content).toContain('10 minutes');
+
+    const timer = timers.values().next().value!;
+    expect(timer.durationMinutes).toBe(10);
+    expect(timer.label).toBe('Deep Work');
+  });
+
+  test('start uses default duration for invalid values', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: -5 });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('25 minutes');
+  });
+
+  test('start generates unique timer IDs', () => {
+    executePomodoro({ action: 'start' });
+    executePomodoro({ action: 'start' });
+    expect(timers.size).toBe(2);
+    const ids = Array.from(timers.keys());
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  // ── pause ────────────────────────────────────────────────────────
+
+  test('pause requires timer_id', () => {
+    const result = executePomodoro({ action: 'pause' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('timer_id is required');
+  });
+
+  test('pause rejects non-existent timer', () => {
+    const result = executePomodoro({ action: 'pause', timer_id: 'nonexist' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('pause stops a running timer', () => {
+    executePomodoro({ action: 'start', label: 'Test' });
+    const id = timers.keys().next().value!;
+
+    const result = executePomodoro({ action: 'pause', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('paused');
+
+    const timer = timers.get(id)!;
+    expect(timer.status).toBe('paused');
+    expect(timer.remainingMs).toBeGreaterThan(0);
+    expect(timer.timeoutHandle).toBeUndefined();
+  });
+
+  test('pause rejects already paused timer', () => {
+    executePomodoro({ action: 'start' });
+    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id });
+
+    const result = executePomodoro({ action: 'pause', timer_id: id });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not running');
+  });
+
+  // ── resume ───────────────────────────────────────────────────────
+
+  test('resume requires timer_id', () => {
+    const result = executePomodoro({ action: 'resume' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('timer_id is required');
+  });
+
+  test('resume rejects non-existent timer', () => {
+    const result = executePomodoro({ action: 'resume', timer_id: 'nonexist' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('resume restarts a paused timer', () => {
+    executePomodoro({ action: 'start', label: 'Test' });
+    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id });
+
+    const result = executePomodoro({ action: 'resume', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('resumed');
+
+    const timer = timers.get(id)!;
+    expect(timer.status).toBe('running');
+    expect(timer.timeoutHandle).toBeDefined();
+  });
+
+  test('resume rejects running timer', () => {
+    executePomodoro({ action: 'start' });
+    const id = timers.keys().next().value!;
+
+    const result = executePomodoro({ action: 'resume', timer_id: id });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not paused');
+  });
+
+  // ── cancel ───────────────────────────────────────────────────────
+
+  test('cancel requires timer_id', () => {
+    const result = executePomodoro({ action: 'cancel' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('timer_id is required');
+  });
+
+  test('cancel rejects non-existent timer', () => {
+    const result = executePomodoro({ action: 'cancel', timer_id: 'nonexist' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('cancel stops a running timer', () => {
+    executePomodoro({ action: 'start', label: 'Cancel me' });
+    const id = timers.keys().next().value!;
+
+    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('cancelled');
+
+    const timer = timers.get(id)!;
+    expect(timer.status).toBe('cancelled');
+    expect(timer.timeoutHandle).toBeUndefined();
+  });
+
+  test('cancel stops a paused timer', () => {
+    executePomodoro({ action: 'start' });
+    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id });
+
+    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('cancelled');
+  });
+
+  test('cancel rejects already cancelled timer', () => {
+    executePomodoro({ action: 'start' });
+    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'cancel', timer_id: id });
+
+    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('already cancelled');
+  });
+
+  test('cancel rejects completed timer', () => {
+    executePomodoro({ action: 'start' });
+    const id = timers.keys().next().value!;
+    // Manually mark as completed for testing
+    const timer = timers.get(id)!;
+    clearTimeout(timer.timeoutHandle!);
+    timer.status = 'completed';
+    timer.timeoutHandle = undefined;
+
+    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('already completed');
+  });
+
+  // ── status ───────────────────────────────────────────────────────
+
+  test('status requires timer_id', () => {
+    const result = executePomodoro({ action: 'status' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('timer_id is required');
+  });
+
+  test('status rejects non-existent timer', () => {
+    const result = executePomodoro({ action: 'status', timer_id: 'nonexist' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('status returns timer details for running timer', () => {
+    executePomodoro({ action: 'start', label: 'Focus', duration_minutes: 25 });
+    const id = timers.keys().next().value!;
+
+    const result = executePomodoro({ action: 'status', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Focus');
+    expect(result.content).toContain(id);
+    expect(result.content).toContain('Running');
+    expect(result.content).toContain('25 minutes');
+    expect(result.content).toContain('Progress:');
+  });
+
+  test('status returns timer details for paused timer', () => {
+    executePomodoro({ action: 'start', label: 'Paused test' });
+    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id });
+
+    const result = executePomodoro({ action: 'status', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Paused');
+  });
+
+  // ── list ─────────────────────────────────────────────────────────
+
+  test('list returns message when no timers exist', () => {
+    const result = executePomodoro({ action: 'list' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('No timers found');
+  });
+
+  test('list returns all timers', () => {
+    executePomodoro({ action: 'start', label: 'Timer A' });
+    executePomodoro({ action: 'start', label: 'Timer B' });
+
+    const result = executePomodoro({ action: 'list' });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Timer A');
+    expect(result.content).toContain('Timer B');
+  });
+
+  // ── timer expiration (fake timers) ───────────────────────────────
+
+  test('timer completes after duration elapses', async () => {
+    // Use a very short duration and manually fire the timeout
+    executePomodoro({ action: 'start', label: 'Quick', duration_minutes: 0.001 });
+    const id = timers.keys().next().value!;
+    const timer = timers.get(id)!;
+
+    expect(timer.status).toBe('running');
+
+    // Wait slightly longer than the timer duration (0.001 min = 60ms)
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(timer.status).toBe('completed');
+    expect(timer.completedAt).toBeDefined();
+    expect(timer.remainingMs).toBe(0);
+    expect(timer.timeoutHandle).toBeUndefined();
+  });
+
+  test('completed timer shows 100% progress', async () => {
+    executePomodoro({ action: 'start', label: 'Done', duration_minutes: 0.001 });
+    const id = timers.keys().next().value!;
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const result = executePomodoro({ action: 'status', timer_id: id });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Completed');
+    expect(result.content).toContain('Progress: 100%');
+    expect(result.content).toContain('Completed at:');
+  });
+
+  // ── pause/resume preserves remaining time ────────────────────────
+
+  test('pause and resume preserves remaining time correctly', async () => {
+    executePomodoro({ action: 'start', label: 'Preserve', duration_minutes: 1 });
+    const id = timers.keys().next().value!;
+
+    // Wait a small amount of time
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    executePomodoro({ action: 'pause', timer_id: id });
+    const pausedTimer = timers.get(id)!;
+    const remainingAtPause = pausedTimer.remainingMs;
+
+    // remaining should be less than full duration (60000ms) but close
+    expect(remainingAtPause).toBeLessThan(60000);
+    expect(remainingAtPause).toBeGreaterThan(59000);
+
+    executePomodoro({ action: 'resume', timer_id: id });
+    const resumedTimer = timers.get(id)!;
+    expect(resumedTimer.status).toBe('running');
+  });
+
+  // ── edge cases ───────────────────────────────────────────────────
+
+  test('multiple operations on same timer work correctly', () => {
+    executePomodoro({ action: 'start', label: 'Multi' });
+    const id = timers.keys().next().value!;
+
+    // Pause
+    let result = executePomodoro({ action: 'pause', timer_id: id });
+    expect(result.isError).toBe(false);
+
+    // Resume
+    result = executePomodoro({ action: 'resume', timer_id: id });
+    expect(result.isError).toBe(false);
+
+    // Pause again
+    result = executePomodoro({ action: 'pause', timer_id: id });
+    expect(result.isError).toBe(false);
+
+    // Cancel
+    result = executePomodoro({ action: 'cancel', timer_id: id });
+    expect(result.isError).toBe(false);
+
+    const timer = timers.get(id)!;
+    expect(timer.status).toBe('cancelled');
+  });
+
+  test('start returns expected end time', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: 30 });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Expected end:');
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -102,6 +102,7 @@ export async function initializeTools(): Promise<void> {
   await import('./skills/load.js');
   await import('./browser/headless-browser.js');
   await import('./weather/get-weather.js');
+  await import('./timer/pomodoro.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded

--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -1,0 +1,322 @@
+import crypto from 'node:crypto';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('pomodoro');
+
+export interface PomodoroTimer {
+  id: string;
+  label: string;
+  durationMinutes: number;
+  startedAt: number;
+  remainingMs: number;
+  status: 'running' | 'paused' | 'completed' | 'cancelled';
+  completedAt?: number;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+/** Module-level map of active timers keyed by timer ID. */
+export const timers = new Map<string, PomodoroTimer>();
+
+function generateTimerId(): string {
+  return crypto.randomUUID().slice(0, 8);
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function formatTimerStatus(timer: PomodoroTimer): string {
+  const totalMs = timer.durationMinutes * 60 * 1000;
+  let elapsedMs: number;
+  let remainingMs: number;
+
+  if (timer.status === 'completed') {
+    elapsedMs = totalMs;
+    remainingMs = 0;
+  } else if (timer.status === 'paused') {
+    elapsedMs = totalMs - timer.remainingMs;
+    remainingMs = timer.remainingMs;
+  } else if (timer.status === 'cancelled') {
+    elapsedMs = totalMs - timer.remainingMs;
+    remainingMs = timer.remainingMs;
+  } else {
+    // running
+    const now = Date.now();
+    elapsedMs = now - timer.startedAt;
+    remainingMs = Math.max(0, totalMs - elapsedMs);
+    // Correct for resumed timers: remainingMs was set at resume time
+    // and startedAt was adjusted, so elapsed = now - startedAt
+    // This is correct because startedAt is adjusted on resume.
+  }
+
+  const percentage = totalMs > 0 ? Math.min(100, Math.round((elapsedMs / totalMs) * 100)) : 100;
+
+  const lines: string[] = [
+    `Timer "${timer.label}" (${timer.id})`,
+    `Status: ${timer.status.charAt(0).toUpperCase() + timer.status.slice(1)}`,
+    `Duration: ${timer.durationMinutes} minutes`,
+    `Elapsed: ${formatDuration(elapsedMs)}`,
+    `Remaining: ${formatDuration(remainingMs)}`,
+    `Progress: ${percentage}%`,
+  ];
+
+  if (timer.completedAt) {
+    lines.push(`Completed at: ${new Date(timer.completedAt).toISOString()}`);
+  }
+
+  return lines.join('\n');
+}
+
+function startAction(input: Record<string, unknown>): ToolExecutionResult {
+  const durationMinutes = typeof input.duration_minutes === 'number' && input.duration_minutes > 0
+    ? input.duration_minutes
+    : 25;
+  const label = typeof input.label === 'string' && input.label.length > 0
+    ? input.label
+    : 'Pomodoro';
+  const id = generateTimerId();
+  const now = Date.now();
+  const durationMs = durationMinutes * 60 * 1000;
+
+  const timer: PomodoroTimer = {
+    id,
+    label,
+    durationMinutes,
+    startedAt: now,
+    remainingMs: durationMs,
+    status: 'running',
+  };
+
+  timer.timeoutHandle = setTimeout(() => {
+    timer.status = 'completed';
+    timer.completedAt = Date.now();
+    timer.remainingMs = 0;
+    timer.timeoutHandle = undefined;
+    log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
+  }, durationMs);
+
+  timers.set(id, timer);
+  log.info({ id, label, durationMinutes }, 'Pomodoro timer started');
+
+  const endTime = new Date(now + durationMs).toISOString();
+  const content = [
+    `Timer "${label}" (${id}) started.`,
+    `Duration: ${durationMinutes} minutes`,
+    `Started at: ${new Date(now).toISOString()}`,
+    `Expected end: ${endTime}`,
+  ].join('\n');
+
+  return { content, isError: false };
+}
+
+function pauseAction(input: Record<string, unknown>): ToolExecutionResult {
+  const timerId = input.timer_id;
+  if (typeof timerId !== 'string' || timerId.length === 0) {
+    return { content: 'Error: timer_id is required for pause action', isError: true };
+  }
+
+  const timer = timers.get(timerId);
+  if (!timer) {
+    return { content: `Error: Timer "${timerId}" not found`, isError: true };
+  }
+
+  if (timer.status !== 'running') {
+    return { content: `Error: Timer "${timerId}" is not running (status: ${timer.status})`, isError: true };
+  }
+
+  const now = Date.now();
+  const elapsed = now - timer.startedAt;
+  const totalMs = timer.durationMinutes * 60 * 1000;
+  timer.remainingMs = Math.max(0, totalMs - elapsed);
+  timer.status = 'paused';
+
+  if (timer.timeoutHandle) {
+    clearTimeout(timer.timeoutHandle);
+    timer.timeoutHandle = undefined;
+  }
+
+  log.info({ id: timerId, remainingMs: timer.remainingMs }, 'Pomodoro timer paused');
+
+  return {
+    content: `Timer "${timer.label}" (${timerId}) paused.\nRemaining: ${formatDuration(timer.remainingMs)}`,
+    isError: false,
+  };
+}
+
+function resumeAction(input: Record<string, unknown>): ToolExecutionResult {
+  const timerId = input.timer_id;
+  if (typeof timerId !== 'string' || timerId.length === 0) {
+    return { content: 'Error: timer_id is required for resume action', isError: true };
+  }
+
+  const timer = timers.get(timerId);
+  if (!timer) {
+    return { content: `Error: Timer "${timerId}" not found`, isError: true };
+  }
+
+  if (timer.status !== 'paused') {
+    return { content: `Error: Timer "${timerId}" is not paused (status: ${timer.status})`, isError: true };
+  }
+
+  const now = Date.now();
+  // Adjust startedAt so that elapsed calculations remain correct.
+  const totalMs = timer.durationMinutes * 60 * 1000;
+  timer.startedAt = now - (totalMs - timer.remainingMs);
+  timer.status = 'running';
+
+  timer.timeoutHandle = setTimeout(() => {
+    timer.status = 'completed';
+    timer.completedAt = Date.now();
+    timer.remainingMs = 0;
+    timer.timeoutHandle = undefined;
+    log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
+  }, timer.remainingMs);
+
+  log.info({ id: timerId, remainingMs: timer.remainingMs }, 'Pomodoro timer resumed');
+
+  return {
+    content: `Timer "${timer.label}" (${timerId}) resumed.\nRemaining: ${formatDuration(timer.remainingMs)}`,
+    isError: false,
+  };
+}
+
+function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
+  const timerId = input.timer_id;
+  if (typeof timerId !== 'string' || timerId.length === 0) {
+    return { content: 'Error: timer_id is required for cancel action', isError: true };
+  }
+
+  const timer = timers.get(timerId);
+  if (!timer) {
+    return { content: `Error: Timer "${timerId}" not found`, isError: true };
+  }
+
+  if (timer.status === 'completed' || timer.status === 'cancelled') {
+    return { content: `Error: Timer "${timerId}" is already ${timer.status}`, isError: true };
+  }
+
+  if (timer.timeoutHandle) {
+    clearTimeout(timer.timeoutHandle);
+    timer.timeoutHandle = undefined;
+  }
+
+  // Preserve remaining time at time of cancellation
+  if (timer.status === 'running') {
+    const now = Date.now();
+    const elapsed = now - timer.startedAt;
+    const totalMs = timer.durationMinutes * 60 * 1000;
+    timer.remainingMs = Math.max(0, totalMs - elapsed);
+  }
+
+  timer.status = 'cancelled';
+  log.info({ id: timerId }, 'Pomodoro timer cancelled');
+
+  return {
+    content: `Timer "${timer.label}" (${timerId}) cancelled.`,
+    isError: false,
+  };
+}
+
+function statusAction(input: Record<string, unknown>): ToolExecutionResult {
+  const timerId = input.timer_id;
+  if (typeof timerId !== 'string' || timerId.length === 0) {
+    return { content: 'Error: timer_id is required for status action', isError: true };
+  }
+
+  const timer = timers.get(timerId);
+  if (!timer) {
+    return { content: `Error: Timer "${timerId}" not found`, isError: true };
+  }
+
+  return { content: formatTimerStatus(timer), isError: false };
+}
+
+function listAction(): ToolExecutionResult {
+  if (timers.size === 0) {
+    return { content: 'No timers found.', isError: false };
+  }
+
+  const entries: string[] = [];
+  for (const timer of timers.values()) {
+    entries.push(formatTimerStatus(timer));
+  }
+
+  return { content: entries.join('\n\n'), isError: false };
+}
+
+export function executePomodoro(input: Record<string, unknown>): ToolExecutionResult {
+  const action = input.action;
+  if (typeof action !== 'string') {
+    return { content: 'Error: action is required', isError: true };
+  }
+
+  switch (action) {
+    case 'start':
+      return startAction(input);
+    case 'pause':
+      return pauseAction(input);
+    case 'resume':
+      return resumeAction(input);
+    case 'cancel':
+      return cancelAction(input);
+    case 'status':
+      return statusAction(input);
+    case 'list':
+      return listAction();
+    default:
+      return {
+        content: `Error: Unknown action "${action}". Valid actions: start, pause, resume, cancel, status, list`,
+        isError: true,
+      };
+  }
+}
+
+class PomodoroTool implements Tool {
+  name = 'pomodoro';
+  description = 'Manage focus timers. Start, pause, resume, cancel, or check status of pomodoro timers.';
+  category = 'timer';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['start', 'pause', 'resume', 'cancel', 'status', 'list'],
+            description: 'Timer action',
+          },
+          timer_id: {
+            type: 'string',
+            description: 'Timer ID (required for pause/resume/cancel/status, auto-generated for start)',
+          },
+          duration_minutes: {
+            type: 'number',
+            description: 'Duration in minutes (required for start, default 25)',
+          },
+          label: {
+            type: 'string',
+            description: 'Optional label for the timer',
+          },
+        },
+        required: ['action'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    return executePomodoro(input);
+  }
+}
+
+registerTool(new PomodoroTool());


### PR DESCRIPTION
## Summary
- Implements the `pomodoro` tool (`assistant/src/tools/timer/pomodoro.ts`) for managing in-memory focus timers within the daemon process
- Supports six actions: start, pause, resume, cancel, status, and list with structured text output suitable for model consumption
- Timers are stored in a module-level `Map<string, PomodoroTimer>` keyed by auto-generated 8-char UUIDs, using `setTimeout` for completion callbacks
- Registers the tool in `registry.ts` via eager import in `initializeTools()`

## Test plan
- [x] 31 tests added in `assistant/src/__tests__/pomodoro.test.ts` covering all six actions
- [x] Error cases tested: missing action, unknown action, missing timer_id, non-existent timer, pause non-running, resume non-paused, cancel already completed/cancelled
- [x] Timer expiration tested with short-duration timers (0.001 min) verifying status transitions to completed
- [x] Pause/resume cycle verified to preserve remaining time correctly
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
