### PR TITLE
Fix recall marker strip to remove injected block, not user content

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -187,14 +187,9 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
     if (message.role !== 'user' || message.content.length === 0) continue;
-    let foundBlock = -1;
-    for (let bi = message.content.length - 1; bi >= 0; bi--) {
-      const block = message.content[bi];
-      if (block.type === 'text' && block.text === recallText) {
-        foundBlock = bi;
-        break;
-      }
-    }
+    const foundBlock = message.content.findIndex(
+      (block) => block.type === 'text' && block.text === recallText,
+    );
     if (foundBlock !== -1) {
       targetIndex = index;
       blockIndex = foundBlock;


### PR DESCRIPTION
## Summary
- Fixed `stripMemoryRecallMessages` to search content blocks from the beginning (using `findIndex`) instead of from the end (reverse loop)
- `injectMemoryRecallIntoUserMessage` always prepends the synthetic recall block at index 0, so the strip function should target index 0, not the last matching block
- The previous reverse search would incorrectly remove a user-authored block if it happened to match `recallText`, leaving the injected marker in persisted history

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Existing tests in `memory-v2-regressions.test.ts` cover recall stripping behavior

Addresses feedback from PR #1018.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
