### PR TITLE
Add file_upload surface type with drag-and-drop (#874)

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -134,9 +134,9 @@ export interface AppDataRequest {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
+export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
 
-export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page'];
+export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page', 'file_upload'];
 
 export interface SurfaceAction {
   id: string;
@@ -195,7 +195,14 @@ export interface DynamicPageSurfaceData {
   appId?: string;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData;
+export interface FileUploadSurfaceData {
+  prompt: string;
+  acceptedTypes?: string[];
+  maxFiles?: number;
+  maxSizeBytes?: number;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -477,12 +484,18 @@ export interface UiSurfaceShowDynamicPage extends UiSurfaceShowBase {
   data: DynamicPageSurfaceData;
 }
 
+export interface UiSurfaceShowFileUpload extends UiSurfaceShowBase {
+  surfaceType: 'file_upload';
+  data: FileUploadSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
   | UiSurfaceShowList
   | UiSurfaceShowConfirmation
-  | UiSurfaceShowDynamicPage;
+  | UiSurfaceShowDynamicPage
+  | UiSurfaceShowFileUpload;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';

--- a/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
@@ -1,0 +1,423 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+import PDFKit
+
+struct FileUploadSurfaceView: View {
+    let data: FileUploadSurfaceData
+    let onAction: (String, [String: Any]?) -> Void
+
+    @State private var selectedFiles: [SelectedFile] = []
+    @State private var isDropTargeted = false
+    @State private var errorMessage: String?
+    @State private var isProcessing = false
+
+    private var effectiveMaxFiles: Int { data.maxFiles ?? 1 }
+    private var effectiveMaxSizeBytes: Int { data.maxSizeBytes ?? (50 * 1024 * 1024) }
+
+    private var canSubmit: Bool {
+        !selectedFiles.isEmpty && !isProcessing
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Prompt
+            Text(data.prompt)
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            // Drop zone
+            dropZone
+
+            // Selected files list
+            if !selectedFiles.isEmpty {
+                filesList
+            }
+
+            // Error message
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+
+            // Action buttons
+            HStack(spacing: VSpacing.lg) {
+                Spacer()
+
+                VButton(label: "Cancel", style: .ghost) {
+                    onAction("cancel", [:])
+                }
+
+                VButton(
+                    label: isProcessing ? "Processing..." : "Submit",
+                    style: .primary,
+                    isDisabled: !canSubmit
+                ) {
+                    submitFiles()
+                }
+            }
+        }
+    }
+
+    // MARK: - Drop Zone
+
+    private var dropZone: some View {
+        VStack(spacing: VSpacing.md) {
+            Image(systemName: "arrow.down.doc")
+                .font(.system(size: 28))
+                .foregroundColor(isDropTargeted ? VColor.accent : VColor.textMuted)
+
+            Text("Drop files here")
+                .font(VFont.bodyMedium)
+                .foregroundColor(isDropTargeted ? VColor.textPrimary : VColor.textSecondary)
+
+            if let types = data.acceptedTypes, !types.isEmpty {
+                Text(types.joined(separator: ", "))
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Button(action: openFilePicker) {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "folder")
+                        .font(VFont.caption)
+                    Text("Browse Files")
+                        .font(VFont.captionMedium)
+                }
+                .foregroundColor(VColor.accent)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.accent.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(VSpacing.xl)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(
+                    isDropTargeted ? VColor.accent : VColor.surfaceBorder,
+                    style: StrokeStyle(lineWidth: 2, dash: [8, 4])
+                )
+        )
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(isDropTargeted ? VColor.accent.opacity(0.05) : Color.clear)
+        )
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted, perform: handleDrop)
+    }
+
+    // MARK: - Files List
+
+    private var filesList: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            ForEach(selectedFiles) { file in
+                HStack(spacing: VSpacing.md) {
+                    // Thumbnail or icon
+                    fileIcon(for: file)
+                        .frame(width: 32, height: 32)
+
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        Text(file.filename)
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+
+                        Text(ByteCountFormatter.string(
+                            fromByteCount: Int64(file.sizeBytes),
+                            countStyle: .file
+                        ))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    }
+
+                    Spacer()
+
+                    Button(action: { removeFile(id: file.id) }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(VSpacing.sm)
+                .background(VColor.backgroundSubtle)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+        }
+    }
+
+    // MARK: - File Icon
+
+    @ViewBuilder
+    private func fileIcon(for file: SelectedFile) -> some View {
+        if file.mimeType.hasPrefix("image/"), let image = NSImage(data: file.data) {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+        } else {
+            Image(systemName: iconName(for: file.mimeType))
+                .font(.system(size: 18))
+                .foregroundColor(VColor.accent)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.accent.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+        }
+    }
+
+    private func iconName(for mimeType: String) -> String {
+        if mimeType == "application/pdf" { return "doc.richtext" }
+        if mimeType.hasPrefix("text/") { return "doc.text" }
+        if mimeType == "application/json" { return "curlybraces" }
+        return "doc"
+    }
+
+    // MARK: - File Picker
+
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = effectiveMaxFiles > 1
+        panel.allowedContentTypes = allowedUTTypes()
+
+        guard panel.runModal() == .OK else { return }
+        addFileURLs(panel.urls)
+    }
+
+    // MARK: - Drag & Drop
+
+    private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        var handled = false
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                handled = true
+                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+                    if error != nil { return }
+                    guard let url = Self.fileURL(from: item) else { return }
+                    DispatchQueue.main.async {
+                        addFileURLs([url])
+                    }
+                }
+            }
+        }
+
+        return handled
+    }
+
+    // MARK: - File Processing
+
+    private func addFileURLs(_ urls: [URL]) {
+        errorMessage = nil
+        var errors: [String] = []
+
+        for url in urls {
+            if selectedFiles.count >= effectiveMaxFiles {
+                errors.append("Maximum \(effectiveMaxFiles) file(s) allowed.")
+                break
+            }
+
+            do {
+                let fileData = try Data(contentsOf: url)
+                let filename = url.lastPathComponent
+                let mimeType = Self.mimeType(for: url.pathExtension)
+
+                // Validate accepted types
+                if let acceptedTypes = self.data.acceptedTypes, !acceptedTypes.isEmpty {
+                    let matches = acceptedTypes.contains { pattern in
+                        if pattern.hasSuffix("/*") {
+                            let prefix = String(pattern.dropLast(2))
+                            return mimeType.hasPrefix(prefix)
+                        }
+                        return mimeType == pattern
+                    }
+                    if !matches {
+                        errors.append("\(filename) is not an accepted file type.")
+                        continue
+                    }
+                }
+
+                // Validate size
+                if fileData.count > effectiveMaxSizeBytes {
+                    let maxSize = ByteCountFormatter.string(
+                        fromByteCount: Int64(effectiveMaxSizeBytes),
+                        countStyle: .file
+                    )
+                    errors.append("\(filename) exceeds the \(maxSize) size limit.")
+                    continue
+                }
+
+                let extractedText = Self.extractText(data: fileData, mimeType: mimeType)
+
+                let file = SelectedFile(
+                    id: UUID(),
+                    filename: filename,
+                    mimeType: mimeType,
+                    sizeBytes: fileData.count,
+                    data: fileData,
+                    extractedText: extractedText
+                )
+                selectedFiles.append(file)
+            } catch {
+                errors.append("Failed to read \(url.lastPathComponent).")
+            }
+        }
+
+        if !errors.isEmpty {
+            errorMessage = errors.joined(separator: " ")
+        }
+    }
+
+    private func removeFile(id: UUID) {
+        selectedFiles.removeAll { $0.id == id }
+        errorMessage = nil
+    }
+
+    // MARK: - Submit
+
+    private func submitFiles() {
+        guard !selectedFiles.isEmpty else { return }
+        isProcessing = true
+
+        let filesPayload: [[String: Any]] = selectedFiles.map { file in
+            var entry: [String: Any] = [
+                "filename": file.filename,
+                "mimeType": file.mimeType,
+                "data": file.data.base64EncodedString(),
+            ]
+            if let text = file.extractedText {
+                entry["extractedText"] = text
+            }
+            return entry
+        }
+
+        let actionData: [String: Any] = ["files": filesPayload]
+        onAction("submit", actionData)
+    }
+
+    // MARK: - UTType Helpers
+
+    private func allowedUTTypes() -> [UTType] {
+        guard let acceptedTypes = data.acceptedTypes, !acceptedTypes.isEmpty else {
+            // Default: all common file types
+            return [.image, .pdf, .plainText, .json]
+        }
+
+        var types: [UTType] = []
+        for pattern in acceptedTypes {
+            if let utType = Self.utType(from: pattern) {
+                types.append(utType)
+            }
+        }
+        return types.isEmpty ? [.data] : types
+    }
+
+    private static func utType(from mimePattern: String) -> UTType? {
+        // Handle wildcard patterns like "image/*"
+        switch mimePattern {
+        case "image/*": return .image
+        case "video/*": return .video
+        case "audio/*": return .audio
+        case "text/*": return .text
+        default: break
+        }
+
+        // Handle specific MIME types
+        if let utType = UTType(mimeType: mimePattern) {
+            return utType
+        }
+        return nil
+    }
+
+    // MARK: - MIME Detection
+
+    private static func mimeType(for pathExtension: String) -> String {
+        switch pathExtension.lowercased() {
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "webp": return "image/webp"
+        case "gif": return "image/gif"
+        case "pdf": return "application/pdf"
+        case "txt": return "text/plain"
+        case "md", "markdown": return "text/markdown"
+        case "json": return "application/json"
+        case "csv": return "text/csv"
+        default: return "application/octet-stream"
+        }
+    }
+
+    // MARK: - Text Extraction
+
+    private static func extractText(data: Data, mimeType: String) -> String? {
+        if mimeType == "application/pdf" {
+            return extractPdfText(data: data)
+        }
+        if mimeType.hasPrefix("text/") || mimeType == "application/json" {
+            let text = String(data: data, encoding: .utf8)
+            return text?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true ? nil : text
+        }
+        return nil
+    }
+
+    private static func extractPdfText(data: Data) -> String? {
+        guard let document = PDFDocument(data: data) else { return nil }
+        var parts: [String] = []
+        for pageIndex in 0..<document.pageCount {
+            guard let page = document.page(at: pageIndex), let text = page.string else { continue }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                parts.append(trimmed)
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - URL Helpers
+
+    private static func fileURL(from item: NSSecureCoding?) -> URL? {
+        if let data = item as? Data {
+            return URL(dataRepresentation: data, relativeTo: nil)
+        }
+        if let url = item as? URL {
+            return url
+        }
+        if let str = item as? String, let url = URL(string: str), url.isFileURL {
+            return url
+        }
+        return nil
+    }
+}
+
+// MARK: - Selected File Model
+
+struct SelectedFile: Identifiable {
+    let id: UUID
+    let filename: String
+    let mimeType: String
+    let sizeBytes: Int
+    let data: Data
+    let extractedText: String?
+}
+
+// MARK: - Preview
+
+#Preview {
+    FileUploadSurfaceView(
+        data: FileUploadSurfaceData(
+            prompt: "Please share the design file you'd like me to review.",
+            acceptedTypes: ["image/*", "application/pdf"],
+            maxFiles: 3,
+            maxSizeBytes: 10 * 1024 * 1024
+        ),
+        onAction: { actionId, data in
+            print("Action: \(actionId), data: \(String(describing: data))")
+        }
+    )
+    .padding()
+    .frame(width: 480)
+    .vPanelBackground()
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -58,6 +58,13 @@ struct SurfaceContainerView: View {
                     width: CGFloat(data.width ?? 380),
                     height: CGFloat(data.height ?? 500)
                 )
+            case .fileUpload(let data):
+                FileUploadSurfaceView(
+                    data: data,
+                    onAction: { actionId, actionData in
+                        viewModel.onAction(actionId, actionData)
+                    }
+                )
             }
 
             // Action buttons for card/list surfaces
