### PR TITLE
Rename macOS app display name to Vellum

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -116,7 +116,7 @@ jobs:
 
           # Create DMG
           hdiutil create \
-            -volname "vellum-assistant" \
+            -volname "Vellum" \
             -srcfolder "$DMG_STAGING" \
             -ov \
             -format UDZO \
@@ -217,7 +217,7 @@ jobs:
           <?xml version="1.0" encoding="utf-8"?>
           <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
             <channel>
-              <title>vellum-assistant</title>
+              <title>Vellum</title>
               <item>
                 <title>${DISPLAY_VERSION}</title>
                 <sparkle:version>${BUILD_VERSION}</sparkle:version>
@@ -255,7 +255,7 @@ jobs:
 
           ---
 
-          Download the DMG, open it, and drag vellum-assistant to your Applications folder.
+          Download the DMG, open it, and drag Vellum to your Applications folder.
           Existing installations will auto-update via Sparkle."
 
           gh release create latest \
@@ -263,7 +263,7 @@ jobs:
             dist/vellum-assistant.zip \
             dist/appcast.xml \
             --repo "$REPO" \
-            --title "vellum-assistant $VERSION" \
+            --title "Vellum $VERSION" \
             --notes "$RELEASE_NOTES" \
             --latest
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -124,7 +124,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <key>CFBundleIdentifier</key>
     <string>$BUNDLE_ID</string>
     <key>CFBundleName</key>
-    <string>$APP_NAME</string>
+    <string>Vellum</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
@@ -142,11 +142,11 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>NSScreenRecordingUsageDescription</key>
-    <string>vellum-assistant needs Screen Recording access to see what's on your screen during computer use tasks.</string>
+    <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>vellum-assistant needs microphone access to transcribe voice commands.</string>
+    <string>Vellum needs microphone access to transcribe voice commands.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
-    <string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+    <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>SUFeedURL</key>
     <string>https://github.com/alex-nork/vellum-assistant-macos-updates/releases/latest/download/appcast.xml</string>
     <key>SUPublicEDKey</key>

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -149,7 +149,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             forName: NSWindow.willCloseNotification, object: nil, queue: .main
         ) { [weak self] notification in
             guard let window = notification.object as? NSWindow,
-                  window.title.contains("Settings") || window.title.contains("vellum") else { return }
+                  window.title.contains("Settings") || window.title.contains("Vellum") else { return }
             // Keep .regular if MainWindow exists; only revert for legacy menu-bar-only mode
             guard self?.mainWindow == nil else { return }
             // Revert to accessory (no dock icon) after settings closes
@@ -174,7 +174,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
-            button.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: "vellum-assistant")
+            button.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: "Vellum")
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
             button.action = #selector(statusBarButtonClicked(_:))
             button.target = self
@@ -301,7 +301,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             if isRecording {
                 self?.statusItem.button?.image = NSImage(
                     systemSymbolName: "mic.fill",
-                    accessibilityDescription: "vellum-assistant"
+                    accessibilityDescription: "Vellum"
                 )
                 if !hasActiveConvo {
                     let window = VoiceTranscriptionWindow()
@@ -337,7 +337,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let iconName = isAmbientActive ? "eye" : "sparkles"
         statusItem.button?.image = NSImage(
             systemSymbolName: iconName,
-            accessibilityDescription: "vellum-assistant"
+            accessibilityDescription: "Vellum"
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -31,7 +31,7 @@ final class ChatViewModel: ObservableObject {
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
         // Add initial greeting
-        let name = UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant"
+        let name = UserDefaults.standard.string(forKey: "assistantName") ?? "Vellum"
         messages.append(ChatMessage(role: .assistant, text: "Hello! I'm \(name). How can I help you today?"))
     }
 

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayView.swift
@@ -9,7 +9,7 @@ struct SessionOverlayView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "cursorarrow.click.2")
                     .foregroundStyle(.blue)
-                Text("vellum-assistant is working...")
+                Text("Vellum is working...")
                     .font(VFont.headline)
                     .lineLimit(1)
             }

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -22,7 +22,7 @@ struct TaskInputView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             HStack {
-                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "vellum-assistant")
+                Text(UserDefaults.standard.string(forKey: "assistantName") ?? "Vellum")
                     .font(VFont.headline)
                     .foregroundStyle(.primary)
                 Spacer()

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -5,11 +5,11 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSScreenRecordingUsageDescription</key>
-    <string>vellum-assistant needs Screen Recording access to see what's on your screen during computer use tasks.</string>
+    <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>vellum-assistant needs microphone access to transcribe voice commands.</string>
+    <string>Vellum needs microphone access to transcribe voice commands.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
-    <string>vellum-assistant uses speech recognition to convert voice commands into tasks.</string>
+    <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- Rename all user-visible references from "vellum-assistant" to "Vellum" (CFBundleName, permission dialogs, overlay text, greeting, accessibility descriptions, DMG volume name, release titles)
- Internal identifiers preserved: bundle ID, binary name, keychain service, filesystem paths, SPM targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
