### PR TITLE
Add persistent readline history for CLI

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -1,6 +1,7 @@
 import * as net from 'node:net';
 import * as readline from 'node:readline';
-import { getSocketPath } from './util/platform.js';
+import { readFileSync, appendFileSync } from 'node:fs';
+import { getSocketPath, getHistoryPath } from './util/platform.js';
 import {
   serialize,
   createMessageParser,
@@ -93,9 +94,22 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     }
   }
 
+  const historyPath = getHistoryPath();
+  let savedHistory: string[] = [];
+  try {
+    savedHistory = readFileSync(historyPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .reverse();
+  } catch {
+    // No history file yet — start fresh
+  }
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
+    history: savedHistory,
+    historySize: 1000,
   });
 
   function prompt(): void {
@@ -671,6 +685,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     if (pendingSessionPick) return;
     if (pendingConfirmation) return;
     if (reconnecting) return;
+
+    // Persist to history file
+    try { appendFileSync(historyPath, content + '\n'); } catch { /* ignore */ }
 
     if (content === '/copy') {
       if (!lastResponse) {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -79,6 +79,10 @@ export function getLogPath(): string {
   return join(getDataDir(), 'logs', 'vellum.log');
 }
 
+export function getHistoryPath(): string {
+  return join(getDataDir(), 'history');
+}
+
 export function ensureDataDir(): void {
   const base = getDataDir();
   const dirs = [


### PR DESCRIPTION
## Summary
- Loads command history from `~/.vellum/history` on startup and passes it to Node's `readline.createInterface({ history })` for up/down arrow recall
- Appends each non-empty input line to the history file for persistence across sessions
- Adds `getHistoryPath()` helper to `platform.ts`
- History capped at 1000 entries in-memory

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test cli.test.ts` — 3/3 pass
- [ ] Manual: start CLI, type a few messages, restart CLI, press up arrow → previous messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
