### PR TITLE
Add client queue state handling for rapid-fire messages (#873)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -5,18 +5,26 @@ enum ChatRole: String {
     case assistant
 }
 
+enum ChatMessageStatus: Equatable {
+    case sent
+    case queued(position: Int)
+    case processing
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
     var text: String
     let timestamp: Date
     var isStreaming: Bool
+    var status: ChatMessageStatus
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent) {
         self.id = id
         self.role = role
         self.text = text
         self.timestamp = timestamp
         self.isStreaming = isStreaming
+        self.status = status
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -6,6 +6,7 @@ struct ChatView: View {
     let isThinking: Bool
     let isSending: Bool
     let errorText: String?
+    let pendingQueuedCount: Int
     let onSend: () -> Void
     let onStop: () -> Void
     let onDismissError: () -> Void
@@ -127,20 +128,20 @@ struct ChatView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop generation")
-            } else {
-                Button(action: {
-                    if canSend {
-                        onSend()
-                    }
-                }) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 24, weight: .medium))
-                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSend)
-                .accessibilityLabel("Send message")
             }
+
+            Button(action: {
+                if canSend {
+                    onSend()
+                }
+            }) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+            .accessibilityLabel("Send message")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -156,7 +157,7 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !isSending && !inputText.trimmingCharacters(in: .whitespaces).isEmpty
+        !inputText.trimmingCharacters(in: .whitespaces).isEmpty
     }
 }
 
@@ -167,11 +168,31 @@ private struct ChatBubble: View {
 
     private var isUser: Bool { message.role == .user }
 
+    private var isQueued: Bool {
+        if case .queued = message.status { return true }
+        return false
+    }
+
+    private var queueLabel: String? {
+        if case .queued(let position) = message.status {
+            return position > 0 ? "Queued (\(ordinal(position)) in line)" : "Queued"
+        }
+        return nil
+    }
+
     var body: some View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
-            bubbleContent
+            VStack(alignment: isUser ? .trailing : .leading, spacing: 2) {
+                bubbleContent
+
+                if let label = queueLabel {
+                    Text(label)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
 
             if !isUser { Spacer(minLength: 0) }
         }
@@ -189,6 +210,24 @@ private struct ChatBubble: View {
                     .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
             )
             .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
+            .opacity(isQueued ? 0.7 : 1.0)
+    }
+
+    private func ordinal(_ n: Int) -> String {
+        let suffix: String
+        let ones = n % 10
+        let tens = (n / 10) % 10
+        if tens == 1 {
+            suffix = "th"
+        } else {
+            switch ones {
+            case 1: suffix = "st"
+            case 2: suffix = "nd"
+            case 3: suffix = "rd"
+            default: suffix = "th"
+            }
+        }
+        return "\(n)\(suffix)"
     }
 }
 
