### PR TITLE
macOS: add stop button and daemon cancel handling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -7,6 +7,7 @@ struct ChatView: View {
     let isSending: Bool
     let errorText: String?
     let onSend: () -> Void
+    let onStop: () -> Void
     let onDismissError: () -> Void
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
@@ -118,18 +119,28 @@ struct ChatView: View {
                     }
                 }
 
-            Button(action: {
-                if canSend {
-                    onSend()
+            if isSending {
+                Button(action: onStop) {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.system(size: 24, weight: .medium))
+                        .foregroundColor(VColor.error)
                 }
-            }) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 24, weight: .medium))
-                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Stop generation")
+            } else {
+                Button(action: {
+                    if canSend {
+                        onSend()
+                    }
+                }) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 24, weight: .medium))
+                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+                .accessibilityLabel("Send message")
             }
-            .buttonStyle(.plain)
-            .disabled(!canSend)
-            .accessibilityLabel("Send message")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -251,6 +262,7 @@ private struct ThinkingIndicator: View {
             isSending: false,
             errorText: nil,
             onSend: {},
+            onStop: {},
             onDismissError: {}
         )
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -164,6 +164,15 @@ final class ChatViewModel: ObservableObject {
             }
             currentAssistantMessageId = nil
 
+        case .generationCancelled:
+            isThinking = false
+            isSending = false
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+
         case .error(let err):
             log.error("Server error: \(err.message)")
             isThinking = false
@@ -174,6 +183,27 @@ final class ChatViewModel: ObservableObject {
         default:
             break
         }
+    }
+
+    func stopGenerating() {
+        guard isSending, let sessionId else { return }
+
+        do {
+            try daemonClient.send(CancelMessage(sessionId: sessionId))
+        } catch {
+            log.error("Failed to send cancel: \(error.localizedDescription)")
+        }
+
+        // Immediately update UI state
+        isThinking = false
+        isSending = false
+
+        // Mark current assistant message as stopped
+        if let existingId = currentAssistantMessageId,
+           let index = messages.firstIndex(where: { $0.id == existingId }) {
+            messages[index].isStreaming = false
+        }
+        currentAssistantMessageId = nil
     }
 
     func dismissError() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,6 +19,7 @@ struct MainWindowView: View {
                 isSending: viewModel.isSending,
                 errorText: viewModel.errorText,
                 onSend: viewModel.sendMessage,
+                onStop: viewModel.stopGenerating,
                 onDismissError: viewModel.dismissError
             )
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -151,6 +151,13 @@ struct TaskSubmitMessage: Encodable, Sendable {
     let attachments: [IPCAttachment]?
 }
 
+/// Sent to cancel the active generation.
+/// Wire type: `"cancel"`
+struct CancelMessage: Encodable, Sendable {
+    let type: String = "cancel"
+    let sessionId: String
+}
+
 /// Keepalive ping.
 /// Wire type: `"ping"`
 struct PingMessage: Encodable, Sendable {
@@ -258,6 +265,11 @@ struct UiSurfaceDismissMessage: Decodable, Sendable {
     let surfaceId: String
 }
 
+/// Confirms generation was cancelled.
+struct GenerationCancelledMessage: Decodable, Sendable {
+    let sessionId: String?
+}
+
 /// Server-level error message.
 struct ErrorMessage: Decodable, Sendable {
     let message: String
@@ -279,6 +291,7 @@ enum ServerMessage: Decodable, Sendable {
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
+    case generationCancelled(GenerationCancelledMessage)
     case pong
     case unknown(String)
 
@@ -330,6 +343,9 @@ enum ServerMessage: Decodable, Sendable {
         case "ui_surface_dismiss":
             let message = try UiSurfaceDismissMessage(from: decoder)
             self = .uiSurfaceDismiss(message)
+        case "generation_cancelled":
+            let message = try GenerationCancelledMessage(from: decoder)
+            self = .generationCancelled(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add `CancelMessage` (client-to-server) and `GenerationCancelledMessage` (server-to-client) IPC message types to support cancelling in-progress generation
- Add `stopGenerating()` method to `ChatViewModel` that sends a cancel message to the daemon and immediately resets UI state
- Replace the send button with a stop button (red `stop.circle.fill` icon) in the chat composer area when generation is in progress
- Handle the `generation_cancelled` server message to gracefully stop streaming when confirmed by the daemon

## Test plan
- [ ] Start a generation in the main-window chat and verify the send button changes to a red stop button
- [ ] Click the stop button and verify generation stops immediately and the composer returns to the send button state
- [ ] Verify the stop button has proper accessibility label ("Stop generation")
- [ ] Verify that after stopping, you can send a new message normally
- [ ] Verify the `generation_cancelled` server message properly resets streaming state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
