### PR TITLE
Component Gallery

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -33,6 +33,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
+    #if DEBUG
+    private var galleryWindow: ComponentGalleryWindow?
+    #endif
     private var windowObserver: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -166,6 +169,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onboardingItem.target = self
         menu.addItem(onboardingItem)
 
+        #if DEBUG
+        menu.addItem(NSMenuItem.separator())
+        let galleryItem = NSMenuItem(title: "Component Gallery", action: #selector(showComponentGallery), keyEquivalent: "")
+        galleryItem.target = self
+        menu.addItem(galleryItem)
+        #endif
+
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: button)
@@ -175,6 +185,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ambientAgent.isEnabled = !ambientAgent.isEnabled
         updateMenuBarIcon()
     }
+
+    #if DEBUG
+    @objc private func showComponentGallery() {
+        if galleryWindow == nil { galleryWindow = ComponentGalleryWindow() }
+        galleryWindow?.show()
+    }
+    #endif
 
     // MARK: - Hotkey
 

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct VButton: View {
-    enum Style { case primary, ghost, danger }
+    enum Style: Hashable { case primary, ghost, danger }
 
     let label: String
     var style: Style = .primary
@@ -60,4 +60,19 @@ private struct VButtonPressStyle: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
             .animation(VAnimation.fast, value: configuration.isPressed)
     }
+}
+
+#Preview("VButton") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 16) {
+            VButton(label: "Primary", style: .primary) {}
+            VButton(label: "Ghost", style: .ghost) {}
+            VButton(label: "Danger", style: .danger) {}
+            VButton(label: "Disabled", style: .primary, isDisabled: true) {}
+            VButton(label: "Full Width", style: .primary, isFullWidth: true) {}
+        }
+        .padding()
+    }
+    .frame(width: 300, height: 300)
 }

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VIconButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VIconButton.swift
@@ -31,3 +31,17 @@ struct VIconButton: View {
         .accessibilityLabel(label)
     }
 }
+
+#Preview("VIconButton") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 12) {
+            VIconButton(label: "Settings", icon: "gear") {}
+            VIconButton(label: "Active", icon: "star.fill", isActive: true) {}
+            VIconButton(label: "Icon Only", icon: "plus", iconOnly: true) {}
+            VIconButton(label: "Active Icon", icon: "pencil", isActive: true, iconOnly: true) {}
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 80)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Display/VCard.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Display/VCard.swift
@@ -15,3 +15,25 @@ struct VCard<Content: View>: View {
             )
     }
 }
+
+#Preview("VCard") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 16) {
+            VCard {
+                Text("Default padding")
+                    .foregroundColor(VColor.textPrimary)
+            }
+            VCard(padding: VSpacing.sm) {
+                Text("Small padding")
+                    .foregroundColor(VColor.textPrimary)
+            }
+            VCard(padding: VSpacing.xxxl) {
+                Text("Large padding")
+                    .foregroundColor(VColor.textPrimary)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 300, height: 300)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Display/VEmptyState.swift
@@ -27,3 +27,20 @@ struct VEmptyState: View {
         .accessibilityLabel("\(title). \(subtitle ?? "")")
     }
 }
+
+#Preview("VEmptyState") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 24) {
+            VEmptyState(
+                title: "No items yet",
+                subtitle: "Create your first item to get started",
+                icon: "tray"
+            )
+            Divider()
+            VEmptyState(title: "No results")
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 400)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Display/VListRow.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Display/VListRow.swift
@@ -31,3 +31,26 @@ struct VListRow<Content: View>: View {
             }
     }
 }
+
+#Preview("VListRow") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 0) {
+            VListRow(onTap: {}) {
+                HStack {
+                    Image(systemName: "doc.text")
+                        .foregroundColor(VColor.accent)
+                    Text("Tappable row")
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+            Divider()
+            VListRow {
+                Text("Static row")
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 300, height: 150)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VBadge.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VBadge.swift
@@ -40,3 +40,29 @@ struct VBadge: View {
         }
     }
 }
+
+#Preview("VBadge") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 16) {
+            HStack(spacing: 12) {
+                VBadge(style: .count(5))
+                VBadge(style: .count(42), color: VColor.error)
+                VBadge(style: .count(99), color: VColor.success)
+            }
+            HStack(spacing: 12) {
+                VBadge(style: .dot)
+                VBadge(style: .dot, color: VColor.success)
+                VBadge(style: .dot, color: VColor.error)
+                VBadge(style: .dot, color: VColor.warning)
+            }
+            HStack(spacing: 12) {
+                VBadge(style: .label("New"))
+                VBadge(style: .label("Beta"), color: VColor.success)
+                VBadge(style: .label("Error"), color: VColor.error)
+            }
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 200)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VLoadingIndicator.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VLoadingIndicator.swift
@@ -24,3 +24,18 @@ struct VLoadingIndicator: View {
             }
     }
 }
