### PR TITLE
Defer auth error mapping until after RuntimeClientError check

### DIFF
--- a/web/src/app/api/assistants/[id]/attachments/route.ts
+++ b/web/src/app/api/assistants/[id]/attachments/route.ts
@@ -113,13 +113,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ attachments: createdAttachments }, { status: 201 });
   } catch (error) {
     console.error("Error uploading attachments:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: error.message || "Failed to upload attachments" },
+        { status: error.status },
+      );
+    }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to upload attachments" },
-      { status },
+      { status: 500 },
     );
   }
 }
@@ -147,13 +152,18 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ deleted_ids: attachmentIds });
   } catch (error) {
     console.error("Error deleting attachments:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to delete attachments" },
+        { status: error.status },
+      );
+    }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to delete attachments" },
-      { status },
+      { status: 500 },
     );
   }
 }

--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -25,12 +25,8 @@ export async function GET(request: Request, { params }: RouteParams) {
       connectionMode: mode,
     });
   } catch (error: unknown) {
-    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
-      return toAuthErrorResponse(error);
-    }
-    console.error("Error checking assistant health:", error);
-
     if (error instanceof RuntimeClientError) {
+      console.error("Error checking assistant health:", error);
       return NextResponse.json(
         {
           status: "unhealthy",
@@ -39,6 +35,10 @@ export async function GET(request: Request, { params }: RouteParams) {
         { status: error.status },
       );
     }
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
+    console.error("Error checking assistant health:", error);
 
     return NextResponse.json(
       {

--- a/web/src/app/api/assistants/[id]/messages/route.ts
+++ b/web/src/app/api/assistants/[id]/messages/route.ts
@@ -45,13 +45,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error: unknown) {
     console.error("Error fetching messages:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to fetch messages" },
+        { status: error.status },
+      );
+    }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to fetch messages" },
-      { status },
+      { status: 500 },
     );
   }
 }
@@ -90,13 +95,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error: unknown) {
     console.error("Error sending message:", error);
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to send message" },
+        { status: error.status },
+      );
+    }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
       return toAuthErrorResponse(error);
     }
-    const status = error instanceof RuntimeClientError ? error.status : 500;
     return NextResponse.json(
       { error: "Failed to send message" },
-      { status },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Reorders catch blocks in health, messages, and attachments routes to check for `RuntimeClientError` before checking auth error messages
- Prevents `RuntimeClientError` instances with response body messages like `NOT_FOUND`, `UNAUTHORIZED`, or `FORBIDDEN` from being misclassified as auth/ownership errors
- Addresses review feedback on PR #739

## Details
`RuntimeClientError` extends `Error` and sets its `message` to the raw HTTP response body. If a runtime returns a non-2xx response with body content matching one of the auth error strings, the previous ordering would route it through `toAuthErrorResponse()` instead of the intended runtime error path (e.g., "Runtime health check returned <status>").

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify health route returns runtime error response (not auth error) when runtime returns 404/401/403
- [ ] Verify auth errors from `requireAssistantOwner` are still correctly mapped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
