### PR TITLE
Make interview optional with warm first-meeting framing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
@@ -51,21 +51,36 @@ struct AliveStepView: View {
                     title: "Start using \(state.assistantName.isEmpty ? "your agent" : state.assistantName)",
                     style: .primary
                 ) {
-                    state.advance()
+                    onComplete()
                 }
                 .font(VFont.cardTitle)
 
-                Button {
-                    onOpenSettings()
-                } label: {
-                    Text("Open Settings first")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    NSCursor.pointingHand.set()
-                    if !hovering { NSCursor.arrow.set() }
+                VStack(spacing: VSpacing.md) {
+                    Button {
+                        state.advance()
+                    } label: {
+                        Text("Say hi to \(state.assistantName.isEmpty ? "your agent" : state.assistantName) first")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        NSCursor.pointingHand.set()
+                        if !hovering { NSCursor.arrow.set() }
+                    }
+
+                    Button {
+                        onOpenSettings()
+                    } label: {
+                        Text("Open Settings first")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        NSCursor.pointingHand.set()
+                        if !hovering { NSCursor.arrow.set() }
+                    }
                 }
             }
             .opacity(showButtons ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -41,7 +41,7 @@ struct InterviewStepView: View {
                     .font(VFont.onboardingTitle)
                     .foregroundColor(VColor.textPrimary)
 
-                Text("Have a quick chat before you get started")
+                Text("Say hi \u{2014} it\u{2019}ll only take a minute")
                     .font(VFont.onboardingSubtitle)
                     .foregroundColor(VColor.textSecondary)
             }
@@ -80,7 +80,7 @@ struct InterviewStepView: View {
                         viewModel.endInterview()
                         onComplete()
                     } label: {
-                        Text("Skip")
+                        Text("I\u{2019}m good, let\u{2019}s go")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -52,10 +52,10 @@ final class InterviewViewModel {
     func startInterview() {
         let prompt = """
         You are \(assistantName.isEmpty ? "Velly" : assistantName), a newly hatched AI assistant meeting your human for the first time. \
-        This is your job interview — you're eager to prove yourself as a great personal assistant. \
-        Introduce yourself warmly in 2-3 sentences. Be genuinely curious about who they are and what they do. \
-        Ask one thoughtful question to get to know them. Keep it conversational and natural, not robotic. \
-        Do not use bullet points or lists. Speak naturally as if in a real interview.
+        You're warm, curious, and genuinely excited to get to know them. \
+        Introduce yourself in 2-3 sentences. Be naturally curious about who they are and what they do. \
+        Ask one thoughtful question to learn about them. Keep it conversational and natural. \
+        Do not use bullet points or lists.
         """
 
         isThinking = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -77,7 +77,7 @@ struct OnboardingFlowView: View {
                 // Bottom caption for interview
                 VStack {
                     Spacer()
-                    Text("Get to know your new assistant")
+                    Text("Your assistant is ready")
                         .font(VFont.onboardingSubtitle)
                         .foregroundColor(Meadow.captionText)
                         .padding(.bottom, VSpacing.lg)


### PR DESCRIPTION
## Summary
- Primary "Start using [name]" button now completes onboarding directly (no interview gate)
- Added secondary "Say hi to [name] first" link that opts into the interview
- Reframed interview system prompt from "job interview" to a warm first meeting
- Updated interview copy: subtitle → "Say hi — it'll only take a minute", skip → "I'm good, let's go", bottom caption → "Your assistant is ready"

## Test plan
- [ ] `./build.sh` compiles cleanly
- [ ] Reset onboarding (`UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")`) and verify:
  - [ ] "Start using [name]" completes onboarding directly
  - [ ] "Say hi to [name] first" advances to interview step
  - [ ] Interview greeting is warm/natural (no "job interview" language)
  - [ ] "I'm good, let's go" skip link works
  - [ ] "Open Settings first" link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
