### PR TITLE
Fix "Permission denied by user" in desktop chat by handling confirmat…

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -30,6 +30,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public let ambientAgent = AmbientAgent()
     let daemonClient = DaemonClient()
     let surfaceManager = SurfaceManager()
+    let toolConfirmationManager = ToolConfirmationManager()
 
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
@@ -59,6 +60,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupVoiceInput()
         setupAmbientAgent()
         setupSurfaceManager()
+        setupToolConfirmationManager()
         setupWindowObserver()
         setupNotifications()
         showMainWindow()
@@ -114,6 +116,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Data response: daemon -> Swift -> JS
         daemonClient.onAppDataResponse = { [weak self] msg in
             self?.surfaceManager.resolveDataResponse(surfaceId: msg.surfaceId, response: msg)
+        }
+    }
+
+    private func setupToolConfirmationManager() {
+        daemonClient.onConfirmationRequest = { [weak self] msg in
+            self?.toolConfirmationManager.showConfirmation(msg)
+        }
+        toolConfirmationManager.onResponse = { [weak self] requestId, decision in
+            try? self?.daemonClient.sendConfirmationResponse(
+                requestId: requestId,
+                decision: decision
+            )
         }
     }
 
@@ -230,6 +244,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.currentSession?.cancel()
                     self?.currentTextSession?.cancel()
                     self?.surfaceManager.dismissAll()
+                    self?.toolConfirmationManager.dismissAll()
                 }
             }
         }
@@ -349,6 +364,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupVoiceInput()
             self?.setupAmbientAgent()
             self?.setupSurfaceManager()
+            self?.setupToolConfirmationManager()
             self?.setupWindowObserver()
             self?.setupNotifications()
 
@@ -578,6 +594,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         voiceInput?.stop()
         ambientAgent.stop()
         surfaceManager.dismissAll()
+        toolConfirmationManager.dismissAll()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -168,6 +168,7 @@ struct ToolConfirmationView: View {
             }
         }
         .padding(VSpacing.xl)
+        .frame(width: 420)
         .vPanelBackground()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -1,0 +1,173 @@
