### PR TITLE
Remove duplicate request_file handler (dead code)

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -847,37 +847,6 @@ export class Session {
       return { content: JSON.stringify({ surfaceId, appId }), isError: false };
     }
 
-    if (toolName === 'request_file') {
-      const prompt = input.prompt as string;
-      const acceptedTypes = input.accepted_types as string[] | undefined;
-      const maxFiles = (input.max_files as number | undefined) ?? 1;
-
-      const surfaceId = uuid();
-      const surfaceData: FileUploadSurfaceData = {
-        prompt,
-        acceptedTypes,
-        maxFiles,
-      };
-
-      this.surfaceState.set(surfaceId, {
-        surfaceType: 'file_upload',
-        data: surfaceData,
-      });
-
-      this.sendToClient({
-        type: 'ui_surface_show',
-        sessionId: this.conversationId,
-        surfaceId,
-        surfaceType: 'file_upload',
-        data: surfaceData,
-      } as UiSurfaceShow);
-
-      // Wait for the user to upload files (interactive surface pattern)
-      return new Promise<ToolExecutionResult>((resolve) => {
-        this.pendingSurfaceActions.set(surfaceId, { resolve });
-      });
-    }
-
     return { content: `Unknown proxy tool: ${toolName}`, isError: true };
   }
 


### PR DESCRIPTION
## Summary
- Removes duplicate `request_file` handler in `surfaceProxyResolver` that was unreachable dead code from a merge conflict resolution error (commits `88546ca` and `d6a452e` both added a handler, and the merge at `6dc03de` kept both)
- Keeps the first handler (line ~729) which has better defensive input validation (`typeof` checks with fallback defaults) and includes `title: 'File Request'` in the surface message
- The second handler (previously at line ~850) used raw `as string` casts without validation and was never reachable

Addresses review feedback from PR #894.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] No functional change -- the removed code was unreachable dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
