### PR TITLE
Fix Swift 6 strict concurrency errors for CI

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -207,7 +207,12 @@ jobs:
       - name: Install Sparkle sign_update tool
         run: |
           brew install sparkle
-          echo "Sparkle tools installed"
+          SPARKLE_BIN=$(find /opt/homebrew/Caskroom/sparkle -name sign_update -type f 2>/dev/null | head -1)
+          if [ -z "$SPARKLE_BIN" ]; then
+            SPARKLE_BIN=$(find /usr/local/Caskroom/sparkle -name sign_update -type f 2>/dev/null | head -1)
+          fi
+          echo "Found sign_update at: $SPARKLE_BIN"
+          echo "$(dirname "$SPARKLE_BIN")" >> "$GITHUB_PATH"
 
       - name: Generate appcast.xml
         env:

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -222,7 +222,13 @@ jobs:
           BUILD_VERSION="${{ steps.version.outputs.build_version }}"
 
           # Sign the ZIP with Sparkle EdDSA key
-          SIGNATURE=$(echo "$SPARKLE_ED_PRIVATE_KEY" | sign_update dist/vellum-assistant.zip)
+          echo "sign_update location: $(which sign_update || echo 'NOT FOUND')"
+          SIGNATURE=$(sign_update dist/vellum-assistant.zip -s "$SPARKLE_ED_PRIVATE_KEY" 2>&1) || {
+            echo "sign_update failed with exit code $?"
+            echo "Output: $SIGNATURE"
+            exit 1
+          }
+          echo "Signature obtained: ${SIGNATURE:0:20}..."
           SIZE=$(stat -f%z dist/vellum-assistant.zip)
 
           cat > dist/appcast.xml << EOF

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -235,9 +235,9 @@ jobs:
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}"
           BUILD_VERSION="${{ steps.version.outputs.build_version }}"
 
-          # Sign the ZIP with Sparkle EdDSA key
+          # Sign the ZIP with Sparkle EdDSA key (pipe key via stdin — -s flag is deprecated)
           echo "sign_update location: $(which sign_update || echo 'NOT FOUND')"
