### PR TITLE
Fix .env.example socket placeholder to avoid accidental autostart override

### DIFF
--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -11,7 +11,7 @@ OLLAMA_BASE_URL=
 
 # Override the daemon socket path (default: ~/.vellum/vellum.sock).
 # Use this to target a forwarded or remote socket.
-# VELLUM_DAEMON_SOCKET=~/.vellum/vellum.sock
+# VELLUM_DAEMON_SOCKET=/path/to/remote/vellum.sock
 
 # Control daemon autostart behavior.
 # When VELLUM_DAEMON_SOCKET is set, autostart is disabled by default.


### PR DESCRIPTION
## Summary
- Changed `VELLUM_DAEMON_SOCKET` example value from `~/.vellum/vellum.sock` (the default path) to `/path/to/remote/vellum.sock` (a clearly non-default placeholder)
- Addresses PR #740 review feedback: uncommenting the old example would set `hasSocketOverride` to true, disabling daemon autostart even though the effective socket path was unchanged

## Test plan
- [ ] Verify `.env.example` shows a non-default placeholder path for `VELLUM_DAEMON_SOCKET`

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
