### PR TITLE
Refine interview UI: update suggestion chips and layout

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Tokens/MeadowTokens.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Tokens/MeadowTokens.swift
@@ -16,4 +16,10 @@ enum Meadow {
 
     // Pixel scaling factor
     static let pixelScale: CGFloat = 2.0
+
+    // Interview palette
+    static let avatarGradientStart = Violet._600
+    static let avatarGradientEnd = Violet._400
+    static let userBubbleGradientStart = Violet._600
+    static let userBubbleGradientEnd = Violet._400
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -71,33 +71,22 @@ struct InterviewChatView: View {
     // MARK: - Suggestion Chips
 
     private static let chipTexts = [
-        "What I do for work",
-        "Something I need help with",
-        "Just exploring for now",
+        "Automate repetitive tasks",
+        "Research & summarize faster",
+        "Help me write & edit",
+        "Just exploring what\u{2019}s possible",
     ]
 
     private var suggestionChips: some View {
-        HStack(spacing: VSpacing.sm) {
-            ForEach(Self.chipTexts, id: \.self) { chip in
-                Button {
-                    onChipTap?(chip)
-                } label: {
-                    Text(chip)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .background(VColor.surface)
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                        )
+        VStack(spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                ForEach(Self.chipTexts.prefix(2), id: \.self) { chip in
+                    chipButton(chip)
                 }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.set() }
-                    else { NSCursor.arrow.set() }
+            }
+            HStack(spacing: VSpacing.sm) {
+                ForEach(Self.chipTexts.suffix(2), id: \.self) { chip in
+                    chipButton(chip)
                 }
             }
         }
@@ -105,26 +94,42 @@ struct InterviewChatView: View {
         .padding(.vertical, VSpacing.sm)
     }
 
+    private func chipButton(_ chip: String) -> some View {
+        Button {
+            onChipTap?(chip)
+        } label: {
+            Text(chip)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.surface)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering { NSCursor.pointingHand.set() }
+            else { NSCursor.arrow.set() }
+        }
+    }
+
     // MARK: - Input Area
 
     private var inputArea: some View {
         HStack(spacing: VSpacing.sm) {
-            TextField("Type a message\u{2026}", text: $inputText)
-                .textFieldStyle(.plain)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
-                .onSubmit {
+            VTextField(
+                placeholder: "Type a message\u{2026}",
+                text: $inputText,
+                onSubmit: {
                     if !inputText.trimmingCharacters(in: .whitespaces).isEmpty {
                         onSend()
                     }
                 }
+            )
 
             VIconButton(
                 label: "Voice",
@@ -139,9 +144,14 @@ struct InterviewChatView: View {
                     onSend()
                 }
             }) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 24, weight: .medium))
-                    .foregroundColor(sendButtonDisabled ? VColor.textMuted : VColor.accent)
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(width: 24, height: 24)
+                    .background(
+                        Circle()
+                            .fill(sendButtonDisabled ? VColor.textMuted : Violet._600)
+                    )
             }
             .buttonStyle(.plain)
             .disabled(sendButtonDisabled)
@@ -165,6 +175,26 @@ struct InterviewChatView: View {
     }
 }
 
+// MARK: - Assistant Avatar
+
+private struct AssistantAvatar: View {
+    let size: CGFloat
+
+    var body: some View {
+        if let url = Bundle.module.url(forResource: "dino", withExtension: "webp"),
+           let nsImage = NSImage(contentsOf: url) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size, height: size)
+        } else {
+            Text("\u{1f995}")
+                .font(.system(size: size * 0.6))
+                .frame(width: size, height: size)
+        }
+    }
+}
+
 // MARK: - Message Bubble
 
 private struct MessageBubble: View {
@@ -173,7 +203,11 @@ private struct MessageBubble: View {
     private var isAssistant: Bool { message.role == .assistant }
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            if isAssistant {
+                AssistantAvatar(size: 28)
+            }
+
             if !isAssistant { Spacer(minLength: 0) }
 
             Text(message.text)
@@ -183,20 +217,46 @@ private struct MessageBubble: View {
                 .padding(.vertical, VSpacing.md)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(isAssistant
-                              ? VColor.surface.opacity(0.5)
-                              : VColor.accent)
+                        .fill(bubbleFill)
                 )
+                .if(!isAssistant) { view in
+                    view.vShadow(VShadow.accentGlow)
+                }
                 .frame(maxWidth: maxBubbleWidth, alignment: isAssistant ? .leading : .trailing)
 
             if isAssistant { Spacer(minLength: 0) }
         }
     }
 
+    private var bubbleFill: some ShapeStyle {
+        if isAssistant {
+            return AnyShapeStyle(VColor.surface.opacity(0.5))
+        } else {
+            return AnyShapeStyle(
+                LinearGradient(
+                    colors: [Meadow.userBubbleGradientStart, Meadow.userBubbleGradientEnd],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+        }
+    }
+
     private var maxBubbleWidth: CGFloat {
-        // Approximate 75% of a typical container width.
-        // GeometryReader-based approach is used in the parent if needed.
         340
+    }
+}
+
+// MARK: - Conditional Modifier
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
 }
 
