### PR TITLE
macOS: add basic chat view shell in main window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum ChatRole: String {
+    case user
+    case assistant
+}
+
+struct ChatMessage: Identifiable {
+    let id: UUID
+    let role: ChatRole
+    var text: String
+    let timestamp: Date
+    var isStreaming: Bool
+
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.timestamp = timestamp
+        self.isStreaming = isStreaming
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+struct ChatView: View {
+    let messages: [ChatMessage]
+    @Binding var inputText: String
+    let isThinking: Bool
+    let isSending: Bool
+    let onSend: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            messageList
+            composerArea
+        }
+    }
+
+    // MARK: - Message List
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: VSpacing.md) {
+                    ForEach(messages) { message in
+                        ChatBubble(message: message)
+                            .id(message.id)
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+
+                    if isThinking {
+                        ThinkingIndicator()
+                            .id("thinking-indicator")
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+            }
+            .onChange(of: messages.count) {
+                withAnimation(VAnimation.standard) {
+                    if let lastMessage = messages.last {
+                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                    }
+                }
+            }
+            .onChange(of: isThinking) {
+                if isThinking {
+                    withAnimation(VAnimation.standard) {
+                        proxy.scrollTo("thinking-indicator", anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Composer Area
+
+    private var composerArea: some View {
+        HStack(spacing: VSpacing.sm) {
+            TextField("Type a message\u{2026}", text: $inputText)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.md)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+                .onSubmit {
+                    if canSend {
+                        onSend()
+                    }
+                }
+
+            Button(action: {
+                if canSend {
+                    onSend()
+                }
+            }) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+            .accessibilityLabel("Send message")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            VColor.surface.opacity(0.5)
+                .overlay(
+                    VStack {
+                        Divider().background(VColor.surfaceBorder.opacity(0.4))
+                        Spacer()
+                    }
+                )
+        )
+    }
+
+    private var canSend: Bool {
+        !isSending && !inputText.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}
+
+// MARK: - Chat Bubble
+
+private struct ChatBubble: View {
+    let message: ChatMessage
+
+    private var isUser: Bool { message.role == .user }
+
+    var body: some View {
+        HStack {
+            if isUser { Spacer(minLength: 0) }
+
+            Text(message.text)
+                .font(VFont.body)
+                .foregroundColor(isUser ? .white : VColor.textPrimary)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
+                )
+                .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
+
+            if !isUser { Spacer(minLength: 0) }
+        }
+    }
+}
+
+// MARK: - Thinking Indicator
+
+private struct ThinkingIndicator: View {
+    @State private var phase: Int = 0
+    @State private var timer: Timer?
+
+    var body: some View {
+        HStack {
+            HStack(spacing: VSpacing.xs) {
+                Text("Thinking")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(VColor.textSecondary)
+                        .frame(width: 5, height: 5)
+                        .opacity(dotOpacity(for: index))
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surface.opacity(0.5))
+            )
+
+            Spacer()
+        }
+        .onAppear { startAnimation() }
+        .onDisappear { timer?.invalidate() }
+    }
+
+    private func dotOpacity(for index: Int) -> Double {
+        phase == index ? 1.0 : 0.4
+    }
+
+    private func startAnimation() {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: 0.3)) {
+                phase = (phase + 1) % 3
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("ChatView") {
+    @Previewable @State var text = ""
+
+    let sampleMessages: [ChatMessage] = [
+        ChatMessage(role: .assistant, text: "Hello! How can I help you today?"),
+        ChatMessage(role: .user, text: "Can you tell me about SwiftUI?"),
+        ChatMessage(
+            role: .assistant,
+            text: "SwiftUI is a declarative framework for building user interfaces across Apple platforms. It uses a reactive data-binding model and composable view hierarchy."
+        ),
+        ChatMessage(role: .user, text: "That sounds great, thanks!"),
+    ]
+
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ChatView(
+            messages: sampleMessages,
+            inputText: $text,
+            isThinking: true,
+            isSending: false,
+            onSend: {}
+        )
+    }
+    .frame(width: 600, height: 500)
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,22 +1,41 @@
 import SwiftUI
 
 struct MainWindowView: View {
+    @State private var messages: [ChatMessage] = [
+        ChatMessage(role: .assistant, text: "Hello! I'm \(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant"). How can I help you today?"),
+    ]
+    @State private var inputText = ""
+    @State private var isThinking = false
+
     var body: some View {
         ZStack {
             VColor.background
                 .ignoresSafeArea()
 
-            VStack(spacing: VSpacing.lg) {
-                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
-                    .font(VFont.display)
-                    .foregroundStyle(VColor.textPrimary)
-
-                Text("Main window — components coming soon")
-                    .font(VFont.body)
-                    .foregroundStyle(VColor.textSecondary)
-            }
+            ChatView(
+                messages: messages,
+                inputText: $inputText,
+                isThinking: isThinking,
+                isSending: false,
+                onSend: sendMessage
+            )
         }
         .frame(minWidth: 800, minHeight: 600)
+    }
+
+    private func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+
+        messages.append(ChatMessage(role: .user, text: text))
+        inputText = ""
+        isThinking = true
+
+        // Simulate an assistant reply for demo purposes
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            isThinking = false
+            messages.append(ChatMessage(role: .assistant, text: "This is a placeholder response. Daemon integration coming soon."))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ChatMessage` model (`ChatRole` enum + `Identifiable` struct with id, role, text, timestamp, isStreaming)
- Add `ChatView` presentational component with role-styled message bubbles, thinking indicator, and composer area using existing design tokens (`VColor`, `VFont`, `VSpacing`, `VRadius`, `VAnimation`)
- Replace the static "components coming soon" placeholder in `MainWindowView` with a live `ChatView` wired to local `@State` and a simulated assistant reply for demo purposes

## Test plan
- [ ] `swift build` passes with no new errors
- [ ] Run the app and open the main window -- chat view should appear with a greeting message
- [ ] Type a message and press Send or Return -- user bubble appears right-aligned with accent background, thinking indicator shows, then a placeholder assistant reply appears left-aligned
- [ ] Verify previews render correctly for both `ChatView` and `MainWindowView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
