### PR TITLE
M1: Create VSlider design system component

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+struct VSlider: View {
+    @Binding var value: Double
+    var range: ClosedRange<Double> = 0...100
+    var step: Double = 1
+    var showTickMarks: Bool = false
+
+    // MARK: - Layout Constants
+
+    private let trackHeight: CGFloat = 6
+    private let thumbWidth: CGFloat = 20
+    private let thumbHeight: CGFloat = 24
+    private let tickMarkHeight: CGFloat = 8
+    private let tickMarkWidth: CGFloat = 1
+    private let gripLineCount: Int = 3
+    private let gripLineWidth: CGFloat = 1
+    private let gripLineHeight: CGFloat = 10
+    private let gripLineSpacing: CGFloat = 2.5
+
+    // MARK: - State
+
+    @State private var isDragging = false
+
+    // MARK: - Body
+
+    var body: some View {
+        GeometryReader { geometry in
+            let trackWidth = geometry.size.width - thumbWidth
+            let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
+            let thumbOffset = trackWidth * fraction
+
+            ZStack(alignment: .leading) {
+                // Tick marks (behind track)
+                if showTickMarks {
+                    tickMarksView(trackWidth: trackWidth)
+                }
+
+                // Track
+                trackView(thumbOffset: thumbOffset, trackWidth: trackWidth)
+
+                // Thumb
+                thumbView
+                    .offset(x: thumbOffset)
+            }
+            .frame(height: thumbHeight)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { drag in
+                        isDragging = true
+                        let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
+                        let clampedFraction = min(max(newFraction, 0), 1)
+                        let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
+                        value = round(rawValue / step) * step
+                        value = min(max(value, range.lowerBound), range.upperBound)
+                    }
+                    .onEnded { _ in
+                        isDragging = false
+                    }
+            )
+        }
+        .frame(height: thumbHeight)
+    }
+
+    // MARK: - Track
+
+    private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
+        ZStack(alignment: .leading) {
+            // Unfilled track
+            Capsule()
+                .fill(Slate._700)
+                .frame(height: trackHeight)
+                .padding(.horizontal, thumbWidth / 2)
+
+            // Filled track
+            Capsule()
+                .fill(VColor.accent)
+                .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
+                .padding(.leading, thumbWidth / 2)
+        }
+    }
+
+    // MARK: - Thumb
+
+    private var thumbView: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(Slate._200)
+                .frame(width: thumbWidth, height: thumbHeight)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .stroke(Slate._400, lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
+
+            // Grip lines
+            HStack(spacing: gripLineSpacing) {
+                ForEach(0..<gripLineCount, id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 0.5)
+                        .fill(Slate._500)
+                        .frame(width: gripLineWidth, height: gripLineHeight)
+                }
+            }
+        }
+        .scaleEffect(isDragging ? 1.05 : 1.0)
+        .animation(.easeOut(duration: 0.15), value: isDragging)
+    }
+
+    // MARK: - Tick Marks
+
+    private func tickMarksView(trackWidth: CGFloat) -> some View {
+        let totalSteps = Int((range.upperBound - range.lowerBound) / step)
+        let maxTicks = 20
+        let tickStep = totalSteps > maxTicks ? totalSteps / maxTicks : 1
+        let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
+
+        return ZStack(alignment: .leading) {
+            ForEach(0...totalSteps, id: \.self) { i in
+                if i % tickStep == 0 {
+                    let tickFraction = Double(i) / Double(totalSteps)
+                    let tickX = trackWidth * tickFraction + thumbWidth / 2
+
+                    RoundedRectangle(cornerRadius: 0.5)
+                        .fill(tickFraction <= fraction ? VColor.accent.opacity(0.4) : Slate._600)
+                        .frame(width: tickMarkWidth, height: tickMarkHeight)
+                        .offset(x: tickX - tickMarkWidth / 2)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("VSlider") {
+    @Previewable @State var value1: Double = 50
+    @Previewable @State var value2: Double = 30
+    @Previewable @State var value3: Double = 5
+
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Default: \(Int(value1))")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                VSlider(value: $value1)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("With tick marks: \(Int(value2))")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                VSlider(value: $value2, range: 0...100, step: 5, showTickMarks: true)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Small range (1-10): \(Int(value3))")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                VSlider(value: $value3, range: 1...10, step: 1, showTickMarks: true)
+            }
+        }
+        .padding(VSpacing.xl)
+    }
+    .frame(width: 400, height: 300)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -6,6 +6,9 @@ struct InputsGallerySection: View {
     @State private var textEditorValue = ""
     @State private var minHeight: CGFloat = 80
     @State private var maxHeight: CGFloat = 200
+    @State private var sliderValue: Double = 50
+    @State private var sliderSteppedValue: Double = 25
+    @State private var sliderSmallValue: Double = 5
     @State private var toggleA: Bool = true
     @State private var toggleB: Bool = false
 
@@ -56,6 +59,41 @@ struct InputsGallerySection: View {
                             leadingIcon: "magnifyingglass",
                             trailingIcon: "xmark.circle"
                         )
+                    }
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSlider
+            GallerySectionHeader(
+                title: "VSlider",
+                description: "Custom slider with rounded capsule track, grip-line thumb, and optional tick marks."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Live value: \(Int(sliderValue))")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textMuted)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Default (0–100, step 1)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VSlider(value: $sliderValue)
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("With tick marks (0–100, step 5): \(Int(sliderSteppedValue))")
+                            .font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VSlider(value: $sliderSteppedValue, range: 0...100, step: 5, showTickMarks: true)
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Small range (1–10, step 1): \(Int(sliderSmallValue))")
+                            .font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VSlider(value: $sliderSmallValue, range: 1...10, step: 1, showTickMarks: true)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -152,8 +152,7 @@ struct ControlPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                Slider(value: $maxSteps, in: 1...100, step: 1)
-                    .tint(VColor.accent)
+                VSlider(value: $maxSteps, range: 1...100, step: 1)
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
Closes #1005.

## Summary
- New VSlider component (DesignSystem/Components/Inputs/VSlider.swift) with thick rounded capsule track, grip-line thumb, optional tick marks, and configurable range/step
- Updated InputsGallerySection with VSlider showcase (three variants with live value display)
- Updated ControlPanel to replace native Slider with VSlider for Max Steps setting

## Test plan
- [ ] Build succeeds: cd clients/macos && ./build.sh
- [ ] Open Component Gallery > Inputs section - VSlider renders correctly
- [ ] Drag VSlider thumb - value updates smoothly and snaps to step increments
- [ ] Open Control Panel > Settings - Max Steps slider uses VSlider
- [ ] Tick marks display correctly on filled/unfilled portions
- [ ] Thumb shows grip lines pattern and scales slightly on drag

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
