### PR TITLE
Xcode Debug and Preview Support

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -73,6 +73,11 @@ A background screen-watching system that runs alongside the manual session loop:
 
 ### App Lifecycle
 
+The package is split into two targets for Xcode Preview support:
+- **`VellumAssistantLib`** (library) — all app code, resources, and linker settings. Previews work on any SwiftUI view here.
+- **`vellum-assistant`** (executable) — thin `@main` entry point in `vellum-assistant-app/` that imports `VellumAssistantLib`.
+
+
 `AppDelegate` sets up: NSStatusItem with NSPopover, global hotkey (Cmd+Shift+G via HotKey package), global Escape monitor, voice input, ambient agent, and onboarding flow. `VellumAssistantApp` is the `@main` entry point with `@NSApplicationDelegateAdaptor`.
 
 ### Onboarding
@@ -83,7 +88,7 @@ A background screen-watching system that runs alongside the manual session loop:
 
 - **LSUIElement app** — no dock icon; uses `.accessory` activation policy. Must temporarily switch to `.regular` when showing Settings window.
 - **`Bundle.main.bundleIdentifier` is nil** in SPM builds. All `os.Logger` instances use hardcoded fallback `"com.vellum.vellum-assistant"`.
-- **Adding .swift files**: Auto-picked up by SPM. No manual project file edits needed.
+- **Adding .swift files**: Auto-picked up by SPM. No manual project file edits needed. New files go in `vellum-assistant/` (library target); only `@main` entry point lives in `vellum-assistant-app/`.
 - **Chrome special handling** — `ChromeAccessibilityHelper` detects when Chrome's AX tree lacks web content and auto-restarts Chrome with `--force-renderer-accessibility`.
 - **Popover close delay** — 300ms initial delay before session starts to let the popover close and target app regain focus.
 - **SessionState enum** must stay in sync with `SessionOverlayView` pattern matching.

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -7,6 +7,10 @@ let package = Package(
         .macOS(.v14)
     ],
     products: [
+        .library(
+            name: "VellumAssistantLib",
+            targets: ["VellumAssistantLib"]
+        ),
         .executable(
             name: "vellum-assistant",
             targets: ["vellum-assistant"]
@@ -16,8 +20,8 @@ let package = Package(
         .package(url: "https://github.com/soffes/HotKey", from: "0.2.1"),
     ],
     targets: [
-        .executableTarget(
-            name: "vellum-assistant",
+        .target(
+            name: "VellumAssistantLib",
             dependencies: ["HotKey"],
             path: "vellum-assistant",
             exclude: ["Resources/Info.plist"],
@@ -42,9 +46,14 @@ let package = Package(
                 .linkedFramework("SpriteKit"),
             ]
         ),
+        .executableTarget(
+            name: "vellum-assistant",
+            dependencies: ["VellumAssistantLib"],
+            path: "vellum-assistant-app"
+        ),
         .testTarget(
             name: "vellum-assistantTests",
-            dependencies: ["vellum-assistant"],
+            dependencies: ["VellumAssistantLib"],
             path: "vellum-assistantTests"
         )
     ]

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -75,10 +75,72 @@ Grant these in System Settings → Privacy & Security.
 7. Watch the overlay as vellum-assistant works through the task
 8. Press Escape at any time to cancel
 
+## Xcode Previews
+
+The package is split into a library target (`VellumAssistantLib`) and a thin executable target (`vellum-assistant`). This lets you preview SwiftUI views live in Xcode without building and running the whole app.
+
+### Prerequisites
+
+1. **Install Xcode** — Download from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835) (free, requires macOS). It's a large download (~7 GB), so this may take a while.
+2. **Open Xcode once** after installing and accept the license agreement. It will install additional components automatically.
+
+### Step-by-step: Opening the project
+
+1. Open Terminal and run:
+   ```bash
+   open clients/macos/Package.swift
+   ```
+   This opens the Swift package in Xcode. You can also double-click `Package.swift` in Finder.
+
+2. Xcode will open and start resolving dependencies (you'll see a spinner in the top status bar). Wait for it to finish — this only takes a few seconds.
+
+### Step-by-step: Viewing a preview
+
+1. **Select the library scheme.** At the very top center of the Xcode window, there's a dropdown button that shows the current scheme (it probably says `vellum-assistant > My Mac`). Click it and switch to **`VellumAssistantLib`**. Previews only work on the library target — the executable target will show an error about `ENABLE_DEBUG_DYLIB`.
+
+2. **Open a SwiftUI file.** In the left sidebar (file navigator), expand `vellum-assistant` and navigate to any SwiftUI view, for example:
+   - `Features/Settings/SettingsView.swift`
+   - `Features/Onboarding/OnboardingFlowView.swift`
+   - `UI/SessionOverlayView.swift`
+
+3. **Show the Canvas.** Go to the menu bar: **Editor → Canvas** (or press `⌥⌘↩` / Option+Command+Return). A preview panel appears on the right side of the editor.
+
+4. **Resume the preview.** If the canvas says "Preview paused", click the **Resume** button at the top of the canvas (or press `⌥⌘P` / Option+Command+P). Xcode will build the library and render the preview.
+
+### Important: Views need a `#Preview` block
+
+A SwiftUI file will **only show a preview** if it contains a `#Preview` block. If you open a file and the canvas is blank or says "No preview available", the file is missing one.
+
+To add a preview, put this at the bottom of the file (outside any struct):
+
+```swift
+#Preview {
+    MyViewName()
+}
+```
+
+For example, `SettingsView` requires an argument:
+
+```swift
+#Preview {
+    SettingsView(ambientAgent: AmbientAgent())
+}
+```
+
+### Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| "ENABLE_DEBUG_DYLIB" error | Switch the scheme to **`VellumAssistantLib`** (not `vellum-assistant`) |
+| Canvas is blank / "No preview available" | The file needs a `#Preview { ... }` block — see above |
+| "Preview paused" | Click **Resume** in the canvas or press `⌥⌘P` |
+| Build errors in the canvas | Try **Product → Clean Build Folder** (`⇧⌘K`) then resume |
+
 ## Architecture
 
 ```
-App/                  Entry point, AppDelegate, menu bar setup, permissions, voice input
+App/                  AppDelegate, menu bar setup, permissions, voice input
+vellum-assistant-app/ Entry point (@main VellumAssistantApp — thin wrapper)
 ComputerUse/          Core perception + action pipeline
   AccessibilityTree   AX element enumeration & formatting
   AXTreeDiff          Diff between AX tree snapshots across steps

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -131,7 +131,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 PLIST
 
 # 4. Copy SPM resource bundle (contains Recipes, processed assets)
-SPM_BUNDLE="$BIN_PATH/${APP_NAME}_${APP_NAME}.bundle"
+LIB_TARGET="VellumAssistantLib"
+SPM_BUNDLE="$BIN_PATH/${LIB_TARGET}_${LIB_TARGET}.bundle"
 if [ -d "$SPM_BUNDLE" ]; then
     cp -R "$SPM_BUNDLE" "$RESOURCES_DIR/"
 fi

--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VellumAssistantLib
 
 @main
 struct VellumAssistantApp: App {

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -15,7 +15,7 @@ enum AmbientAgentState: Equatable {
 }
 
 @MainActor
-final class AmbientAgent: ObservableObject {
+public final class AmbientAgent: ObservableObject {
     @Published var state: AmbientAgentState = .disabled {
         didSet { appDelegate?.updateMenuBarIcon() }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -13,7 +13,7 @@ enum InteractionType {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
     private var hotKey: HotKey?
@@ -27,7 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     private var thinkingWindow: ThinkingIndicatorWindow?
-    let ambientAgent = AmbientAgent()
+    public let ambientAgent = AmbientAgent()
     let daemonClient = DaemonClient()
     let surfaceManager = SurfaceManager()
 
@@ -38,7 +38,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     #endif
     private var windowObserver: Any?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    public func applicationDidFinishLaunching(_ notification: Notification) {
         registerBundledFonts()
 
         #if DEBUG
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {
             mainWindow?.show()
         }
@@ -519,7 +519,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func applicationWillTerminate(_ notification: Notification) {
+    public func applicationWillTerminate(_ notification: Notification) {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }
@@ -530,14 +530,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    nonisolated func userNotificationCenter(
+    nonisolated public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         [.banner, .sound]
     }
 
-    nonisolated func userNotificationCenter(
+    nonisolated public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,3 +19,7 @@ struct MainWindowView: View {
         .frame(minWidth: 800, minHeight: 600)
     }
 }
+
+#Preview {
+    MainWindowView()
+}

--- a/clients/macos/vellum-assistant/Features/Session/ConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ConfirmationView.swift
@@ -43,3 +43,12 @@ struct ConfirmationView: View {
         .frame(width: 400)
     }
 }
+
+#Preview {
+    ConfirmationView(
+        reason: "This action will press Cmd+Delete which may delete files.",
+        onAllow: {},
+        onBlock: {},
+        onStop: {}
+    )
+}

--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -1,6 +1,10 @@
 import AppKit
 import SwiftUI
 
+#Preview {
+    ThinkingIndicatorView()
+}
+
 struct ThinkingIndicatorView: View {
     var body: some View {
         HStack(spacing: 8) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct SettingsView: View {
+public struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
     @State private var maxSteps: Double = {
@@ -21,10 +21,14 @@ struct SettingsView: View {
     }()
     var ambientAgent: AmbientAgent
 
+    public init(ambientAgent: AmbientAgent) {
+        self.ambientAgent = ambientAgent
+    }
+
     // Re-check permissions every 2 seconds while the window is open
     private let permissionTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
-    var body: some View {
+    public var body: some View {
         Form {
             Section("Anthropic API Key") {
                 if hasKey {
@@ -504,4 +508,8 @@ private struct KnowledgeEntriesView: View {
         }
         .frame(width: 500, height: 400)
     }
+}
+
+#Preview {
+    SettingsView(ambientAgent: AmbientAgent())
 }

--- a/clients/macos/vellum-assistant/Features/Surfaces/CardSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/CardSurfaceView.swift
@@ -44,3 +44,16 @@ struct CardSurfaceView: View {
         .vCard()
     }
 }
+
+#Preview {
+    CardSurfaceView(data: CardSurfaceData(
+        title: "Task Complete",
+        subtitle: "Finished in 3 steps",
+        body: "Successfully filled in the **name field** and submitted the form.",
+        metadata: [
+            (label: "Duration", value: "12s"),
+            (label: "Steps", value: "3"),
+        ]
+    ))
+    .padding()
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -63,3 +63,36 @@ struct ConfirmationSurfaceView: View {
         }
     }
 }
+
+#Preview("Default") {
+    ConfirmationSurfaceView(
+        data: ConfirmationSurfaceData(
+            message: "Delete this file?",
+            detail: "This action cannot be undone. The file will be permanently removed.",
+            confirmLabel: "Delete",
+            cancelLabel: "Keep",
+            destructive: true
+        ),
+        actions: [
+            SurfaceActionButton(id: "cancel", label: "Keep", style: .secondary),
+            SurfaceActionButton(id: "confirm", label: "Delete", style: .destructive),
+        ],
+        onAction: { _ in }
+    )
+    .padding()
+}
+
+#Preview("Non-destructive") {
+    ConfirmationSurfaceView(
+        data: ConfirmationSurfaceData(
+            message: "Submit this form?",
+            detail: "Your responses will be sent to the server.",
+            confirmLabel: nil,
+            cancelLabel: nil,
+            destructive: false
+        ),
+        actions: [],
+        onAction: { _ in }
+    )
+    .padding()
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
@@ -156,3 +156,25 @@ struct FormSurfaceView: View {
         onSubmit(values)
     }
 }
+
+#Preview {
+    FormSurfaceView(
+        data: FormSurfaceData(
+            description: "Configure your assistant preferences.",
+            fields: [
+                FormField(id: "name", type: .text, label: "Name", placeholder: "Enter your name", required: true, defaultValue: nil, options: nil),
+                FormField(id: "bio", type: .textarea, label: "Bio", placeholder: "Tell us about yourself", required: false, defaultValue: nil, options: nil),
+                FormField(id: "role", type: .select, label: "Role", placeholder: "Select a role", required: true, defaultValue: nil, options: [
+                    FormFieldOption(label: "Developer", value: "dev"),
+                    FormFieldOption(label: "Designer", value: "design"),
+                    FormFieldOption(label: "Manager", value: "pm"),
+                ]),
+                FormField(id: "notifications", type: .toggle, label: "Enable notifications", placeholder: nil, required: false, defaultValue: .boolean(true), options: nil),
+            ],
+            submitLabel: "Save"
+        ),
+        onSubmit: { _ in }
+    )
+    .padding()
+    .frame(width: 380)
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/ListSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ListSurfaceView.swift
@@ -69,3 +69,18 @@ struct ListSurfaceView: View {
         onSelect(Array(selectedIds))
     }
 }
+
+#Preview {
+    ListSurfaceView(
+        data: ListSurfaceData(
+            items: [
+                ListItemData(id: "1", title: "Safari", subtitle: "Web browser", icon: "safari", selected: false),
+                ListItemData(id: "2", title: "Mail", subtitle: "Email client", icon: "envelope", selected: true),
+                ListItemData(id: "3", title: "Notes", subtitle: "Note taking", icon: "note.text", selected: false),
+            ],
+            selectionMode: .single
+        ),
+        onSelect: { _ in }
+    )
+    .padding()
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -104,3 +104,27 @@ struct SurfaceContainerView: View {
         }
     }
 }
+
+#Preview {
+    SurfaceContainerView(
+        viewModel: SurfaceViewModel(
+            surface: Surface(
+                id: "preview",
+                sessionId: "session-1",
+                type: .card,
+                title: "Task Summary",
+                data: .card(CardSurfaceData(
+                    title: "Screenshot Captured",
+                    subtitle: "Step 2 of 5",
+                    body: "Captured the current screen state for analysis.",
+                    metadata: nil
+                )),
+                actions: [
+                    SurfaceActionButton(id: "dismiss", label: "Dismiss", style: .secondary),
+                    SurfaceActionButton(id: "continue", label: "Continue", style: .primary),
+                ]
+            ),
+            onAction: { _, _ in }
+        )
+    )
+}

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -315,6 +315,10 @@ struct TaskInputView: View {
     }
 }
 
+#Preview {
+    TaskInputView(onSubmit: { _ in })
+}
+
 private extension NSImage {
     func pngData() -> Data? {
         guard let tiff = tiffRepresentation,

--- a/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
+++ b/clients/macos/vellum-assistantTests/AccessibilityTreeTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 final class AccessibilityTreeTests: XCTestCase {
 

--- a/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
+++ b/clients/macos/vellum-assistantTests/ActionVerifierTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 final class ActionVerifierTests: XCTestCase {
     var verifier: ActionVerifier!

--- a/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 @MainActor
 final class DaemonClientSocketPathTests: XCTestCase {

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import CoreGraphics
 import Combine
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 // MARK: - Mock Daemon Client
 

--- a/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
+++ b/clients/macos/vellum-assistantTests/ToolDefinitionsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 final class ToolDefinitionsTests: XCTestCase {
 


### PR DESCRIPTION
## Summary

Splits the macOS Swift package into a library target (`VellumAssistantLib`) and a thin executable target (`vellum-assistant`) so that Xcode Previews work natively on SwiftUI views without requiring `ENABLE_DEBUG_DYLIB`. Zero behavioral change — same binary name, same build commands, same app behavior.

## Changes

- Split `Package.swift` single `executableTarget` into `.target` (library) + `.executableTarget` (entry point)
- Move `@main` entry point to `vellum-assistant-app/` directory with `import VellumAssistantLib`
- Make `AppDelegate`, `AmbientAgent`, and `SettingsView` public for cross-module access
- Update `build.sh` resource bundle name to match new library target
- Update all 5 test files to `@testable import VellumAssistantLib`
- Add `#Preview` blocks to 9 main feature and surface views
- Add detailed step-by-step Xcode Previews guide to `README.md`
- Document library/executable split in `CLAUDE.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
