### PR TITLE
Fix HTTP busy-session handling and remove duplicate request_file handler

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -495,6 +495,12 @@ export class DaemonServer {
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
 
+    // Reject concurrent requests upfront. The HTTP path should never use
+    // the message queue — it returns 409 to the caller instead.
+    if (session.isProcessing()) {
+      throw new Error('Session is already processing a message');
+    }
+
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
       ? attachmentsStore.getAttachmentsByIds(assistantId, attachmentIds).map((a) => ({

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -847,37 +847,6 @@ export class Session {
       return { content: JSON.stringify({ surfaceId, appId }), isError: false };
     }
 
-    if (toolName === 'request_file') {
-      const prompt = input.prompt as string;
-      const acceptedTypes = input.accepted_types as string[] | undefined;
-      const maxFiles = (input.max_files as number | undefined) ?? 1;
-
-      const surfaceId = uuid();
-      const surfaceData: FileUploadSurfaceData = {
-        prompt,
-        acceptedTypes,
-        maxFiles,
-      };
-
-      this.surfaceState.set(surfaceId, {
-        surfaceType: 'file_upload',
-        data: surfaceData,
-      });
-
-      this.sendToClient({
-        type: 'ui_surface_show',
-        sessionId: this.conversationId,
-        surfaceId,
-        surfaceType: 'file_upload',
-        data: surfaceData,
-      } as UiSurfaceShow);
-
-      // Wait for the user to upload files (interactive surface pattern)
-      return new Promise<ToolExecutionResult>((resolve) => {
-        this.pendingSurfaceActions.set(surfaceId, { resolve });
-      });
-    }
-
     return { content: `Unknown proxy tool: ${toolName}`, isError: true };
   }
 


### PR DESCRIPTION
## Summary
- **HTTP busy-session guard**: Added explicit `session.isProcessing()` check in `DaemonServer.persistAndProcessMessage()` before calling `session.persistUserMessage()`. This closes a race window where two rapid HTTP requests could both reach `persistUserMessage` before the processing flag is set, bypassing the intended 409 busy rejection. The HTTP path should never use the message queue — it returns 409 to the caller instead.
- **Remove dead code**: Removed the second (unreachable) `if (toolName === 'request_file')` block in `Session.surfaceProxyResolver()`, which was dead code from a bad merge. The first handler (with `title: 'File Request'` and proper `typeof` input validation) is retained.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that rapid concurrent HTTP POST /messages requests to the same session return 409 for the second request
- [ ] Confirm `request_file` tool still works correctly via IPC (the first handler remains intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
