### PR TITLE
Fix SSH tunnel macOS compatibility and startup verification

### DIFF
--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -35,8 +35,10 @@ read_pid() {
 
 is_tunnel_process() {
   local pid="$1"
-  # Verify the PID is an ssh process to avoid acting on reused PIDs
-  ps -p "$pid" -o comm= 2>/dev/null | grep -q '^ssh$'
+  # Verify the PID is an ssh process to avoid acting on reused PIDs.
+  # On macOS, `ps -o comm=` returns the full path (e.g. /usr/bin/ssh),
+  # while on Linux it returns just the command name (ssh).
+  ps -p "$pid" -o comm= 2>/dev/null | grep -qE '(^|/)ssh$'
 }
 
 is_running() {
@@ -79,13 +81,37 @@ cmd_start() {
   ensure_dir
 
   echo "Starting SSH tunnel: localhost:${local_port} -> ${ssh_host}:${remote_port} ..."
-  ssh -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host" &
+  ssh -N \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=3 \
+    -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" \
+    "$ssh_host" &
   local pid=$!
 
-  # Verify the SSH process is still alive after a brief pause
-  sleep 1
+  # Wait for the tunnel to become usable. ExitOnForwardFailure=yes ensures SSH
+  # exits if it cannot bind the local port, but we also need to wait for the
+  # connection to be fully established before declaring success.
+  local attempts=0
+  local max_attempts=10
+  while (( attempts < max_attempts )); do
+    sleep 0.5
+    if ! kill -0 "$pid" 2>/dev/null; then
+      die "SSH tunnel process exited — check SSH connectivity and port availability"
+    fi
+    # Try connecting to the forwarded local port to confirm the tunnel is ready
+    if (echo > /dev/tcp/127.0.0.1/"${local_port}") 2>/dev/null; then
+      break
+    fi
+    (( attempts++ ))
+  done
+
   if ! kill -0 "$pid" 2>/dev/null; then
-    die "SSH tunnel process exited immediately"
+    die "SSH tunnel process exited — check SSH connectivity and port availability"
+  fi
+
+  if (( attempts == max_attempts )); then
+    echo "warning: tunnel process is running but forwarded port ${local_port} is not responding yet" >&2
   fi
 
   echo "$pid" > "$PID_FILE"


### PR DESCRIPTION
## Summary

Addresses review feedback on #1015:

- **Fix `is_tunnel_process` on macOS**: `ps -o comm=` returns the full executable path on macOS (e.g. `/usr/bin/ssh`) but just the command name on Linux (`ssh`). Changed the grep pattern from `^ssh$` to `(^|/)ssh$` so it matches both formats. Without this fix, `is_running` always returned false on macOS, causing duplicate tunnels, orphaned processes, and incorrect status reporting.

- **Improve SSH startup verification**: The previous `ssh ... &` + `sleep 1` + `kill -0` approach treated any still-alive process as a successful tunnel, even when forwarding wasn't ready. Now uses:
  - `ExitOnForwardFailure=yes` so SSH exits immediately if it cannot bind the local port
  - A retry loop (up to 5s) that probes the forwarded port via `/dev/tcp` to confirm the tunnel is actually usable before declaring success
  - `ServerAliveInterval=15` / `ServerAliveCountMax=3` keepalive options to detect dead connections

## Test plan
- [ ] Verify `is_tunnel_process` matches both `/usr/bin/ssh` (macOS) and `ssh` (Linux)
- [ ] Verify `start` detects immediate SSH failure (e.g. bad host)
- [ ] Verify `start` waits for port to become available before reporting success
- [ ] Verify `stop`, `status`, and `print-env` work correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
