### PR TITLE
Add SkillsManager and skills catalog UI in AgentPanel (#1038)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 struct MainWindowView: View {
     @StateObject private var threadManager: ThreadManager
     @State private var activePanel: SidePanelType?
+    let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
 
     init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
+        self.daemonClient = daemonClient
         _threadManager = StateObject(wrappedValue: ThreadManager(daemonClient: daemonClient))
         self.ambientAgent = ambientAgent
     }
@@ -57,7 +59,7 @@ struct MainWindowView: View {
             case .generated:
                 GeneratedPanel(onClose: { activePanel = nil })
             case .agent:
-                AgentPanel(onClose: { activePanel = nil })
+                AgentPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .control:
                 ControlPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent)
             case .directory:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -2,13 +2,22 @@ import SwiftUI
 
 struct AgentPanel: View {
     var onClose: () -> Void
+    let daemonClient: DaemonClient
+
+    @StateObject private var skillsManager: SkillsManager
+    @State private var expandedSkillId: String?
+
+    init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
+        self.onClose = onClose
+        self.daemonClient = daemonClient
+        _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
+    }
 
     var body: some View {
         VSidePanel(title: "Agent", onClose: onClose) {
             VStack(alignment: .leading, spacing: VSpacing.xl) {
                 sectionHeader("Skills")
-                VEmptyState(title: "No skills", subtitle: "Agent skills will appear here", icon: "bolt.fill")
-                    .frame(height: 150)
+                skillsContent
 
                 Divider()
 
@@ -16,6 +25,95 @@ struct AgentPanel: View {
                 VEmptyState(title: "No nodes", subtitle: "Agent nodes will appear here", icon: "point.3.connected.trianglepath.dotted")
                     .frame(height: 150)
             }
+        }
+        .onAppear {
+            skillsManager.fetchSkills()
+        }
+    }
+
+    @ViewBuilder
+    private var skillsContent: some View {
+        if skillsManager.isLoading {
+            HStack {
+                Spacer()
+                ProgressView()
+                    .controlSize(.small)
+                Spacer()
+            }
+            .frame(height: 150)
+        } else if skillsManager.skills.isEmpty {
+            VEmptyState(title: "No skills", subtitle: "Agent skills will appear here", icon: "bolt.fill")
+                .frame(height: 150)
+        } else {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(skillsManager.skills) { skill in
+                    skillRow(skill)
+                }
+            }
+        }
+    }
+
+    private func skillRow(_ skill: SkillSummaryItem) -> some View {
+        let isExpanded = expandedSkillId == skill.id
+
+        return VStack(alignment: .leading, spacing: 0) {
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    if isExpanded {
+                        expandedSkillId = nil
+                    } else {
+                        expandedSkillId = skill.id
+                        skillsManager.fetchSkillBody(skillId: skill.id)
+                    }
+                }
+            }) {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 12)
+                        .padding(.top, 3)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(skill.name)
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textPrimary)
+                        Text(skill.description)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .lineLimit(isExpanded ? nil : 2)
+                    }
+
+                    Spacer()
+                }
+                .padding(.vertical, VSpacing.sm)
+                .padding(.horizontal, VSpacing.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                skillBody(for: skill.id)
+                    .padding(.leading, 12 + VSpacing.sm)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.bottom, VSpacing.sm)
+            }
+        }
+        .background(isExpanded ? VColor.surface.opacity(0.5) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    @ViewBuilder
+    private func skillBody(for skillId: String) -> some View {
+        if let body = skillsManager.loadedBodies[skillId] {
+            Text(body)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .textSelection(.enabled)
+        } else {
+            ProgressView()
+                .controlSize(.small)
+                .padding(.vertical, VSpacing.sm)
         }
     }
 
@@ -27,5 +125,5 @@ struct AgentPanel: View {
 }
 
 #Preview {
-    AgentPanel(onClose: {})
+    AgentPanel(onClose: {}, daemonClient: DaemonClient())
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+@MainActor
+final class SkillsManager: ObservableObject {
+    @Published var skills: [SkillSummaryItem] = []
+    @Published var loadedBodies: [String: String] = [:]
+    @Published var isLoading = false
+
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func fetchSkills() {
+        guard !isLoading else { return }
+        isLoading = true
+
+        Task {
+            do {
+                try daemonClient.send(SkillsListRequestMessage())
+            } catch {
+                isLoading = false
+                return
+            }
+
+            let stream = daemonClient.subscribe()
+            for await message in stream {
+                if case .skillsListResponse(let response) = message {
+                    skills = response.skills
+                    isLoading = false
+                    return
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    func fetchSkillBody(skillId: String) {
+        guard loadedBodies[skillId] == nil else { return }
+
+        Task {
+            do {
+                try daemonClient.send(SkillDetailRequestMessage(skillId: skillId))
+            } catch {
+                return
+            }
+
+            let stream = daemonClient.subscribe()
+            for await message in stream {
+                if case .skillDetailResponse(let response) = message,
+                   response.skillId == skillId {
+                    if let error = response.error {
+                        loadedBodies[skillId] = "Error: \(error)"
+                    } else {
+                        loadedBodies[skillId] = response.body
+                    }
+                    return
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `SkillsManager` class that fetches skills list and skill details from the daemon via IPC
- Replace static empty state in `AgentPanel` with dynamic skills catalog featuring expandable rows with lazy-loaded body text
- Pass `daemonClient` through `MainWindowView` to `AgentPanel` for IPC communication

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] AgentPanel shows loading spinner then skills list when daemon responds to `skills_list` IPC message
- [ ] Clicking a skill row expands it and fetches skill detail body via `skill_detail` IPC message
- [ ] Empty state shown when no skills returned
- [ ] Nodes section still shows its empty state placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
