### PR TITLE
Escape newlines in callId for JS interpolation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -169,6 +169,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             let safeCallId = response.callId
                 .replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
             webView?.evaluateJavaScript(
                 "window.vellum.data._resolve('\(safeCallId)', \(response.success), \(resultJson), \(errorStr))"
             )


### PR DESCRIPTION
## Summary
- Add `\n` and `\r` escaping to `safeCallId` in `resolveDataResponse`, matching the escaping already applied to error strings

Addresses review feedback on #875.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
