### PR TITLE
Exclude request_file from CU tools and fix queue ID mapping

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -200,7 +200,9 @@ export class ComputerUseSession {
     const systemPrompt = buildComputerUseSystemPrompt(this.screenWidth, this.screenHeight);
     const toolDefs: ToolDefinition[] = [
       ...allComputerUseTools.map((t) => t.getDefinition()),
-      ...allUiSurfaceTools.map((t) => t.getDefinition()),
+      ...allUiSurfaceTools
+        .filter((t) => t.name !== 'request_file')
+        .map((t) => t.getDefinition()),
     ];
 
     const prompter = new PermissionPrompter(this.sendToClient);

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -37,10 +37,17 @@ final class ChatViewModel: ObservableObject {
         if isSending && sessionId == nil { return }
 
         // Append user message immediately for responsive UX
-        let status: ChatMessageStatus = isSending ? .queued(position: 0) : .sent
+        let willBeQueued = isSending && sessionId != nil
+        let status: ChatMessageStatus = willBeQueued ? .queued(position: 0) : .sent
         let userMessage = ChatMessage(role: .user, text: text, status: status)
         messages.append(userMessage)
-        pendingMessageIds.append(userMessage.id)
+        // Only track in pendingMessageIds when the message will actually be
+        // queued by the daemon (i.e. sent while another message is processing).
+        // Messages processed immediately never receive a messageQueued event,
+        // so adding them would corrupt the FIFO mapping.
+        if willBeQueued {
+            pendingMessageIds.append(userMessage.id)
+        }
         inputText = ""
         errorText = nil
 


### PR DESCRIPTION
## Summary
- **Filter `request_file` out of CU session tool definitions.** The `allUiSurfaceTools` array (which includes `request_file`) was being used unfiltered to build CU tool defs. The CU proxy resolver only handles `ui_show`, `ui_update`, and `ui_dismiss` — `request_file` fell through to the CU action path and was treated as an unknown tool, which the macOS CU mapper interpreted as `.done`, prematurely ending the session.
- **Fix `pendingMessageIds` FIFO corruption in `ChatViewModel`.** Previously, every call to `sendMessage()` appended the user message UUID to `pendingMessageIds` unconditionally. Messages processed immediately (when the daemon is not busy) never receive a `messageQueued` event, leaving stale entries that corrupted the FIFO mapping — subsequent `messageQueued` handlers would pop the wrong UUID, attaching the "Queued" label to the wrong message. Now, entries are only added when the message is expected to be queued (`isSending && sessionId != nil`).

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] Swift build passes (`./build.sh`)
- [ ] Verify CU sessions no longer terminate prematurely when `request_file` is defined in `allUiSurfaceTools`
- [ ] Verify that sending a message when the daemon is idle does not add a stale entry to `pendingMessageIds`
- [ ] Verify that sending a message while the daemon is processing another correctly shows "Queued" status on the right message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