+import AppKit
+import SwiftUI
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ToolConfirmationManager")
+
+/// Manages floating confirmation panels for daemon tool permission requests.
+///
+/// When the daemon needs user approval for a tool invocation, it sends a
+/// `confirmation_request` message. This manager creates a floating NSPanel
+/// with Allow/Deny buttons and sends back a `confirmation_response`.
+@MainActor
+final class ToolConfirmationManager {
+
+    private var panels: [String: NSPanel] = [:]
+    private let panelWidth: CGFloat = 420
+    private let panelMargin: CGFloat = 20
+
+    var onResponse: ((String, String) -> Void)?
+
+    func showConfirmation(_ message: ConfirmationRequestMessage) {
+        // Dismiss existing panel for same request, if any
+        dismissConfirmation(requestId: message.requestId)
+
+        let view = ToolConfirmationView(
+            toolName: message.toolName,
+            riskLevel: message.riskLevel,
+            diff: message.diff,
+            onAllow: { [weak self] in
+                self?.respond(requestId: message.requestId, decision: "allow")
+            },
+            onDeny: { [weak self] in
+                self?.respond(requestId: message.requestId, decision: "deny")
+            }
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let panelHeight: CGFloat = message.diff != nil ? 340 : 160
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.contentViewController = hostingController
+        panel.level = .floating
+        panel.isMovableByWindowBackground = true
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.alphaValue = 0.95
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        // Position at top-right of screen
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let x = screenFrame.maxX - panelWidth - panelMargin
+            let y = screenFrame.maxY - panelHeight - panelMargin
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        panels[message.requestId] = panel
+        panel.orderFront(nil)
+
+        log.info("Showing tool confirmation: requestId=\(message.requestId), tool=\(message.toolName), risk=\(message.riskLevel)")
+    }
+
+    func dismissConfirmation(requestId: String) {
+        panels[requestId]?.close()
+        panels.removeValue(forKey: requestId)
+    }
+
+    func dismissAll() {
+        for (_, panel) in panels {
+            panel.close()
+        }
+        panels.removeAll()
+    }
+
+    private func respond(requestId: String, decision: String) {
+        dismissConfirmation(requestId: requestId)
+        onResponse?(requestId, decision)
+    }
+}
+
+// MARK: - ToolConfirmationView
+
+struct ToolConfirmationView: View {
+    let toolName: String
+    let riskLevel: String
+    let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+
+    private var isHighRisk: Bool { riskLevel == "High" }
+
+    private var toolDisplayName: String {
+        switch toolName {
+        case "file_write": return "Write File"
+        case "file_edit": return "Edit File"
+        case "bash": return "Run Command"
+        case "web_fetch": return "Fetch URL"
+        default: return toolName.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: isHighRisk ? "exclamationmark.triangle.fill" : "shield.checkered")
+                    .font(.title2)
+                    .foregroundStyle(isHighRisk ? VColor.error : VColor.warning)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Tool Permission Request")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.textPrimary)
+                    Text("\(toolDisplayName) — \(riskLevel) risk")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                Spacer()
+            }
+
+            // Diff preview
+            if let diff = diff {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text(diff.filePath)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    if diff.isNewFile {
+                        Text("New file")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.success)
+                    }
+
+                    ScrollView {
+                        Text(diff.newContent.prefix(500))
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 140)
+                    .padding(VSpacing.sm)
+                    .background(VColor.surface)
+                    .cornerRadius(VRadius.md)
+                }
+            }
+
+            // Action buttons
+            HStack(spacing: VSpacing.lg) {
+                Spacer()
+
+                VButton(label: "Deny", style: .ghost) {
+                    onDeny()
+                }
+
+                VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
+                    onAllow()
+                }
+            }
+        }
+        .padding(VSpacing.xl)
+        .vPanelBackground()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -73,8 +73,9 @@ final class ToolConfirmationManager {
     }
 
     func dismissAll() {
-        for (_, panel) in panels {
+        for (requestId, panel) in panels {
             panel.close()
+            onResponse?(requestId, "deny")
         }
         panels.removeAll()
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -94,7 +94,7 @@ struct ToolConfirmationView: View {
     let onAllow: () -> Void
     let onDeny: () -> Void
 
-    private var isHighRisk: Bool { riskLevel == "High" }
+    private var isHighRisk: Bool { riskLevel.lowercased() == "high" }
 
     private var toolDisplayName: String {
         switch toolName {

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -50,6 +50,9 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `generation_handoff` message.
     var onGenerationHandoff: ((GenerationHandoffMessage) -> Void)?
 
+    /// Called when the daemon sends a `confirmation_request` message for tool permission approval.
+    var onConfirmationRequest: ((ConfirmationRequestMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -269,6 +272,23 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(message)
     }
 
+    // MARK: - Confirmation Response
+
+    /// Send a confirmation response for a tool permission request.
+    func sendConfirmationResponse(
+        requestId: String,
+        decision: String,
+        selectedPattern: String? = nil,
+        selectedScope: String? = nil
+    ) throws {
+        try send(ConfirmationResponseMessage(
+            requestId: requestId,
+            decision: decision,
+            selectedPattern: selectedPattern,
+            selectedScope: selectedScope
+        ))
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -388,6 +408,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onMessageDequeued?(msg)
         case .generationHandoff(let msg):
             onGenerationHandoff?(msg)
+        case .confirmationRequest(let msg):
+            onConfirmationRequest?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -346,6 +346,44 @@ struct AppDataResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Permission confirmation request from daemon.
+/// Wire type: `"confirmation_request"`
+struct ConfirmationRequestMessage: Decodable, Sendable {
+    let requestId: String
+    let toolName: String
+    let input: [String: AnyCodable]
+    let riskLevel: String
+    let allowlistOptions: [ConfirmationAllowlistOption]
+    let scopeOptions: [ConfirmationScopeOption]
+    let diff: ConfirmationDiffInfo?
+    let sandboxed: Bool?
+
+    struct ConfirmationAllowlistOption: Decodable, Sendable {
+        let label: String
+        let pattern: String
+    }
+    struct ConfirmationScopeOption: Decodable, Sendable {
+        let label: String
+        let scope: String
+    }
+    struct ConfirmationDiffInfo: Decodable, Sendable {
+        let filePath: String
+        let oldContent: String
+        let newContent: String
+        let isNewFile: Bool
+    }
+}
+
+/// Client response to a permission confirmation request.
+/// Wire type: `"confirmation_response"`
+struct ConfirmationResponseMessage: Encodable, Sendable {
+    let type: String = "confirmation_response"
+    let requestId: String
+    let decision: String
+    let selectedPattern: String?
+    let selectedScope: String?
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {
@@ -364,6 +402,7 @@ enum ServerMessage: Decodable, Sendable {
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
     case generationCancelled(GenerationCancelledMessage)
     case generationHandoff(GenerationHandoffMessage)
+    case confirmationRequest(ConfirmationRequestMessage)
     case appDataResponse(AppDataResponseMessage)
     case messageQueued(MessageQueuedMessage)
     case messageDequeued(MessageDequeuedMessage)
@@ -424,6 +463,9 @@ enum ServerMessage: Decodable, Sendable {
         case "generation_handoff":
             let message = try GenerationHandoffMessage(from: decoder)
             self = .generationHandoff(message)
+        case "confirmation_request":
+            let message = try ConfirmationRequestMessage(from: decoder)
+            self = .confirmationRequest(message)
         case "app_data_response":
             let message = try AppDataResponseMessage(from: decoder)
             self = .appDataResponse(message)


### PR DESCRIPTION
…ion_request IPC

The macOS client's ServerMessage enum didn't include a case for confirmation_request messages from the daemon. When the assistant tried to use medium/high-risk tools (file_write, file_edit, bash), the daemon sent a confirmation prompt that the client silently dropped, causing a timeout → deny → "Permission denied by user" error.

This adds:
- ConfirmationRequestMessage/ConfirmationResponseMessage IPC types
- confirmation_request case in ServerMessage enum + decoder
- onConfirmationRequest callback in DaemonClient
- sendConfirmationResponse convenience method
- ToolConfirmationManager with floating NSPanel UI showing tool name, risk level, and diff preview with Allow/Deny buttons
- Wiring in AppDelegate to connect daemon messages to the UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
