### PR TITLE
M1: Make VTab close button always visible

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -30,7 +30,7 @@ struct VTab: View {
         .buttonStyle(.plain)
         .onHover { hovering in isHovered = hovering }
         .overlay(alignment: .trailing) {
-            if isCloseable, let onClose = onClose, isHovered {
+            if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: 10, weight: .bold))


### PR DESCRIPTION
## Summary
- Removed the `isHovered` condition from the VTab close button overlay
- Close button (xmark) is now always visible when `isCloseable` is true, matching the UI mockup
- Previously the close button only appeared on hover, which didn't match the design

Part of #1045. Closes #1046.

## Test plan
- [ ] Build and run the app
- [ ] Verify close buttons are visible on thread tabs without hovering
- [ ] Verify clicking close buttons still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
