### PR TITLE
Add request_file handler to CU session proxy resolver

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -9,7 +9,7 @@
 import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
@@ -278,6 +278,36 @@ export class ComputerUseSession {
         this.pendingSurfaceActions.delete(surfaceId);
         this.surfaceState.delete(surfaceId);
         return { content: 'Surface dismissed', isError: false };
+      }
+
+      // ── File request proxying ──────────────────────────────────────
+      if (toolName === 'request_file') {
+        const surfaceId = uuid();
+        const prompt = typeof input.prompt === 'string' ? input.prompt : 'Please share a file';
+        const acceptedTypes = Array.isArray(input.accepted_types) ? input.accepted_types as string[] : undefined;
+        const maxFiles = typeof input.max_files === 'number' ? input.max_files : 1;
+
+        const data: FileUploadSurfaceData = {
+          prompt,
+          acceptedTypes,
+          maxFiles,
+        };
+
+        this.surfaceState.set(surfaceId, { surfaceType: 'file_upload', data });
+
+        this.sendToClient({
+          type: 'ui_surface_show',
+          sessionId: this.sessionId,
+          surfaceId,
+          surfaceType: 'file_upload',
+          title: 'File Request',
+          data,
+        } as UiSurfaceShow);
+
+        // Always await — file upload is interactive
+        return new Promise<ToolExecutionResult>((resolve) => {
+          this.pendingSurfaceActions.set(surfaceId, { resolve });
+        });
       }
 
       // ── Computer-use tool proxying ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a `request_file` handler to the computer-use session's `proxyResolver` in `computer-use-session.ts`
- Without this fix, `request_file` tool invocations in CU sessions fell through to the CU action path and were sent as `cu_action` to the client, causing session stalls (the macOS CU mapper treats unknown tool names as `.done`, prematurely terminating the task)
- The new handler mirrors the text-session handler in `session.ts`: it creates a `file_upload` surface, sends it to the client via `ui_surface_show`, and awaits the user's response

Addresses review feedback on #893.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Verify that a CU session invoking `request_file` now shows a file upload surface instead of hanging or terminating prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
