### PR TITLE
Recompute queued message positions after dequeue (#892)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -207,6 +207,12 @@ final class ChatViewModel: ObservableObject {
                let index = messages.firstIndex(where: { $0.id == messageId }) {
                 messages[index].status = .processing
             }
+            // Recompute positions for remaining queued messages
+            for i in messages.indices {
+                if case .queued(let position) = messages[i].status, position > 0 {
+                    messages[i].status = .queued(position: position - 1)
+                }
+            }
             // The dequeued message is now being processed
             isThinking = true
             isSending = true


### PR DESCRIPTION
## Summary
- After a queued message is dequeued and transitions to `.processing`, remaining queued messages kept stale position values (e.g., "2nd in line" even after the queue advanced). This iterates remaining `.queued` messages and decrements their positions by 1 so the UI shows correct ordinals.
- Addresses the remaining P2 review feedback from PR #892 (Fixes 1 and 2 were already addressed in PR #895).

## Test plan
- [ ] Send 3+ rapid-fire messages while the first is processing
- [ ] Verify queued messages show correct position labels ("1st in line", "2nd in line", etc.)
- [ ] As each message is dequeued, verify remaining queued labels update (positions decrement)
- [ ] Confirm thinking indicator and stop button appear correctly for dequeued messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
