### PR TITLE
Add ThreadTabBar for multi-thread navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -9,8 +9,14 @@ struct MainWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Row 1 — thread bar slot (placeholder)
-            Color.clear.frame(height: 36)
+            // Row 1 — thread tab bar
+            ThreadTabBar(
+                threads: threadManager.threads,
+                activeThreadId: threadManager.activeThreadId,
+                onSelect: { threadManager.selectThread(id: $0) },
+                onClose: { threadManager.closeThread(id: $0) },
+                onCreate: { threadManager.createThread() }
+            )
 
             // Row 2 — toolbar slot (placeholder)
             Color.clear.frame(height: 36)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct ThreadTabBar: View {
+    let threads: [ThreadModel]
+    let activeThreadId: UUID?
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onCreate: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach(threads) { thread in
+                    VTab(
+                        label: thread.title,
+                        icon: "flame",
+                        isSelected: thread.id == activeThreadId,
+                        isCloseable: threads.count > 1,
+                        onSelect: { onSelect(thread.id) },
+                        onClose: { onClose(thread.id) }
+                    )
+                }
+
+                Spacer()
+
+                Button(action: onCreate) {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "plus")
+                        Text("Thread")
+                    }
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .vHover()
+                .accessibilityLabel("New Thread")
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .frame(height: 36)
+            .background(VColor.backgroundSubtle)
+
+            Divider()
+        }
+    }
+}
+
+#Preview("ThreadTabBar") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ThreadTabBar(
+            threads: [
+                ThreadModel(title: "New Thread"),
+                ThreadModel(title: "Debug Session"),
+                ThreadModel(title: "Research"),
+            ],
+            activeThreadId: nil,
+            onSelect: { _ in },
+            onClose: { _ in },
+            onCreate: {}
+        )
+    }
+    .frame(width: 600, height: 60)
+}


### PR DESCRIPTION
## Summary
- Create `ThreadTabBar` component using `VTab` for each thread with flame icon, close/select actions, and a "+ Thread" button
- Wire `ThreadTabBar` into `MainWindowView` Row 1 slot, replacing the `Color.clear` placeholder
- Close button is disabled when only one thread remains to prevent closing the last thread

## Test plan
- [ ] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] Verify thread tabs render with flame icon and thread title
- [ ] Verify clicking a tab selects the thread
- [ ] Verify close button appears on hover and closes the thread
- [ ] Verify close button is hidden when only one thread exists
- [ ] Verify "+ Thread" button creates a new thread
- [ ] Verify accessibility label on "+ Thread" button reads "New Thread"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
