### PR TITLE
Make daemon cancel session-aware for multi-thread safety (#980)

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -13,6 +13,7 @@ import type {
   ConfirmationResponse,
   SessionCreateRequest,
   SessionSwitchRequest,
+  CancelRequest,
   ModelSetRequest,
   HistoryRequest,
   UndoRequest,
@@ -209,7 +210,7 @@ const handlers: DispatchMap = {
   session_list: (_msg, socket, ctx) => handleSessionList(socket, ctx),
   session_create: handleSessionCreate,
   session_switch: handleSessionSwitch,
-  cancel: (_msg, socket, ctx) => handleCancel(socket, ctx),
+  cancel: handleCancel,
   model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
   model_set: handleModelSet,
   history_request: handleHistoryRequest,
@@ -371,8 +372,8 @@ async function handleSessionSwitch(
   });
 }
 
-function handleCancel(socket: net.Socket, ctx: HandlerContext): void {
-  const sessionId = ctx.socketToSession.get(socket);
+function handleCancel(msg: CancelRequest, socket: net.Socket, ctx: HandlerContext): void {
+  const sessionId = msg.sessionId || ctx.socketToSession.get(socket);
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -54,6 +54,7 @@ export interface PingMessage {
 
 export interface CancelRequest {
   type: 'cancel';
+  sessionId?: string;
 }
 
 export interface ModelGetRequest {


### PR DESCRIPTION
## Summary
- Fixes the critical bug identified by Codex (P1) and Devin (Bug) in PR #980 where `closeThread`'s `stopGenerating()` could cancel the wrong session when multiple threads share a `DaemonClient`
- Adds `sessionId` to the daemon's `CancelRequest` interface and updates `handleCancel` to use `msg.sessionId` when provided, falling back to `socketToSession` for backwards compatibility
- No Swift changes needed: `CancelMessage` already includes `sessionId` and `stopGenerating()` already sends it

## Root cause
The daemon's `handleCancel` ignored the `sessionId` field in the `CancelMessage` and looked up the session via `ctx.socketToSession.get(socket)` -- a mapping that points to whichever session most recently sent a `user_message`. Since all ChatViewModels share the same DaemonClient/socket, this could cancel a different thread's generation.

## Test plan
- [ ] `bunx tsc --noEmit` passes in `assistant/`
- [ ] `./build.sh` succeeds in `clients/macos/`
- [ ] Manual: Open two threads, send messages in both, close Thread A while Thread B is generating -- verify Thread B's generation continues uninterrupted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
