### PR TITLE
Sync ambient toggle via @AppStorage in ControlPanel (#979)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -8,7 +8,7 @@ struct ControlPanel: View {
     @State private var apiKeyText: String = ""
     @State private var hasKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
-    @State private var ambientEnabled: Bool = false
+    @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
 
     private enum ControlTab: String, CaseIterable {
         case profile, settings, channels, overview
@@ -62,7 +62,6 @@ struct ControlPanel: View {
         }
         .onAppear {
             hasKey = APIKeyManager.getKey() != nil
-            ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced `@State` with `@AppStorage("ambientAgentEnabled")` for the `ambientEnabled` property in `ControlPanel`, so the toggle stays in sync with `SettingsView` and any other view that reads/writes the same UserDefaults key.
- Kept the `.onChange(of: ambientEnabled)` handler so `ambientAgent.isEnabled` still receives start/stop side effects when the toggle changes.
- Removed the manual `UserDefaults.standard.bool(forKey:)` read from `.onAppear` since `@AppStorage` handles initial value and cross-view synchronization automatically.

Addresses feedback from #979.

## Test plan
- [ ] Open ControlPanel and verify the ambient toggle reflects the current setting
- [ ] Toggle ambient mode in SettingsView, then open ControlPanel — verify it shows the updated state
- [ ] Toggle ambient mode in ControlPanel and verify SettingsView reflects the change
- [ ] Toggle ambient mode on/off in ControlPanel and verify the ambient agent starts/stops correctly

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
