### PR TITLE
Fix socket path trimming to strip newlines

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -133,8 +133,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Accepts an optional environment dictionary for testability.
     static func resolveSocketPath(environment: [String: String]? = nil) -> String {
         let env = environment ?? ProcessInfo.processInfo.environment
-        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespaces).isEmpty {
-            let trimmed = envPath.trimmingCharacters(in: .whitespaces)
+        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.hasPrefix("~/") {
                 return NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
             }

--- a/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientSocketPathTests.swift
@@ -39,6 +39,18 @@ final class DaemonClientSocketPathTests: XCTestCase {
         XCTAssertEqual(path, NSHomeDirectory() + "/.vellum/vellum.sock")
     }
 
+    func testNewlinesAreTrimmed() {
+        let env = ["VELLUM_DAEMON_SOCKET": "/tmp/custom.sock\n"]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, "/tmp/custom.sock")
+    }
+
+    func testNewlineOnlyFallsBackToDefault() {
+        let env = ["VELLUM_DAEMON_SOCKET": "\n"]
+        let path = DaemonClient.resolveSocketPath(environment: env)
+        XCTAssertEqual(path, NSHomeDirectory() + "/.vellum/vellum.sock")
+    }
+
     func testNilEnvironmentUsesProcessInfo() {
         // When no environment is passed, it uses ProcessInfo.processInfo.environment.
         // We just verify it returns a non-empty string (the default path).


### PR DESCRIPTION
## Summary
- Changed `resolveSocketPath` to use `.whitespacesAndNewlines` instead of `.whitespaces` so that trailing `\n`/`\r` characters (common when env vars are read from files) are properly stripped before passing to `NWEndpoint.unix`.
- Aligns behavior with the CLI resolver (`assistant/src/util/platform.ts`) which uses `.trim()`.
- Added two test cases: one for trailing newline trimming, one for newline-only fallback to default.

Addresses review feedback on #737.

## Test plan
- [x] `testNewlinesAreTrimmed` — verifies `/tmp/custom.sock\n` resolves to `/tmp/custom.sock`
- [x] `testNewlineOnlyFallsBackToDefault` — verifies `\n` falls back to default path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
