### PR TITLE
Fix generation_handoff busy state and session-id filtering

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -399,10 +399,14 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       }
 
       case 'generation_handoff': {
-        // Treat handoff the same as message_complete from the CLI's perspective:
-        // the generation for the current request is done.
+        // The current request's generation is done; show usage and re-prompt.
+        // However, only clear `generating` when no queued work remains —
+        // otherwise SIGINT should still send `cancel` to stop the next
+        // queued generation instead of detaching.
         spinner.stop();
-        generating = false;
+        if (msg.queuedCount === 0) {
+          generating = false;
+        }
         if (lastUsage) {
           const cost = lastUsage.estimatedCost > 0
             ? ` ~$${lastUsage.estimatedCost.toFixed(4)}`

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -107,13 +107,18 @@ final class TextSession: ObservableObject {
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_) where self.daemonSessionId != nil,
-                     .generationHandoff(_) where self.daemonSessionId != nil:
+                case .messageComplete(_) where self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     // Set state before appending to messages — the $state Combine sink
                     // triggers a layout pass, and if state is still .streaming when the
                     // committed message is already in messages, both the streaming bubble
                     // and committed bubble render simultaneously (doubled response).
+                    self.state = .ready
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == self.daemonSessionId:
+                    let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
@@ -177,8 +182,13 @@ final class TextSession: ObservableObject {
                 case .assistantThinkingDelta(let delta):
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_),
-                     .generationHandoff(_):
+                case .messageComplete(_):
+                    let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
+                    self.state = .ready
+                    self.messages.append(ConversationMessage(role: .assistant, text: responseText))
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == sessionId:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -150,8 +150,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete where self.sessionId != nil,
-                     .generationHandoff where self.sessionId != nil:
+                case .messageComplete where self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -160,6 +159,17 @@ final class InterviewViewModel {
                         text: finalText
                     ))
                     log.info("Interview greeting complete (\(accumulated.count) chars)")
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    log.info("Interview greeting complete via handoff (\(accumulated.count) chars)")
                     return
 
                 case .cuError(let error) where error.sessionId == self.sessionId:
@@ -263,8 +273,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete,
-                     .generationHandoff:
+                case .messageComplete:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -276,6 +285,20 @@ final class InterviewViewModel {
                         self.isFinished = true
                     }
                     log.info("Follow-up response complete (\(accumulated.count) chars)")
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    if isLastTurn {
+                        self.isFinished = true
+                    }
+                    log.info("Follow-up response complete via handoff (\(accumulated.count) chars)")
                     return
 
                 case .cuError(let error) where error.sessionId == sessionId:


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #943 ("Handle generation_handoff event in all clients to prevent hangs"):

- **P1 — CLI busy state during queued handoff**: The `generation_handoff` handler in `cli.ts` unconditionally set `generating = false`, which meant `SIGINT` would take the "idle" path (detach) instead of sending `cancel` while the next queued generation was still running. Now only clears `generating` when `msg.queuedCount === 0`.
- **P2 — Session-id filtering in macOS clients**: The `generationHandoff` cases in `InterviewViewModel.swift` and `TextSession.swift` did not inspect which session produced the event, so any handoff from a concurrent daemon session could end the stream early and commit partial/empty assistant text. Now binds the handoff payload and requires `handoff.sessionId == self.sessionId` before finalizing. (`ProfileExtractor.swift` and `ChatViewModel.swift` already had correct filtering.)

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] macOS build passes (`./build.sh`)
- [x] CLI: When `queuedCount > 0`, `generating` stays `true` so `SIGINT` sends `cancel`
- [x] CLI: When `queuedCount === 0`, `generating` is cleared as before
- [x] macOS: `generationHandoff` events from other sessions are ignored in InterviewViewModel and TextSession

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
