### PR TITLE
Handle generation_handoff event in all clients to prevent hangs

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -381,6 +381,26 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
         break;
       }
 
+      case 'generation_handoff': {
+        // Treat handoff the same as message_complete from the CLI's perspective:
+        // the generation for the current request is done.
+        spinner.stop();
+        generating = false;
+        if (lastUsage) {
+          const cost = lastUsage.estimatedCost > 0
+            ? ` ~$${lastUsage.estimatedCost.toFixed(4)}`
+            : '';
+          process.stdout.write(
+            `\n\n\x1B[2m[${lastUsage.inputTokens.toLocaleString()} in / ${lastUsage.outputTokens.toLocaleString()} out${cost}]\x1B[0m\n\n`,
+          );
+          lastUsage = null;
+        } else {
+          process.stdout.write('\n\n');
+        }
+        prompt();
+        break;
+      }
+
       case 'generation_cancelled':
         spinner.stop();
         generating = false;

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -107,7 +107,8 @@ final class TextSession: ObservableObject {
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_) where self.daemonSessionId != nil:
+                case .messageComplete(_) where self.daemonSessionId != nil,
+                     .generationHandoff(_) where self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     // Set state before appending to messages — the $state Combine sink
                     // triggers a layout pass, and if state is still .streaming when the
@@ -176,7 +177,8 @@ final class TextSession: ObservableObject {
                 case .assistantThinkingDelta(let delta):
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_):
+                case .messageComplete(_),
+                     .generationHandoff(_):
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -150,7 +150,8 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete where self.sessionId != nil:
+                case .messageComplete where self.sessionId != nil,
+                     .generationHandoff where self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -262,7 +263,8 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete:
+                case .messageComplete,
+                     .generationHandoff:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -136,6 +136,11 @@ final class ProfileExtractor {
                 processExtractionResponse(accumulated)
                 return
 
+            case .generationHandoff(let handoff) where handoff.sessionId == sessionId && sessionId != nil:
+                log.info("Extraction response complete via handoff (\(accumulated.count) chars)")
+                processExtractionResponse(accumulated)
+                return
+
             case .cuError(let error) where error.sessionId == sessionId:
                 log.error("Extraction session error: \(error.message)")
                 return

--- a/web/src/lib/local-daemon-ipc.ts
+++ b/web/src/lib/local-daemon-ipc.ts
@@ -384,6 +384,7 @@ export class LocalDaemonClient {
           break;
         }
         case "message_complete":
+        case "generation_handoff":
           return {
             assistantText: assistantText.trim(),
             usage,


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #935: the `generation_handoff` event was not handled by any client, causing hangs/timeouts when checkpoint handoff occurs
- CLI (`cli.ts`): Add `generation_handoff` case that stops spinner, clears `generating` flag, prints usage, and re-prompts -- same behavior as `message_complete`
- Web client (`local-daemon-ipc.ts`): Add `generation_handoff` as a terminal case alongside `message_complete` in `sendUserMessage` to return the result instead of looping until timeout
- macOS `TextSession.swift`: Handle `.generationHandoff` alongside `.messageComplete` in both `run()` and `sendFollowUp()` message loops
- macOS `InterviewViewModel.swift`: Handle `.generationHandoff` alongside `.messageComplete` in both `startInterview()` and `sendMessage()` message loops
- macOS `ProfileExtractor.swift`: Handle `.generationHandoff` with sessionId filtering alongside `.messageComplete` in the extraction stream loop

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] Session queue tests pass (22 tests)
- [x] IPC snapshot tests pass (68 tests)
- [x] All clients treat `generation_handoff` as terminal, same as `message_complete`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
