### PR TITLE
Fix invalid HTTP status when runtime is unreachable

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to upload attachments" },
       { status },
@@ -150,7 +150,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to delete attachments" },
       { status },

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to fetch messages" },
       { status },
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to send message" },
       { status },

--- a/web/src/app/api/assistants/[id]/runs/[runId]/decision/route.ts
+++ b/web/src/app/api/assistants/[id]/runs/[runId]/decision/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(result);
   } catch (error: unknown) {
     console.error("Error submitting run decision:", error);
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to submit decision" },
       { status },

--- a/web/src/app/api/assistants/[id]/runs/[runId]/route.ts
+++ b/web/src/app/api/assistants/[id]/runs/[runId]/route.ts
@@ -30,7 +30,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(result);
   } catch (error: unknown) {
     console.error("Error fetching run:", error);
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to fetch run" },
       { status },

--- a/web/src/app/api/assistants/[id]/runs/route.ts
+++ b/web/src/app/api/assistants/[id]/runs/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(result, { status: 201 });
   } catch (error: unknown) {
     console.error("Error creating run:", error);
-    const status = error instanceof RuntimeClientError ? error.status : 500;
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
     return NextResponse.json(
       { error: "Failed to create run" },
       { status },

--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -46,6 +46,11 @@ export class RuntimeClientError extends Error {
     super(message);
     this.name = "RuntimeClientError";
   }
+
+  /** Return a status safe to use in an HTTP response (200–599). Connection failures set status to 0, which is invalid. */
+  get httpStatus(): number {
+    return this.status >= 200 && this.status <= 599 ? this.status : 502;
+  }
 }
 
 export function createRuntimeClient(


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #738: `RuntimeClientError.status` is set to `0` for connection failures (runtime down/unreachable), but `NextResponse.json` only accepts status codes 200-599, causing the error handler itself to throw.
- Added an `httpStatus` getter to `RuntimeClientError` that normalizes invalid status codes to `502` (Bad Gateway).
- Updated all 7 route error handlers to use `error.httpStatus` instead of `error.status`.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit` in `web/`)
- [ ] Simulate runtime being down and confirm endpoints return `502` with structured JSON error instead of crashing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
