### PR TITLE
Check file size before reading into memory in FileUploadSurfaceView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
@@ -219,15 +219,17 @@ struct FileUploadSurfaceView: View {
             return
         }
 
-        // Read file data
-        guard let fileData = try? Data(contentsOf: url) else {
-            errorMessage = "Could not read file: \(url.lastPathComponent)"
+        // Check file size before reading into memory to avoid OOM on large files
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        let fileSize = attrs?[.size] as? Int ?? 0
+        if fileSize > data.maxSizeBytes {
+            errorMessage = "\(url.lastPathComponent) exceeds the \(formatFileSize(data.maxSizeBytes)) size limit."
             return
         }
 
-        // Check file size
-        if fileData.count > data.maxSizeBytes {
-            errorMessage = "\(url.lastPathComponent) exceeds the \(formatFileSize(data.maxSizeBytes)) size limit."
+        // Now safe to read the file data
+        guard let fileData = try? Data(contentsOf: url) else {
+            errorMessage = "Could not read file: \(url.lastPathComponent)"
             return
         }
 


### PR DESCRIPTION
## Summary
- Fix OOM risk in `FileUploadSurfaceView.addFile(from:)` where the entire file was loaded into memory via `Data(contentsOf:)` before validating the file size against `maxSizeBytes`
- Now uses `FileManager.default.attributesOfItem(atPath:)` to check the file size on disk first, rejecting oversized files without reading them into memory
- A user dragging a multi-GB file will now see the size limit error instantly instead of potentially crashing the app

## Test plan
- [ ] Drag a file larger than `maxSizeBytes` onto the drop zone -- should show error without memory spike
- [ ] Drag a valid file -- should still be accepted and displayed normally
- [ ] Browse and select an oversized file -- should show error
- [ ] Browse and select a valid file -- should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
