### PR TITLE
Fix ambient toggle lifecycle and mask API key in ControlPanel (#970)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -379,7 +379,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.show()
             return
         }
-        let main = MainWindow(daemonClient: daemonClient)
+        let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent)
         main.show()
         mainWindow = main
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -4,10 +4,12 @@ import SwiftUI
 @MainActor
 final class MainWindow {
     private let daemonClient: DaemonClient
+    private let ambientAgent: AmbientAgent
     private var window: NSWindow?
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
         self.daemonClient = daemonClient
+        self.ambientAgent = ambientAgent
     }
 
     func show() {
@@ -15,14 +17,14 @@ final class MainWindow {
         if let existing = window {
             // Rebuild the SwiftUI view hierarchy so it picks up any
             // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient))
+            existing.contentViewController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient, ambientAgent: ambientAgent))
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient))
+        let hostingController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient, ambientAgent: ambientAgent))
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 struct MainWindowView: View {
     @StateObject private var threadManager: ThreadManager
     @State private var activePanel: SidePanelType?
+    let ambientAgent: AmbientAgent
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
         _threadManager = StateObject(wrappedValue: ThreadManager(daemonClient: daemonClient))
+        self.ambientAgent = ambientAgent
     }
 
     var body: some View {
@@ -57,7 +59,7 @@ struct MainWindowView: View {
             case .agent:
                 AgentPanel(onClose: { activePanel = nil })
             case .control:
-                ControlPanel(onClose: { activePanel = nil })
+                ControlPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent)
             case .directory:
                 DirectoryPanel(onClose: { activePanel = nil })
             case .debug:
@@ -70,5 +72,5 @@ struct MainWindowView: View {
 }
 
 #Preview {
-    MainWindowView(daemonClient: DaemonClient())
+    MainWindowView(daemonClient: DaemonClient(), ambientAgent: AmbientAgent())
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 struct ControlPanel: View {
     var onClose: () -> Void
+    var ambientAgent: AmbientAgent
 
     @State private var selectedTab: ControlTab = .settings
-    @State private var apiKey: String = ""
+    @State private var apiKeyText: String = ""
+    @State private var hasKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
-    @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
+    @State private var ambientEnabled: Bool = false
 
     private enum ControlTab: String, CaseIterable {
         case profile, settings, channels, overview
@@ -59,7 +61,8 @@ struct ControlPanel: View {
             }
         }
         .onAppear {
-            loadAPIKey()
+            hasKey = APIKeyManager.getKey() != nil
+            ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
         }
     }
 
@@ -89,18 +92,37 @@ struct ControlPanel: View {
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
 
-                Text("Enter API Key")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+                if hasKey {
+                    HStack {
+                        Text("sk-ant-...configured")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            APIKeyManager.deleteKey()
+                            hasKey = false
+                            apiKeyText = ""
+                        }
+                    }
+                } else {
+                    Text("Enter API Key")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
 
-                VTextField(placeholder: "This is your private generated key", text: $apiKey)
+                    SecureField("Enter API key", text: $apiKeyText)
+                        .textFieldStyle(.roundedBorder)
 
-                Text("Get your API key at console.anthropic.com")
-                    .font(VFont.small)
-                    .foregroundColor(VColor.textMuted)
+                    Text("Get your API key at console.anthropic.com")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
 
-                VButton(label: "Save", style: .primary) {
-                    saveAPIKey()
+                    VButton(label: "Save", style: .primary) {
+                        let trimmed = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        APIKeyManager.setKey(trimmed)
+                        hasKey = true
+                        apiKeyText = ""
+                    }
                 }
             }
             .padding(VSpacing.lg)
@@ -138,6 +160,9 @@ struct ControlPanel: View {
                     .tint(VColor.accent)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
+                    .onChange(of: ambientEnabled) { _, newValue in
+                        ambientAgent.isEnabled = newValue
+                    }
             }
             .padding(VSpacing.lg)
             .vCard()
@@ -192,25 +217,12 @@ struct ControlPanel: View {
         }
     }
 
-    // MARK: - API Key Management
-
-    private func saveAPIKey() {
-        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed)
-    }
-
-    private func loadAPIKey() {
-        if let key = APIKeyManager.getKey() {
-            apiKey = key
-        }
-    }
 }
 
 #Preview("ControlPanel") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        ControlPanel(onClose: {})
+        ControlPanel(onClose: {}, ambientAgent: AmbientAgent())
     }
     .frame(width: 600, height: 700)
 }


### PR DESCRIPTION
## Summary
- **Ambient toggle fix**: ControlPanel's ambient agent toggle now properly calls `ambientAgent.isEnabled = newValue` which triggers `start()`/`stop()` side effects, instead of only writing to UserDefaults via `@AppStorage`. Mirrors the pattern in `SettingsView.swift`.
- **API key masking**: API key is no longer loaded from Keychain and displayed in plaintext via `VTextField`. Now uses `SecureField` for input and shows a masked placeholder (`sk-ant-...configured`) with a Clear button when a key exists. Mirrors the pattern in `SettingsView.swift`.
- **Dependency threading**: `AmbientAgent` is now passed through `AppDelegate` -> `MainWindow` -> `MainWindowView` -> `ControlPanel` so the toggle can call the proper lifecycle methods.

## Test plan
- [ ] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] Open Control Panel > Settings tab
- [ ] Verify API key field shows "sk-ant-...configured" when key is set (not the actual key)
- [ ] Verify Clear button removes the key and shows SecureField
- [ ] Verify saving a new key via SecureField works
- [ ] Verify ambient toggle properly starts/stops the ambient agent (check logs)
- [ ] Verify Xcode previews still render for ControlPanel, MainWindowView

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
