### PR TITLE
M3: Onboarding Interview Flow Integration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -272,7 +272,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         guard onboardingWindow == nil else { return }
         popover.performClose(nil)
 
-        let onboarding = OnboardingWindow()
+        let onboarding = OnboardingWindow(daemonClient: daemonClient)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.assistantName, forKey: "assistantName")
@@ -289,7 +289,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Onboarding
 
     private func showOnboarding() {
-        let onboarding = OnboardingWindow()
+        setupDaemonClient()
+
+        let onboarding = OnboardingWindow(daemonClient: daemonClient)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
@@ -299,7 +301,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onboarding.close()
             self?.onboardingWindow = nil
 
-            self?.setupDaemonClient()
             self?.setupMenuBar()
             self?.setupHotKey()
             self?.setupEscapeMonitor()

--- a/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
@@ -51,7 +51,7 @@ struct AliveStepView: View {
                     title: "Start using \(state.assistantName.isEmpty ? "your agent" : state.assistantName)",
                     style: .primary
                 ) {
-                    onComplete()
+                    state.advance()
                 }
                 .font(VFont.cardTitle)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct InterviewStepView: View {
+    @Bindable var state: OnboardingState
+    let daemonClient: DaemonClientProtocol
+    let onComplete: () -> Void
+
+    @State private var viewModel: InterviewViewModel
+    @State private var showControls = false
+
+    init(state: OnboardingState, daemonClient: DaemonClientProtocol, onComplete: @escaping () -> Void) {
+        self.state = state
+        self.daemonClient = daemonClient
+        self.onComplete = onComplete
+        self._viewModel = State(initialValue: InterviewViewModel(
+            daemonClient: daemonClient,
+            assistantName: state.assistantName
+        ))
+    }
+
+    /// Combines finalized messages with any in-progress streaming text.
+    private var displayedMessages: [InterviewMessage] {
+        var msgs = viewModel.messages
+        if !viewModel.streamingText.isEmpty {
+            msgs.append(InterviewMessage(role: .assistant, text: viewModel.streamingText))
+        }
+        return msgs
+    }
+
+    /// Show the "ready" button once we have at least one assistant message.
+    private var hasAssistantMessage: Bool {
+        viewModel.messages.contains { $0.role == .assistant }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title area
+            VStack(spacing: VSpacing.xs) {
+                Text("Meet \(state.assistantName.isEmpty ? "your assistant" : state.assistantName)")
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Have a quick chat before you get started")
+                    .font(VFont.onboardingSubtitle)
+                    .foregroundColor(VColor.textSecondary)
+            }
+            .padding(.top, VSpacing.xl)
+            .padding(.bottom, VSpacing.md)
+
+            // Chat area
+            InterviewChatView(
+                messages: displayedMessages,
+                inputText: $viewModel.inputText,
+                isThinking: viewModel.isThinking,
+                onSend: { viewModel.sendMessage() },
+                onVoiceToggle: {},
+                isRecording: false
+            )
+            .frame(maxHeight: .infinity)
+
+            // Bottom controls
+            VStack(spacing: VSpacing.md) {
+                if hasAssistantMessage && showControls {
+                    OnboardingButton(
+                        title: "I\u{2019}m ready to go!",
+                        style: .primary
+                    ) {
+                        state.interviewCompleted = true
+                        viewModel.endInterview()
+                        onComplete()
+                    }
+                }
+
+                Button {
+                    viewModel.endInterview()
+                    onComplete()
+                } label: {
+                    Text("Skip")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    NSCursor.pointingHand.set()
+                    if !hovering { NSCursor.arrow.set() }
+                }
+            }
+            .padding(.vertical, VSpacing.lg)
+        }
+        .onAppear {
+            viewModel.startInterview()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showControls = true
+                }
+            }
+        }
+        .onDisappear {
+            viewModel.cancel()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        InterviewStepView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 7
+                s.assistantName = "Velly"
+                return s
+            }(),
+            daemonClient: DaemonClient(),
+            onComplete: {}
+        )
+        .frame(width: 520, height: 600)
+    }
+    .frame(width: 1366, height: 849)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct OnboardingFlowView: View {
     @Bindable var state: OnboardingState
+    let daemonClient: DaemonClientProtocol
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
@@ -9,53 +10,78 @@ struct OnboardingFlowView: View {
         ZStack {
             MeadowBackground()
 
-            // Centered egg + panel
-            HStack(alignment: .center, spacing: VSpacing.xxxl) {
-                // LEFT: SpriteKit egg scene
-                EggSceneView(state: state)
-                    .frame(width: 260, height: 380)
+            if state.currentStep <= 6 {
+                // Centered egg + panel (steps 0-6)
+                HStack(alignment: .center, spacing: VSpacing.xxxl) {
+                    // LEFT: SpriteKit egg scene
+                    EggSceneView(state: state)
+                        .frame(width: 260, height: 380)
 
-                // RIGHT: Compact floating panel
-                OnboardingPanel {
-                    Group {
-                        switch state.currentStep {
-                        case 0:
-                            WakeUpStepView(state: state)
-                        case 1:
-                            NamingStepView(state: state)
-                        case 2:
-                            FnKeyStepView(state: state)
-                        case 3:
-                            SpeechPermissionStepView(state: state)
-                        case 4:
-                            AccessibilityPermissionStepView(state: state)
-                        case 5:
-                            ScreenPermissionStepView(state: state)
-                        case 6:
-                            AliveStepView(
-                                state: state,
-                                onComplete: onComplete,
-                                onOpenSettings: onOpenSettings
-                            )
-                        default:
-                            EmptyView()
+                    // RIGHT: Compact floating panel
+                    OnboardingPanel {
+                        Group {
+                            switch state.currentStep {
+                            case 0:
+                                WakeUpStepView(state: state)
+                            case 1:
+                                NamingStepView(state: state)
+                            case 2:
+                                FnKeyStepView(state: state)
+                            case 3:
+                                SpeechPermissionStepView(state: state)
+                            case 4:
+                                AccessibilityPermissionStepView(state: state)
+                            case 5:
+                                ScreenPermissionStepView(state: state)
+                            case 6:
+                                AliveStepView(
+                                    state: state,
+                                    onComplete: onComplete,
+                                    onOpenSettings: onOpenSettings
+                                )
+                            default:
+                                EmptyView()
+                            }
                         }
+                        .transition(
+                            .opacity.combined(with: .scale(scale: 0.97))
+                        )
+                        .id(state.currentStep)
                     }
-                    .transition(
-                        .opacity.combined(with: .scale(scale: 0.97))
-                    )
-                    .id(state.currentStep)
                 }
-            }
-            .padding(.horizontal, VSpacing.xxxl)
+                .padding(.horizontal, VSpacing.xxxl)
 
-            // Bottom caption
-            VStack {
-                Spacer()
-                Text("Let\u{2019}s hatch this assistant by giving it enough permissions to live")
-                    .font(VFont.onboardingSubtitle)
-                    .foregroundColor(Meadow.captionText)
-                    .padding(.bottom, VSpacing.lg)
+                // Bottom caption
+                VStack {
+                    Spacer()
+                    Text("Let\u{2019}s hatch this assistant by giving it enough permissions to live")
+                        .font(VFont.onboardingSubtitle)
+                        .foregroundColor(Meadow.captionText)
+                        .padding(.bottom, VSpacing.lg)
+                }
+            } else {
+                // Step 7: Interview — full-width, no egg
+                OnboardingPanel {
+                    InterviewStepView(
+                        state: state,
+                        daemonClient: daemonClient,
+                        onComplete: onComplete
+                    )
+                }
+                .frame(maxWidth: 560, maxHeight: 640)
+                .transition(
+                    .opacity.combined(with: .scale(scale: 0.97))
+                )
+                .id(state.currentStep)
+
+                // Bottom caption for interview
+                VStack {
+                    Spacer()
+                    Text("Get to know your new assistant")
+                        .font(VFont.onboardingSubtitle)
+                        .foregroundColor(Meadow.captionText)
+                        .padding(.bottom, VSpacing.lg)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -66,6 +92,7 @@ struct OnboardingFlowView: View {
 #Preview {
     OnboardingFlowView(
         state: OnboardingState(),
+        daemonClient: DaemonClient(),
         onComplete: {},
         onOpenSettings: {}
     )

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -25,6 +25,7 @@ final class OnboardingState {
     var screenGranted: Bool = false
     var skipPermissionChecks: Bool = false
     var hasHatched: Bool = false
+    var interviewCompleted: Bool = false
 
     var anyPermissionDenied: Bool {
         !speechGranted || !accessibilityGranted || !screenGranted
@@ -40,7 +41,7 @@ final class OnboardingState {
         case 4: return accessibilityGranted ? 0.75 : 0.60
         case 5: return screenGranted ? 0.95 : 0.80
         case 6: return 1.0
-        default: return 0.0
+        default: return 1.0
         }
     }
 
@@ -56,6 +57,7 @@ final class OnboardingState {
                 chosenKey = key
             }
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
+            interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
         }
     }
 
@@ -72,10 +74,11 @@ final class OnboardingState {
         UserDefaults.standard.set(assistantName, forKey: "onboarding.name")
         UserDefaults.standard.set(chosenKey.rawValue, forKey: "onboarding.key")
         UserDefaults.standard.set(hasHatched, forKey: "onboarding.hatched")
+        UserDefaults.standard.set(interviewCompleted, forKey: "onboarding.interviewCompleted")
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -5,7 +5,12 @@ import SwiftUI
 final class OnboardingWindow {
     private var window: NSWindow?
     let state = OnboardingState()
+    let daemonClient: DaemonClientProtocol
     var onComplete: ((OnboardingState) -> Void)?
+
+    init(daemonClient: DaemonClientProtocol) {
+        self.daemonClient = daemonClient
+    }
 
     func show() {
         #if DEBUG
@@ -16,6 +21,7 @@ final class OnboardingWindow {
 
         let flowView = OnboardingFlowView(
             state: state,
+            daemonClient: daemonClient,
             onComplete: { [weak self] in
                 guard let self else { return }
                 self.onComplete?(self.state)


### PR DESCRIPTION
## Summary
- Integrates the assistant interview (InterviewChatView + InterviewViewModel from M1/M2) into the onboarding flow as an optional step 7
- Moves daemon client setup before onboarding window creation so the interview has connectivity when reached
- Adds InterviewStepView wrapper view with streaming text support, skip/complete controls, and glass panel styling

## Changes
- **InterviewStepView** (new): Wrapper view that creates InterviewViewModel, merges streamed text into displayed messages, shows "I'm ready to go!" button after first assistant message, and provides a "Skip" option
- **OnboardingFlowView**: Accepts `daemonClient`, shows interview step full-width (no egg) for step 7+
- **AliveStepView**: Primary button now calls `state.advance()` to go to step 7 instead of `onComplete()`
- **OnboardingWindow**: Accepts and threads `DaemonClientProtocol` through to flow view
- **OnboardingState**: Added `interviewCompleted` persisted property, updated `crackProgress` default to 1.0
- **AppDelegate**: Calls `setupDaemonClient()` before showing onboarding, passes `daemonClient` to OnboardingWindow

## Test plan
- [ ] Launch fresh onboarding (clear `hasCompletedOnboarding` default), verify steps 0-6 work as before
- [ ] After "Start using..." on step 6, verify step 7 interview appears with chat interface
- [ ] Verify streaming text from daemon appears as live assistant message
- [ ] Click "Skip" to verify onboarding completes without setting `interviewCompleted`
- [ ] Click "I'm ready to go!" to verify onboarding completes with `interviewCompleted = true`
- [ ] Replay onboarding from menu bar, verify interview step works with existing daemon connection
- [ ] Kill app during interview step, relaunch, verify state resumes at step 7

Part of #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
