### PR TITLE
Refresh MainWindow content view on reuse to reflect updated UserDefaults

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -8,6 +8,9 @@ final class MainWindow {
     func show() {
         // Reuse the existing window if one already exists
         if let existing = window {
+            // Rebuild the SwiftUI view hierarchy so it picks up any
+            // UserDefaults changes (e.g. assistantName set during onboarding replay)
+            existing.contentViewController = NSHostingController(rootView: MainWindowView())
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
## Summary
- When `MainWindow.show()` reuses an existing window, it now rebuilds the `NSHostingController(rootView: MainWindowView())` so the SwiftUI view hierarchy picks up any `UserDefaults` changes (e.g. `assistantName` set during `AppDelegate.replayOnboarding`)
- Previously the early-return reuse path skipped view reconstruction, leaving stale onboarding values visible until app restart
- Addresses Codex P2 feedback on PR #843

## Test plan
- [ ] Launch the app and complete onboarding (sets `assistantName` in UserDefaults)
- [ ] Trigger `replayOnboarding` (which calls `MainWindow.show()` again)
- [ ] Verify the main window displays the updated assistant name without requiring a restart
- [ ] Verify the reused window preserves its size and position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
