### PR TITLE
Fix ThreadTabBar preview to select first thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -46,15 +46,15 @@ struct ThreadTabBar: View {
 }
 
 #Preview("ThreadTabBar") {
+    @Previewable @State var threads = [
+        ThreadModel(title: "New Thread"),
+    ]
+
     ZStack {
         VColor.background.ignoresSafeArea()
         ThreadTabBar(
-            threads: [
-                ThreadModel(title: "New Thread"),
-                ThreadModel(title: "Debug Session"),
-                ThreadModel(title: "Research"),
-            ],
-            activeThreadId: nil,
+            threads: threads,
+            activeThreadId: threads.first?.id,
             onSelect: { _ in },
             onClose: { _ in },
             onCreate: {}


### PR DESCRIPTION
## Summary
- Use `@Previewable @State` for threads so the preview shows an active (selected) tab, matching real app behavior where one thread is always selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
