### PR TITLE
Fix JS injection and escaping in resolveDataResponse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -157,12 +157,20 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             }
             let errorStr: String
             if let error = response.error {
-                errorStr = "'\(error.replacingOccurrences(of: "'", with: "\\'"))'"
+                let escaped = error
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                    .replacingOccurrences(of: "\r", with: "\\r")
+                errorStr = "'\(escaped)'"
             } else {
                 errorStr = "null"
             }
+            let safeCallId = response.callId
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
             webView?.evaluateJavaScript(
-                "window.vellum.data._resolve('\(response.callId)', \(response.success), \(resultJson), \(errorStr))"
+                "window.vellum.data._resolve('\(safeCallId)', \(response.success), \(resultJson), \(errorStr))"
             )
         }
 


### PR DESCRIPTION
## Summary
- Sanitize `callId` by escaping backslashes and single quotes before JS interpolation
- Fix incomplete `error` string escaping: escape backslashes first, then single quotes, newlines, carriage returns
- Prevents JavaScript injection via malicious callId or error strings from daemon responses

Addresses review feedback on #867.

## Test plan
- [x] Swift build succeeds with no errors
- [ ] Verify data requests/responses work end-to-end in a dynamic page surface
- [ ] Verify error messages with special characters (quotes, backslashes, newlines) display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
