### PR TITLE
Restructure MainWindowView with three-row shell layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,29 +1,39 @@
 import SwiftUI
 
 struct MainWindowView: View {
-    @StateObject private var viewModel: ChatViewModel
+    @StateObject private var threadManager: ThreadManager
 
     init(daemonClient: DaemonClient) {
-        _viewModel = StateObject(wrappedValue: ChatViewModel(daemonClient: daemonClient))
+        _threadManager = StateObject(wrappedValue: ThreadManager(daemonClient: daemonClient))
     }
 
     var body: some View {
-        ZStack {
-            VColor.background
-                .ignoresSafeArea()
+        VStack(spacing: 0) {
+            // Row 1 — thread bar slot (placeholder)
+            Color.clear.frame(height: 36)
 
-            ChatView(
-                messages: viewModel.messages,
-                inputText: $viewModel.inputText,
-                isThinking: viewModel.isThinking,
-                isSending: viewModel.isSending,
-                errorText: viewModel.errorText,
-                pendingQueuedCount: viewModel.pendingQueuedCount,
-                onSend: viewModel.sendMessage,
-                onStop: viewModel.stopGenerating,
-                onDismissError: viewModel.dismissError
-            )
+            // Row 2 — toolbar slot (placeholder)
+            Color.clear.frame(height: 36)
+
+            // Row 3 — chat content bound to active thread
+            if let viewModel = threadManager.activeViewModel {
+                ChatView(
+                    messages: viewModel.messages,
+                    inputText: Binding(
+                        get: { viewModel.inputText },
+                        set: { viewModel.inputText = $0 }
+                    ),
+                    isThinking: viewModel.isThinking,
+                    isSending: viewModel.isSending,
+                    errorText: viewModel.errorText,
+                    pendingQueuedCount: viewModel.pendingQueuedCount,
+                    onSend: viewModel.sendMessage,
+                    onStop: viewModel.stopGenerating,
+                    onDismissError: viewModel.dismissError
+                )
+            }
         }
+        .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }
 }


### PR DESCRIPTION
## Summary
- Replace `@StateObject private var viewModel: ChatViewModel` with `@StateObject private var threadManager: ThreadManager` to support multi-thread architecture
- Restructure body as `VStack(spacing: 0)` with three rows: thread bar placeholder (36pt), toolbar placeholder (36pt), and ChatView content area
- Bind ChatView to `threadManager.activeViewModel` via `if let` safe unwrap, mapping all props (messages, inputText binding, isThinking, isSending, errorText, pendingQueuedCount, onSend, onStop, onDismissError)
- Background uses `VColor.background.ignoresSafeArea()`
- No changes needed to `MainWindow.swift` since init signature (`daemonClient: DaemonClient`) is unchanged

## Test plan
- [x] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] Launch app and verify chat still works via the active thread's viewmodel
- [ ] Verify placeholder rows render as transparent 36pt slots above chat content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
