### PR TITLE
M1: Add flat style variant to VTab for thread tabs

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -1,14 +1,29 @@
 import SwiftUI
 
+enum VTabStyle {
+    case pill   // Shows background fill on selected/hover
+    case flat   // No background fill, only text color changes
+}
+
 struct VTab: View {
     let label: String
     var icon: String? = nil    // SF Symbol
     var isSelected: Bool = false
     var isCloseable: Bool = true
+    var style: VTabStyle = .pill
     var onSelect: () -> Void
     var onClose: (() -> Void)? = nil
 
     @State private var isHovered = false
+
+    private var background: Color {
+        switch style {
+        case .pill:
+            return isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        case .flat:
+            return .clear
+        }
+    }
 
     var body: some View {
         Button(action: onSelect) {
@@ -24,7 +39,7 @@ struct VTab: View {
             .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
-            .background(isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear))
+            .background(background)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -16,6 +16,7 @@ struct ThreadTabBar: View {
                         icon: "flame",
                         isSelected: thread.id == activeThreadId,
                         isCloseable: threads.count > 1,
+                        style: .flat,
                         onSelect: { onSelect(thread.id) },
                         onClose: { onClose(thread.id) }
                     )


### PR DESCRIPTION
## Summary
- Added `VTabStyle` enum with `.pill` (default, existing behavior) and `.flat` (no background fill)
- Flat style only changes text color for selection state, no background on selected/hover
- ThreadTabBar now uses `.flat` style so thread tabs match the mockup's flat appearance
- NavigationToolbar continues using default `.pill` style

Part of #1051. Closes #1052.

## Test plan
- [ ] Build and run the app
- [ ] Verify thread tabs have no pill background (flat text/icon/close on the bar)
- [ ] Verify Chat tab in nav toolbar still has pill background
- [ ] Verify thread tab text color still changes when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
