### PR TITLE
Extract INTERACTIVE_SURFACE_TYPES constant and fix tautological test (#821)

### DIFF
--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect } from 'bun:test';
+import {
+  INTERACTIVE_SURFACE_TYPES,
+} from '../daemon/ipc-protocol.js';
 import type {
   DynamicPageSurfaceData,
   UiSurfaceShowDynamicPage,
@@ -82,8 +85,7 @@ describe('UiSurfaceShowDynamicPage structure', () => {
 // ---------------------------------------------------------------------------
 
 describe('dynamic_page interactivity', () => {
-  test('dynamic_page is treated as an interactive surface type', () => {
-    const interactiveSurfaceTypes = ['form', 'confirmation', 'dynamic_page'];
-    expect(interactiveSurfaceTypes.includes('dynamic_page')).toBe(true);
+  test('dynamic_page is in the interactive surface types list', () => {
+    expect(INTERACTIVE_SURFACE_TYPES).toContain('dynamic_page');
   });
 });

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -8,6 +8,7 @@
 
 import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
+import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
@@ -220,7 +221,7 @@ export class ComputerUseSession {
         // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
         const isInteractive = surfaceType === 'list'
           ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-          : ['form', 'confirmation', 'dynamic_page'].includes(surfaceType);
+          : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -124,6 +124,8 @@ export interface AmbientObservation {
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
 
+export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page'];
+
 export interface SurfaceAction {
   id: string;
   label: string;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
+import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
@@ -635,7 +636,7 @@ export class Session {
       // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
       const isInteractive = surfaceType === 'list'
         ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-        : ['form', 'confirmation', 'dynamic_page'].includes(surfaceType);
+        : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
       // Track surface state for ui_update merging


### PR DESCRIPTION
## Summary
- Exports a shared `INTERACTIVE_SURFACE_TYPES` constant from `ipc-protocol.ts` so the interactive surface type list is defined in one place.
- Updates `session.ts` and `computer-use-session.ts` to import and use the constant instead of inline arrays.
- Fixes the tautological interactivity test in `dynamic-page-surface.test.ts` to import the production constant, so the test will actually fail if `dynamic_page` is ever removed.

## Test plan
- [x] `bunx bun test src/__tests__/dynamic-page-surface.test.ts` — all 6 tests pass
- [x] `bunx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
