### PR TITLE
Fix blank main window after onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -30,7 +30,7 @@ struct MainWindowView: View {
                 Image("bg", bundle: .module)
                     .resizable()
                     .scaledToFill()
-                    .frame(maxWidth: .infinity)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
                     .allowsHitTesting(false)
 
@@ -55,6 +55,7 @@ struct MainWindowView: View {
                     panelContent
                 })
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)


### PR DESCRIPTION
## Summary
Fixes the main window appearing completely blank (just dark background) after onboarding completes.

**Root cause:** The botanical background image (`bg@2x.png`, 2732x1698pt) added in PR #992 used `.scaledToFill()` without height constraints. This caused the ZStack to expand to the image's intrinsic height, pushing the ThreadTabBar and NavigationToolbar off the visible window area.

**Fix:** Added `maxHeight: .infinity` to both the Image's `.frame()` and the ZStack's `.frame()` so they fill the available space within the VStack instead of using the image's natural dimensions.

## Test plan
- [x] Build passes
- [ ] Launch app, complete onboarding — main window shows ThreadTabBar, NavigationToolbar, chat area with botanical background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
