### PR TITLE
Fix mock signup server session isolation and duplicate account guard (#973)

### DIFF
--- a/assistant/src/__tests__/fixtures/mock-signup-server.ts
+++ b/assistant/src/__tests__/fixtures/mock-signup-server.ts
@@ -201,9 +201,21 @@ export function createMockSignupServer(): MockSignupServer {
     const method = req.method;
     const cookieHeader = req.headers.get('cookie');
 
+    // ── Early 404 for non-signup paths ────────────────────────────
+    // Avoid creating orphaned sessions for requests to unknown routes.
+    if (!path.startsWith('/signup')) {
+      return new Response('Not Found', { status: 404 });
+    }
+
     // ── Test-only endpoint ────────────────────────────────────────
+    // Returns the verification code for the caller's session (looked up
+    // via the session cookie) so parallel / multi-session tests work.
     if (method === 'GET' && path === '/signup/verify-code') {
-      return new Response(JSON.stringify({ code: lastVerificationCode }), {
+      const cookies = parseCookies(cookieHeader);
+      const sid = cookies['signup_session'];
+      const sess = sid ? sessions.get(sid) : undefined;
+      const code = sess ? sess.verificationCode : lastVerificationCode;
+      return new Response(JSON.stringify({ code }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -308,6 +320,11 @@ export function createMockSignupServer(): MockSignupServer {
     if (method === 'POST' && path === '/signup/step4') {
       if (session.step < 3) {
         return redirect('/signup', id);
+      }
+      // Guard: if already completed, redirect to the completion page
+      // instead of creating a duplicate account.
+      if (session.step >= 4) {
+        return redirect('/signup/complete', id);
       }
       const body = parseFormBody(await req.text());
       const captchaSolved = body['captcha_solved'];


### PR DESCRIPTION
## Summary
- **Prevent orphaned sessions on unknown routes (P1):** Added early 404 return for non-`/signup` paths before `getOrCreateSession` is called, so requests to unknown routes no longer create orphaned sessions that overwrite `lastVerificationCode`.
- **Scope verify-code endpoint to caller's session (P1):** The `/signup/verify-code` test endpoint now looks up the verification code from the caller's session cookie first, falling back to `lastVerificationCode` only when no session cookie is present. This makes parallel/multi-session tests reliable.
- **Block duplicate account creation on repeated step4 POST (P2):** Added a guard in `POST /signup/step4` that redirects to `/signup/complete` when `session.step >= 4`, preventing duplicate accounts from being appended on resubmit.

## Test plan
- [x] All 20 existing tests pass (`bun test mock-signup-server`)
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that hitting an unknown route (e.g. `/nonexistent`) no longer creates an orphaned session
- [ ] Verify that `/signup/verify-code` with a session cookie returns that session's code
- [ ] Verify that resubmitting step4 does not create duplicate accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