@@ -207,7 +267,9 @@ private struct TypingIndicator: View {
     @State private var timer: Timer?
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            AssistantAvatar(size: 28)
+
             HStack(spacing: VSpacing.xs) {
                 ForEach(0..<3, id: \.self) { index in
                     Circle()

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -9,6 +9,8 @@ struct InterviewStepView: View {
     @State private var showControls = false
     @State private var streamingMessageId = UUID()
     @State private var isRecording = false
+    @State private var headerCollapsed = false
+    @State private var floatOffset: CGFloat = 0
 
     @State private var voiceInputManager = VoiceInputManager()
     private let profileExtractor: ProfileExtractor
@@ -38,25 +40,14 @@ struct InterviewStepView: View {
         viewModel.messages.filter { $0.role == .assistant }.count >= 2
     }
 
-    /// Show the skip link once the first assistant greeting has fully completed.
-    private var hasAssistantMessage: Bool {
-        viewModel.messages.contains { $0.role == .assistant }
+    private var displayName: String {
+        state.assistantName.isEmpty ? "your assistant" : state.assistantName
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            // Title area
-            VStack(spacing: VSpacing.xs) {
-                Text("Meet \(state.assistantName.isEmpty ? "your assistant" : state.assistantName)")
-                    .font(VFont.onboardingTitle)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text("Say hi \u{2014} it\u{2019}ll only take a minute")
-                    .font(VFont.onboardingSubtitle)
-                    .foregroundColor(VColor.textSecondary)
-            }
-            .padding(.top, VSpacing.xl)
-            .padding(.bottom, VSpacing.md)
+            // Title area — collapses after first user message
+            header
 
             // Chat area
             InterviewChatView(
@@ -79,20 +70,19 @@ struct InterviewStepView: View {
             VStack(spacing: VSpacing.md) {
                 if hasEnoughExchanges && showControls {
                     OnboardingButton(
-                        title: viewModel.isFinished ? "Let\u{2019}s get started!" : "I\u{2019}m ready to go!",
+                        title: "Let\u{2019}s get started \u{2192}",
                         style: .primary
                     ) {
                         completeInterview()
                     }
-                    .scaleEffect(viewModel.isFinished ? 1.05 : 1.0)
-                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: viewModel.isFinished)
+                    .transition(.opacity)
                 }
 
-                if !viewModel.isFinished && hasAssistantMessage {
+                if !viewModel.isFinished && showControls {
                     Button {
                         completeInterview()
                     } label: {
-                        Text("I\u{2019}m good, let\u{2019}s go")
+                        Text("Skip setup for now")
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
@@ -101,13 +91,27 @@ struct InterviewStepView: View {
                         NSCursor.pointingHand.set()
                         if !hovering { NSCursor.arrow.set() }
                     }
+                    .transition(.opacity)
                 }
             }
             .padding(.vertical, VSpacing.lg)
+            .animation(.easeOut(duration: 0.5), value: hasEnoughExchanges)
+        }
+        .onChange(of: displayedMessages.count) {
+            let hasUserMessage = displayedMessages.contains { $0.role == .user }
+            if hasUserMessage && !headerCollapsed {
+                withAnimation(.easeInOut(duration: 0.4)) {
+                    headerCollapsed = true
+                }
+            }
         }
         .onAppear {
             viewModel.startInterview()
             setupVoiceCallbacks()
+            // Gentle floating animation for the avatar
+            withAnimation(.easeInOut(duration: 2.5).repeatForever(autoreverses: true)) {
+                floatOffset = -6
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 withAnimation(.easeOut(duration: 0.5)) {
                     showControls = true
@@ -117,6 +121,55 @@ struct InterviewStepView: View {
         .onDisappear {
             voiceInputManager.stop()
             viewModel.cancel()
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        if headerCollapsed {
+            // Collapsed: just the title, smaller
+            Text("Meet \(displayName)")
+                .font(Font.custom("Silkscreen-Regular", size: 18))
+                .foregroundColor(VColor.textPrimary)
+                .padding(.top, VSpacing.lg)
+                .padding(.bottom, VSpacing.sm)
+        } else {
+            // Expanded: avatar + title + subtitle + divider
+            VStack(spacing: VSpacing.xs) {
+                headerAvatar
+                    .offset(y: floatOffset)
+
+                Text("Meet \(displayName)")
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Say hi \u{2014} it\u{2019}ll only take a minute")
+                    .font(VFont.onboardingSubtitle)
+                    .foregroundColor(VColor.textSecondary)
+
+                Divider()
+                    .background(VColor.surfaceBorder.opacity(0.3))
+                    .padding(.horizontal, VSpacing.xl)
+            }
+            .padding(.top, VSpacing.xl)
+            .padding(.bottom, VSpacing.md)
+        }
+    }
+
+    @ViewBuilder
+    private var headerAvatar: some View {
+        if let url = Bundle.module.url(forResource: "dino", withExtension: "webp"),
+           let nsImage = NSImage(contentsOf: url) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 48, height: 48)
+        } else {
+            Text("\u{1f995}")
+                .font(.system(size: 32))
+                .frame(width: 48, height: 48)
         }
     }
 


### PR DESCRIPTION
## Summary
- Update suggestion chip text to be more action-oriented ("Automate repetitive tasks", "Research & summarize faster", etc.)
- Refactor chip layout from single HStack to 2x2 VStack grid
- Extract chip button into reusable helper
- Add interview palette tokens to MeadowTokens (avatar/user bubble gradients)

## Test plan
- [ ] `./build.sh` compiles cleanly
- [ ] Onboarding interview step renders chips in 2x2 grid
- [ ] Tapping chips still sends text to interview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