@@ -76,12 +83,15 @@ struct SurfaceContainerView: View {
         if case .dynamicPage(let data) = surface.data {
             return CGFloat(data.width ?? 380)
         }
+        if case .fileUpload = surface.data {
+            return 480
+        }
         return 380
     }
 
     private var isFormOrConfirmation: Bool {
         switch surface.data {
-        case .form, .confirmation, .dynamicPage:
+        case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
         case .card, .list:
             return false

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -124,6 +124,9 @@ final class SurfaceManager: ObservableObject {
         if case .dynamicPage(let dpData) = surface.data {
             surfacePanelWidth = CGFloat(dpData.width ?? Int(panelWidth))
             surfacePanelHeight = CGFloat(dpData.height ?? 500)
+        } else if case .fileUpload = surface.data {
+            surfacePanelWidth = 480
+            surfacePanelHeight = 500
         } else {
             surfacePanelWidth = panelWidth
             surfacePanelHeight = 140
@@ -248,7 +251,10 @@ final class SurfaceManager: ObservableObject {
         var stackIndex = 0
         for surfaceId in surfaceOrder {
             guard let panel = panels[surfaceId] else { continue }
-            if case .dynamicPage = activeSurfaces[surfaceId]?.data {
+            let surfaceData = activeSurfaces[surfaceId]?.data
+            if case .dynamicPage = surfaceData {
+                centerPanel(panel)
+            } else if case .fileUpload = surfaceData {
                 centerPanel(panel)
             } else {
                 positionPanel(panel, at: stackIndex)

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -8,6 +8,7 @@ enum SurfaceType: String, Codable, Sendable {
     case list
     case confirmation
     case dynamicPage = "dynamic_page"
+    case fileUpload = "file_upload"
 }
 
 enum SurfaceActionStyle: String, Codable, Sendable {
@@ -121,12 +122,20 @@ struct DynamicPageSurfaceData: Sendable {
     let appId: String?
 }
 
+struct FileUploadSurfaceData: Sendable {
+    let prompt: String
+    let acceptedTypes: [String]?
+    let maxFiles: Int?
+    let maxSizeBytes: Int?
+}
+
 enum SurfaceData: Sendable {
     case card(CardSurfaceData)
     case form(FormSurfaceData)
     case list(ListSurfaceData)
     case confirmation(ConfirmationSurfaceData)
     case dynamicPage(DynamicPageSurfaceData)
+    case fileUpload(FileUploadSurfaceData)
 }
 
 struct SurfaceActionButton: Identifiable, Sendable {
@@ -211,6 +220,8 @@ extension Surface {
             return parseConfirmationData(dict).map { .confirmation($0) }
         case .dynamicPage:
             return parseDynamicPageData(dict).map { .dynamicPage($0) }
+        case .fileUpload:
+            return parseFileUploadData(dict).map { .fileUpload($0) }
         }
     }
 
@@ -231,6 +242,8 @@ extension Surface {
             return .confirmation(mergeConfirmationData(existing: confirmation, update: update))
         case .dynamicPage(let dp):
             return .dynamicPage(mergeDynamicPageData(existing: dp, update: update))
+        case .fileUpload(let fu):
+            return .fileUpload(mergeFileUploadData(existing: fu, update: update))
         }
     }
 
@@ -447,6 +460,35 @@ extension Surface {
             width: dict["width"] as? Int,
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String
+        )
+    }
+
+    private static func parseFileUploadData(_ dict: [String: Any?]) -> FileUploadSurfaceData? {
+        guard let prompt = dict["prompt"] as? String else { return nil }
+        let acceptedTypes = (dict["acceptedTypes"] as? [Any])?.compactMap { $0 as? String }
+        return FileUploadSurfaceData(
+            prompt: prompt,
+            acceptedTypes: acceptedTypes,
+            maxFiles: dict["maxFiles"] as? Int,
+            maxSizeBytes: dict["maxSizeBytes"] as? Int
+        )
+    }
+
+    private static func mergeFileUploadData(existing: FileUploadSurfaceData, update: [String: Any?]) -> FileUploadSurfaceData {
+        let prompt = (update["prompt"] as? String) ?? existing.prompt
+        let acceptedTypes: [String]?
+        if update.keys.contains("acceptedTypes") {
+            acceptedTypes = (update["acceptedTypes"] as? [Any])?.compactMap { $0 as? String }
+        } else {
+            acceptedTypes = existing.acceptedTypes
+        }
+        let maxFiles: Int? = update.keys.contains("maxFiles") ? (update["maxFiles"] as? Int) : existing.maxFiles
+        let maxSizeBytes: Int? = update.keys.contains("maxSizeBytes") ? (update["maxSizeBytes"] as? Int) : existing.maxSizeBytes
+        return FileUploadSurfaceData(
+            prompt: prompt,
+            acceptedTypes: acceptedTypes,
+            maxFiles: maxFiles,
+            maxSizeBytes: maxSizeBytes
         )
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new `file_upload` surface type to both the daemon IPC protocol and the macOS Swift client
- Enables the assistant to request files/images from users via a just-in-time floating panel with drag-and-drop support
- Includes MIME type filtering, file size validation, image thumbnails, PDF text extraction, and base64-encoded payloads on submit

## Changes

### Daemon IPC (`assistant/src/daemon/ipc-protocol.ts`)
- Added `'file_upload'` to `SurfaceType` union and `INTERACTIVE_SURFACE_TYPES`
- Added `FileUploadSurfaceData` interface with `prompt`, `acceptedTypes`, `maxFiles`, `maxSizeBytes`
- Added `UiSurfaceShowFileUpload` interface and included it in the `UiSurfaceShow` discriminated union

### Swift Client
- **SurfaceTypes.swift**: Added `fileUpload` case to `SurfaceType` and `SurfaceData` enums, `FileUploadSurfaceData` struct, plus `parseFileUploadData` and `mergeFileUploadData` helpers
- **FileUploadSurfaceView.swift** (new): Full SwiftUI view with dashed-border drop zone (`onDrop`), NSOpenPanel file picker, MIME/UTType filtering, size validation, image thumbnail previews, document type icons, PDF text extraction, and Submit/Cancel action buttons
- **SurfaceContainerView.swift**: Routes `.fileUpload` data to `FileUploadSurfaceView`, sets 480px width, includes in `isFormOrConfirmation` to hide generic action buttons
- **SurfaceManager.swift**: Sets file upload panel size to 480x500 and centers it on screen

## Test plan
- [ ] TypeScript type-check passes (`bunx tsc --noEmit`) -- verified
- [ ] Swift build passes (`./build.sh`) -- verified
- [ ] Daemon can send `ui_surface_show` with `surfaceType: "file_upload"` and client renders the upload panel
- [ ] Drag-and-drop files onto the drop zone adds them to the file list
- [ ] "Browse Files" button opens NSOpenPanel with correct type filtering
- [ ] File size validation rejects files exceeding `maxSizeBytes`
- [ ] MIME type filtering rejects files not matching `acceptedTypes`
- [ ] Submit sends base64-encoded file data with extracted text for PDFs/text files
- [ ] Cancel dismisses the surface

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
