### PR TITLE
Gate socket cleanup on isSocket() to prevent accidental deletion

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,10 +1,12 @@
 import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+
 import { resolve } from 'node:path';
 import {
   getSocketPath,
   getPidPath,
   ensureDataDir,
+  removeSocketFile,
 } from '../util/platform.js';
 import { initializeDb } from '../memory/db.js';
 import { rotateToolInvocations } from '../memory/tool-usage-store.js';
@@ -83,11 +85,9 @@ export async function startDaemon(): Promise<{
 
   ensureDataDir();
 
-  // Clean up stale socket
+  // Clean up stale socket (only if it's actually a Unix socket)
   const socketPath = getSocketPath();
-  if (existsSync(socketPath)) {
-    unlinkSync(socketPath);
-  }
+  removeSocketFile(socketPath);
 
   // Spawn the daemon as a detached child process
   const mainPath = resolve(

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
-import { unlinkSync, existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:fs';
+import { existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
-import { getSocketPath, getDataDir } from '../util/platform.js';
+import { getSocketPath, getDataDir, removeSocketFile } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -52,10 +52,8 @@ export class DaemonServer {
   }
 
   async start(): Promise<void> {
-    // Clean up stale socket
-    if (existsSync(this.socketPath)) {
-      unlinkSync(this.socketPath);
-    }
+    // Clean up stale socket (only if it's actually a Unix socket)
+    removeSocketFile(this.socketPath);
 
     this.startFileWatchers();
 
@@ -96,9 +94,7 @@ export class DaemonServer {
     const serverClosed = new Promise<void>((resolve) => {
       if (this.server) {
         this.server.close(() => {
-          if (existsSync(this.socketPath)) {
-            unlinkSync(this.socketPath);
-          }
+          removeSocketFile(this.socketPath);
           resolve();
         });
       } else {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync } from 'node:fs';
+import { mkdirSync, existsSync, statSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -49,6 +49,22 @@ function expandHomePath(p: string): string {
   if (p === '~') return homedir();
   if (p.startsWith('~/')) return join(homedir(), p.slice(2));
   return p;
+}
+
+/**
+ * Remove a socket file only if it is actually a Unix socket.
+ * Refuses to delete regular files, directories, etc. to prevent
+ * accidental data loss when VELLUM_DAEMON_SOCKET points to a non-socket path.
+ */
+export function removeSocketFile(socketPath: string): void {
+  if (!existsSync(socketPath)) return;
+  const stat = statSync(socketPath);
+  if (!stat.isSocket()) {
+    throw new Error(
+      `Refusing to remove ${socketPath}: not a Unix socket (found ${stat.isFile() ? 'regular file' : stat.isDirectory() ? 'directory' : 'non-socket'})`,
+    );
+  }
+  unlinkSync(socketPath);
 }
 
 export function getPidPath(): string {


### PR DESCRIPTION
## Summary

Addresses review feedback on #728: the `VELLUM_DAEMON_SOCKET` override allows pointing at arbitrary paths, but the daemon unconditionally calls `unlinkSync` on that path during startup/shutdown cleanup. A typo or inherited env var (e.g. `/home/user/.bashrc`) would delete a real file.

- Added `removeSocketFile()` to `platform.ts` that checks `statSync().isSocket()` before unlinking, and throws an error if the path is a non-socket file
- Updated `lifecycle.ts` (`startDaemon`) and `server.ts` (`start`/`stop`) to use `removeSocketFile()` instead of raw `unlinkSync`

## Test plan
- [ ] Set `VELLUM_DAEMON_SOCKET` to a regular file path, verify daemon refuses to start and does not delete the file
- [ ] Set `VELLUM_DAEMON_SOCKET` to a valid socket path, verify daemon starts and cleans up normally
- [ ] Verify default socket path (no env override) still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
