### PR TITLE
Add sessionId to text delta and message complete IPC messages

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -157,6 +157,7 @@ exports[`IPC message snapshots ClientMessage types app_data_request serializes t
 
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
+  "sessionId": "sess-001",
   "text": "Here is some output",
   "type": "assistant_text_delta",
 }
@@ -239,6 +240,7 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
 
 exports[`IPC message snapshots ServerMessage types message_complete serializes to expected JSON 1`] = `
 {
+  "sessionId": "sess-001",
   "type": "message_complete",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -124,6 +124,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   assistant_text_delta: {
     type: 'assistant_text_delta',
     text: 'Here is some output',
+    sessionId: 'sess-001',
   },
   assistant_thinking_delta: {
     type: 'assistant_thinking_delta',
@@ -173,6 +174,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   message_complete: {
     type: 'message_complete',
+    sessionId: 'sess-001',
   },
   session_info: {
     type: 'session_info',

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -238,6 +238,7 @@ export type ClientMessage =
 export interface AssistantTextDelta {
   type: 'assistant_text_delta';
   text: string;
+  sessionId?: string;
 }
 
 export interface AssistantThinkingDelta {
@@ -279,6 +280,7 @@ export interface ConfirmationRequest {
 
 export interface MessageComplete {
   type: 'message_complete';
+  sessionId?: string;
 }
 
 export interface SessionInfo {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -423,7 +423,7 @@ export class Session {
       const buildEventHandler = () => (event: import('../agent/loop.js').AgentEvent) => {
         switch (event.type) {
           case 'text_delta':
-            onEvent({ type: 'assistant_text_delta', text: event.text });
+            onEvent({ type: 'assistant_text_delta', text: event.text, sessionId: this.conversationId });
             if (isFirstMessage) firstAssistantText += event.text;
             break;
           case 'thinking_delta':
@@ -576,7 +576,7 @@ export class Session {
       if (abortController.signal.aborted) {
         onEvent({ type: 'generation_cancelled' });
       } else {
-        onEvent({ type: 'message_complete' });
+        onEvent({ type: 'message_complete', sessionId: this.conversationId });
       }
 
       // Auto-generate conversation title after first exchange

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -105,15 +105,11 @@ final class ProfileExtractor {
         ))
 
         // Wait for session creation, send the transcript, and accumulate the response.
+        // Filter all streaming events by sessionId so we only process deltas and
+        // completion from our own extraction session, not from unrelated concurrent
+        // sessions (e.g., a chat the user starts while extraction runs).
         var sessionId: String?
         var accumulated = ""
-        // Track whether we've sent the user message and received at least one
-        // text delta back. Since `assistant_text_delta` and `message_complete`
-        // don't carry a sessionId, we use this flag to avoid acting on events
-        // from unrelated concurrent sessions (e.g., a chat the user starts
-        // while extraction is running in the background).
-        var messageSent = false
-        var receivedDelta = false
 
         for await message in stream {
             switch message {
@@ -127,30 +123,18 @@ final class ProfileExtractor {
                         content: "Here is the interview transcript to analyze:\n\n\(transcript)",
                         attachments: nil
                     ))
-                    messageSent = true
                 }
 
-            case .assistantTextDelta(let delta) where messageSent:
+            case .assistantTextDelta(let delta) where delta.sessionId == sessionId && sessionId != nil:
                 accumulated += delta.text
-                receivedDelta = true
 
-            case .assistantThinkingDelta where messageSent:
-                if !receivedDelta {
-                    // Thinking deltas from our session also count as evidence
-                    // that this session's response has started.
-                    receivedDelta = true
-                }
+            case .assistantThinkingDelta where sessionId != nil:
+                break
 
-            case .messageComplete where receivedDelta:
+            case .messageComplete(let complete) where complete.sessionId == sessionId && sessionId != nil:
                 log.info("Extraction response complete (\(accumulated.count) chars)")
                 processExtractionResponse(accumulated)
                 return
-
-            case .messageComplete where messageSent && !receivedDelta:
-                // A message_complete arrived after we sent our message but
-                // before we received any deltas — this belongs to another
-                // session (e.g., the interview finishing). Ignore it.
-                log.debug("Ignoring message_complete from unrelated session")
 
             case .cuError(let error) where error.sessionId == sessionId:
                 log.error("Extraction session error: \(error.message)")

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -222,6 +222,12 @@ struct CuErrorMessage: Decodable, Sendable {
 /// Streamed text delta from the assistant's response.
 struct AssistantTextDeltaMessage: Decodable, Sendable {
     let text: String
+    let sessionId: String?
+
+    init(text: String, sessionId: String? = nil) {
+        self.text = text
+        self.sessionId = sessionId
+    }
 }
 
 /// Streamed thinking delta from the assistant's reasoning.
@@ -231,6 +237,11 @@ struct AssistantThinkingDeltaMessage: Decodable, Sendable {
 
 /// Signals that the assistant's message is complete.
 struct MessageCompleteMessage: Decodable, Sendable {
+    let sessionId: String?
+
+    init(sessionId: String? = nil) {
+        self.sessionId = sessionId
+    }
 }
 
 /// Session metadata from the server (e.g. generated title).


### PR DESCRIPTION
## Summary
- Add optional `sessionId` field to `AssistantTextDelta` and `MessageComplete` IPC messages in the protocol, daemon, and Swift client
- Populate `sessionId` from `Session.conversationId` when the daemon sends these events
- Filter incoming deltas and completion events by `sessionId` in `ProfileExtractor` so it only processes events from its own extraction session

Fixes the critical bug from #887 review feedback: ProfileExtractor accumulated text deltas from unrelated sessions because `assistant_text_delta` and `message_complete` had no session identifier. If a user started a chat while extraction was still streaming, the extractor would pick up deltas from the chat session, corrupt the accumulated text, and fail to parse JSON -- silently losing the profile.

## Test plan
- [ ] Complete an interview and immediately start a chat — verify `~/.vellum/SOUL.md` is still created correctly
- [ ] Verify existing chat, TextSession, and InterviewViewModel still work (sessionId is optional, backward compatible)
- [ ] Run `bunx tsc --noEmit` — passes
- [ ] Run `swift build` — passes
- [ ] Run IPC snapshot tests — all 53 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
