### PR TITLE
M2: Create VToggle design system component

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct VToggle: View {
+    @Binding var isOn: Bool
+    var label: String? = nil
+
+    // MARK: - Layout Constants
+
+    private let trackWidth: CGFloat = 40
+    private let trackHeight: CGFloat = 22
+    private let knobSize: CGFloat = 16
+    private let knobPadding: CGFloat = 3
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            toggleTrack
+
+            if let label = label {
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityValue(isOn ? "On" : "Off")
+        .accessibilityLabel(label ?? "Toggle")
+    }
+
+    // MARK: - Track
+
+    private var toggleTrack: some View {
+        ZStack(alignment: isOn ? .trailing : .leading) {
+            // Track background
+            RoundedRectangle(cornerRadius: VRadius.pill)
+                .fill(isOn ? Emerald._500 : Slate._700)
+                .frame(width: trackWidth, height: trackHeight)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.pill)
+                        .stroke(Slate._600, lineWidth: 1)
+                )
+
+            // Knob
+            Circle()
+                .fill(Color.white)
+                .frame(width: knobSize, height: knobSize)
+                .padding(.horizontal, knobPadding)
+        }
+        .onTapGesture {
+            withAnimation(VAnimation.fast) {
+                isOn.toggle()
+            }
+        }
+    }
+}
+
+#Preview("VToggle") {
+    @Previewable @State var isOnA = true
+    @Previewable @State var isOnB = false
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(alignment: .leading, spacing: 16) {
+            VToggle(isOn: $isOnA, label: "Enabled toggle")
+            VToggle(isOn: $isOnB, label: "Disabled toggle")
+            VToggle(isOn: $isOnA)
+        }
+        .padding()
+    }
+    .frame(width: 300, height: 200)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -6,6 +6,8 @@ struct InputsGallerySection: View {
     @State private var textEditorValue = ""
     @State private var minHeight: CGFloat = 80
     @State private var maxHeight: CGFloat = 200
+    @State private var toggleA: Bool = true
+    @State private var toggleB: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
@@ -97,6 +99,34 @@ struct InputsGallerySection: View {
                     Text("Characters: \(textEditorValue.count)")
                         .font(VFont.small)
                         .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VToggle
+            GallerySectionHeader(
+                title: "VToggle",
+                description: "Custom toggle switch with animated knob and color transition."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Toggle A: \(toggleA ? "ON" : "OFF")  |  Toggle B: \(toggleB ? "ON" : "OFF")")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("With label").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VToggle(isOn: $toggleA, label: "Enable feature")
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Without label").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VToggle(isOn: $toggleB)
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -164,17 +164,12 @@ struct ControlPanel: View {
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
 
-                Toggle(isOn: $ambientEnabled) {
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Enable ambient screen watching")
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 12))
-                            .foregroundColor(VColor.textMuted)
-                    }
+                HStack(spacing: VSpacing.xs) {
+                    VToggle(isOn: $ambientEnabled, label: "Enable ambient screen watching")
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.textMuted)
                 }
-                .tint(VColor.accent)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
                 .onChange(of: ambientEnabled) { _, newValue in
                     ambientAgent.isEnabled = newValue
                 }


### PR DESCRIPTION
## Summary
Closes #1006.

- Created `VToggle`, a custom SwiftUI toggle component with a pill-shaped track, animated white knob, and Emerald/Slate color scheme
- Added VToggle showcase section to the component gallery (`InputsGallerySection`)
- Replaced the native `Toggle` in `ControlPanel` with the new `VToggle` component

## Details

**VToggle component** (`VToggle.swift`):
- Accepts `isOn: Binding<Bool>` and optional `label: String?`
- ON state: `Emerald._500` green background with white knob on the right
- OFF state: `Slate._700` dark background with white knob on the left
- Subtle `Slate._600` border around the track
- Smooth animation using `VAnimation.fast` (0.15s ease-out)
- Pill shape via `VRadius.pill`
- Compact 40x22 proportions with a 16pt white circular knob
- Full accessibility support (button trait, on/off value, label)
- SwiftUI Preview showing both ON and OFF states

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] VToggle renders correctly in the component gallery with live toggle interaction
- [ ] ControlPanel ambient agent toggle uses the new VToggle and correctly starts/stops the ambient agent
- [ ] Toggle knob animates smoothly between ON and OFF positions
- [ ] Accessibility: VoiceOver reads toggle state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
