### PR TITLE
Add ThreadModel and ThreadManager for multi-thread support

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1,0 +1,60 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
+
+@MainActor
+final class ThreadManager: ObservableObject {
+    @Published var threads: [ThreadModel] = []
+    @Published var activeThreadId: UUID?
+
+    private var chatViewModels: [UUID: ChatViewModel] = [:]
+    private let daemonClient: DaemonClient
+
+    var activeViewModel: ChatViewModel? {
+        guard let activeThreadId else { return nil }
+        return chatViewModels[activeThreadId]
+    }
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        // Create one default thread so the window is never empty
+        createThread()
+    }
+
+    func createThread() {
+        let thread = ThreadModel()
+        let viewModel = ChatViewModel(daemonClient: daemonClient)
+        threads.append(thread)
+        chatViewModels[thread.id] = viewModel
+        activeThreadId = thread.id
+        log.info("Created thread \(thread.id) with title \"\(thread.title)\"")
+    }
+
+    func closeThread(id: UUID) {
+        // No-op if only 1 thread remains
+        guard threads.count > 1 else { return }
+
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+
+        threads.remove(at: index)
+        chatViewModels.removeValue(forKey: id)
+
+        // If the closed thread was active, select an adjacent thread
+        if activeThreadId == id {
+            // Prefer the thread at the same index (next), otherwise fall back to last
+            if index < threads.count {
+                activeThreadId = threads[index].id
+            } else {
+                activeThreadId = threads.last?.id
+            }
+        }
+
+        log.info("Closed thread \(id)")
+    }
+
+    func selectThread(id: UUID) {
+        guard threads.contains(where: { $0.id == id }) else { return }
+        activeThreadId = id
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ThreadModel: Identifiable, Hashable {
+    let id: UUID
+    let title: String
+    let createdAt: Date
+
+    init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date()) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ThreadModel` struct (Identifiable, Hashable) with `id`, `title`, and `createdAt` fields
- Adds `ThreadManager` class (@MainActor ObservableObject) that manages thread lifecycle: create, close, and select threads
- Each thread gets its own `ChatViewModel` instance, stored in a private dictionary keyed by thread ID

## Test plan
- [x] Build succeeds with `./build.sh`
- [ ] Verify ThreadManager creates a default thread on init
- [ ] Verify `createThread()` appends a new thread and sets it active
- [ ] Verify `closeThread()` is a no-op when only 1 thread remains
- [ ] Verify `closeThread()` selects adjacent thread after closing active thread
- [ ] Verify `selectThread()` updates `activeThreadId` and `activeViewModel`

Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
