### PR TITLE
Fix error.httpStatus in suggestion and health routes

### DIFF
--- a/web/src/app/api/assistants/[id]/health/route.ts
+++ b/web/src/app/api/assistants/[id]/health/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: Request, { params }: RouteParams) {
           status: "unhealthy",
           message: `Runtime health check returned ${error.status}`,
         },
-        { status: error.status },
+        { status: error.httpStatus },
       );
     }
     if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {

--- a/web/src/app/api/assistants/[id]/suggestion/route.ts
+++ b/web/src/app/api/assistants/[id]/suggestion/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (error instanceof RuntimeClientError) {
       return NextResponse.json(
         { suggestion: null, messageId: null, source: "none" as const },
-        { status: error.status },
+        { status: error.httpStatus },
       );
     }
     console.error("Error fetching suggestion:", error);


### PR DESCRIPTION
## Summary
- Fix `suggestion/route.ts` and `health/route.ts` to use `error.httpStatus` instead of `error.status` in NextResponse.json options
- When runtime is unreachable, `RuntimeClientError.status` is `0` which is invalid for `NextResponse.json` (accepts 200-599), causing the error handler itself to crash
- These two routes were missed by PR #1027 which fixed the same issue in other routes

Addresses review feedback from Devin on #1027.

## Test plan
- [ ] Verify suggestion endpoint returns structured JSON error when runtime is unreachable (instead of crashing)
- [ ] Verify health endpoint returns `{"status": "unhealthy"}` JSON when runtime is unreachable (instead of crashing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
