### PR TITLE
Bundle daemon binary + Sparkle auto-update for macOS app

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -70,10 +70,26 @@ jobs:
           echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
           echo "Display version: $DISPLAY_VERSION / Build version: $BUILD_VERSION"
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build daemon binary
+        working-directory: assistant
+        run: |
+          bun install
+          bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
+            --outfile ../clients/macos/daemon-bin/vellum-daemon
+          chmod +x ../clients/macos/daemon-bin/vellum-daemon
+          echo "Daemon binary built:"
+          ls -lh ../clients/macos/daemon-bin/vellum-daemon
+
       - name: Build release .app
         run: |
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}" \
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
+          SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
           SIGN_IDENTITY="Developer ID Application" \
           ./build.sh release
 
@@ -173,6 +189,50 @@ jobs:
           xcrun stapler validate "$DMG_PATH"
           echo "Notarization ticket stapled and validated"
 
+      - name: Build ZIP for Sparkle auto-update
+        run: |
+          cd dist
+          ditto -c -k --keepParent vellum-assistant.app vellum-assistant.zip
+          echo "Sparkle ZIP created:"
+          ls -lh vellum-assistant.zip
+
+      - name: Install Sparkle sign_update tool
+        run: |
+          brew install sparkle
+          echo "Sparkle tools installed"
+
+      - name: Generate appcast.xml
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          DISPLAY_VERSION="${{ steps.version.outputs.display_version }}"
+          BUILD_VERSION="${{ steps.version.outputs.build_version }}"
+
+          # Sign the ZIP with Sparkle EdDSA key
+          SIGNATURE=$(echo "$SPARKLE_ED_PRIVATE_KEY" | sign_update dist/vellum-assistant.zip)
+          SIZE=$(stat -f%z dist/vellum-assistant.zip)
+
+          cat > dist/appcast.xml << EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+              <title>vellum-assistant</title>
+              <item>
+                <title>${DISPLAY_VERSION}</title>
+                <sparkle:version>${BUILD_VERSION}</sparkle:version>
+                <sparkle:shortVersionString>${DISPLAY_VERSION}</sparkle:shortVersionString>
+                <enclosure
+                  url="https://github.com/alex-nork/vellum-assistant-macos-updates/releases/latest/download/vellum-assistant.zip"
+                  sparkle:edSignature="${SIGNATURE}"
+                  length="${SIZE}"
+                  type="application/octet-stream" />
+              </item>
+            </channel>
+          </rss>
+          EOF
+
+          echo "Appcast generated with signature"
+
       - name: Create GitHub Release on public repo
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_PAT }}
@@ -187,16 +247,20 @@ jobs:
           gh release delete latest --repo "$REPO" --yes 2>/dev/null || true
           gh api "repos/$REPO/git/refs/tags/latest" -X DELETE 2>/dev/null || true
 
