### PR TITLE
Fix WKWebView HTML reload and retain cycle in DynamicPageSurfaceView (#822)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -6,7 +6,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     let onAction: (String, Any?) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction)
+        Coordinator(onAction: onAction, currentHTML: data.html)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -38,17 +38,28 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        // Reload if the HTML content has changed.
         context.coordinator.onAction = onAction
+
+        // Reload if the HTML content has changed.
+        if data.html != context.coordinator.currentHTML {
+            context.coordinator.currentHTML = data.html
+            webView.loadHTMLString(data.html, baseURL: nil)
+        }
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "vellumBridge")
     }
 
     // MARK: - Coordinator
 
     class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         var onAction: (String, Any?) -> Void
+        var currentHTML: String
 
-        init(onAction: @escaping (String, Any?) -> Void) {
+        init(onAction: @escaping (String, Any?) -> Void, currentHTML: String) {
             self.onAction = onAction
+            self.currentHTML = currentHTML
         }
 
         func userContentController(


### PR DESCRIPTION
## Summary
- **HTML reload**: `updateNSView` now tracks the current HTML in the Coordinator and reloads the WKWebView when the daemon sends a `UiSurfaceUpdateMessage` with different HTML content. Previously, updated HTML was silently ignored.
- **Retain cycle fix**: Added `dismantleNSView` to remove the `vellumBridge` script message handler, breaking the strong-retain cycle between `WKUserContentController` and the `Coordinator` that prevented proper cleanup.

Addresses review feedback from Devin and Codex on #822.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Verify dynamic page surfaces update when the daemon sends new HTML
- [ ] Verify no memory leaks via Instruments when dismissing dynamic page surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
