### PR TITLE
Fix session isolation and cancel on thread close (#957)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -26,6 +26,7 @@ exports[`IPC message snapshots ClientMessage types session_list serializes to ex
 
 exports[`IPC message snapshots ClientMessage types session_create serializes to expected JSON 1`] = `
 {
+  "correlationId": "corr-001",
   "title": "New session",
   "type": "session_create",
 }
@@ -254,6 +255,7 @@ exports[`IPC message snapshots ServerMessage types message_complete serializes t
 
 exports[`IPC message snapshots ServerMessage types session_info serializes to expected JSON 1`] = `
 {
+  "correlationId": "corr-001",
   "sessionId": "sess-001",
   "title": "My session",
   "type": "session_info",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -35,6 +35,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   session_create: {
     type: 'session_create',
     title: 'New session',
+    correlationId: 'corr-001',
   },
   session_switch: {
     type: 'session_switch',
@@ -184,6 +185,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'session_info',
     sessionId: 'sess-001',
     title: 'My session',
+    correlationId: 'corr-001',
   },
   session_list_response: {
     type: 'session_list_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -348,6 +348,7 @@ async function handleSessionCreate(
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'New Conversation',
+    ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
   });
 }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -40,6 +40,7 @@ export interface SessionCreateRequest {
   title?: string;
   systemPromptOverride?: string;
   maxResponseTokens?: number;
+  correlationId?: string;
 }
 
 export interface SessionSwitchRequest {
@@ -293,6 +294,7 @@ export interface SessionInfo {
   type: 'session_info';
   sessionId: string;
   title: string;
+  correlationId?: string;
 }
 
 export interface SessionListResponse {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -15,6 +15,9 @@ final class ChatViewModel: ObservableObject {
     private let daemonClient: DaemonClient
     var sessionId: String?
     private var pendingUserMessage: String?
+    /// Nonce sent with `session_create` and echoed back in `session_info`.
+    /// Used to ensure this ChatViewModel only claims its own session.
+    private var bootstrapCorrelationId: String?
     private var messageLoopTask: Task<Void, Never>?
     private var currentAssistantMessageId: UUID?
     /// When true, incoming deltas are suppressed until the daemon acknowledges
@@ -68,6 +71,11 @@ final class ChatViewModel: ObservableObject {
         isThinking = true
         pendingUserMessage = userMessage
 
+        // Generate a unique correlation ID so this ChatViewModel only claims
+        // the session_info response that belongs to its own session_create request.
+        let correlationId = UUID().uuidString
+        self.bootstrapCorrelationId = correlationId
+
         Task { @MainActor in
             // Ensure daemon connection
             if !daemonClient.isConnected {
@@ -77,6 +85,7 @@ final class ChatViewModel: ObservableObject {
                     log.error("Failed to connect to daemon: \(error.localizedDescription)")
                     self.isThinking = false
                     self.isSending = false
+                    self.bootstrapCorrelationId = nil
                     self.errorText = "Cannot connect to daemon. Please ensure it's running."
                     return
                 }
@@ -85,13 +94,14 @@ final class ChatViewModel: ObservableObject {
             // Subscribe to daemon stream
             self.startMessageLoop()
 
-            // Send session_create
+            // Send session_create with correlation ID
             do {
-                try daemonClient.send(SessionCreateMessage(title: nil))
+                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId))
             } catch {
                 log.error("Failed to send session_create: \(error.localizedDescription)")
                 self.isThinking = false
                 self.isSending = false
+                self.bootstrapCorrelationId = nil
                 self.errorText = "Failed to create session."
             }
         }
@@ -170,8 +180,21 @@ final class ChatViewModel: ObservableObject {
     func handleServerMessage(_ message: ServerMessage) {
         switch message {
         case .sessionInfo(let info):
+            // Only claim this session_info if:
+            // 1. We don't have a session yet, AND
+            // 2. The correlation ID matches our bootstrap request (if we sent one).
+            //    Session info without a correlation ID is accepted when we have no
+            //    bootstrap correlation (backwards compatibility with older daemons).
             if sessionId == nil {
+                if let expected = bootstrapCorrelationId {
+                    guard info.correlationId == expected else {
+                        // This session_info belongs to a different ChatViewModel's request.
+                        break
+                    }
+                }
+
                 sessionId = info.sessionId
+                bootstrapCorrelationId = nil
                 log.info("Chat session created: \(info.sessionId)")
 
                 // Send the queued user message
@@ -319,6 +342,7 @@ final class ChatViewModel: ObservableObject {
         // cancel on the daemon side.
         if sessionId == nil {
             pendingUserMessage = nil
+            bootstrapCorrelationId = nil
             isThinking = false
             isSending = false
             return

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -37,6 +37,10 @@ final class ThreadManager: ObservableObject {
 
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
 
+        // Cancel any active generation so the daemon doesn't keep processing
+        // an orphaned request after the view model is removed.
+        chatViewModels[id]?.stopGenerating()
+
         threads.remove(at: index)
         chatViewModels.removeValue(forKey: id)
 

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -132,11 +132,16 @@ struct SessionCreateMessage: Encodable, Sendable {
     let title: String?
     let systemPromptOverride: String?
     let maxResponseTokens: Int?
+    /// Client-generated nonce echoed back in `session_info` so the caller can
+    /// correlate the response to its specific request. Prevents multiple
+    /// ChatViewModels sharing one DaemonClient from stealing each other's sessions.
+    let correlationId: String?
 
-    init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil) {
+    init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil) {
         self.title = title
         self.systemPromptOverride = systemPromptOverride
         self.maxResponseTokens = maxResponseTokens
+        self.correlationId = correlationId
     }
 }
 
@@ -255,6 +260,15 @@ struct MessageCompleteMessage: Decodable, Sendable {
 struct SessionInfoMessage: Decodable, Sendable {
     let sessionId: String
     let title: String
+    /// Echoed from the `session_create` request so the caller can match
+    /// this response to its specific request.
+    let correlationId: String?
+
+    init(sessionId: String, title: String, correlationId: String? = nil) {
+        self.sessionId = sessionId
+        self.title = title
+        self.correlationId = correlationId
+    }
 }
 
 /// Daemon response after classifying and routing a task_submit.

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -837,4 +837,49 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.messages[1].isStreaming)
     }
+
+    // MARK: - Session Isolation (Correlation ID)
+
+    func testSessionInfoWithWrongCorrelationIdIsIgnored() {
+        // Simulate a ChatViewModel that has sent a session_create with a correlation ID.
+        // A session_info with a different correlation ID should be ignored.
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        // At this point the VM is bootstrapping and has a correlationId set internally.
+        XCTAssertNil(viewModel.sessionId)
+        XCTAssertTrue(viewModel.isSending)
+
+        // A session_info from a different ChatViewModel's request (different correlation ID)
+        let foreignInfo = SessionInfoMessage(sessionId: "foreign-session", title: "Foreign", correlationId: "wrong-id")
+        viewModel.handleServerMessage(.sessionInfo(foreignInfo))
+
+        // Should NOT have claimed the foreign session
+        XCTAssertNil(viewModel.sessionId, "Should not claim session_info with non-matching correlationId")
+    }
+
+    func testSessionInfoWithNilCorrelationIdIsIgnoredWhenBootstrapping() {
+        // When a ChatViewModel is bootstrapping (has a correlationId), a session_info
+        // without any correlationId should also be rejected to prevent cross-contamination.
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertNil(viewModel.sessionId)
+
+        // Legacy session_info without correlationId
+        let legacyInfo = SessionInfoMessage(sessionId: "legacy-session", title: "Legacy")
+        viewModel.handleServerMessage(.sessionInfo(legacyInfo))
+
+        // Should NOT have claimed the legacy session
+        XCTAssertNil(viewModel.sessionId, "Should not claim session_info without correlationId when bootstrapping with one")
+    }
+
+    func testSessionInfoWithoutCorrelationIdAcceptedWhenNoBootstrap() {
+        // When a ChatViewModel has no bootstrap correlationId (e.g., backwards compat),
+        // it should still accept session_info without a correlationId.
+        // Simulate the old behavior: directly set up state without going through
+        // bootstrapSession (which would generate a correlationId)
+        let info = SessionInfoMessage(sessionId: "test-session", title: "Test")
+        viewModel.handleServerMessage(.sessionInfo(info))
+
+        XCTAssertEqual(viewModel.sessionId, "test-session", "Should accept session_info when no correlationId was set")
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `correlationId` nonce to `session_create` / `session_info` IPC messages to prevent multiple ChatViewModels from stealing each other's sessions during concurrent bootstrap
- Calls `stopGenerating()` before removing a thread's ChatViewModel in `closeThread` to cancel orphaned daemon requests
- Adds 3 new tests for session isolation behavior

## Test plan
- [x] Build succeeds with `./build.sh`
- [x] All 113 tests pass (including 3 new session isolation tests)
- [ ] Manual: Open two threads, send a message in each quickly -- verify each thread gets its own session
- [ ] Manual: Close a thread while it's generating -- verify daemon stops processing

Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