@@ -261,6 +300,7 @@ private struct ThinkingIndicator: View {
             isThinking: true,
             isSending: false,
             errorText: nil,
+            pendingQueuedCount: 0,
             onSend: {},
             onStop: {},
             onDismissError: {}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -10,6 +10,7 @@ final class ChatViewModel: ObservableObject {
     @Published var isThinking: Bool = false
     @Published var isSending: Bool = false
     @Published var errorText: String?
+    @Published var pendingQueuedCount: Int = 0
 
     private let daemonClient: DaemonClient
     var sessionId: String?
@@ -26,10 +27,14 @@ final class ChatViewModel: ObservableObject {
 
     func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespaces)
-        guard !text.isEmpty, !isSending else { return }
+        guard !text.isEmpty else { return }
+
+        // Block rapid-fire only when bootstrapping (no session yet)
+        if isSending && sessionId == nil { return }
 
         // Append user message immediately for responsive UX
-        messages.append(ChatMessage(role: .user, text: text))
+        let status: ChatMessageStatus = isSending ? .queued(position: 0) : .sent
+        messages.append(ChatMessage(role: .user, text: text, status: status))
         inputText = ""
         errorText = nil
 
@@ -37,7 +42,7 @@ final class ChatViewModel: ObservableObject {
             // First message: need to bootstrap session
             bootstrapSession(userMessage: text)
         } else {
-            // Subsequent messages: send directly
+            // Subsequent messages: send directly (daemon queues if busy)
             sendUserMessage(text)
         }
     }
@@ -172,6 +177,24 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+
+        case .messageQueued(let queued):
+            pendingQueuedCount += 1
+            // Update the most recent user message that's in queued state with its position
+            if let index = messages.lastIndex(where: { $0.role == .user && $0.status != .sent && $0.status != .processing }) {
+                messages[index].status = .queued(position: queued.position)
+            }
+
+        case .messageDequeued:
+            pendingQueuedCount = max(0, pendingQueuedCount - 1)
+            // Mark the oldest queued user message as processing
+            if let index = messages.firstIndex(where: { msg in
+                guard msg.role == .user else { return false }
+                if case .queued = msg.status { return true }
+                return false
+            }) {
+                messages[index].status = .processing
+            }
 
         case .error(let err):
             log.error("Server error: \(err.message)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -18,6 +18,7 @@ struct MainWindowView: View {
                 isThinking: viewModel.isThinking,
                 isSending: viewModel.isSending,
                 errorText: viewModel.errorText,
+                pendingQueuedCount: viewModel.pendingQueuedCount,
                 onSend: viewModel.sendMessage,
                 onStop: viewModel.stopGenerating,
                 onDismissError: viewModel.dismissError

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -305,6 +305,21 @@ struct AppDataResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Confirms a message has been queued by the daemon.
+/// Wire type: `"message_queued"`
+struct MessageQueuedMessage: Decodable, Sendable {
+    let sessionId: String
+    let requestId: String
+    let position: Int
+}
+
+/// Confirms a queued message has been dequeued and is being processed.
+/// Wire type: `"message_dequeued"`
+struct MessageDequeuedMessage: Decodable, Sendable {
+    let sessionId: String
+    let requestId: String
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {
@@ -323,6 +338,8 @@ enum ServerMessage: Decodable, Sendable {
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
     case generationCancelled(GenerationCancelledMessage)
     case appDataResponse(AppDataResponseMessage)
+    case messageQueued(MessageQueuedMessage)
+    case messageDequeued(MessageDequeuedMessage)
     case pong
     case unknown(String)
 
@@ -380,6 +397,12 @@ enum ServerMessage: Decodable, Sendable {
         case "app_data_response":
             let message = try AppDataResponseMessage(from: decoder)
             self = .appDataResponse(message)
+        case "message_queued":
+            let message = try MessageQueuedMessage(from: decoder)
+            self = .messageQueued(message)
+        case "message_dequeued":
+            let message = try MessageDequeuedMessage(from: decoder)
+            self = .messageDequeued(message)
         case "pong":
             self = .pong
         default:

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -67,14 +67,34 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1) // Just greeting
     }
 
-    func testSendWhileSendingDoesNothing() {
+    func testSendWhileBootstrappingDoesNothing() {
+        // When no session exists yet (bootstrapping), rapid-fire is blocked
         viewModel.inputText = "First"
         viewModel.sendMessage()
 
         viewModel.inputText = "Second"
-        viewModel.sendMessage() // Should be ignored since isSending is set by bootstrapSession
+        viewModel.sendMessage() // Should be ignored since isSending is set by bootstrapSession and sessionId is nil
 
         XCTAssertEqual(viewModel.messages.count, 2) // greeting + first only
+    }
+
+    func testSendWhileSendingWithSessionAppendsMessage() {
+        // When a session exists, sending while isSending is allowed (daemon queues)
+        viewModel.sessionId = "test-session"
+        viewModel.isSending = true
+
+        viewModel.inputText = "Queued message"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 2) // greeting + queued message
+        XCTAssertEqual(viewModel.messages[1].role, .user)
+        XCTAssertEqual(viewModel.messages[1].text, "Queued message")
+        // Message should have queued status since isSending was true
+        if case .queued = viewModel.messages[1].status {
+            // Expected
+        } else {
+            XCTFail("Expected message to have queued status")
+        }
     }
 
     func testSendMessageClearsExistingError() {
@@ -239,6 +259,76 @@ final class ChatViewModelTests: XCTestCase {
     func testThinkingDeltaDoesNotCreateMessage() {
         viewModel.handleServerMessage(.assistantThinkingDelta(AssistantThinkingDeltaMessage(thinking: "Hmm...")))
         XCTAssertEqual(viewModel.messages.count, 1) // Only the greeting
+    }
+
+    // MARK: - Message Queue
+
+    func testMessageQueuedIncrementsPendingCount() {
+        XCTAssertEqual(viewModel.pendingQueuedCount, 0)
+
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
+        viewModel.handleServerMessage(.messageQueued(queued))
+
+        XCTAssertEqual(viewModel.pendingQueuedCount, 1)
+    }
+
+    func testMessageDequeuedDecrementsPendingCount() {
+        // Start with some queued
+        let queued1 = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
+        let queued2 = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-2", position: 2)
+        viewModel.handleServerMessage(.messageQueued(queued1))
+        viewModel.handleServerMessage(.messageQueued(queued2))
+        XCTAssertEqual(viewModel.pendingQueuedCount, 2)
+
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
+        viewModel.handleServerMessage(.messageDequeued(dequeued))
+
+        XCTAssertEqual(viewModel.pendingQueuedCount, 1)
+    }
+
+    func testMessageDequeuedDoesNotGoBelowZero() {
+        XCTAssertEqual(viewModel.pendingQueuedCount, 0)
+
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
+        viewModel.handleServerMessage(.messageDequeued(dequeued))
+
+        XCTAssertEqual(viewModel.pendingQueuedCount, 0)
+    }
+
+    func testMessageQueuedUpdatesMessageStatus() {
+        // Add a user message with queued status
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        // Daemon confirms it's queued at position 2
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 2)
+        viewModel.handleServerMessage(.messageQueued(queued))
+
+        // The user message should have its position updated
+        if case .queued(let position) = viewModel.messages[1].status {
+            XCTAssertEqual(position, 2)
+        } else {
+            XCTFail("Expected message to have queued status with position 2")
+        }
+    }
+
+    func testMessageDequeuedUpdatesMessageStatusToProcessing() {
+        // Add a user message with queued status
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        // Daemon confirms queued then dequeued
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
+        viewModel.handleServerMessage(.messageQueued(queued))
+
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
+        viewModel.handleServerMessage(.messageDequeued(dequeued))
+
+        XCTAssertEqual(viewModel.messages[1].status, .processing)
     }
 
     // MARK: - Full Conversation Flow


### PR DESCRIPTION
## Summary
- Add `message_queued` and `message_dequeued` IPC message types to `ServerMessage` enum so the client can track daemon-side queueing of rapid-fire messages
- Allow sending follow-up messages while `isSending` is true (when a session exists) — the daemon handles queueing, and the UI shows the message immediately with a subtle "Queued" indicator
- Track `pendingQueuedCount` in `ChatViewModel` and update individual `ChatMessage.status` (`.sent`, `.queued(position:)`, `.processing`) as queue events arrive
- Show send button alongside stop button in the composer, and dim queued message bubbles with a "Queued (2nd in line)" label

## Test plan
- [x] Build passes (`./build.sh`)
- [x] All 92 tests pass (`./build.sh test`), including 5 new queue-related tests:
  - `testMessageQueuedIncrementsPendingCount`
  - `testMessageDequeuedDecrementsPendingCount`
  - `testMessageDequeuedDoesNotGoBelowZero`
  - `testMessageQueuedUpdatesMessageStatus`
  - `testMessageDequeuedUpdatesMessageStatusToProcessing`
- [x] Updated `testSendWhileBootstrappingDoesNothing` (renamed) and added `testSendWhileSendingWithSessionAppendsMessage`
- [ ] Manual: send multiple messages rapidly while assistant is streaming; verify queued labels appear and clear as messages are processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
