### PR TITLE
Preserve domain-specific error messages in toAuthErrorResponse

### DIFF
--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -107,5 +107,8 @@ export function toAuthErrorResponse(error: unknown): NextResponse {
   if (message === "Contact not found") {
     return NextResponse.json({ error: "Contact not found" }, { status: 404 });
   }
-  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  return NextResponse.json(
+    { error: error instanceof Error ? error.message : "Internal server error" },
+    { status: 500 }
+  );
 }


### PR DESCRIPTION
## Summary
- Addresses review feedback on PR #1020: the catch-all in `toAuthErrorResponse` was returning a hard-coded `"Internal server error"` for all non-whitelisted exceptions, which hid useful domain-specific errors from routes like Telegram channel connect/disconnect handlers.
- The fix preserves the original error message for `Error` instances in the catch-all case. Auth-sensitive errors (`UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`) are already handled by the explicit checks above with safe messages, so errors reaching the catch-all are domain-specific and safe to surface to the authenticated user.

## Test plan
- [ ] Verify Telegram channel connect with an invalid bot token shows the specific failure reason in the UI
- [ ] Verify auth errors (unauthenticated, wrong owner) still return safe generic messages
- [ ] Verify non-Error exceptions still return "Internal server error"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
