### PR TITLE
Fix stop generation race conditions in ChatViewModel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -17,6 +17,9 @@ final class ChatViewModel: ObservableObject {
     private var pendingUserMessage: String?
     private var messageLoopTask: Task<Void, Never>?
     private var currentAssistantMessageId: UUID?
+    /// When true, incoming deltas are suppressed until the daemon acknowledges
+    /// the cancellation (via `generation_cancelled` or `message_complete`).
+    private var isCancelling: Bool = false
     /// Maps daemon requestId to the user message UUID in the messages array.
     private var requestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
@@ -195,6 +198,8 @@ final class ChatViewModel: ObservableObject {
 
         case .assistantTextDelta(let delta):
             guard belongsToSession(delta.sessionId) else { return }
+            // Suppress late-arriving deltas after the user clicked stop.
+            guard !isCancelling else { return }
             isThinking = false
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -209,6 +214,7 @@ final class ChatViewModel: ObservableObject {
 
         case .messageComplete(let complete):
             guard belongsToSession(complete.sessionId) else { return }
+            isCancelling = false
             isThinking = false
             // Only clear isSending if no messages are still queued
             if pendingQueuedCount == 0 {
@@ -229,6 +235,7 @@ final class ChatViewModel: ObservableObject {
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
+            isCancelling = false
             isThinking = false
             if pendingQueuedCount == 0 {
                 isSending = false
@@ -304,24 +311,37 @@ final class ChatViewModel: ObservableObject {
     }
 
     func stopGenerating() {
-        guard isSending, let sessionId else { return }
+        guard isSending else { return }
+
+        // If we're still bootstrapping (no session yet), cancel locally:
+        // discard the pending message so it won't be sent when session_info
+        // arrives, and reset UI state immediately since there's nothing to
+        // cancel on the daemon side.
+        if sessionId == nil {
+            pendingUserMessage = nil
+            isThinking = false
+            isSending = false
+            return
+        }
 
         do {
-            try daemonClient.send(CancelMessage(sessionId: sessionId))
+            try daemonClient.send(CancelMessage(sessionId: sessionId!))
         } catch {
             log.error("Failed to send cancel: \(error.localizedDescription)")
         }
 
-        // Immediately update UI state
+        // Set cancelling flag so late-arriving deltas are suppressed.
+        // isSending stays true until the daemon acknowledges the cancel
+        // (via generation_cancelled or message_complete) to prevent the
+        // user from sending a new message before the daemon has stopped.
+        isCancelling = true
         isThinking = false
-        isSending = false
 
         // Mark current assistant message as stopped
         if let existingId = currentAssistantMessageId,
            let index = messages.firstIndex(where: { $0.id == existingId }) {
             messages[index].isStreaming = false
         }
-        currentAssistantMessageId = nil
     }
 
     func dismissError() {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -224,7 +224,7 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - Stop Generating
 
-    func testStopGeneratingResetsState() {
+    func testStopGeneratingKeepsSendingUntilAcknowledged() {
         // Set up as if we're in a streaming session
         viewModel.isSending = true
         viewModel.isThinking = true
@@ -233,9 +233,75 @@ final class ChatViewModelTests: XCTestCase {
 
         viewModel.stopGenerating()
 
-        XCTAssertFalse(viewModel.isSending)
+        // isSending stays true until daemon acknowledges
+        XCTAssertTrue(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
         XCTAssertFalse(viewModel.messages[1].isStreaming)
+
+        // Daemon acknowledges cancellation
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testStopGeneratingSuppressesLateDeltas() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.sessionId = "test-session"
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+
+        viewModel.stopGenerating()
+
+        // Late-arriving delta after stop should be suppressed
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " late text")))
+
+        // Should still only have the original partial text, no new message
+        XCTAssertEqual(viewModel.messages.count, 2) // greeting + 1 assistant
+        XCTAssertEqual(viewModel.messages[1].text, "Partial")
+
+        // Daemon acknowledges cancellation — clears isCancelling
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        XCTAssertFalse(viewModel.isSending)
+
+        // After acknowledgment, new deltas should work normally
+        viewModel.isSending = true
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "New response")))
+        XCTAssertEqual(viewModel.messages.count, 3)
+        XCTAssertEqual(viewModel.messages[2].text, "New response")
+    }
+
+    func testStopGeneratingSuppressedByMessageComplete() {
+        // If a message_complete arrives instead of generation_cancelled
+        // (race between cancel and normal completion), it should also
+        // reset the cancelling state.
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.sessionId = "test-session"
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
+
+        viewModel.stopGenerating()
+
+        // Late delta suppressed
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " extra")))
+        XCTAssertEqual(viewModel.messages[1].text, "Response")
+
+        // message_complete arrives instead of generation_cancelled
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testStopGeneratingDuringBootstrapCancelsLocally() {
+        // Simulate bootstrap: isSending is true but sessionId is nil
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertNil(viewModel.sessionId)
+
+        viewModel.stopGenerating()
+
+        // Should reset immediately since there's no daemon session to cancel
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
     }
 
     func testStopGeneratingWithNoSessionDoesNothing() {


### PR DESCRIPTION
## Summary
- Add `isCancelling` flag to suppress late-arriving text deltas after the user clicks stop, preventing orphaned assistant message bubbles from appearing after cancellation
- Keep `isSending` true until the daemon acknowledges the cancel (via `generation_cancelled` or `message_complete`), preventing users from sending new messages before the daemon has stopped processing
- Allow `stopGenerating()` to work during first-message bootstrap (when `sessionId` is nil) by discarding the pending message and resetting UI state locally

Addresses review feedback from #863.

## Test plan
- [x] `testStopGeneratingKeepsSendingUntilAcknowledged` — verifies `isSending` stays true until `generation_cancelled` arrives
- [x] `testStopGeneratingSuppressesLateDeltas` — verifies late text deltas are ignored after stop, and new deltas work after acknowledgment
- [x] `testStopGeneratingSuppressedByMessageComplete` — verifies `message_complete` also resets the cancelling state (race with normal completion)
- [x] `testStopGeneratingDuringBootstrapCancelsLocally` — verifies cancel works when no session exists yet
- [x] All 48 existing ChatViewModelTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
