### PR TITLE
Add test for messageDequeued isSending/isThinking restoration

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -331,6 +331,27 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[1].status, .processing)
     }
 
+    func testMessageDequeuedRestoresSendingAndThinkingState() {
+        // Simulate: message A completes, then queued message B is dequeued
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Message A completes — clears isSending and isThinking
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+
+        // Message B is dequeued and starts processing
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-2")
+        viewModel.handleServerMessage(.messageDequeued(dequeued))
+
+        // isSending and isThinking must be restored so the UI shows
+        // the thinking indicator and stop button
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+    }
+
     // MARK: - Full Conversation Flow
 
     func testFullConversationFlow() {


### PR DESCRIPTION
## Summary
- Adds a test (`testMessageDequeuedRestoresSendingAndThinkingState`) that verifies the `messageDequeued` handler correctly sets `isSending = true` and `isThinking = true` when a queued message starts processing
- This covers the scenario where message A completes (clearing both flags), then queued message B is dequeued -- the UI must re-show the thinking indicator and stop button

## Test plan
- [x] `./build.sh test` passes (93 tests, 0 failures)
- [x] New test specifically validates the flag restoration after `messageComplete` clears them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
