### PR TITLE
Fix daemon resource leaks: tool registry spam, surface races, CU abort

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -101,6 +101,13 @@ exports[`IPC message snapshots ClientMessage types cu_session_create serializes 
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types cu_session_abort serializes to expected JSON 1`] = `
+{
+  "sessionId": "cu-sess-001",
+  "type": "cu_session_abort",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types cu_observation serializes to expected JSON 1`] = `
 {
   "axDiff": "+ new element",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -76,6 +76,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     screenWidth: 1920,
     screenHeight: 1080,
   },
+  cu_session_abort: {
+    type: 'cu_session_abort',
+    sessionId: 'cu-sess-001',
+  },
   cu_observation: {
     type: 'cu_observation',
     sessionId: 'cu-sess-001',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -746,6 +746,13 @@ function handleCuSessionAbort(
   }
   session.abort();
   ctx.cuSessions.delete(msg.sessionId);
+  // Clean up socketToCuSession so disconnect handler doesn't see stale ID
+  for (const [sock, ids] of ctx.socketToCuSession) {
+    if (ids.delete(msg.sessionId)) {
+      if (ids.size === 0) ctx.socketToCuSession.delete(sock);
+      break;
+    }
+  }
   log.info({ sessionId: msg.sessionId }, 'Computer-use session aborted by client');
 }
 


### PR DESCRIPTION
## Summary
- Register UI surface and app tools once at daemon startup instead of per-session, eliminating ~20 warn-level log lines per request
- Add `respondedSurfaces` guard in `SurfaceManager` to prevent duplicate surface actions (e.g. submit + dismiss) from racing to the daemon
- Add `cu_session_abort` IPC message so cancelling a CU session from the client actually aborts the server-side session — previously Stop only cancelled the local Swift task while the daemon kept looping and burning tokens indefinitely

## Test plan
- [ ] Start daemon, interact with chat — verify no "Tool already registered, overwriting" warnings in `~/.vellum/logs/vellum.log`
- [ ] Show an interactive surface (form/confirmation), submit it, verify no "No pending surface action found" warnings
- [ ] Start a CU session, click Stop, verify daemon logs show "Computer-use session aborted by client" and token usage stops immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
