### PR TITLE
Restore NULL/empty guards in backfill candidate query

### DIFF
--- a/web/scripts/backfill-created-by.ts
+++ b/web/scripts/backfill-created-by.ts
@@ -40,11 +40,15 @@ async function main() {
       process.exit(1);
     }
 
-    // Find assistants whose created_by is not already a user.id
+    // Find assistants whose created_by is not already a user.id.
+    // Keep the NULL/empty guards to avoid a race condition: a row inserted
+    // with created_by = NULL after the precheck would cause .trim() to throw.
     const nonCanonical = await sql`
       SELECT a.id, a.created_by
       FROM assistants a
-      WHERE NOT EXISTS (
+      WHERE a.created_by IS NOT NULL
+        AND a.created_by != ''
+        AND NOT EXISTS (
           SELECT 1 FROM "user" u WHERE u.id = a.created_by
         )
     `;


### PR DESCRIPTION
## Summary
- Restores the `created_by IS NOT NULL AND created_by != ''` predicates in the backfill candidate query that were removed in PR #1032
- Prevents a race condition where a row with `created_by = NULL` inserted after the precheck but before the nonCanonical query would cause `(row.created_by as string).trim()` to throw at runtime

## Context
PR #1032 added a precheck that fails early if any NULL/empty `created_by` values exist. However, it also removed the NULL/empty filters from the main backfill query. This creates a TOCTOU race: between the precheck and the query, new rows with NULL `created_by` could appear and cause a runtime crash.

The fix adds the guards back so the query itself is safe regardless of concurrent writes.

## Test plan
- [x] Verified the SQL query correctly filters out NULL and empty `created_by` values
- [x] Confirmed the precheck still runs first as an early-exit safety net
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
