### PR TITLE
M2: Add agent tools for persistent apps

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -14,6 +14,8 @@ import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/ty
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { registerUiSurfaceTools } from '../tools/ui-surface/registry.js';
+import { allAppTools } from '../tools/apps/definitions.js';
+import { registerAppTools } from '../tools/apps/registry.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
@@ -85,10 +87,12 @@ export class Session {
     // Registration is done here (not at daemon startup) so that surface tools
     // are only available in sessions that have surface proxy infrastructure.
     registerUiSurfaceTools();
+    registerAppTools();
 
     const toolDefs = [
       ...getAllToolDefinitions(),
       ...allUiSurfaceTools.map((t) => t.getDefinition()),
+      ...allAppTools.map((t) => t.getDefinition()),
     ];
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
       return this.executor.execute(name, input, {

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -1,0 +1,279 @@
+/**
+ * App tool definitions.
+ *
+ * These tools allow the model to create, list, update, open, query, and delete
+ * persistent user-defined apps.  Most are local tools that call functions in
+ * the app-store data layer; `app_open` is a proxy tool forwarded to the
+ * connected macOS client (same pattern as ui_show).
+ */
+
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolExecutionResult, ToolContext } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import * as appStore from '../../memory/app-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function proxyExecute(): Promise<ToolExecutionResult> {
+  throw new Error('Proxy tool: execution must be forwarded to the connected client');
+}
+
+// ---------------------------------------------------------------------------
+// app_create
+// ---------------------------------------------------------------------------
+
+export const appCreateTool: Tool = {
+  name: 'app_create',
+  description:
+    'Create a persistent app with a name, optional description, JSON schema, and HTML definition.',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'local',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name of the app',
+          },
+          description: {
+            type: 'string',
+            description: 'Optional description of the app',
+          },
+          schema_json: {
+            type: 'string',
+            description: 'JSON schema defining the app data structure',
+          },
+          html: {
+            type: 'string',
+            description: 'HTML definition for rendering the app',
+          },
+        },
+        required: ['name', 'schema_json', 'html'],
+      },
+    };
+  },
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const name = input.name as string;
+    const description = input.description as string | undefined;
+    const schemaJson = input.schema_json as string;
+    const htmlDefinition = input.html as string;
+
+    const app = appStore.createApp({ name, description, schemaJson, htmlDefinition });
+    return { content: JSON.stringify(app), isError: false };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// app_open
+// ---------------------------------------------------------------------------
+
+export const appOpenTool: Tool = {
+  name: 'app_open',
+  description:
+    'Open a persistent app in a dynamic_page surface on the connected client.',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          app_id: {
+            type: 'string',
+            description: 'The ID of the app to open',
+          },
+        },
+        required: ['app_id'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
+// app_list
+// ---------------------------------------------------------------------------
+
+export const appListTool: Tool = {
+  name: 'app_list',
+  description: 'List all persistent apps. Returns an array of {id, name, description, updatedAt}.',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'local',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {},
+      },
+    };
+  },
+
+  async execute(_input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const apps = appStore.listApps().map((a) => ({
+      id: a.id,
+      name: a.name,
+      description: a.description,
+      updatedAt: a.updatedAt,
+    }));
+    return { content: JSON.stringify(apps), isError: false };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// app_query
+// ---------------------------------------------------------------------------
+
+export const appQueryTool: Tool = {
+  name: 'app_query',
+  description: 'Query all records for a persistent app. Returns an array of records.',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'local',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          app_id: {
+            type: 'string',
+            description: 'The ID of the app to query records for',
+          },
+        },
+        required: ['app_id'],
+      },
+    };
+  },
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const appId = input.app_id as string;
+    const records = appStore.queryAppRecords(appId);
+    return { content: JSON.stringify(records), isError: false };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// app_update
+// ---------------------------------------------------------------------------
+
+export const appUpdateTool: Tool = {
+  name: 'app_update',
+  description:
+    'Update a persistent app definition. Provide the app_id and any fields to update (name, description, schema_json, html).',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'local',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          app_id: {
+            type: 'string',
+            description: 'The ID of the app to update',
+          },
+          name: {
+            type: 'string',
+            description: 'Updated name for the app',
+          },
+          description: {
+            type: 'string',
+            description: 'Updated description for the app',
+          },
+          schema_json: {
+            type: 'string',
+            description: 'Updated JSON schema',
+          },
+          html: {
+            type: 'string',
+            description: 'Updated HTML definition',
+          },
+        },
+        required: ['app_id'],
+      },
+    };
+  },
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const appId = input.app_id as string;
+    const updates: Partial<Pick<appStore.AppDefinition, 'name' | 'description' | 'schemaJson' | 'htmlDefinition'>> = {};
+    if (typeof input.name === 'string') updates.name = input.name;
+    if (typeof input.description === 'string') updates.description = input.description;
+    if (typeof input.schema_json === 'string') updates.schemaJson = input.schema_json;
+    if (typeof input.html === 'string') updates.htmlDefinition = input.html;
+
+    const app = appStore.updateApp(appId, updates);
+    return { content: JSON.stringify(app), isError: false };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// app_delete
+// ---------------------------------------------------------------------------
+
+export const appDeleteTool: Tool = {
+  name: 'app_delete',
+  description: 'Delete a persistent app and all its records.',
+  category: 'apps',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'local',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          app_id: {
+            type: 'string',
+            description: 'The ID of the app to delete',
+          },
+        },
+        required: ['app_id'],
+      },
+    };
+  },
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const appId = input.app_id as string;
+    appStore.deleteApp(appId);
+    return { content: JSON.stringify({ deleted: true, appId }), isError: false };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All tools exported as array for convenience
+// ---------------------------------------------------------------------------
+
+export const allAppTools: Tool[] = [
+  appCreateTool,
+  appOpenTool,
+  appListTool,
+  appQueryTool,
+  appUpdateTool,
+  appDeleteTool,
+];

