### PR TITLE
Guard profile extraction against unrelated message_complete events

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -107,6 +107,13 @@ final class ProfileExtractor {
         // Wait for session creation, send the transcript, and accumulate the response.
         var sessionId: String?
         var accumulated = ""
+        // Track whether we've sent the user message and received at least one
+        // text delta back. Since `assistant_text_delta` and `message_complete`
+        // don't carry a sessionId, we use this flag to avoid acting on events
+        // from unrelated concurrent sessions (e.g., a chat the user starts
+        // while extraction is running in the background).
+        var messageSent = false
+        var receivedDelta = false
 
         for await message in stream {
             switch message {
@@ -120,18 +127,30 @@ final class ProfileExtractor {
                         content: "Here is the interview transcript to analyze:\n\n\(transcript)",
                         attachments: nil
                     ))
+                    messageSent = true
                 }
 
-            case .assistantTextDelta(let delta) where sessionId != nil:
+            case .assistantTextDelta(let delta) where messageSent:
                 accumulated += delta.text
+                receivedDelta = true
 
-            case .assistantThinkingDelta where sessionId != nil:
-                break
+            case .assistantThinkingDelta where messageSent:
+                if !receivedDelta {
+                    // Thinking deltas from our session also count as evidence
+                    // that this session's response has started.
+                    receivedDelta = true
+                }
 
-            case .messageComplete where sessionId != nil:
+            case .messageComplete where receivedDelta:
                 log.info("Extraction response complete (\(accumulated.count) chars)")
                 processExtractionResponse(accumulated)
                 return
+
+            case .messageComplete where messageSent && !receivedDelta:
+                // A message_complete arrived after we sent our message but
+                // before we received any deltas — this belongs to another
+                // session (e.g., the interview finishing). Ignore it.
+                log.debug("Ignoring message_complete from unrelated session")
 
             case .cuError(let error) where error.sessionId == sessionId:
                 log.error("Extraction session error: \(error.message)")


### PR DESCRIPTION
## Summary
- Fixes a bug where `ProfileExtractor` could pick up `assistant_text_delta` and `message_complete` events from unrelated concurrent sessions (e.g., a user chat started while extraction runs in the background)
- Adds `messageSent` and `receivedDelta` flags to scope event handling: only accumulates deltas after the extraction's user message is sent, and only acts on `message_complete` after receiving at least one delta from the extraction's response stream
- Stray `message_complete` events from other sessions are now logged and safely ignored

## Context
Follow-up to PR #887 (profile extraction). The `assistant_text_delta` and `message_complete` IPC events don't carry a `sessionId` (confirmed in `ipc-protocol.ts`), so the extractor previously had no way to distinguish its own events from those of other sessions. This caused silent failures: the extraction would parse chat response text as JSON, fail decoding, and never write `SOUL.md` or store the profile.

## Test plan
- [ ] Complete onboarding interview, then immediately start a chat in the main window while extraction is running in the background -- verify `SOUL.md` is still written and profile is stored in UserDefaults
- [ ] Complete onboarding interview with no concurrent activity -- verify extraction still works normally
- [ ] Verify build succeeds with `./build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
