### PR TITLE
docs: document opportunistic message queueing in daemon + macOS chat

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,7 +127,7 @@ graph TB
 
     %% Main Window Chat flow
     CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel"| IPC_SERVER
-    IPC_SERVER -->|"session_info +<br/>text deltas +<br/>message_complete"| CHAT_VM
+    IPC_SERVER -->|"session_info +<br/>text deltas +<br/>message_complete +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff"| CHAT_VM
     CHAT_VIEW --> CHAT_VM
 
     %% Ambient flow
@@ -540,6 +540,9 @@ graph LR
         S9["memory_recalled<br/>context segments"]
         S10["usage_update / error"]
         S11["generation_cancelled"]
+        S12["message_queued<br/>position in queue"]
+        S13["message_dequeued<br/>queue drained"]
+        S14["generation_handoff<br/>sessionId, requestId?,<br/>queuedCount"]
     end
 
     C1 --> SOCKET
@@ -563,6 +566,45 @@ graph LR
     SOCKET --> S9
     SOCKET --> S10
     SOCKET --> S11
+    SOCKET --> S12
+    SOCKET --> S13
+    SOCKET --> S14
+```
+
+---
+
+## Opportunistic Message Queue — Handoff Flow
+
+When the daemon is busy generating a response, the client can continue sending messages. These are queued (FIFO, max 10) and drained automatically at safe checkpoints in the tool loop, not only at full completion.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Chat as ChatView
+    participant VM as ChatViewModel
+    participant DC as DaemonClient
+    participant Daemon as Daemon
+
+    User->>Chat: send message while busy
+    Chat->>VM: enqueue message
+    VM->>DC: user_message
+    DC->>Daemon: IPC
+    Daemon-->>DC: message_queued (position)
+    DC-->>VM: show queue status
+
+    Note over Daemon: Processing previous request...<br/>Reaches safe tool-loop checkpoint
+
+    Daemon-->>DC: generation_handoff (sessionId, queuedCount)
+    Note over Daemon: Daemon yields current generation
+
+    Daemon-->>DC: message_dequeued
+    DC-->>VM: next queued message now processing
+
+    Note over Daemon: Processes queued message...
+
+    Daemon-->>DC: assistant_text_delta (streaming)
+    Daemon-->>DC: message_complete
+    DC-->>VM: generation finished
 ```
 
 ---

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -78,7 +78,16 @@ Grant these in System Settings → Privacy & Security.
 10. Responses stream in real-time from the daemon
 11. Click the stop button to cancel an in-progress generation
 
-**Current limitations:** Single active generation at a time, text-only messages, no conversation history browser.
+### Opportunistic Message Queueing
+
+Users can send multiple messages while the assistant is busy. Messages are queued (FIFO, max 10) and processed automatically:
+
+- The queue drains at safe tool-loop checkpoints, not just at full completion
+- UI shows queue status: "N messages queued, sending automatically"
+- Message bubbles show status: queued (dimmed) -> processing -> sent
+- The daemon emits `generation_handoff` when it yields to queued work at a checkpoint, followed by `message_dequeued` as each queued message begins processing
+
+**Current limitations:** Text-only messages, no conversation history browser.
 
 ## Xcode Previews
 
@@ -160,6 +169,8 @@ Inference/            AI action selection
 IPC/                  Daemon communication
   DaemonClient        Unix domain socket IPC client (auto-reconnect, ping/pong)
   IPCMessages         Codable structs mirroring ipc-protocol.ts
+                      Includes: message_queued, message_dequeued,
+                      generation_handoff (sessionId, requestId?, queuedCount)
 Ambient/              Background screen-watching agent
   AmbientAgent        Periodic capture → OCR → analyze via daemon IPC
   AmbientAnalyzer     Type definitions (AmbientDecision, AmbientAnalysisResult)


### PR DESCRIPTION
## Summary
- Added `generation_handoff`, `message_queued`, and `message_dequeued` events to the IPC Protocol mermaid diagram in `ARCHITECTURE.md`
- Added a new "Opportunistic Message Queue -- Handoff Flow" section with a sequence diagram showing the full queue lifecycle
- Updated the Main Window Chat flow in the system overview diagram to include queue-related events
- Added an "Opportunistic Message Queueing" subsection to `clients/macos/README.md` documenting user-facing behavior (FIFO queue, max 10, checkpoint draining, UI status indicators)
- Listed the new IPC events in the macOS architecture section
- Removed "Single active generation at a time" from the limitations text

## Test plan
- [ ] Verify mermaid diagrams render correctly on GitHub (no syntax errors)
- [ ] Confirm no build breakage: `cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
