### PR TITLE
Add skills_list and skill_detail IPC protocol + handlers (#1036)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
@@ -160,6 +160,19 @@ exports[`IPC message snapshots ClientMessage types app_data_request serializes t
   "method": "query",
   "surfaceId": "surface-001",
   "type": "app_data_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_list serializes to expected JSON 1`] = `
+{
+  "type": "skills_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skill_detail serializes to expected JSON 1`] = `
+{
+  "skillId": "my-skill",
+  "type": "skill_detail",
 }
 `;
 
@@ -521,6 +534,31 @@ exports[`IPC message snapshots ServerMessage types app_data_response serializes 
   "success": true,
   "surfaceId": "surface-001",
   "type": "app_data_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_list_response serializes to expected JSON 1`] = `
+{
+  "skills": [
+    {
+      "description": "A test skill",
+      "id": "my-skill",
+      "name": "My Skill",
+    },
+  ],
+  "type": "skills_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skill_detail_response serializes to expected JSON 1`] = `
+{
+  "body": 
+"# Skill content
+
+Do the thing."
+,
+  "skillId": "my-skill",
+  "type": "skill_detail_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -118,6 +118,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     method: 'query',
     appId: 'app-001',
   },
+  skills_list: {
+    type: 'skills_list',
+  },
+  skill_detail: {
+    type: 'skill_detail',
+    skillId: 'my-skill',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -336,6 +343,17 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     callId: 'call-001',
     success: true,
     result: [{ id: 'rec-001', appId: 'app-001', data: { name: 'Test' }, createdAt: 1700000000, updatedAt: 1700000000 }],
+  },
+  skills_list_response: {
+    type: 'skills_list_response',
+    skills: [
+      { id: 'my-skill', name: 'My Skill', description: 'A test skill' },
+    ],
+  },
+  skill_detail_response: {
+    type: 'skill_detail_response',
+    skillId: 'my-skill',
+    body: '# Skill content\n\nDo the thing.',
   },
   message_queued: {
     type: 'message_queued',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -25,7 +25,10 @@ import type {
   CuObservation,
   TaskSubmit,
   AppDataRequest,
+  SkillsListRequest,
+  SkillDetailRequest,
 } from './ipc-protocol.js';
+import { loadSkillCatalog, loadSkillBySelector } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
@@ -223,6 +226,8 @@ const handlers: DispatchMap = {
   ambient_observation: handleAmbientObservation,
   task_submit: handleTaskSubmit,
   app_data_request: handleAppDataRequest,
+  skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
+  skill_detail: handleSkillDetail,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -567,6 +572,38 @@ function handleUsageRequest(
     estimatedCost: conversation.totalEstimatedCost,
     model: config.model,
   });
+}
+
+// ─── Skills handlers ─────────────────────────────────────────────────────────
+
+function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
+  const catalog = loadSkillCatalog();
+  ctx.send(socket, {
+    type: 'skills_list_response',
+    skills: catalog.map((s) => ({ id: s.id, name: s.name, description: s.description })),
+  });
+}
+
+function handleSkillDetail(
+  msg: SkillDetailRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const result = loadSkillBySelector(msg.skillId);
+  if (result.skill) {
+    ctx.send(socket, {
+      type: 'skill_detail_response',
+      skillId: result.skill.id,
+      body: result.skill.body,
+    });
+  } else {
+    ctx.send(socket, {
+      type: 'skill_detail_response',
+      skillId: msg.skillId,
+      body: '',
+      error: result.error ?? 'Skill not found',
+    });
+  }
 }
 
 // ─── App data handler ────────────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -139,6 +139,15 @@ export interface AppDataRequest {
   data?: Record<string, unknown>;
 }
 
+export interface SkillsListRequest {
+  type: 'skills_list';
+}
+
+export interface SkillDetailRequest {
+  type: 'skill_detail';
+  skillId: string;
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -239,7 +248,9 @@ export type ClientMessage =
   | AmbientObservation
   | TaskSubmit
   | UiSurfaceAction
-  | AppDataRequest;
+  | AppDataRequest
+  | SkillsListRequest
+  | SkillDetailRequest;
 
 // === Server → Client messages ===
 
@@ -468,6 +479,18 @@ export interface AppDataResponse {
   error?: string;
 }
 
+export interface SkillsListResponse {
+  type: 'skills_list_response';
+  skills: Array<{ id: string; name: string; description: string }>;
+}
+
+export interface SkillDetailResponse {
+  type: 'skill_detail_response';
+  skillId: string;
+  body: string;
+  error?: string;
+}
+
 export interface MessageQueued {
   type: 'message_queued';
   sessionId: string;
@@ -573,6 +596,8 @@ export type ServerMessage =
   | UiSurfaceUpdate
   | UiSurfaceDismiss
   | AppDataResponse
+  | SkillsListResponse
+  | SkillDetailResponse
   | MessageQueued
   | MessageDequeued;
 


### PR DESCRIPTION
## Summary
- Add `SkillsListRequest`, `SkillDetailRequest`, `SkillsListResponse`, and `SkillDetailResponse` interfaces to `ipc-protocol.ts` and wire them into the `ClientMessage` and `ServerMessage` unions
- Implement `handleSkillsList` and `handleSkillDetail` handlers in `handlers.ts` that delegate to `loadSkillCatalog()` and `loadSkillBySelector()` from `config/skills.ts`
- Update IPC snapshot tests with the new message types

Closes #1036

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] IPC snapshot tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
