### PR TITLE
Fix recall marker stripping to use last-match semantics

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -187,9 +187,14 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
     if (message.role !== 'user' || message.content.length === 0) continue;
-    const foundBlock = message.content.findIndex(
-      (block) => block.type === 'text' && block.text === recallText,
-    );
+    let foundBlock = -1;
+    for (let bi = message.content.length - 1; bi >= 0; bi--) {
+      const block = message.content[bi];
+      if (block.type === 'text' && block.text === recallText) {
+        foundBlock = bi;
+        break;
+      }
+    }
     if (foundBlock !== -1) {
       targetIndex = index;
       blockIndex = foundBlock;


### PR DESCRIPTION
## Summary
- Restores reverse iteration (last-match semantics) for recall marker stripping in `stripLastMemoryRecallFromHistory`
- `findIndex` (introduced in #1069) strips the wrong block when `deepRepairHistory` merges consecutive user messages, creating duplicate recall markers — the first (stale) block was removed instead of the last (active) one
- Uses a reverse for-loop to find the last matching block, avoiding the need for `findLastIndex` (which requires ES2023 lib)

## Test plan
- [x] All 19 tests in `memory-v2-regressions.test.ts` pass, including the deep-repair merged-content scenario (lines 555-577)
- [x] TypeScript type-check passes (`tsc --noEmit`)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
