### PR TITLE
Add AGENTS.md and symlink during vel setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dist
 .private/
 temp.sh
 context.md
+CLAUDE.md
 .codex
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Vellum Assistant — Agent Instructions
+
+## Keep the README up to date
+
+Whenever you modify, add, or remove a slash command in `.claude/commands/`, you MUST update `README.md` to reflect the change. The README's "Slash Commands" section should always match the current set of commands. Update the TLDR description if the command's purpose changed, add new entries for new commands, and remove entries for deleted commands.
+
+## Slash Commands — TLDR
+
+These are the most commonly used slash commands defined in `.claude/commands/`:
+
+| Command | What it does |
+|---|---|
+| `/work` | Pick one task from `.private/TODO.md` (or a user-provided task), implement it, open a PR, squash-merge it, and update tracking files. |
+| `/do <description>` | Implement a described change in an isolated worktree, ship it to main via a squash-merged PR, and clean up. |
+| `/swarm [workers] [max-tasks]` | Process `.private/TODO.md` in parallel — one worktree per agent, auto-merge PRs, respawn agents until the list is empty. |
+| `/blitz <feature>` | End-to-end feature delivery: plan, create GitHub issues on a project board, swarm-execute in parallel, sweep for review feedback, and report. |
+| `/mainline [title]` | Ship the current uncommitted changes to main via a squash-merged PR. |
+| `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
+| `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |
+| `/execute-plan <plan-file>` | Execute a multi-PR rollout plan from `.private/plans/` sequentially — implement, validate, and mainline each PR in order. |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,44 @@ VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a vellum-assistant
 
 Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
 
+## Claude Code Workflow
+
+This repo includes Claude Code slash commands (in `.claude/commands/`) for agent-driven development.
+
+### Single-task commands
+
+| Command | Purpose |
+|---------|---------|
+| `/do <description>` | Implement a change in an isolated worktree, create a PR, squash-merge it to main, and clean up. |
+| `/mainline` | Ship uncommitted changes already in your working tree to main via a squash-merged PR. |
+| `/work` | Pick up the next task from `.private/TODO.md` (or a task you specify), implement it, PR it, and merge it. |
+
+### Multi-task / parallel commands
+
+| Command | Purpose |
+|---------|---------|
+| `/brainstorm` | Deep-read the codebase, generate a prioritized list of improvements, and update `.private/TODO.md` after approval. |
+| `/swarm [workers] [max-tasks]` | Parallel execution — spawns a pool of agents (default 3) that work through `.private/TODO.md` concurrently, each in its own worktree. |
+| `/blitz <feature>` | End-to-end feature delivery — plans the feature, creates GitHub issues on a project board, swarm-executes them in parallel, sweeps for review feedback, addresses it, and reports. |
+| `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
+
+### Review
+
+| Command | Purpose |
+|---------|---------|
+| `/check-reviews` | Checks for review feedback on unreviewed PRs and creates follow-up tasks. |
+
+### Typical flow
+
+1. **`/brainstorm`** — generate ideas, approve them into `TODO.md`
+2. **`/swarm`** — burn through the TODO list in parallel
+3. **`/check-reviews`** — sweep for reviewer feedback
+4. **`/swarm`** again — address the feedback
+
+Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report).
+
+All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
+
 ## License
 
 Proprietary - Vellum AI

--- a/vel/src/commands/setup.ts
+++ b/vel/src/commands/setup.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, readlinkSync, symlinkSync, unlinkSync } from 'fs';
 import { dirname, join } from 'path';
 
 import { exec, execOutput, runSteps } from '../lib/step-runner';
@@ -40,6 +40,31 @@ export async function setup(): Promise<void> {
         }
 
         await exec('docker', ['compose', 'down'], { cwd: legacyDir });
+      },
+    },
+    {
+      name: 'Symlinking AGENTS.md → CLAUDE.md',
+      run: async () => {
+        const agentsMd = join(repoRoot, 'AGENTS.md');
+        const claudeMd = join(repoRoot, 'CLAUDE.md');
+
+        if (existsSync(claudeMd)) {
+          try {
+            const target = readlinkSync(claudeMd);
+            if (target === 'AGENTS.md') {
+              return; // Already correctly symlinked
+            }
+          } catch {
+            // Not a symlink — remove the regular file so we can create the link
+          }
+          unlinkSync(claudeMd);
+        }
+
+        if (!existsSync(agentsMd)) {
+          throw new Error('AGENTS.md not found at repo root');
+        }
+
+        symlinkSync('AGENTS.md', claudeMd);
       },
     },
     {


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at the repo root with agent instructions to keep the README's slash commands section in sync with `.claude/commands/`
- Adds a `vel setup` step that symlinks `AGENTS.md → CLAUDE.md` so Claude Code picks up the instructions automatically
- Updates README with a "Claude Code Workflow" section documenting all slash commands
- Gitignores `CLAUDE.md` since it's a generated symlink

## Test plan
- [ ] Run `vel setup` and verify `CLAUDE.md` symlink is created pointing to `AGENTS.md`
- [ ] Run `vel setup` again and verify it's idempotent (skips if already correct)
- [ ] Verify `CLAUDE.md` is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
