### PR TITLE
Use safe httpStatus getter in health route

### DIFF
--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: Request, { params }: RouteParams) {
           status: "unhealthy",
           message: `Runtime health check returned ${error.status}`,
         },
-        { status: error.status },
+        { status: error.httpStatus },
       );
     }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {


### PR DESCRIPTION
## Summary
- Changed `error.status` to `error.httpStatus` in the health route catch block
- This aligns the health route with other routes (messages, attachments) that already use the safe `httpStatus` getter
- The `httpStatus` getter maps out-of-range status values to 502, preventing invalid HTTP status codes

Addresses review feedback on PR #1028.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
