### PR TITLE
Guard stopGenerating() against disconnected daemon to prevent stuck isCancelling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -366,6 +366,27 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
+        // If the daemon is not connected, the cancel message cannot reach it
+        // and no acknowledgment (generation_cancelled / message_complete) will
+        // arrive.  Reset all transient state immediately to avoid a permanently
+        // stuck isCancelling flag that would suppress future assistant deltas.
+        guard daemonClient.isConnected else {
+            log.warning("Cannot send cancel: daemon not connected")
+            isSending = false
+            isThinking = false
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
+            return
+        }
+
         do {
             try daemonClient.send(CancelMessage(sessionId: sessionId!))
         } catch {


### PR DESCRIPTION
## Summary
- Fixes a race condition where `stopGenerating()` sets `isCancelling = true` even when the daemon is disconnected, permanently suppressing all future assistant text deltas.
- `DaemonClient.send()` silently returns (without throwing) when `connection` is nil, so the existing `catch` block cleanup is never reached. Adding an `isConnected` guard before the send call ensures transient state is reset immediately when the daemon is unreachable.
- The other review feedback item from PR #945 (resetting `isCancelling` in the `.error` handler) was already addressed in PR #1093.

## Test plan
- [ ] Verify build passes (confirmed locally).
- [ ] With the daemon stopped, click stop generation in the chat; confirm the UI resets properly and subsequent messages are not dropped.
- [ ] With the daemon running, click stop generation; confirm normal cancel flow still works (deltas suppressed until `generation_cancelled` arrives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
