### PR TITLE
Add dismissable JIT surfaces with dynamic page sizing and center positioning

### DIFF
--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -27,8 +27,10 @@ The screen is ${screenWidth}\u00d7${screenHeight} pixels.
 
 You will receive the current screen state as an accessibility tree. Each interactive element has an [ID] number like [3] or [17]. Use these IDs with element_id to target elements \u2014 this is much more reliable than pixel coordinates.
 
-YOUR ONLY AVAILABLE TOOLS ARE: cu_click, cu_double_click, cu_right_click, cu_type_text, cu_key, cu_scroll, cu_drag, cu_wait, cu_open_app, cu_run_applescript, cu_done, cu_respond.
-You MUST only call one of these tools each turn. Do NOT attempt to call any other tool.
+YOUR AVAILABLE TOOLS ARE: cu_click, cu_double_click, cu_right_click, cu_type_text, cu_key, cu_scroll, cu_drag, cu_wait, cu_open_app, cu_run_applescript, cu_done, cu_respond, ui_show, ui_update, ui_dismiss.
+You MUST only call one tool per turn.
+
+UI SURFACES: When the user asks you to build, create, or display something (an app, dashboard, tracker, etc.), use ui_show with surface_type "dynamic_page" to render custom HTML directly instead of trying to build it with computer-use tools. This is your primary way to create visual applications for the user. After calling ui_show, call cu_done immediately — the surface is already displayed to the user.
 
 RULES:
 - Call exactly one tool per turn. After each action, you'll receive the updated screen state.

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -67,4 +67,6 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
 };
 
-export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.`;
+export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.
+
+IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, forms, lists, confirmations) as floating panels on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text. Call ui_show with a card surface to display it. This is your primary way of presenting information to the user.`;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -240,4 +240,12 @@ export async function runDaemon(): Promise<void> {
 
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    log.error({ err: reason }, 'Unhandled promise rejection');
+  });
+
+  process.on('uncaughtException', (err) => {
+    log.error({ err }, 'Uncaught exception');
+  });
 }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -113,6 +113,19 @@ class BrowserManager {
 
     try {
       this.context = await this.contextCreating;
+
+      // Listen for browser disconnection so we can reset state
+      // instead of leaving a stale context reference.
+      const rawCtx = this.context as unknown as { on?: (event: string, handler: (...args: unknown[]) => void) => void };
+      if (typeof rawCtx.on === 'function') {
+        rawCtx.on('close', () => {
+          log.warn('Browser context closed unexpectedly, resetting state');
+          this.context = null;
+          this.pages.clear();
+          this.snapshotMaps.clear();
+        });
+      }
+
       return this.context;
     } finally {
       this.contextCreating = null;

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -67,37 +67,42 @@ async function executeBrowserNavigate(
     // since Playwright follows redirects internally and performs its own DNS resolution.
     if (!allowPrivateNetwork) {
       routeHandler = async (route, request) => {
-        const reqUrl = request.url();
-        let reqParsed: URL;
         try {
-          reqParsed = new URL(reqUrl);
-        } catch {
+          const reqUrl = request.url();
+          let reqParsed: URL;
+          try {
+            reqParsed = new URL(reqUrl);
+          } catch {
+            await route.continue();
+            return;
+          }
+
+          // Check hostname against private/local patterns
+          if (isPrivateOrLocalHost(reqParsed.hostname)) {
+            blockedUrl = sanitizeUrlForOutput(reqParsed);
+            log.warn({ blockedUrl }, 'Blocked navigation to private network target via redirect');
+            await route.abort('blockedbyclient');
+            return;
+          }
+
+          // Resolve DNS and check resolved addresses
+          const resolution = await resolveRequestAddress(
+            reqParsed.hostname,
+            resolveHostAddresses,
+            false,
+          );
+          if (resolution.blockedAddress) {
+            blockedUrl = sanitizeUrlForOutput(reqParsed);
+            log.warn({ blockedUrl, resolvedTo: resolution.blockedAddress }, 'Blocked navigation: DNS resolves to private address');
+            await route.abort('blockedbyclient');
+            return;
+          }
+
           await route.continue();
-          return;
+        } catch (err) {
+          // Route may already be handled if the page navigated or was closed
+          log.debug({ err }, 'Route handler error (route likely already handled)');
         }
-
-        // Check hostname against private/local patterns
-        if (isPrivateOrLocalHost(reqParsed.hostname)) {
-          blockedUrl = sanitizeUrlForOutput(reqParsed);
-          log.warn({ blockedUrl }, 'Blocked navigation to private network target via redirect');
-          await route.abort('blockedbyclient');
-          return;
-        }
-
-        // Resolve DNS and check resolved addresses
-        const resolution = await resolveRequestAddress(
-          reqParsed.hostname,
-          resolveHostAddresses,
-          false,
-        );
-        if (resolution.blockedAddress) {
-          blockedUrl = sanitizeUrlForOutput(reqParsed);
-          log.warn({ blockedUrl, resolvedTo: resolution.blockedAddress }, 'Blocked navigation: DNS resolves to private address');
-          await route.abort('blockedbyclient');
-          return;
-        }
-
-        await route.continue();
       };
       await page.route('**/*', routeHandler);
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -7,7 +7,7 @@ struct MainWindowView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: VSpacing.lg) {
-                Text("vellum-assistant")
+                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
                     .font(VFont.display)
                     .foregroundStyle(VColor.textPrimary)
 

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -9,7 +9,7 @@ struct TextResponseView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "text.bubble.fill")
                     .foregroundStyle(.blue)
-                Text("vellum-assistant")
+                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
                     .font(VFont.headline)
                     .lineLimit(1)
             }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -60,11 +60,18 @@ struct SurfaceContainerView: View {
             }
         }
         .padding(VSpacing.xl)
-        .frame(width: 380)
+        .frame(width: surfaceWidth)
         .vPanelBackground()
     }
 
     // MARK: - Helpers
