### PR TITLE
Isolate pomodoro timers per session and clamp duration (#801)

### DIFF
--- a/assistant/src/__tests__/pomodoro.test.ts
+++ b/assistant/src/__tests__/pomodoro.test.ts
@@ -1,5 +1,15 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { executePomodoro, timers } from '../tools/timer/pomodoro.js';
+import { executePomodoro, timers, MAX_DURATION_MINUTES } from '../tools/timer/pomodoro.js';
+
+const SESSION_A = 'session-a';
+const SESSION_B = 'session-b';
+const ctxA = { sessionId: SESSION_A };
+const ctxB = { sessionId: SESSION_B };
+
+/** Helper to get the per-session timer map (or an empty map if none). */
+function getSessionTimers(sessionId: string) {
+  return timers.get(sessionId) ?? new Map();
+}
 
 describe('pomodoro tool', () => {
   beforeEach(() => {
@@ -8,9 +18,11 @@ describe('pomodoro tool', () => {
 
   afterEach(() => {
     // Clear any lingering timeouts
-    for (const timer of timers.values()) {
-      if (timer.timeoutHandle) {
-        clearTimeout(timer.timeoutHandle);
+    for (const sessionMap of timers.values()) {
+      for (const timer of sessionMap.values()) {
+        if (timer.timeoutHandle) {
+          clearTimeout(timer.timeoutHandle);
+        }
       }
     }
     timers.clear();
@@ -19,13 +31,13 @@ describe('pomodoro tool', () => {
   // ── action validation ────────────────────────────────────────────
 
   test('rejects missing action', () => {
-    const result = executePomodoro({});
+    const result = executePomodoro({}, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('action is required');
   });
 
   test('rejects unknown action', () => {
-    const result = executePomodoro({ action: 'destroy' });
+    const result = executePomodoro({ action: 'destroy' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('Unknown action');
     expect(result.content).toContain('destroy');
@@ -34,78 +46,153 @@ describe('pomodoro tool', () => {
   // ── start ────────────────────────────────────────────────────────
 
   test('start creates a timer with default duration', () => {
-    const result = executePomodoro({ action: 'start' });
+    const result = executePomodoro({ action: 'start' }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('started');
     expect(result.content).toContain('25 minutes');
     expect(result.content).toContain('Pomodoro');
-    expect(timers.size).toBe(1);
 
-    const timer = timers.values().next().value!;
+    const sessionTimers = getSessionTimers(SESSION_A);
+    expect(sessionTimers.size).toBe(1);
+
+    const timer = sessionTimers.values().next().value!;
     expect(timer.status).toBe('running');
     expect(timer.durationMinutes).toBe(25);
     expect(timer.label).toBe('Pomodoro');
   });
 
   test('start creates a timer with custom duration and label', () => {
-    const result = executePomodoro({ action: 'start', duration_minutes: 10, label: 'Deep Work' });
+    const result = executePomodoro({ action: 'start', duration_minutes: 10, label: 'Deep Work' }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Deep Work');
     expect(result.content).toContain('10 minutes');
 
-    const timer = timers.values().next().value!;
+    const timer = getSessionTimers(SESSION_A).values().next().value!;
     expect(timer.durationMinutes).toBe(10);
     expect(timer.label).toBe('Deep Work');
   });
 
   test('start uses default duration for invalid values', () => {
-    const result = executePomodoro({ action: 'start', duration_minutes: -5 });
+    const result = executePomodoro({ action: 'start', duration_minutes: -5 }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('25 minutes');
   });
 
   test('start generates unique timer IDs', () => {
-    executePomodoro({ action: 'start' });
-    executePomodoro({ action: 'start' });
-    expect(timers.size).toBe(2);
-    const ids = Array.from(timers.keys());
+    executePomodoro({ action: 'start' }, ctxA);
+    executePomodoro({ action: 'start' }, ctxA);
+
+    const sessionTimers = getSessionTimers(SESSION_A);
+    expect(sessionTimers.size).toBe(2);
+    const ids = Array.from(sessionTimers.keys());
     expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  // ── duration overflow ─────────────────────────────────────────────
+
+  test('start rejects duration exceeding maximum', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: 1441 }, ctxA);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exceeds maximum');
+    expect(result.content).toContain(String(MAX_DURATION_MINUTES));
+    expect(getSessionTimers(SESSION_A).size).toBe(0);
+  });
+
+  test('start accepts duration at exactly the maximum', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: MAX_DURATION_MINUTES }, ctxA);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('started');
+    expect(getSessionTimers(SESSION_A).size).toBe(1);
+  });
+
+  test('start rejects very large duration that would overflow setTimeout', () => {
+    const result = executePomodoro({ action: 'start', duration_minutes: 100000 }, ctxA);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exceeds maximum');
+  });
+
+  // ── session isolation ─────────────────────────────────────────────
+
+  test('timers are isolated between sessions', () => {
+    // Create a timer in session A
+    executePomodoro({ action: 'start', label: 'Session A Timer' }, ctxA);
+    const timerIdA = getSessionTimers(SESSION_A).keys().next().value!;
+
+    // Create a timer in session B
+    executePomodoro({ action: 'start', label: 'Session B Timer' }, ctxB);
+
+    // Session A list should only show session A timer
+    const listA = executePomodoro({ action: 'list' }, ctxA);
+    expect(listA.content).toContain('Session A Timer');
+    expect(listA.content).not.toContain('Session B Timer');
+
+    // Session B list should only show session B timer
+    const listB = executePomodoro({ action: 'list' }, ctxB);
+    expect(listB.content).toContain('Session B Timer');
+    expect(listB.content).not.toContain('Session A Timer');
+
+    // Session B cannot pause session A's timer
+    const pauseResult = executePomodoro({ action: 'pause', timer_id: timerIdA }, ctxB);
+    expect(pauseResult.isError).toBe(true);
+    expect(pauseResult.content).toContain('not found');
+
+    // Session A can pause its own timer
+    const pauseOwnResult = executePomodoro({ action: 'pause', timer_id: timerIdA }, ctxA);
+    expect(pauseOwnResult.isError).toBe(false);
+  });
+
+  test('session B cannot cancel session A timer', () => {
+    executePomodoro({ action: 'start', label: 'Private Timer' }, ctxA);
+    const timerIdA = getSessionTimers(SESSION_A).keys().next().value!;
+
+    const cancelResult = executePomodoro({ action: 'cancel', timer_id: timerIdA }, ctxB);
+    expect(cancelResult.isError).toBe(true);
+    expect(cancelResult.content).toContain('not found');
+  });
+
+  test('session B cannot get status of session A timer', () => {
+    executePomodoro({ action: 'start', label: 'Private Timer' }, ctxA);
+    const timerIdA = getSessionTimers(SESSION_A).keys().next().value!;
+
+    const statusResult = executePomodoro({ action: 'status', timer_id: timerIdA }, ctxB);
+    expect(statusResult.isError).toBe(true);
+    expect(statusResult.content).toContain('not found');
   });
 
   // ── pause ────────────────────────────────────────────────────────
 
   test('pause requires timer_id', () => {
-    const result = executePomodoro({ action: 'pause' });
+    const result = executePomodoro({ action: 'pause' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('timer_id is required');
   });
 
   test('pause rejects non-existent timer', () => {
-    const result = executePomodoro({ action: 'pause', timer_id: 'nonexist' });
+    const result = executePomodoro({ action: 'pause', timer_id: 'nonexist' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not found');
   });
 
   test('pause stops a running timer', () => {
-    executePomodoro({ action: 'start', label: 'Test' });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Test' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
-    const result = executePomodoro({ action: 'pause', timer_id: id });
+    const result = executePomodoro({ action: 'pause', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('paused');
 
-    const timer = timers.get(id)!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
     expect(timer.status).toBe('paused');
     expect(timer.remainingMs).toBeGreaterThan(0);
     expect(timer.timeoutHandle).toBeUndefined();
   });
 
   test('pause rejects already paused timer', () => {
-    executePomodoro({ action: 'start' });
-    const id = timers.keys().next().value!;
-    executePomodoro({ action: 'pause', timer_id: id });
+    executePomodoro({ action: 'start' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
 
-    const result = executePomodoro({ action: 'pause', timer_id: id });
+    const result = executePomodoro({ action: 'pause', timer_id: id }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not running');
   });
@@ -113,36 +200,36 @@ describe('pomodoro tool', () => {
   // ── resume ───────────────────────────────────────────────────────
 
   test('resume requires timer_id', () => {
-    const result = executePomodoro({ action: 'resume' });
+    const result = executePomodoro({ action: 'resume' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('timer_id is required');
   });
 
   test('resume rejects non-existent timer', () => {
-    const result = executePomodoro({ action: 'resume', timer_id: 'nonexist' });
+    const result = executePomodoro({ action: 'resume', timer_id: 'nonexist' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not found');
   });
 
   test('resume restarts a paused timer', () => {
-    executePomodoro({ action: 'start', label: 'Test' });
-    const id = timers.keys().next().value!;
-    executePomodoro({ action: 'pause', timer_id: id });
+    executePomodoro({ action: 'start', label: 'Test' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
 
-    const result = executePomodoro({ action: 'resume', timer_id: id });
+    const result = executePomodoro({ action: 'resume', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('resumed');
 
-    const timer = timers.get(id)!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
     expect(timer.status).toBe('running');
     expect(timer.timeoutHandle).toBeDefined();
   });
 
   test('resume rejects running timer', () => {
-    executePomodoro({ action: 'start' });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
-    const result = executePomodoro({ action: 'resume', timer_id: id });
+    const result = executePomodoro({ action: 'resume', timer_id: id }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not paused');
   });
@@ -150,60 +237,60 @@ describe('pomodoro tool', () => {
   // ── cancel ───────────────────────────────────────────────────────
 
   test('cancel requires timer_id', () => {
-    const result = executePomodoro({ action: 'cancel' });
+    const result = executePomodoro({ action: 'cancel' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('timer_id is required');
   });
 
   test('cancel rejects non-existent timer', () => {
-    const result = executePomodoro({ action: 'cancel', timer_id: 'nonexist' });
+    const result = executePomodoro({ action: 'cancel', timer_id: 'nonexist' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not found');
   });
 
   test('cancel stops a running timer', () => {
-    executePomodoro({ action: 'start', label: 'Cancel me' });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Cancel me' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
-    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    const result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('cancelled');
 
-    const timer = timers.get(id)!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
     expect(timer.status).toBe('cancelled');
     expect(timer.timeoutHandle).toBeUndefined();
   });
 
   test('cancel stops a paused timer', () => {
-    executePomodoro({ action: 'start' });
-    const id = timers.keys().next().value!;
-    executePomodoro({ action: 'pause', timer_id: id });
+    executePomodoro({ action: 'start' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
 
-    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    const result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('cancelled');
   });
 
   test('cancel rejects already cancelled timer', () => {
-    executePomodoro({ action: 'start' });
-    const id = timers.keys().next().value!;
-    executePomodoro({ action: 'cancel', timer_id: id });
+    executePomodoro({ action: 'start' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
 
-    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    const result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('already cancelled');
   });
 
   test('cancel rejects completed timer', () => {
-    executePomodoro({ action: 'start' });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
     // Manually mark as completed for testing
-    const timer = timers.get(id)!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
     clearTimeout(timer.timeoutHandle!);
     timer.status = 'completed';
     timer.timeoutHandle = undefined;
 
-    const result = executePomodoro({ action: 'cancel', timer_id: id });
+    const result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('already completed');
   });
@@ -211,22 +298,22 @@ describe('pomodoro tool', () => {
   // ── status ───────────────────────────────────────────────────────
 
   test('status requires timer_id', () => {
-    const result = executePomodoro({ action: 'status' });
+    const result = executePomodoro({ action: 'status' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('timer_id is required');
   });
 
   test('status rejects non-existent timer', () => {
-    const result = executePomodoro({ action: 'status', timer_id: 'nonexist' });
+    const result = executePomodoro({ action: 'status', timer_id: 'nonexist' }, ctxA);
     expect(result.isError).toBe(true);
     expect(result.content).toContain('not found');
   });
 
   test('status returns timer details for running timer', () => {
-    executePomodoro({ action: 'start', label: 'Focus', duration_minutes: 25 });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Focus', duration_minutes: 25 }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
-    const result = executePomodoro({ action: 'status', timer_id: id });
+    const result = executePomodoro({ action: 'status', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Focus');
     expect(result.content).toContain(id);
@@ -236,11 +323,11 @@ describe('pomodoro tool', () => {
   });
 
   test('status returns timer details for paused timer', () => {
-    executePomodoro({ action: 'start', label: 'Paused test' });
-    const id = timers.keys().next().value!;
-    executePomodoro({ action: 'pause', timer_id: id });
+    executePomodoro({ action: 'start', label: 'Paused test' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
 
-    const result = executePomodoro({ action: 'status', timer_id: id });
+    const result = executePomodoro({ action: 'status', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Paused');
   });
@@ -248,16 +335,16 @@ describe('pomodoro tool', () => {
   // ── list ─────────────────────────────────────────────────────────
 
   test('list returns message when no timers exist', () => {
-    const result = executePomodoro({ action: 'list' });
+    const result = executePomodoro({ action: 'list' }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('No timers found');
   });
 
   test('list returns all timers', () => {
-    executePomodoro({ action: 'start', label: 'Timer A' });
-    executePomodoro({ action: 'start', label: 'Timer B' });
+    executePomodoro({ action: 'start', label: 'Timer A' }, ctxA);
+    executePomodoro({ action: 'start', label: 'Timer B' }, ctxA);
 
-    const result = executePomodoro({ action: 'list' });
+    const result = executePomodoro({ action: 'list' }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Timer A');
     expect(result.content).toContain('Timer B');
@@ -267,9 +354,9 @@ describe('pomodoro tool', () => {
 
   test('timer completes after duration elapses', async () => {
     // Use a very short duration and manually fire the timeout
-    executePomodoro({ action: 'start', label: 'Quick', duration_minutes: 0.001 });
-    const id = timers.keys().next().value!;
-    const timer = timers.get(id)!;
+    executePomodoro({ action: 'start', label: 'Quick', duration_minutes: 0.001 }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
 
     expect(timer.status).toBe('running');
 
@@ -283,12 +370,12 @@ describe('pomodoro tool', () => {
   });
 
   test('completed timer shows 100% progress', async () => {
-    executePomodoro({ action: 'start', label: 'Done', duration_minutes: 0.001 });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Done', duration_minutes: 0.001 }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    const result = executePomodoro({ action: 'status', timer_id: id });
+    const result = executePomodoro({ action: 'status', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Completed');
     expect(result.content).toContain('Progress: 100%');
@@ -298,53 +385,53 @@ describe('pomodoro tool', () => {
   // ── pause/resume preserves remaining time ────────────────────────
 
   test('pause and resume preserves remaining time correctly', async () => {
-    executePomodoro({ action: 'start', label: 'Preserve', duration_minutes: 1 });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Preserve', duration_minutes: 1 }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
     // Wait a small amount of time
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    executePomodoro({ action: 'pause', timer_id: id });
-    const pausedTimer = timers.get(id)!;
+    executePomodoro({ action: 'pause', timer_id: id }, ctxA);
+    const pausedTimer = getSessionTimers(SESSION_A).get(id)!;
     const remainingAtPause = pausedTimer.remainingMs;
 
     // remaining should be less than full duration (60000ms) but close
     expect(remainingAtPause).toBeLessThan(60000);
     expect(remainingAtPause).toBeGreaterThan(59000);
 
-    executePomodoro({ action: 'resume', timer_id: id });
-    const resumedTimer = timers.get(id)!;
+    executePomodoro({ action: 'resume', timer_id: id }, ctxA);
+    const resumedTimer = getSessionTimers(SESSION_A).get(id)!;
     expect(resumedTimer.status).toBe('running');
   });
 
   // ── edge cases ───────────────────────────────────────────────────
 
   test('multiple operations on same timer work correctly', () => {
-    executePomodoro({ action: 'start', label: 'Multi' });
-    const id = timers.keys().next().value!;
+    executePomodoro({ action: 'start', label: 'Multi' }, ctxA);
+    const id = getSessionTimers(SESSION_A).keys().next().value!;
 
     // Pause
-    let result = executePomodoro({ action: 'pause', timer_id: id });
+    let result = executePomodoro({ action: 'pause', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
 
     // Resume
-    result = executePomodoro({ action: 'resume', timer_id: id });
+    result = executePomodoro({ action: 'resume', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
 
     // Pause again
-    result = executePomodoro({ action: 'pause', timer_id: id });
+    result = executePomodoro({ action: 'pause', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
 
     // Cancel
-    result = executePomodoro({ action: 'cancel', timer_id: id });
+    result = executePomodoro({ action: 'cancel', timer_id: id }, ctxA);
     expect(result.isError).toBe(false);
 
-    const timer = timers.get(id)!;
+    const timer = getSessionTimers(SESSION_A).get(id)!;
     expect(timer.status).toBe('cancelled');
   });
 
   test('start returns expected end time', () => {
-    const result = executePomodoro({ action: 'start', duration_minutes: 30 });
+    const result = executePomodoro({ action: 'start', duration_minutes: 30 }, ctxA);
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Expected end:');
   });

--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -18,8 +18,21 @@ export interface PomodoroTimer {
   timeoutHandle?: ReturnType<typeof setTimeout>;
 }
 
-/** Module-level map of active timers keyed by timer ID. */
-export const timers = new Map<string, PomodoroTimer>();
+/** Maximum allowed duration in minutes (24 hours). */
+export const MAX_DURATION_MINUTES = 1440;
+
+/** Module-level map of active timers keyed by sessionId -> timerId. */
+export const timers = new Map<string, Map<string, PomodoroTimer>>();
+
+/** Returns the per-session timer map, creating it if needed. */
+function getSessionTimers(sessionId: string): Map<string, PomodoroTimer> {
+  let session = timers.get(sessionId);
+  if (!session) {
+    session = new Map();
+    timers.set(sessionId, session);
+  }
+  return session;
+}
 
 function generateTimerId(): string {
   return crypto.randomUUID().slice(0, 8);
@@ -74,10 +87,18 @@ function formatTimerStatus(timer: PomodoroTimer): string {
   return lines.join('\n');
 }
 
-function startAction(input: Record<string, unknown>): ToolExecutionResult {
+function startAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
   const durationMinutes = typeof input.duration_minutes === 'number' && input.duration_minutes > 0
     ? input.duration_minutes
     : 25;
+
+  if (durationMinutes > MAX_DURATION_MINUTES) {
+    return {
+      content: `Error: duration_minutes exceeds maximum of ${MAX_DURATION_MINUTES} (24 hours). Requested: ${durationMinutes}`,
+      isError: true,
+    };
+  }
+
   const label = typeof input.label === 'string' && input.label.length > 0
     ? input.label
     : 'Pomodoro';
@@ -102,8 +123,9 @@ function startAction(input: Record<string, unknown>): ToolExecutionResult {
     log.info({ id: timer.id, label: timer.label }, 'Pomodoro timer completed');
   }, durationMs);
 
-  timers.set(id, timer);
-  log.info({ id, label, durationMinutes }, 'Pomodoro timer started');
+  const sessionTimers = getSessionTimers(sessionId);
+  sessionTimers.set(id, timer);
+  log.info({ id, label, durationMinutes, sessionId }, 'Pomodoro timer started');
 
   const endTime = new Date(now + durationMs).toISOString();
   const content = [
@@ -116,13 +138,14 @@ function startAction(input: Record<string, unknown>): ToolExecutionResult {
   return { content, isError: false };
 }
 
-function pauseAction(input: Record<string, unknown>): ToolExecutionResult {
+function pauseAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
   const timerId = input.timer_id;
   if (typeof timerId !== 'string' || timerId.length === 0) {
     return { content: 'Error: timer_id is required for pause action', isError: true };
   }
 
-  const timer = timers.get(timerId);
+  const sessionTimers = getSessionTimers(sessionId);
+  const timer = sessionTimers.get(timerId);
   if (!timer) {
     return { content: `Error: Timer "${timerId}" not found`, isError: true };
   }
@@ -150,13 +173,14 @@ function pauseAction(input: Record<string, unknown>): ToolExecutionResult {
   };
 }
 
-function resumeAction(input: Record<string, unknown>): ToolExecutionResult {
+function resumeAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
   const timerId = input.timer_id;
   if (typeof timerId !== 'string' || timerId.length === 0) {
     return { content: 'Error: timer_id is required for resume action', isError: true };
   }
 
-  const timer = timers.get(timerId);
+  const sessionTimers = getSessionTimers(sessionId);
+  const timer = sessionTimers.get(timerId);
   if (!timer) {
     return { content: `Error: Timer "${timerId}" not found`, isError: true };
   }
@@ -187,13 +211,14 @@ function resumeAction(input: Record<string, unknown>): ToolExecutionResult {
   };
 }
 
-function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
+function cancelAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
   const timerId = input.timer_id;
   if (typeof timerId !== 'string' || timerId.length === 0) {
     return { content: 'Error: timer_id is required for cancel action', isError: true };
   }
 
-  const timer = timers.get(timerId);
+  const sessionTimers = getSessionTimers(sessionId);
+  const timer = sessionTimers.get(timerId);
   if (!timer) {
     return { content: `Error: Timer "${timerId}" not found`, isError: true };
   }
@@ -224,13 +249,14 @@ function cancelAction(input: Record<string, unknown>): ToolExecutionResult {
   };
 }
 
-function statusAction(input: Record<string, unknown>): ToolExecutionResult {
+function statusAction(input: Record<string, unknown>, sessionId: string): ToolExecutionResult {
   const timerId = input.timer_id;
   if (typeof timerId !== 'string' || timerId.length === 0) {
     return { content: 'Error: timer_id is required for status action', isError: true };
   }
 
-  const timer = timers.get(timerId);
+  const sessionTimers = getSessionTimers(sessionId);
+  const timer = sessionTimers.get(timerId);
   if (!timer) {
     return { content: `Error: Timer "${timerId}" not found`, isError: true };
   }
@@ -238,38 +264,44 @@ function statusAction(input: Record<string, unknown>): ToolExecutionResult {
   return { content: formatTimerStatus(timer), isError: false };
 }
 
-function listAction(): ToolExecutionResult {
-  if (timers.size === 0) {
+function listAction(sessionId: string): ToolExecutionResult {
+  const sessionTimers = getSessionTimers(sessionId);
+  if (sessionTimers.size === 0) {
     return { content: 'No timers found.', isError: false };
   }
 
   const entries: string[] = [];
-  for (const timer of timers.values()) {
+  for (const timer of sessionTimers.values()) {
     entries.push(formatTimerStatus(timer));
   }
 
   return { content: entries.join('\n\n'), isError: false };
 }
 
-export function executePomodoro(input: Record<string, unknown>): ToolExecutionResult {
+export function executePomodoro(
+  input: Record<string, unknown>,
+  context: { sessionId: string },
+): ToolExecutionResult {
   const action = input.action;
   if (typeof action !== 'string') {
     return { content: 'Error: action is required', isError: true };
   }
 
+  const { sessionId } = context;
+
   switch (action) {
     case 'start':
-      return startAction(input);
+      return startAction(input, sessionId);
     case 'pause':
-      return pauseAction(input);
+      return pauseAction(input, sessionId);
     case 'resume':
-      return resumeAction(input);
+      return resumeAction(input, sessionId);
     case 'cancel':
-      return cancelAction(input);
+      return cancelAction(input, sessionId);
     case 'status':
-      return statusAction(input);
+      return statusAction(input, sessionId);
     case 'list':
-      return listAction();
+      return listAction(sessionId);
     default:
       return {
         content: `Error: Unknown action "${action}". Valid actions: start, pause, resume, cancel, status, list`,
@@ -314,8 +346,8 @@ class PomodoroTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executePomodoro(input);
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executePomodoro(input, context);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Session isolation**: Changed the `timers` map from `Map<string, PomodoroTimer>` to `Map<string, Map<string, PomodoroTimer>>` keyed by `context.sessionId`, so all actions (start, pause, resume, cancel, status, list) only see/mutate timers belonging to the current session.
- **Duration clamping**: Reject `duration_minutes` above 1440 (24 hours) to prevent setTimeout overflow (values > ~24.8 days wrap to ~1ms in Node.js, causing immediate completion).
- **Updated tests**: All `executePomodoro()` calls now pass a mock context with `sessionId`. Added tests for session isolation (cross-session visibility/mutation) and duration overflow rejection.

## Test plan
- [x] All 37 existing tests pass with session context threaded through
- [x] New test: timers from session A are not visible in session B's `list`
- [x] New test: session B cannot `pause`, `cancel`, or `status` session A's timer
- [x] New test: `start` rejects duration > 1440 minutes
- [x] New test: `start` accepts duration at exactly 1440 minutes
- [x] New test: `start` rejects very large duration (100000 min) that would overflow setTimeout
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
