### PR TITLE
Rename executable binary to Vellum for System Settings

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -1,12 +1,12 @@
-# Scrub — Kill, Wipe, and Relaunch vellum-assistant
+# Scrub — Kill, Wipe, and Relaunch Vellum
 
-Kill the running vellum-assistant app, delete all persistent data so the next launch behaves like a first run (including onboarding), then start the daemon and rebuild/launch the app.
+Kill the running Vellum app, delete all persistent data so the next launch behaves like a first run (including onboarding), then start the daemon and rebuild/launch the app.
 
 ## Steps
 
-1. Kill any running `vellum-assistant` processes:
+1. Kill any running Vellum processes:
    ```bash
-   pkill -f "vellum-assistant"
+   pkill -f "Vellum"
    ```
 
 2. Remove session logs and knowledge store:

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -91,9 +91,9 @@ rm -rf "$APP_DIR"
 FRAMEWORKS_DIR="$CONTENTS/Frameworks"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
-# Copy executable and add Frameworks rpath for bundled dynamic frameworks
-cp "$EXECUTABLE" "$MACOS_DIR/$APP_NAME"
-install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$APP_NAME" 2>/dev/null || true
+# Copy executable (renamed to match display name) and add Frameworks rpath
+cp "$EXECUTABLE" "$MACOS_DIR/$BUNDLE_DISPLAY_NAME"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$BUNDLE_DISPLAY_NAME" 2>/dev/null || true
 
 # Copy Sparkle.framework into bundle (required — it's a dynamic framework)
 SPARKLE_FW="$BIN_PATH/Sparkle.framework"
@@ -121,7 +121,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 <plist version="1.0">
 <dict>
     <key>CFBundleExecutable</key>
-    <string>$APP_NAME</string>
+    <string>$BUNDLE_DISPLAY_NAME</string>
     <key>CFBundleIdentifier</key>
     <string>$BUNDLE_ID</string>
     <key>CFBundleName</key>
@@ -206,7 +206,7 @@ echo "Built: $APP_DIR"
 if [ "$CMD" = "run" ]; then
     echo "Launching..."
     # Kill existing instance if running
-    pkill -x "$APP_NAME" 2>/dev/null || true
+    pkill -x "$BUNDLE_DISPLAY_NAME" 2>/dev/null || true
     sleep 0.3
     # Launch via `open` so Launch Services registers the bundle —
     # this is required for macOS TCC to associate the app with its


### PR DESCRIPTION
## Summary
- Rename the executable binary inside the .app bundle from `vellum-assistant` to `Vellum` so macOS System Settings (Privacy & Security) shows "Vellum" instead of "vellum-assistant"
- Update `CFBundleExecutable` to match
- Update `/scrub` command copywriting to say "Vellum"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