+
+    private var surfaceWidth: CGFloat {
+        if case .dynamicPage(let data) = surface.data {
+            return CGFloat(data.width ?? 380)
+        }
+        return 380
+    }
 
     private var isFormOrConfirmation: Bool {
         switch surface.data {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -7,11 +7,20 @@ struct SurfaceContainerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Optional title
-            if let title = surface.title {
-                Text(title)
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.textPrimary)
+            // Title row with dismiss button
+            HStack(alignment: .top) {
+                if let title = surface.title {
+                    Text(title)
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+                }
+                Spacer()
+                Button(action: { viewModel.onDismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .buttonStyle(.plain)
             }
 
             // Type-specific content

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -10,10 +10,12 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 final class SurfaceViewModel: ObservableObject {
     @Published var surface: Surface
     let onAction: (String, [String: Any]?) -> Void
+    let onDismiss: () -> Void
 
-    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void) {
+    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void, onDismiss: @escaping () -> Void) {
         self.surface = surface
         self.onAction = onAction
+        self.onDismiss = onDismiss
     }
 }
 
@@ -66,6 +68,10 @@ final class SurfaceManager: ObservableObject {
             surface: surface,
             onAction: { [weak self] actionId, data in
                 self?.onAction?(surface.sessionId, surface.id, actionId, data)
+            },
+            onDismiss: { [weak self] in
+                self?.onAction?(surface.sessionId, surface.id, "dismiss", nil)
+                self?.dismissSurfaceById(surface.id)
             }
         )
         viewModels[surface.id] = viewModel

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -80,8 +80,18 @@ final class SurfaceManager: ObservableObject {
 
         let hostingController = NSHostingController(rootView: view)
 
+        let surfacePanelWidth: CGFloat
+        let surfacePanelHeight: CGFloat
+        if case .dynamicPage(let dpData) = surface.data {
+            surfacePanelWidth = CGFloat(dpData.width ?? Int(panelWidth))
+            surfacePanelHeight = CGFloat(dpData.height ?? 500)
+        } else {
+            surfacePanelWidth = panelWidth
+            surfacePanelHeight = 140
+        }
+
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 140),
+            contentRect: NSRect(x: 0, y: 0, width: surfacePanelWidth, height: surfacePanelHeight),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -157,14 +167,26 @@ final class SurfaceManager: ObservableObject {
 
     // MARK: - Positioning
 
+    private func centerPanel(_ panel: NSPanel) {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        let panelFrame = panel.frame
+
+        let x = screenFrame.midX - panelFrame.width / 2
+        let y = screenFrame.midY - panelFrame.height / 2
+
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
     private func positionPanel(_ panel: NSPanel, at index: Int) {
         guard let screen = NSScreen.main else { return }
         let screenFrame = screen.visibleFrame
 
+        let actualWidth = panel.frame.width
         let estimatedPanelHeight: CGFloat = 140
         let yOffset = CGFloat(index) * (estimatedPanelHeight + panelSpacing)
 
-        let x = screenFrame.maxX - panelWidth - panelMargin
+        let x = screenFrame.maxX - actualWidth - panelMargin
         let y = screenFrame.minY + panelMargin + yOffset
 
         panel.setFrameOrigin(NSPoint(x: x, y: y))
@@ -173,9 +195,14 @@ final class SurfaceManager: ObservableObject {
     /// Reposition all visible panels based on their order in `surfaceOrder`.
     /// Called after show and dismiss to prevent gaps and overlaps.
     private func repositionAllPanels() {
-        for (index, surfaceId) in surfaceOrder.enumerated() {
-            if let panel = panels[surfaceId] {
-                positionPanel(panel, at: index)
+        var stackIndex = 0
+        for surfaceId in surfaceOrder {
+            guard let panel = panels[surfaceId] else { continue }
+            if case .dynamicPage = activeSurfaces[surfaceId]?.data {
+                centerPanel(panel)
+            } else {
+                positionPanel(panel, at: stackIndex)
+                stackIndex += 1
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -25,7 +25,7 @@ struct TaskInputView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             HStack {
-                Text("vellum-assistant")
+                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
                     .font(VFont.headline)
                     .foregroundStyle(.primary)
                 Spacer()


### PR DESCRIPTION
The purpose of this PR is to make JIT surface panels dismissable, dynamically sized, and properly centered on screen for dynamic pages.

## Changes Made
- Add dismiss button (X) to all surface panels via `SurfaceContainerView` + `SurfaceViewModel.onDismiss`
- Make dynamic page panels respect `width`/`height` from surface data instead of hardcoded 380px
- Center dynamic page panels on screen; other surface types still stack bottom-right
- Update CU system prompt to include `ui_show`/`dynamic_page` tools and instruct `cu_done` after showing a surface
- Replace hardcoded "vellum-assistant" label with `UserDefaults("assistantName")` in TextResponseView, TaskInputView, MainWindowView
- Add daemon resilience fixes: global `unhandledRejection`/`uncaughtException` handlers, Playwright route handler try/catch, browser context close listener

## Testing
- Manual testing: onboarding flow, dynamic page surface generation (e.g. "build me a fitness tracker"), dismiss button, panel centering, assistant name display
- Build passes (`./build.sh`)

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
