### PR TITLE
Return isError for invalid system_info sections (#802)

### DIFF
--- a/assistant/src/__tests__/system-info.test.ts
+++ b/assistant/src/__tests__/system-info.test.ts
@@ -53,6 +53,7 @@ mock.module('node:child_process', () => ({
 // Import after mocks are set up
 // ---------------------------------------------------------------------------
 const { buildSystemInfo } = await import('../tools/system/system-info.js');
+const { getTool } = await import('../tools/registry.js');
 
 describe('system_info', () => {
   beforeEach(() => {
@@ -155,6 +156,14 @@ describe('system_info', () => {
     expect(result).toContain('Error: No valid sections specified');
     expect(result).toContain('memory');
     expect(result).toContain('cpu');
+  });
+
+  test('execute returns isError true when only invalid sections are provided', async () => {
+    const tool = getTool('system_info');
+    expect(tool).toBeDefined();
+    const result = await tool!.execute({ sections: ['memroy', 'bogus'] }, {} as ToolContext);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Error: No valid sections specified');
   });
 
   test('handles missing battery gracefully (desktop Mac)', () => {

--- a/assistant/src/tools/system/system-info.ts
+++ b/assistant/src/tools/system/system-info.ts
@@ -192,7 +192,8 @@ class SystemInfoTool implements Tool {
     try {
       const sections = Array.isArray(input.sections) ? input.sections.filter((s): s is string => typeof s === 'string') : undefined;
       const content = buildSystemInfo(sections);
-      return { content, isError: false };
+      const isError = content.startsWith('Error:');
+      return { content, isError };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, 'system_info failed');


### PR DESCRIPTION
## Summary
- When `buildSystemInfo` returns an error string (e.g., all requested sections are invalid), `execute()` now returns `isError: true` instead of `false`, allowing the model to detect and retry with corrected arguments.
- Added a test that calls `execute()` with only invalid section names and verifies `isError: true` is returned.

Fixes #802

## Test plan
- [x] Existing tests pass (18/18)
- [x] New test verifies `execute()` returns `isError: true` for invalid-only sections
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
