### PR TITLE
Address interview review feedback from PRs #882 and #883

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -48,6 +48,15 @@ final class VoiceInputManager {
         stopRecording()
     }
 
+    /// Directly toggle recording on/off — used by UI mic buttons that bypass the Fn-key hold flow.
+    func toggleRecording() {
+        if isRecording {
+            stopRecording()
+        } else {
+            beginRecording()
+        }
+    }
+
     // MARK: - Fn Key Detection
 
     private func setupFnKeyMonitors() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -7,13 +7,15 @@ struct InterviewChatView: View {
     let onSend: () -> Void
     let onVoiceToggle: () -> Void
     let isRecording: Bool
+    let isStreaming: Bool
     var onChipTap: ((String) -> Void)? = nil
 
     /// Whether suggestion chips should be visible.
+    /// Only show after the first assistant greeting has fully completed (not while streaming).
     private var showSuggestionChips: Bool {
         let hasGreeting = messages.contains { $0.role == .assistant }
         let hasUserMessage = messages.contains { $0.role == .user }
-        return hasGreeting && !hasUserMessage && inputText.isEmpty
+        return hasGreeting && !hasUserMessage && inputText.isEmpty && !isStreaming
     }
 
     var body: some View {
@@ -264,7 +266,8 @@ private struct TypingIndicator: View {
                 isThinking: true,
                 onSend: {},
                 onVoiceToggle: {},
-                isRecording: false
+                isRecording: false,
+                isStreaming: false
             )
             .frame(height: 400)
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -10,7 +10,7 @@ struct InterviewStepView: View {
     @State private var streamingMessageId = UUID()
     @State private var isRecording = false
 
-    private let voiceInputManager = VoiceInputManager()
+    @State private var voiceInputManager = VoiceInputManager()
     private let profileExtractor: ProfileExtractor
 
     init(state: OnboardingState, daemonClient: DaemonClientProtocol, onComplete: @escaping () -> Void) {
@@ -66,6 +66,7 @@ struct InterviewStepView: View {
                 onSend: { viewModel.sendMessage() },
                 onVoiceToggle: { toggleVoice() },
                 isRecording: isRecording,
+                isStreaming: !viewModel.streamingText.isEmpty,
                 onChipTap: { chip in
                     viewModel.inputText = chip
                     viewModel.sendMessage()
@@ -154,11 +155,7 @@ struct InterviewStepView: View {
     }
 
     private func toggleVoice() {
-        if isRecording {
-            voiceInputManager.stop()
-        } else {
-            voiceInputManager.start()
-        }
+        voiceInputManager.toggleRecording()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -59,7 +59,7 @@ final class InterviewViewModel {
 
         STRICT RULES:
         - NEVER exceed 2-3 sentences per response. Brevity is warmth.
-        - ALWAYS end with a follow-up question that shows you were actually listening.
+        - ALWAYS end with a follow-up question that shows you were actually listening (except during the closing phase — see below).
         - Mirror their specific words back. Ask about the feeling behind what they said. Notice what they emphasize.
 
         NEVER do any of these:
@@ -218,7 +218,7 @@ final class InterviewViewModel {
         case 3...4:
             contentToSend += "\n\n[Deep-dive phase: Follow up on what they've shared. Ask about the WHY behind what they told you. Show you were listening by referencing specific things they said.]"
         default:
-            contentToSend += "\n\n[Closing phase: This is your final response. In 2-3 sentences, reflect back ONE specific thing you learned about them that stood out. Express genuine forward-looking excitement about that ONE thing, not everything. End warmly.]"
+            contentToSend += "\n\n[Closing phase: This is your final response. In 2-3 sentences, reflect back ONE specific thing you learned about them that stood out. Express genuine forward-looking excitement about that ONE thing, not everything. End warmly. Do NOT ask a follow-up question — the conversation is wrapping up.]"
         }
 
         let isLastTurn = nextTurn >= maxTurns


### PR DESCRIPTION
## Summary
- **System prompt closing phase**: Drop the "always ask a follow-up question" rule for the final turn so the assistant wraps up naturally without asking a question when input is about to be disabled
- **Mic button fix**: Add `toggleRecording()` to `VoiceInputManager` so the UI mic button directly starts/stops audio recording instead of just toggling Fn-key event monitors
- **VoiceInputManager instance churn**: Move from plain stored property to `@State` so SwiftUI doesn't recreate it on every re-render
- **Suggestion chips streaming guard**: Gate chip visibility on completed (non-streaming) assistant messages to prevent chips from appearing while the greeting is still being streamed

## Test plan
- [ ] Start the interview and verify the greeting streams fully before suggestion chips appear
- [ ] Let the interview reach the final turn and confirm the assistant does not end with a question
- [ ] Tap the mic button and verify it begins recording (audio waveform/indicator visible)
- [ ] Tap the mic button again and verify it stops recording and transcribes
- [ ] Use the skip link and verify onboarding advances correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
