### PR TITLE
macOS: improve chat UI feedback for queued and handoff states

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -22,6 +22,7 @@ struct ChatView: View {
             if let errorText {
                 errorBanner(errorText)
             }
+            queueSummary
             composerArea
         }
     }
@@ -99,6 +100,26 @@ struct ChatView: View {
         .background(VColor.error)
     }
 
+    // MARK: - Queue Summary
+
+    @ViewBuilder
+    private var queueSummary: some View {
+        if pendingQueuedCount > 0 {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                    .font(VFont.caption)
+                Text(pendingQueuedCount == 1
+                     ? "1 message queued, sending automatically"
+                     : "\(pendingQueuedCount) messages queued, sending automatically")
+                    .font(VFont.caption)
+            }
+            .foregroundColor(VColor.textSecondary)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.xs)
+            .transition(.opacity)
+        }
+    }
+
     // MARK: - Composer Area
 
     private var composerArea: some View {
@@ -168,16 +189,23 @@ private struct ChatBubble: View {
 
     private var isUser: Bool { message.role == .user }
 
-    private var isQueued: Bool {
-        if case .queued = message.status { return true }
-        return false
+    private var statusLabel: String? {
+        switch message.status {
+        case .queued(let position):
+            return position > 0 ? "Queued (\(ordinal(position)) in line)" : "Queued"
+        case .processing:
+            return "Sending\u{2026}"
+        case .sent:
+            return nil
+        }
     }
 
-    private var queueLabel: String? {
-        if case .queued(let position) = message.status {
-            return position > 0 ? "Queued (\(ordinal(position)) in line)" : "Queued"
+    private var bubbleOpacity: Double {
+        switch message.status {
+        case .queued: return 0.7
+        case .processing: return 0.85
+        case .sent: return 1.0
         }
-        return nil
     }
 
     var body: some View {
@@ -187,7 +215,7 @@ private struct ChatBubble: View {
             VStack(alignment: isUser ? .trailing : .leading, spacing: 2) {
                 bubbleContent
 
-                if let label = queueLabel {
+                if let label = statusLabel {
                     Text(label)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
@@ -210,7 +238,7 @@ private struct ChatBubble: View {
                     .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
             )
             .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
-            .opacity(isQueued ? 0.7 : 1.0)
+            .opacity(bubbleOpacity)
     }
 
     private func ordinal(_ n: Int) -> String {


### PR DESCRIPTION
## Summary
- Add a queue status summary line above the composer area that shows when messages are pending (e.g. "2 messages queued, sending automatically")
- Add visual treatment for `.processing` status on chat bubbles: 0.85 opacity and "Sending..." label, complementing the existing `.queued` treatment (0.7 opacity)
- Consolidate `isQueued`/`queueLabel` into unified `statusLabel`/`bubbleOpacity` computed properties for cleaner code

## Test plan
- [ ] Verify queue summary appears above composer when `pendingQueuedCount > 0`
- [ ] Verify queue summary disappears when `pendingQueuedCount == 0`
- [ ] Verify singular/plural text ("1 message queued" vs "N messages queued")
- [ ] Verify processing messages show "Sending..." label and 0.85 opacity
- [ ] Verify queued messages still show "Queued (Nth in line)" label and 0.7 opacity
- [ ] Verify sent messages show no label and full opacity
- [ ] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
