### PR TITLE
Fix persistent Screen Recording permission dialog

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -215,6 +215,13 @@ final class AmbientAgent: ObservableObject {
                 log.debug("[\(cycle)] AX tree not useful (<3 elements), using OCR fallback")
             }
 
+            // Before attempting screenshot, check permission
+            guard PermissionManager.screenRecordingStatus() == .granted else {
+                log.debug("[\(cycle)] Screen recording not permitted — skipping OCR fallback")
+                state = .watching
+                return
+            }
+
             let screenshot: Data
             do {
                 screenshot = try await screenCapture.captureScreen()

--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -1,5 +1,4 @@
 import ApplicationServices
-import ScreenCaptureKit
 
 enum PermissionStatus {
     case granted
@@ -14,12 +13,11 @@ enum PermissionManager {
         return trusted ? .granted : .denied
     }
 
-    static func screenRecordingStatus() async -> PermissionStatus {
-        do {
-            _ = try await SCShareableContent.current
-            return .granted
-        } catch {
-            return .denied
-        }
+    static func screenRecordingStatus() -> PermissionStatus {
+        return CGPreflightScreenCaptureAccess() ? .granted : .denied
+    }
+
+    static func requestScreenRecordingAccess() {
+        CGRequestScreenCaptureAccess()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
@@ -1,4 +1,3 @@
-import ScreenCaptureKit
 import SwiftUI
 
 struct ScreenPermissionStepView: View {
@@ -74,16 +73,14 @@ struct ScreenPermissionStepView: View {
                 }
                 return
             }
-            Task {
-                let status = await PermissionManager.screenRecordingStatus()
-                if status == .granted {
-                    grantPermission()
-                    return
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                    withAnimation(.easeOut(duration: 0.5)) {
-                        showContent = true
-                    }
+            let status = PermissionManager.screenRecordingStatus()
+            if status == .granted {
+                grantPermission()
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showContent = true
                 }
             }
         }
@@ -93,23 +90,15 @@ struct ScreenPermissionStepView: View {
     }
 
     private func requestScreenPermission() {
-        Task {
-            do {
-                _ = try await SCShareableContent.current
-                grantPermission()
-            } catch {
-                startPolling()
-            }
-        }
+        PermissionManager.requestScreenRecordingAccess()
+        startPolling()
     }
 
     private func startPolling() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-            Task { @MainActor in
-                let status = await PermissionManager.screenRecordingStatus()
-                if status == .granted {
-                    grantPermission()
-                }
+            let status = PermissionManager.screenRecordingStatus()
+            if status == .granted {
+                grantPermission()
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -138,10 +138,8 @@ struct SettingsView: View {
                     Spacer()
                     if !screenRecordingGranted {
                         Button("Check") {
-                            Task {
-                                let status = await PermissionManager.screenRecordingStatus()
-                                screenRecordingGranted = status == .granted
-                            }
+                            let status = PermissionManager.screenRecordingStatus()
+                            screenRecordingGranted = status == .granted
                         }
                     }
                 }
@@ -174,10 +172,8 @@ struct SettingsView: View {
 
     private func checkPermissions() {
         accessibilityGranted = PermissionManager.accessibilityStatus() == .granted
-        Task {
-            let status = await PermissionManager.screenRecordingStatus()
-            screenRecordingGranted = status == .granted
-        }
+        let status = PermissionManager.screenRecordingStatus()
+        screenRecordingGranted = status == .granted
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `SCShareableContent.current` with `CGPreflightScreenCaptureAccess()` in `PermissionManager.screenRecordingStatus()` to check permission without triggering the system dialog
- Use `CGRequestScreenCaptureAccess()` only when user explicitly clicks to grant permission in onboarding
- Guard ambient agent's OCR fallback with permission check to prevent repeated dialog triggers
- Update SettingsView to use now-synchronous permission check

Fixes #818

## Test plan
- [ ] Build the macOS app and verify it compiles without errors
- [ ] Deny Screen Recording permission and verify the dialog does not reappear
- [ ] Grant Screen Recording permission and verify the ambient agent captures screenshots normally
- [ ] Verify the onboarding screen recording step still works (shows dialog once on button click)
- [ ] Verify the Settings view correctly shows permission status

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
