### PR TITLE
Fix VToggle label click not toggling state

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VToggle.swift
@@ -21,6 +21,12 @@ struct VToggle: View {
                     .foregroundColor(VColor.textPrimary)
             }
         }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(VAnimation.fast) {
+                isOn.toggle()
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityValue(isOn ? "On" : "Off")
@@ -45,11 +51,6 @@ struct VToggle: View {
                 .fill(Color.white)
                 .frame(width: knobSize, height: knobSize)
                 .padding(.horizontal, knobPadding)
-        }
-        .onTapGesture {
-            withAnimation(VAnimation.fast) {
-                isOn.toggle()
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes P2 feedback from PR #1008: clicking the label text in VToggle did not toggle the switch — only the 40x22 track was tappable
- Moved `.onTapGesture` from the track `ZStack` to the outer `HStack` and added `.contentShape(Rectangle())` so the entire row is tappable, matching native `Toggle` behavior

## Test plan
- [ ] Click on the toggle track — switch toggles with animation
- [ ] Click on the label text — switch toggles with animation
- [ ] Toggle without a label still works (track-only VToggle)
- [ ] VoiceOver reads toggle state correctly (accessibility unchanged)
- [ ] Build succeeds (`./build.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
