### PR TITLE
fix: merge consecutive same-role messages in repairHistory to prevent handoff retry

### DIFF
--- a/assistant/src/__tests__/history-repair-observability.test.ts
+++ b/assistant/src/__tests__/history-repair-observability.test.ts
@@ -14,6 +14,7 @@ describe('history-repair observability', () => {
     expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
+    expect(stats.consecutiveSameRoleMerged).toBe(0);
   });
 
   test('stats are non-zero only when repairs are applied', () => {
@@ -48,7 +49,8 @@ describe('history-repair observability', () => {
     const shouldLog =
       stats.assistantToolResultsMigrated > 0 ||
       stats.missingToolResultsInserted > 0 ||
-      stats.orphanToolResultsDowngraded > 0;
+      stats.orphanToolResultsDowngraded > 0 ||
+      stats.consecutiveSameRoleMerged > 0;
     expect(shouldLog).toBe(true);
   });
 });

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -354,12 +354,70 @@ describe('repairHistory', () => {
     });
   });
 
+  test('merges consecutive user messages (checkpoint handoff scenario)', () => {
+    // After a checkpoint handoff the history can end with:
+    //   assistant(tool_use) -> user(tool_result) -> user(new_message)
+    // repairHistory should merge the two consecutive user messages.
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu_1', name: 'bash', input: { cmd: 'ls' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu_1', content: 'file1' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Now do something else' }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.consecutiveSameRoleMerged).toBe(1);
+    expect(repaired).toHaveLength(3);
+    expect(repaired[2].role).toBe('user');
+    expect(repaired[2].content).toHaveLength(2);
+    expect(repaired[2].content[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: 'file1',
+    });
+    expect(repaired[2].content[1]).toEqual({
+      type: 'text',
+      text: 'Now do something else',
+    });
+  });
+
+  test('merges multiple consecutive same-role messages', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'A' }] },
+      { role: 'user', content: [{ type: 'text', text: 'B' }] },
+      { role: 'user', content: [{ type: 'text', text: 'C' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.consecutiveSameRoleMerged).toBe(2);
+    expect(repaired).toHaveLength(2);
+    expect(repaired[0].role).toBe('user');
+    expect(repaired[0].content).toHaveLength(3);
+  });
+
   test('handles empty message array', () => {
     const { messages, stats } = repairHistory([]);
     expect(messages).toEqual([]);
     expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
+    expect(stats.consecutiveSameRoleMerged).toBe(0);
   });
 });
 

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -9,6 +9,7 @@ export interface RepairStats {
   assistantToolResultsMigrated: number;
   missingToolResultsInserted: number;
   orphanToolResultsDowngraded: number;
+  consecutiveSameRoleMerged: number;
 }
 
 export interface RepairResult {
@@ -23,6 +24,7 @@ export function repairHistory(messages: Message[]): RepairResult {
     assistantToolResultsMigrated: 0,
     missingToolResultsInserted: 0,
     orphanToolResultsDowngraded: 0,
+    consecutiveSameRoleMerged: 0,
   };
 
   const result: Message[] = [];
@@ -128,7 +130,21 @@ export function repairHistory(messages: Message[]): RepairResult {
     result.push(buildResultMessage(pendingToolUseIds, recoveredResults, stats));
   }
 
-  return { messages: result, stats };
+  // Merge consecutive same-role messages. This can occur after a checkpoint
+  // handoff where a user(tool_result) message is followed by a user(new_message),
+  // or from other history reconstruction artifacts.
+  const merged: Message[] = [];
+  for (const msg of result) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.role === msg.role) {
+      prev.content = [...prev.content, ...msg.content];
+      stats.consecutiveSameRoleMerged++;
+    } else {
+      merged.push({ role: msg.role, content: [...msg.content] });
+    }
+  }
+
+  return { messages: merged, stats };
 }
 
 function buildResultMessage(
@@ -157,10 +173,11 @@ function buildResultMessage(
 
 /**
  * Aggressive repair pass that handles edge cases beyond repairHistory:
- * - Merges consecutive same-role messages
- * - Ensures the first message is from the user
  * - Removes empty messages
- * Then applies the standard repairHistory on top.
+ * - Ensures the first message is from the user
+ * - Merges consecutive same-role messages (before tool-use/result repair)
+ * Then applies the standard repairHistory on top (which also merges any
+ * consecutive same-role messages introduced by tool-use/result repair).
  */
 export function deepRepairHistory(messages: Message[]): RepairResult {
   // 1. Remove messages with no content blocks

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -168,7 +168,7 @@ export class Session {
       });
 
     const { messages: repairedMessages, stats } = repairHistory(parsedMessages);
-    if (stats.assistantToolResultsMigrated > 0 || stats.missingToolResultsInserted > 0 || stats.orphanToolResultsDowngraded > 0) {
+    if (stats.assistantToolResultsMigrated > 0 || stats.missingToolResultsInserted > 0 || stats.orphanToolResultsDowngraded > 0 || stats.consecutiveSameRoleMerged > 0) {
       log.warn({ conversationId: this.conversationId, phase: 'load', ...stats }, 'Repaired persisted history');
     }
     this.messages = repairedMessages;
@@ -437,7 +437,7 @@ export class Session {
       // containing tool_result).
       let preRepairMessages = runMessages;
       const preRunRepair = repairHistory(runMessages);
-      if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0) {
+      if (preRunRepair.stats.assistantToolResultsMigrated > 0 || preRunRepair.stats.missingToolResultsInserted > 0 || preRunRepair.stats.orphanToolResultsDowngraded > 0 || preRunRepair.stats.consecutiveSameRoleMerged > 0) {
         rlog.warn({ phase: 'pre_run', ...preRunRepair.stats }, 'Repaired runtime history before provider call');
         runMessages = preRunRepair.messages;
       }


### PR DESCRIPTION
## Summary
- Adds consecutive same-role message merging to `repairHistory()` as a post-pass, fixing a bug where every checkpoint handoff triggered an unnecessary provider ordering-error retry
- After a checkpoint handoff, the history ends with `user(tool_result)` followed by `user(new_message)`, which the provider rejects. Previously only `deepRepairHistory()` (used in the retry path) merged these, meaning every handoff always failed on the first attempt and required a retry, doubling API calls
- Adds a `consecutiveSameRoleMerged` stat counter for observability and updates both `session.ts` log guards to include the new stat

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 22 tests pass across `history-repair.test.ts` and `history-repair-observability.test.ts`
- [x] New test: consecutive user messages (checkpoint handoff scenario) are merged by `repairHistory()`
- [x] New test: multiple consecutive same-role messages are merged with correct count
- [x] Existing tests continue to pass (no regressions)
- [x] `deepRepairHistory` tests still pass (it delegates to `repairHistory` which now handles merging)

Addresses review feedback on #934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
