### PR TITLE
Remove non-functional attachment button from chat composer (#959)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -146,15 +146,6 @@ struct ChatView: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop generation")
             }
-
-            // Attachment button
-            Button(action: { /* future: open file picker */ }) {
-                Image(systemName: "paperclip")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(VColor.textMuted)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Attach file")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)


### PR DESCRIPTION
## Summary
- Removes the paperclip attachment button from the chat composer that had an empty placeholder action
- Addresses Codex P2 review feedback on PR #959: the button created a broken UI affordance since clicking it did nothing
- The button can be re-added when file attachment functionality is actually implemented

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Composer renders correctly without the paperclip button
- [ ] Stop generation button still appears when generation is active
- [ ] Text input and send-on-Enter still work as expected

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
