### PR TITLE
Fix (( attempts++ )) exit under set -e in tunnel startup

### DIFF
--- a/scripts/vellum-runtime-tunnel.sh
+++ b/scripts/vellum-runtime-tunnel.sh
@@ -103,7 +103,7 @@ cmd_start() {
     if (echo > /dev/tcp/127.0.0.1/"${local_port}") 2>/dev/null; then
       break
     fi
-    (( attempts++ ))
+    (( ++attempts ))
   done
 
   if ! kill -0 "$pid" 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Post-increment `(( attempts++ ))` evaluates to 0 on first iteration when `attempts=0`, causing `(( 0 ))` to return exit code 1
- With `set -euo pipefail` enabled, this kills the script immediately on the first retry loop iteration, preventing any retries
- Changed to pre-increment `(( ++attempts ))` which evaluates to 1 (truthy/success exit code)

## Test plan
- [ ] Verify `bash -c 'set -euo pipefail; x=0; (( ++x )); echo survived'` prints "survived"
- [ ] Confirm tunnel startup retry loop works when port is not immediately available

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