-          # Create new release with the DMG attached
+          # Create new release with DMG + ZIP + appcast
           RELEASE_NOTES="**Build:** \`$VERSION\`
           **Commit:** [\`$SHORT_SHA\`](https://github.com/${{ github.repository }}/commit/$FULL_SHA)
           **Built at:** $TIMESTAMP
 
           ---
 
-          Download the DMG, open it, and drag vellum-assistant to your Applications folder."
+          Download the DMG, open it, and drag vellum-assistant to your Applications folder.
+          Existing installations will auto-update via Sparkle."
 
-          gh release create latest "$DMG_PATH" \
+          gh release create latest \
+            "$DMG_PATH" \
+            dist/vellum-assistant.zip \
+            dist/appcast.xml \
             --repo "$REPO" \
             --title "vellum-assistant $VERSION" \
             --notes "$RELEASE_NOTES" \

--- a/clients/macos/.gitignore
+++ b/clients/macos/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 .DS_Store
 context.md
 Local.xcconfig
+daemon-bin/

--- a/clients/macos/Package.resolved
+++ b/clients/macos/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "a3cf605d7a96f6ff50e04fcb6dea6e2613cfcbe4",
         "version" : "0.2.1"
       }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
+        "version" : "2.8.1"
+      }
     }
   ],
   "version" : 2

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -18,11 +18,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/soffes/HotKey", from: "0.2.1"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
     ],
     targets: [
         .target(
             name: "VellumAssistantLib",
-            dependencies: ["HotKey"],
+            dependencies: ["HotKey", "Sparkle"],
             path: "vellum-assistant",
             exclude: ["Resources/Info.plist"],
             resources: [

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -87,10 +87,31 @@ fi
 # 2. Create .app bundle structure
 echo "Packaging $APP_NAME.app..."
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+FRAMEWORKS_DIR="$CONTENTS/Frameworks"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
-# Copy executable
+# Copy executable and add Frameworks rpath for bundled dynamic frameworks
 cp "$EXECUTABLE" "$MACOS_DIR/$APP_NAME"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$APP_NAME" 2>/dev/null || true
+
+# Copy Sparkle.framework into bundle (required — it's a dynamic framework)
+SPARKLE_FW="$BIN_PATH/Sparkle.framework"
+if [ -d "$SPARKLE_FW" ]; then
+    echo "Bundling Sparkle.framework..."
+    cp -R "$SPARKLE_FW" "$FRAMEWORKS_DIR/"
+else
+    echo "WARNING: Sparkle.framework not found at $SPARKLE_FW"
+fi
+
+# Copy bundled daemon binary (if available — built by CI or locally)
+DAEMON_BIN="$SCRIPT_DIR/daemon-bin/vellum-daemon"
+if [ -f "$DAEMON_BIN" ]; then
+    echo "Bundling daemon binary..."
+    cp "$DAEMON_BIN" "$MACOS_DIR/vellum-daemon"
+    chmod +x "$MACOS_DIR/vellum-daemon"
+else
+    echo "No daemon binary at $DAEMON_BIN — skipping (dev mode)"
+fi
 
 # 3. Generate Info.plist with resolved values
 cat > "$CONTENTS/Info.plist" <<PLIST
@@ -126,6 +147,12 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>vellum-assistant needs microphone access to transcribe voice commands.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+    <key>SUFeedURL</key>
+    <string>https://github.com/alex-nork/vellum-assistant-macos-updates/releases/latest/download/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>${SU_PUBLIC_ED_KEY:-}</string>
+    <key>SUAutomaticallyUpdate</key>
+    <true/>
 </dict>
 </plist>
 PLIST
@@ -151,6 +178,17 @@ fi
 
 # 6. Code sign
 echo "Signing with: $SIGN_IDENTITY"
+
+# Sign daemon binary separately with its own entitlements (JIT, network)
+if [ -f "$MACOS_DIR/vellum-daemon" ]; then
+    DAEMON_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY" --entitlements "$SCRIPT_DIR/daemon-entitlements.plist")
+    if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+        DAEMON_SIGN_FLAGS+=(--timestamp --options runtime)
+    fi
+    codesign "${DAEMON_SIGN_FLAGS[@]}" "$MACOS_DIR/vellum-daemon"
+    echo "Daemon binary signed"
+fi
+
 CODESIGN_FLAGS=(--force --sign "$SIGN_IDENTITY" --deep)
 if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
     CODESIGN_FLAGS+=(--timestamp --options runtime)

--- a/clients/macos/daemon-entitlements.plist
+++ b/clients/macos/daemon-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -31,6 +31,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     let daemonClient = DaemonClient()
     let surfaceManager = SurfaceManager()
     let toolConfirmationManager = ToolConfirmationManager()
+    private let daemonLauncher = DaemonLauncher()
+    private let updateManager = UpdateManager()
 
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
@@ -63,17 +65,27 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         setupToolConfirmationManager()
         setupWindowObserver()
         setupNotifications()
+        setupAutoUpdate()
         showMainWindow()
     }
 
     private func setupDaemonClient() {
         Task {
+            // Launch the bundled daemon if present (release builds)
+            try? await daemonLauncher.launchIfNeeded()
             try? await daemonClient.connect()
             // Once connected, start ambient agent if it was waiting for daemon
             if daemonClient.isConnected {
                 setupAmbientAgent()
             }
         }
+    }
+
+    private func setupAutoUpdate() {
+        updateManager.onWillInstallUpdate = { [weak self] in
+            self?.daemonLauncher.stop()
+        }
+        updateManager.startAutomaticChecks()
     }
 
     private func setupSurfaceManager() {
@@ -197,6 +209,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         ambientItem.target = self
         menu.addItem(ambientItem)
 
+        let updateItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
+        updateItem.target = self
+        updateItem.isEnabled = updateManager.canCheckForUpdates
+        menu.addItem(updateItem)
+
         let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")
         onboardingItem.target = self
         menu.addItem(onboardingItem)
@@ -211,6 +228,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: button)
+    }
+
+    @objc private func checkForUpdates() {
+        updateManager.checkForUpdates()
     }
 
     @objc private func toggleAmbientAgent() {
@@ -367,6 +388,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.setupToolConfirmationManager()
             self?.setupWindowObserver()
             self?.setupNotifications()
+            self?.setupAutoUpdate()
 
             self?.showMainWindow()
         }
@@ -595,6 +617,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         ambientAgent.stop()
         surfaceManager.dismissAll()
         toolConfirmationManager.dismissAll()
+        daemonLauncher.stop()
     }
 }
 

--- a/clients/macos/vellum-assistant/App/DaemonLauncher.swift
+++ b/clients/macos/vellum-assistant/App/DaemonLauncher.swift
@@ -1,0 +1,122 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DaemonLauncher")
+
+/// Manages the lifecycle of the bundled daemon binary.
+///
+/// In release builds the daemon is embedded at `Contents/MacOS/vellum-daemon`
+/// inside the app bundle. In local dev (binary absent) we skip launching and
+/// assume the developer runs the daemon externally.
+@MainActor
+final class DaemonLauncher {
+
+    private var process: Process?
+    private let vellumDir: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".vellum")
+    private var pidFileURL: URL {
+        vellumDir.appendingPathComponent("vellum.pid")
+    }
+    private var socketURL: URL {
+        vellumDir.appendingPathComponent("vellum.sock")
+    }
+
+    /// URL of the bundled daemon binary, if it exists.
+    private var daemonBinaryURL: URL? {
+        guard let execURL = Bundle.main.executableURL else { return nil }
+        let candidate = execURL.deletingLastPathComponent().appendingPathComponent("vellum-daemon")
+        return FileManager.default.fileExists(atPath: candidate.path) ? candidate : nil
+    }
+
+    // MARK: - Public API
+
+    /// Launch the bundled daemon if it isn't already running.
+    /// Falls back silently when the binary isn't present (local dev).
+    func launchIfNeeded() async throws {
+        guard let binaryURL = daemonBinaryURL else {
+            log.info("No bundled daemon binary found — assuming external daemon (dev mode)")
+            return
+        }
+
+        if isAlreadyRunning() {
+            log.info("Daemon already running (PID file check)")
+            return
+        }
+
+        try launch(binaryURL: binaryURL)
+        try await waitForSocket()
+    }
+
+    /// Gracefully stop the daemon (SIGTERM → wait → SIGKILL).
+    func stop() {
+        guard let proc = process, proc.isRunning else {
+            cleanupPIDFile()
+            return
+        }
+
+        log.info("Stopping daemon (pid \(proc.processIdentifier))")
+        proc.terminate() // SIGTERM
+
+        // Give it 2 seconds to exit gracefully
+        let deadline = Date().addingTimeInterval(2.0)
+        while proc.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        if proc.isRunning {
+            log.warning("Daemon did not exit after SIGTERM, sending SIGKILL")
+            kill(proc.processIdentifier, SIGKILL)
+            proc.waitUntilExit()
+        }
+
+        process = nil
+        cleanupPIDFile()
+    }
+
+    // MARK: - Private
+
+    private func isAlreadyRunning() -> Bool {
+        guard let pidData = try? Data(contentsOf: pidFileURL),
+              let pidString = String(data: pidData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = pid_t(pidString) else {
+            return false
+        }
+        // kill(pid, 0) returns 0 if the process exists and we can signal it
+        return kill(pid, 0) == 0
+    }
+
+    private func launch(binaryURL: URL) throws {
+        log.info("Launching daemon from \(binaryURL.path)")
+
+        let proc = Process()
+        proc.executableURL = binaryURL
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+
+        // Ensure ~/.vellum/ exists for PID/socket/logs
+        try FileManager.default.createDirectory(at: vellumDir, withIntermediateDirectories: true)
+
+        try proc.run()
+        process = proc
+        log.info("Daemon launched with pid \(proc.processIdentifier)")
+    }
+
+    private func waitForSocket() async throws {
+        let maxWait: TimeInterval = 5.0
+        let pollInterval: UInt64 = 100_000_000 // 100ms in nanoseconds
+        let start = Date()
+
+        while Date().timeIntervalSince(start) < maxWait {
+            if FileManager.default.fileExists(atPath: socketURL.path) {
+                log.info("Daemon socket ready at \(self.socketURL.path)")
+                return
+            }
+            try await Task.sleep(nanoseconds: pollInterval)
+        }
+
+        log.warning("Daemon socket did not appear within \(maxWait)s — continuing anyway")
+    }
+
+    private func cleanupPIDFile() {
+        try? FileManager.default.removeItem(at: pidFileURL)
+    }
+}

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Sparkle
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "UpdateManager")
+
+/// Thin wrapper around Sparkle's `SPUUpdater` for auto-update functionality.
+///
+/// The appcast URL points to the public releases repo where CI publishes
+/// signed ZIPs alongside an `appcast.xml`.
+@MainActor
+final class UpdateManager: NSObject, SPUUpdaterDelegate {
+
+    private var updaterController: SPUStandardUpdaterController!
+
+    /// Called before the app is replaced — stop the daemon so the new version
+    /// can launch its own bundled daemon cleanly.
+    var onWillInstallUpdate: (() -> Void)?
+
+    override init() {
+        super.init()
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: self,
+            userDriverDelegate: nil
+        )
+    }
+
+    /// Begin automatic background update checks.
+    func startAutomaticChecks() {
+        do {
+            try updaterController.updater.start()
+            log.info("Sparkle auto-update checks started")
+        } catch {
+            log.error("Failed to start Sparkle updater: \(error.localizedDescription)")
+        }
+    }
+
+    /// Manually trigger "Check for Updates…" (shows UI).
+    func checkForUpdates() {
+        updaterController.checkForUpdates(nil)
+    }
+
+    /// Whether the "Check for Updates…" menu item should be enabled.
+    var canCheckForUpdates: Bool {
+        updaterController.updater.canCheckForUpdates
+    }
+
+    // MARK: - SPUUpdaterDelegate
+
+    nonisolated func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        Task { @MainActor in
+            log.info("Will install update \(item.displayVersionString)")
+            onWillInstallUpdate?()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
@@ -102,9 +102,11 @@ struct ScreenPermissionStepView: View {
 
     private func startPolling() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-            let status = PermissionManager.screenRecordingStatus()
-            if status == .granted {
-                grantPermission()
+            Task { @MainActor in
+                let status = PermissionManager.screenRecordingStatus()
+                if status == .granted {
+                    grantPermission()
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
@@ -101,7 +101,7 @@ struct SpeechPermissionStepView: View {
 
     private func requestSpeechPermission() {
         SFSpeechRecognizer.requestAuthorization { status in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 switch status {
                 case .authorized:
                     grantPermission()
@@ -118,7 +118,7 @@ struct SpeechPermissionStepView: View {
     private func startPolling() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             let status = SFSpeechRecognizer.authorizationStatus()
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 if status == .authorized {
                     grantPermission()
                 }

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -73,15 +73,17 @@ final class TextResponseWindow {
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification, object: panel, queue: .main
         ) { notification in
-            guard let window = notification.object as? NSPanel else { return }
-            UserDefaults.standard.set(Double(window.frame.width), forKey: "textResponsePanelWidth")
+            Task { @MainActor in
+                guard let window = notification.object as? NSPanel else { return }
+                UserDefaults.standard.set(Double(window.frame.width), forKey: "textResponsePanelWidth")
+            }
         }
 
         // Fire onClose when the panel is closed by the user
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification, object: panel, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
+        ) { _ in
+            Task { @MainActor [weak self] in
                 self?.onClose?()
             }
         }

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -12,7 +12,7 @@ struct TaskInputView: View {
     @State private var attachmentError: String?
     @State private var isDropTargeted = false
     @FocusState private var isTextFieldFocused: Bool
-    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openSettings) private var openSettings: OpenSettingsAction
 
     private var canSubmit: Bool {
         let trimmed = taskText.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary
- Bundles the TypeScript daemon as a compiled binary (`vellum-daemon`) inside the .app at `Contents/MacOS/`, so the app is fully self-contained — no external daemon process needed
- Adds Sparkle 2.x auto-update: background update checks, EdDSA-signed appcast, "Check for Updates..." menu item, daemon stop-before-replace hook
- Updates CI to compile the daemon via `bun build --compile`, bundle Sparkle.framework, generate appcast.xml, and upload ZIP + appcast alongside the DMG

## New files
- `DaemonLauncher.swift` — find bundled binary, launch, poll socket, graceful stop (SIGTERM→SIGKILL), dev-mode fallback
- `UpdateManager.swift` — SPUUpdater wrapper, auto-check start, willInstallUpdate daemon-stop callback
- `daemon-entitlements.plist` — JIT + unsigned-executable-memory + network.client for Bun runtime

## Key changes
- `build.sh` — copies daemon binary + Sparkle.framework into bundle, adds `@executable_path/../Frameworks` rpath, signs daemon with entitlements, adds Sparkle plist keys
- `AppDelegate.swift` — integrates both: launches daemon on start, stops on quit, wires update menu item
- `Package.swift` — adds Sparkle dependency
- CI workflow — bun install → daemon compile → app build → ZIP + appcast.xml → release upload

## Setup required after merge
1. Generate Sparkle EdDSA keys: `brew install sparkle && generate_keys`
2. Store as GitHub secrets: `SPARKLE_ED_PUBLIC_KEY`, `SPARKLE_ED_PRIVATE_KEY`
3. Ensure `alex-nork/vellum-assistant-macos-updates` repo is public

## Test plan
- [x] SPM resolves with Sparkle 2.8.1
- [x] Daemon compiles via `bun build --compile` (65MB binary)
- [x] `./build.sh` succeeds — Swift build, .app bundle, daemon + Sparkle bundling, codesign
- [x] App launches from /Applications with bundled daemon (no external daemon needed)
- [x] DaemonLauncher correctly skips when dev daemon is already running
- [x] Sparkle logs expected error when no EdDSA key configured (local dev)
- [ ] CI workflow produces valid DMG + ZIP + appcast.xml
- [ ] Auto-update flow with staged older build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
