### PR TITLE
Fix subscribe-before-send race condition in SkillsManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -17,6 +17,9 @@ final class SkillsManager: ObservableObject {
         isLoading = true
 
         Task {
+            // Subscribe before sending so we don't miss fast daemon responses
+            let stream = daemonClient.subscribe()
+
             do {
                 try daemonClient.send(SkillsListRequestMessage())
             } catch {
@@ -24,7 +27,6 @@ final class SkillsManager: ObservableObject {
                 return
             }
 
-            let stream = daemonClient.subscribe()
             for await message in stream {
                 if case .skillsListResponse(let response) = message {
                     skills = response.skills
@@ -40,13 +42,15 @@ final class SkillsManager: ObservableObject {
         guard loadedBodies[skillId] == nil else { return }
 
         Task {
+            // Subscribe before sending so we don't miss fast daemon responses
+            let stream = daemonClient.subscribe()
+
             do {
                 try daemonClient.send(SkillDetailRequestMessage(skillId: skillId))
             } catch {
                 return
             }
 
-            let stream = daemonClient.subscribe()
             for await message in stream {
                 if case .skillDetailResponse(let response) = message,
                    response.skillId == skillId {


### PR DESCRIPTION
## Summary
- Moves `daemonClient.subscribe()` before `daemonClient.send()` in both `fetchSkills()` and `fetchSkillBody()` to prevent missing fast daemon responses
- Addresses review feedback from Codex and Devin on PR #1043
- Matches the established subscribe-before-send pattern used in `Session.swift`, `AmbientAgent.swift`, and `ProfileExtractor.swift`

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Manual: Open skills catalog, verify skills list loads without getting stuck on spinner
- [ ] Manual: Expand a skill row, verify body loads without perpetual spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
