### PR TITLE
Add /scrub command for macOS client

### DIFF
--- a/clients/macos/.claude/commands/scrub.md
+++ b/clients/macos/.claude/commands/scrub.md
@@ -1,0 +1,46 @@
+# Scrub — Kill, Wipe, and Relaunch vellum-assistant
+
+Kill the running vellum-assistant app, delete all persistent data so the next launch behaves like a first run (including onboarding), then start the daemon and rebuild/launch the app.
+
+## Steps
+
+1. Kill any running `vellum-assistant` processes:
+   ```bash
+   pkill -f "vellum-assistant"
+   ```
+
+2. Remove session logs and knowledge store:
+   ```bash
+   rm -rf ~/Library/Application\ Support/vellum-assistant/logs/
+   rm -f ~/Library/Application\ Support/vellum-assistant/knowledge.json
+   ```
+
+3. Remove caches:
+   ```bash
+   rm -rf ~/Library/Caches/vellum-assistant/
+   ```
+
+4. Reset UserDefaults:
+   ```bash
+   defaults delete com.vellum.vellum-assistant
+   ```
+
+5. Confirm everything is clean by listing what remains (if anything) in `~/Library/Application Support/vellum-assistant/`.
+
+6. Check if the daemon is already running:
+   ```bash
+   pgrep -f "src/index.ts daemon"
+   ```
+   If it's NOT running, start it in the background from the assistant repo:
+   ```bash
+   cd /Users/jasonzhou/Vellum/vellum-assistant/assistant && bun run src/index.ts daemon start
+   ```
+   If it IS already running, skip this step and report that the daemon is already up.
+
+7. Build and launch the macOS app:
+   ```bash
+   cd /Users/jasonzhou/Vellum/vellum-assistant/clients/macos && ./build.sh run
+   ```
+   Run this in the background so it doesn't block.
+
+Report what was cleaned up and confirm both the daemon and app are running.


### PR DESCRIPTION
## Summary
- Add `/scrub` Claude Code command that kills vellum-assistant, wipes all persistent data (logs, knowledge store, caches, UserDefaults), restarts the daemon, and rebuilds/launches the app for a clean first-run experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
