### PR TITLE
Fix CI daemon build by excluding Playwright transitive deps

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           bun install
           bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
+            --external electron --external "chromium-bidi/*" \
             --outfile ../clients/macos/daemon-bin/vellum-daemon
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
           echo "Daemon binary built:"


### PR DESCRIPTION
## Summary
- Add `--external electron` and `--external "chromium-bidi/*"` flags to the `bun build --compile` step in the CI workflow
- These exclude unresolvable transitive requires from `playwright-core` that the daemon doesn't use

Fixes the failing build-sign-release job: https://github.com/vellum-ai/vellum-assistant/actions/runs/21959103074/job/63431385617

## Test plan
- [ ] CI build-sign-release job passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
