### PR TITLE
Rename .app bundle to Vellum.app for correct dock name

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -94,7 +94,7 @@ jobs:
           SIGN_IDENTITY="Developer ID Application" \
           ./build.sh release
 
-          APP_PATH="dist/vellum-assistant.app"
+          APP_PATH="dist/Vellum.app"
 
           # Verify the app exists
           ls -la "$APP_PATH"
@@ -105,8 +105,8 @@ jobs:
 
       - name: Create DMG
         run: |
-          APP_PATH="dist/vellum-assistant.app"
-          APP_NAME="vellum-assistant.app"
+          APP_PATH="dist/Vellum.app"
+          APP_NAME="Vellum.app"
 
           # Create staging directory for DMG contents
           DMG_STAGING="build/dmg-staging"
@@ -193,7 +193,7 @@ jobs:
       - name: Build ZIP for Sparkle auto-update
         run: |
           cd dist
-          ditto -c -k --keepParent vellum-assistant.app vellum-assistant.zip
+          ditto -c -k --keepParent Vellum.app vellum-assistant.zip
           echo "Sparkle ZIP created:"
           ls -lh vellum-assistant.zip
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -23,7 +23,8 @@ cd "$SCRIPT_DIR"
 
 BUNDLE_ID="com.vellum.vellum-assistant"
 APP_NAME="vellum-assistant"
-APP_DIR="$SCRIPT_DIR/dist/$APP_NAME.app"
+BUNDLE_DISPLAY_NAME="Vellum"
+APP_DIR="$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app"
 CONTENTS="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS/MacOS"
 RESOURCES_DIR="$CONTENTS/Resources"
@@ -85,7 +86,7 @@ if [ ! -f "$EXECUTABLE" ]; then
 fi
 
 # 2. Create .app bundle structure
-echo "Packaging $APP_NAME.app..."
+echo "Packaging $BUNDLE_DISPLAY_NAME.app..."
 rm -rf "$APP_DIR"
 FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
@@ -124,6 +125,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <key>CFBundleIdentifier</key>
     <string>$BUNDLE_ID</string>
     <key>CFBundleName</key>
+    <string>Vellum</string>
+    <key>CFBundleDisplayName</key>
     <string>Vellum</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>


### PR DESCRIPTION
## Summary
- Rename `.app` bundle from `vellum-assistant.app` to `Vellum.app` so macOS dock shows "Vellum" instead of "vellum-assistant"
- Add `CFBundleDisplayName` to Info.plist for completeness
- Update all CI workflow references to the new bundle name (ZIP artifact filename kept as `vellum-assistant.zip` for Sparkle update URL compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