+
+#Preview("VLoadingIndicator") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 24) {
+            VLoadingIndicator(size: 14)
+            VLoadingIndicator()
+            VLoadingIndicator(size: 32)
+            VLoadingIndicator(color: VColor.success)
+            VLoadingIndicator(color: VColor.error)
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 100)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VToast.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VToast.swift
@@ -55,3 +55,17 @@ struct VToast: View {
         }
     }
 }
+
+#Preview("VToast") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 12) {
+            VToast(message: "Information message", style: .info)
+            VToast(message: "Success message", style: .success)
+            VToast(message: "Warning message", style: .warning)
+            VToast(message: "Error message", style: .error)
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 300)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextEditor.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextEditor.swift
@@ -36,3 +36,16 @@ struct VTextEditor: View {
         )
     }
 }
+
+#Preview("VTextEditor") {
+    @Previewable @State var text = ""
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 16) {
+            VTextEditor(placeholder: "Write something...", text: $text)
+            VTextEditor(placeholder: "Short editor", text: $text, minHeight: 40, maxHeight: 80)
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 350)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextField.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextField.swift
@@ -43,3 +43,18 @@ struct VTextField: View {
         )
     }
 }
+
+#Preview("VTextField") {
+    @Previewable @State var text = ""
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 16) {
+            VTextField(placeholder: "Plain text field", text: $text)
+            VTextField(placeholder: "With leading icon", text: $text, leadingIcon: "magnifyingglass")
+            VTextField(placeholder: "With trailing icon", text: $text, trailingIcon: "envelope")
+            VTextField(placeholder: "Both icons", text: $text, leadingIcon: "magnifyingglass", trailingIcon: "xmark.circle")
+        }
+        .padding()
+    }
+    .frame(width: 350, height: 280)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
@@ -37,3 +37,20 @@ struct VSidePanel<Content: View>: View {
         .background(VColor.backgroundSubtle)
     }
 }
+
+#Preview("VSidePanel") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VSidePanel(title: "Inspector", onClose: {}) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Panel content here")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Text("With scrollable content area")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+    }
+    .frame(width: 300, height: 300)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -47,3 +47,25 @@ extension VSplitView where Panel == EmptyView {
         self.showPanel = false
     }
 }
+
+#Preview("VSplitView") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VSplitView(panelWidth: 200, showPanel: true) {
+            VStack {
+                Text("Main Content")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.surface)
+        } panel: {
+            VSidePanel(title: "Panel") {
+                Text("Side panel")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+    }
+    .frame(width: 600, height: 300)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VToolbar.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VToolbar.swift
@@ -12,3 +12,17 @@ struct VToolbar<Content: View>: View {
         .background(VColor.backgroundSubtle)
     }
 }
+
+#Preview("VToolbar") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VToolbar {
+            VIconButton(label: "Home", icon: "house") {}
+            VIconButton(label: "Search", icon: "magnifyingglass") {}
+            VIconButton(label: "Settings", icon: "gear", isActive: true) {}
+            Spacer()
+            VIconButton(label: "Add", icon: "plus", iconOnly: true) {}
+        }
+    }
+    .frame(width: 500, height: 60)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -27,3 +27,13 @@ struct VSegmentedControl: View {
         }
     }
 }
+
+#Preview("VSegmentedControl") {
+    @Previewable @State var selection = 0
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VSegmentedControl(items: ["All", "Active", "Archived"], selection: $selection)
+            .padding()
+    }
+    .frame(width: 400, height: 80)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -43,3 +43,16 @@ struct VTab: View {
         }
     }
 }
+
+#Preview("VTab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 8) {
+            VTab(label: "Dashboard", icon: "house", isSelected: true, onSelect: {})
+            VTab(label: "Settings", icon: "gear", onSelect: {})
+            VTab(label: "Not closeable", isCloseable: false, onSelect: {})
+        }
+        .padding()
+    }
+    .frame(width: 450, height: 80)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTabBar.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTabBar.swift
@@ -14,3 +14,15 @@ struct VTabBar<Content: View>: View {
         .background(VColor.backgroundSubtle)
     }
 }
