### PR TITLE
Fix stale confirmation dialog and transient poll errors in InteractionTab

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -113,7 +113,11 @@ export class RunOrchestrator {
       session.updateClient(() => {});
     };
 
-    session.runAgentLoop(content, messageId, () => {}).then(() => {
+    session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
+      if (msg.type === 'error') {
+        lastError = msg.message;
+      }
+    }).then(() => {
       if (lastError) {
         log.error({ runId: run.id, error: lastError }, 'Run failed (error event from agent loop)');
         runsStore.failRun(run.id, lastError);

--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -35,8 +35,10 @@ read_pid() {
 
 is_tunnel_process() {
   local pid="$1"
-  # Verify the PID is an ssh process to avoid acting on reused PIDs
-  ps -p "$pid" -o comm= 2>/dev/null | grep -q '^ssh$'
+  # Verify the PID is an ssh process to avoid acting on reused PIDs.
+  # On macOS, `ps -o comm=` returns the full path (e.g. /usr/bin/ssh),
+  # while on Linux it returns just the command name (ssh).
+  ps -p "$pid" -o comm= 2>/dev/null | grep -qE '(^|/)ssh$'
 }
 
 is_running() {
@@ -79,13 +81,37 @@ cmd_start() {
   ensure_dir
 
   echo "Starting SSH tunnel: localhost:${local_port} -> ${ssh_host}:${remote_port} ..."
-  ssh -N -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" "$ssh_host" &
+  ssh -N \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=3 \
+    -L "127.0.0.1:${local_port}:127.0.0.1:${remote_port}" \
+    "$ssh_host" &
   local pid=$!
 
-  # Verify the SSH process is still alive after a brief pause
-  sleep 1
+  # Wait for the tunnel to become usable. ExitOnForwardFailure=yes ensures SSH
+  # exits if it cannot bind the local port, but we also need to wait for the
+  # connection to be fully established before declaring success.
+  local attempts=0
+  local max_attempts=10
+  while (( attempts < max_attempts )); do
+    sleep 0.5
+    if ! kill -0 "$pid" 2>/dev/null; then
+      die "SSH tunnel process exited — check SSH connectivity and port availability"
+    fi
+    # Try connecting to the forwarded local port to confirm the tunnel is ready
+    if (echo > /dev/tcp/127.0.0.1/"${local_port}") 2>/dev/null; then
+      break
+    fi
+    (( attempts++ ))
+  done
+
   if ! kill -0 "$pid" 2>/dev/null; then
-    die "SSH tunnel process exited immediately"
+    die "SSH tunnel process exited — check SSH connectivity and port availability"
+  fi
+
+  if (( attempts == max_attempts )); then
+    echo "warning: tunnel process is running but forwarded port ${local_port} is not responding yet" >&2
   fi
 
   echo "$pid" > "$PID_FILE"

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -354,7 +354,11 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
         const res = await fetch(`/api/assistants/${assistantId}/runs/${activeRunId}`);
         if (cancelled) return;
         if (!res.ok) {
+          // Transient errors (5xx) — keep polling; the run may still be alive
+          if (res.status >= 500) return;
+          // Terminal errors (4xx, e.g. 404 after assistant switch) — stop polling
           setActiveRunId(null);
+          setPendingConfirmation(null);
           setIsLoading(false);
           await fetchMessages();
           return;


### PR DESCRIPTION
## Summary

Addresses review feedback on #1033:

- **Fix stale confirmation dialog**: Added `setPendingConfirmation(null)` in the `!res.ok` error handler. Without this, if a run was in `needs_confirmation` state when the poll fails (e.g. 404 after switching assistants), the confirmation dialog remains visible but `handleDecision` no-ops because `activeRunId` is null, leaving the composer permanently blocked.

- **Handle transient errors gracefully**: Previously any non-OK poll response immediately dropped `activeRunId` and stopped polling. Since transient runtime connectivity issues surface as 502 (via `RuntimeClientError`), a brief backend hiccup would permanently stop polling an otherwise-live run. Now 5xx errors are ignored (polling continues), while only 4xx errors are treated as terminal.

## Test plan
- [ ] Verify switching assistants while a run is in `needs_confirmation` clears the confirmation dialog
- [ ] Verify a transient 502 poll error does not stop polling (run recovers when backend comes back)
- [ ] Verify a 404 poll error properly resets the run state and clears confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
