### PR TITLE
Decouple JIT surfaces from blocking agent response loop

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -720,8 +720,6 @@ export class Session {
       log.warn({ surfaceId, actionId }, 'No pending surface action found');
       return;
     }
-    this.pendingSurfaceActions.delete(surfaceId);
-
     const content = JSON.stringify({
       surfaceAction: true,
       surfaceId,
@@ -735,6 +733,7 @@ export class Session {
 
     const result = this.enqueueMessage(content, [], onEvent, requestId);
     if (result.queued) {
+      this.pendingSurfaceActions.delete(surfaceId);
       log.info({ surfaceId, actionId, requestId }, 'Surface action queued (session busy)');
       onEvent({
         type: 'message_queued',
@@ -751,6 +750,7 @@ export class Session {
       return;
     }
 
+    this.pendingSurfaceActions.delete(surfaceId);
     log.info({ surfaceId, actionId, requestId }, 'Processing surface action as follow-up');
     this.processMessage(content, [], onEvent, requestId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -83,7 +83,7 @@ export class Session {
   private currentRequestId?: string;
   private messageQueue: QueuedMessage[] = [];
   private pendingSurfaceActions = new Map<string, {
-    resolve: (result: ToolExecutionResult) => void;
+    surfaceType: SurfaceType;
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
 
@@ -214,10 +214,6 @@ export class Session {
       log.info({ conversationId: this.conversationId }, 'Aborting in-flight processing');
       this.abortController?.abort();
       this.prompter.dispose();
-      // Resolve any pending surface actions
-      for (const [, pending] of this.pendingSurfaceActions) {
-        pending.resolve({ content: 'Session aborted', isError: true });
-      }
       this.pendingSurfaceActions.clear();
       this.surfaceState.clear();
 
@@ -725,9 +721,41 @@ export class Session {
       return;
     }
     this.pendingSurfaceActions.delete(surfaceId);
-    pending.resolve({
-      content: JSON.stringify({ actionId, data: data ?? {} }),
-      isError: false,
+
+    const content = JSON.stringify({
+      surfaceAction: true,
+      surfaceId,
+      surfaceType: pending.surfaceType,
+      actionId,
+      data: data ?? {},
+    });
+
+    const requestId = uuid();
+    const onEvent = (msg: ServerMessage) => this.sendToClient(msg);
+
+    const result = this.enqueueMessage(content, [], onEvent, requestId);
+    if (result.queued) {
+      log.info({ surfaceId, actionId, requestId }, 'Surface action queued (session busy)');
+      onEvent({
+        type: 'message_queued',
+        sessionId: this.conversationId,
+        requestId,
+        position: this.getQueueDepth(),
+      });
+      return;
+    }
+
+    if (result.rejected) {
+      log.error({ surfaceId, actionId }, 'Surface action rejected — queue full');
+      onEvent({ type: 'error', message: 'Surface action rejected — session queue is full' });
+      return;
+    }
+
+    log.info({ surfaceId, actionId, requestId }, 'Processing surface action as follow-up');
+    this.processMessage(content, [], onEvent, requestId).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ err, surfaceId, actionId }, 'Error processing surface action');
+      onEvent({ type: 'error', message: `Failed to process surface action: ${message}` });
     });
   }
 
@@ -792,10 +820,16 @@ export class Session {
         data,
       } as UiSurfaceShow);
 
-      // Always await — file upload is interactive
-      return new Promise<ToolExecutionResult>((resolve) => {
-        this.pendingSurfaceActions.set(surfaceId, { resolve });
-      });
+      // Non-blocking: return immediately, user action arrives as follow-up message
+      this.pendingSurfaceActions.set(surfaceId, { surfaceType: 'file_upload' as SurfaceType });
+      return {
+        content: JSON.stringify({
+          surfaceId,
+          status: 'awaiting_user_action',
+          message: 'File upload dialog displayed. The uploaded file data will arrive as a follow-up message.',
+        }),
+        isError: false,
+      };
     }
 
     if (toolName === 'ui_show') {
@@ -825,9 +859,15 @@ export class Session {
       } as unknown as UiSurfaceShow);
 
       if (awaitAction) {
-        return new Promise<ToolExecutionResult>((resolve) => {
-          this.pendingSurfaceActions.set(surfaceId, { resolve });
-        });
+        this.pendingSurfaceActions.set(surfaceId, { surfaceType });
+        return {
+          content: JSON.stringify({
+            surfaceId,
+            status: 'awaiting_user_action',
+            message: 'Surface displayed. The user\'s response will arrive as a follow-up message.',
+          }),
+          isError: false,
+        };
       }
       return { content: JSON.stringify({ surfaceId }), isError: false };
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -182,8 +182,9 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             ) { result, _ in
                 guard let json = result as? String,
                       let data = json.data(using: .utf8),
-                      let size = try? JSONSerialization.jsonObject(with: data) as? [String: CGFloat],
-                      let w = size["w"], let h = size["h"],
+                      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let w = (dict["w"] as? NSNumber).map({ CGFloat($0.doubleValue) }),
+                      let h = (dict["h"] as? NSNumber).map({ CGFloat($0.doubleValue) }),
                       let window = webView.window else { return }
 
                 let screen = NSScreen.main?.visibleFrame ?? window.screen?.visibleFrame


### PR DESCRIPTION
The purpose of this PR is to make interactive JIT surfaces (form, confirmation, dynamic_page, file_upload) non-blocking so that `message_complete` and title generation fire immediately after the text response streams, rather than waiting for the user to interact with or close the surface.

## Changes Made

### Decouple surfaces from agent loop (`session.ts`)
- Make `surfaceProxyResolver` return immediately for interactive surfaces instead of blocking on a Promise
- Rewrite `handleSurfaceAction` to route user surface actions as follow-up messages via the existing queue system (`enqueueMessage`/`processMessage`)
- Update `pendingSurfaceActions` map to store `surfaceType` instead of Promise resolvers
- Simplify `abort()` — no more Promises to resolve, just clear the tracking map

### Fix dynamic page auto-resize (`DynamicPageSurfaceView.swift`)
- Fix `JSONSerialization` cast bug from #948: `jsonObject(with:)` returns `NSNumber` values, not `CGFloat`, so the direct cast to `[String: CGFloat]` always failed and panels never auto-resized. Parse as `[String: Any]` and extract via `NSNumber.doubleValue`.

## Testing
- Manual: trigger a JIT surface, verify `message_complete` fires immediately, surface stays visible, and interacting with it triggers a follow-up turn
- TypeScript and Swift both compile cleanly

## Notes
- No IPC protocol changes — existing `ui_surface_action` message type is reused
- No client (macOS/web) changes needed for the decoupling — SurfaceManager already keeps surfaces visible independently
- No changes to `loop.ts`, `executor.ts`, or `handlers.ts`

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
