### PR TITLE
tests: cover opportunistic queue handoff across daemon and macOS

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -793,7 +793,69 @@ describe('AgentLoop', () => {
     expect(checkpoints[0].hasToolUse).toBe(true);
   });
 
-  // 23. Yield on second turn — first turn proceeds, second stops
+  // 23. Multiple checkpoints across a multi-turn run with selective yield on turn 3
+  test('multiple checkpoints with selective yield — executes turns 0-2, yields at turn 3, never runs 4+', async () => {
+    // Mock provider to return tool_use for 5 turns, then text
+    const responses: ProviderResponse[] = [];
+    for (let i = 0; i < 5; i++) {
+      responses.push(toolUseResponse(`t${i}`, 'read_file', { path: `/file${i}.txt` }));
+    }
+    responses.push(textResponse('Should never reach this'));
+
+    const { provider, calls } = createMockProvider(responses);
+    const toolExecutor = async () => ({ content: 'data', isError: false });
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+
+    const checkpoints: CheckpointInfo[] = [];
+    const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
+      checkpoints.push(checkpoint);
+      // Yield on turn 3 (0-indexed)
+      return checkpoint.turnIndex === 3 ? 'yield' : 'continue';
+    };
+
+    const events: AgentEvent[] = [];
+    const history = await loop.run([userMessage], collectEvents(events), undefined, undefined, onCheckpoint);
+
+    // Turns 0, 1, 2, 3 execute (4 provider calls). Turn 3 yields, so turns 4+ never execute.
+    expect(calls).toHaveLength(4);
+
+    // Checkpoints should have been called for turns 0 through 3
+    expect(checkpoints).toHaveLength(4);
+    expect(checkpoints[0].turnIndex).toBe(0);
+    expect(checkpoints[1].turnIndex).toBe(1);
+    expect(checkpoints[2].turnIndex).toBe(2);
+    expect(checkpoints[3].turnIndex).toBe(3);
+
+    // History should contain results from turns 0-3:
+    // user, assistant(t0), user(result0), assistant(t1), user(result1),
+    // assistant(t2), user(result2), assistant(t3), user(result3)
+    // = 1 original + 4*(assistant + user) = 9
+    expect(history).toHaveLength(9);
+
+    // Verify the last two messages are from turn 3
+    expect(history[7].role).toBe('assistant');
+    const lastAssistantToolUse = history[7].content.find((b) => b.type === 'tool_use');
+    expect(lastAssistantToolUse).toBeDefined();
+    if (lastAssistantToolUse && lastAssistantToolUse.type === 'tool_use') {
+      expect(lastAssistantToolUse.id).toBe('t3');
+    }
+    expect(history[8].role).toBe('user');
+    const lastToolResult = history[8].content.find(
+      (b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result',
+    );
+    expect(lastToolResult).toBeDefined();
+    expect(lastToolResult!.tool_use_id).toBe('t3');
+
+    // Verify turns 4+ never executed — no tool_use event for t4
+    const toolUseEvents = events.filter(
+      (e): e is Extract<AgentEvent, { type: 'tool_use' }> => e.type === 'tool_use',
+    );
+    const toolUseNames = toolUseEvents.map((e) => e.id);
+    expect(toolUseNames).toEqual(['t0', 't1', 't2', 't3']);
+    expect(toolUseNames).not.toContain('t4');
+  });
+
+  // 24. Yield on second turn — first turn proceeds, second stops
   test('yield on second turn lets first turn proceed and stops on second', async () => {
     const { provider, calls } = createMockProvider([
       toolUseResponse('t1', 'read_file', { path: '/a.txt' }),

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -707,6 +707,161 @@ describe('Session checkpoint handoff', () => {
     expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
   });
 
+  test('active run with repeated tool turns + queued message triggers checkpoint handoff', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events1: ServerMessage[] = [];
+    const events2: ServerMessage[] = [];
+
+    // Start processing first message
+    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue a second message while the first is processing
+    session.enqueueMessage('msg-2', [], (e) => events2.push(e), 'req-2');
+    expect(session.hasQueuedMessages()).toBe(true);
+
+    // Simulate tool-use turns: the agent loop calls onCheckpoint at each turn boundary.
+    // Because there is a queued message, the callback should return 'yield'.
+    const run = pendingRuns[0];
+    expect(run.onCheckpoint).toBeDefined();
+
+    // Simulate multiple tool-use turns before the checkpoint fires
+    // Turn 0 — checkpoint yields because msg-2 is waiting
+    const decision = run.onCheckpoint!({
+      turnIndex: 0,
+      toolCount: 1,
+      hasToolUse: true,
+    });
+    expect(decision).toBe('yield');
+
+    // Complete the run (AgentLoop resolves after yielding)
+    resolveRun(0);
+    await p1;
+
+    // Verify generation_handoff was emitted (not plain message_complete)
+    const handoff = events1.find((e) => e.type === 'generation_handoff');
+    expect(handoff).toBeDefined();
+    expect(handoff).toMatchObject({
+      type: 'generation_handoff',
+      sessionId: 'conv-1',
+      requestId: 'req-1',
+      queuedCount: 1,
+    });
+    // message_complete should NOT be in events1 (handoff replaces it)
+    const messageComplete = events1.find((e) => e.type === 'message_complete' && 'sessionId' in e);
+    expect(messageComplete).toBeUndefined();
+
+    // The queued message should subsequently drain
+    await waitForPendingRun(2);
+    expect(events2.some((e) => e.type === 'message_dequeued')).toBe(true);
+
+    // Complete the second run
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test('queued messages still drain FIFO under multiple handoffs', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const dequeueOrder: string[] = [];
+
+    const eventsA: ServerMessage[] = [];
+    const makeHandler = (label: string) => (e: ServerMessage) => {
+      if (e.type === 'message_dequeued') dequeueOrder.push(label);
+    };
+
+    // Start processing message A
+    const pA = session.processMessage('msg-A', [], (e) => eventsA.push(e), 'req-A');
+    await waitForPendingRun(1);
+
+    // Enqueue messages B, C, D
+    session.enqueueMessage('msg-B', [], makeHandler('B'), 'req-B');
+    session.enqueueMessage('msg-C', [], makeHandler('C'), 'req-C');
+    session.enqueueMessage('msg-D', [], makeHandler('D'), 'req-D');
+    expect(session.getQueueDepth()).toBe(3);
+
+    // Handoff from A -> B
+    const runA = pendingRuns[0];
+    expect(runA.onCheckpoint).toBeDefined();
+    expect(runA.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true })).toBe('yield');
+    resolveRun(0);
+    await pA;
+
+    // B should be draining
+    await waitForPendingRun(2);
+
+    // Handoff from B -> C
+    const runB = pendingRuns[1];
+    expect(runB.onCheckpoint).toBeDefined();
+    expect(runB.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true })).toBe('yield');
+    resolveRun(1);
+    await waitForPendingRun(3);
+
+    // Handoff from C -> D
+    const runC = pendingRuns[2];
+    expect(runC.onCheckpoint).toBeDefined();
+    // Only D remains, still should yield
+    expect(runC.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true })).toBe('yield');
+    resolveRun(2);
+    await waitForPendingRun(4);
+
+    // D has no more queued -> checkpoint should return 'continue'
+    const runD = pendingRuns[3];
+    expect(runD.onCheckpoint).toBeDefined();
+    expect(runD.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true })).toBe('continue');
+
+    resolveRun(3);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify FIFO dequeue order
+    expect(dequeueOrder).toEqual(['B', 'C', 'D']);
+  });
+
+  test('queued persistence failure does not strand later messages', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const eventsA: ServerMessage[] = [];
+    const eventsB: ServerMessage[] = [];
+    const eventsC: ServerMessage[] = [];
+
+    // Start processing message A
+    const pA = session.processMessage('msg-A', [], (e) => eventsA.push(e), 'req-A');
+    await waitForPendingRun(1);
+
+    // Enqueue B (empty content — will fail to persist) and C (valid)
+    session.enqueueMessage('', [], (e) => eventsB.push(e), 'req-B');
+    session.enqueueMessage('msg-C', [], (e) => eventsC.push(e), 'req-C');
+    expect(session.getQueueDepth()).toBe(2);
+
+    // Complete message A — triggers drain. B should fail, C should proceed.
+    resolveRun(0);
+    await pA;
+
+    // C should have been dequeued and started a new AgentLoop.run
+    await waitForPendingRun(2);
+
+    // B should have received an error event
+    const errB = eventsB.find((e) => e.type === 'error');
+    expect(errB).toBeDefined();
+    if (errB && errB.type === 'error') {
+      expect(errB.message).toContain('required');
+    }
+
+    // C should have received a dequeued event
+    expect(eventsC.some((e) => e.type === 'message_dequeued')).toBe(true);
+
+    // Complete C's run
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // C should have completed successfully
+    expect(eventsC.some((e) => e.type === 'message_complete')).toBe(true);
+  });
+
   test('onCheckpoint callback is passed to both initial and retry runs', async () => {
     const session = makeSession();
     await session.loadFromDb();

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -497,6 +497,98 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[6].isStreaming, "Third assistant message should be finalized")
     }
 
