### PR TITLE
Add file upload surface type (#874)

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -134,9 +134,9 @@ export interface AppDataRequest {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
+export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
 
-export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page'];
+export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page', 'file_upload'];
 
 export interface SurfaceAction {
   id: string;
@@ -195,7 +195,14 @@ export interface DynamicPageSurfaceData {
   appId?: string;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData;
+export interface FileUploadSurfaceData {
+  prompt: string;
+  acceptedTypes?: string[];
+  maxFiles?: number;
+  maxSizeBytes?: number;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -464,12 +471,18 @@ export interface UiSurfaceShowDynamicPage extends UiSurfaceShowBase {
   data: DynamicPageSurfaceData;
 }
 
+export interface UiSurfaceShowFileUpload extends UiSurfaceShowBase {
+  surfaceType: 'file_upload';
+  data: FileUploadSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
   | UiSurfaceShowList
   | UiSurfaceShowConfirmation
-  | UiSurfaceShowDynamicPage;
+  | UiSurfaceShowDynamicPage
+  | UiSurfaceShowFileUpload;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';

--- a/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
@@ -1,0 +1,352 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FileUploadSurfaceView: View {
+    let data: FileUploadSurfaceData
+    let onSubmit: ([[String: Any]]) -> Void
+    let onCancel: () -> Void
+
+    @State private var selectedFiles: [SelectedFile] = []
+    @State private var isDragOver = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Prompt text
+            Text(data.prompt)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            // Drop zone
+            dropZone
+
+            // Error message
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            // File previews
+            if !selectedFiles.isEmpty {
+                fileList
+            }
+
+            // Constraints hint
+            constraintsHint
+
+            // Action buttons
+            HStack(spacing: VSpacing.lg) {
+                Spacer()
+
+                VButton(label: "Cancel", style: .ghost) {
+                    onCancel()
+                }
+
+                VButton(
+                    label: "Upload",
+                    style: .primary
+                ) {
+                    submitFiles()
+                }
+                .opacity(selectedFiles.isEmpty ? 0.5 : 1.0)
+                .allowsHitTesting(!selectedFiles.isEmpty)
+            }
+        }
+    }
+
+    // MARK: - Drop Zone
+
+    private var dropZone: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(
+                    isDragOver ? VColor.accent : VColor.textMuted,
+                    style: StrokeStyle(lineWidth: 2, dash: [8, 4])
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isDragOver ? VColor.accent.opacity(0.08) : Color.clear)
+                )
+
+            VStack(spacing: VSpacing.md) {
+                Image(systemName: "arrow.down.doc.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(isDragOver ? VColor.accent : VColor.textMuted)
+
+                Text("Drop files here")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+
+                Button(action: { browseFiles() }) {
+                    Text("Browse files")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.accent)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(VSpacing.xl)
+        }
+        .frame(height: 140)
+        .onDrop(of: [.fileURL], isTargeted: $isDragOver) { providers in
+            handleDrop(providers)
+            return true
+        }
+    }
+
+    // MARK: - File List
+
+    private var fileList: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            ForEach(Array(selectedFiles.enumerated()), id: \.element.id) { index, file in
+                HStack(spacing: VSpacing.md) {
+                    fileIcon(for: file)
+                        .frame(width: 32, height: 32)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(file.filename)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+
+                        Text(formatFileSize(file.size))
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    Spacer()
+
+                    Button(action: { removeFile(at: index) }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(VColor.backgroundSubtle)
+                )
+            }
+        }
+    }
+
+    // MARK: - Constraints Hint
+
+    private var constraintsHint: some View {
+        HStack(spacing: VSpacing.sm) {
+            if data.maxFiles > 1 {
+                Text("Max \(data.maxFiles) files")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+            if let types = data.acceptedTypes, !types.isEmpty {
+                Text(types.joined(separator: ", "))
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+    }
+
+    // MARK: - File Icon
+
+    @ViewBuilder
+    private func fileIcon(for file: SelectedFile) -> some View {
+        if file.mimeType.hasPrefix("image/"), let nsImage = NSImage(data: file.data) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 32, height: 32)
+                .cornerRadius(4)
+                .clipped()
+        } else {
+            Image(systemName: iconName(for: file.mimeType))
+                .font(.system(size: 20))
+                .foregroundColor(VColor.accent)
+                .frame(width: 32, height: 32)
+        }
+    }
+
+    private func iconName(for mimeType: String) -> String {
+        if mimeType.hasPrefix("image/") { return "photo" }
+        if mimeType == "application/pdf" { return "doc.richtext" }
+        if mimeType.contains("spreadsheet") || mimeType.contains("csv") { return "tablecells" }
+        if mimeType.contains("presentation") { return "rectangle.on.rectangle" }
+        return "doc"
+    }
+
+    // MARK: - Actions
+
+    private func browseFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = data.maxFiles > 1
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        if let types = data.acceptedTypes {
+            let utTypes = types.compactMap { utType(from: $0) }
+            if !utTypes.isEmpty {
+                panel.allowedContentTypes = utTypes
+            }
+        }
+
+        guard panel.runModal() == .OK else { return }
+
+        for url in panel.urls {
+            addFile(from: url)
+        }
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) {
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
+                DispatchQueue.main.async {
+                    addFile(from: url)
+                }
+            }
+        }
+    }
+
+    private func addFile(from url: URL) {
+        errorMessage = nil
+
+        // Check max files limit
+        if selectedFiles.count >= data.maxFiles {
+            errorMessage = "Maximum of \(data.maxFiles) file\(data.maxFiles == 1 ? "" : "s") allowed."
+            return
+        }
+
+        // Read file data
+        guard let fileData = try? Data(contentsOf: url) else {
+            errorMessage = "Could not read file: \(url.lastPathComponent)"
+            return
+        }
+
+        // Check file size
+        if fileData.count > data.maxSizeBytes {
+            errorMessage = "\(url.lastPathComponent) exceeds the \(formatFileSize(data.maxSizeBytes)) size limit."
+            return
+        }
+
+        // Check accepted types
+        let mimeType = mimeType(for: url)
+        if let acceptedTypes = data.acceptedTypes, !acceptedTypes.isEmpty {
+            let matches = acceptedTypes.contains { pattern in
+                if pattern.hasSuffix("/*") {
+                    let prefix = String(pattern.dropLast(2))
+                    return mimeType.hasPrefix(prefix)
+                }
+                return mimeType == pattern
+            }
+            if !matches {
+                errorMessage = "\(url.lastPathComponent) is not an accepted file type."
+                return
+            }
+        }
+
+        // Check for duplicates
+        let filename = url.lastPathComponent
+        if selectedFiles.contains(where: { $0.filename == filename }) {
+            return
+        }
+
+        selectedFiles.append(SelectedFile(
+            filename: filename,
+            mimeType: mimeType,
+            data: fileData,
+            size: fileData.count
+        ))
+    }
+
+    private func removeFile(at index: Int) {
+        guard index < selectedFiles.count else { return }
+        selectedFiles.remove(at: index)
+        errorMessage = nil
+    }
+
+    private func submitFiles() {
+        guard !selectedFiles.isEmpty else { return }
+
+        let filesPayload: [[String: Any]] = selectedFiles.map { file in
+            var dict: [String: Any] = [
+                "filename": file.filename,
+                "mimeType": file.mimeType,
+                "data": file.data.base64EncodedString(),
+            ]
+            // Extract text from known text-based formats
+            if let text = extractText(from: file) {
+                dict["extractedText"] = text
+            }
+            return dict
+        }
+
+        onSubmit(filesPayload)
+    }
+
+    // MARK: - Helpers
+
+    private func mimeType(for url: URL) -> String {
+        if let utType = UTType(filenameExtension: url.pathExtension) {
+            return utType.preferredMIMEType ?? "application/octet-stream"
+        }
+        return "application/octet-stream"
+    }
+
+    private func utType(from mimePattern: String) -> UTType? {
+        if mimePattern.hasSuffix("/*") {
+            // Wildcard type — map common categories
+            let prefix = String(mimePattern.dropLast(2))
+            switch prefix {
+            case "image": return .image
+            case "video": return .video
+            case "audio": return .audio
+            case "text": return .text
+            default: return nil
+            }
+        }
+        return UTType(mimeType: mimePattern)
+    }
+
+    private func formatFileSize(_ bytes: Int) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(bytes))
+    }
+
+    private func extractText(from file: SelectedFile) -> String? {
+        let textTypes = ["text/plain", "text/csv", "text/html", "text/markdown",
+                         "application/json", "application/xml"]
+        if textTypes.contains(file.mimeType) || file.mimeType.hasPrefix("text/") {
+            return String(data: file.data, encoding: .utf8)
+        }
+        return nil
+    }
+}
+
+// MARK: - Supporting Types
+
+private struct SelectedFile: Identifiable {
+    let id = UUID()
+    let filename: String
+    let mimeType: String
+    let data: Data
+    let size: Int
+}
+
+#Preview {
+    FileUploadSurfaceView(
+        data: FileUploadSurfaceData(
+            prompt: "Please share the design file you'd like me to review.",
+            acceptedTypes: ["image/*", "application/pdf"],
+            maxFiles: 3,
+            maxSizeBytes: 50 * 1024 * 1024
+        ),
+        onSubmit: { _ in },
+        onCancel: {}
+    )
+    .padding()
+    .frame(width: 380)
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -58,6 +58,17 @@ struct SurfaceContainerView: View {
                     width: CGFloat(data.width ?? 380),
                     height: CGFloat(data.height ?? 500)
                 )
