### PR TITLE
Fix blank main window after onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -25,37 +25,33 @@ struct MainWindowView: View {
             NavigationToolbar(activePanel: $activePanel)
 
             // Row 3 — chat content with optional side panel
-            ZStack(alignment: .bottom) {
-                // Botanical background decoration
+            VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
+                if let viewModel = threadManager.activeViewModel {
+                    ChatView(
+                        messages: viewModel.messages,
+                        inputText: Binding(
+                            get: { viewModel.inputText },
+                            set: { viewModel.inputText = $0 }
+                        ),
+                        isThinking: viewModel.isThinking,
+                        isSending: viewModel.isSending,
+                        errorText: viewModel.errorText,
+                        pendingQueuedCount: viewModel.pendingQueuedCount,
+                        onSend: viewModel.sendMessage,
+                        onStop: viewModel.stopGenerating,
+                        onDismissError: viewModel.dismissError
+                    )
+                }
+            }, panel: {
+                panelContent
+            })
+            .background(alignment: .bottom) {
                 Image("bg", bundle: .module)
                     .resizable()
                     .scaledToFill()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
                     .allowsHitTesting(false)
-
-                VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
-                    if let viewModel = threadManager.activeViewModel {
-                        ChatView(
-                            messages: viewModel.messages,
-                            inputText: Binding(
-                                get: { viewModel.inputText },
-                                set: { viewModel.inputText = $0 }
-                            ),
-                            isThinking: viewModel.isThinking,
-                            isSending: viewModel.isSending,
-                            errorText: viewModel.errorText,
-                            pendingQueuedCount: viewModel.pendingQueuedCount,
-                            onSend: viewModel.sendMessage,
-                            onStop: viewModel.stopGenerating,
-                            onDismissError: viewModel.dismissError
-                        )
-                    }
-                }, panel: {
-                    panelContent
-                })
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)


### PR DESCRIPTION
## Summary
- Replace ZStack wrapping VSplitView with `.background()` modifier for the botanical background image
- The ZStack with `scaledToFill()` caused the image's intrinsic size (2732x1698pt) to expand the layout beyond window bounds, pushing ThreadTabBar, NavigationToolbar, and ChatView off-screen
- `.background()` keeps the image purely decorative without participating in layout

## Test plan
- [x] Build passes (`./build.sh`)
- [x] All 113 tests pass (`./build.sh test`)
- [ ] Launch app after onboarding — verify thread tab bar, toolbar, and chat are all visible
- [ ] Verify botanical background is still visible behind the chat area

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
