### PR TITLE
macOS: decode generation_handoff daemon message

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -47,6 +47,9 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `message_dequeued` message.
     var onMessageDequeued: ((MessageDequeuedMessage) -> Void)?
 
+    /// Called when the daemon sends a `generation_handoff` message.
+    var onGenerationHandoff: ((GenerationHandoffMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -383,6 +386,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onMessageQueued?(msg)
         case .messageDequeued(let msg):
             onMessageDequeued?(msg)
+        case .generationHandoff(let msg):
+            onGenerationHandoff?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -308,6 +308,14 @@ struct GenerationCancelledMessage: Decodable, Sendable {
     let sessionId: String?
 }
 
+/// Notifies client that active generation yielded to queued work at a checkpoint.
+/// Wire type: `"generation_handoff"`
+struct GenerationHandoffMessage: Decodable, Sendable {
+    let sessionId: String
+    let requestId: String?
+    let queuedCount: Int
+}
+
 /// Notifies client that a message has been queued for processing.
 /// Wire type: `"message_queued"`
 struct MessageQueuedMessage: Decodable, Sendable {
@@ -355,6 +363,7 @@ enum ServerMessage: Decodable, Sendable {
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
     case generationCancelled(GenerationCancelledMessage)
+    case generationHandoff(GenerationHandoffMessage)
     case appDataResponse(AppDataResponseMessage)
     case messageQueued(MessageQueuedMessage)
     case messageDequeued(MessageDequeuedMessage)
@@ -412,6 +421,9 @@ enum ServerMessage: Decodable, Sendable {
         case "generation_cancelled":
             let message = try GenerationCancelledMessage(from: decoder)
             self = .generationCancelled(message)
+        case "generation_handoff":
+            let message = try GenerationHandoffMessage(from: decoder)
+            self = .generationHandoff(message)
         case "app_data_response":
             let message = try AppDataResponseMessage(from: decoder)
             self = .appDataResponse(message)


### PR DESCRIPTION
## Summary
- Add `GenerationHandoffMessage` struct in `IPCMessages.swift` to decode the new `generation_handoff` daemon event (with `sessionId`, `requestId`, and `queuedCount` fields)
- Add `.generationHandoff` case to the `ServerMessage` enum and its `init(from:)` decoder
- Add `onGenerationHandoff` callback in `DaemonClient` and route the message in `handleServerMessage`

## Test plan
- [x] macOS client builds successfully with `swift build`
- [ ] Verify `generation_handoff` messages from the daemon are correctly decoded and routed to the callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
