### PR TITLE
Add dynamic_page to isInteractive in computer-use sessions (#820)

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -220,7 +220,7 @@ export class ComputerUseSession {
         // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
         const isInteractive = surfaceType === 'list'
           ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-          : ['form', 'confirmation'].includes(surfaceType);
+          : ['form', 'confirmation', 'dynamic_page'].includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging


### PR DESCRIPTION
## Summary
- Adds `dynamic_page` to the `isInteractive` surface type check in `computer-use-session.ts`, matching the already-updated logic in `session.ts:638`.
- Without this fix, `dynamic_page` surfaces in computer-use sessions would not default to awaiting user action, causing them to behave as passive surfaces when they should be interactive.
- Addresses review feedback from both Devin and Codex on PR #820.

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors.
- [ ] Verify that `dynamic_page` surfaces in computer-use sessions correctly await user action by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
