### PR TITLE
Restyle VSlider track and thumb for dark theme (#1063)

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -8,14 +8,14 @@ struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 6
+    private let trackHeight: CGFloat = 10
     private let thumbWidth: CGFloat = 20
-    private let thumbHeight: CGFloat = 24
+    private let thumbHeight: CGFloat = 10
     private let tickMarkHeight: CGFloat = 8
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 10
+    private let gripLineHeight: CGFloat = 6
     private let gripLineSpacing: CGFloat = 2.5
 
     // MARK: - State
@@ -68,13 +68,13 @@ struct VSlider: View {
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
         ZStack(alignment: .leading) {
             // Unfilled track
-            Capsule()
-                .fill(Slate._700)
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(Slate._800)
                 .frame(height: trackHeight)
                 .padding(.horizontal, thumbWidth / 2)
 
             // Filled track
-            Capsule()
+            RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(VColor.accent)
                 .frame(width: thumbOffset, height: trackHeight)
                 .padding(.leading, thumbWidth / 2)
@@ -85,20 +85,19 @@ struct VSlider: View {
 
     private var thumbView: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: VRadius.sm)
-                .fill(Slate._200)
+            RoundedRectangle(cornerRadius: VRadius.xs)
+                .fill(Slate._600)
                 .frame(width: thumbWidth, height: thumbHeight)
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(Slate._400, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: VRadius.xs)
+                        .stroke(Slate._700, lineWidth: 1)
                 )
-                .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(Slate._500)
+                        .fill(Slate._400)
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }


### PR DESCRIPTION
## Summary
- Restyle VSlider to match the dark-theme mockup with a flush thumb and taller track
- Track uses RoundedRectangle instead of Capsule, increased from 6 to 10px height
- Thumb is now flush with track (same height), dark-colored with lighter grip lines
- Unfilled track darkened, shadow removed for cleaner integrated look

Closes #1063

## Test plan
- [ ] Verify slider appears with flush thumb at same height as track
- [ ] Verify filled track is purple (VColor.accent) and unfilled is dark gray
- [ ] Verify grip lines are visible on the dark thumb
- [ ] Verify drag interaction still works correctly
- [ ] Check ControlPanel "Max Steps per Session" slider renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
