### PR TITLE
Guard messageLoopTask cleanup to prevent cancelled loop from clearing replacement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -19,6 +19,9 @@ final class ChatViewModel: ObservableObject {
     /// Used to ensure this ChatViewModel only claims its own session.
     private var bootstrapCorrelationId: String?
     private var messageLoopTask: Task<Void, Never>?
+    /// Monotonically increasing ID used to distinguish successive message-loop
+    /// tasks so that a cancelled loop's cleanup doesn't clear a newer replacement.
+    private var messageLoopGeneration: UInt64 = 0
     private var currentAssistantMessageId: UUID?
     /// When true, incoming deltas are suppressed until the daemon acknowledges
     /// the cancellation (via `generation_cancelled` or `message_complete`).
@@ -153,6 +156,9 @@ final class ChatViewModel: ObservableObject {
         messageLoopTask?.cancel()
         let messageStream = daemonClient.subscribe()
 
+        messageLoopGeneration &+= 1
+        let generation = messageLoopGeneration
+
         messageLoopTask = Task { @MainActor [weak self] in
             for await message in messageStream {
                 guard let self, !Task.isCancelled else { break }
@@ -160,7 +166,12 @@ final class ChatViewModel: ObservableObject {
             }
             // Stream ended (e.g. daemon disconnected) — clear the task reference
             // so the next sendUserMessage() call will re-subscribe.
-            self?.messageLoopTask = nil
+            // Only nil out if this task is still the current one; a cancelled
+            // loop that finishes after its replacement must not wipe the new
+            // task reference, which would cause duplicate subscriptions.
+            if self?.messageLoopGeneration == generation {
+                self?.messageLoopTask = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #944 (flagged by both Codex and Devin)
- When `startMessageLoop()` cancels an older loop and installs a new one, the cancelled task's cleanup block could finish later and unconditionally nil out `messageLoopTask`, causing `sendUserMessage` to incorrectly create duplicate subscriptions
- Adds a monotonic `messageLoopGeneration` counter so the cleanup block only clears `messageLoopTask` when the exiting task is still the current generation

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Manual: open chat, send messages rapidly to trigger loop restarts; verify no duplicate message handling
- [ ] Manual: disconnect daemon mid-stream, reconnect, verify single subscription resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
