### PR TITLE
Add guardrails for computer-use session lifecycle and loop limits

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -351,6 +351,44 @@ describe('AgentLoop', () => {
     expect(reminderBlock).toBeDefined();
   });
 
+  test('stops after configured maxToolUseTurns to prevent runaway loops', async () => {
+    const responses: ProviderResponse[] = [
+      toolUseResponse('t1', 'read_file', { path: '/one.txt' }),
+      toolUseResponse('t2', 'read_file', { path: '/two.txt' }),
+      toolUseResponse('t3', 'read_file', { path: '/three.txt' }),
+      textResponse('Should never be requested'),
+    ];
+    const { provider, calls } = createMockProvider(responses);
+    const toolExecutor = async () => ({ content: 'data', isError: false });
+    const loop = new AgentLoop(
+      provider,
+      'system',
+      { maxToolUseTurns: 3 },
+      dummyTools,
+      toolExecutor,
+    );
+
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events));
+
+    // The loop should stop immediately after the 3rd tool-use turn, before the next provider call.
+    expect(calls).toHaveLength(3);
+
+    const errorEvents = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'error' }> => e.type === 'error',
+    );
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].error.message).toContain('Tool-use turn limit reached (3)');
+
+    const lastMessage = history[history.length - 1];
+    expect(lastMessage.role).toBe('user');
+    const limitText = lastMessage.content.find(
+      (b): b is Extract<ContentBlock, { type: 'text' }> =>
+        b.type === 'text' && b.text.includes('Tool-use turn limit reached (3)'),
+    );
+    expect(limitText).toBeDefined();
+  });
+
   // 9. Tool executor error results are forwarded correctly
   test('forwards tool error results to provider', async () => {
     const { provider, calls } = createMockProvider([

--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from 'bun:test';
+import { ComputerUseSession } from '../daemon/computer-use-session.js';
+import type { Provider, ProviderResponse } from '../providers/types.js';
+import type { CuObservation, ServerMessage } from '../daemon/ipc-protocol.js';
+import { registerComputerUseTools } from '../tools/computer-use/registry.js';
+
+registerComputerUseTools();
+
+function createProvider(responses: ProviderResponse[]): { provider: Provider; getCalls: () => number } {
+  let calls = 0;
+  const provider: Provider = {
+    name: 'mock',
+    async sendMessage() {
+      const response = responses[calls] ?? responses[responses.length - 1];
+      calls++;
+      return response;
+    },
+  };
+  return { provider, getCalls: () => calls };
+}
+
+describe('ComputerUseSession lifecycle', () => {
+  test('stops provider loop immediately after terminal cu_done tool', async () => {
+    const { provider, getCalls } = createProvider([
+      {
+        content: [{
+          type: 'tool_use',
+          id: 'tu-1',
+          name: 'cu_done',
+          input: { summary: 'Task finished' },
+        }],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'tool_use',
+      },
+      {
+        content: [{ type: 'text', text: 'This should never be requested' }],
+        model: 'mock-model',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const sentMessages: ServerMessage[] = [];
+    let terminalCalls = 0;
+
+    const session = new ComputerUseSession(
+      'cu-test-1',
+      'test task',
+      1440,
+      900,
+      provider,
+      (msg) => { sentMessages.push(msg); },
+      'computer_use',
+      () => { terminalCalls++; },
+    );
+
+    const observation: CuObservation = {
+      type: 'cu_observation',
+      sessionId: 'cu-test-1',
+      axTree: 'Window "Test" [1]',
+    };
+
+    await session.handleObservation(observation);
+
+    // If cu_done does not abort the loop, we'd see an extra provider call.
+    expect(getCalls()).toBe(1);
+    expect(session.getState()).toBe('complete');
+    expect(terminalCalls).toBe(1);
+
+    const completes = sentMessages.filter(
+      (msg): msg is Extract<ServerMessage, { type: 'cu_complete' }> => msg.type === 'cu_complete',
+    );
+    expect(completes).toHaveLength(1);
+    expect(completes[0].summary).toBe('Task finished');
+  });
+
+  test('notifies terminal callback only once on repeated abort calls', () => {
+    const { provider } = createProvider([
+      {
+        content: [{ type: 'text', text: 'unused' }],
+        model: 'mock-model',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    let terminalCalls = 0;
+    const session = new ComputerUseSession(
+      'cu-test-2',
+      'test task',
+      1440,
+      900,
+      provider,
+      () => {},
+      'computer_use',
+      () => { terminalCalls++; },
+    );
+
+    session.abort();
+    session.abort();
+
+    expect(terminalCalls).toBe(1);
+    expect(session.getState()).toBe('error');
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -7,6 +7,7 @@ export interface AgentLoopConfig {
   maxTokens: number;
   thinking?: { enabled: boolean; budgetTokens: number };
   toolChoice?: { type: 'auto' } | { type: 'any' } | { type: 'tool'; name: string };
+  maxToolUseTurns?: number;
 }
 
 export type AgentEvent =
@@ -21,6 +22,7 @@ export type AgentEvent =
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 64000,
+  maxToolUseTurns: 30,
 };
 
 const PROGRESS_CHECK_INTERVAL = 5;
@@ -240,6 +242,16 @@ export class AgentLoop {
 
         // Track tool-use turns and inject progress reminder every N turns
         toolUseTurns++;
+        if (this.config.maxToolUseTurns && this.config.maxToolUseTurns > 0 && toolUseTurns >= this.config.maxToolUseTurns) {
+          const limitMessage = `Tool-use turn limit reached (${this.config.maxToolUseTurns}). Stopping to prevent runaway loops; ask the user for guidance.`;
+          onEvent({ type: 'error', error: new Error(limitMessage) });
+          resultBlocks.push({
+            type: 'text',
+            text: `[System: ${limitMessage}]`,
+          });
+          history.push({ role: 'user', content: resultBlocks });
+          break;
+        }
         if (toolUseTurns % PROGRESS_CHECK_INTERVAL === 0) {
           resultBlocks.push({
             type: 'text',

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -417,7 +417,9 @@ export class ComputerUseSession {
       {
         maxTokens: 4096,
         toolChoice: { type: 'any' },
-        maxToolUseTurns: MAX_STEPS,
+        // Allow MAX_STEPS non-terminal actions plus one terminal turn
+        // (cu_done/cu_respond), since AgentLoop caps tool turns globally.
+        maxToolUseTurns: MAX_STEPS + 1,
       },
       toolDefs,
       toolExecutor,

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -52,6 +52,7 @@ export class ComputerUseSession {
   private readonly provider: Provider;
   private sendToClient: (msg: ServerMessage) => void;
   private readonly interactionType: 'computer_use' | 'text_qa';
+  private readonly onTerminal?: (sessionId: string) => void;
 
   private state: SessionState = 'idle';
   private stepCount = 0;
@@ -69,6 +70,7 @@ export class ComputerUseSession {
     resolve: (result: ToolExecutionResult) => void;
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
+  private terminalNotified = false;
 
   // Tracks the agent loop promise so callers can await session completion
   private loopPromise: Promise<void> | null = null;
@@ -81,6 +83,7 @@ export class ComputerUseSession {
     provider: Provider,
     sendToClient: (msg: ServerMessage) => void,
     interactionType?: 'computer_use' | 'text_qa',
+    onTerminal?: (sessionId: string) => void,
   ) {
     this.sessionId = sessionId;
     this.task = task;
@@ -89,6 +92,7 @@ export class ComputerUseSession {
     this.provider = provider;
     this.sendToClient = sendToClient;
     this.interactionType = interactionType ?? 'computer_use';
+    this.onTerminal = onTerminal;
   }
 
   // ---------------------------------------------------------------------------
@@ -175,6 +179,7 @@ export class ComputerUseSession {
       sessionId: this.sessionId,
       message: 'Session aborted by user',
     });
+    this.notifyTerminal();
   }
 
   isComplete(): boolean {
@@ -344,6 +349,9 @@ export class ComputerUseSession {
           isResponse: toolName === 'cu_respond' ? true : undefined,
         });
         this.state = 'complete';
+        // Stop AgentLoop immediately so terminal tools cannot trigger extra provider calls.
+        this.abortController?.abort();
+        this.notifyTerminal();
         return { content: 'Session complete', isError: false };
       }
 
@@ -358,6 +366,7 @@ export class ComputerUseSession {
           message: `Step limit (${MAX_STEPS}) exceeded`,
         });
         this.abortController?.abort();
+        this.notifyTerminal();
         return { content: `Step limit (${MAX_STEPS}) exceeded`, isError: true };
       }
 
@@ -408,6 +417,7 @@ export class ComputerUseSession {
       {
         maxTokens: 4096,
         toolChoice: { type: 'any' },
+        maxToolUseTurns: MAX_STEPS,
       },
       toolDefs,
       toolExecutor,
@@ -427,6 +437,7 @@ export class ComputerUseSession {
                   sessionId: this.sessionId,
                   message: event.error.message,
                 });
+                this.notifyTerminal();
               }
               break;
             case 'usage':
@@ -451,6 +462,7 @@ export class ComputerUseSession {
           sessionId: this.sessionId,
           message: 'Agent loop ended unexpectedly',
         });
+        this.notifyTerminal();
       }
     } catch (err) {
       if (this.abortController?.signal.aborted) {
@@ -466,6 +478,7 @@ export class ComputerUseSession {
           sessionId: this.sessionId,
           message,
         });
+        this.notifyTerminal();
       }
     } finally {
       // Always clear session timer to prevent resource leaks
@@ -474,6 +487,12 @@ export class ComputerUseSession {
         this.sessionTimer = null;
       }
     }
+  }
+
+  private notifyTerminal(): void {
+    if (this.terminalNotified) return;
+    this.terminalNotified = true;
+    this.onTerminal?.(this.sessionId);
   }
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -681,6 +681,23 @@ async function handleTaskSubmit(
 
 // ─── Computer-use handlers ──────────────────────────────────────────────────
 
+function removeCuSessionReferences(
+  ctx: HandlerContext,
+  sessionId: string,
+  expectedSession?: ComputerUseSession,
+): void {
+  const current = ctx.cuSessions.get(sessionId);
+  if (expectedSession && current && current !== expectedSession) {
+    return;
+  }
+  ctx.cuSessions.delete(sessionId);
+  for (const [sock, ids] of ctx.socketToCuSession) {
+    if (ids.delete(sessionId) && ids.size === 0) {
+      ctx.socketToCuSession.delete(sock);
+    }
+  }
+}
+
 function handleCuSessionCreate(
   msg: CuSessionCreate,
   socket: net.Socket,
@@ -692,12 +709,7 @@ function handleCuSessionCreate(
   const existingSession = ctx.cuSessions.get(msg.sessionId);
   if (existingSession) {
     existingSession.abort();
-    for (const [otherSocket, ids] of ctx.socketToCuSession) {
-      if (ids.delete(msg.sessionId)) {
-        if (ids.size === 0) ctx.socketToCuSession.delete(otherSocket);
-        break;
-      }
-    }
+    removeCuSessionReferences(ctx, msg.sessionId, existingSession);
   }
 
   const config = getConfig();
@@ -711,6 +723,12 @@ function handleCuSessionCreate(
     ctx.send(socket, serverMsg);
   };
 
+  let sessionRef: ComputerUseSession | undefined;
+  const onTerminal = (sessionId: string) => {
+    removeCuSessionReferences(ctx, sessionId, sessionRef);
+    log.info({ sessionId }, 'Computer-use session cleaned up after terminal state');
+  };
+
   const session = new ComputerUseSession(
     msg.sessionId,
     msg.task,
@@ -719,7 +737,9 @@ function handleCuSessionCreate(
     provider,
     sendToClient,
     msg.interactionType,
+    onTerminal,
   );
+  sessionRef = session;
 
   ctx.cuSessions.set(msg.sessionId, session);
 
@@ -745,14 +765,7 @@ function handleCuSessionAbort(
     return;
   }
   session.abort();
-  ctx.cuSessions.delete(msg.sessionId);
-  // Clean up socketToCuSession so disconnect handler doesn't see stale ID
-  for (const [sock, ids] of ctx.socketToCuSession) {
-    if (ids.delete(msg.sessionId)) {
-      if (ids.size === 0) ctx.socketToCuSession.delete(sock);
-      break;
-    }
-  }
+  removeCuSessionReferences(ctx, msg.sessionId, session);
   log.info({ sessionId: msg.sessionId }, 'Computer-use session aborted by client');
 }
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -723,9 +723,9 @@ function handleCuSessionCreate(
     ctx.send(socket, serverMsg);
   };
 
-  let sessionRef: ComputerUseSession | undefined;
+  const sessionRef: { current?: ComputerUseSession } = {};
   const onTerminal = (sessionId: string) => {
-    removeCuSessionReferences(ctx, sessionId, sessionRef);
+    removeCuSessionReferences(ctx, sessionId, sessionRef.current);
     log.info({ sessionId }, 'Computer-use session cleaned up after terminal state');
   };
 
@@ -739,7 +739,7 @@ function handleCuSessionCreate(
     msg.interactionType,
     onTerminal,
   );
-  sessionRef = session;
+  sessionRef.current = session;
 
   ctx.cuSessions.set(msg.sessionId, session);
 

--- a/web/src/lib/local-daemon-ipc.ts
+++ b/web/src/lib/local-daemon-ipc.ts
@@ -337,9 +337,17 @@ export class LocalDaemonClient {
     let usage: DaemonUsageUpdate | null = null;
     const toolCalls: DaemonToolCall[] = [];
     let currentToolCall: DaemonToolCall | null = null;
+    const deadline = Date.now() + timeoutMs;
 
     while (true) {
-      const message = await this.waitFor(() => true, timeoutMs);
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        throw new LocalDaemonError(
+          "TIMEOUT",
+          `Timed out waiting for daemon response after ${timeoutMs}ms`
+        );
+      }
+      const message = await this.waitFor(() => true, remainingMs);
 
       switch (message.type) {
         case "assistant_text_delta": {


### PR DESCRIPTION
## Summary
- stop computer-use agent loop immediately after terminal tools (cu_done / cu_respond) so sessions cannot continue making provider requests
- add terminal-session cleanup hooks to remove completed/errored CU sessions from daemon maps and avoid stale session buildup
- add hard agent-loop tool-turn cap (maxToolUseTurns) and wire computer-use to its existing MAX_STEPS budget
- enforce absolute deadline timeout in local daemon IPC sendUserMessage to prevent indefinite waits under noisy traffic
- add regression tests for agent-loop cap and computer-use terminal lifecycle behavior

## Testing
- bun test src/__tests__/agent-loop.test.ts src/__tests__/computer-use-session-lifecycle.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
