### PR TITLE
Add system_info tool with OS/CPU/memory/disk/battery reporting (#795)

### DIFF
--- a/assistant/src/__tests__/system-info.test.ts
+++ b/assistant/src/__tests__/system-info.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { ToolContext } from '../tools/types.js';
+import * as realOs from 'node:os';
+import * as realChildProcess from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Mock os module — spread real module so imports like `homedir` still work
+// ---------------------------------------------------------------------------
+const mockOs = {
+  ...realOs,
+  totalmem: mock(() => 34_359_738_368), // 32 GB
+  freemem: mock(() => 10_307_921_100), // ~9.6 GB
+  cpus: mock(() =>
+    Array.from({ length: 12 }, () => ({
+      model: 'Apple M2 Max',
+      speed: 3490,
+      times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+    })),
+  ),
+  loadavg: mock(() => [2.34, 1.87, 1.52]),
+  uptime: mock(() => 277920), // 3 days, 5 hours, 12 minutes
+  hostname: mock(() => 'MacBook-Pro'),
+  type: mock(() => 'Darwin'),
+  release: mock(() => '24.6.0'),
+  arch: mock(() => 'arm64'),
+};
+
+mock.module('node:os', () => mockOs);
+
+// ---------------------------------------------------------------------------
+// Mock child_process module — spread real module, override execSync
+// ---------------------------------------------------------------------------
+const dfOutput = `Filesystem     Size   Used  Avail Capacity  iused ifree %iused  Mounted on
+/dev/disk3s1  1.0Ti  456Gi  544Gi    46%   500000 10000000    5%   /
+`;
+
+const batteryOutput = `Now drawing from 'AC Power'
+ -InternalBattery-0 (id=12345)	87%; charging; 1:23 remaining present: true
+`;
+
+const mockExecSync = mock((cmd: string): string => {
+  if (cmd === 'df -h /') return dfOutput;
+  if (cmd === 'pmset -g batt') return batteryOutput;
+  throw new Error(`Unknown command: ${cmd}`);
+});
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  execSync: mockExecSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are set up
+// ---------------------------------------------------------------------------
+const { buildSystemInfo } = await import('../tools/system/system-info.js');
+
+describe('system_info', () => {
+  beforeEach(() => {
+    mockOs.totalmem.mockImplementation(() => 34_359_738_368);
+    mockOs.freemem.mockImplementation(() => 10_307_921_100);
+    mockOs.cpus.mockImplementation(() =>
+      Array.from({ length: 12 }, () => ({
+        model: 'Apple M2 Max',
+        speed: 3490,
+        times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+      })),
+    );
+    mockOs.loadavg.mockImplementation(() => [2.34, 1.87, 1.52]);
+    mockOs.uptime.mockImplementation(() => 277920);
+    mockOs.hostname.mockImplementation(() => 'MacBook-Pro');
+    mockOs.type.mockImplementation(() => 'Darwin');
+    mockOs.release.mockImplementation(() => '24.6.0');
+    mockOs.arch.mockImplementation(() => 'arm64');
+
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'df -h /') return dfOutput;
+      if (cmd === 'pmset -g batt') return batteryOutput;
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+  });
+
+  test('returns all sections by default', () => {
+    const result = buildSystemInfo();
+    expect(result).toContain('## System Info');
+    expect(result).toContain('MacBook-Pro');
+    expect(result).toContain('OS: Darwin 24.6.0 (arm64)');
+    expect(result).toContain('Uptime:');
+    expect(result).toContain('### Memory');
+    expect(result).toContain('### CPU');
+    expect(result).toContain('### Disk (/)');
+    expect(result).toContain('### Battery');
+  });
+
+  test('formats memory correctly', () => {
+    const result = buildSystemInfo(['memory']);
+    expect(result).toContain('### Memory');
+    expect(result).toContain('32.0 GB');
+    expect(result).toContain('Free:');
+    expect(result).toContain('Used:');
+    expect(result).toMatch(/\d+% used/);
+  });
+
+  test('formats CPU correctly', () => {
+    const result = buildSystemInfo(['cpu']);
+    expect(result).toContain('### CPU');
+    expect(result).toContain('Apple M2 Max');
+    expect(result).toContain('12 cores');
+    expect(result).toContain('Load Average: 2.34, 1.87, 1.52');
+  });
+
+  test('formats disk correctly', () => {
+    const result = buildSystemInfo(['disk']);
+    expect(result).toContain('### Disk (/)');
+    expect(result).toContain('1.0Ti');
+    expect(result).toContain('456Gi');
+    expect(result).toContain('544Gi');
+    expect(result).toContain('46%');
+  });
+
+  test('formats battery correctly', () => {
+    const result = buildSystemInfo(['battery']);
+    expect(result).toContain('### Battery');
+    expect(result).toContain('87%');
+    expect(result).toContain('Charging');
+  });
+
+  test('formats uptime correctly', () => {
+    const result = buildSystemInfo(['uptime']);
+    expect(result).toContain('Uptime: 3 days, 5 hours, 12 minutes');
+  });
+
+  test('formats OS correctly', () => {
+    const result = buildSystemInfo(['os']);
+    expect(result).toContain('OS: Darwin 24.6.0 (arm64)');
+  });
+
+  test('filters to requested sections only', () => {
+    const result = buildSystemInfo(['memory', 'cpu']);
+    expect(result).toContain('### Memory');
+    expect(result).toContain('### CPU');
+    expect(result).not.toContain('### Disk');
+    expect(result).not.toContain('### Battery');
+    expect(result).not.toContain('Uptime:');
+    expect(result).not.toContain('OS:');
+  });
+
+  test('ignores invalid section names', () => {
+    const result = buildSystemInfo(['memory', 'invalid_section']);
+    expect(result).toContain('### Memory');
+    expect(result).not.toContain('invalid_section');
+  });
+
+  test('returns error for no valid sections', () => {
+    const result = buildSystemInfo(['invalid']);
+    expect(result).toContain('Error: No valid sections specified');
+    expect(result).toContain('memory');
+    expect(result).toContain('cpu');
+  });
+
+  test('handles missing battery gracefully (desktop Mac)', () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'df -h /') return dfOutput;
+      if (cmd === 'pmset -g batt') throw new Error('Command failed');
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+
+    const result = buildSystemInfo(['battery']);
+    expect(result).toContain('### Battery');
+    expect(result).toContain('No battery information available');
+  });
+
+  test('handles disk command failure gracefully', () => {
+    mockExecSync.mockImplementation((_cmd: string) => {
+      throw new Error('Command failed');
+    });
+
+    const result = buildSystemInfo(['disk']);
+    expect(result).toContain('### Disk (/)');
+    expect(result).toContain('Unable to retrieve disk information');
+  });
+
+  test('formats uptime with singular units correctly', () => {
+    mockOs.uptime.mockImplementation(() => 90060); // 1 day, 1 hour, 1 minute
+    const result = buildSystemInfo(['uptime']);
+    expect(result).toContain('1 day, 1 hour, 1 minute');
+  });
+
+  test('formats uptime with zero days correctly', () => {
+    mockOs.uptime.mockImplementation(() => 7320); // 0 days, 2 hours, 2 minutes
+    const result = buildSystemInfo(['uptime']);
+    expect(result).toContain('2 hours, 2 minutes');
+    expect(result).not.toContain('day');
+  });
+
+  test('detects discharging battery state', () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'df -h /') return dfOutput;
+      if (cmd === 'pmset -g batt') {
+        return `Now drawing from 'Battery Power'
+ -InternalBattery-0 (id=12345)\t45%; discharging; 3:45 remaining present: true
+`;
+      }
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+
+    const result = buildSystemInfo(['battery']);
+    expect(result).toContain('45%');
+    expect(result).toContain('Discharging');
+  });
+
+  test('detects charged battery state', () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'df -h /') return dfOutput;
+      if (cmd === 'pmset -g batt') {
+        return `Now drawing from 'AC Power'
+ -InternalBattery-0 (id=12345)\t100%; charged; 0:00 remaining present: true
+`;
+      }
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+
+    const result = buildSystemInfo(['battery']);
+    expect(result).toContain('100%');
+    expect(result).toContain('Charged');
+  });
+
+  test('battery output with no percentage returns fallback', () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'df -h /') return dfOutput;
+      if (cmd === 'pmset -g batt') return 'No battery info';
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+
+    const result = buildSystemInfo(['battery']);
+    expect(result).toContain('No battery information available');
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -103,6 +103,7 @@ export async function initializeTools(): Promise<void> {
   await import('./browser/headless-browser.js');
   await import('./weather/get-weather.js');
   await import('./timer/pomodoro.js');
+  await import('./system/system-info.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded

--- a/assistant/src/tools/system/system-info.ts
+++ b/assistant/src/tools/system/system-info.ts
@@ -1,0 +1,204 @@
+import * as os from 'node:os';
+import { execSync } from 'node:child_process';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('system-info');
+
+const VALID_SECTIONS = ['memory', 'cpu', 'disk', 'battery', 'uptime', 'os'] as const;
+type Section = (typeof VALID_SECTIONS)[number];
+
+function formatBytes(bytes: number): string {
+  const gb = bytes / (1024 ** 3);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)} GB`;
+  }
+  const mb = bytes / (1024 ** 2);
+  return `${mb.toFixed(0)} MB`;
+}
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days} day${days !== 1 ? 's' : ''}`);
+  if (hours > 0) parts.push(`${hours} hour${hours !== 1 ? 's' : ''}`);
+  parts.push(`${minutes} minute${minutes !== 1 ? 's' : ''}`);
+
+  return parts.join(', ');
+}
+
+function getMemorySection(): string {
+  const total = os.totalmem();
+  const free = os.freemem();
+  const used = total - free;
+  const percentage = Math.round((used / total) * 100);
+
+  return `### Memory\nTotal: ${formatBytes(total)} | Used: ${formatBytes(used)} | Free: ${formatBytes(free)} (${percentage}% used)`;
+}
+
+function getCpuSection(): string {
+  const cpus = os.cpus();
+  const model = cpus.length > 0 ? cpus[0].model : 'Unknown';
+  const cores = cpus.length;
+  const loadAvg = os.loadavg();
+
+  return `### CPU\n${model} (${cores} cores)\nLoad Average: ${loadAvg[0].toFixed(2)}, ${loadAvg[1].toFixed(2)}, ${loadAvg[2].toFixed(2)}`;
+}
+
+function getDiskSection(): string {
+  try {
+    const output = execSync('df -h /', { encoding: 'utf8', timeout: 5000 });
+    const lines = output.trim().split('\n');
+    if (lines.length < 2) {
+      return '### Disk (/)\nUnable to parse disk information';
+    }
+
+    // df -h output varies by platform but generally:
+    // Filesystem  Size  Used  Avail  Use%  Mounted
+    const dataLine = lines[1];
+    const parts = dataLine.split(/\s+/);
+
+    // On macOS: Filesystem Size Used Avail Capacity iused ifree %iused Mounted
+    // On Linux: Filesystem Size Used Avail Use% Mounted
+    // We need to find Size, Used, Avail, and percentage
+    if (parts.length >= 5) {
+      const size = parts[1];
+      const used = parts[2];
+      const avail = parts[3];
+      const capacity = parts[4];
+
+      return `### Disk (/)\nTotal: ${size} | Used: ${used} | Available: ${avail} (${capacity} used)`;
+    }
+
+    return '### Disk (/)\nUnable to parse disk information';
+  } catch (err) {
+    log.debug({ err }, 'Failed to get disk info');
+    return '### Disk (/)\nUnable to retrieve disk information';
+  }
+}
+
+function getBatterySection(): string {
+  try {
+    const output = execSync('pmset -g batt', { encoding: 'utf8', timeout: 5000 });
+
+    // Parse percentage: look for pattern like "85%"
+    const percentMatch = /(\d+)%/.exec(output);
+    if (!percentMatch) {
+      return '### Battery\nNo battery information available';
+    }
+    const percent = percentMatch[1];
+
+    // Parse state: "charging", "discharging", "charged", "AC attached"
+    let state = 'Unknown';
+    if (/charging/i.test(output) && !/discharging/i.test(output) && !/not charging/i.test(output)) {
+      state = 'Charging';
+    } else if (/discharging/i.test(output)) {
+      state = 'Discharging';
+    } else if (/charged/i.test(output)) {
+      state = 'Charged';
+    } else if (/AC attached/i.test(output) || /not charging/i.test(output)) {
+      state = 'AC Power';
+    }
+
+    return `### Battery\n${percent}% \u2014 ${state}`;
+  } catch (err) {
+    log.debug({ err }, 'Failed to get battery info');
+    return '### Battery\nNo battery information available';
+  }
+}
+
+function getUptimeSection(): string {
+  const uptime = os.uptime();
+  return `Uptime: ${formatUptime(uptime)}`;
+}
+
+function getOsSection(): string {
+  return `OS: ${os.type()} ${os.release()} (${os.arch()})`;
+}
+
+export function buildSystemInfo(sections?: string[]): string {
+  const hostname = os.hostname();
+  const requestedSections: Section[] = sections && sections.length > 0
+    ? sections.filter((s): s is Section => VALID_SECTIONS.includes(s as Section))
+    : [...VALID_SECTIONS];
+
+  if (requestedSections.length === 0) {
+    return 'Error: No valid sections specified. Valid sections: ' + VALID_SECTIONS.join(', ');
+  }
+
+  const lines: string[] = [`## System Info \u2014 ${hostname}`];
+
+  // OS and uptime go in the header area
+  if (requestedSections.includes('os')) {
+    lines.push(getOsSection());
+  }
+  if (requestedSections.includes('uptime')) {
+    lines.push(getUptimeSection());
+  }
+
+  // Add a blank line before detail sections
+  const detailSections: Section[] = ['memory', 'cpu', 'disk', 'battery'];
+  const hasDetails = detailSections.some((s) => requestedSections.includes(s));
+  if (hasDetails) {
+    lines.push('');
+  }
+
+  if (requestedSections.includes('memory')) {
+    lines.push(getMemorySection());
+  }
+  if (requestedSections.includes('cpu')) {
+    lines.push(getCpuSection());
+  }
+  if (requestedSections.includes('disk')) {
+    lines.push(getDiskSection());
+  }
+  if (requestedSections.includes('battery')) {
+    lines.push(getBatterySection());
+  }
+
+  return lines.join('\n');
+}
+
+class SystemInfoTool implements Tool {
+  name = 'system_info';
+  description = 'Get current system information including CPU, memory, disk, battery, and uptime';
+  category = 'system';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          sections: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional filter for which sections to return. Valid sections: "memory", "cpu", "disk", "battery", "uptime", "os". Defaults to all sections.',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    try {
+      const sections = Array.isArray(input.sections) ? input.sections.filter((s): s is string => typeof s === 'string') : undefined;
+      const content = buildSystemInfo(sections);
+      return { content, isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err }, 'system_info failed');
+      return { content: `Error: Failed to gather system info: ${msg}`, isError: true };
+    }
+  }
+}
+
+registerTool(new SystemInfoTool());


### PR DESCRIPTION
## Summary
- Adds a new `system_info` tool in `assistant/src/tools/system/system-info.ts` that reports CPU, memory, disk, battery, uptime, and OS information using Node.js `os` module and `child_process.execSync`
- Supports optional `sections` parameter to filter which sections are returned (defaults to all)
- Registers the tool in `registry.ts` alongside existing tools
- Includes comprehensive tests covering output formatting, section filtering, singular/plural units, and error handling for missing battery or disk info

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 17 tests pass (`bun test src/__tests__/system-info.test.ts`)
- [x] Tests cover: all sections individually, section filtering, invalid sections, missing battery (desktop Mac), disk command failure, singular time units, battery states (charging/discharging/charged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
