### PR TITLE
Add Generated, Agent, Directory, Debug, and Doctor panel components

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct AgentPanel: View {
+    var onClose: () -> Void
+
+    var body: some View {
+        VSidePanel(title: "Agent", onClose: onClose) {
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                sectionHeader("Skills")
+                VEmptyState(title: "No skills", subtitle: "Agent skills will appear here", icon: "bolt.fill")
+                    .frame(height: 150)
+
+                Divider()
+
+                sectionHeader("Nodes")
+                VEmptyState(title: "No nodes", subtitle: "Agent nodes will appear here", icon: "point.3.connected.trianglepath.dotted")
+                    .frame(height: 150)
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(VFont.captionMedium)
+            .foregroundColor(VColor.textSecondary)
+    }
+}
+
+#Preview {
+    AgentPanel(onClose: {})
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct DebugPanel: View {
+    var onClose: () -> Void
+    var body: some View {
+        VSidePanel(title: "Debug", onClose: onClose) {
+            VEmptyState(title: "No debug info", subtitle: "Debug information will appear here", icon: "ant")
+        }
+    }
+}
+
+#Preview {
+    DebugPanel(onClose: {})
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct DirectoryPanel: View {
+    var onClose: () -> Void
+    var body: some View {
+        VSidePanel(title: "Directory", onClose: onClose) {
+            VEmptyState(title: "No files", subtitle: "Markdown files will appear here", icon: "doc.text")
+        }
+    }
+}
+
+#Preview {
+    DirectoryPanel(onClose: {})
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DoctorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DoctorPanel.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct DoctorPanel: View {
+    var onClose: () -> Void
+    var body: some View {
+        VSidePanel(title: "Doctor", onClose: onClose) {
+            VEmptyState(title: "No conversations", subtitle: "Support chat will appear here", icon: "stethoscope")
+        }
+    }
+}
+
+#Preview {
+    DoctorPanel(onClose: {})
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct GeneratedPanel: View {
+    var onClose: () -> Void
+
+    var body: some View {
+        VSidePanel(title: "Generated", onClose: onClose) {
+            VEmptyState(
+                title: "No generated items",
+                subtitle: "Items created by your assistant will appear here",
+                icon: "wand.and.stars"
+            )
+        }
+    }
+}
+
+#Preview {
+    GeneratedPanel(onClose: {})
+}


### PR DESCRIPTION
## Summary
- Creates 5 placeholder panel views (`GeneratedPanel`, `AgentPanel`, `DirectoryPanel`, `DebugPanel`, `DoctorPanel`) under `Features/MainWindow/Panels/`
- All panels use `VSidePanel` + `VEmptyState` from the design system with appropriate icons and placeholder text
- `AgentPanel` includes Skills and Nodes section headers using `VFont.captionMedium` and `VColor.textSecondary`
- Each panel accepts an `onClose` callback and includes a SwiftUI preview

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Verify each panel renders correctly in SwiftUI Previews
- [ ] Verify panels display properly when wired into MainWindowView navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
