### PR TITLE
Fix run orchestrator to capture agent-loop errors from onEvent

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -113,7 +113,11 @@ export class RunOrchestrator {
       session.updateClient(() => {});
     };
 
-    session.runAgentLoop(content, messageId, () => {}).then(() => {
+    session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
+      if (msg.type === 'error') {
+        lastError = msg.message;
+      }
+    }).then(() => {
       if (lastError) {
         log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
         runsStore.failRun(run.id, lastError);

--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -35,8 +35,10 @@ read_pid() {
 
 is_tunnel_process() {
   local pid="$1"
-  # Verify the PID is an ssh process to avoid acting on reused PIDs
-  ps -p "$pid" -o comm= 2>/dev/null | grep -q '^ssh$'
+  # Verify the PID is an ssh process to avoid acting on reused PIDs.
+  # On macOS, `ps -o comm=` returns the full path (e.g. /usr/bin/ssh),
+  # while on Linux it returns just the command name (ssh).
+  ps -p "$pid" -o comm= 2>/dev/null | grep -qE '(^|/)ssh$'
 }
 
 is_running() {
@@ -79,13 +81,37 @@ cmd_start() {
   ensure_dir
 
   echo "Starting SSH tunnel: localhost:${local_port} -> ${ssh_host}:${remote_port} ..."
-  ssh -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host" &
+  ssh -N \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=3 \
+    -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" \
+    "$ssh_host" &
   local pid=$!
 
-  # Verify the SSH process is still alive after a brief pause
-  sleep 1
+  # Wait for the tunnel to become usable. ExitOnForwardFailure=yes ensures SSH
+  # exits if it cannot bind the local port, but we also need to wait for the
+  # connection to be fully established before declaring success.
+  local attempts=0
+  local max_attempts=10
+  while (( attempts < max_attempts )); do
+    sleep 0.5
+    if ! kill -0 "$pid" 2>/dev/null; then
+      die "SSH tunnel process exited — check SSH connectivity and port availability"
+    fi
+    # Try connecting to the forwarded local port to confirm the tunnel is ready
+    if (echo > /dev/tcp/127.0.0.1/"${local_port}") 2>/dev/null; then
+      break
+    fi
+    (( attempts++ ))
+  done
+
   if ! kill -0 "$pid" 2>/dev/null; then
-    die "SSH tunnel process exited immediately"
+    die "SSH tunnel process exited — check SSH connectivity and port availability"
+  fi
+
+  if (( attempts == max_attempts )); then
+    echo "warning: tunnel process is running but forwarded port ${local_port} is not responding yet" >&2
   fi
 
   echo "$pid" > "$PID_FILE"


### PR DESCRIPTION
## Summary

Addresses review feedback on #1025:

- **Agent-loop errors were silently swallowed**: `session.runAgentLoop` dispatches error events through its `onEvent` callback (3rd argument), not through `session.updateClient`. The code was passing `() => {}` as `onEvent`, so `lastError` was never set from agent-loop errors, and runs were incorrectly marked as `completed` instead of `failed`.

- **Fix**: Replace the no-op `() => {}` with a callback that checks for `msg.type === 'error'` and sets `lastError`, matching the existing pattern already present in the `updateClient` callback. Both channels now properly track errors.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed)
- [ ] Verify that a run whose agent loop emits an error event is marked `failed`, not `completed`
- [ ] Verify that runs completing without errors are still marked `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
