### PR TITLE
M1: Interview Chat UI Components

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+struct InterviewChatView: View {
+    let messages: [InterviewMessage]
+    @Binding var inputText: String
+    let isThinking: Bool
+    let onSend: () -> Void
+    let onVoiceToggle: () -> Void
+    let isRecording: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            messageList
+            inputArea
+        }
+    }
+
+    // MARK: - Message List
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: VSpacing.md) {
+                    ForEach(messages) { message in
+                        MessageBubble(message: message)
+                            .id(message.id)
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+
+                    if isThinking {
+                        TypingIndicator()
+                            .id("typing-indicator")
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+            }
+            .onChange(of: messages.count) {
+                withAnimation(VAnimation.standard) {
+                    if let lastMessage = messages.last {
+                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                    }
+                }
+            }
+            .onChange(of: isThinking) {
+                if isThinking {
+                    withAnimation(VAnimation.standard) {
+                        proxy.scrollTo("typing-indicator", anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Input Area
+
+    private var inputArea: some View {
+        HStack(spacing: VSpacing.sm) {
+            TextField("Type a message\u{2026}", text: $inputText)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.md)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+                .onSubmit {
+                    if !inputText.trimmingCharacters(in: .whitespaces).isEmpty {
+                        onSend()
+                    }
+                }
+
+            VIconButton(
+                label: "Voice",
+                icon: "mic.fill",
+                isActive: isRecording,
+                iconOnly: true,
+                action: onVoiceToggle
+            )
+
+            Button(action: {
+                if !inputText.trimmingCharacters(in: .whitespaces).isEmpty {
+                    onSend()
+                }
+            }) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundColor(sendButtonDisabled ? VColor.textMuted : VColor.accent)
+            }
+            .buttonStyle(.plain)
+            .disabled(sendButtonDisabled)
+            .accessibilityLabel("Send message")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            VColor.surface.opacity(0.5)
+                .overlay(
+                    VStack {
+                        Divider().background(VColor.surfaceBorder.opacity(0.4))
+                        Spacer()
+                    }
+                )
+        )
+    }
+
+    private var sendButtonDisabled: Bool {
+        inputText.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}
+
+// MARK: - Message Bubble
+
+private struct MessageBubble: View {
+    let message: InterviewMessage
+
+    private var isAssistant: Bool { message.role == .assistant }
+
+    var body: some View {
+        HStack {
+            if !isAssistant { Spacer(minLength: 0) }
+
+            Text(message.text)
+                .font(VFont.body)
+                .foregroundColor(isAssistant ? VColor.textPrimary : .white)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(isAssistant
+                              ? VColor.surface.opacity(0.5)
+                              : VColor.accent)
+                )
+                .frame(maxWidth: maxBubbleWidth, alignment: isAssistant ? .leading : .trailing)
+
+            if isAssistant { Spacer(minLength: 0) }
+        }
+    }
+
+    private var maxBubbleWidth: CGFloat {
+        // Approximate 75% of a typical container width.
+        // GeometryReader-based approach is used in the parent if needed.
+        340
+    }
+}
+
+// MARK: - Typing Indicator
+
+private struct TypingIndicator: View {
+    @State private var phase: Int = 0
+
+    var body: some View {
+        HStack {
+            HStack(spacing: VSpacing.xs) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(VColor.textSecondary)
+                        .frame(width: 6, height: 6)
+                        .opacity(dotOpacity(for: index))
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surface.opacity(0.5))
+            )
+
+            Spacer()
+        }
+        .onAppear { startAnimation() }
+    }
+
+    private func dotOpacity(for index: Int) -> Double {
+        phase == index ? 1.0 : 0.4
+    }
+
+    private func startAnimation() {
+        Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: 0.3)) {
+                phase = (phase + 1) % 3
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("InterviewChatView") {
+    @Previewable @State var text = ""
+
+    let sampleMessages: [InterviewMessage] = [
+        InterviewMessage(role: .assistant, text: "Hi there! I just hatched and I am so excited to meet you."),
+        InterviewMessage(role: .user, text: "Welcome! What can you do?"),
+        InterviewMessage(
+            role: .assistant,
+            text: "I can help you with all sorts of things -- voice conversations, taking actions on your computer, and context-aware assistance!"
+        ),
+        InterviewMessage(role: .user, text: "That sounds great, tell me more."),
+    ]
+
+    ZStack {
+        MeadowBackground()
+        OnboardingPanel {
+            InterviewChatView(
+                messages: sampleMessages,
+                inputText: $text,
+                isThinking: true,
+                onSend: {},
+                onVoiceToggle: {},
+                isRecording: false
+            )
+            .frame(height: 400)
+        }
+    }
+    .frame(width: 600, height: 600)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewMessage.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct InterviewMessage: Identifiable {
+    enum Role {
+        case assistant
+        case user
+    }
+
+    let id: UUID
+    let role: Role
+    let text: String
+    let timestamp: Date
+
+    init(id: UUID = UUID(), role: Role, text: String, timestamp: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.timestamp = timestamp
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `InterviewMessage` model with nested `Role` enum (`.assistant`, `.user`) and properties: `id`, `role`, `text`, `timestamp`
- Adds `InterviewChatView` with scrollable message list, typing indicator, text input, voice toggle, and send button
- Uses existing Meadow/V design tokens for consistent styling with the onboarding flow

## Test plan
- [ ] Verify build succeeds with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- [ ] Check `#Preview` renders correctly in Xcode previews
- [ ] Verify assistant messages appear left-aligned with surface background
- [ ] Verify user messages appear right-aligned with accent background
- [ ] Verify typing indicator animates when `isThinking` is true
- [ ] Verify send button is disabled when input is empty
- [ ] Verify Enter key submits the message

Part of #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
