### PR TITLE
Fix TextResponseWindow session leak and voice input cleanup (#926)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -245,6 +245,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // Route to active conversation if one exists and is ready
             if let textSession = self?.currentTextSession, textSession.state == .ready {
                 textSession.sendFollowUp(text: text)
+                self?.textResponseWindow?.updatePartialTranscription("")
             } else {
                 self?.startSession(task: text)
             }
@@ -502,6 +503,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
                 // Clean up when the user closes the panel
                 window.onClose = { [weak self] in
+                    self?.currentTextSession?.cancel()
                     self?.textResponseWindow = nil
                     self?.currentTextSession = nil
                     self?.ambientAgent.resume()


### PR DESCRIPTION
## Summary
- **Cancel TextSession on window close**: The `onClose` callback now calls `session.cancel()` before clearing the reference, preventing orphaned `messageLoopTask` and daemon subscribers when the user closes the panel while a follow-up is in progress (`.thinking` or `.streaming` state).
- **Clear voice input text after auto-send**: After routing a voice transcription to `sendFollowUp` on an active conversation, the composer input is cleared via `updatePartialTranscription("")` so the just-sent utterance doesn't remain visible in the input field.

Addresses review feedback on #926.

## Test plan
- [ ] Open a text conversation, trigger a follow-up (voice or typed), then close the panel mid-stream -- verify no background task leak (check logs for daemon unsubscribe)
- [ ] Hold Fn to voice-input a follow-up into an active ready conversation -- verify the composer input field is cleared after the message is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
