### PR TITLE
macOS: add ChatViewModel tests for session, streaming, and cancel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -12,7 +12,7 @@ final class ChatViewModel: ObservableObject {
     @Published var errorText: String?
 
     private let daemonClient: DaemonClient
-    private var sessionId: String?
+    var sessionId: String?
     private var pendingUserMessage: String?
     private var messageLoopTask: Task<Void, Never>?
     private var currentAssistantMessageId: UUID?
@@ -112,7 +112,7 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func handleServerMessage(_ message: ServerMessage) {
+    func handleServerMessage(_ message: ServerMessage) {
         switch message {
         case .sessionInfo(let info):
             if sessionId == nil {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ChatViewModelTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        viewModel = ChatViewModel(daemonClient: daemonClient)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initialization
+
+    func testInitCreatesGreetingMessage() {
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].role, .assistant)
+        XCTAssertTrue(viewModel.messages[0].text.contains("How can I help"))
+    }
+
+    func testInitStartsWithEmptyInput() {
+        XCTAssertEqual(viewModel.inputText, "")
+    }
+
+    func testInitStartsNotSending() {
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testInitStartsNotThinking() {
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    func testInitStartsWithNoError() {
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    // MARK: - Send Message
+
+    func testSendMessageAppendsUserMessage() {
+        viewModel.inputText = "Hello world"
+        viewModel.sendMessage()
+
+        // Should have greeting + user message
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].role, .user)
+        XCTAssertEqual(viewModel.messages[1].text, "Hello world")
+    }
+
+    func testSendMessageClearsInput() {
+        viewModel.inputText = "Hello world"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.inputText, "")
+    }
+
+    func testSendEmptyMessageDoesNothing() {
+        viewModel.inputText = "   "
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messages.count, 1) // Just greeting
+    }
+
+    func testSendWhileSendingDoesNothing() {
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Second"
+        viewModel.sendMessage() // Should be ignored since isSending is set by bootstrapSession
+
+        XCTAssertEqual(viewModel.messages.count, 2) // greeting + first only
+    }
+
+    func testSendMessageClearsExistingError() {
+        viewModel.errorText = "Previous error"
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    // MARK: - Session Info
+
+    func testSessionInfoStoresSessionId() {
+        let info = SessionInfoMessage(sessionId: "test-123", title: "Test")
+        viewModel.handleServerMessage(.sessionInfo(info))
+        XCTAssertEqual(viewModel.sessionId, "test-123")
+    }
+
+    func testSessionInfoDoesNotOverwriteExistingSession() {
+        viewModel.sessionId = "first-session"
+        let info = SessionInfoMessage(sessionId: "second-session", title: "Test")
+        viewModel.handleServerMessage(.sessionInfo(info))
+        XCTAssertEqual(viewModel.sessionId, "first-session")
+    }
+
+    // MARK: - Streaming Deltas
+
+    func testTextDeltaCreatesAssistantMessage() {
+        let delta = AssistantTextDeltaMessage(text: "Hello")
+        viewModel.handleServerMessage(.assistantTextDelta(delta))
+
+        // Should have greeting + new assistant message
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].role, .assistant)
+        XCTAssertEqual(viewModel.messages[1].text, "Hello")
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+    }
+
+    func testTextDeltaClearsThinkingState() {
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Hi")))
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    func testTextDeltasAccumulateInSingleMessage() {
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Hel")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "lo ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "world")))
+
+        XCTAssertEqual(viewModel.messages.count, 2) // greeting + 1 assistant
+        XCTAssertEqual(viewModel.messages[1].text, "Hello world")
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+    }
+
+    // MARK: - Message Complete
+
+    func testMessageCompleteFinalizesState() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Start streaming
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
+
+        // Complete
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+
+    func testMessageCompleteWithoutStreamingMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Complete without any text deltas
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    // MARK: - Generation Cancelled
+
+    func testGenerationCancelledClearsLoadingState() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+
+    func testGenerationCancelledWithoutStreamingMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    // MARK: - Error Handling
+
+    func testErrorSetsErrorText() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.error(ErrorMessage(message: "Something failed")))
+
+        XCTAssertEqual(viewModel.errorText, "Something failed")
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    func testDismissErrorClearsErrorText() {
+        viewModel.errorText = "Some error"
+        viewModel.dismissError()
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    // MARK: - Stop Generating
+
+    func testStopGeneratingResetsState() {
+        // Set up as if we're in a streaming session
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.sessionId = "test-session"
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial response")))
+
+        viewModel.stopGenerating()
+
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+
+    func testStopGeneratingWithNoSessionDoesNothing() {
+        // Not sending, no session
+        viewModel.stopGenerating()
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testStopGeneratingWhenNotSendingDoesNothing() {
+        // Has session but not sending
+        viewModel.sessionId = "test-session"
+        viewModel.stopGenerating()
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    // MARK: - Thinking Delta
+
+    func testThinkingDeltaKeepsThinkingState() {
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantThinkingDelta(AssistantThinkingDeltaMessage(thinking: "Let me think...")))
+        XCTAssertTrue(viewModel.isThinking)
+    }
+
+    func testThinkingDeltaDoesNotCreateMessage() {
+        viewModel.handleServerMessage(.assistantThinkingDelta(AssistantThinkingDeltaMessage(thinking: "Hmm...")))
+        XCTAssertEqual(viewModel.messages.count, 1) // Only the greeting
+    }
+
+    // MARK: - Full Conversation Flow
+
+    func testFullConversationFlow() {
+        // Simulate a complete conversation: session created, text streamed, completed
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        XCTAssertEqual(viewModel.sessionId, "sess-1")
+
+        // Thinking starts
+        viewModel.isThinking = true
+        viewModel.isSending = true
+        viewModel.handleServerMessage(.assistantThinkingDelta(AssistantThinkingDeltaMessage(thinking: "Analyzing...")))
+        XCTAssertTrue(viewModel.isThinking)
+
+        // Text deltas arrive
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "The answer")))
+        XCTAssertFalse(viewModel.isThinking) // Thinking cleared on first text delta
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " is 42.")))
+        XCTAssertEqual(viewModel.messages[1].text, "The answer is 42.")
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+
+        // Message completes
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+}


### PR DESCRIPTION
## Summary
- Add 27 focused unit tests for `ChatViewModel` covering all core state machine transitions: initialization, message sending guards, session info handling, streaming text deltas, message completion, generation cancellation, error handling, stop generating, and a full conversation flow integration test.
- Change `handleServerMessage` and `sessionId` from `private` to `internal` visibility in `ChatViewModel.swift` so tests can drive the state machine directly via `@testable import`.

## Test plan
- [x] All 27 new `ChatViewModelTests` pass
- [x] Full test suite (86 tests) passes with 0 failures
- [x] Project builds cleanly with `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
