### PR TITLE
Add voice activation key setting to Settings

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -18,10 +18,11 @@ final class VoiceInputManager {
     private var holdTask: Task<Void, Never>?
     private static let holdDelay: UInt64 = 300_000_000 // 300ms in nanoseconds
 
-    private var activationFlag: NSEvent.ModifierFlags {
+    private var activationFlag: NSEvent.ModifierFlags? {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         switch stored {
         case "ctrl": return .control
+        case "none": return nil
         default: return .function // fn and globe are the same physical key
         }
     }
@@ -64,7 +65,7 @@ final class VoiceInputManager {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let flag = activationFlag
+        guard let flag = activationFlag else { return }
         let keyPressed = event.modifierFlags.contains(flag)
         var otherModifiers: NSEvent.ModifierFlags = [.command, .shift, .control, .option, .function]
         otherModifiers.remove(flag)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -8,14 +8,16 @@ enum OrbMood {
     case celebrating
 }
 
-enum ActivationKey: String {
+enum ActivationKey: String, CaseIterable {
     case fn
     case ctrl
+    case none
 
     var displayName: String {
         switch self {
         case .fn: return "fn"
         case .ctrl: return "ctrl"
+        case .none: return "Off"
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -15,6 +15,10 @@ struct SettingsView: View {
         return val == 0 ? 30 : val
     }()
     @State private var showingPrivacy = false
+    @State private var activationKey: ActivationKey = {
+        let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
+        return ActivationKey(rawValue: stored) ?? .fn
+    }()
     var ambientAgent: AmbientAgent
 
     // Re-check permissions every 2 seconds while the window is open
@@ -67,6 +71,21 @@ struct SettingsView: View {
                     .onChange(of: maxSteps) { _, newValue in
                         UserDefaults.standard.set(newValue, forKey: "maxStepsPerSession")
                     }
+            }
+
+            Section("Voice Activation") {
+                Picker("Activation key", selection: $activationKey) {
+                    ForEach(ActivationKey.allCases, id: \.self) { key in
+                        Text(key.displayName).tag(key)
+                    }
+                }
+                .onChange(of: activationKey) { _, newValue in
+                    UserDefaults.standard.set(newValue.rawValue, forKey: "activationKey")
+                }
+
+                Text("Hold the activation key to start voice input. Set to Off to disable voice activation.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Ambient Agent") {


### PR DESCRIPTION
## Summary
- Adds a "Voice Activation" section to the Settings view with a picker to change the voice hotkey (fn, ctrl) or disable it entirely (Off)
- Previously the activation key was only configurable during onboarding with no way to change or unset it afterward
- Adds a `.none` case to `ActivationKey` enum so voice activation can be fully disabled

## Test plan
- [ ] Open Settings, verify the "Voice Activation" section appears between "Computer Use" and "Ambient Agent"
- [ ] Change activation key from fn to ctrl, verify voice input triggers on ctrl hold
- [ ] Set to "Off", verify holding fn/ctrl no longer triggers voice input
- [ ] Re-run onboarding, verify fn key step still works correctly
- [ ] Build with `./build.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
