### PR TITLE
Fix cross-user assistant access via non-unique display name

### DIFF
--- a/web/src/app/api/assistants/route.ts
+++ b/web/src/app/api/assistants/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     }
 
     const sql = getDb();
-    const identifiers = [user.id, user.username, user.name].filter(Boolean);
+    const identifiers = [user.id, user.username].filter(Boolean);
     const assistants = await sql`SELECT * FROM assistants WHERE created_by = ANY(${identifiers}) ORDER BY created_at DESC`;
     return NextResponse.json(assistants as unknown as Assistant[]);
   } catch (error: unknown) {

--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -82,15 +82,12 @@ export async function requireAssistantOwner(
     return { assistant, user };
   }
 
-  // Backward compatibility: created_by may store a username or display name.
-  if (
-    createdBy &&
-    ((user.username && createdBy === user.username) ||
-      (user.name && createdBy === user.name))
-  ) {
+  // Backward compatibility: created_by may store a username.
+  if (createdBy && user.username && createdBy === user.username) {
     // Migrate to canonical user ID for future lookups.
     await sql`UPDATE assistants SET created_by = ${user.id} WHERE id = ${assistantId}`;
-    return { assistant, user };
+    const updatedResult = await sql`SELECT * FROM assistants WHERE id = ${assistantId}`;
+    return { assistant: updatedResult[0] as Assistant, user };
   }
 
   throw new Error("FORBIDDEN");


### PR DESCRIPTION
## Summary
- Remove `user.name` (display name) from ownership identifiers in `GET /api/assistants` and `requireAssistantOwner` to prevent cross-user assistant access when two users share the same non-unique display name
- Return refreshed assistant object after migrating `created_by` to canonical user ID, fixing stale data being returned to callers

Addresses review feedback on PR #1021.

## Test plan
- [ ] Verify users can still access their own assistants via `user.id` and `user.username`
- [ ] Verify legacy assistants with `created_by` set to a username are still migrated correctly
- [ ] Verify that two users with the same display name no longer see each other's assistants
- [ ] Verify the returned assistant object after migration has the updated `created_by` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
