### PR TITLE
macOS: reset processing status to sent on message completion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -188,6 +188,12 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
 
         case .generationCancelled:
             isThinking = false
@@ -199,6 +205,12 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
 
         case .messageQueued(let queued):
             pendingQueuedCount += 1
@@ -236,6 +248,12 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
 
         case .error(let err):
             log.error("Server error: \(err.message)")

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -352,6 +352,90 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isThinking)
     }
 
+    // MARK: - Processing Status Reset
+
+    func testProcessingStatusResetToSentOnMessageComplete() {
+        // Set up session and send a message while busy (gets queued)
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        // greeting(0), A(1)
+
+        // Send message B while busy (will be queued)
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+        // greeting(0), A(1), B(2)
+        XCTAssertEqual(viewModel.messages.count, 3)
+
+        // Daemon confirms B is queued
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+
+        // Assistant responds to A, then handoff
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+
+        // Daemon dequeues B — status becomes .processing
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing, "Message B should be processing after dequeue")
+
+        // Assistant responds to B, then message_complete
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        // After message_complete, the processing user message should be reset to .sent
+        XCTAssertEqual(viewModel.messages[2].status, .sent, "Message B should be .sent after messageComplete, not .processing")
+    }
+
+    func testProcessingStatusResetToSentOnGenerationCancelled() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        // Daemon confirms B is queued, then dequeued
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing)
+
+        // Generation is cancelled
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+
+        XCTAssertEqual(viewModel.messages[2].status, .sent, "Message B should be .sent after generationCancelled, not .processing")
+    }
+
+    func testProcessingStatusResetToSentOnGenerationHandoff() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message C"
+        viewModel.sendMessage()
+
+        // Queue B and C
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-C", position: 2)))
+
+        // A completes via handoff, B is dequeued and becomes processing
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 2)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing)
+
+        // B completes via handoff (C is still queued)
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+
+        // B should be reset to .sent after generationHandoff
+        XCTAssertEqual(viewModel.messages[2].status, .sent, "Message B should be .sent after generationHandoff, not .processing")
+    }
+
     // MARK: - Generation Handoff
 
     func testGenerationHandoffKeepsSendingTrue() {


### PR DESCRIPTION
## Summary
- Fix bug where `.processing` status was never reset to `.sent` when a queued message's response completed
- This caused the "Sending..." label and 0.85 opacity to persist indefinitely on user chat bubbles after their response finished
- Add processing-to-sent reset in `messageComplete`, `generationCancelled`, and `generationHandoff` handlers in `ChatViewModel.swift`

## Test plan
- [x] Added `testProcessingStatusResetToSentOnMessageComplete` -- verifies queued message goes through `.processing` then back to `.sent` after `messageComplete`
- [x] Added `testProcessingStatusResetToSentOnGenerationCancelled` -- verifies reset on `generationCancelled`
- [x] Added `testProcessingStatusResetToSentOnGenerationHandoff` -- verifies reset on `generationHandoff`
- [x] All 42 ChatViewModelTests pass
- [x] Build succeeds

Addresses review feedback on #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
