### PR TITLE
Add per-session message queue for rapid-fire messages (#871)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -503,3 +503,20 @@ exports[`IPC message snapshots ServerMessage types app_data_response serializes 
   "type": "app_data_response",
 }
 `;
+
+exports[`IPC message snapshots ServerMessage types message_queued serializes to expected JSON 1`] = `
+{
+  "position": 1,
+  "requestId": "req-queue-001",
+  "sessionId": "sess-001",
+  "type": "message_queued",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types message_dequeued serializes to expected JSON 1`] = `
+{
+  "requestId": "req-queue-001",
+  "sessionId": "sess-001",
+  "type": "message_dequeued",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -323,6 +323,17 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     result: [{ id: 'rec-001', appId: 'app-001', data: { name: 'Test' }, createdAt: 1700000000, updatedAt: 1700000000 }],
   },
+  message_queued: {
+    type: 'message_queued',
+    sessionId: 'sess-001',
+    requestId: 'req-queue-001',
+    position: 1,
+  },
+  message_dequeued: {
+    type: 'message_dequeued',
+    sessionId: 'sess-001',
+    requestId: 'req-queue-001',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent } from '../agent/loop.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede the Session import so Bun applies them at load time.
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    systemPrompt: {},
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => [],
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: 'conv-1' }),
+  listConversations: () => [],
+  addMessage: (_convId: string, _role: string, _content: string) => {
+    return { id: `msg-${Date.now()}` };
+  },
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Controllable AgentLoop mock.
+//
+// Each `run()` call returns a promise that does NOT resolve until the test
+// explicitly calls the stored `resolve` callback. This lets us simulate a
+// long-running agent loop so we can enqueue messages while the first one is
+// still "processing".
+// ---------------------------------------------------------------------------
+
+interface PendingRun {
+  resolve: (history: Message[]) => void;
+  reject: (err: Error) => void;
+  messages: Message[];
+  onEvent: (event: AgentEvent) => void;
+}
+
+let pendingRuns: PendingRun[] = [];
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(
+      messages: Message[],
+      onEvent: (event: AgentEvent) => void,
+      _signal?: AbortSignal,
+    ): Promise<Message[]> {
+      return new Promise<Message[]>((resolve, reject) => {
+        pendingRuns.push({ resolve, reject, messages, onEvent });
+      });
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import Session AFTER mocks are registered.
+// ---------------------------------------------------------------------------
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: 'mock',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+/**
+ * Wait until the pending runs array has at least `count` entries.
+ * This is needed because `processMessage` is async and goes through
+ * several awaited steps (context compaction, memory recall) before
+ * reaching `agentLoop.run()`.
+ */
+async function waitForPendingRun(count: number, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (pendingRuns.length < count) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for ${count} pending runs (have ${pendingRuns.length})`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+/**
+ * Resolve the Nth pending AgentLoop.run() call. Fires the minimal events
+ * that `runAgentLoop` expects (usage + message_complete) so the session
+ * cleanly transitions out of its processing state.
+ */
+function resolveRun(index: number) {
+  const run = pendingRuns[index];
+  if (!run) throw new Error(`No pending run at index ${index}`);
+  // Emit the events runAgentLoop expects
+  const assistantMsg: Message = {
+    role: 'assistant',
+    content: [{ type: 'text', text: `reply-${index}` }],
+  };
+  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+  run.onEvent({ type: 'message_complete', message: assistantMsg });
+  // Return updated history with the assistant message appended
+  run.resolve([...run.messages, assistantMsg]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Session message queue', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('second message is queued when session is busy (does not throw)', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+
+    // Start first message — this will block on AgentLoop.run
+    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+
+    // Wait for the first AgentLoop.run to be registered
+    await waitForPendingRun(1);
+
+    // Session should now be processing
+    expect(session.isProcessing()).toBe(true);
+
+    // Enqueue second message — should NOT throw
+    const result = session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+    expect(result.queued).toBe(true);
+    expect(result.requestId).toBe('req-2');
+    expect(session.getQueueDepth()).toBe(1);
+
+    // Complete the first message
+    resolveRun(0);
+    await p1;
+
+    // After the first run resolves, the queue drains and triggers a second run.
+    await waitForPendingRun(2);
+
+    // The dequeued event should have been sent to events2
+    expect(events2.some((e) => e.type === 'message_dequeued')).toBe(true);
+
+    // A second AgentLoop.run should now be pending
+    expect(pendingRuns.length).toBe(2);
+
+    // Complete the second run
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('queued messages are processed in FIFO order', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const processedOrder: string[] = [];
+
+    const makeHandler = (label: string) => (e: ServerMessage) => {
+      if (e.type === 'message_complete') processedOrder.push(label);
+    };
+
+    // Start first message
+    const p1 = session.processMessage('msg-1', [], makeHandler('msg-1'), 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue two more
+    session.enqueueMessage('msg-2', [], makeHandler('msg-2'), 'req-2');
+    session.enqueueMessage('msg-3', [], makeHandler('msg-3'), 'req-3');
+    expect(session.getQueueDepth()).toBe(2);
+
+    // Complete first → triggers second
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Complete second → triggers third
+    resolveRun(1);
+    await waitForPendingRun(3);
+
+    // Complete third
+    resolveRun(2);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(processedOrder).toEqual(['msg-1', 'msg-2', 'msg-3']);
+  });
+
+  test('message_queued and message_dequeued events are emitted', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events2: ServerMessage[] = [];
+
+    // Start first message
+    const p1 = session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue second — simulating what handleUserMessage does
+    const result = session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+    expect(result.queued).toBe(true);
+
+    // Complete first
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Check for message_dequeued with correct fields
+    const dequeued = events2.find((e) => e.type === 'message_dequeued');
+    expect(dequeued).toBeDefined();
+    expect(dequeued).toEqual({
+      type: 'message_dequeued',
+      sessionId: 'conv-1',
+      requestId: 'req-2',
+    });
+
+    // Complete second run so the session finishes cleanly
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('abort() clears the queue and sends errors for each queued message', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events2: ServerMessage[] = [];
+    const events3: ServerMessage[] = [];
+
+    // Start first message
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue two more
+    session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+    session.enqueueMessage('msg-3', [], (e) => events3.push(e), 'req-3');
+    expect(session.getQueueDepth()).toBe(2);
+
+    // Abort
+    session.abort();
+
+    // Queue should be empty
+    expect(session.getQueueDepth()).toBe(0);
+
+    // Both queued messages should have received error events
+    const err2 = events2.find((e) => e.type === 'error');
+    expect(err2).toBeDefined();
+    expect(err2!.type === 'error' && err2!.message).toContain('queued message discarded');
+
+    const err3 = events3.find((e) => e.type === 'error');
+    expect(err3).toBeDefined();
+    expect(err3!.type === 'error' && err3!.message).toContain('queued message discarded');
+  });
+
+  test('queue depth is reported correctly as messages are added and drained', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start first message
+    const p1 = session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    expect(session.getQueueDepth()).toBe(0);
+
+    session.enqueueMessage('msg-2', [], () => {}, 'req-2');
+    expect(session.getQueueDepth()).toBe(1);
+
+    session.enqueueMessage('msg-3', [], () => {}, 'req-3');
+    expect(session.getQueueDepth()).toBe(2);
+
+    session.enqueueMessage('msg-4', [], () => {}, 'req-4');
+    expect(session.getQueueDepth()).toBe(3);
+
+    // Complete first → drains one from queue
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    expect(session.getQueueDepth()).toBe(2);
+
+    // Complete second → drains another
+    resolveRun(1);
+    await waitForPendingRun(3);
+
+    expect(session.getQueueDepth()).toBe(1);
+
+    // Complete third → drains last
+    resolveRun(2);
+    await waitForPendingRun(4);
+
+    expect(session.getQueueDepth()).toBe(0);
+
+    // Complete fourth (final queued message)
+    resolveRun(3);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -254,10 +254,23 @@ async function handleUserMessage(
   try {
     ctx.socketToSession.set(socket, msg.sessionId);
     const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+
+    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+
+    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
+    if (result.queued) {
+      rlog.info({ position: session.getQueueDepth() }, 'Message queued (session busy)');
+      ctx.send(socket, {
+        type: 'message_queued',
+        sessionId: msg.sessionId,
+        requestId,
+        position: session.getQueueDepth(),
+      });
+      return; // Don't await — message will be processed when current one finishes
+    }
+
     rlog.info('Processing user message');
-    await session.processMessage(msg.content ?? '', msg.attachments ?? [], (event) => {
-      ctx.send(socket, event);
-    }, requestId);
+    await session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error processing user message (session or provider failure)');

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -428,6 +428,19 @@ export interface AppDataResponse {
   error?: string;
 }
 
+export interface MessageQueued {
+  type: 'message_queued';
+  sessionId: string;
+  requestId: string;
+  position: number;
+}
+
+export interface MessageDequeued {
+  type: 'message_dequeued';
+  sessionId: string;
+  requestId: string;
+}
+
 /** Common fields shared by all UiSurfaceShow variants. */
 interface UiSurfaceShowBase {
   type: 'ui_surface_show';
@@ -512,7 +525,9 @@ export type ServerMessage =
   | UiSurfaceShow
   | UiSurfaceUpdate
   | UiSurfaceDismiss
-  | AppDataResponse;
+  | AppDataResponse
+  | MessageQueued
+  | MessageDequeued;
 
 // === Serialization ===
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -57,6 +57,12 @@ export class Session {
   private contextWindowManager: ContextWindowManager;
   private contextCompactedMessageCount = 0;
   private currentRequestId?: string;
+  private messageQueue: Array<{
+    content: string;
+    attachments: UserMessageAttachment[];
+    requestId: string;
+    onEvent: (msg: ServerMessage) => void;
+  }> = [];
   private pendingSurfaceActions = new Map<string, {
     resolve: (result: ToolExecutionResult) => void;
   }>();
@@ -201,7 +207,37 @@ export class Session {
       }
       this.pendingSurfaceActions.clear();
       this.surfaceState.clear();
+
+      // Clear queued messages and notify each caller
+      for (const queued of this.messageQueue) {
+        queued.onEvent({ type: 'error', message: 'Session aborted — queued message discarded' });
+      }
+      this.messageQueue = [];
     }
+  }
+
+  /**
+   * Enqueue a message if the session is busy, or indicate it should be
+   * processed immediately. Returns `{ queued: true }` if the message was
+   * added to the queue, or `{ queued: false }` if the caller should invoke
+   * `processMessage` directly.
+   */
+  enqueueMessage(
+    content: string,
+    attachments: UserMessageAttachment[],
+    onEvent: (msg: ServerMessage) => void,
+    requestId: string,
+  ): { queued: boolean; requestId: string } {
+    if (!this.processing) {
+      return { queued: false, requestId };
+    }
+
+    this.messageQueue.push({ content, attachments, requestId, onEvent });
+    return { queued: true, requestId };
+  }
+
+  getQueueDepth(): number {
+    return this.messageQueue.length;
   }
 
   handleConfirmationResponse(
@@ -554,6 +590,22 @@ export class Session {
       this.abortController = null;
       this.processing = false;
       this.currentRequestId = undefined;
+
+      // Drain next queued message
+      const next = this.messageQueue.shift();
+      if (next) {
+        next.onEvent({
+          type: 'message_dequeued',
+          sessionId: this.conversationId,
+          requestId: next.requestId,
+        });
+        // Fire and forget — don't block the current call
+        this.processMessage(next.content, next.attachments, next.onEvent, next.requestId).catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          log.error({ err, conversationId: this.conversationId }, 'Error processing queued message');
+          next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Replaces the "Session is already processing a message" error with a per-session message queue that buffers incoming messages when the session is busy
- Queued messages are drained in FIFO order after each agent loop completes, with `message_queued` and `message_dequeued` IPC events sent to the client
- On session abort, all queued messages are cleared and error events are sent to each caller

## Test plan
- [x] New `session-queue.test.ts` with 5 tests: queueing behavior, FIFO ordering, event emission, abort cleanup, and queue depth tracking
- [x] IPC snapshot test updated with `message_queued` and `message_dequeued` message types
- [x] TypeScript type-check passes (`tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
