### PR TITLE
M3: Secure credential fill for headless browser

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => '/tmp/browser-fill-credential-test',
+}));
+
+let mockPage: {
+  click: ReturnType<typeof mock>;
+  fill: ReturnType<typeof mock>;
+  press: ReturnType<typeof mock>;
+  evaluate: ReturnType<typeof mock>;
+  title: ReturnType<typeof mock>;
+  url: ReturnType<typeof mock>;
+  goto: ReturnType<typeof mock>;
+  close: () => Promise<void>;
+  isClosed: () => boolean;
+};
+
+let snapshotMaps: Map<string, Map<string, string>>;
+
+mock.module('../tools/browser/browser-manager.js', () => {
+  snapshotMaps = new Map();
+  return {
+    browserManager: {
+      getOrCreateSessionPage: async () => mockPage,
+      closeSessionPage: async () => {},
+      closeAllPages: async () => {},
+      storeSnapshotMap: (sessionId: string, map: Map<string, string>) => {
+        snapshotMaps.set(sessionId, map);
+      },
+      resolveSnapshotSelector: (sessionId: string, elementId: string) => {
+        const map = snapshotMaps.get(sessionId);
+        if (!map) return null;
+        return map.get(elementId) ?? null;
+      },
+    },
+  };
+});
+
+mock.module('../tools/network/url-safety.js', () => ({
+  parseUrl: () => null,
+  isPrivateOrLocalHost: () => false,
+  resolveHostAddresses: async () => [],
+  resolveRequestAddress: async () => ({}),
+  sanitizeUrlForOutput: (url: URL) => url.href,
+}));
+
+let mockGetCredentialValue: ReturnType<typeof mock>;
+
+mock.module('../tools/credentials/vault.js', () => ({
+  getCredentialValue: (...args: unknown[]) => mockGetCredentialValue(...args),
+}));
+
+import { executeBrowserFillCredential } from '../tools/browser/headless-browser.js';
+import type { ToolContext } from '../tools/types.js';
+
+const ctx: ToolContext = {
+  sessionId: 'test-session',
+  conversationId: 'test-conversation',
+  workingDir: '/tmp',
+};
+
+function resetMockPage() {
+  mockPage = {
+    click: mock(async () => {}),
+    fill: mock(async () => {}),
+    press: mock(async () => {}),
+    evaluate: mock(async () => ''),
+    title: mock(async () => 'Test Page'),
+    url: mock(() => 'https://example.com/'),
+    goto: mock(async () => ({ status: () => 200, url: () => 'https://example.com/' })),
+    close: async () => {},
+    isClosed: () => false,
+  };
+}
+
+// ── browser_fill_credential ──────────────────────────────────────────
+
+describe('executeBrowserFillCredential', () => {
+  beforeEach(() => {
+    resetMockPage();
+    snapshotMaps.clear();
+    mockGetCredentialValue = mock(() => 'super-secret-password');
+  });
+
+  test('fills credential into element by element_id', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'gmail', field: 'password', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Filled password for gmail');
+    expect(mockPage.fill).toHaveBeenCalledWith('[data-vellum-eid="e1"]', 'super-secret-password');
+    expect(mockGetCredentialValue).toHaveBeenCalledWith('gmail', 'password');
+  });
+
+  test('fills credential by CSS selector', async () => {
+    const result = await executeBrowserFillCredential(
+      { service: 'github', field: 'token', selector: 'input[name="password"]' },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Filled token for github');
+    expect(mockPage.fill).toHaveBeenCalledWith('input[name="password"]', 'super-secret-password');
+  });
+
+  test('returns error when credential not found', async () => {
+    mockGetCredentialValue = mock(() => undefined);
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'slack', field: 'api_key', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No credential stored for slack/api_key');
+    expect(result.content).toContain('credential_store');
+    expect(mockPage.fill).not.toHaveBeenCalled();
+  });
+
+  test('returns error when element not found', async () => {
+    const result = await executeBrowserFillCredential(
+      { service: 'gmail', field: 'password', element_id: 'e99' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('element_id "e99" not found');
+    expect(result.content).toContain('browser_snapshot');
+  });
+
+  test('presses Enter after fill when press_enter is true', async () => {
+    snapshotMaps.set('test-session', new Map([['e2', '[data-vellum-eid="e2"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'gmail', field: 'password', element_id: 'e2', press_enter: true },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(mockPage.fill).toHaveBeenCalledWith('[data-vellum-eid="e2"]', 'super-secret-password');
+    expect(mockPage.press).toHaveBeenCalledWith('[data-vellum-eid="e2"]', 'Enter');
+  });
+
+  test('credential value NEVER appears in result content', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'gmail', field: 'password', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain('super-secret-password');
+  });
+
+  test('returns error when service is missing', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { field: 'password', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('service is required');
+  });
+
+  test('returns error when field is missing', async () => {
+    snapshotMaps.set('test-session', new Map([['e1', '[data-vellum-eid="e1"]']]));
+    const result = await executeBrowserFillCredential(
+      { service: 'gmail', element_id: 'e1' },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('field is required');
+  });
+});

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -12,6 +12,7 @@ import {
 } from '../network/url-safety.js';
 import { browserManager } from './browser-manager.js';
 import type { RouteHandler } from './browser-manager.js';
+import { getCredentialValue } from '../credentials/vault.js';
 
 const log = getLogger('headless-browser');
 
@@ -806,6 +807,97 @@ class BrowserExtractTool implements Tool {
 
 registerTool(new BrowserExtractTool());
 
+// ── browser_fill_credential ──────────────────────────────────────────
+
+async function executeBrowserFillCredential(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const service = typeof input.service === 'string' ? input.service : '';
+  const field = typeof input.field === 'string' ? input.field : '';
+
+  if (!service) {
+    return { content: 'Error: service is required.', isError: true };
+  }
+  if (!field) {
+    return { content: 'Error: field is required.', isError: true };
+  }
+
+  const { selector, error } = resolveSelector(context.sessionId, input);
+  if (error) return { content: error, isError: true };
+
+  const value = getCredentialValue(service, field);
+  if (!value) {
+    return {
+      content: `No credential stored for ${service}/${field}. Use credential_store to save it first.`,
+      isError: true,
+    };
+  }
+
+  const pressEnter = input.press_enter === true;
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    await page.fill(selector!, value);
+
+    if (pressEnter) {
+      await page.press(selector!, 'Enter');
+    }
+
+    return { content: `Filled ${field} for ${service} into the target element.`, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, selector }, 'Fill credential failed');
+    return { content: `Error: Fill credential failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserFillCredentialTool implements Tool {
+  name = 'browser_fill_credential';
+  description = 'Fill a stored credential into a form field without exposing the value. Target by element_id (from browser_snapshot) or CSS selector.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          service: {
+            type: 'string',
+            description: 'Credential vault service name (e.g. gmail)',
+          },
+          field: {
+            type: 'string',
+            description: 'Credential vault field name (e.g. password)',
+          },
+          element_id: {
+            type: 'string',
+            description: 'Element ID from browser_snapshot',
+          },
+          selector: {
+            type: 'string',
+            description: 'CSS selector for target element',
+          },
+          press_enter: {
+            type: 'boolean',
+            description: 'Press Enter after filling',
+          },
+        },
+        required: ['service', 'field'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserFillCredential(input, context);
+  }
+}
+
+registerTool(new BrowserFillCredentialTool());
+
 export {
   executeBrowserNavigate,
   executeBrowserSnapshot,
@@ -815,4 +907,5 @@ export {
   executeBrowserPressKey,
   executeBrowserWaitFor,
   executeBrowserExtract,
+  executeBrowserFillCredential,
 };


### PR DESCRIPTION
## Summary
- Adds `browser_fill_credential` tool that securely fills stored credentials into form fields via Playwright without exposing values in message history
- Uses the existing `resolveSelector` pattern for targeting elements by `element_id` or CSS selector
- Retrieves credentials from the vault via `getCredentialValue` and fills using `page.fill()`
- 8 unit tests covering all success/error paths and verifying credential values never leak in output

## Test plan
- [x] `bun test browser-fill-credential` -- 8/8 pass
- [x] `bun test headless-browser-interactions` -- 16/16 pass (no regressions)
- [x] `bunx tsc --noEmit` -- clean

Closes #962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
