### PR TITLE
Fix stale path refs and add .private/ setup step

### DIFF
--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -178,7 +178,7 @@ gh api graphql -f query='mutation {
 
 ## Phase 4: Swarm
 
-Read and follow the instructions in `scripts/commands/swarm.md` with these modifications:
+Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
 
 - Pass the `--workers` count (or default 3) as the first argument.
 - **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items from Phase 5 — those are PR-based and have no associated milestone issue):
@@ -237,7 +237,7 @@ gh issue close <issue-number>
 1. Unless `--auto` was passed, pause and ask the user: **"Initial swarm complete. Run sweep for review feedback?"**
    - If the user declines, skip to Phase 6.
 
-2. Run the check-reviews workflow by reading and following `scripts/commands/check-reviews.md`.
+2. Run the check-reviews workflow by reading and following `.claude/commands/check-reviews.md`.
 
 3. After check-reviews completes, read `.private/TODO.md`:
    - If new "Address the feedback" items were added, run another swarm pass (back to Phase 4).

--- a/vel/src/commands/setup.ts
+++ b/vel/src/commands/setup.ts
@@ -1,4 +1,4 @@
-import { existsSync, readlinkSync, symlinkSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, readlinkSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import { exec, execOutput, runSteps } from '../lib/step-runner';
@@ -65,6 +65,21 @@ export async function setup(): Promise<void> {
         }
 
         symlinkSync('AGENTS.md', claudeMd);
+      },
+    },
+    {
+      name: 'Creating .private/ tracking files',
+      run: async () => {
+        const privateDir = join(repoRoot, '.private');
+        if (!existsSync(privateDir)) {
+          mkdirSync(privateDir, { recursive: true });
+        }
+        for (const file of ['TODO.md', 'DONE.md', 'UNREVIEWED_PRS.md']) {
+          const filePath = join(privateDir, file);
+          if (!existsSync(filePath)) {
+            writeFileSync(filePath, '');
+          }
+        }
       },
     },
     {


### PR DESCRIPTION
## Summary
- Fixes stale `scripts/commands/` path references in `blitz.md` (lines 181, 240) → `.claude/commands/`
- Adds a new `vel setup` step to create `.private/` directory and tracking files (`TODO.md`, `DONE.md`, `UNREVIEWED_PRS.md`), matching what `scripts/README.md` promises

Addresses review feedback from #743.

## Test plan
- [ ] Run `vel setup` and verify `.private/` directory and tracking files are created
- [ ] Run `vel setup` again and verify it's idempotent (doesn't overwrite existing files)
- [ ] Verify `/blitz` command references resolve to the correct `.claude/commands/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
