### PR TITLE
Add paper trail comments when addressing coding agent feedback

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -23,12 +23,14 @@ If it's still relevant:
 If you need to break it down into multiple PRs:
 
 - Replace the item in .private/TODO.md in-place with one item per sub-task you need to complete to implement the feature, and let me know that you've done this and wait for more instructions.
+- If this task was addressing feedback on a previous PR, preserve the original PR reference in each sub-task so that the paper trail is maintained. Format each sub-task as: `- <sub-task description> (feedback from <original PR URL>)`
 
 If you can implement it in a single PR:
 
 - Create a PR for it (output a link to the PR)
 - Append the link to only this new PR to .private/UNREVIEWED_PRS.md
 - CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
+- If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a comment on that original PR linking to the new PR. Use: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
 
 After you've handled the item:
 


### PR DESCRIPTION
## Summary
- When `/work` addresses coding agent feedback from a previous PR, it now leaves a comment on the original PR linking to the new fix PR (e.g., "Addressed in #830")
- When a feedback task is broken into multiple sub-tasks, the original PR reference is preserved in each sub-task so the paper trail is maintained across multi-PR breakdowns

## Test plan
- [ ] Run `/work` on a task like "Address the feedback on <PR URL>" and verify a comment is left on the original PR
- [ ] Break down a feedback task into sub-tasks and verify each sub-task includes `(feedback from <PR URL>)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
