### PR TITLE
Add inline markdown rendering to chat bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -251,9 +251,10 @@ private struct ChatBubble: View {
     }
 
     private var bubbleContent: some View {
-        Text(message.text)
+        Text(markdownText)
             .font(VFont.mono)
             .foregroundColor(isUser ? .white : VColor.textPrimary)
+            .tint(isUser ? .white : VColor.accent)
             .textSelection(.enabled)
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
@@ -263,6 +264,14 @@ private struct ChatBubble: View {
             )
             .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
             .opacity(bubbleOpacity)
+    }
+
+    private var markdownText: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: message.text, options: options))
+            ?? AttributedString(message.text)
     }
 
     private func ordinal(_ n: Int) -> String {

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -128,7 +128,7 @@ struct TextResponseView: View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             assistantAvatar
 
-            Text(text)
+            Text(Self.markdownString(text))
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
                 .textSelection(.enabled)
@@ -229,6 +229,16 @@ struct TextResponseView: View {
             .clipShape(Circle())
     }
 
+    // MARK: - Markdown
+
+    static func markdownString(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options))
+            ?? AttributedString(text)
+    }
+
     // MARK: - Helpers
 
     private func sendMessage() {
@@ -254,9 +264,10 @@ private struct ConversationBubble: View {
                 Spacer(minLength: 0)
             }
 
-            Text(message.text)
+            Text(Self.markdownString(message.text))
                 .font(VFont.body)
                 .foregroundColor(isAssistant ? VColor.textPrimary : .white)
+                .tint(isAssistant ? VColor.accent : .white)
                 .if(isAssistant) { view in
                     view.textSelection(.enabled)
                 }
@@ -275,6 +286,10 @@ private struct ConversationBubble: View {
                 Spacer(minLength: 0)
             }
         }
+    }
+
+    static func markdownString(_ text: String) -> AttributedString {
+        TextResponseView.markdownString(text)
     }
 
     private var bubbleFill: some ShapeStyle {


### PR DESCRIPTION
## Summary
- Parse chat message text as `AttributedString` markdown with `.inlineOnlyPreservingWhitespace` so bold, italic, code, and links render inside chat bubbles
- Add `.tint` modifier to color links appropriately in both user (white) and assistant (accent) bubbles
- Share markdown parsing via `TextResponseView.markdownString(_:)` static helper, forwarded by `ConversationBubble`

## Test plan
- [ ] Build and launch the app
- [ ] Send a message containing markdown (e.g. `**bold**, *italic*, `code`, [link](https://example.com)`)
- [ ] Verify formatting renders correctly in user bubbles, assistant bubbles, and streaming bubbles
- [ ] Verify links are tinted white on user bubbles and accent-colored on assistant bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
