### PR TITLE
Fix toAuthErrorResponse: restore 404 for contacts and hide internal errors

### DIFF
--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -94,5 +94,8 @@ export function toAuthErrorResponse(error: unknown): NextResponse {
   if (message === "FORBIDDEN") {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-  return NextResponse.json({ error: message }, { status: 500 });
+  if (message === "Contact not found") {
+    return NextResponse.json({ error: "Contact not found" }, { status: 404 });
+  }
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 }


### PR DESCRIPTION
## Summary
- Restore the `"Contact not found"` -> 404 mapping that was lost when per-route `toErrorResponse` was replaced with the shared `toAuthErrorResponse` helper in PR #729. Without this, approve/block contact endpoints return 500 instead of 404 for missing contacts.
- Change the default fallback to return a generic `"Internal server error"` message instead of leaking raw error messages (e.g. database errors, stack traces) to API clients.

## Test plan
- [ ] Verify approve/block contact endpoints return 404 when contact ID is invalid
- [ ] Verify unrecognized errors return generic "Internal server error" instead of raw message
- [ ] Verify auth errors (NOT_FOUND, UNAUTHORIZED, FORBIDDEN) still map correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
