### PR TITLE
Fix background image overflow and non-interactive attachment icon (#992)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -146,13 +146,10 @@ struct ChatView: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop generation")
             } else {
-                Button {} label: {
-                    Image(systemName: "paperclip")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Attach file")
+                Image(systemName: "paperclip")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(VColor.textSecondary)
+                    .accessibilityHidden(true)
             }
         }
         .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -31,6 +31,7 @@ struct MainWindowView: View {
                     .resizable()
                     .scaledToFill()
                     .frame(maxWidth: .infinity)
+                    .clipped()
                     .allowsHitTesting(false)
 
                 VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #992:

- **Devin**: Added `.clipped()` after `.scaledToFill()` on the botanical background image to prevent it from visually overflowing into the toolbar and tab bar areas above.
- **Codex P2**: Replaced the clickable `Button` with empty action for the paperclip attachment icon with a non-interactive `Image` + `accessibilityHidden(true)`, eliminating the broken UI affordance.

## Test plan
- [x] Build passes
- [ ] Visual: background image does not bleed into toolbar/tab bar
- [ ] Visual: paperclip icon is not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
