### PR TITLE
M1: Multi-turn TextSession data layer

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -8,6 +8,7 @@ enum TextSessionState: Equatable {
     case thinking
     case streaming(text: String)
     case completed(text: String)
+    case ready
     case failed(reason: String)
     case cancelled
 }
@@ -15,6 +16,7 @@ enum TextSessionState: Equatable {
 @MainActor
 final class TextSession: ObservableObject {
     @Published var state: TextSessionState = .idle
+    @Published var messages: [ConversationMessage] = []
     let task: String
     let id: String
 
@@ -90,6 +92,9 @@ final class TextSession: ObservableObject {
                             content: self.task,
                             attachments: ipcAttachments
                         ))
+
+                        // Track the initial user message
+                        self.messages.append(ConversationMessage(role: .user, text: self.task))
                     }
 
                 case .assistantTextDelta(let delta) where self.daemonSessionId != nil:
@@ -101,11 +106,10 @@ final class TextSession: ObservableObject {
                     log.debug("Thinking: \(delta.thinking)")
 
                 case .messageComplete(_) where self.daemonSessionId != nil:
-                    if self.accumulatedText.isEmpty {
-                        self.state = .completed(text: "(No response)")
-                    } else {
-                        self.state = .completed(text: self.accumulatedText)
-                    }
+                    let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
+                    self.state = .completed(text: responseText)
+                    self.state = .ready
                     return
 
                 case .cuError(let error) where error.sessionId == self.daemonSessionId:
@@ -122,7 +126,7 @@ final class TextSession: ObservableObject {
 
         // Stream ended or cancelled — ensure terminal state
         switch state {
-        case .completed, .failed, .cancelled:
+        case .completed, .ready, .failed, .cancelled:
             break
         default:
             if isCancelled {
@@ -136,5 +140,53 @@ final class TextSession: ObservableObject {
     func cancel() {
         isCancelled = true
         messageLoopTask?.cancel()
+        daemonSessionId = nil
+    }
+
+    func sendFollowUp(text: String) {
+        guard let sessionId = daemonSessionId, state == .ready else { return }
+
+        messages.append(ConversationMessage(role: .user, text: text))
+        accumulatedText = ""
+        state = .thinking
+
+        let messageStream = daemonClient.subscribe()
+        try? daemonClient.send(UserMessageMessage(
+            sessionId: sessionId,
+            content: text,
+            attachments: nil
+        ))
+
+        let loopTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            for await message in messageStream {
+                guard !self.isCancelled else { break }
+
+                switch message {
+                case .assistantTextDelta(let delta) where delta.sessionId == sessionId || delta.sessionId == nil:
+                    self.accumulatedText += delta.text
+                    self.state = .streaming(text: self.accumulatedText)
+
+                case .assistantThinkingDelta(let delta):
+                    log.debug("Thinking: \(delta.thinking)")
+
+                case .messageComplete(_):
+                    let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
+                    self.state = .completed(text: responseText)
+                    self.state = .ready
+                    return
+
+                case .cuError(let error) where error.sessionId == sessionId:
+                    self.state = .failed(reason: error.message)
+                    return
+
+                default:
+                    break
+                }
+            }
+        }
+        messageLoopTask = loopTask
     }
 }

--- a/clients/macos/vellum-assistant/Features/Session/ConversationMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ConversationMessage.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ConversationMessage: Identifiable {
+    enum Role {
+        case user
+        case assistant
+    }
+    let id: UUID
+    let role: Role
+    let text: String
+    let timestamp: Date
+
+    init(role: Role, text: String, timestamp: Date = Date()) {
+        self.id = UUID()
+        self.role = role
+        self.text = text
+        self.timestamp = timestamp
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -72,6 +72,15 @@ struct TextResponseView: View {
             }
             .frame(maxHeight: 300)
 
+        case .ready:
+            ScrollView {
+                Text(session.messages.last?.text ?? "")
+                    .font(.system(.caption, design: .default))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: 300)
+
         case .failed(let reason):
             HStack(spacing: 6) {
                 Image(systemName: "xmark.circle.fill")
@@ -108,6 +117,20 @@ struct TextResponseView: View {
                 Button {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(text, forType: .string)
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                Spacer()
+            }
+
+        case .ready:
+            HStack {
+                Button {
+                    let lastText = session.messages.last?.text ?? ""
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(lastText, forType: .string)
                 } label: {
                     Label("Copy", systemImage: "doc.on.doc")
                 }


### PR DESCRIPTION
Part of #919.

## Summary
- Add `ConversationMessage` model (`role`, `text`, `timestamp`, `id`) for tracking conversation history
- Add `@Published var messages: [ConversationMessage]` to `TextSession` for multi-turn message tracking
- Add `.ready` state to `TextSessionState` — signals "response completed, waiting for follow-up"
- Add `sendFollowUp(text:)` method that sends a `user_message` on the existing daemon session and starts a new message loop
- Update `cancel()` to clear `daemonSessionId`, preventing follow-ups on cancelled sessions
- Update `TextResponseView` to handle `.ready` state (same display as `.completed` for now — M2 will overhaul the view)

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Existing text session flow works end-to-end (task → thinking → streaming → ready)
- [ ] `session.messages` array contains user + assistant messages after completion
- [ ] `sendFollowUp()` works when state is `.ready` — sends message and re-enters thinking → streaming → ready
- [ ] `cancel()` prevents further follow-ups
- [ ] TextResponseView renders `.ready` state with copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
