### PR TITLE
Interview UX polish: voice input, button timing, suggestion chips (#881)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -7,12 +7,25 @@ struct InterviewChatView: View {
     let onSend: () -> Void
     let onVoiceToggle: () -> Void
     let isRecording: Bool
+    var onChipTap: ((String) -> Void)? = nil
+
+    /// Whether suggestion chips should be visible.
+    private var showSuggestionChips: Bool {
+        let hasGreeting = messages.contains { $0.role == .assistant }
+        let hasUserMessage = messages.contains { $0.role == .user }
+        return hasGreeting && !hasUserMessage && inputText.isEmpty
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             messageList
+            if showSuggestionChips {
+                suggestionChips
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
             inputArea
         }
+        .animation(VAnimation.standard, value: showSuggestionChips)
     }
 
     // MARK: - Message List
@@ -51,6 +64,43 @@ struct InterviewChatView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Suggestion Chips
+
+    private static let chipTexts = [
+        "What I do for work",
+        "Something I need help with",
+        "Just exploring for now",
+    ]
+
+    private var suggestionChips: some View {
+        HStack(spacing: VSpacing.sm) {
+            ForEach(Self.chipTexts, id: \.self) { chip in
+                Button {
+                    onChipTap?(chip)
+                } label: {
+                    Text(chip)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(VColor.surface)
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.set() }
+                    else { NSCursor.arrow.set() }
+                }
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Input Area

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -8,6 +8,9 @@ struct InterviewStepView: View {
     @State private var viewModel: InterviewViewModel
     @State private var showControls = false
     @State private var streamingMessageId = UUID()
+    @State private var isRecording = false
+
+    private let voiceInputManager = VoiceInputManager()
 
     init(state: OnboardingState, daemonClient: DaemonClientProtocol, onComplete: @escaping () -> Void) {
         self.state = state
@@ -28,7 +31,12 @@ struct InterviewStepView: View {
         return msgs
     }
 
-    /// Show the "ready" button once we have at least one assistant message.
+    /// Show the "ready" button once we have at least 2 complete assistant exchanges.
+    private var hasEnoughExchanges: Bool {
+        viewModel.messages.filter { $0.role == .assistant }.count >= 2
+    }
+
+    /// Show the skip link once the first assistant greeting has fully completed.
     private var hasAssistantMessage: Bool {
         viewModel.messages.contains { $0.role == .assistant }
     }
@@ -54,15 +62,19 @@ struct InterviewStepView: View {
                 inputText: $viewModel.inputText,
                 isThinking: viewModel.isThinking,
                 onSend: { viewModel.sendMessage() },
-                onVoiceToggle: {},
-                isRecording: false
+                onVoiceToggle: { toggleVoice() },
+                isRecording: isRecording,
+                onChipTap: { chip in
+                    viewModel.inputText = chip
+                    viewModel.sendMessage()
+                }
             )
             .frame(maxHeight: .infinity)
             .allowsHitTesting(!viewModel.isFinished)
 
             // Bottom controls
             VStack(spacing: VSpacing.md) {
-                if hasAssistantMessage && showControls {
+                if hasEnoughExchanges && showControls {
                     OnboardingButton(
                         title: viewModel.isFinished ? "Let\u{2019}s get started!" : "I\u{2019}m ready to go!",
                         style: .primary
@@ -75,7 +87,7 @@ struct InterviewStepView: View {
                     .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: viewModel.isFinished)
                 }
 
-                if !viewModel.isFinished {
+                if !viewModel.isFinished && hasAssistantMessage {
                     Button {
                         viewModel.endInterview()
                         onComplete()
@@ -95,6 +107,7 @@ struct InterviewStepView: View {
         }
         .onAppear {
             viewModel.startInterview()
+            setupVoiceCallbacks()
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showControls = true
@@ -102,7 +115,31 @@ struct InterviewStepView: View {
             }
         }
         .onDisappear {
+            voiceInputManager.stop()
             viewModel.cancel()
+        }
+    }
+
+    // MARK: - Voice Input
+
+    private func setupVoiceCallbacks() {
+        voiceInputManager.onTranscription = { text in
+            viewModel.inputText = text
+            viewModel.sendMessage()
+        }
+        voiceInputManager.onPartialTranscription = { text in
+            viewModel.inputText = text
+        }
+        voiceInputManager.onRecordingStateChanged = { recording in
+            isRecording = recording
+        }
+    }
+
+    private func toggleVoice() {
+        if isRecording {
+            voiceInputManager.stop()
+        } else {
+            voiceInputManager.start()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -30,6 +30,7 @@ final class InterviewViewModel {
     private let maxTurns = 7
     private var sessionId: String?
     private var currentTask: Task<Void, Never>?
+    private var startTime: Date?
 
     /// Number of completed assistant responses (greeting counts as turn 1).
     var turnCount: Int {
@@ -58,6 +59,7 @@ final class InterviewViewModel {
         Do not use bullet points or lists.
         """
 
+        startTime = Date()
         isThinking = true
         streamingText = ""
 
@@ -280,6 +282,13 @@ final class InterviewViewModel {
 
     /// Marks the interview as complete and cancels any in-progress streaming.
     func endInterview() {
+        if let startTime {
+            let duration = Date().timeIntervalSince(startTime)
+            let turns = self.turnCount
+            let finished = self.isFinished
+            log.info("Interview completed: turns=\(turns), finished=\(finished), duration=\(String(format: "%.1f", duration))s")
+        }
+
         isComplete = true
         currentTask?.cancel()
         currentTask = nil


### PR DESCRIPTION
## Summary
- Wire `VoiceInputManager` into the interview step so the mic button actually starts/stops recording and auto-sends transcribed text to the chat
- Delay the "I'm ready to go!" button until at least 2 complete assistant exchanges (was 1), encouraging more conversation
- Delay the "I'm good, let's go" skip link until the first assistant greeting has fully completed (prevents premature skip)
- Add suggestion chips ("What I do for work", "Something I need help with", "Just exploring for now") between the message list and input area, shown only before the user's first message, using capsule pill styling with design system tokens
- Track interview `startTime` and log turn count, finished state, and duration on `endInterview()` for analytics

Closes #881

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Run onboarding interview step and verify mic button starts/stops recording
- [ ] Verify suggestion chips appear after the assistant greeting and disappear after the first user message
- [ ] Verify "I'm ready to go!" button only appears after 2 assistant responses
- [ ] Verify "I'm good, let's go" skip link only appears after the first assistant greeting completes
- [ ] Check console logs for "Interview completed" message with turns, finished, and duration metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
