### PR TITLE
Fix queue drain resilience and add queue depth limit

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -134,7 +134,7 @@ mock.module('../agent/loop.js', () => ({
 // Import Session AFTER mocks are registered.
 // ---------------------------------------------------------------------------
 
-import { Session } from '../daemon/session.js';
+import { Session, MAX_QUEUE_DEPTH } from '../daemon/session.js';
 
 function makeSession(): Session {
   const provider = {
@@ -376,5 +376,74 @@ describe('Session message queue', () => {
     // Complete fourth (final queued message)
     resolveRun(3);
     await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('drain continues after a queued message fails to persist', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+    const events3: ServerMessage[] = [];
+
+    // Start first message — blocks on AgentLoop.run
+    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue a message with empty content (will fail persistUserMessage)
+    session.enqueueMessage('', [], (e) => events2.push(e), 'req-2');
+    // Enqueue a valid message after the bad one
+    session.enqueueMessage('msg-3', [], (e) => events3.push(e), 'req-3');
+    expect(session.getQueueDepth()).toBe(2);
+
+    // Complete first message — triggers drain. The empty message should fail
+    // to persist, but the drain should continue to msg-3.
+    resolveRun(0);
+    await p1;
+
+    // msg-3 should have been dequeued and started a new AgentLoop.run
+    await waitForPendingRun(2);
+
+    // The empty message should have received an error event
+    const err2 = events2.find((e) => e.type === 'error');
+    expect(err2).toBeDefined();
+    if (err2 && err2.type === 'error') {
+      expect(err2.message).toContain('required');
+    }
+
+    // msg-3 should have received a dequeued event
+    expect(events3.some((e) => e.type === 'message_dequeued')).toBe(true);
+
+    // Complete the third message's run
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // msg-3 should have completed successfully
+    expect(events3.some((e) => e.type === 'message_complete')).toBe(true);
+  });
+
+  test('queue rejects when at max depth', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start first message to make session busy
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Fill the queue to MAX_QUEUE_DEPTH
+    for (let i = 0; i < MAX_QUEUE_DEPTH; i++) {
+      const result = session.enqueueMessage(`msg-${i + 2}`, [], () => {}, `req-${i + 2}`);
+      expect(result.queued).toBe(true);
+      expect(result.rejected).toBeUndefined();
+    }
+    expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
+
+    // Next enqueue should be rejected
+    const rejected = session.enqueueMessage('overflow', [], () => {}, 'req-overflow');
+    expect(rejected.queued).toBe(false);
+    expect(rejected.rejected).toBe(true);
+
+    // Queue depth should not have increased
+    expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
   });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -267,6 +267,11 @@ async function handleUserMessage(
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
+    if (result.rejected) {
+      rlog.warn('Message rejected — queue is full');
+      ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
+      return;
+    }
     if (result.queued) {
       rlog.info({ position: session.getQueueDepth() }, 'Message queued (session busy)');
       ctx.send(socket, {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,6 +47,8 @@ interface QueuedMessage {
   onEvent: (msg: ServerMessage) => void;
 }
 
+export const MAX_QUEUE_DEPTH = 10;
+
 export class Session {
   public readonly conversationId: string;
   private messages: Message[] = [];
@@ -221,7 +223,8 @@ export class Session {
   /**
    * Enqueue a message if the session is busy, or indicate it should be
    * processed immediately. Returns `{ queued: true }` if the message was
-   * added to the queue, or `{ queued: false }` if the caller should invoke
+   * added to the queue, `{ queued: false, rejected: true }` if the queue
+   * is full, or `{ queued: false }` if the caller should invoke
    * `processMessage` directly.
    */
   enqueueMessage(
@@ -229,9 +232,13 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId: string,
-  ): { queued: boolean; requestId: string } {
+  ): { queued: boolean; rejected?: boolean; requestId: string } {
     if (!this.processing) {
       return { queued: false, requestId };
+    }
+
+    if (this.messageQueue.length >= MAX_QUEUE_DEPTH) {
+      return { queued: false, rejected: true, requestId };
     }
 
     this.messageQueue.push({ content, attachments, requestId, onEvent });
@@ -601,6 +608,12 @@ export class Session {
   /**
    * Process the next message in the queue, if any.
    * Called from the `runAgentLoop` finally block after processing completes.
+   *
+   * When a dequeued message fails to persist (e.g. empty content, DB error),
+   * `processMessage` catches the error and resolves without calling
+   * `runAgentLoop`. Since the drain chain depends on `runAgentLoop`'s `finally`
+   * block, we must explicitly continue draining on failure — otherwise
+   * remaining queued messages would be stranded.
    */
   private drainQueue(): void {
     const next = this.messageQueue.shift();
@@ -613,9 +626,26 @@ export class Session {
       requestId: next.requestId,
     });
 
-    // Fire-and-forget: processMessage sets this.processing = true synchronously
-    // so subsequent messages will still be enqueued.
-    this.processMessage(next.content, next.attachments, next.onEvent, next.requestId).catch((err) => {
+    // Try to persist and run the dequeued message. If persistUserMessage
+    // succeeds, runAgentLoop is called and its finally block will drain
+    // the next message. If persistUserMessage fails, processMessage
+    // resolves early (no runAgentLoop call), so we must continue draining.
+    let userMessageId: string;
+    try {
+      userMessageId = this.persistUserMessage(next.content, next.attachments, next.requestId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
+      next.onEvent({ type: 'error', message });
+      // Continue draining — don't strand remaining messages
+      this.drainQueue();
+      return;
+    }
+
+    // Fire-and-forget: persistUserMessage set this.processing = true
+    // so subsequent messages will still be enqueued. runAgentLoop's
+    // finally block will call drainQueue when this run completes.
+    this.runAgentLoop(next.content, userMessageId, next.onEvent).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Error processing queued message');
       next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });


### PR DESCRIPTION
## Summary
- **Drain resilience:** `drainQueue` now calls `persistUserMessage` directly instead of delegating to `processMessage`. When persist fails (empty content, DB error), the error is sent to the failed message's `onEvent` callback and `drainQueue` recurses to process the next queued item. This prevents the chain from breaking and stranding remaining messages.
- **Queue depth limit:** Added `MAX_QUEUE_DEPTH = 10` constant. `enqueueMessage` returns `{ queued: false, rejected: true }` when the queue is full. `handleUserMessage` in `handlers.ts` handles the rejected case by sending an error to the client.
- **Tests:** Added two new tests in `session-queue.test.ts` verifying drain continues after persist failure and queue rejects at max depth.

Addresses review feedback from PR #886.

## Test plan
- [x] Existing session queue tests pass (5 tests)
- [x] New test: drain continues after a queued message fails to persist
- [x] New test: queue rejects when at max depth
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
