### PR TITLE
Fix run polling: handle transient errors and clear stale confirmation

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -354,9 +354,14 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
         const res = await fetch(`/api/assistants/${assistantId}/runs/${activeRunId}`);
         if (cancelled) return;
         if (!res.ok) {
-          setActiveRunId(null);
-          setIsLoading(false);
-          await fetchMessages();
+          // Only treat 404 as terminal (run no longer exists).
+          // Transient errors (e.g. 502 from runtime connectivity) should not stop polling.
+          if (res.status === 404) {
+            setActiveRunId(null);
+            setPendingConfirmation(null);
+            setIsLoading(false);
+            await fetchMessages();
+          }
           return;
         }
         const run = await res.json() as {


### PR DESCRIPTION
## Summary
- Only treat **404** poll responses as terminal (run no longer exists). Transient errors like 502 from runtime connectivity issues no longer permanently stop polling, allowing the run to recover once the backend is reachable again.
- Add `setPendingConfirmation(null)` to the terminal-error (404) branch so a stale confirmation dialog is dismissed when the polled run disappears, preventing the composer from getting permanently blocked with an unactionable dialog.

Addresses review feedback from Devin and Codex on #1033.

## Test plan
- [ ] Verify polling continues through transient 502 errors (simulate by briefly stopping the runtime)
- [ ] Verify polling stops and UI resets cleanly on 404 (switch assistants while a run is active)
- [ ] Verify confirmation dialog is dismissed when a 404 occurs during `needs_confirmation` state