### PR TITLE
Add accessibilityLabel to emoji permission row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -231,6 +231,7 @@ struct ControlPanel: View {
             Text(emoji)
                 .font(.system(size: 14))
                 .frame(width: 20)
+                .accessibilityLabel(label)
 
             Text(label)
                 .font(VFont.body)


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #999 about the ghost emoji in the Accessibility permission row
- The ghost emoji is an intentional branding/design choice and is kept as-is
- Adds `.accessibilityLabel(label)` to the emoji `Text` view in `permissionRow(emoji:label:granted:)` so screen readers announce the permission name (e.g. "Accessibility") instead of the emoji name (e.g. "ghost")

## Test plan
- [ ] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] VoiceOver reads "Accessibility" for the ghost emoji row in the Control Panel permissions section
- [ ] Visual appearance of the permissions section is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
