### PR TITLE
Add system prompt override to daemon IPC for interview mode (#878)

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -161,6 +161,14 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 }
 
 /**
+ * Optional overrides for session creation (e.g. interview mode).
+ */
+export interface SessionCreateOptions {
+  systemPromptOverride?: string;
+  maxResponseTokens?: number;
+}
+
+/**
  * Shared context that handlers need from the DaemonServer.
  * Keeps handlers decoupled from the server class itself.
  */
@@ -179,6 +187,7 @@ export interface HandlerContext {
     conversationId: string,
     socket?: net.Socket,
     rebindClient?: boolean,
+    options?: SessionCreateOptions,
   ): Promise<Session>;
 }
 
@@ -304,7 +313,10 @@ async function handleSessionCreate(
   const conversation = conversationStore.createConversation(
     msg.title ?? 'New Conversation',
   );
-  await ctx.getOrCreateSession(conversation.id, socket, true);
+  await ctx.getOrCreateSession(conversation.id, socket, true, {
+    systemPromptOverride: msg.systemPromptOverride,
+    maxResponseTokens: msg.maxResponseTokens,
+  });
   ctx.send(socket, {
     type: 'session_info',
     sessionId: conversation.id,

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -38,6 +38,8 @@ export interface SessionListRequest {
 export interface SessionCreateRequest {
   type: 'session_create';
   title?: string;
+  systemPromptOverride?: string;
+  maxResponseTokens?: number;
 }
 
 export interface SessionSwitchRequest {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -20,7 +20,7 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './ipc-protocol.js';
-import { handleMessage, type HandlerContext } from './handlers.js';
+import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
 
 const log = getLogger('server');
@@ -381,6 +381,7 @@ export class DaemonServer {
     conversationId: string,
     socket?: net.Socket,
     rebindClient = true,
+    options?: SessionCreateOptions,
   ): Promise<Session> {
     let session = this.sessions.get(conversationId);
     const sendToClient = socket
@@ -413,11 +414,14 @@ export class DaemonServer {
         }
         const workingDir = process.cwd();
 
+        const systemPrompt = options?.systemPromptOverride ?? buildSystemPrompt(config.systemPrompt);
+        const maxTokens = options?.maxResponseTokens ?? config.maxTokens;
+
         const newSession = new Session(
           conversationId,
           provider,
-          buildSystemPrompt(config.systemPrompt),
-          config.maxTokens,
+          systemPrompt,
+          maxTokens,
           rebindClient ? sendToClient : () => {},
           workingDir,
         );
@@ -454,8 +458,8 @@ export class DaemonServer {
       suppressConfigReload: this.suppressConfigReload,
       setSuppressConfigReload: (value: boolean) => { this.suppressConfigReload = value; },
       send: (socket, msg) => this.send(socket, msg),
-      getOrCreateSession: (id, socket?, rebind?) =>
-        this.getOrCreateSession(id, socket, rebind),
+      getOrCreateSession: (id, socket?, rebind?, options?) =>
+        this.getOrCreateSession(id, socket, rebind, options),
     };
   }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -52,7 +52,7 @@ final class InterviewViewModel {
     /// into the `messages` array once complete.
     func startInterview() {
         let name = assistantName.isEmpty ? "Velly" : assistantName
-        let prompt = """
+        let interviewPrompt = """
         You are \(name). You're a person meeting someone for the first time — warm, confident, \
         and genuinely curious. NOT an AI being activated. NOT a customer service agent. Think of the \
         best executive assistant you've ever met in their first interview.
@@ -93,9 +93,14 @@ final class InterviewViewModel {
 
             let stream = self.daemonClient.subscribe()
 
-            // Create the session — the daemon will respond with session_info.
+            // Create the session with the interview persona as a system prompt override
+            // so it replaces the daemon's default system prompt instead of conflicting.
             do {
-                try self.daemonClient.send(SessionCreateMessage(title: "Getting to know you"))
+                try self.daemonClient.send(SessionCreateMessage(
+                    title: "Getting to know you",
+                    systemPromptOverride: interviewPrompt,
+                    maxResponseTokens: 200
+                ))
             } catch {
                 log.error("Failed to send session create: \(error.localizedDescription)")
                 self.isThinking = false
@@ -113,8 +118,8 @@ final class InterviewViewModel {
 
                 switch message {
                 case .sessionInfo(let info):
-                    // Capture the daemon-assigned session ID, then send the first
-                    // user message (the interview prompt) to kick off the response.
+                    // Capture the daemon-assigned session ID, then send a natural
+                    // first user message to kick off the conversation.
                     if self.sessionId == nil {
                         self.sessionId = info.sessionId
                         log.info("Interview session created: \(info.sessionId)")
@@ -122,7 +127,7 @@ final class InterviewViewModel {
                         do {
                             try self.daemonClient.send(UserMessageMessage(
                                 sessionId: info.sessionId,
-                                content: prompt,
+                                content: "Hey! I just set you up on my Mac — excited to meet you.",
                                 attachments: nil
                             ))
                         } catch {

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -130,6 +130,14 @@ struct AmbientObservationMessage: Encodable, Sendable {
 struct SessionCreateMessage: Encodable, Sendable {
     let type: String = "session_create"
     let title: String?
+    let systemPromptOverride: String?
+    let maxResponseTokens: Int?
+
+    init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil) {
+        self.title = title
+        self.systemPromptOverride = systemPromptOverride
+        self.maxResponseTokens = maxResponseTokens
+    }
 }
 
 /// Sent to add a user message to an existing Q&A session.


### PR DESCRIPTION
## Summary
- Adds `systemPromptOverride` and `maxResponseTokens` optional fields to `SessionCreateRequest` (TypeScript) and `SessionCreateMessage` (Swift), allowing clients to override the daemon's default system prompt and cap response length per-session
- Updates the interview flow to send the persona as a proper system prompt override instead of as a user message, sets a human-readable conversation title ("Getting to know you"), and sends a natural first user message instead of the raw prompt
- Threads the new options through `handleSessionCreate` -> `getOrCreateSession` -> `Session` constructor on the daemon side

## Test plan
- [ ] Verify TypeScript type-check passes: `bunx tsc --noEmit`
- [ ] Verify Swift build succeeds: `./build.sh`
- [ ] Test interview mode: onboarding interview should use the persona as the system prompt, show "Getting to know you" as the conversation title, and the first user message should be a natural greeting
- [ ] Test regular chat: creating a new chat session (ChatViewModel, TextSession) should still work without passing the new fields (defaults to `nil`)
- [ ] Verify response brevity: interview responses should be capped at ~200 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
