### PR TITLE
Handle legacy created_by values in assistants API

### DIFF
--- a/web/src/app/api/assistants/route.ts
+++ b/web/src/app/api/assistants/route.ts
@@ -16,7 +16,8 @@ export async function GET(request: Request) {
     }
 
     const sql = getDb();
-    const assistants = await sql`SELECT * FROM assistants WHERE created_by = ${user.id} ORDER BY created_at DESC`;
+    const identifiers = [user.id, user.username, user.name].filter(Boolean);
+    const assistants = await sql`SELECT * FROM assistants WHERE created_by = ANY(${identifiers}) ORDER BY created_at DESC`;
     return NextResponse.json(assistants as unknown as Assistant[]);
   } catch (error: unknown) {
     console.error("Error fetching assistants:", error);

--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -80,6 +80,17 @@ export async function requireAssistantOwner(
     return { assistant, user };
   }
 
+  // Backward compatibility: created_by may store a username or display name.
+  if (
+    createdBy &&
+    ((user.username && createdBy === user.username) ||
+      (user.name && createdBy === user.name))
+  ) {
+    // Migrate to canonical user ID for future lookups.
+    await sql`UPDATE assistants SET created_by = ${user.id} WHERE id = ${assistantId}`;
+    return { assistant, user };
+  }
+
   throw new Error("FORBIDDEN");
 }
 


### PR DESCRIPTION
## Summary
- **GET /api/assistants** now queries `WHERE created_by = ANY([user.id, user.username, user.name])` instead of only `user.id`, so legacy assistants where `created_by` stores a username or display name are no longer invisible.
- **requireAssistantOwner** now also checks `user.username` and `user.name` as fallbacks, and migrates `created_by` to the canonical user ID on match for future lookups.

Addresses feedback from PR #731.

## Test plan
- [ ] Verify a user with legacy assistants (created_by = username) can see them in the list
- [ ] Verify a user with legacy assistants (created_by = display name) can see them in the list
- [ ] Verify ownership checks pass for legacy assistants and created_by is migrated to user ID
- [ ] Verify new assistants continue to use user.id as created_by

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
