### PR TITLE
Fix doubled responses, pin chat panel to top-right, and polish UI

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -109,8 +109,12 @@ final class TextSession: ObservableObject {
 
                 case .messageComplete(_) where self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
-                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
+                    // Set state before appending to messages — the $state Combine sink
+                    // triggers a layout pass, and if state is still .streaming when the
+                    // committed message is already in messages, both the streaming bubble
+                    // and committed bubble render simultaneously (doubled response).
                     self.state = .ready
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
                 case .cuError(let error) where error.sessionId == self.daemonSessionId:
@@ -174,8 +178,8 @@ final class TextSession: ObservableObject {
 
                 case .messageComplete(_):
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
-                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     self.state = .ready
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
                 case .cuError(let error) where error.sessionId == sessionId:

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TextResponseView: View {
     @ObservedObject var session: TextSession
     @ObservedObject var inputState: ConversationInputState
+    var onClose: (() -> Void)?
 
     /// Whether the session is actively processing (thinking or streaming).
     private var isActiveState: Bool {
@@ -59,7 +60,7 @@ struct TextResponseView: View {
         }
         .overlay(alignment: .topTrailing) {
             Button {
-                NSApp.keyWindow?.close()
+                onClose?()
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .medium))

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -16,11 +16,6 @@ struct TextResponseView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            header
-
-            Divider()
-
             // Scrollable message list
             messageList
 
@@ -62,21 +57,19 @@ struct TextResponseView: View {
                     .padding(.vertical, VSpacing.md)
             }
         }
-        .frame(minWidth: 300, maxWidth: 600)
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        HStack(spacing: VSpacing.sm) {
-            Image(systemName: "text.bubble.fill")
-                .foregroundStyle(.blue)
-            Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
-                .font(VFont.headline)
-                .lineLimit(1)
+        .overlay(alignment: .topTrailing) {
+            Button {
+                NSApp.keyWindow?.close()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+            .padding(VSpacing.lg)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.lg)
+        .frame(minWidth: 300, maxWidth: 600)
     }
 
     // MARK: - Message List

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -33,7 +33,7 @@ final class TextResponseWindow {
 
     func show() {
         let savedWidth = UserDefaults.standard.double(forKey: "textResponsePanelWidth")
-        let initialWidth = savedWidth > 0 ? savedWidth : 400.0
+        let initialWidth = savedWidth > 0 ? savedWidth : 500.0
 
         let view = TextResponseView(session: session, inputState: inputState)
         let hostingController = NSHostingController(rootView: view)
@@ -110,6 +110,7 @@ final class TextResponseWindow {
     }
 
     /// Full size-and-position: used only on initial show.
+    /// Pins the panel to the top-right corner of the screen.
     private func sizeAndPosition(_ panel: NSPanel) {
         if let fittingSize = panel.contentView?.fittingSize {
             let width = panel.frame.width // keep the initial/saved width
@@ -122,17 +123,17 @@ final class TextResponseWindow {
             let height = min(fittingSize.height, maxHeight)
             panel.setContentSize(NSSize(width: width, height: height))
         }
-        // Pin to bottom-right of screen
+        // Pin to top-right of screen
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
             let panelFrame = panel.frame
             let x = screenFrame.maxX - panelFrame.width - 20
-            let y = screenFrame.minY + 20
+            let y = screenFrame.maxY - panelFrame.height - 20
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
     }
 
-    /// Resize height only — keep the bottom edge fixed and the user's horizontal position.
+    /// Resize height only — keep the top edge pinned and grow downward.
     private func resizeHeight(_ panel: NSPanel) {
         guard let fittingSize = panel.contentView?.fittingSize else { return }
         let maxHeight: CGFloat
@@ -141,12 +142,14 @@ final class TextResponseWindow {
         } else {
             maxHeight = 800
         }
-        let newHeight = min(fittingSize.height, maxHeight)
         let currentFrame = panel.frame
-        // Grow upward: keep bottom edge fixed
-        let newOriginY = currentFrame.minY + currentFrame.height - newHeight
+        // Never auto-shrink — only grow taller during a conversation.
+        // The user can still manually drag-resize shorter if they want.
+        let newHeight = max(currentFrame.height, min(fittingSize.height, maxHeight))
+        // Grow downward: keep top edge fixed
+        let topY = currentFrame.maxY
         panel.setFrame(
-            NSRect(x: currentFrame.minX, y: newOriginY, width: currentFrame.width, height: newHeight),
+            NSRect(x: currentFrame.minX, y: topY - newHeight, width: currentFrame.width, height: newHeight),
             display: true,
             animate: false
         )

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -35,7 +35,9 @@ final class TextResponseWindow {
         let savedWidth = UserDefaults.standard.double(forKey: "textResponsePanelWidth")
         let initialWidth = savedWidth > 0 ? savedWidth : 500.0
 
-        let view = TextResponseView(session: session, inputState: inputState)
+        let view = TextResponseView(session: session, inputState: inputState) { [weak self] in
+            self?.panel?.close()
+        }
         let hostingController = NSHostingController(rootView: view)
 
         let panel = NSPanel(


### PR DESCRIPTION
The purpose of this PR is to fix doubled assistant responses in the text chat panel and improve the panel's layout and sizing behavior.

## Changes Made
- Fix doubled assistant responses by setting `state = .ready` before appending to `messages` — the `$state` Combine sink triggers a layout pass that could render both the streaming bubble and committed message simultaneously
- Pin chat panel to top-right corner of screen, growing downward as content increases
- Never auto-shrink panel height during a conversation (only grow taller)
- Remove header (icon + name + divider), add close button matching VSidePanel design system pattern
- Bump default panel width from 400 to 500

## Testing
- Manual testing of multi-turn conversation flow

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
