### PR TITLE
Add dynamic_page surface type to daemon (#813)

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -122,7 +122,7 @@ export interface AmbientObservation {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation';
+export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
 
 export interface SurfaceAction {
   id: string;
@@ -174,7 +174,13 @@ export interface ConfirmationSurfaceData {
   destructive?: boolean;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData;
+export interface DynamicPageSurfaceData {
+  html: string;
+  width?: number;
+  height?: number;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -428,11 +434,17 @@ export interface UiSurfaceShowConfirmation extends UiSurfaceShowBase {
   data: ConfirmationSurfaceData;
 }
 
+export interface UiSurfaceShowDynamicPage extends UiSurfaceShowBase {
+  surfaceType: 'dynamic_page';
+  data: DynamicPageSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
   | UiSurfaceShowList
-  | UiSurfaceShowConfirmation;
+  | UiSurfaceShowConfirmation
+  | UiSurfaceShowDynamicPage;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -635,7 +635,7 @@ export class Session {
       // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
       const isInteractive = surfaceType === 'list'
         ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-        : ['form', 'confirmation'].includes(surfaceType);
+        : ['form', 'confirmation', 'dynamic_page'].includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
       // Track surface state for ui_update merging

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -34,7 +34,9 @@ export const uiShowTool: Tool = {
     '- list: Selectable list of items. ' +
     'data shape: { items: Array<{ id: string, title: string, subtitle?: string, icon?: string, selected?: boolean }>, selectionMode: "single"|"multiple"|"none" }\n' +
     '- confirmation: Yes/no confirmation dialog. ' +
-    'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }',
+    'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }\n' +
+    '- dynamic_page: Custom HTML page rendered in a sandboxed container. ' +
+    'data shape: { html: string, width?: number, height?: number }',
   category: 'ui-surface',
   defaultRiskLevel: RiskLevel.Low,
   executionMode: 'proxy',
@@ -48,7 +50,7 @@ export const uiShowTool: Tool = {
         properties: {
           surface_type: {
             type: 'string',
-            enum: ['card', 'form', 'list', 'confirmation'],
+            enum: ['card', 'form', 'list', 'confirmation', 'dynamic_page'],
             description: 'The type of surface to display',
           },
           title: {


### PR DESCRIPTION
## Summary
- Adds `dynamic_page` to the `SurfaceType` union and introduces `DynamicPageSurfaceData` interface (`{ html: string, width?: number, height?: number }`) in the IPC protocol
- Adds `UiSurfaceShowDynamicPage` variant to the `UiSurfaceShow` discriminated union
- Registers `dynamic_page` in the `ui_show` tool definition enum and description
- Marks `dynamic_page` as an interactive surface in `surfaceProxyResolver` so it awaits user action by default

## Test plan
- [x] `bunx tsc --noEmit` passes with zero errors
- [ ] Verify a connected client can receive and render a `dynamic_page` surface
- [ ] Confirm `await_action` defaults to `true` for `dynamic_page` surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
