### PR TITLE
Fix duplicate tool definitions and remove no-op import

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -93,7 +93,7 @@ export class Session {
     const toolDefs = [
       ...getAllToolDefinitions(),
       ...allUiSurfaceTools.map((t) => t.getDefinition()),
-      ...allAppTools.map((t) => t.getDefinition()),
+      ...allAppTools.filter((t) => t.executionMode === 'proxy').map((t) => t.getDefinition()),
     ];
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
       return this.executor.execute(name, input, {

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -104,8 +104,6 @@ export async function initializeTools(): Promise<void> {
   await import('./weather/get-weather.js');
   await import('./timer/pomodoro.js');
   await import('./system/system-info.js');
-  await import('./apps/definitions.js');
-
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded
   // from getAllToolDefinitions() since regular chat sessions don't use them.


### PR DESCRIPTION
## Summary
- **Fix duplicate tool definitions (P1):** In `session.ts`, `allAppTools.map(...)` was adding all 6 app tool definitions to `toolDefs`, but 5 of them (the local ones) were already included via `getAllToolDefinitions()` after `registerAppTools()` registered them in the global tools map. This caused the Anthropic API to reject requests due to duplicate tool names. Fixed by filtering `allAppTools` to only include proxy tools (`app_open`).
- **Remove no-op import (P2):** `await import('./apps/definitions.js')` in `initializeTools()` was a no-op because that module has no side-effect `registerTool()` calls at module scope — app tool registration happens per-session via `registerAppTools()`.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify that chat sessions correctly expose all 6 app tools (no duplicates) and the Anthropic API accepts requests
- [ ] Verify `app_open` (the only proxy tool) still works as a proxy tool in sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
