### PR TITLE
Move /scrub command to top-level .claude/commands/

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -31,15 +31,15 @@ Kill the running vellum-assistant app, delete all persistent data so the next la
    ```bash
    pgrep -f "src/index.ts daemon"
    ```
-   If it's NOT running, start it in the background from the assistant repo:
+   If it's NOT running, start it in the background from the repo root:
    ```bash
-   cd ../../assistant && export PATH="$HOME/.bun/bin:$PATH" && bun run src/index.ts daemon start
+   cd assistant && bun run src/index.ts daemon start && cd ..
    ```
    If it IS already running, skip this step and report that the daemon is already up.
 
-7. Build and launch the macOS app:
+7. Build and launch the macOS app (from the repo root):
    ```bash
-   ./build.sh run
+   cd clients/macos && ./build.sh run
    ```
    Run this in the background so it doesn't block.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
 | `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |
 | `/execute-plan <plan-file>` | Execute a multi-PR rollout plan from `.private/plans/` sequentially — implement, validate, and mainline each PR in order. |
+| `/scrub` | Kill the running vellum-assistant app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/blitz <feature>` | End-to-end feature delivery — plans the feature, creates GitHub issues on a project board, swarm-executes them in parallel, sweeps for review feedback, addresses it, and reports. |
 | `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
 
+### Utility
+
+| Command | Purpose |
+|---------|---------|
+| `/scrub` | Kill the running vellum-assistant app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+
 ### Review
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary
- The `/scrub` command was added under `clients/macos/.claude/commands/` in #810, but all other commands live at the repo root `.claude/commands/`
- Moved it there and replaced hardcoded `/Users/jasonzhou/...` paths with repo-relative ones

cc @Jasonnnz

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
