### PR TITLE
fix: keep tool_result user turns separate from text user turns in repairHistory

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -354,10 +354,12 @@ describe('repairHistory', () => {
     });
   });
 
-  test('merges consecutive user messages (checkpoint handoff scenario)', () => {
+  test('keeps user(tool_result) separate from user(text) in checkpoint handoff scenario', () => {
     // After a checkpoint handoff the history can end with:
     //   assistant(tool_use) -> user(tool_result) -> user(new_message)
-    // repairHistory should merge the two consecutive user messages.
+    // repairHistory must NOT merge these because isUndoableUserMessage rejects
+    // any user message containing tool_result, which would make the real user
+    // prompt non-undoable.
     const messages: Message[] = [
       { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
       {
@@ -380,16 +382,20 @@ describe('repairHistory', () => {
 
     const { messages: repaired, stats } = repairHistory(messages);
 
-    expect(stats.consecutiveSameRoleMerged).toBe(1);
-    expect(repaired).toHaveLength(3);
+    expect(stats.consecutiveSameRoleMerged).toBe(0);
+    expect(repaired).toHaveLength(4);
+    // tool_result user message stays separate
     expect(repaired[2].role).toBe('user');
-    expect(repaired[2].content).toHaveLength(2);
+    expect(repaired[2].content).toHaveLength(1);
     expect(repaired[2].content[0]).toEqual({
       type: 'tool_result',
       tool_use_id: 'tu_1',
       content: 'file1',
     });
-    expect(repaired[2].content[1]).toEqual({
+    // text user message stays separate and remains undoable
+    expect(repaired[3].role).toBe('user');
+    expect(repaired[3].content).toHaveLength(1);
+    expect(repaired[3].content[0]).toEqual({
       type: 'text',
       text: 'Now do something else',
     });

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -133,10 +133,13 @@ export function repairHistory(messages: Message[]): RepairResult {
   // Merge consecutive same-role messages. This can occur after a checkpoint
   // handoff where a user(tool_result) message is followed by a user(new_message),
   // or from other history reconstruction artifacts.
+  // However, skip merging user messages where one contains tool_result blocks and
+  // the other contains regular user content — merging those would break undo
+  // semantics because isUndoableUserMessage rejects messages with tool_result.
   const merged: Message[] = [];
   for (const msg of result) {
     const prev = merged[merged.length - 1];
-    if (prev && prev.role === msg.role) {
+    if (prev && prev.role === msg.role && !shouldSkipUserMerge(prev, msg)) {
       prev.content = [...prev.content, ...msg.content];
       stats.consecutiveSameRoleMerged++;
     } else {
@@ -188,11 +191,11 @@ export function deepRepairHistory(messages: Message[]): RepairResult {
     cleaned = cleaned.slice(1);
   }
 
-  // 3. Merge consecutive same-role messages
+  // 3. Merge consecutive same-role messages (but preserve tool_result / user-prompt separation)
   const merged: Message[] = [];
   for (const msg of cleaned) {
     const prev = merged[merged.length - 1];
-    if (prev && prev.role === msg.role) {
+    if (prev && prev.role === msg.role && !shouldSkipUserMerge(prev, msg)) {
       prev.content = [...prev.content, ...msg.content];
     } else {
       merged.push({ role: msg.role, content: [...msg.content] });
@@ -201,6 +204,26 @@ export function deepRepairHistory(messages: Message[]): RepairResult {
 
   // 4. Apply standard tool-use/tool-result repair on top
   return repairHistory(merged);
+}
+
+/**
+ * Returns true when two consecutive user messages should NOT be merged.
+ * Specifically, we keep user(tool_result) turns separate from user(text prompt)
+ * turns to preserve undo semantics: isUndoableUserMessage rejects any user
+ * message that contains a tool_result block, so merging the two would make the
+ * real user prompt non-undoable.
+ */
+function shouldSkipUserMerge(prev: Message, next: Message): boolean {
+  if (prev.role !== 'user') return false;
+  const prevHasToolResult = prev.content.some((b) => b.type === 'tool_result');
+  const nextHasToolResult = next.content.some((b) => b.type === 'tool_result');
+  const prevHasNonToolResult = prev.content.some((b) => b.type !== 'tool_result');
+  const nextHasNonToolResult = next.content.some((b) => b.type !== 'tool_result');
+
+  // Skip merge when one side has tool_result and the other has regular content
+  if (prevHasToolResult && nextHasNonToolResult) return true;
+  if (nextHasToolResult && prevHasNonToolResult) return true;
+  return false;
 }
 
 function downgradeToolResult(tr: ToolResultContent): ContentBlock {


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #941 (P1 priority): merging consecutive same-role user messages in `repairHistory` was combining `user(tool_result)` + `user(text prompt)` into one turn, breaking undo after session reloads
- Added `shouldSkipUserMerge()` helper that prevents merging when one user message contains `tool_result` blocks and the other contains regular (non-tool_result) content
- Applied the guard to both `repairHistory` and `deepRepairHistory` merge loops
- Updated the existing test to verify the new separation behavior

## Why
`isUndoableUserMessage()` rejects any user message that contains a `tool_result` block. When `repairHistory` merged `user(tool_result)` with a following `user(text)` message, the real user prompt became embedded in a message containing `tool_result`, making it non-undoable. This caused a functional regression where undo targeted the wrong turn (or failed entirely) after session reconnect/restart.

## Test plan
- [x] Updated existing "checkpoint handoff scenario" test to assert messages stay separate
- [x] All 27 existing tests pass (`history-repair.test.ts`, `history-repair-observability.test.ts`, `session-load-history-repair.test.ts`)
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
