### PR TITLE
docs: describe macOS main-window chat flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,11 @@ graph TB
             TEXT_WIN["TextResponseWindow"]
         end
 
+        subgraph "Main Window Chat"
+            CHAT_VM["ChatViewModel<br/>session bootstrap + streaming"]
+            CHAT_VIEW["ChatView<br/>bubbles + composer + stop"]
+        end
+
         VOICE["VoiceInputManager<br/>Fn hold → SFSpeechRecognizer"]
         ATTACH["Attachment System<br/>images, PDFs, text<br/>drag/drop, paste, picker"]
         PERM["PermissionManager<br/>Accessibility, Screen Recording,<br/>Microphone"]
@@ -119,6 +124,11 @@ graph TB
     %% Text Q&A flow
     TEXT_SESS -->|"SessionCreate +<br/>UserMessage"| IPC_SERVER
     IPC_SERVER -->|"AssistantTextDelta<br/>stream"| TEXT_WIN
+
+    %% Main Window Chat flow
+    CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel"| IPC_SERVER
+    IPC_SERVER -->|"session_info +<br/>text deltas +<br/>message_complete"| CHAT_VM
+    CHAT_VIEW --> CHAT_VM
 
     %% Ambient flow
     WATCH --> AX_CAP
@@ -529,6 +539,7 @@ graph LR
         S8["confirmation_request<br/>tool, risk_level"]
         S9["memory_recalled<br/>context segments"]
         S10["usage_update / error"]
+        S11["generation_cancelled"]
     end
 
     C1 --> SOCKET
@@ -551,6 +562,7 @@ graph LR
     SOCKET --> S8
     SOCKET --> S9
     SOCKET --> S10
+    SOCKET --> S11
 ```
 
 ---

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -74,6 +74,11 @@ Grant these in System Settings → Privacy & Security.
 6. Or hold the Fn key to dictate a task via voice
 7. Watch the overlay as vellum-assistant works through the task
 8. Press Escape at any time to cancel
+9. The main window shows a chat interface — type a message to start a conversation
+10. Responses stream in real-time from the daemon
+11. Click the stop button to cancel an in-progress generation
+
+**Current limitations:** Single active generation at a time, text-only messages, no conversation history browser.
 
 ## Xcode Previews
 
@@ -162,6 +167,10 @@ Ambient/              Background screen-watching agent
   KnowledgeCron       Triggers periodic insight analysis
   InsightStore        Higher-level insights derived from observations
   ScreenOCR           Vision framework OCR
+Features/Chat/        Main window chat interface
+  ChatMessage         Message model (role, text, streaming state)
+  ChatView            Presentational view (bubbles, composer, thinking, error banner)
+  ChatViewModel       Session bootstrap, streaming, cancel via daemon IPC
 UI/                   SwiftUI views + overlay windows
   Onboarding/         First-launch setup flow (permissions, naming, Fn key)
 Logging/              Session recording to JSON


### PR DESCRIPTION
## Summary
- Add "Main Window Chat" subgraph (ChatViewModel, ChatView) and IPC flow connections to the system overview diagram in ARCHITECTURE.md
- Add `generation_cancelled` message type to the IPC Protocol diagram's Server-to-Client list
- Document the `Features/Chat/` module (ChatMessage, ChatView, ChatViewModel) in the macOS README architecture section
- Add usage steps 9-11 covering the main-window chat interface and current MVP limitations

## Test plan
- [x] `swift build` passes — docs-only change, no code affected
- [ ] Verify mermaid diagrams render correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