+    // MARK: - Queue Badges / Status Transitions (handoff → dequeue → complete)
+
+    func testQueueBadgesStatusTransitionsReflectHandoffDequeueComplete() {
+        // Set up viewModel with a session
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+
+        // Send message A (direct — not queued)
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        // greeting(0), A(1)
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+
+        // Send messages B and C while busy (both get queued status)
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+        viewModel.inputText = "Message C"
+        viewModel.sendMessage()
+        // greeting(0), A(1), B(2), C(3)
+        XCTAssertEqual(viewModel.messages.count, 4)
+
+        // Both B and C should have .queued status (position 0 initially)
+        if case .queued = viewModel.messages[2].status {
+            // expected
+        } else {
+            XCTFail("Message B should have queued status")
+        }
+        if case .queued = viewModel.messages[3].status {
+            // expected
+        } else {
+            XCTFail("Message C should have queued status")
+        }
+
+        // Simulate daemon confirming B and C are queued
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-C", position: 2)))
+        XCTAssertEqual(viewModel.pendingQueuedCount, 2)
+
+        // Verify positions were updated
+        if case .queued(let pos) = viewModel.messages[2].status {
+            XCTAssertEqual(pos, 1)
+        } else {
+            XCTFail("Message B should be queued at position 1")
+        }
+        if case .queued(let pos) = viewModel.messages[3].status {
+            XCTAssertEqual(pos, 2)
+        } else {
+            XCTFail("Message C should be queued at position 2")
+        }
+
+        // Assistant responds to A with text delta, then generation_handoff
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        // greeting(0), A(1), B(2), C(3), assistantA(4)
+        XCTAssertEqual(viewModel.messages.count, 5)
+
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 2)))
+
+        // After handoff: isSending stays true, isThinking cleared, streaming finalized
+        XCTAssertTrue(viewModel.isSending, "isSending must stay true during handoff")
+        XCTAssertFalse(viewModel.isThinking, "isThinking cleared after handoff")
+        XCTAssertFalse(viewModel.messages[4].isStreaming, "Assistant message for A should be finalized")
+
+        // B and C remain queued
+        XCTAssertEqual(viewModel.pendingQueuedCount, 2)
+
+        // Simulate messageDequeued for B — first queued goes to .processing
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing, "Message B should now be processing")
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking, "isThinking restored after dequeue")
+        XCTAssertEqual(viewModel.pendingQueuedCount, 1)
+
+        // Assistant responds to B, then another handoff
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        XCTAssertTrue(viewModel.isSending, "isSending stays true — C is still queued")
+
+        // Simulate messageDequeued for C
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-C")))
+        XCTAssertEqual(viewModel.messages[3].status, .processing, "Message C should now be processing")
+        XCTAssertEqual(viewModel.pendingQueuedCount, 0)
+
+        // Assistant responds to C, then message_complete (no more queued)
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to C")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        // isSending should clear when queue is empty and message completes
+        XCTAssertFalse(viewModel.isSending, "isSending should be false — no more queued messages")
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
     // MARK: - Full Conversation Flow
 
     func testFullConversationFlow() {


### PR DESCRIPTION
## Summary
- Add 3 new tests to `session-queue.test.ts`: checkpoint handoff with tool turns yields and emits `generation_handoff`, FIFO ordering preserved under multiple handoffs (B->C->D), and persistence failure on one queued message doesn't strand subsequent messages
- Add 1 new test to `agent-loop.test.ts`: selective yield at turn 3 verifies turns 0-2 execute, turn 3 yields, and turns 4+ never run with correct history contents
- Add 1 new test to `ChatViewModelTests.swift`: full queue badge/status transition flow covering `messageQueued` -> `generationHandoff` -> `messageDequeued` -> `messageComplete` with assertions on `isSending`, `isThinking`, message statuses, and `pendingQueuedCount`

## Test plan
- [x] All 22 session-queue tests pass (`bun test src/__tests__/session-queue.test.ts`)
- [x] All 29 agent-loop tests pass (`bun test src/__tests__/agent-loop.test.ts`)
- [x] All 39 ChatViewModelTests pass (`swift test --filter ChatViewModelTests`)
- [x] Note: session-queue and agent-loop tests must be run separately due to Bun mock.module leakage (pre-existing issue, not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
