### PR TITLE
Add agent file-request tool (#876)

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -134,9 +134,9 @@ export interface AppDataRequest {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page';
+export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
 
-export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page'];
+export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page', 'file_upload'];
 
 export interface SurfaceAction {
   id: string;
@@ -195,7 +195,14 @@ export interface DynamicPageSurfaceData {
   appId?: string;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData;
+export interface FileUploadSurfaceData {
+  prompt: string;
+  acceptedTypes?: string[];
+  maxFiles?: number;
+  maxSizeBytes?: number;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -477,12 +484,18 @@ export interface UiSurfaceShowDynamicPage extends UiSurfaceShowBase {
   data: DynamicPageSurfaceData;
 }
 
+export interface UiSurfaceShowFileUpload extends UiSurfaceShowBase {
+  surfaceType: 'file_upload';
+  data: FileUploadSurfaceData;
+}
+
 export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
   | UiSurfaceShowList
   | UiSurfaceShowConfirmation
-  | UiSurfaceShowDynamicPage;
+  | UiSurfaceShowDynamicPage
+  | UiSurfaceShowFileUpload;
 
 export interface UiSurfaceUpdate {
   type: 'ui_surface_update';

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -773,6 +773,37 @@ export class Session {
       } as UiSurfaceShow);
 
       return { content: JSON.stringify({ surfaceId, appId }), isError: false };
+    }
+
+    if (toolName === 'request_file') {
+      const prompt = input.prompt as string;
+      const acceptedTypes = input.accepted_types as string[] | undefined;
+      const maxFiles = (input.max_files as number | undefined) ?? 1;
+
+      const surfaceId = uuid();
+      const surfaceData: FileUploadSurfaceData = {
+        prompt,
+        acceptedTypes,
+        maxFiles,
+      };
+
+      this.surfaceState.set(surfaceId, {
+        surfaceType: 'file_upload',
+        data: surfaceData,
+      });
+
+      this.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: this.conversationId,
+        surfaceId,
+        surfaceType: 'file_upload',
+        data: surfaceData,
+      } as UiSurfaceShow);
+
+      // Wait for the user to upload files (interactive surface pattern)
+      return new Promise<ToolExecutionResult>((resolve) => {
+        this.pendingSurfaceActions.set(surfaceId, { resolve });
+      });
     }
 
     return { content: `Unknown proxy tool: ${toolName}`, isError: true };

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -158,6 +158,48 @@ export const uiDismissTool: Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// request_file
+// ---------------------------------------------------------------------------
+
+export const requestFileTool: Tool = {
+  name: 'request_file',
+  description:
+    'Request one or more files or images from the user. Shows a file upload surface and waits for the user to provide files. ' +
+    'Returns an array of uploaded files with their filename, MIME type, and base64-encoded data.',
+  category: 'ui-surface',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'What to ask the user for (e.g. "Please upload a screenshot of the error")',
+          },
+          accepted_types: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'MIME type filters (e.g. ["image/*", "application/pdf"]). If omitted, all file types are accepted.',
+          },
+          max_files: {
+            type: 'number',
+            description: 'Maximum number of files to accept. Defaults to 1.',
+          },
+        },
+        required: ['prompt'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
 // All tools exported as array for convenience
 // ---------------------------------------------------------------------------
 
@@ -165,4 +207,5 @@ export const allUiSurfaceTools: Tool[] = [
   uiShowTool,
   uiUpdateTool,
   uiDismissTool,
+  requestFileTool,
 ];


### PR DESCRIPTION
## Summary
- Add `request_file` proxy tool that enables the agent to request files/images from the user mid-conversation
- Tool shows a `file_upload` surface (from #890) and blocks until the user uploads files, using the same interactive surface pattern as `ui_show`
- Includes tool definition with `prompt`, `accepted_types`, and `max_files` parameters

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Verify the tool appears in session tool definitions when a client connects
- [ ] Test that invoking `request_file` sends a `ui_surface_show` with `surfaceType: 'file_upload'` to the client
- [ ] Test that the tool blocks until the client sends a `ui_surface_action` response with uploaded files
- [ ] Test that aborting the session resolves pending file upload surfaces with an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
