### PR TITLE
Fix computer use system prompt and heuristic classifier

### DIFF
--- a/assistant/src/__tests__/classifier.test.ts
+++ b/assistant/src/__tests__/classifier.test.ts
@@ -43,9 +43,9 @@ describe('classifyHeuristic', () => {
     expect(classifyHeuristic('Copy this paragraph')).toBe('computer_use');
     expect(classifyHeuristic('Paste it here')).toBe('computer_use');
     expect(classifyHeuristic('Press enter')).toBe('computer_use');
-    expect(classifyHeuristic('Show me the file')).toBe('computer_use');
     expect(classifyHeuristic('Find the settings menu')).toBe('computer_use');
     expect(classifyHeuristic('Search for cats')).toBe('computer_use');
+    expect(classifyHeuristic('Show me the file')).toBe('computer_use');
     expect(classifyHeuristic('Run the build script')).toBe('computer_use');
   });
 

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -24,7 +24,7 @@ export async function classifyInteraction(task: string): Promise<InteractionType
       client.messages.create({
         model: 'claude-haiku-4-5-20251001',
         max_tokens: 128,
-        system: 'You are a classifier. Determine whether the user\'s request requires computer use (controlling the mouse/keyboard/apps) or is a text Q&A (answerable with text only).',
+        system: 'You are a classifier. Determine whether the user\'s request requires computer use (controlling the GUI — clicking, scrolling, typing into app windows, navigating between apps) or can be handled with local tools (answering questions, running terminal commands, creating/editing/reading files, web searches, writing code). GUI tasks → computer_use. Everything else → text_qa.',
         tools: [{
           name: 'classify_interaction',
           description: 'Classify the user interaction type',


### PR DESCRIPTION
## Summary

Improves the interaction classifier to better distinguish between GUI tasks (`computer_use`) and local tool operations (`text_qa`):

1. **System prompt**: Updated the Haiku classifier prompt to explicitly differentiate GUI interactions (clicking, scrolling, navigating between apps) from local tool operations (terminal commands, file editing, code writing).

2. **Heuristic classifier**: Added filesystem/terminal indicator checks (file extensions, slash-paths, terminal commands, programming keywords) that route to `text_qa` before reaching CU starters, preventing misclassification of file/terminal tasks that use overlapping verbs like "create", "run", "delete".

3. **Review feedback addressed**:
   - URLs are now stripped from input before the `filePath` check (`lower.replace(/https?:\/\/\S+/g, '')`) so that URL-containing tasks like `"Navigate to https://google.com"` are not misrouted to `text_qa`
   - `filePath` regex changed to `/(?:^|\s)\/\w/` — only matches slash-paths at start-of-string or after whitespace, avoiding false positives inside URLs
   - Removed the overly broad `fsKeywords` / `fsContext` checks entirely. Standalone words like "file", "directory", "folder" and even phrase-level patterns like "the file" were catching GUI instructions (e.g., "Click the File menu"). The remaining checks (file extensions, slash-paths, terminal commands, programming keywords) provide sufficient signal for unambiguous filesystem operations
   - Ambiguous cases like `"Show me the file"` and `"Create a new directory called src"` now fall through to CU starters → `computer_use`, which is acceptable since the Haiku API is the primary classifier and handles these correctly

## Review & Testing Checklist for Human

- [ ] **Ambiguous cases now route to `computer_use`**: Without `fsContext`, inputs like `"Show me the file"` and `"Create a new directory called src"` classify as `computer_use` in heuristic fallback. Verify this trade-off is acceptable vs. the previous false positives on GUI phrases
- [ ] **Verify URL-navigation tasks**: Confirm `"Navigate to https://google.com"` and `"Open http://example.com in the browser"` classify as `computer_use` (not caught by filePath after URL stripping)
- [ ] **Test Haiku API classifier with edge cases**: The heuristic is only a fallback — confirm the primary Haiku classifier handles ambiguous inputs correctly (e.g., `"Open the file in VS Code"`, `"Create a new directory called src"`)
- [ ] **Tilde paths without extensions**: `filePath` regex `/(?:^|\s)\/\w/` won't match `~/foo` (no leading `/`). These are caught by `fileExtensions` if they have one (e.g., `~/notes.txt`), but `"Save to ~/mydir"` would not be caught. Decide if this is acceptable

### Notes
- Link to Devin run: https://app.devin.ai/sessions/6c404c36c27f4fd8b259e0959f3da574
- Requested by: @NgoHarrison

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->