### PR TITLE
M3: Voice input routing and dynamic panel sizing

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -242,24 +242,41 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         voiceInput?.onTranscription = { [weak self] text in
             self?.voiceTranscriptionWindow?.close()
             self?.voiceTranscriptionWindow = nil
-            self?.startSession(task: text)
+            // Route to active conversation if one exists and is ready
+            if let textSession = self?.currentTextSession, textSession.state == .ready {
+                textSession.sendFollowUp(text: text)
+            } else {
+                self?.startSession(task: text)
+            }
         }
         voiceInput?.onPartialTranscription = { [weak self] text in
-            self?.voiceTranscriptionWindow?.updateText(text)
+            // Route partial text to active conversation's input field if available
+            if let textSession = self?.currentTextSession, textSession.state == .ready {
+                self?.textResponseWindow?.updatePartialTranscription(text)
+            } else {
+                self?.voiceTranscriptionWindow?.updateText(text)
+            }
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
+            // If there's an active conversation in ready state, route recording state there
+            let hasActiveConvo = self?.currentTextSession?.state == .ready
+
             if isRecording {
                 self?.statusItem.button?.image = NSImage(
                     systemSymbolName: "mic.fill",
                     accessibilityDescription: "vellum-assistant"
                 )
-                let window = VoiceTranscriptionWindow()
-                window.show()
-                self?.voiceTranscriptionWindow = window
+                if !hasActiveConvo {
+                    let window = VoiceTranscriptionWindow()
+                    window.show()
+                    self?.voiceTranscriptionWindow = window
+                }
+                self?.textResponseWindow?.updateRecordingState(true)
             } else {
                 self?.voiceTranscriptionWindow?.close()
                 self?.voiceTranscriptionWindow = nil
                 self?.updateMenuBarIcon()
+                self?.textResponseWindow?.updateRecordingState(false)
             }
         }
         voiceInput?.start()
@@ -477,16 +494,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     existingStream: messageStream
                 )
                 self.currentTextSession = session
-                let window = TextResponseWindow(session: session)
+                let inputState = ConversationInputState()
+                let window = TextResponseWindow(session: session, inputState: inputState)
                 window.show()
                 self.textResponseWindow = window
                 self.ambientAgent.pause()
+
+                // Clean up when the user closes the panel
+                window.onClose = { [weak self] in
+                    self?.textResponseWindow = nil
+                    self?.currentTextSession = nil
+                    self?.ambientAgent.resume()
+                }
+
                 await session.run()
-                try? await Task.sleep(nanoseconds: 10_000_000_000)
-                window.close()
-                self.textResponseWindow = nil
-                self.currentTextSession = nil
-                self.ambientAgent.resume()
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 struct TextResponseView: View {
     @ObservedObject var session: TextSession
-    @State private var inputText = ""
-    @State private var isRecording = false
+    @ObservedObject var inputState: ConversationInputState
 
     /// Whether the session is actively processing (thinking or streaming).
     private var isActiveState: Bool {
@@ -40,7 +39,7 @@ struct TextResponseView: View {
                 stopButton
             }
         }
-        .frame(width: 400)
+        .frame(minWidth: 300, maxWidth: 600)
     }
 
     // MARK: - Header
