### PR TITLE
Forward ChatViewModel objectWillChange through ThreadManager (#965)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import os
 
@@ -6,10 +7,13 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 @MainActor
 final class ThreadManager: ObservableObject {
     @Published var threads: [ThreadModel] = []
-    @Published var activeThreadId: UUID?
+    @Published var activeThreadId: UUID? {
+        didSet { subscribeToActiveViewModel() }
+    }
 
     private var chatViewModels: [UUID: ChatViewModel] = [:]
     private let daemonClient: DaemonClient
+    private var viewModelCancellable: AnyCancellable?
 
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil }
@@ -60,5 +64,16 @@ final class ThreadManager: ObservableObject {
     func selectThread(id: UUID) {
         guard threads.contains(where: { $0.id == id }) else { return }
         activeThreadId = id
+    }
+
+    // MARK: - Private
+
+    /// Subscribe to the active ChatViewModel's objectWillChange so that
+    /// SwiftUI re-evaluates views when the nested view model publishes
+    /// changes (new messages, thinking state, errors, etc.).
+    private func subscribeToActiveViewModel() {
+        viewModelCancellable = activeViewModel?.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes a critical SwiftUI observation bug where `ChatViewModel` state changes (messages, thinking, sending, errors) were not propagated to `MainWindowView` because SwiftUI only subscribed to `ThreadManager.objectWillChange`, not the nested `ChatViewModel`
- Adds Combine-based forwarding: whenever `activeThreadId` changes, `ThreadManager` subscribes to the active `ChatViewModel`'s `objectWillChange` publisher and re-emits it through its own `objectWillChange`
- Addresses review feedback from both Codex (P1) and Devin (Bug) on #965

## Test plan
- [x] `./build.sh` passes (clean build, no warnings)
- [x] `./build.sh test` passes (all 113 tests, 0 failures)
- [ ] Manual: open app, send a message, verify messages appear in real-time
- [ ] Manual: verify thinking indicator shows/hides during generation
- [ ] Manual: verify stop button appears during sending
- [ ] Manual: verify error banners display when errors occur
- [ ] Manual: switch threads, verify new thread's ChatViewModel state is observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
