### PR TITLE
Wire VSplitView and NavigationToolbar into MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainWindowView: View {
     @StateObject private var threadManager: ThreadManager
+    @State private var activePanel: SidePanelType?
 
     init(daemonClient: DaemonClient) {
         _threadManager = StateObject(wrappedValue: ThreadManager(daemonClient: daemonClient))
@@ -18,29 +19,63 @@ struct MainWindowView: View {
                 onCreate: { threadManager.createThread() }
             )
 
-            // Row 2 — toolbar slot (placeholder)
-            Color.clear.frame(height: 36)
+            // Row 2 — navigation toolbar
+            NavigationToolbar(activePanel: $activePanel)
 
-            // Row 3 — chat content bound to active thread
-            if let viewModel = threadManager.activeViewModel {
-                ChatView(
-                    messages: viewModel.messages,
-                    inputText: Binding(
-                        get: { viewModel.inputText },
-                        set: { viewModel.inputText = $0 }
-                    ),
-                    isThinking: viewModel.isThinking,
-                    isSending: viewModel.isSending,
-                    errorText: viewModel.errorText,
-                    pendingQueuedCount: viewModel.pendingQueuedCount,
-                    onSend: viewModel.sendMessage,
-                    onStop: viewModel.stopGenerating,
-                    onDismissError: viewModel.dismissError
-                )
-            }
+            // Row 3 — chat content with optional side panel
+            VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
+                if let viewModel = threadManager.activeViewModel {
+                    ChatView(
+                        messages: viewModel.messages,
+                        inputText: Binding(
+                            get: { viewModel.inputText },
+                            set: { viewModel.inputText = $0 }
+                        ),
+                        isThinking: viewModel.isThinking,
+                        isSending: viewModel.isSending,
+                        errorText: viewModel.errorText,
+                        pendingQueuedCount: viewModel.pendingQueuedCount,
+                        onSend: viewModel.sendMessage,
+                        onStop: viewModel.stopGenerating,
+                        onDismissError: viewModel.dismissError
+                    )
+                }
+            }, panel: {
+                panelContent
+            })
         }
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
+    }
+
+    @ViewBuilder
+    private var panelContent: some View {
+        if let panel = activePanel {
+            switch panel {
+            case .generated:
+                placeholderPanel("Generated", icon: "wand.and.stars")
+            case .agent:
+                placeholderPanel("Agent", icon: "exclamationmark.triangle")
+            case .control:
+                placeholderPanel("Control", icon: "gearshape")
+            case .directory:
+                placeholderPanel("Directory", icon: "doc.text")
+            case .debug:
+                placeholderPanel("Debug", icon: "ant")
+            case .doctor:
+                placeholderPanel("Doctor", icon: "stethoscope")
+            }
+        }
+    }
+
+    private func placeholderPanel(_ title: String, icon: String) -> some View {
+        VSidePanel(title: title, onClose: { activePanel = nil }) {
+            VEmptyState(
+                title: "Coming soon",
+                subtitle: "\(title) panel content will appear here",
+                icon: icon
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the placeholder toolbar slot (`Color.clear.frame(height: 36)`) in Row 2 with `NavigationToolbar`, wiring up panel toggle buttons
- Wrap the Row 3 chat content area in `VSplitView` with a 420px animated side panel
- Add placeholder panels for all 6 `SidePanelType` cases using `VSidePanel` + `VEmptyState` design system components

## Test plan
- [ ] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] NavigationToolbar renders in Row 2 with labeled + icon-only buttons
- [ ] Clicking a toolbar button opens the corresponding side panel with animated slide-in
- [ ] Clicking the same button again closes the panel
- [ ] Clicking a different button switches panel content
- [ ] Each placeholder panel shows the correct title, icon, and "Coming soon" message
- [ ] Panel close (X) button dismisses the panel
- [ ] Chat content remains functional when panel is open/closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