@@ -79,7 +78,7 @@ struct TextResponseView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
-            .frame(maxHeight: 350)
+            .frame(maxHeight: .infinity)
             .onChange(of: session.messages.count) {
                 withAnimation(VAnimation.standard) {
                     if let lastMessage = session.messages.last {
@@ -153,18 +152,16 @@ struct TextResponseView: View {
         HStack(spacing: VSpacing.sm) {
             VTextField(
                 placeholder: "Reply...",
-                text: $inputText,
+                text: $inputState.inputText,
                 onSubmit: sendMessage
             )
 
-            // Mic toggle (placeholder for M3)
-            VIconButton(
-                label: "Voice",
-                icon: "mic.fill",
-                isActive: isRecording,
-                iconOnly: true
-            ) {
-                isRecording.toggle()
+            // Mic indicator — shows when Fn-hold voice input is active
+            if inputState.isRecording {
+                Image(systemName: "mic.fill")
+                    .foregroundStyle(.red)
+                    .font(.system(size: 14))
+                    .symbolEffect(.pulse)
             }
 
             // Send button
@@ -175,11 +172,11 @@ struct TextResponseView: View {
                     .frame(width: 28, height: 28)
                     .background(
                         Circle()
-                            .fill(inputText.isEmpty ? Violet._600.opacity(0.4) : Violet._600)
+                            .fill(inputState.inputText.isEmpty ? Violet._600.opacity(0.4) : Violet._600)
                     )
             }
             .buttonStyle(.plain)
-            .disabled(inputText.isEmpty)
+            .disabled(inputState.inputText.isEmpty)
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -224,9 +221,9 @@ struct TextResponseView: View {
     // MARK: - Helpers
 
     private func sendMessage() {
-        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = inputState.inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
-        inputText = ""
+        inputState.inputText = ""
         session.sendFollowUp(text: text)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -2,23 +2,45 @@ import AppKit
 import Combine
 import SwiftUI
 
+/// Shared state for routing voice input into an active conversation panel.
+@MainActor
+final class ConversationInputState: ObservableObject {
+    @Published var inputText: String = ""
+    @Published var isRecording: Bool = false
+
+    nonisolated init() {
+        // Properties are initialized with defaults above
+    }
+}
+
 @MainActor
 final class TextResponseWindow {
     private var panel: NSPanel?
     private let session: TextSession
+    let inputState: ConversationInputState
     private var stateCancellable: AnyCancellable?
+    private var resizeObserver: Any?
+    private var closeObserver: Any?
+    private var hasBeenPositioned = false
 
-    init(session: TextSession) {
+    /// Called when the user closes the panel (X button or programmatic close).
+    var onClose: (() -> Void)?
+
+    init(session: TextSession, inputState: ConversationInputState = ConversationInputState()) {
         self.session = session
+        self.inputState = inputState
     }
 
     func show() {
-        let view = TextResponseView(session: session)
+        let savedWidth = UserDefaults.standard.double(forKey: "textResponsePanelWidth")
+        let initialWidth = savedWidth > 0 ? savedWidth : 400.0
+
+        let view = TextResponseView(session: session, inputState: inputState)
         let hostingController = NSHostingController(rootView: view)
 
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            contentRect: NSRect(x: 0, y: 0, width: initialWidth, height: 200),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow, .resizable],
             backing: .buffered,
             defer: false
         )
@@ -30,30 +52,75 @@ final class TextResponseWindow {
         panel.titlebarAppearsTransparent = true
         panel.alphaValue = 0.9
         panel.isReleasedWhenClosed = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        panel.collectionBehavior = [.canJoinAllSpaces]
+        panel.minSize = NSSize(width: 300, height: 200)
+        panel.maxSize = NSSize(width: 600, height: 10000)
 
-        // Size window to fit SwiftUI content and resize on every state change
+        // Initial size and position
         sizeAndPosition(panel)
+        hasBeenPositioned = true
+
+        // Resize on state change — only adjust height, keep user's position
         stateCancellable = session.$state
             .sink { [weak self, weak panel] _ in
                 guard let self, let panel else { return }
-                self.sizeAndPosition(panel)
+                self.resizeHeight(panel)
             }
+
+        // Persist width on resize
+        resizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification, object: panel, queue: .main
+        ) { notification in
+            guard let window = notification.object as? NSPanel else { return }
+            UserDefaults.standard.set(Double(window.frame.width), forKey: "textResponsePanelWidth")
+        }
+
+        // Fire onClose when the panel is closed by the user
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onClose?()
+            }
+        }
 
         panel.orderFront(nil)
         self.panel = panel
     }
 
+    /// Called when partial transcription arrives during Fn-hold in an active conversation.
+    func updatePartialTranscription(_ text: String) {
+        inputState.inputText = text
+    }
+
+    /// Called when recording state changes.
+    func updateRecordingState(_ isRecording: Bool) {
+        inputState.isRecording = isRecording
+    }
+
     func close() {
         stateCancellable?.cancel()
         stateCancellable = nil
+        if let resizeObserver { NotificationCenter.default.removeObserver(resizeObserver) }
+        resizeObserver = nil
+        if let closeObserver { NotificationCenter.default.removeObserver(closeObserver) }
+        closeObserver = nil
         panel?.close()
         panel = nil
     }
 
+    /// Full size-and-position: used only on initial show.
     private func sizeAndPosition(_ panel: NSPanel) {
         if let fittingSize = panel.contentView?.fittingSize {
-            panel.setContentSize(fittingSize)
+            let width = panel.frame.width // keep the initial/saved width
+            let maxHeight: CGFloat
+            if let screen = NSScreen.main {
+                maxHeight = screen.visibleFrame.height - 40
+            } else {
+                maxHeight = 800
+            }
+            let height = min(fittingSize.height, maxHeight)
+            panel.setContentSize(NSSize(width: width, height: height))
         }
         // Pin to bottom-right of screen
         if let screen = NSScreen.main {
@@ -63,5 +130,25 @@ final class TextResponseWindow {
             let y = screenFrame.minY + 20
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
+    }
+
+    /// Resize height only — keep the bottom edge fixed and the user's horizontal position.
+    private func resizeHeight(_ panel: NSPanel) {
+        guard let fittingSize = panel.contentView?.fittingSize else { return }
+        let maxHeight: CGFloat
+        if let screen = NSScreen.main {
+            maxHeight = screen.visibleFrame.height - 40
+        } else {
+            maxHeight = 800
+        }
+        let newHeight = min(fittingSize.height, maxHeight)
+        let currentFrame = panel.frame
+        // Grow upward: keep bottom edge fixed
+        let newOriginY = currentFrame.minY + currentFrame.height - newHeight
+        panel.setFrame(
+            NSRect(x: currentFrame.minX, y: newOriginY, width: currentFrame.width, height: newHeight),
+            display: true,
+            animate: false
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Routes Fn-hold voice input to active conversations when a TextResponseWindow is open and session is in `.ready` state, instead of always starting a new session
- Makes TextResponseWindow dynamically sized and resizable (300-600pt width), with width persisted to UserDefaults
- Prevents auto-close after first response -- panel stays open for multi-turn conversation, cleaned up via `onClose` callback when user dismisses
- Adds `ConversationInputState` shared between window and view for voice input relay (partial transcription + recording indicator)

## Test plan
- [ ] Start a text_qa session and verify the panel stays open after first response
- [ ] With panel open, hold Fn and speak -- verify transcription appears in the panel's input field
- [ ] Release Fn and verify the follow-up is sent to the existing conversation
- [ ] Resize the panel horizontally and restart -- verify width is remembered
- [ ] Close the panel with X and verify cleanup (new voice input creates a fresh session)
- [ ] Verify panel grows upward as conversation gets longer, capped at screen height - 40pt

Part of #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
