### PR TITLE
Add Swift IPC message types for skills catalog (#1037)

### DIFF
--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -206,6 +206,19 @@ struct AppDataRequestMessage: Encodable, Sendable {
     let data: [String: AnyCodable]?
 }
 
+/// Sent to request the list of available skills.
+/// Wire type: `"skills_list"`
+struct SkillsListRequestMessage: Encodable, Sendable {
+    let type: String = "skills_list"
+}
+
+/// Sent to request the full body of a specific skill.
+/// Wire type: `"skill_detail"`
+struct SkillDetailRequestMessage: Encodable, Sendable {
+    let type: String = "skill_detail"
+    let skillId: String
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -360,6 +373,27 @@ struct AppDataResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// A single skill summary item from the daemon's skill catalog.
+struct SkillSummaryItem: Decodable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    let description: String
+}
+
+/// Response containing the list of available skills.
+/// Wire type: `"skills_list_response"`
+struct SkillsListResponseMessage: Decodable, Sendable {
+    let skills: [SkillSummaryItem]
+}
+
+/// Response containing the full body of a specific skill.
+/// Wire type: `"skill_detail_response"`
+struct SkillDetailResponseMessage: Decodable, Sendable {
+    let skillId: String
+    let body: String
+    let error: String?
+}
+
 /// Permission confirmation request from daemon.
 /// Wire type: `"confirmation_request"`
 struct ConfirmationRequestMessage: Decodable, Sendable {
@@ -420,6 +454,8 @@ enum ServerMessage: Decodable, Sendable {
     case appDataResponse(AppDataResponseMessage)
     case messageQueued(MessageQueuedMessage)
     case messageDequeued(MessageDequeuedMessage)
+    case skillsListResponse(SkillsListResponseMessage)
+    case skillDetailResponse(SkillDetailResponseMessage)
     case pong
     case unknown(String)
 
@@ -489,6 +525,12 @@ enum ServerMessage: Decodable, Sendable {
         case "message_dequeued":
             let message = try MessageDequeuedMessage(from: decoder)
             self = .messageDequeued(message)
+        case "skills_list_response":
+            let message = try SkillsListResponseMessage(from: decoder)
+            self = .skillsListResponse(message)
+        case "skill_detail_response":
+            let message = try SkillDetailResponseMessage(from: decoder)
+            self = .skillDetailResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Adds `SkillsListRequestMessage` and `SkillDetailRequestMessage` (client → server) for requesting skills catalog data from the daemon
- Adds `SkillSummaryItem`, `SkillsListResponseMessage`, and `SkillDetailResponseMessage` (server → client) for receiving skills catalog responses
- Adds `skillsListResponse` and `skillDetailResponse` cases to the `ServerMessage` enum with corresponding decoder logic

## Test plan
- [x] Project builds successfully with `./build.sh`
- [ ] Verify daemon can send `skills_list_response` and `skill_detail_response` messages and the client decodes them correctly

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
