### PR TITLE
Add --assignee @me to swarm PR creation

### DIFF
--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -68,7 +68,7 @@ ALL work happens here. Do NOT touch the main repo.
 2. Type-check: cd <worktree>/assistant && bunx tsc --noEmit
 3. Commit with a descriptive message.
 4. Push and create a PR:
-   gh pr create --base main --title "<concise title>" --body "<what changed and why>"
+   gh pr create --base main --title "<concise title>" --body "<what changed and why>" --assignee @me
 5. Merge immediately: gh pr merge <number> --squash
 6. Send a message to "lead" with:
    - The PR link


### PR DESCRIPTION
## Summary
- Added `--assignee @me` flag to the `gh pr create` command in the swarm agent prompt template so that PRs created by swarm agents are automatically assigned to the current GitHub user.

## Test plan
- [ ] Run `/swarm` and verify new PRs are assigned to the invoking user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
