### PR TITLE
M2: Update ThreadTabBar background to main dark color

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -38,9 +38,7 @@ struct ThreadTabBar: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .frame(height: 36)
-            .background(VColor.backgroundSubtle)
-
-            Divider()
+            .background(VColor.background)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Changed ThreadTabBar background from `VColor.backgroundSubtle` (Slate._800) to `VColor.background` (Slate._950)
- Removed the `Divider()` between thread tab bar and navigation toolbar
- The color contrast between the darker thread bar and lighter nav toolbar creates a natural visual separator

Part of #1051. Closes #1053.

## Test plan
- [ ] Build and run the app
- [ ] Verify thread tab bar is darker than the navigation toolbar
- [ ] Verify no visible divider line between the two rows
- [ ] Verify the transition between rows looks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
