### PR TITLE
Fix run orchestrator error capture via onEvent callback

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -81,12 +81,9 @@ export class RunOrchestrator {
     const messageId = session.persistUserMessage(content, attachments, requestId);
     const run = runsStore.createRun(assistantId, conversationId, messageId);
 
-    // Hook into session to intercept confirmation_request and error events.
+    // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the
     // run store so the web UI can poll and submit a decision.
-    // We also track error events because session.runAgentLoop catches
-    // internal errors and resolves normally — without tracking these,
-    // the run would be marked as completed even when errors occurred.
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
@@ -100,8 +97,6 @@ export class RunOrchestrator {
           prompterRequestId: msg.requestId,
           session,
         });
-      } else if (msg.type === 'error') {
-        lastError = msg.message;
       }
     });
 
@@ -113,7 +108,11 @@ export class RunOrchestrator {
       session.updateClient(() => {});
     };
 
-    session.runAgentLoop(content, messageId, () => {}).then(() => {
+    session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
+      if (msg.type === 'error') {
+        lastError = msg.message;
+      }
+    }).then(() => {
       if (lastError) {
         log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
         runsStore.failRun(run.id, lastError);


### PR DESCRIPTION
## Summary
- Agent loop errors are dispatched through the `onEvent` callback (3rd argument to `runAgentLoop`), not through `session.updateClient`'s `sendToClient` channel
- The previous code passed a no-op `() => {}` as `onEvent`, so `lastError` was never set and failed runs were incorrectly marked as `completed`
- Moved error tracking into the `onEvent` callback where errors actually flow
- Removed the dead `error` check from `updateClient` since agent loop errors never reach that callback

Addresses review feedback on #1025.

## Test plan
- [ ] Trigger an agent loop error and verify the run is marked `failed` instead of `completed`
- [ ] Verify confirmation requests still work through `updateClient`
- [ ] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
