### PR TITLE
Fail backfill on NULL/empty created_by before NOT NULL migration

### DIFF
--- a/web/scripts/backfill-created-by.ts
+++ b/web/scripts/backfill-created-by.ts
@@ -23,13 +23,28 @@ async function main() {
   const sql = postgres(connectionString);
 
   try {
+    // Check for assistants with NULL or empty created_by — these must be
+    // resolved before the NOT NULL constraint can be applied.
+    const nullOrEmpty = await sql`
+      SELECT id FROM assistants
+      WHERE created_by IS NULL OR created_by = ''
+    `;
+
+    if (nullOrEmpty.length > 0) {
+      const ids = nullOrEmpty.map((r) => r.id as string);
+      console.error(
+        `ERROR: ${nullOrEmpty.length} assistant(s) have NULL or empty created_by.\n` +
+        `These must be resolved before applying the NOT NULL constraint.\n` +
+        `Assistant IDs: ${ids.join(", ")}`
+      );
+      process.exit(1);
+    }
+
     // Find assistants whose created_by is not already a user.id
     const nonCanonical = await sql`
       SELECT a.id, a.created_by
       FROM assistants a
-      WHERE a.created_by IS NOT NULL
-        AND a.created_by != ''
-        AND NOT EXISTS (
+      WHERE NOT EXISTS (
           SELECT 1 FROM "user" u WHERE u.id = a.created_by
         )
     `;


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #744: the backfill script silently skipped assistants with NULL or empty `created_by`, which would cause the `NOT NULL` constraint migration to fail
- Added an upfront check that detects NULL/empty rows and exits with a clear error listing the affected assistant IDs
- Simplified the main canonicalization query since the NULL/empty guard now runs first

## Test plan
- [ ] Run script against a test DB with NULL `created_by` rows -- verify it exits with error listing IDs
- [ ] Run script against a test DB with no NULL rows -- verify it proceeds with canonicalization as before

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
