### PR TITLE
Fix isLoading stuck forever in InteractionTab

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -352,7 +352,13 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
     const poll = async () => {
       try {
         const res = await fetch(`/api/assistants/${assistantId}/runs/${activeRunId}`);
-        if (!res.ok || cancelled) return;
+        if (cancelled) return;
+        if (!res.ok) {
+          setActiveRunId(null);
+          setIsLoading(false);
+          await fetchMessages();
+          return;
+        }
         const run = await res.json() as {
           status: string;
           pendingConfirmation?: PendingRunConfirmation | null;
@@ -659,6 +665,9 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
         const data = await response.json() as { id?: string };
         if (data.id) {
           setActiveRunId(data.id);
+        } else {
+          setIsLoading(false);
+          await fetchMessages();
         }
         setPendingAttachments((prev) => prev.filter((attachment) => !attachmentIds.includes(attachment.attachmentId || "")));
       } catch (error) {


### PR DESCRIPTION
## Summary
- When POST `/runs` response lacks an `id`, add fallback to reset `isLoading` and fetch messages so the composer doesn't get permanently blocked.
- When run polling returns a non-OK response (e.g. 404 after assistant switch), reset `activeRunId` and `isLoading` instead of silently returning, preventing the composer from getting stuck.

Addresses review feedback from #745.

## Test plan
- [ ] Send a message where the `/runs` endpoint returns a response without an `id` field — verify the loading state clears and messages refresh.
- [ ] Switch assistants while a run is in progress — verify the composer becomes usable again after the poll 404s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
