### PR TITLE
Clean up pendingMessageIds on send failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -56,7 +56,7 @@ final class ChatViewModel: ObservableObject {
             bootstrapSession(userMessage: text)
         } else {
             // Subsequent messages: send directly (daemon queues if busy)
-            sendUserMessage(text)
+            sendUserMessage(text, queuedMessageId: willBeQueued ? userMessage.id : nil)
         }
     }
 
@@ -94,7 +94,7 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func sendUserMessage(_ text: String) {
+    private func sendUserMessage(_ text: String, queuedMessageId: UUID? = nil) {
         guard let sessionId else { return }
         isSending = true
         isThinking = true
@@ -115,6 +115,10 @@ final class ChatViewModel: ObservableObject {
             isSending = false
             isThinking = false
             errorText = "Failed to send message."
+            // Remove the queued message ID to prevent stale FIFO entries
+            if let queuedMessageId {
+                pendingMessageIds.removeAll { $0 == queuedMessageId }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix stale `pendingMessageIds` entry when `sendUserMessage` throws, which corrupted the FIFO mapping between queued request IDs and user message IDs
- Pass `queuedMessageId` to `sendUserMessage` so it can remove the entry on failure
- Prevents queue-position labels from attaching to the wrong messages after a send error

Addresses review feedback from #910 (Devin flagged the FIFO corruption path).

## Test plan
- [ ] Send a message while another is processing — verify queue position label appears on the correct message
- [ ] Simulate a send failure (e.g. disconnect daemon mid-send) — verify no stale queue entries remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
