### PR TITLE
M4: Add Swift client RPC bridge for persistent apps

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -97,6 +97,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 data: codableData
             )
         }
+
+        // Data request: JS -> Swift -> daemon
+        surfaceManager.onDataRequest = { [weak self] surfaceId, callId, method, appId, recordId, data in
+            let codableData = data?.mapValues { AnyCodable($0) }
+            try? self?.daemonClient.send(AppDataRequestMessage(
+                surfaceId: surfaceId,
+                callId: callId,
+                method: method,
+                appId: appId,
+                recordId: recordId,
+                data: codableData
+            ))
+        }
+
+        // Data response: daemon -> Swift -> JS
+        daemonClient.onAppDataResponse = { [weak self] msg in
+            self?.surfaceManager.resolveDataResponse(surfaceId: msg.surfaceId, response: msg)
+        }
     }
 
     private func setupWindowObserver() {

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -4,20 +4,69 @@ import WebKit
 struct DynamicPageSurfaceView: NSViewRepresentable {
     let data: DynamicPageSurfaceData
     let onAction: (String, Any?) -> Void
+    let appId: String?
+    let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
+    let onCoordinatorReady: ((Coordinator) -> Void)?
+
+    init(
+        data: DynamicPageSurfaceData,
+        onAction: @escaping (String, Any?) -> Void,
+        appId: String? = nil,
+        onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
+        onCoordinatorReady: ((Coordinator) -> Void)? = nil
+    ) {
+        self.data = data
+        self.onAction = onAction
+        self.appId = appId
+        self.onDataRequest = onDataRequest
+        self.onCoordinatorReady = onCoordinatorReady
+    }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction, currentHTML: data.html)
+        Coordinator(onAction: onAction, onDataRequest: onDataRequest, currentHTML: data.html)
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        let userScript = WKUserScript(
-            source: """
-                window.vellum = {
-                    sendAction: function(actionId, data) {
-                        window.webkit.messageHandlers.vellumBridge.postMessage({actionId: actionId, data: data});
+        var jsSource = """
+            window.vellum = {
+                sendAction: function(actionId, data) {
+                    window.webkit.messageHandlers.vellumBridge.postMessage({actionId: actionId, data: data});
+                }
+            };
+            """
+
+        if appId != nil {
+            jsSource += """
+
+                window.vellum.data = {
+                    _pending: {},
+                    _nextId: 1,
+                    _call: function(method, params) {
+                        return new Promise(function(resolve, reject) {
+                            var callId = 'c' + (window.vellum.data._nextId++);
+                            window.vellum.data._pending[callId] = { resolve: resolve, reject: reject };
+                            var msg = { type: 'data_request', callId: callId, method: method };
+                            if (params.recordId !== undefined) msg.recordId = params.recordId;
+                            if (params.data !== undefined) msg.data = params.data;
+                            window.webkit.messageHandlers.vellumBridge.postMessage(msg);
+                        });
+                    },
+                    query: function() { return this._call('query', {}); },
+                    create: function(data) { return this._call('create', { data: data }); },
+                    update: function(recordId, data) { return this._call('update', { recordId: recordId, data: data }); },
+                    delete: function(recordId) { return this._call('delete', { recordId: recordId }); },
+                    _resolve: function(callId, success, result, error) {
+                        var p = this._pending[callId];
+                        if (!p) return;
+                        delete this._pending[callId];
+                        if (success) p.resolve(result); else p.reject(new Error(error || 'Unknown error'));
                     }
                 };
-                """,
+                """
+        }
+
+        let userScript = WKUserScript(
+            source: jsSource,
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
@@ -32,6 +81,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.allowsLinkPreview = false
         webView.navigationDelegate = context.coordinator
+        context.coordinator.webView = webView
+        onCoordinatorReady?(context.coordinator)
         webView.loadHTMLString(data.html, baseURL: nil)
 
         return webView
@@ -39,6 +90,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.onAction = onAction
+        context.coordinator.onDataRequest = onDataRequest
 
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
@@ -55,10 +107,17 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
     class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         var onAction: (String, Any?) -> Void
+        var onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
         var currentHTML: String
+        weak var webView: WKWebView?
 
-        init(onAction: @escaping (String, Any?) -> Void, currentHTML: String) {
+        init(
+            onAction: @escaping (String, Any?) -> Void,
+            onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
+            currentHTML: String
+        ) {
             self.onAction = onAction
+            self.onDataRequest = onDataRequest
             self.currentHTML = currentHTML
         }
 
@@ -66,12 +125,45 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             _ userContentController: WKUserContentController,
             didReceive message: WKScriptMessage
         ) {
-            guard let body = message.body as? [String: Any],
-                  let actionId = body["actionId"] as? String else {
+            guard let body = message.body as? [String: Any] else { return }
+
+            // Handle data_request messages from the RPC bridge.
+            if let type = body["type"] as? String, type == "data_request" {
+                guard let callId = body["callId"] as? String,
+                      let method = body["method"] as? String else { return }
+                let recordId = body["recordId"] as? String
+                let data = body["data"] as? [String: Any]
+                onDataRequest?(callId, method, recordId, data)
                 return
             }
+
+            // Existing sendAction handling.
+            guard let actionId = body["actionId"] as? String else { return }
             let data = body["data"]
             onAction(actionId, data)
+        }
+
+        func resolveDataResponse(_ response: AppDataResponseMessage) {
+            let resultJson: String
+            if let result = response.result {
+                if let jsonData = try? JSONEncoder().encode(result),
+                   let jsonStr = String(data: jsonData, encoding: .utf8) {
+                    resultJson = jsonStr
+                } else {
+                    resultJson = "null"
+                }
+            } else {
+                resultJson = "null"
+            }
+            let errorStr: String
+            if let error = response.error {
+                errorStr = "'\(error.replacingOccurrences(of: "'", with: "\\'"))'"
+            } else {
+                errorStr = "null"
+            }
+            webView?.evaluateJavaScript(
+                "window.vellum.data._resolve('\(response.callId)', \(response.success), \(resultJson), \(errorStr))"
+            )
         }
 
         func webView(

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -45,9 +45,15 @@ struct SurfaceContainerView: View {
                     }
                 )
             case .dynamicPage(let data):
-                DynamicPageSurfaceView(data: data, onAction: { actionId, actionData in
-                    viewModel.onAction(actionId, actionData as? [String: Any])
-                })
+                DynamicPageSurfaceView(
+                    data: data,
+                    onAction: { actionId, actionData in
+                        viewModel.onAction(actionId, actionData as? [String: Any])
+                    },
+                    appId: viewModel.appId,
+                    onDataRequest: viewModel.onDataRequest,
+                    onCoordinatorReady: viewModel.onCoordinatorReady
+                )
                 .frame(
                     width: CGFloat(data.width ?? 380),
                     height: CGFloat(data.height ?? 500)

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -11,11 +11,24 @@ final class SurfaceViewModel: ObservableObject {
     @Published var surface: Surface
     let onAction: (String, [String: Any]?) -> Void
     let onDismiss: () -> Void
+    let appId: String?
+    let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
+    let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
 
-    init(surface: Surface, onAction: @escaping (String, [String: Any]?) -> Void, onDismiss: @escaping () -> Void) {
+    init(
+        surface: Surface,
+        onAction: @escaping (String, [String: Any]?) -> Void,
+        onDismiss: @escaping () -> Void,
+        appId: String? = nil,
+        onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
+        onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil
+    ) {
         self.surface = surface
         self.onAction = onAction
         self.onDismiss = onDismiss
+        self.appId = appId
+        self.onDataRequest = onDataRequest
+        self.onCoordinatorReady = onCoordinatorReady
     }
 }
 
@@ -35,6 +48,12 @@ final class SurfaceManager: ObservableObject {
     private var panels: [String: NSPanel] = [:]
     private var viewModels: [String: SurfaceViewModel] = [:]
 
+    /// Tracks appId per surface for persistent app RPC routing.
+    var surfaceAppIds: [String: String] = [:]
+
+    /// Tracks Coordinator per surface for routing data responses back to WebView.
+    var surfaceCoordinators: [String: DynamicPageSurfaceView.Coordinator] = [:]
+
     /// Ordered list of surface IDs for deterministic stacking positions.
     private var surfaceOrder: [String] = []
 
@@ -47,6 +66,10 @@ final class SurfaceManager: ObservableObject {
     /// Called when a user interacts with a surface action button.
     /// Parameters: sessionId, surfaceId, actionId, optional data dictionary.
     var onAction: ((String, String, String, [String: Any]?) -> Void)?
+
+    /// Called when a persistent app's JS makes a data request via the RPC bridge.
+    /// Parameters: surfaceId, callId, method, appId, recordId, data.
+    var onDataRequest: ((String, String, String, String, String?, [String: Any]?) -> Void)?
 
     // MARK: - Show
 
@@ -64,6 +87,14 @@ final class SurfaceManager: ObservableObject {
         activeSurfaces[surface.id] = surface
         surfaceOrder.append(surface.id)
 
+        // Extract and track appId for persistent app RPC routing.
+        let dict = message.data.value as? [String: Any?] ?? [:]
+        if let appId = dict["appId"] as? String {
+            surfaceAppIds[surface.id] = appId
+        }
+
+        let appId = surfaceAppIds[surface.id]
+
         let viewModel = SurfaceViewModel(
             surface: surface,
             onAction: { [weak self] actionId, data in
@@ -72,7 +103,15 @@ final class SurfaceManager: ObservableObject {
             onDismiss: { [weak self] in
                 self?.onAction?(surface.sessionId, surface.id, "dismiss", nil)
                 self?.dismissSurfaceById(surface.id)
-            }
+            },
+            appId: appId,
+            onDataRequest: appId != nil ? { [weak self] callId, method, recordId, data in
+                guard let appId = self?.surfaceAppIds[surface.id] else { return }
+                self?.onDataRequest?(surface.id, callId, method, appId, recordId, data)
+            } : nil,
+            onCoordinatorReady: appId != nil ? { [weak self] coordinator in
+                self?.surfaceCoordinators[surface.id] = coordinator
+            } : nil
         )
         viewModels[surface.id] = viewModel
 
@@ -153,6 +192,8 @@ final class SurfaceManager: ObservableObject {
             log.info("Dismissed surface: id=\(id)")
         }
         surfaceOrder.removeAll()
+        surfaceAppIds.removeAll()
+        surfaceCoordinators.removeAll()
     }
 
     private func dismissSurfaceById(_ surfaceId: String) {
@@ -160,9 +201,18 @@ final class SurfaceManager: ObservableObject {
         panels.removeValue(forKey: surfaceId)
         viewModels.removeValue(forKey: surfaceId)
         activeSurfaces.removeValue(forKey: surfaceId)
+        surfaceAppIds.removeValue(forKey: surfaceId)
+        surfaceCoordinators.removeValue(forKey: surfaceId)
         surfaceOrder.removeAll { $0 == surfaceId }
         repositionAllPanels()
         log.info("Dismissed surface: id=\(surfaceId)")
+    }
+
+    // MARK: - Data Response Routing
+
+    /// Routes a data response from the daemon back to the correct WebView coordinator.
+    func resolveDataResponse(surfaceId: String, response: AppDataResponseMessage) {
+        surfaceCoordinators[surfaceId]?.resolveDataResponse(response)
     }
 
     // MARK: - Positioning

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -38,6 +38,9 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `ui_surface_dismiss` message.
     var onSurfaceDismiss: ((UiSurfaceDismissMessage) -> Void)?
 
+    /// Called when the daemon sends an `app_data_response` message.
+    var onAppDataResponse: ((AppDataResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -368,6 +371,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSurfaceUpdate?(msg)
         case .uiSurfaceDismiss(let msg):
             onSurfaceDismiss?(msg)
+        case .appDataResponse(let msg):
+            onAppDataResponse?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -174,6 +174,18 @@ struct UiSurfaceActionMessage: Encodable, Sendable {
     let data: [String: AnyCodable]?
 }
 
+/// Sent when a persistent app's JS makes a data request via the RPC bridge.
+/// Wire type: `"app_data_request"`
+struct AppDataRequestMessage: Encodable, Sendable {
+    let type: String = "app_data_request"
+    let surfaceId: String
+    let callId: String
+    let method: String
+    let appId: String
+    let recordId: String?
+    let data: [String: AnyCodable]?
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -275,6 +287,16 @@ struct ErrorMessage: Decodable, Sendable {
     let message: String
 }
 
+/// Response from the daemon for a persistent app data request.
+/// Wire type: `"app_data_response"`
+struct AppDataResponseMessage: Decodable, Sendable {
+    let surfaceId: String
+    let callId: String
+    let success: Bool
+    let result: AnyCodable?
+    let error: String?
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {
@@ -292,6 +314,7 @@ enum ServerMessage: Decodable, Sendable {
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
     case generationCancelled(GenerationCancelledMessage)
+    case appDataResponse(AppDataResponseMessage)
     case pong
     case unknown(String)
 
@@ -346,6 +369,9 @@ enum ServerMessage: Decodable, Sendable {
         case "generation_cancelled":
             let message = try GenerationCancelledMessage(from: decoder)
             self = .generationCancelled(message)
+        case "app_data_response":
+            let message = try AppDataResponseMessage(from: decoder)
+            self = .appDataResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add `AppDataRequestMessage` and `AppDataResponseMessage` IPC structs with `ServerMessage` decoder support for the `app_data_request`/`app_data_response` wire types
- Inject `window.vellum.data` JavaScript API (query/create/update/delete) into WKWebView when a surface has an `appId`, enabling persistent apps to make async data requests via the bridge
- Wire the full RPC round-trip: JS calls post to native Coordinator, which forwards through SurfaceManager to DaemonClient, and responses route back from daemon through DaemonClient callback to the correct surface's Coordinator which evaluates the JS resolve callback

## Test plan
- [ ] Verify build succeeds with `./build.sh`
- [ ] Confirm existing surface types (card, form, list, confirmation, dynamic_page without appId) work unchanged
- [ ] Test persistent app surface with appId: verify `window.vellum.data` is available in JS
- [ ] Test data request round-trip: JS `query()` -> daemon receives `app_data_request` -> daemon sends `app_data_response` -> JS promise resolves
- [ ] Test error path: daemon sends response with `success: false` -> JS promise rejects with error
- [ ] Verify surface dismiss cleans up surfaceAppIds and surfaceCoordinators

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
