### PR TITLE
Fix stuck processing status in error and cancel-failure paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -325,8 +325,15 @@ final class ChatViewModel: ObservableObject {
             log.error("Server error: \(err.message)")
             isThinking = false
             isSending = false
+            isCancelling = false
             currentAssistantMessageId = nil
             errorText = err.message
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
 
         default:
             break
@@ -352,6 +359,24 @@ final class ChatViewModel: ObservableObject {
             try daemonClient.send(CancelMessage(sessionId: sessionId!))
         } catch {
             log.error("Failed to send cancel: \(error.localizedDescription)")
+            // Cancel failed to send, so no generationCancelled or
+            // messageComplete event will arrive from the daemon. Reset
+            // all transient state now to avoid stuck UI.
+            isSending = false
+            isThinking = false
+            // Mark current assistant message as stopped
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
+            return
         }
 
         // Set cancelling flag so late-arriving deltas are suppressed.


### PR DESCRIPTION
## Summary
- Add processing-to-sent message status reset in the `.error` server message handler, preventing user messages from being permanently stuck with "Sending..." label and 0.85 opacity when the server reports an error while a message has `.processing` status.
- Add full UI state cleanup in the `stopGenerating()` catch block when the cancel message fails to send, since no `generationCancelled` or `messageComplete` acknowledgement will arrive from the daemon.
- Also clears `isCancelling` in the error handler to prevent delta suppression from persisting after an error.

Addresses review feedback from PR #942.

## Test plan
- [ ] Send a message that triggers a server error while a queued message is in `.processing` state; verify the message resets to `.sent` and the UI is not stuck.
- [ ] Disconnect the daemon while a generation is in progress, then click stop; verify the UI resets cleanly instead of staying stuck in the sending state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
