### PR TITLE
M2: Move + Thread button next to tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -21,8 +21,6 @@ struct ThreadTabBar: View {
                     )
                 }
 
-                Spacer()
-
                 Button(action: onCreate) {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "plus")
@@ -34,6 +32,8 @@ struct ThreadTabBar: View {
                 .buttonStyle(.plain)
                 .vHover()
                 .accessibilityLabel("New Thread")
+
+                Spacer()
             }
             .padding(.horizontal, VSpacing.lg)
             .frame(height: 36)


### PR DESCRIPTION
## Summary
- Moved `Spacer()` from before the `+ Thread` button to after it in ThreadTabBar
- The button now sits right next to the last thread tab instead of being pushed to the far right
- Matches the UI mockup layout

Part of #1045. Closes #1047.

## Test plan
- [ ] Build and run the app
- [ ] Verify `+ Thread` button appears next to the last thread tab
- [ ] Verify clicking `+ Thread` still creates a new thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
