### PR TITLE
Add 7-turn interview limit with natural wrap-up

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -58,32 +58,37 @@ struct InterviewStepView: View {
                 isRecording: false
             )
             .frame(maxHeight: .infinity)
+            .allowsHitTesting(!viewModel.isFinished)
 
             // Bottom controls
             VStack(spacing: VSpacing.md) {
                 if hasAssistantMessage && showControls {
                     OnboardingButton(
-                        title: "I\u{2019}m ready to go!",
+                        title: viewModel.isFinished ? "Let\u{2019}s get started!" : "I\u{2019}m ready to go!",
                         style: .primary
                     ) {
                         state.interviewCompleted = true
                         viewModel.endInterview()
                         onComplete()
                     }
+                    .scaleEffect(viewModel.isFinished ? 1.05 : 1.0)
+                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: viewModel.isFinished)
                 }
 
-                Button {
-                    viewModel.endInterview()
-                    onComplete()
-                } label: {
-                    Text("Skip")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    NSCursor.pointingHand.set()
-                    if !hovering { NSCursor.arrow.set() }
+                if !viewModel.isFinished {
+                    Button {
+                        viewModel.endInterview()
+                        onComplete()
+                    } label: {
+                        Text("Skip")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        NSCursor.pointingHand.set()
+                        if !hovering { NSCursor.arrow.set() }
+                    }
                 }
             }
             .padding(.vertical, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -17,6 +17,7 @@ final class InterviewViewModel {
     var inputText: String = ""
     var isThinking: Bool = false
     var isComplete: Bool = false
+    var isFinished: Bool = false
     var streamingText: String = ""
 
     // MARK: - Dependencies
@@ -26,8 +27,14 @@ final class InterviewViewModel {
 
     // MARK: - Internal State
 
+    private let maxTurns = 7
     private var sessionId: String?
     private var currentTask: Task<Void, Never>?
+
+    /// Number of completed assistant responses (greeting counts as turn 1).
+    var turnCount: Int {
+        messages.filter { $0.role == .assistant }.count
+    }
 
     // MARK: - Init
 
@@ -161,7 +168,7 @@ final class InterviewViewModel {
     /// rather than creating a new session, keeping the conversation context intact.
     func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty, !isFinished else { return }
         guard let sessionId else {
             log.warning("Cannot send message — no active session")
             return
@@ -172,6 +179,20 @@ final class InterviewViewModel {
         inputText = ""
         isThinking = true
         streamingText = ""
+
+        // Inject wrap-up hints based on how many assistant turns remain.
+        let nextTurn = turnCount + 1 // the response about to be generated
+        let remaining = maxTurns - nextTurn
+        var contentToSend = text
+        if remaining <= 0 {
+            contentToSend += "\n\n[This is your final response in this interview. " +
+                "Wrap up warmly — summarize what you've learned about them and express genuine excitement to work together. Keep it to 2-3 sentences.]"
+        } else if remaining <= 2 {
+            contentToSend += "\n\n[You have \(remaining) exchange\(remaining == 1 ? "" : "s") left. " +
+                "Start naturally wrapping up the conversation.]"
+        }
+
+        let isLastTurn = remaining <= 0
 
         currentTask?.cancel()
         currentTask = nil
@@ -184,7 +205,7 @@ final class InterviewViewModel {
             do {
                 try self.daemonClient.send(UserMessageMessage(
                     sessionId: sessionId,
-                    content: text,
+                    content: contentToSend,
                     attachments: nil
                 ))
             } catch {
@@ -220,6 +241,9 @@ final class InterviewViewModel {
                         role: .assistant,
                         text: finalText
                     ))
+                    if isLastTurn {
+                        self.isFinished = true
+                    }
                     log.info("Follow-up response complete (\(accumulated.count) chars)")
                     return
 


### PR DESCRIPTION
## Summary
- Interview now has a 7-turn arc (assistant responses, including greeting)
- Turns 5-6: hidden hint tells the assistant to start wrapping up naturally
- Turn 7: hidden hint tells the assistant to summarize and sign off warmly
- After turn 7: input disabled, Skip hidden, button changes to "Let's get started!" with a gentle pulse animation

## Test plan
- [ ] Start interview, exchange 7 messages — assistant wraps up naturally on final turn
- [ ] After turn 7, input area is non-interactive and Skip button is gone
- [ ] "Let's get started!" button pulses gently and completes onboarding
- [ ] Skipping before turn 7 still works normally
- [ ] Early "I'm ready to go!" button still works at any point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
