### PR TITLE
Distinguish no-pending-decision from missing run in submitDecision

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -534,11 +534,17 @@ export class RuntimeHttpServer {
       );
     }
 
-    const applied = this.runOrchestrator.submitDecision(runId, decision);
-    if (!applied) {
+    const result = this.runOrchestrator.submitDecision(runId, decision);
+    if (result === 'run_not_found') {
       return Response.json(
         { error: 'Run not found' },
         { status: 404 },
+      );
+    }
+    if (result === 'no_pending_decision') {
+      return Response.json(
+        { error: 'No confirmation pending for this run' },
+        { status: 409 },
       );
     }
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -138,11 +138,13 @@ export class RunOrchestrator {
 
   /**
    * Submit a permission decision for a pending confirmation.
-   * Returns true if the decision was applied or was already handled
-   * (idempotent). Returns false if the run doesn't exist or is in
-   * a state where no confirmation is pending.
+   *
+   * Returns:
+   * - `'applied'`         – decision was applied or already handled (idempotent)
+   * - `'run_not_found'`   – no run exists with the given ID
+   * - `'no_pending_decision'` – run exists but is not awaiting a confirmation
    */
-  submitDecision(runId: string, decision: UserDecision): boolean {
+  submitDecision(runId: string, decision: UserDecision): 'applied' | 'run_not_found' | 'no_pending_decision' {
     const pendingState = this.pending.get(runId);
     if (pendingState) {
       runsStore.clearRunConfirmation(runId);
@@ -151,12 +153,12 @@ export class RunOrchestrator {
         decision,
       );
       this.pending.delete(runId);
-      return true;
+      return 'applied';
     }
 
     // No in-memory pending state — check if the run exists.
     const run = runsStore.getRun(runId);
-    if (!run) return false;
+    if (!run) return 'run_not_found';
 
     // If the run is still needs_confirmation but there's no in-memory
     // state, the prompter already timed out and auto-denied. Fail the
@@ -164,18 +166,18 @@ export class RunOrchestrator {
     // to complete it.
     if (run.status === 'needs_confirmation') {
       runsStore.failRun(runId, 'Prompter timed out (no active handler)');
-      return true;
+      return 'applied';
     }
 
     // Terminal states (completed/failed) mean the decision was already
     // handled (double-submit). Treat as idempotent success.
     if (run.status === 'completed' || run.status === 'failed') {
-      return true;
+      return 'applied';
     }
 
     // Run is in 'running' state with no pending confirmation — the
     // agent loop hasn't reached a confirmation point yet. Reject so
     // the client doesn't mistakenly treat the decision as accepted.
-    return false;
+    return 'no_pending_decision';
   }
 }


### PR DESCRIPTION
## Summary
- Changed `submitDecision` return type from `boolean` to a discriminated string union (`'applied' | 'run_not_found' | 'no_pending_decision'`) so callers can distinguish between the two failure cases.
- Updated the HTTP handler to return **404** for non-existent runs and **409 Conflict** with message `"No confirmation pending for this run"` for runs that exist but have no pending confirmation.
- Addresses review feedback on PR #1031 from both Devin and Codex reviewers.

## Test plan
- [ ] Verify that submitting a decision for a non-existent run returns 404 with `"Run not found"`
- [ ] Verify that submitting a decision for a run in `running` state (no pending confirmation) returns 409 with `"No confirmation pending for this run"`
- [ ] Verify that submitting a decision for a run with a pending confirmation returns 200 with `{ accepted: true }`
- [ ] Verify type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
