### PR TITLE
Return 200 immediately from Telegram webhook to prevent retries

### DIFF
--- a/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.test.ts
+++ b/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+
+let webhookResolved = false;
+
+mock.module("@/lib/channels/service", () => ({
+  handleTelegramWebhook: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    webhookResolved = true;
+    return { status: "ok" };
+  },
+}));
+
+mock.module("next/server", () => ({
+  NextRequest: globalThis.Request,
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "content-type": "application/json" },
+      }),
+  },
+  after: (callback: () => void) => {
+    // Simulate Next.js after(): fires callback after the response is sent
+    Promise.resolve().then(() => callback());
+  },
+}));
+
+const { POST } = await import("./route");
+
+describe("Telegram webhook route", () => {
+  beforeEach(() => {
+    webhookResolved = false;
+  });
+
+  test("returns 200 immediately without waiting for webhook processing", async () => {
+    const request = new Request(
+      "http://localhost/api/webhooks/channels/telegram/test-account-id",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          update_id: 12345,
+          message: {
+            message_id: 1,
+            chat: { id: 100, type: "private" },
+            from: { id: 200, is_bot: false, first_name: "Test" },
+            text: "hello",
+            date: 1234567890,
+          },
+        }),
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+    const response = await POST(request as unknown as Parameters<typeof POST>[0], {
+      params: Promise.resolve({ channelAccountId: "test-account-id" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+
+    // webhook processing should NOT have completed yet.
+    // With after(): response returns before processing finishes → false ✓
+    // Without after() (await): response waits for processing → true ✗
+    expect(webhookResolved).toBe(false);
+  });
+});

--- a/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.ts
+++ b/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.ts
@@ -11,18 +11,14 @@ interface RouteParams {
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const { channelAccountId } = await params;
   const payload = (await request.json()) as Record<string, unknown>;
-  console.log("[TG webhook] POST received for channelAccountId:", channelAccountId);
-  console.log("[TG webhook] Payload:", JSON.stringify(payload, null, 2));
-  console.log("[TG webhook] Headers x-telegram-bot-api-secret-token:", request.headers.get("x-telegram-bot-api-secret-token"));
 
   after(async () => {
     try {
-      const result = await handleTelegramWebhook({
+      await handleTelegramWebhook({
         channelAccountId,
         headers: request.headers,
         payload,
       });
-      console.log("[TG webhook] Result:", JSON.stringify(result));
     } catch (error) {
       console.error("[TG webhook] Error processing Telegram channel webhook:", error);
     }

--- a/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.ts
+++ b/web/src/app/api/webhooks/channels/telegram/[channelAccountId]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 
 import { handleTelegramWebhook } from "@/lib/channels/service";
 
@@ -9,23 +9,26 @@ interface RouteParams {
 }
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  try {
-    const { channelAccountId } = await params;
-    const payload = (await request.json()) as Record<string, unknown>;
-    const result = await handleTelegramWebhook({
-      channelAccountId,
-      headers: request.headers,
-      payload,
-    });
+  const { channelAccountId } = await params;
+  const payload = (await request.json()) as Record<string, unknown>;
+  console.log("[TG webhook] POST received for channelAccountId:", channelAccountId);
+  console.log("[TG webhook] Payload:", JSON.stringify(payload, null, 2));
+  console.log("[TG webhook] Headers x-telegram-bot-api-secret-token:", request.headers.get("x-telegram-bot-api-secret-token"));
 
-    return NextResponse.json({ ok: true, ...result });
-  } catch (error) {
-    console.error("Error processing Telegram channel webhook:", error);
-    return NextResponse.json(
-      { ok: false, error: "Failed to process Telegram webhook" },
-      { status: 500 }
-    );
-  }
+  after(async () => {
+    try {
+      const result = await handleTelegramWebhook({
+        channelAccountId,
+        headers: request.headers,
+        payload,
+      });
+      console.log("[TG webhook] Result:", JSON.stringify(result));
+    } catch (error) {
+      console.error("[TG webhook] Error processing Telegram channel webhook:", error);
+    }
+  });
+
+  return NextResponse.json({ ok: true });
 }
 
 export async function GET(_request: NextRequest, { params }: RouteParams) {


### PR DESCRIPTION
## Summary
- Use Next.js `after()` to return HTTP 200 immediately from the Telegram webhook endpoint, deferring message processing to after the response is sent
- Prevents Telegram's 60s webhook timeout from triggering retries, which can cascade into duplicate processing and block the per-chat update stream
- Adds a test that verifies the response returns before `handleTelegramWebhook` completes (fails without `after()`, passes with it)

## Test plan
- [x] Test passes with `after()` — response returns before processing completes
- [x] Test fails without `after()` — confirms the test catches the old blocking behavior
- [x] Manually verified Telegram no longer retries when processing is slow (tested with 65s artificial sleep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
