### PR TITLE
Fix run orchestrator error propagation, ownership checks, and stale callback

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -492,13 +492,13 @@ export class RuntimeHttpServer {
     }
   }
 
-  private handleGetRun(_assistantId: string, runId: string): Response {
+  private handleGetRun(assistantId: string, runId: string): Response {
     if (!this.runOrchestrator) {
       return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
     }
 
     const run = this.runOrchestrator.getRun(runId);
-    if (!run) {
+    if (!run || run.assistantId !== assistantId) {
       return Response.json({ error: 'Run not found' }, { status: 404 });
     }
 
@@ -513,9 +513,15 @@ export class RuntimeHttpServer {
     });
   }
 
-  private async handleRunDecision(_assistantId: string, runId: string, req: Request): Promise<Response> {
+  private async handleRunDecision(assistantId: string, runId: string, req: Request): Promise<Response> {
     if (!this.runOrchestrator) {
       return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
+    }
+
+    // Verify the run belongs to this assistant before applying a decision
+    const run = this.runOrchestrator.getRun(runId);
+    if (!run || run.assistantId !== assistantId) {
+      return Response.json({ error: 'Run not found' }, { status: 404 });
     }
 
     const body = await req.json() as { decision?: string };

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -81,9 +81,13 @@ export class RunOrchestrator {
     const messageId = session.persistUserMessage(content, attachments, requestId);
     const run = runsStore.createRun(assistantId, conversationId, messageId);
 
-    // Hook into session to intercept confirmation_request events.
-    // When the prompter sends one, we record it in the run store so
-    // the web UI can poll and submit a decision.
+    // Hook into session to intercept confirmation_request and error events.
+    // When the prompter sends a confirmation_request, we record it in the
+    // run store so the web UI can poll and submit a decision.
+    // We also track error events because session.runAgentLoop catches
+    // internal errors and resolves normally — without tracking these,
+    // the run would be marked as completed even when errors occurred.
+    let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
         runsStore.setRunConfirmation(run.id, {
@@ -96,18 +100,32 @@ export class RunOrchestrator {
           prompterRequestId: msg.requestId,
           session,
         });
+      } else if (msg.type === 'error') {
+        lastError = msg.message;
       }
     });
 
     // Fire-and-forget the agent loop
-    session.runAgentLoop(content, messageId, () => {}).then(() => {
-      runsStore.completeRun(run.id);
+    const cleanup = () => {
       this.pending.delete(run.id);
+      // Reset the session's client callback to a no-op so the stale
+      // closure doesn't intercept events from future runs on the same session.
+      session.updateClient(() => {});
+    };
+
+    session.runAgentLoop(content, messageId, () => {}).then(() => {
+      if (lastError) {
+        log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
+        runsStore.failRun(run.id, lastError);
+      } else {
+        runsStore.completeRun(run.id);
+      }
+      cleanup();
     }).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, runId: run.id }, 'Run failed');
       runsStore.failRun(run.id, message);
-      this.pending.delete(run.id);
+      cleanup();
     });
 
     return run;


### PR DESCRIPTION
## Summary
- **Error propagation**: Track `error` events emitted by `session.runAgentLoop` via the `updateClient` callback. Since `runAgentLoop` catches internal errors and resolves normally, the `.then()` handler now checks for captured errors and marks the run as `failed` instead of `completed`.
- **Ownership checks**: Validate that `run.assistantId` matches the URL's `assistantId` in both `handleGetRun` and `handleRunDecision` to prevent cross-assistant state reads and mutations.
- **Stale callback cleanup**: Reset the session's `updateClient` to a no-op after run completion (in both `.then()` and `.catch()`) so the captured `run.id` closure doesn't corrupt completed runs when the session is reused.

Addresses review feedback on #733.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that a run whose agent loop emits an error event is marked `failed`, not `completed`
- [ ] Verify GET `/runs/:id` returns 404 when the run belongs to a different assistant
- [ ] Verify POST `/runs/:id/decision` returns 404 when the run belongs to a different assistant
- [ ] Verify that after a run completes, reusing the same session does not corrupt the completed run's state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
