### PR TITLE
Move README and worktree script from scripts/ to .claude/

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,10 +1,20 @@
-# Scripts
+# Claude Code Configuration
 
-This directory contains automation commands for Claude Code and helper scripts for development workflows.
+This directory contains Claude Code slash commands, helper scripts, and documentation for development workflows.
 
 ## Utility Scripts
 
-### `vellum-runtime-tunnel.sh` — SSH tunnel for remote runtime access
+### `worktree` — Git worktree management
+
+Creates and removes isolated git worktrees for parallel development. Used by `/swarm`, `/do`, and `/blitz` commands.
+
+```bash
+.claude/worktree create feat/streaming
+.claude/worktree remove feat/streaming --delete-branch
+.claude/worktree list
+```
+
+### `scripts/vellum-runtime-tunnel.sh` — SSH tunnel for remote runtime access
 
 Forwards a local TCP port to a remote Vellum runtime HTTP server via SSH. Use this when running the web app in local mode against a remote assistant daemon.
 
@@ -17,9 +27,6 @@ scripts/vellum-runtime-tunnel.sh status
 
 # Print env vars for web local mode
 scripts/vellum-runtime-tunnel.sh print-env
-# Output:
-#   ASSISTANT_CONNECTION_MODE=local
-#   LOCAL_RUNTIME_URL=http://127.0.0.1:7821
 
 # Stop the tunnel
 scripts/vellum-runtime-tunnel.sh stop
@@ -27,7 +34,7 @@ scripts/vellum-runtime-tunnel.sh stop
 
 Options: `--local-port PORT` and `--remote-port PORT` (both default to 7821).
 
-## Automation Commands
+## Slash Commands
 
 Slash commands for Claude Code that automate development workflows. They live in `.claude/commands/` (committed to the repo) and manage a shared task list (`.private/TODO.md`), create PRs, merge them, and track review status.
 

--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -285,4 +285,4 @@ gh project view "$GH_PROJECT_NUMBER" --owner "$GH_PROJECT_OWNER" --format json |
 - Don't sleep for more than 15 seconds at a time while waiting for agents to finish.
 - If an agent reports failure, put the item back in TODO.md and note the failure.
 - If an agent hits merge conflicts, tell it to rebase: `git pull --rebase origin main`.
-- Use `scripts/worktree` for isolation (same as swarm).
+- Use `.claude/worktree` for isolation (same as swarm).

--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -21,7 +21,7 @@ Fetch the latest main and create the worktree based on `origin/main` so the bran
 
 ```bash
 git fetch origin main
-scripts/worktree create do/<slug> origin/main
+.claude/worktree create do/<slug> origin/main
 ```
 
 Remember the worktree path printed by the script. ALL work happens in the worktree — do NOT modify files in the main repo.
@@ -87,7 +87,7 @@ Change back to the main repo directory first (you may still be inside the worktr
 
 ```bash
 cd <main-repo>
-scripts/worktree remove do/<slug> --delete-branch
+.claude/worktree remove do/<slug> --delete-branch
 ```
 
 ### 8. Pull main

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -39,7 +39,7 @@ These are tasks to read review comments on an already-merged PR, then create a N
 
 For each task being handed off:
 
-1. Create a worktree: `scripts/worktree create swarm/task-<counter>`.
+1. Create a worktree: `.claude/worktree create swarm/task-<counter>`.
 2. Create a `TaskCreate` entry for tracking.
 3. Spawn a `general-purpose` agent via the `Task` tool with `team_name: "swarm"`. The prompt must include:
 
@@ -92,7 +92,7 @@ For "Address the feedback on <PR URL>" tasks:
 3. Mark the TaskCreate entry as completed.
 4. Increment the **completed count**.
 5. Send the agent a shutdown request.
-6. Remove the worktree: `scripts/worktree remove swarm/task-<counter> --delete-branch`.
+6. Remove the worktree: `.claude/worktree remove swarm/task-<counter> --delete-branch`.
 7. **Report to the user**: show the completed item, the PR link, a summary of what changed, and which files were modified. Don't abbreviate — give enough detail that the user understands what happened without clicking the PR.
 8. Remove the item from the in-flight list.
 9. Pull the latest main branch to ensure the worktree is up to date.

--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"  # .claude/ → repo root
 PARENT_DIR="$(dirname "$REPO_ROOT")"
 
 usage() {
-  echo "Usage: scripts/worktree <create|remove|list> [args]"
+  echo "Usage: .claude/worktree <create|remove|list> [args]"
   echo ""
   echo "Commands:"
   echo "  create <branch-name> [start-point]  Create a worktree + branch and install deps"
@@ -17,10 +17,10 @@ usage() {
   echo "  --no-delete-branch   Never delete the branch (no prompt)"
   echo ""
   echo "Examples:"
-  echo "  scripts/worktree create feat/streaming"
-  echo "  scripts/worktree remove feat/streaming"
-  echo "  scripts/worktree remove feat/streaming --delete-branch"
-  echo "  scripts/worktree list"
+  echo "  .claude/worktree create feat/streaming"
+  echo "  .claude/worktree remove feat/streaming"
+  echo "  .claude/worktree remove feat/streaming --delete-branch"
+  echo "  .claude/worktree list"
 }
 
 create() {

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dist
 *.pem
 .claude/*
 !.claude/commands/
+!.claude/README.md
+!.claude/worktree
 .private/
 temp.sh
 context.md


### PR DESCRIPTION
## Summary
- Moved `scripts/README.md` → `.claude/README.md` and `scripts/worktree` → `.claude/worktree` to colocate with slash commands
- Updated all references in `swarm.md`, `do.md`, `blitz.md` from `scripts/worktree` → `.claude/worktree`
- Added `.gitignore` exemptions for `.claude/README.md` and `.claude/worktree`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