-          SIGNATURE=$(sign_update dist/vellum-assistant.zip -s "$SPARKLE_ED_PRIVATE_KEY" 2>&1) || {
+          SIGNATURE=$(echo "$SPARKLE_ED_PRIVATE_KEY" | sign_update dist/vellum-assistant.zip 2>&1) || {
             echo "sign_update failed with exit code $?"
             echo "Output: $SIGNATURE"
             exit 1

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -103,6 +103,13 @@ jobs:
           codesign --verify --deep --strict "$APP_PATH"
           echo "Code signature verified"
 
+      - name: Free disk space
+        run: |
+          rm -rf .build daemon-bin
+          rm -rf ../assistant/node_modules
+          df -h .
+          echo "Disk space freed"
+
       - name: Create DMG
         run: |
           APP_PATH="dist/vellum-assistant.app"

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -107,6 +107,9 @@ jobs:
         run: |
           rm -rf .build daemon-bin
           rm -rf ../assistant/node_modules
+          # Clear Xcode caches
+          rm -rf ~/Library/Developer/Xcode/DerivedData 2>/dev/null || true
+          rm -rf ~/Library/Caches/org.swift.swiftpm 2>/dev/null || true
           df -h .
           echo "Disk space freed"
 
@@ -121,13 +124,24 @@ jobs:
           cp -R "$APP_PATH" "$DMG_STAGING/"
           ln -s /Applications "$DMG_STAGING/Applications"
 
-          # Create DMG
+          echo "Staging directory size:"
+          du -sh "$DMG_STAGING"
+
+          # Two-step DMG creation to avoid auto-sizing issues:
+          # 1. Create read-write image (auto-sizes more generously)
           hdiutil create \
             -volname "vellum-assistant" \
             -srcfolder "$DMG_STAGING" \
             -ov \
+            -format UDRW \
+            "build/temp.dmg"
+
+          # 2. Convert to compressed UDZO
+          hdiutil convert "build/temp.dmg" \
             -format UDZO \
-            "$DMG_PATH"
+            -ov \
+            -o "$DMG_PATH"
+          rm "build/temp.dmg"
 
           echo "DMG created at $DMG_PATH"
           ls -lh "$DMG_PATH"

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -235,13 +235,17 @@ jobs:
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}"
           BUILD_VERSION="${{ steps.version.outputs.build_version }}"
 
-          # Sign the ZIP with Sparkle EdDSA key (pipe key via stdin — -s flag is deprecated)
+          # Sign the ZIP with Sparkle EdDSA key (write to temp file — CLI arg is deprecated)
           echo "sign_update location: $(which sign_update || echo 'NOT FOUND')"
-          SIGNATURE=$(echo "$SPARKLE_ED_PRIVATE_KEY" | sign_update dist/vellum-assistant.zip 2>&1) || {
+          ED_KEY_FILE=$(mktemp)
+          echo "$SPARKLE_ED_PRIVATE_KEY" > "$ED_KEY_FILE"
+          SIGNATURE=$(sign_update dist/vellum-assistant.zip --ed-key-file "$ED_KEY_FILE" 2>&1) || {
             echo "sign_update failed with exit code $?"
             echo "Output: $SIGNATURE"
+            rm -f "$ED_KEY_FILE"
             exit 1
           }
+          rm -f "$ED_KEY_FILE"
           echo "Signature obtained: ${SIGNATURE:0:20}..."
           SIZE=$(stat -f%z dist/vellum-assistant.zip)
 

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -118,9 +118,11 @@ public final class AmbientAgent: ObservableObject {
             }
             guard !Task.isCancelled else { return }
             guard let self else { return }
+            let observations = await self.knowledgeStore.entries
+            let insights = await self.knowledgeCron?.insightStore.insights ?? []
             await sync.syncExisting(
-                observations: await self.knowledgeStore.entries,
-                insights: await self.knowledgeCron?.insightStore.insights ?? []
+                observations: observations,
+                insights: insights
             )
         }
 

--- a/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientSyncClient.swift
@@ -41,7 +41,8 @@ actor AmbientSyncClient {
         self.encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
-        log.info("Sync base URL: \(self.baseURL.absoluteString)")
+        let urlString = self.baseURL.absoluteString
+        log.info("Sync base URL: \(urlString)")
     }
 
     // MARK: - Health Check

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,16 +148,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         windowObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification, object: nil, queue: .main
         ) { [weak self] notification in
-            guard let window = notification.object as? NSWindow,
-                  window.title.contains("Settings") || window.title.contains("vellum") else { return }
-            Task { @MainActor [weak self] in
+            // Queue is .main so we're already on the main thread
+            MainActor.assumeIsolated {
+                guard let window = notification.object as? NSWindow,
+                      window.title.contains("Settings") || window.title.contains("vellum") else { return }
                 // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
                 guard self?.mainWindow == nil else { return }
                 // Revert to accessory (no dock icon) after settings closes
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
-                if !hasVisibleWindows {
-                    NSApp.setActivationPolicy(.accessory)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    MainActor.assumeIsolated {
+                        let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
+                        if !hasVisibleWindows {
+                            NSApp.setActivationPolicy(.accessory)
+                        }
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -150,10 +150,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] notification in
             guard let window = notification.object as? NSWindow,
                   window.title.contains("Settings") || window.title.contains("vellum") else { return }
-            // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
-            guard self?.mainWindow == nil else { return }
-            // Revert to accessory (no dock icon) after settings closes
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            Task { @MainActor [weak self] in
+                // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
+                guard self?.mainWindow == nil else { return }
+                // Revert to accessory (no dock icon) after settings closes
+                try? await Task.sleep(nanoseconds: 200_000_000)
                 let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
                 if !hasVisibleWindows {
                     NSApp.setActivationPolicy(.accessory)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -150,19 +150,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] notification in
             // Queue is .main so we're already on the main thread
             MainActor.assumeIsolated {
+                guard let self else { return }
                 guard let window = notification.object as? NSWindow,
                       window.title.contains("Settings") || window.title.contains("vellum") else { return }
                 // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
-                guard self?.mainWindow == nil else { return }
-                // Revert to accessory (no dock icon) after settings closes
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    MainActor.assumeIsolated {
-                        let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self?.statusItem.button?.window }
-                        if !hasVisibleWindows {
-                            NSApp.setActivationPolicy(.accessory)
-                        }
-                    }
-                }
+                guard self.mainWindow == nil else { return }
+                self.scheduleActivationPolicyRevert()
+            }
+        }
+    }
+
+    /// Revert to accessory activation policy after a short delay if no visible windows remain.
+    private func scheduleActivationPolicyRevert() {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard let self else { return }
+            let hasVisibleWindows = NSApp.windows.contains { $0.isVisible && $0 !== self.statusItem.button?.window }
+            if !hasVisibleWindows {
+                NSApp.setActivationPolicy(.accessory)
             }
         }
     }

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -1,4 +1,4 @@
-import AppKit
+@preconcurrency import AppKit
 import ApplicationServices
 import os
 
@@ -77,11 +77,19 @@ final class ChromeAccessibilityHelper {
 
         // Relaunch with accessibility flag
         do {
-            let config = NSWorkspace.OpenConfiguration()
-            config.arguments = ["--force-renderer-accessibility"]
-            config.activates = true
-
-            _ = try await NSWorkspace.shared.openApplication(at: bundleURL, configuration: config)
+            // Use completion handler to avoid Sendable warnings with NSWorkspace types
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let config = NSWorkspace.OpenConfiguration()
+                config.arguments = ["--force-renderer-accessibility"]
+                config.activates = true
+                NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                }
+            }
             log.info("Chrome relaunched with accessibility flag")
 
             // Wait for Chrome to start and restore tabs