+            case .fileUpload(let data):
+                FileUploadSurfaceView(
+                    data: data,
+                    onSubmit: { files in
+                        let actionId = surface.actions.first?.id ?? "submit"
+                        viewModel.onAction(actionId, ["files": files])
+                    },
+                    onCancel: {
+                        viewModel.onAction("cancel", ["files": [Any]()])
+                    }
+                )
             }
 
             // Action buttons for card/list surfaces
@@ -81,7 +92,7 @@ struct SurfaceContainerView: View {
 
     private var isFormOrConfirmation: Bool {
         switch surface.data {
-        case .form, .confirmation, .dynamicPage:
+        case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
         case .card, .list:
             return false

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -8,6 +8,7 @@ enum SurfaceType: String, Codable, Sendable {
     case list
     case confirmation
     case dynamicPage = "dynamic_page"
+    case fileUpload = "file_upload"
 }
 
 enum SurfaceActionStyle: String, Codable, Sendable {
@@ -121,12 +122,20 @@ struct DynamicPageSurfaceData: Sendable {
     let appId: String?
 }
 
+struct FileUploadSurfaceData: Sendable {
+    let prompt: String
+    let acceptedTypes: [String]?
+    let maxFiles: Int
+    let maxSizeBytes: Int
+}
+
 enum SurfaceData: Sendable {
     case card(CardSurfaceData)
     case form(FormSurfaceData)
     case list(ListSurfaceData)
     case confirmation(ConfirmationSurfaceData)
     case dynamicPage(DynamicPageSurfaceData)
+    case fileUpload(FileUploadSurfaceData)
 }
 
 struct SurfaceActionButton: Identifiable, Sendable {
@@ -211,6 +220,8 @@ extension Surface {
             return parseConfirmationData(dict).map { .confirmation($0) }
         case .dynamicPage:
             return parseDynamicPageData(dict).map { .dynamicPage($0) }
+        case .fileUpload:
+            return parseFileUploadData(dict).map { .fileUpload($0) }
         }
     }
 
@@ -231,6 +242,8 @@ extension Surface {
             return .confirmation(mergeConfirmationData(existing: confirmation, update: update))
         case .dynamicPage(let dp):
             return .dynamicPage(mergeDynamicPageData(existing: dp, update: update))
+        case .fileUpload(let fu):
+            return .fileUpload(mergeFileUploadData(existing: fu, update: update))
         }
     }
 
@@ -447,6 +460,34 @@ extension Surface {
             width: dict["width"] as? Int,
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String
+        )
+    }
+
+    private static func parseFileUploadData(_ dict: [String: Any?]) -> FileUploadSurfaceData? {
+        guard let prompt = dict["prompt"] as? String else { return nil }
+        let acceptedTypes = dict["acceptedTypes"] as? [String]
+        let maxFiles = dict["maxFiles"] as? Int ?? 1
+        let maxSizeBytes = dict["maxSizeBytes"] as? Int ?? (50 * 1024 * 1024)
+        return FileUploadSurfaceData(
+            prompt: prompt,
+            acceptedTypes: acceptedTypes,
+            maxFiles: maxFiles,
+            maxSizeBytes: maxSizeBytes
+        )
+    }
+
+    private static func mergeFileUploadData(existing: FileUploadSurfaceData, update: [String: Any?]) -> FileUploadSurfaceData {
+        let prompt = (update["prompt"] as? String) ?? existing.prompt
+        let acceptedTypes: [String]? = update.keys.contains("acceptedTypes")
+            ? (update["acceptedTypes"] as? [String])
+            : existing.acceptedTypes
+        let maxFiles = (update["maxFiles"] as? Int) ?? existing.maxFiles
+        let maxSizeBytes = (update["maxSizeBytes"] as? Int) ?? existing.maxSizeBytes
+        return FileUploadSurfaceData(
+            prompt: prompt,
+            acceptedTypes: acceptedTypes,
+            maxFiles: maxFiles,
+            maxSizeBytes: maxSizeBytes
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add `file_upload` as a new surface type to the IPC protocol and both daemon/client implementations
- Define `FileUploadSurfaceData` interface (TS) and struct (Swift) with `prompt`, `acceptedTypes`, `maxFiles`, and `maxSizeBytes` fields
- Create `FileUploadSurfaceView.swift` with drag-and-drop zone, NSOpenPanel file picker, image thumbnails, file type filtering, size validation, and base64-encoded submission

## Test plan
- [ ] Verify TypeScript type-checks pass (`bunx tsc --noEmit`)
- [ ] Verify Swift builds cleanly (`swift build`)
- [ ] Test file upload surface renders correctly with prompt text and drop zone
- [ ] Test drag-and-drop files onto the drop zone
- [ ] Test "Browse files" button opens NSOpenPanel
- [ ] Test file type filtering respects `acceptedTypes` (e.g. only images when `image/*`)
- [ ] Test file size validation rejects files over `maxSizeBytes`
- [ ] Test multi-file support when `maxFiles > 1`
- [ ] Test submit sends base64-encoded file data with correct MIME types
- [ ] Test cancel sends empty files array

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
