### PR TITLE
Add appId to DynamicPageSurfaceData + validate handler inputs

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -543,13 +543,17 @@ function handleAppDataRequest(
         result = queryAppRecords(appId);
         break;
       case 'create':
-        result = createAppRecord(appId, data!);
+        if (!data) throw new Error('data is required for create');
+        result = createAppRecord(appId, data);
         break;
       case 'update':
-        result = updateAppRecord(appId, recordId!, data!);
+        if (!recordId) throw new Error('recordId is required for update');
+        if (!data) throw new Error('data is required for update');
+        result = updateAppRecord(appId, recordId, data);
         break;
       case 'delete':
-        deleteAppRecord(appId, recordId!);
+        if (!recordId) throw new Error('recordId is required for delete');
+        deleteAppRecord(appId, recordId);
         result = null;
         break;
       default:

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -190,6 +190,7 @@ export interface DynamicPageSurfaceData {
   html: string;
   width?: number;
   height?: number;
+  appId?: string;
 }
 
 export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -708,7 +708,7 @@ export class Session {
       const surfaceId = uuid();
       this.surfaceState.set(surfaceId, {
         surfaceType: 'dynamic_page',
-        data: { html: app.htmlDefinition } as DynamicPageSurfaceData,
+        data: { html: app.htmlDefinition, appId: app.id } as DynamicPageSurfaceData,
       });
 
       this.sendToClient({
@@ -718,7 +718,7 @@ export class Session {
         surfaceType: 'dynamic_page',
         title: app.name,
         data: { html: app.htmlDefinition, appId: app.id },
-      } as unknown as UiSurfaceShow);
+      } as UiSurfaceShow);
 
       return { content: JSON.stringify({ surfaceId, appId }), isError: false };
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -118,6 +118,7 @@ struct DynamicPageSurfaceData: Sendable {
     let html: String
     let width: Int?
     let height: Int?
+    let appId: String?
 }
 
 enum SurfaceData: Sendable {
@@ -321,7 +322,8 @@ extension Surface {
         let html = (update["html"] as? String) ?? existing.html
         let width: Int? = update.keys.contains("width") ? (update["width"] as? Int) : existing.width
         let height: Int? = update.keys.contains("height") ? (update["height"] as? Int) : existing.height
-        return DynamicPageSurfaceData(html: html, width: width, height: height)
+        let appId: String? = update.keys.contains("appId") ? (update["appId"] as? String) : existing.appId
+        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId)
     }
 
     // MARK: - Field Parsing Helpers
@@ -443,7 +445,8 @@ extension Surface {
         return DynamicPageSurfaceData(
             html: html,
             width: dict["width"] as? Int,
-            height: dict["height"] as? Int
+            height: dict["height"] as? Int,
+            appId: dict["appId"] as? String
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add `appId?: string` to `DynamicPageSurfaceData` interface so `app_open` proxy data flows through typed protocol
- Update Swift `DynamicPageSurfaceData` struct, parser, and merge function to extract `appId`
- Update `surfaceState` storage to include `appId` and remove unsafe `as unknown` cast
- Add validation guards in `handleAppDataRequest` for `data` and `recordId` fields, replacing non-null assertions

Addresses review feedback on #864.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
