### PR TITLE
Fix VSlider tick marks hidden behind track

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -11,12 +11,16 @@ struct VSlider: View {
     private let trackHeight: CGFloat = 10
     private let thumbWidth: CGFloat = 20
     private let thumbHeight: CGFloat = 10
-    private let tickMarkHeight: CGFloat = 8
+    private let tickMarkHeight: CGFloat = 14
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
     private let gripLineHeight: CGFloat = 6
     private let gripLineSpacing: CGFloat = 2.5
+
+    private var sliderHeight: CGFloat {
+        showTickMarks ? max(thumbHeight, tickMarkHeight) : thumbHeight
+    }
 
     // MARK: - State
 
@@ -43,7 +47,7 @@ struct VSlider: View {
                 thumbView
                     .offset(x: thumbOffset)
             }
-            .frame(height: thumbHeight)
+            .frame(height: sliderHeight)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
@@ -60,7 +64,7 @@ struct VSlider: View {
                     }
             )
         }
-        .frame(height: thumbHeight)
+        .frame(height: sliderHeight)
     }
 
     // MARK: - Track


### PR DESCRIPTION
## Summary
- Increase `tickMarkHeight` from 8 to 14 so tick marks peek above and below the 10px track instead of being completely covered
- Add computed `sliderHeight` property so the container frame accommodates the taller tick marks when `showTickMarks` is enabled
- Addresses review feedback from Codex and Devin on #1065

## Test plan
- [ ] Verify tick marks are visible above and below the track when `showTickMarks: true`
- [ ] Verify slider without tick marks is unaffected (same 10px height)
- [ ] Verify drag interaction still works correctly
- [ ] Check ControlPanel "Max Steps per Session" slider renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
