### PR TITLE
M3: Add IPC data bridge and app_open proxy resolver

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -145,6 +145,16 @@ exports[`IPC message snapshots ClientMessage types ui_surface_action serializes 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types app_data_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "callId": "call-001",
+  "method": "query",
+  "surfaceId": "surface-001",
+  "type": "app_data_request",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "text": "Here is some output",
@@ -471,5 +481,25 @@ exports[`IPC message snapshots ServerMessage types ui_surface_dismiss serializes
   "sessionId": "sess-001",
   "surfaceId": "surface-001",
   "type": "ui_surface_dismiss",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types app_data_response serializes to expected JSON 1`] = `
+{
+  "callId": "call-001",
+  "result": [
+    {
+      "appId": "app-001",
+      "createdAt": 1700000000,
+      "data": {
+        "name": "Test",
+      },
+      "id": "rec-001",
+      "updatedAt": 1700000000,
+    },
+  ],
+  "success": true,
+  "surfaceId": "surface-001",
+  "type": "app_data_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -106,6 +106,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     actionId: 'btn-ok',
     data: { selectedItem: 'item-1' },
   },
+  app_data_request: {
+    type: 'app_data_request',
+    surfaceId: 'surface-001',
+    callId: 'call-001',
+    method: 'query',
+    appId: 'app-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -308,6 +315,13 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'ui_surface_dismiss',
     sessionId: 'sess-001',
     surfaceId: 'surface-001',
+  },
+  app_data_response: {
+    type: 'app_data_response',
+    surfaceId: 'surface-001',
+    callId: 'call-001',
+    success: true,
+    result: [{ id: 'rec-001', appId: 'app-001', data: { name: 'Test' }, createdAt: 1700000000, updatedAt: 1700000000 }],
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -22,9 +22,11 @@ import type {
   CuSessionCreate,
   CuObservation,
   TaskSubmit,
+  AppDataRequest,
 } from './ipc-protocol.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
+import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -208,6 +210,7 @@ const handlers: DispatchMap = {
   cu_observation: handleCuObservation,
   ambient_observation: handleAmbientObservation,
   task_submit: handleTaskSubmit,
+  app_data_request: handleAppDataRequest,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -523,6 +526,53 @@ function handleUsageRequest(
     estimatedCost: conversation.totalEstimatedCost,
     model: config.model,
   });
+}
+
+// ─── App data handler ────────────────────────────────────────────────────────
+
+function handleAppDataRequest(
+  msg: AppDataRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const { surfaceId, callId, method, appId, recordId, data } = msg;
+  try {
+    let result: unknown = null;
+    switch (method) {
+      case 'query':
+        result = queryAppRecords(appId);
+        break;
+      case 'create':
+        result = createAppRecord(appId, data!);
+        break;
+      case 'update':
+        result = updateAppRecord(appId, recordId!, data!);
+        break;
+      case 'delete':
+        deleteAppRecord(appId, recordId!);
+        result = null;
+        break;
+      default:
+        throw new Error(`Unknown app data method: ${method}`);
+    }
+    ctx.send(socket, {
+      type: 'app_data_response',
+      surfaceId,
+      callId,
+      success: true,
+      result,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, method, appId, recordId }, 'Error handling app_data_request');
+    ctx.send(socket, {
+      type: 'app_data_response',
+      surfaceId,
+      callId,
+      success: false,
+      error: message,
+    });
+  }
 }
 
 // ─── Task submit handler ────────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -120,6 +120,16 @@ export interface AmbientObservation {
   timestamp: number;
 }
 
+export interface AppDataRequest {
+  type: 'app_data_request';
+  surfaceId: string;
+  callId: string;
+  method: 'query' | 'create' | 'update' | 'delete';
+  appId: string;
+  recordId?: string;
+  data?: Record<string, unknown>;
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
@@ -210,7 +220,8 @@ export type ClientMessage =
   | CuObservation
   | AmbientObservation
   | TaskSubmit
-  | UiSurfaceAction;
+  | UiSurfaceAction
+  | AppDataRequest;
 
 // === Server → Client messages ===
 
@@ -407,6 +418,15 @@ export interface AmbientResult {
   suggestion?: string;
 }
 
+export interface AppDataResponse {
+  type: 'app_data_response';
+  surfaceId: string;
+  callId: string;
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
 /** Common fields shared by all UiSurfaceShow variants. */
 interface UiSurfaceShowBase {
   type: 'ui_surface_show';
@@ -490,7 +510,8 @@ export type ServerMessage =
   | AmbientResult
   | UiSurfaceShow
   | UiSurfaceUpdate
-  | UiSurfaceDismiss;
+  | UiSurfaceDismiss
+  | AppDataResponse;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2,12 +2,13 @@ import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { getApp } from '../memory/app-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/types.js';
@@ -697,6 +698,29 @@ export class Session {
       this.pendingSurfaceActions.delete(surfaceId);
       this.surfaceState.delete(surfaceId);
       return { content: 'Surface dismissed', isError: false };
+    }
+
+    if (toolName === 'app_open') {
+      const appId = input.app_id as string;
+      const app = getApp(appId);
+      if (!app) return { content: `App not found: ${appId}`, isError: true };
+
+      const surfaceId = uuid();
+      this.surfaceState.set(surfaceId, {
+        surfaceType: 'dynamic_page',
+        data: { html: app.htmlDefinition } as DynamicPageSurfaceData,
+      });
+
+      this.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: this.conversationId,
+        surfaceId,
+        surfaceType: 'dynamic_page',
+        title: app.name,
+        data: { html: app.htmlDefinition, appId: app.id },
+      } as unknown as UiSurfaceShow);
+
+      return { content: JSON.stringify({ surfaceId, appId }), isError: false };
     }
 
     return { content: `Unknown proxy tool: ${toolName}`, isError: true };


### PR DESCRIPTION
## Summary
- Add `AppDataRequest` / `AppDataResponse` IPC message types for the JS-to-daemon data bridge, enabling dynamic page surfaces to perform CRUD operations on app records without involving the agent loop
- Add `app_data_request` daemon handler that dispatches to `app-store.ts` functions (`queryAppRecords`, `createAppRecord`, `updateAppRecord`, `deleteAppRecord`) with proper error handling
- Add `app_open` branch to `surfaceProxyResolver` in `Session` so the agent can open an app as a `dynamic_page` surface that communicates via the RPC bridge independently (non-blocking — agent continues immediately)

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests updated and passing (51 tests, 0 failures)
- [ ] Manual: verify `app_data_request` messages route correctly through the daemon handler
- [ ] Manual: verify `app_open` proxy tool creates a dynamic page surface and returns immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
