### PR TITLE
Add NavigationToolbar and SidePanelType enum

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct NavigationToolbar: View {
+    @Binding var activePanel: SidePanelType?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: VSpacing.sm) {
+                // Left group
+                VTab(label: "Chat", icon: "bubble.left.fill", isSelected: true, isCloseable: false, onSelect: {})
+
+                Spacer()
+
+                // Right group — labeled buttons
+                VIconButton(label: "Generated", icon: "wand.and.stars", isActive: activePanel == .generated) {
+                    togglePanel(.generated)
+                }
+                VIconButton(label: "Agent", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
+                    togglePanel(.agent)
+                }
+                VIconButton(label: "Control", icon: "gearshape", isActive: activePanel == .control) {
+                    togglePanel(.control)
+                }
+
+                // Right group — icon-only buttons
+                VIconButton(label: "Directory", icon: "doc.text", isActive: activePanel == .directory, iconOnly: true) {
+                    togglePanel(.directory)
+                }
+                VIconButton(label: "Debug", icon: "ant", isActive: activePanel == .debug, iconOnly: true) {
+                    togglePanel(.debug)
+                }
+                VIconButton(label: "Doctor", icon: "stethoscope", isActive: activePanel == .doctor, iconOnly: true) {
+                    togglePanel(.doctor)
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.backgroundSubtle)
+
+            Divider()
+        }
+    }
+
+    private func togglePanel(_ panel: SidePanelType) {
+        if activePanel == panel {
+            activePanel = nil
+        } else {
+            activePanel = panel
+        }
+    }
+}
+
+#Preview("NavigationToolbar") {
+    @Previewable @State var panel: SidePanelType? = .control
+    NavigationToolbar(activePanel: $panel)
+        .frame(width: 700)
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -1,0 +1,8 @@
+enum SidePanelType: Hashable, CaseIterable {
+    case generated
+    case agent
+    case control
+    case directory
+    case debug
+    case doctor
+}


### PR DESCRIPTION
## Summary
- Creates `SidePanelType` enum with cases: generated, agent, control, directory, debug, doctor
- Creates `NavigationToolbar` view with Chat tab on the left and panel toggle buttons on the right
- Labeled buttons (Generated, Agent, Control) and icon-only buttons (Directory, Debug, Doctor)
- Uses existing design system components (VTab, VIconButton) and tokens (VSpacing, VColor)

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Xcode Preview renders NavigationToolbar correctly
- [ ] Clicking panel buttons toggles activePanel binding
- [ ] Clicking an active panel button deactivates it (sets to nil)
- [ ] Chat tab is always selected and not closeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
