### PR TITLE
Extend ThreadTabBar into titlebar with safe area and padding (#1059)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -48,6 +48,7 @@ struct MainWindowView: View {
                 panelContent
             })
         }
+        .ignoresSafeArea(edges: .top)
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -36,7 +36,8 @@ struct ThreadTabBar: View {
 
                 Spacer()
             }
-            .padding(.horizontal, VSpacing.lg)
+            .padding(.leading, 78)
+            .padding(.trailing, VSpacing.lg)
             .frame(height: 36)
             .background(VColor.background)
         }


### PR DESCRIPTION
## Summary
- Add `.ignoresSafeArea(edges: .top)` to MainWindowView's VStack to extend content into the transparent titlebar area
- Add 78px left padding to ThreadTabBar to clear the macOS traffic light buttons (close/minimize/fullscreen)
- Thread tabs now appear inline with the window controls, matching the mockup design

Closes #1059

## Test plan
- [ ] Verify thread tabs appear at the same vertical level as the traffic light buttons
- [ ] Verify tabs don't overlap with close/minimize/fullscreen buttons
- [ ] Verify tab interactions (select, close, create) still work correctly
- [ ] Verify the NavigationToolbar and chat content below are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
