### PR TITLE
macOS: inject shared DaemonClient into main window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -327,7 +327,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.show()
             return
         }
-        let main = MainWindow()
+        let main = MainWindow(daemonClient: daemonClient)
         main.show()
         mainWindow = main
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -3,21 +3,26 @@ import SwiftUI
 
 @MainActor
 final class MainWindow {
+    private let daemonClient: DaemonClient
     private var window: NSWindow?
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
 
     func show() {
         // Reuse the existing window if one already exists
         if let existing = window {
             // Rebuild the SwiftUI view hierarchy so it picks up any
             // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView())
+            existing.contentViewController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient))
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView())
+        let hostingController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient))
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct MainWindowView: View {
+    let daemonClient: DaemonClient
+
     @State private var messages: [ChatMessage] = [
         ChatMessage(role: .assistant, text: "Hello! I'm \(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant"). How can I help you today?"),
     ]
@@ -40,5 +42,5 @@ struct MainWindowView: View {
 }
 
 #Preview {
-    MainWindowView()
+    MainWindowView(daemonClient: DaemonClient())
 }


### PR DESCRIPTION
## Summary
- Thread the shared `DaemonClient` instance from `AppDelegate` through `MainWindow` into `MainWindowView` via constructor injection
- `MainWindow` now requires a `DaemonClient` parameter in its initializer and forwards it when creating `MainWindowView` hosting controllers
- `MainWindowView` stores the `DaemonClient` as a property for use by a `ChatViewModel` in a follow-up PR
- No behavioral changes — existing demo chat state and placeholder `sendMessage()` are untouched

## Test plan
- [x] `swift build` succeeds with no errors
- [ ] Launch the app and verify the main window opens as before
- [ ] Verify the placeholder chat UI still works (send a message, receive placeholder response)
- [ ] Verify window reuse on dock click / reopen still works
- [ ] Verify onboarding replay -> main window transition still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
