### PR TITLE
macOS: streaming response view enhancements

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -5,11 +5,21 @@ struct ChatView: View {
     @Binding var inputText: String
     let isThinking: Bool
     let isSending: Bool
+    let errorText: String?
     let onSend: () -> Void
+    let onDismissError: () -> Void
+
+    /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
+    private var streamingScrollTrigger: Int {
+        messages.last?.text.count ?? 0
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             messageList
+            if let errorText {
+                errorBanner(errorText)
+            }
             composerArea
         }
     }
@@ -49,7 +59,42 @@ struct ChatView: View {
                     }
                 }
             }
+            .onChange(of: streamingScrollTrigger) {
+                withAnimation(VAnimation.fast) {
+                    if let lastMessage = messages.last {
+                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                    }
+                }
+            }
         }
+    }
+
+    // MARK: - Error Banner
+
+    private func errorBanner(_ text: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(VFont.small)
+
+            Text(text)
+                .font(VFont.small)
+                .lineLimit(2)
+
+            Spacer()
+
+            Button {
+                onDismissError()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(VFont.caption)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss error")
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.error)
     }
 
     // MARK: - Composer Area
@@ -115,19 +160,24 @@ private struct ChatBubble: View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
-            Text(message.text)
-                .font(VFont.body)
-                .foregroundColor(isUser ? .white : VColor.textPrimary)
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.vertical, VSpacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
-                )
-                .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
+            bubbleContent
 
             if !isUser { Spacer(minLength: 0) }
         }
+    }
+
+    private var bubbleContent: some View {
+        Text(message.text)
+            .font(VFont.body)
+            .foregroundColor(isUser ? .white : VColor.textPrimary)
+            .textSelection(.enabled)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
+            )
+            .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
     }
 }
 
@@ -199,7 +249,9 @@ private struct ThinkingIndicator: View {
             inputText: $text,
             isThinking: true,
             isSending: false,
-            onSend: {}
+            errorText: nil,
+            onSend: {},
+            onDismissError: {}
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -176,6 +176,10 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
+    func dismissError() {
+        errorText = nil
+    }
+
     deinit {
         messageLoopTask?.cancel()
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -17,7 +17,9 @@ struct MainWindowView: View {
                 inputText: $viewModel.inputText,
                 isThinking: viewModel.isThinking,
                 isSending: viewModel.isSending,
-                onSend: viewModel.sendMessage
+                errorText: viewModel.errorText,
+                onSend: viewModel.sendMessage,
+                onDismissError: viewModel.dismissError
             )
         }
         .frame(minWidth: 800, minHeight: 600)


### PR DESCRIPTION
## Summary
- **Auto-scroll during streaming**: Added an `onChange` handler that watches the last message's text length (`streamingScrollTrigger`), so the scroll view keeps up as streaming text deltas arrive -- previously it only scrolled when `messages.count` changed.
- **Text selection**: Enabled `.textSelection(.enabled)` on chat bubble text so users can select and copy assistant (and user) messages.
- **Error banner**: Added a dismissible red error banner above the composer that surfaces `ChatViewModel.errorText`. Includes a warning icon, error text, and an X dismiss button. Added `dismissError()` method to `ChatViewModel`.

## Files modified
- `clients/macos/vellum-assistant/Features/Chat/ChatView.swift` -- streaming scroll trigger, error banner view, text selection on bubbles
- `clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift` -- `dismissError()` method
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift` -- pass `errorText` and `onDismissError` to ChatView

## Test plan
- [ ] Open chat, send a message, verify scroll keeps up as the assistant streams its response
- [ ] Verify you can click and drag to select text in assistant message bubbles
- [ ] Simulate an error (e.g. disconnect daemon) and verify the red error banner appears above the composer
- [ ] Click the X button on the error banner and verify it dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
