### PR TITLE
Move background image inside ChatView for visibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -17,13 +17,21 @@ struct ChatView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            messageList
-            if let errorText {
-                errorBanner(errorText)
+        ZStack(alignment: .bottom) {
+            Image("bg", bundle: .module)
+                .resizable()
+                .scaledToFit()
+                .opacity(0.3)
+                .allowsHitTesting(false)
+
+            VStack(spacing: 0) {
+                messageList
+                if let errorText {
+                    errorBanner(errorText)
+                }
+                queueSummary
+                composerArea
             }
-            queueSummary
-            composerArea
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -45,13 +45,6 @@ struct MainWindowView: View {
             }, panel: {
                 panelContent
             })
-            .background(alignment: .bottom) {
-                Image("bg", bundle: .module)
-                    .resizable()
-                    .scaledToFill()
-                    .clipped()
-                    .allowsHitTesting(false)
-            }
         }
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)


### PR DESCRIPTION
## Summary
- Moved the `bg.png` background image from a `.background()` modifier on `VSplitView` (in `MainWindowView`) into a `ZStack` layer inside `ChatView`
- The image was invisible because macOS's `NSScrollView` (backing SwiftUI's `ScrollView`) renders an opaque layer that covers `.background()` content placed behind it
- Image is now bottom-aligned with 30% opacity so it blends with the dark theme without obscuring chat content

## Test plan
- [ ] Build and run the app
- [ ] Verify the background image (pixel art creature) is visible at the bottom of the chat area
- [ ] Verify messages render correctly on top of the image
- [ ] Verify the image doesn't interfere with scrolling or clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