+
+#Preview("VTabBar") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VTabBar {
+            VTab(label: "Home", icon: "house", isSelected: true, onSelect: {})
+            VTab(label: "Sessions", icon: "list.bullet", onSelect: {})
+            VTab(label: "Logs", icon: "doc.text", onSelect: {})
+        }
+    }
+    .frame(width: 500, height: 60)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -1,0 +1,88 @@
+#if DEBUG
+import SwiftUI
+
+enum GalleryCategory: String, CaseIterable, Identifiable {
+    case buttons = "Buttons"
+    case display = "Display"
+    case feedback = "Feedback"
+    case inputs = "Inputs"
+    case layout = "Layout"
+    case navigation = "Navigation"
+    case modifiers = "Modifiers"
+    case tokens = "Tokens"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .buttons: return "hand.tap"
+        case .display: return "rectangle.on.rectangle"
+        case .feedback: return "bell"
+        case .inputs: return "character.cursor.ibeam"
+        case .layout: return "rectangle.split.3x1"
+        case .navigation: return "arrow.triangle.branch"
+        case .modifiers: return "paintbrush"
+        case .tokens: return "paintpalette"
+        }
+    }
+}
+
+struct ComponentGalleryView: View {
+    @State private var selectedCategory: GalleryCategory? = .buttons
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selectedCategory) {
+                ForEach(GalleryCategory.allCases) { category in
+                    Label(category.rawValue, systemImage: category.icon)
+                        .tag(category)
+                }
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 240)
+        } detail: {
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xxl) {
+                    if let category = selectedCategory {
+                        switch category {
+                        case .buttons: ButtonsGallerySection()
+                        case .display: DisplayGallerySection()
+                        case .feedback: FeedbackGallerySection()
+                        case .inputs: InputsGallerySection()
+                        case .layout: LayoutGallerySection()
+                        case .navigation: NavigationGallerySection()
+                        case .modifiers: ModifiersGallerySection()
+                        case .tokens: TokensGallerySection()
+                        }
+                    } else {
+                        VEmptyState(
+                            title: "Select a category",
+                            subtitle: "Choose a component category from the sidebar",
+                            icon: "sidebar.left"
+                        )
+                    }
+                }
+                .padding(VSpacing.xxl)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.background)
+        }
+    }
+}
+
+struct GallerySectionHeader: View {
+    let title: String
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(title)
+                .font(VFont.largeTitle)
+                .foregroundColor(VColor.textPrimary)
+            Text(description)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryWindow.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryWindow.swift
@@ -1,0 +1,46 @@
+#if DEBUG
+import AppKit
+import SwiftUI
+
+@MainActor
+final class ComponentGalleryWindow {
+    private var window: NSWindow?
+
+    func show() {
+        if let existing = window {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hostingController = NSHostingController(rootView: ComponentGalleryView())
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1100, height: 700),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "Component Gallery"
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = NSSize(width: 800, height: 500)
+
+        window.setContentSize(NSSize(width: 1100, height: 700))
+        window.center()
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -1,0 +1,126 @@
+#if DEBUG
+import SwiftUI
+
+struct ButtonsGallerySection: View {
+    @State private var selectedStyle: VButton.Style = .primary
+    @State private var isFullWidth = false
+    @State private var isDisabled = false
+    @State private var isActive = false
+    @State private var iconOnly = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VButton
+            GallerySectionHeader(
+                title: "VButton",
+                description: "Primary action button with style, full-width, and disabled options."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Controls
+                    HStack(spacing: VSpacing.xl) {
+                        Picker("Style", selection: $selectedStyle) {
+                            Text("Primary").tag(VButton.Style.primary)
+                            Text("Ghost").tag(VButton.Style.ghost)
+                            Text("Danger").tag(VButton.Style.danger)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(maxWidth: 300)
+
+                        Toggle("Full Width", isOn: $isFullWidth)
+                        Toggle("Disabled", isOn: $isDisabled)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    // Live preview
+                    VButton(
+                        label: "Click Me",
+                        style: selectedStyle,
+                        isFullWidth: isFullWidth,
+                        isDisabled: isDisabled
+                    ) {}
+                }
+            }
+
+            // All Variants grid
+            Text("All Variants")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    ForEach([VButton.Style.primary, .ghost, .danger], id: \.self) { style in
+                        VStack(spacing: VSpacing.md) {
+                            VButton(label: styleName(style), style: style) {}
+                            VButton(label: "Disabled", style: style, isDisabled: true) {}
+                            VButton(label: "Full Width", style: style, isFullWidth: true) {}
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VIconButton
+            GallerySectionHeader(
+                title: "VIconButton",
+                description: "Compact button with SF Symbol icon and optional label."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    HStack(spacing: VSpacing.xl) {
+                        Toggle("Active", isOn: $isActive)
+                        Toggle("Icon Only", isOn: $iconOnly)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    HStack(spacing: VSpacing.lg) {
+                        VIconButton(label: "Settings", icon: "gear", isActive: isActive, iconOnly: iconOnly) {}
+                        VIconButton(label: "Refresh", icon: "arrow.clockwise", isActive: isActive, iconOnly: iconOnly) {}
+                        VIconButton(label: "Add", icon: "plus", isActive: isActive, iconOnly: iconOnly) {}
+                    }
+                }
+            }
+
+            // All VIconButton variants
+            Text("All Variants")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Default").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Edit", icon: "pencil") {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Active").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Edit", icon: "pencil", isActive: true) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Icon Only").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Edit", icon: "pencil", iconOnly: true) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Active + Icon Only").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VIconButton(label: "Edit", icon: "pencil", isActive: true, iconOnly: true) {}
+                    }
+                }
+            }
+        }
+    }
+
+    private func styleName(_ style: VButton.Style) -> String {
+        switch style {
+        case .primary: return "Primary"
+        case .ghost: return "Ghost"
+        case .danger: return "Danger"
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -1,0 +1,141 @@
+#if DEBUG
+import SwiftUI
+
+struct DisplayGallerySection: View {
+    @State private var cardPadding: CGFloat = 24
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VCard
+            GallerySectionHeader(
+                title: "VCard",
+                description: "Container with surface background, border, and configurable padding."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    HStack {
+                        Text("Padding: \(Int(cardPadding))pt")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Slider(value: $cardPadding, in: 0...48, step: 4)
+                            .frame(maxWidth: 200)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VCard(padding: cardPadding) {
+                        Text("Card content with \(Int(cardPadding))pt padding")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                }
+            }
+
+            // Padding variants
+            Text("Padding Variants")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            HStack(spacing: VSpacing.lg) {
+                ForEach([
+                    ("xs", VSpacing.xs),
+                    ("sm", VSpacing.sm),
+                    ("md", VSpacing.md),
+                    ("lg", VSpacing.lg),
+                    ("xl", VSpacing.xl)
+                ], id: \.0) { name, padding in
+                    VCard(padding: padding) {
+                        VStack(spacing: VSpacing.xs) {
+                            Text(name)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("\(Int(padding))pt")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VEmptyState
+            GallerySectionHeader(
+                title: "VEmptyState",
+                description: "Centered placeholder for empty content areas."
+            )
+
+            HStack(spacing: VSpacing.lg) {
+                VCard {
+                    VEmptyState(
+                        title: "No items",
+                        subtitle: "Create your first item to get started",
+                        icon: "tray"
+                    )
+                    .frame(height: 200)
+                }
+                VCard {
+                    VEmptyState(title: "No results")
+                        .frame(height: 200)
+                }
+                VCard {
+                    VEmptyState(
+                        title: "Empty inbox",
+                        icon: "envelope"
+                    )
+                    .frame(height: 200)
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VListRow
+            GallerySectionHeader(
+                title: "VListRow",
+                description: "List item with hover highlight and optional tap action."
+            )
+
+            VCard(padding: 0) {
+                VStack(spacing: 0) {
+                    VListRow(onTap: {}) {
+                        HStack {
+                            Image(systemName: "doc.text")
+                                .foregroundColor(VColor.accent)
+                            Text("Tappable row with icon")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 10))
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VListRow(onTap: {}) {
+                        HStack {
+                            Image(systemName: "folder")
+                                .foregroundColor(VColor.warning)
+                            Text("Another tappable row")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                            Spacer()
+                            VBadge(style: .count(3))
+                        }
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VListRow {
+                        Text("Static row (no tap action)")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -1,0 +1,125 @@
+#if DEBUG
+import SwiftUI
+
+struct FeedbackGallerySection: View {
+    @State private var badgeCount: Double = 5
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VBadge
+            GallerySectionHeader(
+                title: "VBadge",
+                description: "Compact status indicator: count, dot, or label."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Count badges with slider
+                    HStack {
+                        Text("Count: \(Int(badgeCount))")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Slider(value: $badgeCount, in: 1...99, step: 1)
+                            .frame(maxWidth: 200)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    // Count row
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Accent").font(VFont.small).foregroundColor(VColor.textMuted)
+                            VBadge(style: .count(Int(badgeCount)), color: VColor.accent)
+                        }
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Success").font(VFont.small).foregroundColor(VColor.textMuted)
+                            VBadge(style: .count(Int(badgeCount)), color: VColor.success)
+                        }
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Error").font(VFont.small).foregroundColor(VColor.textMuted)
+                            VBadge(style: .count(Int(badgeCount)), color: VColor.error)
+                        }
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Warning").font(VFont.small).foregroundColor(VColor.textMuted)
+                            VBadge(style: .count(Int(badgeCount)), color: VColor.warning)
+                        }
+                    }
+
+                    // Dot row
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Dot").font(VFont.small).foregroundColor(VColor.textMuted)
+                            HStack(spacing: VSpacing.md) {
+                                VBadge(style: .dot, color: VColor.accent)
+                                VBadge(style: .dot, color: VColor.success)
+                                VBadge(style: .dot, color: VColor.error)
+                                VBadge(style: .dot, color: VColor.warning)
+                            }
+                        }
+                    }
+
+                    // Label row
+                    HStack(spacing: VSpacing.lg) {
+                        VBadge(style: .label("New"), color: VColor.accent)
+                        VBadge(style: .label("Beta"), color: VColor.success)
+                        VBadge(style: .label("Error"), color: VColor.error)
+                        VBadge(style: .label("Warn"), color: VColor.warning)
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VLoadingIndicator
+            GallerySectionHeader(
+                title: "VLoadingIndicator",
+                description: "Spinning loading indicator with configurable size and color."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xxl) {
+                    VStack(spacing: VSpacing.md) {
+                        Text("Small (14)").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator(size: 14, color: VColor.accent)
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Default (20)").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator()
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Large (32)").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator(size: 32, color: VColor.accent)
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Success").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator(color: VColor.success)
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Error").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator(color: VColor.error)
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Warning").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VLoadingIndicator(color: VColor.warning)
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VToast
+            GallerySectionHeader(
+                title: "VToast",
+                description: "Notification toast with info, success, warning, and error styles."
+            )
+
+            VStack(spacing: VSpacing.md) {
+                VToast(message: "Here's some useful information.", style: .info)
+                VToast(message: "Operation completed successfully!", style: .success)
+                VToast(message: "Please check your configuration.", style: .warning)
+                VToast(message: "Something went wrong.", style: .error)
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -1,0 +1,105 @@
+#if DEBUG
+import SwiftUI
+
+struct InputsGallerySection: View {
+    @State private var textFieldValue = ""
+    @State private var textEditorValue = ""
+    @State private var minHeight: CGFloat = 80
+    @State private var maxHeight: CGFloat = 200
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VTextField
+            GallerySectionHeader(
+                title: "VTextField",
+                description: "Single-line text input with optional leading/trailing icons."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Live value: \"\(textFieldValue)\"")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Plain").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTextField(placeholder: "Type something...", text: $textFieldValue)
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Leading icon").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTextField(
+                            placeholder: "Search...",
+                            text: $textFieldValue,
+                            leadingIcon: "magnifyingglass"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Trailing icon").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTextField(
+                            placeholder: "Enter email...",
+                            text: $textFieldValue,
+                            trailingIcon: "envelope"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Both icons").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTextField(
+                            placeholder: "Search files...",
+                            text: $textFieldValue,
+                            leadingIcon: "magnifyingglass",
+                            trailingIcon: "xmark.circle"
+                        )
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VTextEditor
+            GallerySectionHeader(
+                title: "VTextEditor",
+                description: "Multi-line text editor with placeholder and height controls."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(alignment: .leading) {
+                            Text("Min Height: \(Int(minHeight))")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                            Slider(value: $minHeight, in: 40...200, step: 10)
+                                .frame(maxWidth: 200)
+                        }
+                        VStack(alignment: .leading) {
+                            Text("Max Height: \(Int(maxHeight))")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                            Slider(value: $maxHeight, in: 100...400, step: 20)
+                                .frame(maxWidth: 200)
+                        }
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VTextEditor(
+                        placeholder: "Write your thoughts...",
+                        text: $textEditorValue,
+                        minHeight: minHeight,
+                        maxHeight: maxHeight
+                    )
+
+                    Text("Characters: \(textEditorValue.count)")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -1,0 +1,103 @@
+#if DEBUG
+import SwiftUI
+
+struct LayoutGallerySection: View {
+    @State private var showPanel = true
+    @State private var panelWidth: CGFloat = 280
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VToolbar
+            GallerySectionHeader(
+                title: "VToolbar",
+                description: "Horizontal toolbar container for icon buttons and actions."
+            )
+
+            VCard(padding: 0) {
+                VToolbar {
+                    VIconButton(label: "Home", icon: "house") {}
+                    VIconButton(label: "Search", icon: "magnifyingglass") {}
+                    VIconButton(label: "Settings", icon: "gear", isActive: true) {}
+                    Spacer()
+                    VIconButton(label: "Add", icon: "plus", iconOnly: true) {}
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSidePanel
+            GallerySectionHeader(
+                title: "VSidePanel",
+                description: "Side panel with title header and close button."
+            )
+
+            VCard(padding: 0) {
+                VSidePanel(title: "Inspector", onClose: {}) {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Panel content goes here")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                        Text("This panel has a title header with a close button and scrollable content area.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+                .frame(width: 300, height: 200)
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSplitView
+            GallerySectionHeader(
+                title: "VSplitView",
+                description: "Split layout with main content and a togglable side panel."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    HStack(spacing: VSpacing.xl) {
+                        Toggle("Show Panel", isOn: $showPanel)
+                        VStack(alignment: .leading) {
+                            Text("Panel Width: \(Int(panelWidth))")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                            Slider(value: $panelWidth, in: 200...400, step: 20)
+                                .frame(maxWidth: 200)
+                        }
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VSplitView(
+                        panelWidth: panelWidth,
+                        showPanel: showPanel
+                    ) {
+                        VStack {
+                            Text("Main Content")
+                                .font(VFont.title)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("This is the primary area")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(VColor.surface)
+                    } panel: {
+                        VSidePanel(title: "Details", onClose: { showPanel = false }) {
+                            Text("Side panel content")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                    }
+                    .frame(height: 250)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -1,0 +1,113 @@
+#if DEBUG
+import SwiftUI
+
+struct ModifiersGallerySection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - .vCard()
+            GallerySectionHeader(
+                title: ".vCard(radius:)",
+                description: "View modifier that applies card styling with configurable corner radius."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    ForEach([
+                        ("xs", VRadius.xs),
+                        ("sm", VRadius.sm),
+                        ("md", VRadius.md),
+                        ("lg", VRadius.lg),
+                        ("xl", VRadius.xl)
+                    ], id: \.0) { name, radius in
+                        VStack(spacing: VSpacing.md) {
+                            Text("Sample content")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .padding(VSpacing.xl)
+                                .vCard(radius: radius)
+
+                            Text(".\(name) (\(Int(radius))pt)")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - .vHover()
+            GallerySectionHeader(
+                title: ".vHover()",
+                description: "Adds a subtle background highlight on mouse hover."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Hover over the items below:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+
+                    ForEach(["First item", "Second item", "Third item"], id: \.self) { item in
+                        Text(item)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .padding(VSpacing.md)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .vHover()
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - .vPanelBackground()
+            GallerySectionHeader(
+                title: ".vPanelBackground()",
+                description: "Fills the view with the subtle background color used for panels."
+            )
+
+            HStack(spacing: VSpacing.lg) {
+                VStack(spacing: VSpacing.md) {
+                    Text("With .vPanelBackground()")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+
+                    VStack(spacing: VSpacing.md) {
+                        Text("Panel content")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                    .frame(width: 200, height: 100)
+                    .vPanelBackground()
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                }
+
+                VStack(spacing: VSpacing.md) {
+                    Text("Without (default background)")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+
+                    VStack(spacing: VSpacing.md) {
+                        Text("Regular content")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                    .frame(width: 200, height: 100)
+                    .background(VColor.background)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -1,0 +1,111 @@
+#if DEBUG
+import SwiftUI
+
+struct NavigationGallerySection: View {
+    @State private var segmentSelection = 0
+    @State private var selectedTab = 0
+
+    private let segmentItems = ["All", "Active", "Archived", "Drafts"]
+    private let tabs = [
+        (label: "Dashboard", icon: "house"),
+        (label: "Sessions", icon: "list.bullet"),
+        (label: "Settings", icon: "gear"),
+        (label: "Logs", icon: "doc.text"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - VSegmentedControl
+            GallerySectionHeader(
+                title: "VSegmentedControl",
+                description: "Underlined segmented control for switching between views."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Selected: \(segmentItems[segmentSelection])")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VSegmentedControl(items: segmentItems, selection: $segmentSelection)
+
+                    // Show a placeholder for the selected segment
+                    VCard {
+                        Text("Content for \"\(segmentItems[segmentSelection])\" tab")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(VSpacing.xl)
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VTabBar + VTab
+            GallerySectionHeader(
+                title: "VTabBar + VTab",
+                description: "Horizontal scrollable tab bar with selectable and closeable tabs."
+            )
+
+            VCard(padding: 0) {
+                VStack(spacing: 0) {
+                    VTabBar {
+                        ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+                            VTab(
+                                label: tab.label,
+                                icon: tab.icon,
+                                isSelected: selectedTab == index,
+                                isCloseable: index > 0,
+                                onSelect: { selectedTab = index },
+                                onClose: index > 0 ? {} : nil
+                            )
+                        }
+                    }
+
+                    // Content area
+                    VStack {
+                        Text(tabs[selectedTab].label)
+                            .font(VFont.title)
+                            .foregroundColor(VColor.textPrimary)
+                        Text("Tab content area")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 120)
+                    .background(VColor.background)
+                }
+            }
+
+            // Tab states
+            Text("Tab States")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Default").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", isSelected: true, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Not closeable").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", isCloseable: false, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("No icon").font(VFont.small).foregroundColor(VColor.textMuted)
+                        VTab(label: "Plain Tab", isCloseable: false, onSelect: {})
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -1,0 +1,271 @@
+#if DEBUG
+import SwiftUI
+
+struct TokensGallerySection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // MARK: - Colors: Semantic
+            GallerySectionHeader(
+                title: "Colors",
+                description: "Semantic color tokens for consistent theming."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Semantic Tokens")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+
+                    let semanticColors: [(String, Color)] = [
+                        ("background", VColor.background),
+                        ("backgroundSubtle", VColor.backgroundSubtle),
+                        ("surface", VColor.surface),
+                        ("surfaceBorder", VColor.surfaceBorder),
+                        ("textPrimary", VColor.textPrimary),
+                        ("textSecondary", VColor.textSecondary),
+                        ("textMuted", VColor.textMuted),
+                        ("accent", VColor.accent),
+                        ("accentSubtle", VColor.accentSubtle),
+                        ("success", VColor.success),
+                        ("error", VColor.error),
+                        ("warning", VColor.warning),
+                    ]
+
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: VSpacing.md), count: 4), spacing: VSpacing.md) {
+                        ForEach(semanticColors, id: \.0) { name, color in
+                            VStack(spacing: VSpacing.xs) {
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .fill(color)
+                                    .frame(height: 40)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: VRadius.sm)
+                                            .stroke(VColor.surfaceBorder, lineWidth: 1)
+                                    )
+                                Text(name)
+                                    .font(VFont.small)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Color scales
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Color Scales")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+
+                    colorScaleRow(name: "Slate", colors: [
+                        Slate._900, Slate._800, Slate._700, Slate._600, Slate._500,
+                        Slate._400, Slate._300, Slate._200, Slate._100, Slate._50
+                    ])
+                    colorScaleRow(name: "Violet", colors: [
+                        Violet._950, Violet._900, Violet._800, Violet._700, Violet._600,
+                        Violet._500, Violet._400, Violet._300, Violet._200, Violet._100
+                    ])
+                    colorScaleRow(name: "Emerald", colors: [
+                        Emerald._950, Emerald._900, Emerald._800, Emerald._700, Emerald._600,
+                        Emerald._500, Emerald._400, Emerald._300, Emerald._200, Emerald._100
+                    ])
+                    colorScaleRow(name: "Rose", colors: [
+                        Rose._950, Rose._900, Rose._800, Rose._700, Rose._600,
+                        Rose._500, Rose._400, Rose._300, Rose._200, Rose._100
+                    ])
+                    colorScaleRow(name: "Amber", colors: [
+                        Amber._950, Amber._900, Amber._800, Amber._700, Amber._600,
+                        Amber._500, Amber._400, Amber._300, Amber._200, Amber._100
+                    ])
+                    colorScaleRow(name: "Indigo", colors: [
+                        Indigo._950, Indigo._900, Indigo._800, Indigo._700, Indigo._600,
+                        Indigo._500, Indigo._400, Indigo._300, Indigo._200, Indigo._100
+                    ])
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Typography
+            GallerySectionHeader(
+                title: "Typography",
+                description: "Font scale tokens for consistent text styling."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    typographySample("largeTitle", font: VFont.largeTitle)
+                    typographySample("title", font: VFont.title)
+                    typographySample("headline", font: VFont.headline)
+                    typographySample("body", font: VFont.body)
+                    typographySample("bodyMedium", font: VFont.bodyMedium)
+                    typographySample("bodyBold", font: VFont.bodyBold)
+                    typographySample("caption", font: VFont.caption)
+                    typographySample("captionMedium", font: VFont.captionMedium)
+                    typographySample("small", font: VFont.small)
+                    typographySample("mono", font: VFont.mono)
+                    typographySample("monoSmall", font: VFont.monoSmall)
+                    typographySample("display", font: VFont.display)
+                    typographySample("cardTitle", font: VFont.cardTitle)
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Spacing
+            GallerySectionHeader(
+                title: "Spacing",
+                description: "Spacing scale tokens for consistent layout."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    let spacings: [(String, CGFloat)] = [
+                        ("xxs", VSpacing.xxs), ("xs", VSpacing.xs), ("sm", VSpacing.sm),
+                        ("md", VSpacing.md), ("lg", VSpacing.lg), ("xl", VSpacing.xl),
+                        ("xxl", VSpacing.xxl), ("xxxl", VSpacing.xxxl),
+                    ]
+
+                    ForEach(spacings, id: \.0) { name, value in
+                        HStack(spacing: VSpacing.lg) {
+                            Text("\(name) (\(Int(value))pt)")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(width: 120, alignment: .trailing)
+                            RoundedRectangle(cornerRadius: VRadius.xs)
+                                .fill(VColor.accent)
+                                .frame(width: value, height: 16)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Radius
+            GallerySectionHeader(
+                title: "Radius",
+                description: "Corner radius tokens for consistent rounding."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    let radii: [(String, CGFloat)] = [
+                        ("xs", VRadius.xs), ("sm", VRadius.sm), ("md", VRadius.md),
+                        ("lg", VRadius.lg), ("xl", VRadius.xl), ("pill", VRadius.pill),
+                    ]
+
+                    ForEach(radii, id: \.0) { name, radius in
+                        VStack(spacing: VSpacing.md) {
+                            RoundedRectangle(cornerRadius: radius)
+                                .fill(VColor.accent.opacity(0.3))
+                                .frame(width: 60, height: 60)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: radius)
+                                        .stroke(VColor.accent, lineWidth: 2)
+                                )
+                            Text(name)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("\(Int(radius))pt")
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Shadows
+            GallerySectionHeader(
+                title: "Shadows",
+                description: "Shadow tokens for depth and emphasis."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xxl) {
+                    let shadows: [(String, VShadow.Definition)] = [
+                        ("sm", VShadow.sm), ("md", VShadow.md), ("lg", VShadow.lg),
+                        ("glow", VShadow.glow), ("accentGlow", VShadow.accentGlow),
+                    ]
+
+                    ForEach(shadows, id: \.0) { name, shadow in
+                        VStack(spacing: VSpacing.lg) {
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .fill(VColor.surface)
+                                .frame(width: 80, height: 80)
+                                .vShadow(shadow)
+                            Text(name)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                    }
+                }
+                .padding(VSpacing.xl)
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Animations
+            GallerySectionHeader(
+                title: "Animations",
+                description: "Animation timing tokens."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    let animations: [(String, String)] = [
+                        ("fast", "0.15s easeOut"),
+                        ("standard", "0.25s easeInOut"),
+                        ("slow", "0.4s easeInOut"),
+                        ("spring", "response: 0.3, damping: 0.8"),
+                        ("panel", "response: 0.35, damping: 0.85"),
+                        ("bouncy", "response: 0.3, damping: 0.5"),
+                    ]
+
+                    ForEach(animations, id: \.0) { name, description in
+                        HStack(spacing: VSpacing.lg) {
+                            Text(name)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textPrimary)
+                                .frame(width: 80, alignment: .trailing)
+                            Text(description)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func colorScaleRow(name: String, colors: [Color]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(name)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textSecondary)
+            HStack(spacing: 2) {
+                ForEach(0..<colors.count, id: \.self) { i in
+                    Rectangle()
+                        .fill(colors[i])
+                        .frame(height: 32)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+    }
+
+    private func typographySample(_ name: String, font: Font) -> some View {
+        HStack(spacing: VSpacing.lg) {
+            Text(name)
+                .font(VFont.mono)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 140, alignment: .trailing)
+            Text("The quick brown fox jumps")
+                .font(font)
+                .foregroundColor(VColor.textPrimary)
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
@@ -19,3 +19,17 @@ extension View {
         modifier(CardModifier(radius: radius))
     }
 }
+
+#Preview("CardModifier") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 16) {
+            Text("xs").padding().vCard(radius: VRadius.xs)
+            Text("md").padding().vCard(radius: VRadius.md)
+            Text("xl").padding().vCard(radius: VRadius.xl)
+        }
+        .foregroundColor(VColor.textPrimary)
+        .padding()
+    }
+    .frame(width: 400, height: 120)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/HoverEffect.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/HoverEffect.swift
@@ -17,3 +17,23 @@ extension View {
         modifier(HoverEffectModifier())
     }
 }
+
+#Preview("HoverEffect") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: 4) {
+            Text("Hover over me")
+                .foregroundColor(VColor.textPrimary)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .vHover()
+            Text("Hover here too")
+                .foregroundColor(VColor.textPrimary)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .vHover()
+        }
+        .padding()
+    }
+    .frame(width: 300, height: 150)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/PanelBackground.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/PanelBackground.swift
@@ -13,3 +13,20 @@ extension View {
         modifier(PanelBackgroundModifier())
     }
 }
+
+#Preview("PanelBackground") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 0) {
+            Text("Main area")
+                .foregroundColor(VColor.textPrimary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            Text("Panel area")
+                .foregroundColor(VColor.textPrimary)
+                .frame(width: 150)
+                .vPanelBackground()
+        }
+    }
+    .frame(width: 400, height: 200)
+}


### PR DESCRIPTION
## Summary

Adds a debug-only Component Gallery window for visually browsing and interacting with all design system components, modifiers, and tokens. Accessible via right-click on the status bar icon. Also adds `#Preview` blocks to all 19 component and modifier files for Xcode Previews.

## Changes

- Add `ComponentGalleryWindow` (NSWindow wrapper, 1100x700) and `ComponentGalleryView` (NavigationSplitView with 8 sidebar categories)
- Add 8 gallery section files: Buttons, Display, Feedback, Inputs, Layout, Navigation, Modifiers, Tokens
- Wire gallery to `AppDelegate` context menu with `#if DEBUG` guard
- Add `#Preview` blocks to all 16 components and 3 modifiers
- Make `VButton.Style` conform to `Hashable` for gallery `Picker`/`ForEach` support
- All gallery code wrapped in `#if DEBUG` — zero impact on release builds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
