### PR TITLE
Fix CAPTCHA prompt: tool availability and await_action (#981)

### DIFF
--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -68,9 +68,9 @@ When a signup or login flow requires a verification code (email, SMS, or authent
 3. Type the code into the appropriate field
 
 CAPTCHA HANDLING:
-When you encounter a CAPTCHA (use browser_detect_captcha to check):
-1. Use ui_show with surface_type "card" to inform the user:
-   ui_show({ surface_type: "card", title: "CAPTCHA Detected", data: { body: "A CAPTCHA appeared. Please solve it in your browser." }, actions: [{ id: "done", label: "Done", style: "primary" }] })
+When you see a CAPTCHA or "verify you are human" challenge on the screen:
+1. Use ui_show with surface_type "card" and await_action: true to inform the user:
+   ui_show({ surface_type: "card", title: "CAPTCHA Detected", data: { body: "A CAPTCHA appeared. Please solve it in your browser." }, actions: [{ id: "done", label: "Done", style: "primary" }], await_action: true })
 2. Wait for the user to respond
 3. Refresh the page and continue
 


### PR DESCRIPTION
## Summary
- **P1 fix**: Removed reference to `browser_detect_captcha` tool from the computer-use system prompt. That tool is a headless browser tool and is not exposed in computer-use sessions (which only have `allComputerUseTools` + UI surface tools). The prompt now instructs the agent to visually detect CAPTCHAs from the screen state instead.
- **P2 fix**: Added `await_action: true` to the CAPTCHA `ui_show` example. The `card` surface type is not in `INTERACTIVE_SURFACE_TYPES`, so without this flag the call returns immediately and the agent would continue before the user solves the CAPTCHA.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm the system prompt no longer references `browser_detect_captcha`
- [ ] Confirm the CAPTCHA `ui_show` example includes `await_action: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
