### PR TITLE
Fix VSplitView divider transition and VBadge pluralization

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VBadge.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Feedback/VBadge.swift
@@ -20,7 +20,7 @@ struct VBadge: View {
                 .padding(.vertical, VSpacing.xxs)
                 .background(color)
                 .clipShape(Capsule())
-                .accessibilityLabel("\(count) items")
+                .accessibilityLabel("\(count) \(count == 1 ? "item" : "items")")
 
         case .dot:
             Circle()

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -14,6 +14,7 @@ struct VSplitView<Main: View, Panel: View>: View {
             if showPanel, let panel = panel {
                 Divider()
                     .background(VColor.surfaceBorder)
+                    .transition(.move(edge: .trailing))
 
                 panel
                     .frame(width: panelWidth)


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #797. Fixes two design system issues: VSplitView's Divider fading instead of sliding with the panel, and VBadge announcing "1 items" instead of "1 item" for VoiceOver.

## Changes

- Add `.transition(.move(edge: .trailing))` to VSplitView Divider so it slides in sync with the panel
- Fix VBadge count accessibility label to use correct singular/plural ("1 item" vs "N items")
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
