### PR TITLE
Fix VSlider snap math and filled track overflow

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -52,7 +52,7 @@ struct VSlider: View {
                         let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
-                        value = round(rawValue / step) * step
+                        value = range.lowerBound + round((rawValue - range.lowerBound) / step) * step
                         value = min(max(value, range.lowerBound), range.upperBound)
                     }
                     .onEnded { _ in
@@ -76,7 +76,7 @@ struct VSlider: View {
             // Filled track
             Capsule()
                 .fill(VColor.accent)
-                .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
+                .frame(width: thumbOffset, height: trackHeight)
                 .padding(.leading, thumbWidth / 2)
         }
     }


### PR DESCRIPTION
## Summary
- Fix snap calculation to be relative to `range.lowerBound` so non-zero-based ranges (e.g. `1...10, step: 2`) correctly snap to `1,3,5,7,9` instead of `2,4,6,8,10`
- Fix filled track capsule width overflow at max value by removing the extra `thumbWidth / 2` offset that caused the accent track to extend past the unfilled track

## Test plan
- [ ] Drag VSlider with `range: 1...10, step: 2` and verify values snap to 1, 3, 5, 7, 9
- [ ] Drag VSlider to max value and verify filled track does not extend beyond the unfilled track
- [ ] Verify standard `0...100` slider still works correctly

Addresses review feedback from PR #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
