### PR TITLE
daemon: add explicit queue policy types for handoff checkpoints

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -135,6 +135,7 @@ mock.module('../agent/loop.js', () => ({
 // ---------------------------------------------------------------------------
 
 import { Session, MAX_QUEUE_DEPTH } from '../daemon/session.js';
+import type { QueueDrainReason, QueuePolicy } from '../daemon/session.js';
 
 function makeSession(): Session {
   const provider = {
@@ -445,5 +446,104 @@ describe('Session message queue', () => {
 
     // Queue depth should not have increased
     expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue policy primitives
+// ---------------------------------------------------------------------------
+
+describe('Session queue policy helpers', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('hasQueuedMessages() returns false on a fresh session', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+    expect(session.hasQueuedMessages()).toBe(false);
+  });
+
+  test('hasQueuedMessages() returns true after enqueuing while processing', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start processing to make the session busy
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue a message while processing
+    session.enqueueMessage('msg-2', [], () => {}, 'req-2');
+    expect(session.hasQueuedMessages()).toBe(true);
+
+    // Cleanup: resolve the pending run
+    resolveRun(0);
+    await waitForPendingRun(2);
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('canHandoffAtCheckpoint() returns false when not processing', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Not processing, no queued messages
+    expect(session.canHandoffAtCheckpoint()).toBe(false);
+  });
+
+  test('canHandoffAtCheckpoint() returns false when processing but no queued messages', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start processing — but don't enqueue anything
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    expect(session.isProcessing()).toBe(true);
+    expect(session.hasQueuedMessages()).toBe(false);
+    expect(session.canHandoffAtCheckpoint()).toBe(false);
+
+    // Cleanup
+    resolveRun(0);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('canHandoffAtCheckpoint() returns true when processing and queue has messages', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start processing
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue a message
+    session.enqueueMessage('msg-2', [], () => {}, 'req-2');
+
+    expect(session.isProcessing()).toBe(true);
+    expect(session.hasQueuedMessages()).toBe(true);
+    expect(session.canHandoffAtCheckpoint()).toBe(true);
+
+    // Cleanup
+    resolveRun(0);
+    await waitForPendingRun(2);
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('QueueDrainReason type accepts expected values', () => {
+    // Compile-time verification that these are valid QueueDrainReason values
+    const reason1: QueueDrainReason = 'loop_complete';
+    const reason2: QueueDrainReason = 'checkpoint_handoff';
+    expect(reason1).toBe('loop_complete');
+    expect(reason2).toBe('checkpoint_handoff');
+  });
+
+  test('QueuePolicy type accepts expected shape', () => {
+    // Compile-time verification that the QueuePolicy interface works
+    const policy: QueuePolicy = { checkpointHandoffEnabled: true };
+    expect(policy.checkpointHandoffEnabled).toBe(true);
+
+    const disabledPolicy: QueuePolicy = { checkpointHandoffEnabled: false };
+    expect(disabledPolicy.checkpointHandoffEnabled).toBe(false);
   });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,6 +47,22 @@ interface QueuedMessage {
 
 export const MAX_QUEUE_DEPTH = 10;
 
+/**
+ * Describes why a queued message was promoted from the queue.
+ * - `loop_complete`: the agent loop finished normally and the next message was drained.
+ * - `checkpoint_handoff`: a turn-boundary checkpoint decided to yield to the queued message.
+ */
+export type QueueDrainReason = 'loop_complete' | 'checkpoint_handoff';
+
+/**
+ * Configuration for how/when checkpoint handoff is allowed.
+ * When `checkpointHandoffEnabled` is true, the agent loop may yield at
+ * a turn boundary if there are queued messages waiting.
+ */
+export interface QueuePolicy {
+  checkpointHandoffEnabled: boolean;
+}
+
 export class Session {
   public readonly conversationId: string;
   private messages: Message[] = [];
@@ -239,6 +255,22 @@ export class Session {
 
   getQueueDepth(): number {
     return this.messageQueue.length;
+  }
+
+  /**
+   * Returns true if there are messages waiting in the queue.
+   */
+  hasQueuedMessages(): boolean {
+    return this.messageQueue.length > 0;
+  }
+
+  /**
+   * Returns true if the session is currently processing and there are queued
+   * messages waiting. This is the predicate used to decide whether to yield
+   * at a turn boundary (checkpoint handoff).
+   */
+  canHandoffAtCheckpoint(): boolean {
+    return this.processing && this.hasQueuedMessages();
   }
 
   handleConfirmationResponse(


### PR DESCRIPTION
## Summary
- Add `QueueDrainReason` union type (`'loop_complete' | 'checkpoint_handoff'`) and `QueuePolicy` interface to describe why queued messages are promoted and how checkpoint handoff is configured
- Add `hasQueuedMessages()` and `canHandoffAtCheckpoint()` public helper methods to `Session` class for upcoming turn-boundary yield logic
- Add 7 new tests covering the helpers and type correctness; all 14 tests in session-queue.test.ts pass

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [x] `bun test src/__tests__/session-queue.test.ts` — all 14 tests pass (7 existing + 7 new)
- [x] No existing behavior changed — purely additive types and predicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
