### PR TITLE
Fix suggestion staleness: guard messageId mismatch in text-search loop

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -262,6 +262,15 @@ export class RuntimeHttpServer {
       const text = rendered.text.trim();
       if (!text) continue;
 
+      // If a messageId was requested and the first text-bearing assistant
+      // message is a *different* message, the request is stale.  This
+      // prevents returning a suggestion for an older assistant turn when
+      // the latest turn was a tool-only message (empty text) that passed
+      // the pre-check above.
+      if (requestedMessageId && msg.id !== requestedMessageId) {
+        return Response.json({ suggestion: null, messageId: null, source: 'none' as const, stale: true });
+      }
+
       // Return cached suggestion if we already generated one for this message
       const cached = this.suggestionCache.get(msg.id);
       if (cached !== undefined) {


### PR DESCRIPTION
## Summary
- Addresses feedback on #698: when the latest assistant turn is tool-only (no text), the staleness pre-check passes but the text-search loop walks back to an older assistant message and returns a suggestion for the wrong messageId.
- Adds a guard inside the text-search loop that returns `stale: true` if the found message's ID doesn't match the `requestedMessageId`.

## Test plan
- [ ] Verify that requesting a suggestion with a `messageId` matching a tool-only (empty text) latest assistant turn returns `stale: true` instead of a suggestion from an older turn.
- [ ] Verify that requesting a suggestion with a `messageId` matching a text-bearing latest assistant turn still works normally.
- [ ] Verify that requests without a `messageId` continue to work as before.

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
