### PR TITLE
Fix MainWindow to reuse existing window instead of creating duplicates

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -317,6 +317,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showMainWindow() {
+        if let existing = mainWindow {
+            existing.show()
+            return
+        }
         let main = MainWindow()
         main.show()
         mainWindow = main

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -6,6 +6,14 @@ final class MainWindow {
     private var window: NSWindow?
 
     func show() {
+        // Reuse the existing window if one already exists
+        if let existing = window {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
         let hostingController = NSHostingController(rootView: MainWindowView())
 
         let window = NSWindow(


### PR DESCRIPTION
## Summary
- Made `MainWindow.show()` reuse existing `NSWindow` via `makeKeyAndOrderFront` instead of always creating a new one, preventing memory leaks
- Added guard in `AppDelegate.showMainWindow()` to reuse existing `MainWindow` instance, preventing duplicate windows after onboarding replay
- Addresses Codex P1 + P2 and Devin critical feedback on PR #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
