### PR TITLE
Make JIT surface panels resizable with native macOS resize handles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/ListSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ListSurfaceView.swift
@@ -42,7 +42,6 @@ struct ListSurfaceView: View {
                 }
             }
         }
-        .frame(maxHeight: 300)
         .onAppear {
             // Initialize from pre-selected items
             selectedIds = Set(data.items.filter(\.selected).map(\.id))

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -6,6 +6,21 @@ struct SurfaceContainerView: View {
     private var surface: Surface { viewModel.surface }
 
     var body: some View {
+        Group {
+            if case .dynamicPage = surface.data {
+                innerContent
+            } else {
+                ScrollView(.vertical) {
+                    innerContent
+                }
+            }
+        }
+        .frame(minWidth: 280, maxWidth: .infinity)
+        .vPanelBackground()
+    }
+
+    @ViewBuilder
+    private var innerContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Title row with dismiss button
             HStack(alignment: .top) {
@@ -54,10 +69,7 @@ struct SurfaceContainerView: View {
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady
                 )
-                .frame(
-                    width: CGFloat(data.width ?? 380),
-                    height: CGFloat(data.height ?? 500)
-                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):
                 FileUploadSurfaceView(
                     data: data,
@@ -77,18 +89,9 @@ struct SurfaceContainerView: View {
             }
         }
         .padding(VSpacing.xl)
-        .frame(width: surfaceWidth)
-        .vPanelBackground()
     }
 
     // MARK: - Helpers
-
-    private var surfaceWidth: CGFloat {
-        if case .dynamicPage(let data) = surface.data {
-            return CGFloat(data.width ?? 380)
-        }
-        return 380
-    }
 
     private var isFormOrConfirmation: Bool {
         switch surface.data {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -137,12 +137,13 @@ final class SurfaceManager: ObservableObject {
             surfacePanelHeight = CGFloat(dpData.height ?? 500)
         } else {
             surfacePanelWidth = panelWidth
-            surfacePanelHeight = 140
+            let fittingHeight = hostingController.view.fittingSize.height
+            surfacePanelHeight = max(fittingHeight, 100)
         }
 
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: surfacePanelWidth, height: surfacePanelHeight),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow, .resizable],
             backing: .buffered,
             defer: false
         )
@@ -155,6 +156,14 @@ final class SurfaceManager: ObservableObject {
         panel.alphaValue = 0.95
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        if case .dynamicPage = surface.data {
+            panel.minSize = NSSize(width: 280, height: 200)
+            panel.maxSize = NSSize(width: 1200, height: 10000)
+        } else {
+            panel.minSize = NSSize(width: 280, height: 100)
+            panel.maxSize = NSSize(width: 600, height: 10000)
+        }
 
         panels[surface.id] = panel
 
@@ -241,13 +250,11 @@ final class SurfaceManager: ObservableObject {
         panel.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
-    private func positionPanel(_ panel: NSPanel, at index: Int) {
+    private func positionPanel(_ panel: NSPanel, yOffset: CGFloat) {
         guard let screen = NSScreen.main else { return }
         let screenFrame = screen.visibleFrame
 
         let actualWidth = panel.frame.width
-        let estimatedPanelHeight: CGFloat = 140
-        let yOffset = CGFloat(index) * (estimatedPanelHeight + panelSpacing)
 
         let x = screenFrame.maxX - actualWidth - panelMargin
         let y = screenFrame.minY + panelMargin + yOffset
@@ -258,14 +265,14 @@ final class SurfaceManager: ObservableObject {
     /// Reposition all visible panels based on their order in `surfaceOrder`.
     /// Called after show and dismiss to prevent gaps and overlaps.
     private func repositionAllPanels() {
-        var stackIndex = 0
+        var yOffset: CGFloat = 0
         for surfaceId in surfaceOrder {
             guard let panel = panels[surfaceId] else { continue }
             if case .dynamicPage = activeSurfaces[surfaceId]?.data {
                 centerPanel(panel)
             } else {
-                positionPanel(panel, at: stackIndex)
-                stackIndex += 1
+                positionPanel(panel, yOffset: yOffset)
+                yOffset += panel.frame.height + panelSpacing
             }
         }
     }


### PR DESCRIPTION
The purpose of this PR is to make JIT surface panels user-resizable using native macOS resize handles, so they feel like first-class macOS UI.

## Changes Made
- Add `.resizable` to NSPanel style mask and set `minSize`/`maxSize` constraints per surface type
- Use `fittingSize` for initial panel height instead of hardcoded 140px
- Fix panel stacking to use actual frame heights instead of estimated constants
- Make SwiftUI layout flexible (`minWidth`/`maxWidth` instead of fixed width) and wrap non-dynamic-page content in `ScrollView` for overflow
- Remove `maxHeight: 300` cap from `ListSurfaceView` so lists fill available space

## Testing
- Build passes (`./build.sh`)
- Manual verification needed: trigger surfaces and confirm resize handles, content reflow, scroll behavior, and stacked panel spacing

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
