### PR TITLE
Fix session eviction dropping systemPromptOverride and maxResponseTokens

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -33,6 +33,9 @@ export class DaemonServer {
   private socketToCuSession = new Map<net.Socket, Set<string>>();
   private connectedSockets = new Set<net.Socket>();
   private socketSandboxOverride = new Map<net.Socket, boolean>();
+  // Persisted session options (e.g. systemPromptOverride, maxResponseTokens)
+  // so that evicted sessions can be recreated with the same overrides.
+  private sessionOptions = new Map<string, SessionCreateOptions>();
   // Guards against duplicate session creation when multiple clients connect
   // with the same conversation ID concurrently. The first caller creates the
   // session; subsequent callers await the same promise.
@@ -393,6 +396,14 @@ export class DaemonServer {
       target.setSandboxOverride(this.socketSandboxOverride.get(socket));
     };
 
+    // Persist session options so they survive eviction/recreation.
+    if (options && (options.systemPromptOverride || options.maxResponseTokens)) {
+      this.sessionOptions.set(conversationId, {
+        ...this.sessionOptions.get(conversationId),
+        ...options,
+      });
+    }
+
     if (!session || (session.isStale() && !session.isProcessing())) {
       // Check if another caller is already creating this session.
       // Without this guard, two concurrent getOrCreateSession calls for the
@@ -405,6 +416,9 @@ export class DaemonServer {
         return session;
       }
 
+      // Recover stored options for this conversation (survives eviction).
+      const storedOptions = this.sessionOptions.get(conversationId);
+
       const createPromise = (async () => {
         const config = getConfig();
         let provider = getProvider(config.provider);
@@ -414,8 +428,8 @@ export class DaemonServer {
         }
         const workingDir = process.cwd();
 
-        const systemPrompt = options?.systemPromptOverride ?? buildSystemPrompt(config.systemPrompt);
-        const maxTokens = options?.maxResponseTokens ?? config.maxTokens;
+        const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt(config.systemPrompt);
+        const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const newSession = new Session(
           conversationId,


### PR DESCRIPTION
## Summary
- Fixes a bug where `systemPromptOverride` and `maxResponseTokens` were silently lost when an in-memory Session was evicted (e.g. by config/prompt file changes) and later recreated from the database
- Adds a `sessionOptions` map on `DaemonServer` keyed by conversation ID that persists these overrides across eviction/recreation cycles
- When `getOrCreateSession` receives options, they are stored in the map; when recreating an evicted session, stored options are recovered automatically

## Test plan
- [ ] Start an interview session (which sets `systemPromptOverride` and `maxResponseTokens`)
- [ ] Edit `SOUL.md` or `config.json` to trigger session eviction
- [ ] Send another message -- verify the interview system prompt is still active (not replaced by the default system prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
