### PR TITLE
Fix JIT surface panel sizing: screen-relative defaults, auto-resize, and nested ScrollView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -176,6 +176,35 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             )
         }
 
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            webView.evaluateJavaScript(
+                "JSON.stringify({w: document.documentElement.scrollWidth, h: document.documentElement.scrollHeight})"
+            ) { result, _ in
+                guard let json = result as? String,
+                      let data = json.data(using: .utf8),
+                      let size = try? JSONSerialization.jsonObject(with: data) as? [String: CGFloat],
+                      let w = size["w"], let h = size["h"],
+                      let window = webView.window else { return }
+
+                let screen = NSScreen.main?.visibleFrame ?? window.screen?.visibleFrame
+                    ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+                let maxW = min(screen.width * 0.85, 1200)
+                let maxH = min(screen.height * 0.85, 1000)
+                // Add padding for title bar and container chrome
+                let targetW = min(max(w + 40, window.frame.width), maxW)
+                let targetH = min(max(h + 80, window.frame.height), maxH)
+
+                // Resize keeping center position
+                let currentCenter = NSPoint(x: window.frame.midX, y: window.frame.midY)
+                let newOrigin = NSPoint(x: currentCenter.x - targetW / 2, y: currentCenter.y - targetH / 2)
+                window.setFrame(
+                    NSRect(x: newOrigin.x, y: newOrigin.y, width: targetW, height: targetH),
+                    display: true,
+                    animate: true
+                )
+            }
+        }
+
         func webView(
             _ webView: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -9,6 +9,8 @@ struct SurfaceContainerView: View {
         Group {
             if case .dynamicPage = surface.data {
                 innerContent
+            } else if case .list = surface.data {
+                innerContent
             } else {
                 ScrollView(.vertical) {
                     innerContent

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -133,12 +133,12 @@ final class SurfaceManager: ObservableObject {
         let surfacePanelWidth: CGFloat
         let surfacePanelHeight: CGFloat
         if case .dynamicPage(let dpData) = surface.data {
-            surfacePanelWidth = CGFloat(dpData.width ?? Int(panelWidth))
-            surfacePanelHeight = CGFloat(dpData.height ?? 500)
+            let screen = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+            surfacePanelWidth = CGFloat(dpData.width ?? Int(min(screen.width * 0.5, 800)))
+            surfacePanelHeight = CGFloat(dpData.height ?? Int(min(screen.height * 0.75, 900)))
         } else {
             surfacePanelWidth = panelWidth
-            let fittingHeight = hostingController.view.fittingSize.height
-            surfacePanelHeight = max(fittingHeight, 100)
+            surfacePanelHeight = 300
         }
 
         let panel = NSPanel(
@@ -149,6 +149,15 @@ final class SurfaceManager: ObservableObject {
         )
 
         panel.contentViewController = hostingController
+
+        // Re-measure fittingSize for non-dynamic panels now that the view is attached to a window.
+        if case .dynamicPage = surface.data {
+            // Dynamic pages handle their own sizing via webView didFinish.
+        } else if let fittingSize = panel.contentView?.fittingSize {
+            let maxH = (NSScreen.main?.visibleFrame.height ?? 800) - 40
+            let newHeight = min(max(fittingSize.height, 150), maxH)
+            panel.setContentSize(NSSize(width: surfacePanelWidth, height: newHeight))
+        }
         panel.level = .floating
         panel.isMovableByWindowBackground = true
         panel.titleVisibility = .hidden


### PR DESCRIPTION
The purpose of this PR is to fix JIT surface panels rendering at incorrect sizes — dynamic pages defaulted to thumbnail size (380x500) and non-dynamic panels measured layout before being attached to a window.

## Changes Made
- **Dynamic page defaults**: Use screen-relative sizing (50% width / 75% height, capped at 800x900) instead of hardcoded 380x500 when LLM omits dimensions
- **Auto-resize on load**: WKWebView `didFinish` measures `scrollWidth`/`scrollHeight` and resizes the panel to fit actual HTML content (clamped to 85% screen, animated)
- **fittingSize timing**: Move `fittingSize` measurement to after `contentViewController` is set so the view is attached to a window and produces reliable values
- **Nested ScrollView fix**: Exclude `.list` surfaces from the outer `ScrollView` wrapper since `ListSurfaceView` already has its own, preventing double-nesting

## Testing
- Build passes (`./build.sh`)
- Manual testing: dynamic_page without explicit width/height, card/form surfaces, list surfaces with many items

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
