### PR TITLE
Fix pkill flag, kill legacy process, and update docs for app rename

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -8,7 +8,7 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 1. Kill any running Vellum processes:
    ```bash
-   pkill -f "Vellum"
+   pkill -x "Vellum"
    ```
 
 2. Remove session logs and knowledge store:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,4 +22,4 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
 | `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |
 | `/execute-plan <plan-file>` | Execute a multi-PR rollout plan from `.private/plans/` sequentially — implement, validate, and mainline each PR in order. |
-| `/scrub` | Kill the running vellum-assistant app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The macOS app also supports `VELLUM_DAEMON_SOCKET`. Launch it from the terminal:
 
 ```bash
 ssh -L ~/.vellum/remote.sock:/home/user/.vellum/vellum.sock user@remote-host -N &
-VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a vellum-assistant
+VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a Vellum
 ```
 
 ### Troubleshooting
@@ -149,7 +149,7 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 
 | Command | Purpose |
 |---------|---------|
-| `/scrub` | Kill the running vellum-assistant app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
 
 ### Review
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -207,6 +207,8 @@ if [ "$CMD" = "run" ]; then
     echo "Launching..."
     # Kill existing instance if running
     pkill -x "$BUNDLE_DISPLAY_NAME" 2>/dev/null || true
+    # Also kill legacy pre-rename process name if still running
+    pkill -x "vellum-assistant" 2>/dev/null || true
     sleep 0.3
     # Launch via `open` so Launch Services registers the bundle —
     # this is required for macOS TCC to associate the app with its


### PR DESCRIPTION
## Summary
- **Fix scrub command (`pkill -f` -> `pkill -x`)**: The `/scrub` command used `pkill -f "Vellum"` which matches against the full command line and could kill unrelated processes. Changed to `pkill -x "Vellum"` for exact process name matching, consistent with `build.sh`.
- **Kill legacy process name in `build.sh`**: The restart logic only killed processes named `Vellum` but left any pre-rename `vellum-assistant` process alive. Added `pkill -x "vellum-assistant"` alongside the existing kill.
- **Update docs for renamed app**: Updated README.md and AGENTS.md to say "Vellum app" instead of "vellum-assistant app" in the `/scrub` description, and updated the macOS launch example from `open -a vellum-assistant` to `open -a Vellum`.

Addresses review feedback on #1086.

## Test plan
- [ ] Run `/scrub` and verify only the Vellum process is killed (not unrelated processes)
- [ ] Run `./build.sh run` with a legacy `vellum-assistant` process and confirm it gets killed
- [ ] Verify README.md and AGENTS.md accurately describe the `/scrub` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
