### PR TITLE
Fix scrub.md paths to be relative to clients/macos working directory

### DIFF
--- a/clients/macos/.claude/commands/scrub.md
+++ b/clients/macos/.claude/commands/scrub.md
@@ -33,13 +33,13 @@ Kill the running vellum-assistant app, delete all persistent data so the next la
    ```
    If it's NOT running, start it in the background from the assistant repo:
    ```bash
-   cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun run src/index.ts daemon start
+   cd ../../assistant && export PATH="$HOME/.bun/bin:$PATH" && bun run src/index.ts daemon start
    ```
    If it IS already running, skip this step and report that the daemon is already up.
 
 7. Build and launch the macOS app:
    ```bash
-   cd clients/macos && ./build.sh run
+   ./build.sh run
    ```
    Run this in the background so it doesn't block.
 


### PR DESCRIPTION
## Summary
- Fixes `cd assistant` in step 6 to `cd ../../assistant` since the command runs from `clients/macos/`, not the repo root
- Fixes `cd clients/macos && ./build.sh run` in step 7 to just `./build.sh run` since we're already in `clients/macos/`

Addresses reviewer feedback on #842 (Devin, Codex) that the relative paths were still incorrect because they assumed repo root as the working directory rather than `clients/macos/`.

## Test plan
- [ ] Run `/scrub` from the macOS client and verify the daemon starts correctly (step 6 navigates to the right directory)
- [ ] Verify `./build.sh run` executes successfully without needing to cd (step 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
