### PR TITLE
Fix ChatViewModel session bootstrap: reconnect, filtering, offline sends

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -96,6 +96,20 @@ final class ChatViewModel: ObservableObject {
 
     private func sendUserMessage(_ text: String, queuedMessageId: UUID? = nil) {
         guard let sessionId else { return }
+
+        // Check connectivity before entering sending state so the UI
+        // doesn't get stuck with isSending/isThinking = true when the
+        // daemon has disconnected between turns.
+        guard daemonClient.isConnected else {
+            log.error("Cannot send user_message: daemon not connected")
+            errorText = "Cannot connect to daemon. Please ensure it's running."
+            // Remove the queued message ID to prevent stale FIFO entries
+            if let queuedMessageId {
+                pendingMessageIds.removeAll { $0 == queuedMessageId }
+            }
+            return
+        }
+
         isSending = true
         isThinking = true
 
@@ -131,7 +145,23 @@ final class ChatViewModel: ObservableObject {
                 guard let self, !Task.isCancelled else { break }
                 self.handleServerMessage(message)
             }
+            // Stream ended (e.g. daemon disconnected) — clear the task reference
+            // so the next sendUserMessage() call will re-subscribe.
+            self?.messageLoopTask = nil
         }
+    }
+
+    /// Returns true if the given session ID belongs to this chat session.
+    /// Messages with a nil sessionId are always accepted; messages whose
+    /// sessionId doesn't match the current session are silently ignored
+    /// to prevent cross-session contamination (e.g. from a popover text_qa flow).
+    private func belongsToSession(_ messageSessionId: String?) -> Bool {
+        guard let messageSessionId else { return true }
+        guard let sessionId else {
+            // No session established yet — accept all messages
+            return true
+        }
+        return messageSessionId == sessionId
     }
 
     func handleServerMessage(_ message: ServerMessage) {
@@ -164,6 +194,7 @@ final class ChatViewModel: ObservableObject {
             break
 
         case .assistantTextDelta(let delta):
+            guard belongsToSession(delta.sessionId) else { return }
             isThinking = false
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -176,7 +207,8 @@ final class ChatViewModel: ObservableObject {
                 messages.append(msg)
             }
 
-        case .messageComplete:
+        case .messageComplete(let complete):
+            guard belongsToSession(complete.sessionId) else { return }
             isThinking = false
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
@@ -195,7 +227,8 @@ final class ChatViewModel: ObservableObject {
                 }
             }
 
-        case .generationCancelled:
+        case .generationCancelled(let cancelled):
+            guard belongsToSession(cancelled.sessionId) else { return }
             isThinking = false
             if pendingQueuedCount == 0 {
                 isSending = false
@@ -213,6 +246,7 @@ final class ChatViewModel: ObservableObject {
             }
 
         case .messageQueued(let queued):
+            guard belongsToSession(queued.sessionId) else { return }
             pendingQueuedCount += 1
             // Associate this requestId with the oldest pending user message
             if let messageId = pendingMessageIds.first {
@@ -224,6 +258,7 @@ final class ChatViewModel: ObservableObject {
             }
 
         case .messageDequeued(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
             pendingQueuedCount = max(0, pendingQueuedCount - 1)
             // Mark the associated user message as processing
             if let messageId = requestIdToMessageId.removeValue(forKey: msg.requestId),
@@ -240,7 +275,8 @@ final class ChatViewModel: ObservableObject {
             isThinking = true
             isSending = true
 
-        case .generationHandoff:
+        case .generationHandoff(let handoff):
+            guard belongsToSession(handoff.sessionId) else { return }
             isThinking = false
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -10,6 +10,9 @@ final class ChatViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         daemonClient = DaemonClient()
+        // Mark as connected so send-path tests don't hit the disconnected guard.
+        // Tests that verify disconnected behaviour explicitly set isConnected = false.
+        daemonClient.isConnected = true
         viewModel = ChatViewModel(daemonClient: daemonClient)
     }
 
@@ -671,6 +674,76 @@ final class ChatViewModelTests: XCTestCase {
         // isSending should clear when queue is empty and message completes
         XCTAssertFalse(viewModel.isSending, "isSending should be false — no more queued messages")
         XCTAssertFalse(viewModel.isThinking)
+    }
+
+    // MARK: - Session Filtering
+
+    func testTextDeltaFromDifferentSessionIsIgnored() {
+        viewModel.sessionId = "my-session"
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", sessionId: "other-session")))
+        // Should still be thinking — delta was ignored
+        XCTAssertTrue(viewModel.isThinking)
+        XCTAssertEqual(viewModel.messages.count, 1) // Only greeting
+    }
+
+    func testTextDeltaFromSameSessionIsAccepted() {
+        viewModel.sessionId = "my-session"
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: "my-session")))
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].text, "hello")
+    }
+
+    func testTextDeltaWithNilSessionIdIsAccepted() {
+        viewModel.sessionId = "my-session"
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: nil)))
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertEqual(viewModel.messages.count, 2)
+    }
+
+    func testMessageCompleteFromDifferentSessionIsIgnored() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "other-session")))
+        // Should still be sending/thinking — message was ignored
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+    }
+
+    func testMessageCompleteFromSameSessionIsAccepted() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "my-session")))
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    // MARK: - Disconnected Send Handling
+
+    func testSendUserMessageWhenDisconnectedShowsError() {
+        // Set up a session but daemon is disconnected
+        viewModel.sessionId = "test-session"
+        daemonClient.isConnected = false
+
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        // User message should still appear in the list
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].role, .user)
+
+        // But isSending/isThinking should NOT be set since the send was rejected
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+
+        // Error text should be surfaced
+        XCTAssertNotNil(viewModel.errorText)
+        XCTAssertTrue(viewModel.errorText?.contains("daemon") == true)
     }
 
     // MARK: - Full Conversation Flow


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #859 (ChatViewModel session bootstrap):

- **Clear `messageLoopTask` on stream end** -- After a daemon disconnect, the `for await` loop exits but `messageLoopTask` stayed non-nil, preventing re-subscription on subsequent sends. Now sets `messageLoopTask = nil` after the stream ends so the next `sendUserMessage()` call re-subscribes.

- **Filter server messages by session ID** -- `DaemonClient` broadcasts all messages to all subscribers, so messages from other sessions (e.g. popover text_qa flows) could corrupt the chat thread. Added `belongsToSession(_:)` guard to `assistantTextDelta`, `messageComplete`, `generationCancelled`, `messageQueued`, `messageDequeued`, and `generationHandoff` handlers.

- **Check connectivity before entering sending state** -- `sendUserMessage` previously set `isSending`/`isThinking = true` before calling `send()`, but `DaemonClient.send()` silently returns when disconnected, leaving the UI permanently stuck. Now checks `isConnected` first and surfaces an error immediately if the daemon is unreachable.

## Test plan
- [x] All 48 existing `ChatViewModelTests` pass
- [x] New test: `testTextDeltaFromDifferentSessionIsIgnored`
- [x] New test: `testTextDeltaFromSameSessionIsAccepted`
- [x] New test: `testTextDeltaWithNilSessionIdIsAccepted`
- [x] New test: `testMessageCompleteFromDifferentSessionIsIgnored`
- [x] New test: `testMessageCompleteFromSameSessionIsAccepted`
- [x] New test: `testSendUserMessageWhenDisconnectedShowsError`

## Files modified
- `clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift`
- `clients/macos/vellum-assistantTests/ChatViewModelTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
