### PR TITLE
Add request_file agent tool for multimodal file requests (#876)

### DIFF
--- a/assistant/src/__tests__/request-file-tool.test.ts
+++ b/assistant/src/__tests__/request-file-tool.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  INTERACTIVE_SURFACE_TYPES,
+} from '../daemon/ipc-protocol.js';
+import type {
+  FileUploadSurfaceData,
+  UiSurfaceShowFileUpload,
+} from '../daemon/ipc-protocol.js';
+import { requestFileTool, uiShowTool } from '../tools/ui-surface/definitions.js';
+
+// ---------------------------------------------------------------------------
+// request_file tool definition
+// ---------------------------------------------------------------------------
+
+describe('requestFileTool definition', () => {
+  test('has the correct name and category', () => {
+    expect(requestFileTool.name).toBe('request_file');
+    expect(requestFileTool.category).toBe('ui-surface');
+    expect(requestFileTool.executionMode).toBe('proxy');
+  });
+
+  test('getDefinition returns correct input_schema', () => {
+    const definition = requestFileTool.getDefinition();
+
+    expect(definition.name).toBe('request_file');
+    expect(definition.description).toContain('file');
+
+    const schema = definition.input_schema as {
+      type: string;
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+
+    expect(schema.type).toBe('object');
+    expect(schema.required).toEqual(['prompt']);
+    expect(schema.properties).toHaveProperty('prompt');
+    expect(schema.properties).toHaveProperty('accepted_types');
+    expect(schema.properties).toHaveProperty('max_files');
+  });
+
+  test('prompt property is a string type', () => {
+    const definition = requestFileTool.getDefinition();
+    const props = (definition.input_schema as {
+      properties: Record<string, { type: string }>;
+    }).properties;
+
+    expect(props.prompt.type).toBe('string');
+  });
+
+  test('accepted_types property is an array of strings', () => {
+    const definition = requestFileTool.getDefinition();
+    const props = (definition.input_schema as {
+      properties: Record<string, { type: string; items?: { type: string } }>;
+    }).properties;
+
+    expect(props.accepted_types.type).toBe('array');
+    expect(props.accepted_types.items).toEqual({ type: 'string' });
+  });
+
+  test('max_files property is a number type', () => {
+    const definition = requestFileTool.getDefinition();
+    const props = (definition.input_schema as {
+      properties: Record<string, { type: string }>;
+    }).properties;
+
+    expect(props.max_files.type).toBe('number');
+  });
+
+  test('execute throws proxy error', () => {
+    expect(() => requestFileTool.execute({}, {} as never)).toThrow(
+      'Proxy tool: execution must be forwarded to the connected client',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileUploadSurfaceData shape
+// ---------------------------------------------------------------------------
+
+describe('FileUploadSurfaceData shape', () => {
+  test('accepts an object with prompt, acceptedTypes, and maxFiles', () => {
+    const data: FileUploadSurfaceData = {
+      prompt: 'Please share the design file',
+      acceptedTypes: ['image/*', 'application/pdf'],
+      maxFiles: 3,
+    };
+
+    expect(data.prompt).toBe('Please share the design file');
+    expect(data.acceptedTypes).toEqual(['image/*', 'application/pdf']);
+    expect(data.maxFiles).toBe(3);
+  });
+
+  test('acceptedTypes and maxFiles are optional', () => {
+    const data: FileUploadSurfaceData = {
+      prompt: 'Upload a file',
+    };
+
+    expect(data.prompt).toBe('Upload a file');
+    expect(data.acceptedTypes).toBeUndefined();
+    expect(data.maxFiles).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UiSurfaceShowFileUpload structure
+// ---------------------------------------------------------------------------
+
+describe('UiSurfaceShowFileUpload structure', () => {
+  test('can construct a well-typed UiSurfaceShowFileUpload object', () => {
+    const msg: UiSurfaceShowFileUpload = {
+      type: 'ui_surface_show',
+      sessionId: 'session-abc',
+      surfaceId: 'surface-123',
+      surfaceType: 'file_upload',
+      title: 'File Request',
+      data: { prompt: 'Share a screenshot' },
+    };
+
+    expect(msg.type).toBe('ui_surface_show');
+    expect(msg.surfaceType).toBe('file_upload');
+    expect(msg.data.prompt).toBe('Share a screenshot');
+    expect(msg.title).toBe('File Request');
+    expect(msg.sessionId).toBe('session-abc');
+    expect(msg.surfaceId).toBe('surface-123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactivity
+// ---------------------------------------------------------------------------
+
+describe('file_upload interactivity', () => {
+  test('file_upload is in the interactive surface types list', () => {
+    expect(INTERACTIVE_SURFACE_TYPES).toContain('file_upload');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ui_show tool includes file_upload in surface_type enum
+// ---------------------------------------------------------------------------
+
+describe('ui_show tool includes file_upload', () => {
+  test('input_schema surface_type enum includes file_upload', () => {
+    const definition = uiShowTool.getDefinition();
+    const surfaceTypeEnum = (
+      definition.input_schema as {
+        properties: { surface_type: { enum: string[] } };
+      }
+    ).properties.surface_type.enum;
+
+    expect(surfaceTypeEnum).toContain('file_upload');
+  });
+
+  test('description mentions file_upload', () => {
+    const definition = uiShowTool.getDefinition();
+    expect(definition.description).toContain('file_upload');
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
@@ -696,6 +696,35 @@ export class Session {
     toolName: string,
     input: Record<string, unknown>,
   ): Promise<ToolExecutionResult> {
+    if (toolName === 'request_file') {
+      const surfaceId = uuid();
+      const prompt = typeof input.prompt === 'string' ? input.prompt : 'Please share a file';
+      const acceptedTypes = Array.isArray(input.accepted_types) ? input.accepted_types as string[] : undefined;
+      const maxFiles = typeof input.max_files === 'number' ? input.max_files : 1;
+
+      const data: FileUploadSurfaceData = {
+        prompt,
+        acceptedTypes,
+        maxFiles,
+      };
+
+      this.surfaceState.set(surfaceId, { surfaceType: 'file_upload', data });
+
+      this.sendToClient({
+        type: 'ui_surface_show',
+        sessionId: this.conversationId,
+        surfaceId,
+        surfaceType: 'file_upload',
+        title: 'File Request',
+        data,
+      } as UiSurfaceShow);
+
+      // Always await — file upload is interactive
+      return new Promise<ToolExecutionResult>((resolve) => {
+        this.pendingSurfaceActions.set(surfaceId, { resolve });
+      });
+    }
+
     if (toolName === 'ui_show') {
       const surfaceId = uuid();
       const surfaceType = input.surface_type as SurfaceType;

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -36,7 +36,9 @@ export const uiShowTool: Tool = {
     '- confirmation: Yes/no confirmation dialog. ' +
     'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }\n' +
     '- dynamic_page: Custom HTML page rendered in a sandboxed container. ' +
-    'data shape: { html: string, width?: number, height?: number }',
+    'data shape: { html: string, width?: number, height?: number }\n' +
+    '- file_upload: File upload dialog where the user can drag-and-drop or browse for files. ' +
+    'data shape: { prompt: string, acceptedTypes?: string[], maxFiles?: number }',
   category: 'ui-surface',
   defaultRiskLevel: RiskLevel.Low,
   executionMode: 'proxy',
@@ -50,7 +52,7 @@ export const uiShowTool: Tool = {
         properties: {
           surface_type: {
             type: 'string',
-            enum: ['card', 'form', 'list', 'confirmation', 'dynamic_page'],
+            enum: ['card', 'form', 'list', 'confirmation', 'dynamic_page', 'file_upload'],
             description: 'The type of surface to display',
           },
           title: {
@@ -158,6 +160,49 @@ export const uiDismissTool: Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// request_file
+// ---------------------------------------------------------------------------
+
+export const requestFileTool: Tool = {
+  name: 'request_file',
+  description:
+    'Request a file or image from the user. Shows a file upload dialog where the user can drag-and-drop or browse for files. ' +
+    'Use this when you need the user to share a file (image, document, PDF, etc.) to continue the conversation. ' +
+    'The result contains the uploaded file data including base64 content and MIME type.',
+  category: 'ui-surface',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'What to ask the user for, e.g. "Please share the design file you\'d like me to review"',
+          },
+          accepted_types: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'MIME type filters, e.g. ["image/*", "application/pdf"]. If omitted, all supported file types are accepted.',
+          },
+          max_files: {
+            type: 'number',
+            description: 'Maximum number of files to accept. Defaults to 1.',
+          },
+        },
+        required: ['prompt'],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
 // All tools exported as array for convenience
 // ---------------------------------------------------------------------------
 
@@ -165,4 +210,5 @@ export const allUiSurfaceTools: Tool[] = [
   uiShowTool,
   uiUpdateTool,
   uiDismissTool,
+  requestFileTool,
 ];


### PR DESCRIPTION
## Summary
- Added a new `request_file` proxy tool that the assistant can invoke mid-conversation to request files/images from the user
- The tool shows the existing `file_upload` surface (implemented in M3/PR #890) and returns uploaded file data via the pending surface action mechanism
- Updated the `ui_show` tool's `surface_type` enum to include `file_upload` so both tools can trigger file uploads
- Added 12 tests covering tool definition schema, data shape types, interactivity, and proxy behavior

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 12 new tests pass (`bun test src/__tests__/request-file-tool.test.ts`)
- [ ] Manual: invoke `request_file` tool from agent conversation and verify file upload dialog appears
- [ ] Manual: verify uploaded file data is returned to the agent as tool result

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
