### PR TITLE
Prevent internal error leaks in toAuthErrorResponse

### DIFF
--- a/web/src/lib/auth/server-session.ts
+++ b/web/src/lib/auth/server-session.ts
@@ -3,6 +3,17 @@ import { NextResponse } from "next/server";
 import { Assistant, getDb } from "@/lib/db";
 import { auth } from "@/lib/auth/better-auth";
 
+/**
+ * Error subclass for user-safe domain errors whose message can be returned
+ * in API responses without leaking internal details.
+ */
+export class DomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DomainError";
+  }
+}
+
 export interface RequestUser {
   id: string | null;
   username: string | null;
@@ -108,7 +119,7 @@ export function toAuthErrorResponse(error: unknown): NextResponse {
     return NextResponse.json({ error: "Contact not found" }, { status: 404 });
   }
   return NextResponse.json(
-    { error: error instanceof Error ? error.message : "Internal server error" },
+    { error: error instanceof DomainError ? error.message : "Internal server error" },
     { status: 500 }
   );
 }

--- a/web/src/lib/channels/service.ts
+++ b/web/src/lib/channels/service.ts
@@ -15,6 +15,7 @@ import {
   upsertAssistantChannelContact,
 } from "@/lib/channels/db";
 import { getChannelPlugin } from "@/lib/channels/plugins";
+import { DomainError } from "@/lib/auth/server-session";
 import { createRuntimeClient } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
 
@@ -82,7 +83,7 @@ export async function connectTelegramChannel(params: {
 }) {
   const plugin = getChannelPlugin("telegram");
   if (!plugin) {
-    throw new Error("Telegram channel plugin is not registered");
+    throw new DomainError("Telegram channel plugin is not registered");
   }
 
   const existing = await getAssistantChannelAccount(params.assistantId, "telegram");
@@ -160,7 +161,7 @@ export async function connectTelegramChannel(params: {
             config: (existing.config || {}) as Record<string, unknown>,
             lastError: `${message} (rollback unavailable; channel disabled)`,
           });
-          throw new Error(
+          throw new DomainError(
             `Telegram connection failed: ${message} (rollback unavailable; disabled account ${disabled.id})`
           );
         }
@@ -186,7 +187,7 @@ export async function connectTelegramChannel(params: {
             config: (existing.config || {}) as Record<string, unknown>,
             lastError: `${message} (rollback failed: ${rollbackMessage})`,
           });
-          throw new Error(
+          throw new DomainError(
             `Telegram connection failed: ${message} (rollback failed: ${rollbackMessage}; disabled account ${disabled.id})`
           );
         }
@@ -202,7 +203,7 @@ export async function connectTelegramChannel(params: {
         lastError: message,
       });
 
-      throw new Error(
+      throw new DomainError(
         `Telegram connection failed: ${message} (kept existing active channel)`
       );
     }
@@ -216,7 +217,7 @@ export async function connectTelegramChannel(params: {
       config: provisionalConfig,
       lastError: message,
     });
-    throw new Error(
+    throw new DomainError(
       `Telegram connection failed: ${message} (account ${failed.id})`
     );
   }
@@ -225,7 +226,7 @@ export async function connectTelegramChannel(params: {
 export async function disconnectTelegramChannel(assistantId: string) {
   const plugin = getChannelPlugin("telegram");
   if (!plugin) {
-    throw new Error("Telegram channel plugin is not registered");
+    throw new DomainError("Telegram channel plugin is not registered");
   }
 
   const account = await getAssistantChannelAccount(assistantId, "telegram");
@@ -298,12 +299,12 @@ async function updateTelegramContactStatus(params: {
 }) {
   const account = await getAssistantChannelAccount(params.assistantId, "telegram");
   if (!account) {
-    throw new Error("Telegram channel is not configured for this assistant");
+    throw new DomainError("Telegram channel is not configured for this assistant");
   }
 
   const contact = await getAssistantChannelContactById(params.contactId);
   if (!contact || contact.assistant_channel_account_id !== account.id) {
-    throw new Error("Contact not found");
+    throw new DomainError("Contact not found");
   }
 
   const updated = await updateAssistantChannelContactStatus({
@@ -311,7 +312,7 @@ async function updateTelegramContactStatus(params: {
     status: params.status,
   });
   if (!updated) {
-    throw new Error("Failed to update contact status");
+    throw new DomainError("Failed to update contact status");
   }
 
   return updated;
@@ -353,7 +354,7 @@ export async function handleTelegramWebhook(params: {
 }) {
   const plugin = getChannelPlugin("telegram");
   if (!plugin) {
-    throw new Error("Telegram channel plugin is not registered");
+    throw new DomainError("Telegram channel plugin is not registered");
   }
 
   const account = await getAssistantChannelAccountById(params.channelAccountId);


### PR DESCRIPTION
## Summary

- Introduces a `DomainError` class in `web/src/lib/auth/server-session.ts` for user-safe errors whose messages can be returned in API responses
- Updates `toAuthErrorResponse` catch-all to only surface `error.message` for `DomainError` instances; all other errors return generic "Internal server error"
- Converts service-layer throws in `web/src/lib/channels/service.ts` to `DomainError` where the message is safe for API consumers (Telegram connection failures, contact not found, plugin not registered, etc.)
- Internal errors like missing `APP_URL` remain as plain `Error` and will be masked

Addresses security feedback on PR #1078 from Devin and Codex reviewers.

## Test plan

- [ ] Verify Telegram connect/disconnect errors surface user-safe messages via `DomainError`
- [ ] Verify DB errors, infra config errors (e.g. missing APP_URL) return "Internal server error" instead of raw message
- [ ] Verify existing auth error paths (NOT_FOUND, UNAUTHORIZED, FORBIDDEN) still work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
