### PR TITLE
Fix RuntimeClientError status code and sanitized URL in fetch catch

### DIFF
--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -32,7 +32,7 @@ function sanitizeUrl(url: string): string {
     const parsed = new URL(url);
     parsed.username = "";
     parsed.password = "";
-    return `${parsed.protocol}//${parsed.host}`;
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
   } catch {
     return url.replace(/\/\/[^@]*@/, "//[REDACTED]@");
   }
@@ -71,9 +71,9 @@ export function createRuntimeClient(
         headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
       });
     } catch (err) {
-      const sanitized = sanitizeUrl(baseUrl);
+      const sanitized = sanitizeUrl(prefix);
       throw new RuntimeClientError(
-        0,
+        502,
         `Failed to connect to runtime at ${sanitized}${path}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #732 (remote mode diagnostics):

- **Fix invalid status code**: Changed `RuntimeClientError` status from `0` to `502` (Bad Gateway) for fetch connection errors. Status `0` is outside the valid HTTP range (200-599) and causes a `RangeError` when API route handlers pass it to `NextResponse`.
- **Fix wrong URL in error message**: Changed `sanitizeUrl(baseUrl)` to `sanitizeUrl(prefix)` so the error message includes the full path (`/v1/assistants/:id/...`) instead of just the host.
- **Preserve pathname in sanitizeUrl**: Updated `sanitizeUrl` to include `parsed.pathname` so path components aren't stripped when sanitizing.

## Files modified
- `web/src/lib/runtime/client.ts`

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- Verified that API routes (e.g. health, messages, suggestion) use `error.status` as the response status code, confirming the 502 fix prevents `RangeError`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
