### PR TITLE
Scope top safe area override to ThreadTabBar only (#1060 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -48,7 +48,6 @@ struct MainWindowView: View {
                 panelContent
             })
         }
-        .ignoresSafeArea(edges: .top)
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -41,6 +41,7 @@ struct ThreadTabBar: View {
             .frame(height: 36)
             .background(VColor.background)
         }
+        .ignoresSafeArea(edges: .top)
     }
 }
 


### PR DESCRIPTION
## Summary
- Moved `.ignoresSafeArea(edges: .top)` from the root `VStack` in `MainWindowView` to `ThreadTabBar`'s outer `VStack`
- The previous placement removed the top safe area inset in **all** window states, causing controls to render under the notch/menu bar region in fullscreen on notched MacBooks
- Scoping it to `ThreadTabBar` only preserves the transparent-titlebar overlap effect while letting fullscreen mode correctly respect top safe area insets

## Test plan
- [ ] Verify ThreadTabBar still extends behind the transparent titlebar in normal windowed mode
- [ ] Enter fullscreen on a notched MacBook and verify controls are not obscured by the notch/menu bar
- [ ] Verify background color still fills the full window area (via the separate `.background(VColor.background.ignoresSafeArea())`)

Addresses feedback from #1060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
