### PR TITLE
Fix shutdown hang when removeSocketFile throws in server.close callback

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -94,7 +94,11 @@ export class DaemonServer {
     const serverClosed = new Promise<void>((resolve) => {
       if (this.server) {
         this.server.close(() => {
-          removeSocketFile(this.socketPath);
+          try {
+            removeSocketFile(this.socketPath);
+          } catch (err) {
+            log.warn({ err, socketPath: this.socketPath }, 'Failed to remove socket file during shutdown');
+          }
           resolve();
         });
       } else {


### PR DESCRIPTION
## Summary
- Wraps `removeSocketFile()` in try/catch inside the `server.close()` callback in `DaemonServer.stop()`
- If `removeSocketFile` throws (e.g. socket path replaced by a non-socket file, or TOCTOU race on `statSync`), the exception previously prevented `resolve()` from being called, causing `await serverClosed` to hang indefinitely until the 10-second force-exit timer killed the process
- Now any cleanup error is logged as a warning and `resolve()` is always called, ensuring graceful shutdown completes promptly

Addresses review feedback on #1019 from Codex and Devin.

## Test plan
- Verify type-check passes (`bunx tsc --noEmit`)
- Confirm shutdown path completes promptly even if the socket file is replaced by a regular file before stop() is called
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
