### PR TITLE
Fail safely when file metadata is unavailable in size guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FileUploadSurfaceView.swift
@@ -220,8 +220,11 @@ struct FileUploadSurfaceView: View {
         }
 
         // Check file size before reading into memory to avoid OOM on large files
-        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
-        let fileSize = attrs?[.size] as? Int ?? 0
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let fileSize = attrs[.size] as? Int else {
+            errorMessage = "Could not read file: \(url.lastPathComponent)"
+            return
+        }
         if fileSize > data.maxSizeBytes {
             errorMessage = "\(url.lastPathComponent) exceeds the \(formatFileSize(data.maxSizeBytes)) size limit."
             return
@@ -230,6 +233,12 @@ struct FileUploadSurfaceView: View {
         // Now safe to read the file data
         guard let fileData = try? Data(contentsOf: url) else {
             errorMessage = "Could not read file: \(url.lastPathComponent)"
+            return
+        }
+
+        // Re-check size after read in case file changed between stat and read
+        if fileData.count > data.maxSizeBytes {
+            errorMessage = "\(url.lastPathComponent) exceeds the \(formatFileSize(data.maxSizeBytes)) size limit."
             return
         }
 


### PR DESCRIPTION
## Summary
- Fix file size guard in `FileUploadSurfaceView` that silently bypassed the max-size check when `attributesOfItem` failed (fileSize defaulted to 0)
- Use `guard let` to reject files when metadata is unavailable instead of proceeding with unknown size
- Add secondary `fileData.count` validation after read to catch TOCTOU changes between stat and read

Addresses review feedback from #908 (both Codex and Devin flagged the same issue).

## Test plan
- [ ] Drag a file into the upload surface — verify it still works normally
- [ ] Drag a file exceeding the size limit — verify the error message appears
- [ ] Verify edge case where file metadata is unavailable produces a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
