### PR TITLE
Fix auth check order to prevent resource existence leaking

### DIFF
--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -61,6 +61,12 @@ export async function requireAssistantOwner(
   request: Request,
   assistantId: string
 ): Promise<{ assistant: Assistant; user: RequestUser }> {
+  // Authenticate before lookup to avoid leaking resource existence.
+  const user = await getRequestUser(request);
+  if (!user.id) {
+    throw new Error("UNAUTHORIZED");
+  }
+
   const sql = getDb();
   const result = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
   if (result.length === 0) {
@@ -68,10 +74,6 @@ export async function requireAssistantOwner(
   }
 
   const assistant = result[0] as Assistant & { created_by?: string | null };
-  const user = await getRequestUser(request);
-  if (!user.id) {
-    throw new Error("UNAUTHORIZED");
-  }
 
   const createdBy =
     assistant.created_by?.trim() || assistant.createdBy?.trim() || null;


### PR DESCRIPTION
## Summary
- Reorders `requireAssistantOwner` to authenticate the caller **before** performing the DB lookup, so unauthenticated users always receive `401` regardless of whether the assistant ID exists
- Previously the DB lookup ran first, allowing callers to distinguish existing vs non-existing assistants by observing `404` vs `401`
- This is a single shared function used by all ownership-gated routes, so the fix applies everywhere

Addresses review feedback on PR #734.

## Test plan
- [ ] Unauthenticated request with a valid assistant ID returns 401
- [ ] Unauthenticated request with an invalid assistant ID returns 401
- [ ] Authenticated non-owner request returns 404 (masks existence)
- [ ] Authenticated owner request succeeds as before

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
