### PR TITLE
Exclude RuntimeClientError from auth error check

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -113,7 +113,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
   } catch (error) {
     console.error("Error uploading attachments:", error);
-    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+    if (error instanceof Error && !(error instanceof RuntimeClientError) && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
     const status = error instanceof RuntimeClientError ? error.status : 500;
@@ -147,7 +147,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ deleted_ids: attachmentIds });
   } catch (error) {
     console.error("Error deleting attachments:", error);
-    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+    if (error instanceof Error && !(error instanceof RuntimeClientError) && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
     const status = error instanceof RuntimeClientError ? error.status : 500;

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error: unknown) {
     console.error("Error fetching messages:", error);
-    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+    if (error instanceof Error && !(error instanceof RuntimeClientError) && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
     const status = error instanceof RuntimeClientError ? error.status : 500;
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error: unknown) {
     console.error("Error sending message:", error);
-    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+    if (error instanceof Error && !(error instanceof RuntimeClientError) && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
     const status = error instanceof RuntimeClientError ? error.status : 500;


### PR DESCRIPTION
## Summary
- Adds `!(error instanceof RuntimeClientError)` guard to all four catch blocks in messages and attachments routes
- Prevents RuntimeClientError instances (whose message could match "NOT_FOUND", "UNAUTHORIZED", or "FORBIDDEN") from being misrouted to `toAuthErrorResponse` instead of the RuntimeClientError-specific handler
- Addresses review feedback on PR #736

## Files changed
- `web/src/app/api/assistants/[id]/messages/route.ts` (2 catch blocks)
- `web/src/app/api/assistants/[id]/attachments/route.ts` (2 catch blocks)

## Test plan
- [ ] Verify type-check passes (confirmed locally)
- [ ] Auth errors (NOT_FOUND, UNAUTHORIZED, FORBIDDEN) from `requireAssistantOwner` still route to `toAuthErrorResponse`
- [ ] RuntimeClientError with matching message strings now correctly handled by the RuntimeClientError branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