--- a/assistant/src/tools/apps/registry.ts
+++ b/assistant/src/tools/apps/registry.ts
@@ -1,0 +1,16 @@
+/**
+ * Registers all app tools with the daemon's tool registry.
+ *
+ * Called per-session by Session (not at daemon startup) so that app tools
+ * including the proxy tool (app_open) are only available in contexts where
+ * a surfaceProxyResolver is wired up to handle them.
+ */
+
+import { registerTool } from '../registry.js';
+import { allAppTools } from './definitions.js';
+
+export function registerAppTools(): void {
+  for (const tool of allAppTools) {
+    registerTool(tool);
+  }
+}

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -104,6 +104,7 @@ export async function initializeTools(): Promise<void> {
   await import('./weather/get-weather.js');
   await import('./timer/pomodoro.js');
   await import('./system/system-info.js');
+  await import('./apps/definitions.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded


### PR DESCRIPTION
## Summary
- Create 6 tool definitions (`app_create`, `app_open`, `app_list`, `app_query`, `app_update`, `app_delete`) in `assistant/src/tools/apps/definitions.ts` following the existing `ui-surface` tool pattern
- Create `registerAppTools()` in `assistant/src/tools/apps/registry.ts` matching the `ui-surface` registry pattern
- Wire app tools into `Session` constructor in `session.ts` (registration + tool definitions)
- Add eager import of app definitions in `initializeTools()` in `registry.ts`

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify `app_create` creates an app via app-store and returns the object
- [ ] Verify `app_list` returns summary objects for all apps
- [ ] Verify `app_query` returns records for a given app
- [ ] Verify `app_update` applies partial updates to an existing app
- [ ] Verify `app_delete` removes app and all its records
- [ ] Verify `app_open` is treated as a proxy tool and forwarded to the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
