### PR TITLE
Restore chat bubble styling and fix background image

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -48,6 +48,7 @@ struct ChatView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
+            .scrollContentBackground(.hidden)
             .onChange(of: messages.count) {
                 withAnimation(VAnimation.standard) {
                     if let lastMessage = messages.last {
@@ -212,24 +213,40 @@ private struct ChatBubble: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(message.text)
-                .font(VFont.mono)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
-                .opacity(bubbleOpacity)
+        HStack {
+            if isUser { Spacer(minLength: 0) }
 
-            if let label = statusLabel {
-                Text(label)
+            VStack(alignment: isUser ? .trailing : .leading, spacing: 2) {
+                bubbleContent
+
+                if let label = statusLabel {
+                    Text(label)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Text(formattedTimestamp)
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
             }
 
-            Text(formattedTimestamp)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
+            if !isUser { Spacer(minLength: 0) }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var bubbleContent: some View {
+        Text(message.text)
+            .font(VFont.mono)
+            .foregroundColor(isUser ? .white : VColor.textPrimary)
+            .textSelection(.enabled)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isUser ? VColor.accent : VColor.surface.opacity(0.5))
+            )
+            .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
+            .opacity(bubbleOpacity)
     }
 
     private func ordinal(_ n: Int) -> String {


### PR DESCRIPTION
## Summary
- Restore rounded rectangle backgrounds for chat bubbles (violet for user, dark surface for assistant)
- Restore user/assistant alignment differentiation (user right-aligned, assistant left-aligned)
- Add padding and max-width 500 constraint back to bubbles
- Keep timestamps and monospace font from the recent restyle
- Add `.scrollContentBackground(.hidden)` to ScrollView so the botanical background image shows through

## Test plan
- [x] Build passes (`./build.sh`)
- [x] All 113 tests pass (`./build.sh test`)
- [ ] Chat messages have rounded background bubbles
- [ ] User messages are right-aligned with violet background
- [ ] Assistant messages are left-aligned with dark surface background
- [ ] Botanical background image is visible behind the chat area
- [ ] Timestamps still display below each message

Closes #1001, closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
