### PR TITLE
Fix recall marker stripping to remove last matching block

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -552,6 +552,30 @@ describe('Memory V2 regressions', () => {
     expect(cleaned[2]).toEqual(originalUserTail);
   });
 
+  test('recall stripping removes last matching block in merged content after deep-repair', () => {
+    const memoryRecallText = '[Memory Recall v1]\n- [item:abc] user prefers concise answers';
+    // Simulate deep-repair merging two consecutive user messages where both
+    // contain the recall text. The injected (active) recall block is the last one.
+    const mergedUserMessage = {
+      role: 'user' as const,
+      content: [
+        { type: 'text', text: memoryRecallText },
+        { type: 'text', text: 'Earlier user request' },
+        { type: 'text', text: memoryRecallText },
+        { type: 'text', text: 'Latest user request' },
+      ],
+    };
+
+    const cleaned = stripMemoryRecallMessages([mergedUserMessage], memoryRecallText);
+    expect(cleaned).toHaveLength(1);
+    // The last (active) recall block should be stripped, the first (leaked) one preserved
+    expect(cleaned[0].content).toEqual([
+      { type: 'text', text: memoryRecallText },
+      { type: 'text', text: 'Earlier user request' },
+      { type: 'text', text: 'Latest user request' },
+    ]);
+  });
+
   test('aborting memory recall embedding returns a non-degraded aborted recall result', async () => {
     const originalFetch = globalThis.fetch;
     const controller = new AbortController();

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -187,9 +187,14 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
     if (message.role !== 'user' || message.content.length === 0) continue;
-    const foundBlock = message.content.findIndex(
-      (block) => block.type === 'text' && block.text === recallText,
-    );
+    let foundBlock = -1;
+    for (let bi = message.content.length - 1; bi >= 0; bi--) {
+      const block = message.content[bi];
+      if (block.type === 'text' && block.text === recallText) {
+        foundBlock = bi;
+        break;
+      }
+    }
     if (foundBlock !== -1) {
       targetIndex = index;
       blockIndex = foundBlock;


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #703: `findIndex` was stripping the **first** matching recall block, but after `deepRepairHistory` merges consecutive user messages, the injected recall block is typically **later** in the merged content array.
- Changed to a reverse search (manual loop since ES2022 target lacks `findLastIndex`) so we strip the **last** (most recently injected) recall block, preserving any earlier occurrences that may be legitimate user content.
- Added a regression test that validates the correct block is stripped when duplicate recall text exists in merged content.

## Files modified
- `assistant/src/memory/retriever.ts` - Changed `findIndex` to reverse loop in `stripMemoryRecallMessages`
- `assistant/src/__tests__/memory-v2-regressions.test.ts` - Added test for last-match stripping behavior

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 19 memory-v2-regressions tests pass
- [x] New test validates that the last matching recall block is stripped, not the first
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
