### PR TITLE
Fix path traversal and orphaned records in app-store

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -40,6 +40,12 @@ export interface AppRecord {
   updatedAt: number;
 }
 
+function validateId(id: string): void {
+  if (!id || id.includes('/') || id.includes('\\') || id.includes('..') || id !== id.trim()) {
+    throw new Error(`Invalid ID: ${id}`);
+  }
+}
+
 export function getAppsDir(): string {
   const dir = join(getDataDir(), 'apps');
   mkdirSync(dir, { recursive: true });
@@ -68,6 +74,7 @@ export function createApp(params: {
 }
 
 export function getApp(id: string): AppDefinition | null {
+  validateId(id);
   const filePath = join(getAppsDir(), `${id}.json`);
   if (!existsSync(filePath)) return null;
   const raw = readFileSync(filePath, 'utf-8');
@@ -96,6 +103,7 @@ export function updateApp(
   id: string,
   updates: Partial<Pick<AppDefinition, 'name' | 'description' | 'schemaJson' | 'htmlDefinition'>>,
 ): AppDefinition {
+  validateId(id);
   const existing = getApp(id);
   if (!existing) throw new Error(`App not found: ${id}`);
   const updated: AppDefinition = {
@@ -108,6 +116,7 @@ export function updateApp(
 }
 
 export function deleteApp(id: string): void {
+  validateId(id);
   const dir = getAppsDir();
   const filePath = join(dir, `${id}.json`);
   if (existsSync(filePath)) {
@@ -118,6 +127,9 @@ export function deleteApp(id: string): void {
 }
 
 export function createAppRecord(appId: string, data: Record<string, unknown>): AppRecord {
+  validateId(appId);
+  const app = getApp(appId);
+  if (!app) throw new Error(`App not found: ${appId}`);
   const recordsDir = join(getAppsDir(), appId, 'records');
   mkdirSync(recordsDir, { recursive: true });
   const now = Date.now();
@@ -133,6 +145,8 @@ export function createAppRecord(appId: string, data: Record<string, unknown>): A
 }
 
 export function getAppRecord(appId: string, recordId: string): AppRecord | null {
+  validateId(appId);
+  validateId(recordId);
   const filePath = join(getAppsDir(), appId, 'records', `${recordId}.json`);
   if (!existsSync(filePath)) return null;
   const raw = readFileSync(filePath, 'utf-8');
@@ -140,6 +154,7 @@ export function getAppRecord(appId: string, recordId: string): AppRecord | null 
 }
 
 export function queryAppRecords(appId: string): AppRecord[] {
+  validateId(appId);
   const recordsDir = join(getAppsDir(), appId, 'records');
   if (!existsSync(recordsDir)) return [];
   const entries = readdirSync(recordsDir);
@@ -161,6 +176,8 @@ export function updateAppRecord(
   recordId: string,
   data: Record<string, unknown>,
 ): AppRecord {
+  validateId(appId);
+  validateId(recordId);
   const existing = getAppRecord(appId, recordId);
   if (!existing) throw new Error(`AppRecord not found: ${appId}/${recordId}`);
   const updated: AppRecord = {
@@ -176,6 +193,8 @@ export function updateAppRecord(
 }
 
 export function deleteAppRecord(appId: string, recordId: string): void {
+  validateId(appId);
+  validateId(recordId);
   const filePath = join(getAppsDir(), appId, 'records', `${recordId}.json`);
   if (existsSync(filePath)) {
     unlinkSync(filePath);


### PR DESCRIPTION
## Summary
- Add `validateId()` helper to reject IDs containing path separators (`/`, `\`), `..`, leading/trailing whitespace, or empty strings, preventing directory traversal attacks in all app-store functions
- Guard `createAppRecord` against non-existent apps by checking `getApp(appId)` before creating the records directory, preventing orphaned record files
- Especially critical for `deleteApp` which calls `rmSync` with `recursive: true, force: true`

## Test plan
- [ ] Verify `validateId` rejects malicious inputs: `../../etc`, `foo/bar`, ` spaced `, empty string
- [ ] Verify `createAppRecord` throws when given a non-existent appId
- [ ] Verify all normal CRUD operations still work with valid UUID ids
- [ ] `bunx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
