### PR TITLE
Fix SSH tunnel PID detection, quoting, and validation

### DIFF
--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -33,10 +33,16 @@ read_pid() {
   fi
 }
 
+is_tunnel_process() {
+  local pid="$1"
+  # Verify the PID is an ssh process to avoid acting on reused PIDs
+  ps -p "$pid" -o comm= 2>/dev/null | grep -q '^ssh$'
+}
+
 is_running() {
   local pid
   pid=$(read_pid)
-  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && is_tunnel_process "$pid"
 }
 
 cmd_start() {
@@ -73,20 +79,20 @@ cmd_start() {
   ensure_dir
 
   echo "Starting SSH tunnel: localhost:${local_port} -> ${ssh_host}:${remote_port} ..."
-  ssh -f -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host"
+  ssh -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host" &
+  local pid=$!
 
-  # Find the ssh process we just spawned
-  local pid
-  pid=$(pgrep -f "ssh.*-L.*127.0.0.1:${local_port}:127.0.0.1:${remote_port}.*${ssh_host}" | tail -1)
-  if [[ -z "$pid" ]]; then
-    die "failed to find SSH tunnel process"
+  # Verify the SSH process is still alive after a brief pause
+  sleep 1
+  if ! kill -0 "$pid" 2>/dev/null; then
+    die "SSH tunnel process exited immediately"
   fi
 
   echo "$pid" > "$PID_FILE"
   cat > "$INFO_FILE" <<EOINFO
-LOCAL_PORT=${local_port}
-REMOTE_PORT=${remote_port}
-SSH_HOST=${ssh_host}
+LOCAL_PORT="${local_port}"
+REMOTE_PORT="${remote_port}"
+SSH_HOST="${ssh_host}"
 EOINFO
 
   echo "Tunnel running (PID ${pid})"


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #726:

- **Replace pgrep-based PID detection with `$!`**: The old approach used `ssh -f` then `pgrep -f` with a regex to find the process, which was racy and could capture the wrong PID. Now uses `ssh ... &` with `$!` to capture the exact PID directly.
- **Quote values in INFO_FILE**: Values written to `~/.vellum/runtime-tunnel.info` are now double-quoted to prevent code injection when the file is sourced in `cmd_print_env`.
- **Validate PID belongs to SSH before acting on it**: Added `is_tunnel_process()` which checks via `ps` that the stored PID is still an `ssh` process. This prevents `stop` from killing unrelated processes if the PID was reused after a reboot, and prevents `is_running` from falsely reporting a tunnel as active.

## Test plan
- [ ] Run `vellum-runtime-tunnel.sh start <host>` and verify PID file contains the correct ssh process
- [ ] Verify `vellum-runtime-tunnel.sh status` correctly identifies running tunnel
- [ ] Verify `vellum-runtime-tunnel.sh stop` only kills the ssh tunnel process
- [ ] Verify `print-env` works correctly with quoted values in INFO_FILE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
