### PR TITLE
ipc: add generation_handoff event for queue-driven preemption visibility

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
@@ -294,6 +294,15 @@ exports[`IPC message snapshots ServerMessage types pong serializes to expected J
 exports[`IPC message snapshots ServerMessage types generation_cancelled serializes to expected JSON 1`] = `
 {
   "type": "generation_cancelled",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types generation_handoff serializes to expected JSON 1`] = `
+{
+  "queuedCount": 2,
+  "requestId": "req-handoff-001",
+  "sessionId": "sess-001",
+  "type": "generation_handoff",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -202,6 +202,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   generation_cancelled: {
     type: 'generation_cancelled',
   },
+  generation_handoff: {
+    type: 'generation_handoff',
+    sessionId: 'sess-001',
+    requestId: 'req-handoff-001',
+    queuedCount: 2,
+  },
   model_info: {
     type: 'model_info',
     model: 'claude-sonnet-4-5-20250929',

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -591,8 +591,15 @@ describe('Session checkpoint handoff', () => {
     resolveRun(0);
     await p1;
 
-    // After yield, the first message should emit message_complete
-    expect(events1.some((e) => e.type === 'message_complete')).toBe(true);
+    // After yield, the first message should emit generation_handoff
+    const handoff = events1.find((e) => e.type === 'generation_handoff');
+    expect(handoff).toBeDefined();
+    expect(handoff).toMatchObject({
+      type: 'generation_handoff',
+      sessionId: 'conv-1',
+      requestId: 'req-1',
+      queuedCount: 1,
+    });
 
     // The queued message should now be draining (second run started)
     await waitForPendingRun(2);
@@ -634,7 +641,7 @@ describe('Session checkpoint handoff', () => {
     const processedOrder: string[] = [];
 
     const makeHandler = (label: string) => (e: ServerMessage) => {
-      if (e.type === 'message_complete') processedOrder.push(label);
+      if (e.type === 'message_complete' || e.type === 'generation_handoff') processedOrder.push(label);
     };
 
     // Start first message

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -313,6 +313,13 @@ export interface GenerationCancelled {
   type: 'generation_cancelled';
 }
 
+export interface GenerationHandoff {
+  type: 'generation_handoff';
+  sessionId: string;
+  requestId?: string;
+  queuedCount: number;
+}
+
 export interface ModelInfo {
   type: 'model_info';
   model: string;
@@ -544,6 +551,7 @@ export type ServerMessage =
   | ErrorMessage
   | PongMessage
   | GenerationCancelled
+  | GenerationHandoff
   | ModelInfo
   | HistoryResponse
   | UndoComplete

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -610,7 +610,12 @@ export class Session {
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent);
 
       if (yieldedForHandoff) {
-        onEvent({ type: 'message_complete', sessionId: this.conversationId });
+        onEvent({
+          type: 'generation_handoff',
+          sessionId: this.conversationId,
+          requestId: reqId,
+          queuedCount: this.getQueueDepth(),
+        });
       } else if (abortController.signal.aborted) {
         onEvent({ type: 'generation_cancelled' });
       } else {


### PR DESCRIPTION
## Summary
- Add new `GenerationHandoff` IPC interface (`type: 'generation_handoff'`) with `sessionId`, `requestId`, and `queuedCount` fields
- Emit `generation_handoff` instead of `message_complete` when the active generation yields to queued work at a checkpoint, giving clients visibility into yield-vs-completion semantics
- Add snapshot test fixture and update session-queue tests to validate the new event shape and FIFO ordering

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests regenerated and passing (55 tests)
- [x] Session queue tests updated and passing (19 tests), including checkpoint handoff assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
