### PR TITLE
Fix design system components to match mockups

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VIconButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Buttons/VIconButton.swift
@@ -21,10 +21,10 @@ struct VIconButton: View {
             .padding(.horizontal, iconOnly ? VSpacing.md : VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
             .background(isActive ? VColor.surfaceBorder : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .stroke(isActive ? VColor.surfaceBorder : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isActive ? VColor.textSecondary : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
             )
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
@@ -10,7 +10,7 @@ struct VSidePanel<Content: View>: View {
             // Header
             HStack {
                 Text(title.uppercased())
-                    .font(VFont.mono)
+                    .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
                 if let onClose = onClose {

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -15,17 +15,17 @@ struct VTab: View {
             HStack(spacing: VSpacing.xs) {
                 if let icon = icon {
                     Image(systemName: icon)
-                        .font(.system(size: 10))
+                        .font(.system(size: 12))
                 }
                 Text(label)
-                    .font(VFont.caption)
+                    .font(VFont.body)
                     .lineLimit(1)
             }
             .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
             .background(isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
         .buttonStyle(.plain)
         .onHover { hovering in isHovered = hovering }
@@ -33,7 +33,7 @@ struct VTab: View {
             if isCloseable, let onClose = onClose, isHovered {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .bold))
+                        .font(.system(size: 10, weight: .bold))
                         .foregroundColor(VColor.textMuted)
                         .padding(.trailing, VSpacing.xs)
                 }


### PR DESCRIPTION
## Summary
- **VTab**: Bump text font from `VFont.caption` (11pt) to `VFont.body` (13pt), icon from 10pt to 12pt, close button from 8pt to 10pt, corner radius from `VRadius.sm` (4pt) to `VRadius.md` (8pt)
- **VIconButton**: Corner radius from `VRadius.sm` (4pt) to `VRadius.md` (8pt), active state border from `VColor.surfaceBorder` to `VColor.textSecondary` for stronger visual contrast
- **VSidePanel**: Title font from `VFont.mono` to `VFont.display`

## Test plan
- [x] Build succeeds with `./build.sh`
- [ ] Verify VTab previews render correctly with larger text, icons, and rounder corners
- [ ] Verify VIconButton active state shows brighter border and rounder corners
- [ ] Verify VSidePanel title uses display font
- [ ] Check gallery sections (NavigationGallerySection, ButtonsGallerySection, LayoutGallerySection) render without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
