### PR TITLE
Fix interview review feedback: leaks, races, crash paths

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -260,6 +260,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func updateMenuBarIcon() {
+        guard statusItem != nil else { return }
         let isAmbientActive = ambientAgent.state == .watching || ambientAgent.state == .analyzing
         let iconName = isAmbientActive ? "eye" : "sparkles"
         statusItem.button?.image = NSImage(
@@ -271,6 +272,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func replayOnboarding() {
         guard onboardingWindow == nil else { return }
         popover.performClose(nil)
+
+        // Ensure daemon connectivity for the interview step
+        if !daemonClient.isConnected {
+            setupDaemonClient()
+        }
 
         let onboarding = OnboardingWindow(daemonClient: daemonClient)
         onboarding.onComplete = { [weak self] state in

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -152,6 +152,7 @@ private struct MessageBubble: View {
 
 private struct TypingIndicator: View {
     @State private var phase: Int = 0
+    @State private var timer: Timer?
 
     var body: some View {
         HStack {
@@ -173,6 +174,7 @@ private struct TypingIndicator: View {
             Spacer()
         }
         .onAppear { startAnimation() }
+        .onDisappear { timer?.invalidate() }
     }
 
     private func dotOpacity(for index: Int) -> Double {
@@ -180,7 +182,7 @@ private struct TypingIndicator: View {
     }
 
     private func startAnimation() {
-        Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
             withAnimation(.easeInOut(duration: 0.3)) {
                 phase = (phase + 1) % 3
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -7,6 +7,7 @@ struct InterviewStepView: View {
 
     @State private var viewModel: InterviewViewModel
     @State private var showControls = false
+    @State private var streamingMessageId = UUID()
 
     init(state: OnboardingState, daemonClient: DaemonClientProtocol, onComplete: @escaping () -> Void) {
         self.state = state
@@ -22,7 +23,7 @@ struct InterviewStepView: View {
     private var displayedMessages: [InterviewMessage] {
         var msgs = viewModel.messages
         if !viewModel.streamingText.isEmpty {
-            msgs.append(InterviewMessage(role: .assistant, text: viewModel.streamingText))
+            msgs.append(InterviewMessage(id: streamingMessageId, role: .assistant, text: viewModel.streamingText))
         }
         return msgs
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -54,6 +54,9 @@ final class InterviewViewModel {
         isThinking = true
         streamingText = ""
 
+        currentTask?.cancel()
+        currentTask = nil
+
         currentTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
@@ -170,6 +173,9 @@ final class InterviewViewModel {
         isThinking = true
         streamingText = ""
 
+        currentTask?.cancel()
+        currentTask = nil
+
         currentTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
@@ -253,6 +259,7 @@ final class InterviewViewModel {
         isComplete = true
         currentTask?.cancel()
         currentTask = nil
+        sessionId = nil
         isThinking = false
         streamingText = ""
     }
@@ -263,5 +270,6 @@ final class InterviewViewModel {
     func cancel() {
         currentTask?.cancel()
         currentTask = nil
+        sessionId = nil
     }
 }


### PR DESCRIPTION
## Summary
- **Timer leak** (PR #835): Store `TypingIndicator` timer reference and invalidate on disappear, preventing accumulated leaked timers
- **Task race conditions** (PR #837): Cancel previous `currentTask` before reassignment in `sendMessage()`/`startInterview()` to prevent duplicate message processing; reset `sessionId` on end/cancel for reuse
- **Streaming flicker** (PR #838): Use stable UUID for the in-progress streaming message so SwiftUI doesn't re-animate transitions on every text delta
- **Crash guard** (PR #838): Guard `updateMenuBarIcon()` against nil `statusItem` IUO during onboarding when ambient agent connects early
- **Replay connectivity** (PR #838): Reconnect daemon in `replayOnboarding()` so the interview step has IPC connectivity

## Test plan
- [ ] Verify typing indicator dots animate smoothly and stop when hidden
- [ ] Send multiple messages rapidly — no duplicate assistant responses
- [ ] Streaming text appears smoothly without flickering/re-animation
- [ ] Fresh install onboarding completes without crash
- [ ] Replay onboarding interview receives assistant greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