--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AppKit
+import AppKit
 import ApplicationServices
 import os
 

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -133,6 +133,7 @@ struct VSlider: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("VSlider") {
     @Previewable @State var value1: Double = 50
     @Previewable @State var value2: Double = 30
@@ -166,3 +167,4 @@ struct VSlider: View {
     }
     .frame(width: 400, height: 300)
 }
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextEditor.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextEditor.swift
@@ -37,6 +37,7 @@ struct VTextEditor: View {
     }
 }
 
+#if DEBUG
 #Preview("VTextEditor") {
     @Previewable @State var text = ""
     ZStack {
@@ -49,3 +50,4 @@ struct VTextEditor: View {
     }
     .frame(width: 400, height: 350)
 }
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextField.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VTextField.swift
@@ -44,6 +44,7 @@ struct VTextField: View {
     }
 }
 
+#if DEBUG
 #Preview("VTextField") {
     @Previewable @State var text = ""
     ZStack {
@@ -58,3 +59,4 @@ struct VTextField: View {
     }
     .frame(width: 350, height: 280)
 }
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
@@ -54,6 +54,7 @@ struct VToggle: View {
     }
 }
 
+#if DEBUG
 #Preview("VToggle") {
     @Previewable @State var isOnA = true
     @Previewable @State var isOnB = false
@@ -68,3 +69,4 @@ struct VToggle: View {
     }
     .frame(width: 300, height: 200)
 }
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -28,6 +28,7 @@ struct VSegmentedControl: View {
     }
 }
 
+#if DEBUG
 #Preview("VSegmentedControl") {
     @Previewable @State var selection = 0
     ZStack {
@@ -37,3 +38,4 @@ struct VSegmentedControl: View {
     }
     .frame(width: 400, height: 80)
 }
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -315,6 +315,7 @@ private struct ThinkingIndicator: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("ChatView") {
     @Previewable @State var text = ""
 
@@ -344,3 +345,4 @@ private struct ThinkingIndicator: View {
     }
     .frame(width: 600, height: 500)
 }
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -50,8 +50,10 @@ struct NavigationToolbar: View {
     }
 }
 
