### PR TITLE
Wire real panel components into MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -53,28 +53,18 @@ struct MainWindowView: View {
         if let panel = activePanel {
             switch panel {
             case .generated:
-                placeholderPanel("Generated", icon: "wand.and.stars")
+                GeneratedPanel(onClose: { activePanel = nil })
             case .agent:
-                placeholderPanel("Agent", icon: "exclamationmark.triangle")
+                AgentPanel(onClose: { activePanel = nil })
             case .control:
-                placeholderPanel("Control", icon: "gearshape")
+                ControlPanel(onClose: { activePanel = nil })
             case .directory:
-                placeholderPanel("Directory", icon: "doc.text")
+                DirectoryPanel(onClose: { activePanel = nil })
             case .debug:
-                placeholderPanel("Debug", icon: "ant")
+                DebugPanel(onClose: { activePanel = nil })
             case .doctor:
-                placeholderPanel("Doctor", icon: "stethoscope")
+                DoctorPanel(onClose: { activePanel = nil })
             }
-        }
-    }
-
-    private func placeholderPanel(_ title: String, icon: String) -> some View {
-        VSidePanel(title: title, onClose: { activePanel = nil }) {
-            VEmptyState(
-                title: "Coming soon",
-                subtitle: "\(title) panel content will appear here",
-                icon: icon
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces inline `placeholderPanel()` calls in MainWindowView with the actual panel components (ControlPanel, GeneratedPanel, AgentPanel, DirectoryPanel, DebugPanel, DoctorPanel)
- Removes the now-unused `placeholderPanel(_:icon:)` helper function

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Each toolbar button opens the corresponding panel
- [ ] ControlPanel shows settings UI (API key, max steps, ambient toggle, permissions)
- [ ] Other panels show appropriate empty states
- [ ] Panel close button dismisses the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
