### PR TITLE
Fix persistUserMessage cleanup on DB failure

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -302,8 +302,6 @@ export class Session {
     this.processing = true;
     this.abortController = new AbortController();
 
-    let userMessageId = '';
-
     const userMessage = createUserMessage(content, attachments.map((attachment) => ({
       id: attachment.id,
       filename: attachment.filename,
@@ -312,21 +310,26 @@ export class Session {
       extractedText: attachment.extractedText,
     })));
     this.messages.push(userMessage);
-    const persistedUserMessage = conversationStore.addMessage(
-      this.conversationId,
-      'user',
-      JSON.stringify(userMessage.content),
-    );
-    userMessageId = persistedUserMessage.id;
 
-    if (!userMessageId) {
+    try {
+      const persistedUserMessage = conversationStore.addMessage(
+        this.conversationId,
+        'user',
+        JSON.stringify(userMessage.content),
+      );
+
+      if (!persistedUserMessage.id) {
+        throw new Error('Failed to persist user message');
+      }
+
+      return persistedUserMessage.id;
+    } catch (err) {
+      this.messages.pop();
       this.processing = false;
       this.abortController = null;
       this.currentRequestId = undefined;
-      throw new Error('Failed to persist user message');
+      throw err;
     }
-
-    return userMessageId;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Wraps `conversationStore.addMessage()` in `try/catch` inside `persistUserMessage` so that a DB error properly resets session state (`processing`, `abortController`, `currentRequestId`) instead of leaving the session permanently stuck as "already processing".
- Pops the already-pushed user message from `this.messages` on failure to prevent orphaned entries from corrupting conversation history.

Addresses review feedback from PR #722.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that if `conversationStore.addMessage()` throws, the session can still accept new messages
- [ ] Confirm that a failed persistence does not leave an orphan user message in `this.messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