+#if DEBUG
 #Preview("NavigationToolbar") {
     @Previewable @State var panel: SidePanelType? = .control
     NavigationToolbar(activePanel: $panel)
         .frame(width: 700)
 }
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct ControlPanel: View {
     var onClose: () -> Void
     var ambientAgent: AmbientAgent

--- a/clients/macos/vellum-assistant/Features/Onboarding/AccessibilityPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AccessibilityPermissionStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct AccessibilityPermissionStepView: View {
     @Bindable var state: OnboardingState
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AliveStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct AliveStepView: View {
     @Bindable var state: OnboardingState
     var onComplete: () -> Void

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct FnKeyStepView: View {
     @Bindable var state: OnboardingState
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingHatchView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingHatchView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Legacy wrapper — the egg hatch is now rendered by EggSceneView in the split layout.
 /// This file is kept to avoid breaking any remaining references during transition.
+@MainActor
 struct OnboardingHatchView: View {
     @Bindable var state: OnboardingState
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -219,6 +219,7 @@ private struct TypingIndicator: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("InterviewChatView") {
     @Previewable @State var text = ""
 
@@ -246,3 +247,4 @@ private struct TypingIndicator: View {
     }
     .frame(width: 600, height: 600)
 }
+#endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct InterviewStepView: View {
     @Bindable var state: OnboardingState
     let daemonClient: DaemonClientProtocol
@@ -178,7 +179,7 @@ struct InterviewStepView: View {
 
     // MARK: - Voice Input
 
-    @MainActor private func setupVoiceCallbacks() {
+    private func setupVoiceCallbacks() {
         voiceInputManager.onTranscription = { text in
             viewModel.inputText = text
             viewModel.sendMessage()
@@ -191,7 +192,7 @@ struct InterviewStepView: View {
         }
     }
 
-    @MainActor private func toggleVoice() {
+    private func toggleVoice() {
         voiceInputManager.toggleRecording()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewStepView.swift
@@ -178,7 +178,7 @@ struct InterviewStepView: View {
 
     // MARK: - Voice Input
 
-    private func setupVoiceCallbacks() {
+    @MainActor private func setupVoiceCallbacks() {
         voiceInputManager.onTranscription = { text in
             viewModel.inputText = text
             viewModel.sendMessage()
@@ -191,7 +191,7 @@ struct InterviewStepView: View {
         }
     }
 
-    private func toggleVoice() {
+    @MainActor private func toggleVoice() {
         voiceInputManager.toggleRecording()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
@@ -62,7 +62,7 @@ struct NamingStepView: View {
         }
     }
 
-    private func confirmName() {
+    @MainActor private func confirmName() {
         guard !state.assistantName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
         state.advance()
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/NamingStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct NamingStepView: View {
     @Bindable var state: OnboardingState
 
@@ -62,7 +63,7 @@ struct NamingStepView: View {
         }
     }
 
-    @MainActor private func confirmName() {
+    private func confirmName() {
         guard !state.assistantName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
         state.advance()
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct OnboardingFlowView: View {
     @Bindable var state: OnboardingState
     let daemonClient: DaemonClientProtocol

--- a/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
@@ -111,7 +111,7 @@ struct ScreenPermissionStepView: View {
         }
     }
 
-    private func grantPermission() {
+    @MainActor private func grantPermission() {
         pollTimer?.invalidate()
         permissionGranted = true
         state.screenGranted = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ScreenPermissionStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct ScreenPermissionStepView: View {
     @Bindable var state: OnboardingState
 
@@ -111,7 +112,7 @@ struct ScreenPermissionStepView: View {
         }
     }
 
-    @MainActor private func grantPermission() {
+    private func grantPermission() {
         pollTimer?.invalidate()
         permissionGranted = true
         state.screenGranted = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
@@ -1,6 +1,7 @@
 import Speech
 import SwiftUI
 
+@MainActor
 struct SpeechPermissionStepView: View {
     @Bindable var state: OnboardingState
 
@@ -126,7 +127,7 @@ struct SpeechPermissionStepView: View {
         }
     }
 
-    @MainActor private func grantPermission() {
+    private func grantPermission() {
         pollTimer?.invalidate()
         permissionGranted = true
         permissionDenied = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/SpeechPermissionStepView.swift
@@ -126,7 +126,7 @@ struct SpeechPermissionStepView: View {
         }
     }
 
-    private func grantPermission() {
+    @MainActor private func grantPermission() {
         pollTimer?.invalidate()
         permissionGranted = true
         permissionDenied = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct WakeUpStepView: View {
     @Bindable var state: OnboardingState
 

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -72,10 +72,11 @@ final class TextResponseWindow {
         // Persist width on resize
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification, object: panel, queue: .main
-        ) { [weak panel] _ in
-            Task { @MainActor in
-                guard let panel else { return }
-                UserDefaults.standard.set(Double(panel.frame.width), forKey: "textResponsePanelWidth")
+        ) { notification in
+            // Queue is .main so we're already on the main thread
+            MainActor.assumeIsolated {
+                guard let window = notification.object as? NSPanel else { return }
+                UserDefaults.standard.set(Double(window.frame.width), forKey: "textResponsePanelWidth")
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -72,10 +72,10 @@ final class TextResponseWindow {
         // Persist width on resize
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification, object: panel, queue: .main
-        ) { notification in
+        ) { [weak panel] _ in
             Task { @MainActor in
-                guard let window = notification.object as? NSPanel else { return }
-                UserDefaults.standard.set(Double(window.frame.width), forKey: "textResponsePanelWidth")
+                guard let panel else { return }
+                UserDefaults.standard.set(Double(panel.frame.width), forKey: "textResponsePanelWidth")
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import WebKit
+@preconcurrency import WebKit
 
 struct DynamicPageSurfaceView: NSViewRepresentable {
     let data: DynamicPageSurfaceData

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -12,7 +12,10 @@ struct TaskInputView: View {
     @State private var attachmentError: String?
     @State private var isDropTargeted = false
     @FocusState private var isTextFieldFocused: Bool
-    @Environment(\.openSettings) private var openSettings
+    // Use NSApp action instead of @Environment(\.openSettings) for Xcode 16.2 compatibility
+    private func openSettings() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
 
     private var canSubmit: Bool {
         let trimmed = taskText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -12,7 +12,7 @@ struct TaskInputView: View {
     @State private var attachmentError: String?
     @State private var isDropTargeted = false
     @FocusState private var isTextFieldFocused: Bool
-    @Environment(\.openSettings) private var openSettings: OpenSettingsAction
+    @Environment(\.openSettings) private var openSettings
 
     private var canSubmit: Bool {
         let trimmed = taskText.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary
- Add `@MainActor` to onboarding view methods (`setupVoiceCallbacks`, `toggleVoice`, `confirmName`, `grantPermission`) that access main-actor-isolated properties
- Remove explicit `OpenSettingsAction` type annotation in `TaskInputView` (type not available on CI's Xcode 16.2)

Follow-up to #1055 — these fixes were in the branch but missed the squash merge.

## Test plan
- [ ] CI build-sign-release job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
