### PR TITLE
macOS: add chat view model with daemon session bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -1,0 +1,182 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel")
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var inputText: String = ""
+    @Published var isThinking: Bool = false
+    @Published var isSending: Bool = false
+    @Published var errorText: String?
+
+    private let daemonClient: DaemonClient
+    private var sessionId: String?
+    private var pendingUserMessage: String?
+    private var messageLoopTask: Task<Void, Never>?
+    private var currentAssistantMessageId: UUID?
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        // Add initial greeting
+        let name = UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant"
+        messages.append(ChatMessage(role: .assistant, text: "Hello! I'm \(name). How can I help you today?"))
+    }
+
+    func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty, !isSending else { return }
+
+        // Append user message immediately for responsive UX
+        messages.append(ChatMessage(role: .user, text: text))
+        inputText = ""
+        errorText = nil
+
+        if sessionId == nil {
+            // First message: need to bootstrap session
+            bootstrapSession(userMessage: text)
+        } else {
+            // Subsequent messages: send directly
+            sendUserMessage(text)
+        }
+    }
+
+    private func bootstrapSession(userMessage: String) {
+        isSending = true
+        isThinking = true
+        pendingUserMessage = userMessage
+
+        Task { @MainActor in
+            // Ensure daemon connection
+            if !daemonClient.isConnected {
+                do {
+                    try await daemonClient.connect()
+                } catch {
+                    log.error("Failed to connect to daemon: \(error.localizedDescription)")
+                    self.isThinking = false
+                    self.isSending = false
+                    self.errorText = "Cannot connect to daemon. Please ensure it's running."
+                    return
+                }
+            }
+
+            // Subscribe to daemon stream
+            self.startMessageLoop()
+
+            // Send session_create
+            do {
+                try daemonClient.send(SessionCreateMessage(title: nil))
+            } catch {
+                log.error("Failed to send session_create: \(error.localizedDescription)")
+                self.isThinking = false
+                self.isSending = false
+                self.errorText = "Failed to create session."
+            }
+        }
+    }
+
+    private func sendUserMessage(_ text: String) {
+        guard let sessionId else { return }
+        isSending = true
+        isThinking = true
+
+        // Make sure we're listening
+        if messageLoopTask == nil {
+            startMessageLoop()
+        }
+
+        do {
+            try daemonClient.send(UserMessageMessage(
+                sessionId: sessionId,
+                content: text,
+                attachments: nil
+            ))
+        } catch {
+            log.error("Failed to send user_message: \(error.localizedDescription)")
+            isSending = false
+            isThinking = false
+            errorText = "Failed to send message."
+        }
+    }
+
+    private func startMessageLoop() {
+        messageLoopTask?.cancel()
+        let messageStream = daemonClient.subscribe()
+
+        messageLoopTask = Task { @MainActor [weak self] in
+            for await message in messageStream {
+                guard let self, !Task.isCancelled else { break }
+                self.handleServerMessage(message)
+            }
+        }
+    }
+
+    private func handleServerMessage(_ message: ServerMessage) {
+        switch message {
+        case .sessionInfo(let info):
+            if sessionId == nil {
+                sessionId = info.sessionId
+                log.info("Chat session created: \(info.sessionId)")
+
+                // Send the queued user message
+                if let pending = pendingUserMessage {
+                    pendingUserMessage = nil
+                    do {
+                        try daemonClient.send(UserMessageMessage(
+                            sessionId: info.sessionId,
+                            content: pending,
+                            attachments: nil
+                        ))
+                    } catch {
+                        log.error("Failed to send queued user_message: \(error.localizedDescription)")
+                        isSending = false
+                        isThinking = false
+                        errorText = "Failed to send message."
+                    }
+                }
+            }
+
+        case .assistantThinkingDelta:
+            // Stay in thinking state
+            break
+
+        case .assistantTextDelta(let delta):
+            isThinking = false
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                // Append to existing streaming message
+                messages[index].text += delta.text
+            } else {
+                // Create new assistant message
+                let msg = ChatMessage(role: .assistant, text: delta.text, isStreaming: true)
+                currentAssistantMessageId = msg.id
+                messages.append(msg)
+            }
+
+        case .messageComplete:
+            isThinking = false
+            isSending = false
+            // Mark the current assistant message as complete
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+
+        case .error(let err):
+            log.error("Server error: \(err.message)")
+            isThinking = false
+            isSending = false
+            currentAssistantMessageId = nil
+            errorText = err.message
+
+        default:
+            break
+        }
+    }
+
+    deinit {
+        messageLoopTask?.cancel()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
 struct MainWindowView: View {
-    let daemonClient: DaemonClient
+    @StateObject private var viewModel: ChatViewModel
 
-    @State private var messages: [ChatMessage] = [
-        ChatMessage(role: .assistant, text: "Hello! I'm \(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant"). How can I help you today?"),
-    ]
-    @State private var inputText = ""
-    @State private var isThinking = false
+    init(daemonClient: DaemonClient) {
+        _viewModel = StateObject(wrappedValue: ChatViewModel(daemonClient: daemonClient))
+    }
 
     var body: some View {
         ZStack {
@@ -15,29 +13,14 @@ struct MainWindowView: View {
                 .ignoresSafeArea()
 
             ChatView(
-                messages: messages,
-                inputText: $inputText,
-                isThinking: isThinking,
-                isSending: false,
-                onSend: sendMessage
+                messages: viewModel.messages,
+                inputText: $viewModel.inputText,
+                isThinking: viewModel.isThinking,
+                isSending: viewModel.isSending,
+                onSend: viewModel.sendMessage
             )
         }
         .frame(minWidth: 800, minHeight: 600)
-    }
-
-    private func sendMessage() {
-        let text = inputText.trimmingCharacters(in: .whitespaces)
-        guard !text.isEmpty else { return }
-
-        messages.append(ChatMessage(role: .user, text: text))
-        inputText = ""
-        isThinking = true
-
-        // Simulate an assistant reply for demo purposes
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            isThinking = false
-            messages.append(ChatMessage(role: .assistant, text: "This is a placeholder response. Daemon integration coming soon."))
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **New file: `ChatViewModel.swift`** -- `@MainActor ObservableObject` that manages the full daemon IPC lifecycle for the chat UI: session creation, user message sending, streaming text deltas, thinking state, message completion, and error handling.
- **Updated `MainWindowView.swift`** -- Replaced inline `@State` demo state and placeholder `sendMessage()` with `@StateObject` backed by `ChatViewModel`, wiring all published properties into `ChatView`.

## How it works
1. On the first user message, `ChatViewModel` connects to the daemon (if needed), subscribes to the server message stream, and sends a `session_create` IPC message.
2. When `session_info` arrives with the assigned session ID, the queued user message is sent as a `user_message`.
3. Subsequent messages skip session creation and send directly.
4. `assistant_text_delta` messages stream into the UI in real time, `assistant_thinking_delta` keeps the thinking indicator visible, and `message_complete` finalizes the response.
5. Errors surface via `errorText` for future UI display.

## Test plan
- [x] `swift build` passes cleanly
- [ ] Manual: launch app, send a message with daemon running -- verify streaming response appears
- [ ] Manual: send a message with daemon not running -- verify error state shown
- [ ] Manual: send multiple messages in one session -- verify they reuse the same session ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
