### PR TITLE
Add /check-reviews-and-swarm command and review thread resolution

### DIFF
--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -1,0 +1,27 @@
+Run `/check-reviews` to triage pending PR reviews, then immediately `/swarm` to address any feedback that was found.
+
+Arguments (optional): $ARGUMENTS
+
+Parse positional arguments (these are passed through to `/swarm`):
+
+- **First argument** (optional): number of parallel workers (default: 3).
+- **Second argument** (optional): maximum number of tasks to complete before shutting down.
+
+## Phase 1: Check reviews
+
+Run the `/check-reviews` skill. Wait for it to complete and note how many "Address the feedback" items were added to `.private/TODO.md`.
+
+If no feedback items were added (all PRs were approved or still pending), report the results and stop — there's nothing to swarm on.
+
+## Phase 2: Swarm on feedback
+
+If feedback items were added, run the `/swarm` skill, passing through any arguments the user provided.
+
+## Output
+
+After both phases complete, print a combined summary:
+
+| Phase         | Result                                      |
+| ------------- | ------------------------------------------- |
+| Check Reviews | _e.g., "3 PRs reviewed, 2 had feedback"_    |
+| Swarm         | _e.g., "2 feedback items addressed, 0 failed"_ |

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -80,6 +80,14 @@ For "Address the feedback on <PR URL>" tasks:
 - Read the review comments on the referenced PR to understand what changes are requested.
 - Implement the requested fixes in your worktree (on a new branch — this will become a new PR).
 - Follow the same PR creation and merge workflow above.
+- After creating the followup PR, leave a paper trail on the original PR:
+  1. Comment on the original PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
+  2. Reply to each review thread and resolve it. Fetch threads:
+     `gh api graphql -f query='query { repository(owner:"vellum-ai", name:"vellum-assistant") { pullRequest(number:<original-PR-number>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
+  3. For each unresolved thread from `chatgpt-codex-connector[bot]` or `devin-ai-integration[bot]`, reply and resolve:
+     `gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in <new-PR-URL>"}) { comment { id } } }'`
+     `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'`
+  4. Leave human review threads untouched.
 ```
 
 ## Phase 4: When an agent finishes

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -30,7 +30,16 @@ If you can implement it in a single PR:
 - Create a PR for it (output a link to the PR)
 - Append the link to only this new PR to .private/UNREVIEWED_PRS.md
 - CRITICAL: Merge it immediately with `gh pr merge <N> --squash` and switch back to the main branch
-- If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a comment on that original PR linking to the new PR. Use: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
+- If this task was addressing feedback on a previous PR (either "Address the feedback on <PR URL>" or a sub-task with "(feedback from <PR URL>)"), leave a paper trail on the original PR:
+  1. **Comment on the original PR** linking to the new PR: `gh pr comment <original-PR-number> --body "Addressed in <new-PR-URL>"`
+  2. **Reply to each review thread** on the original PR with a link to the followup PR, then resolve the thread. For each review thread:
+     - Fetch all review threads: `gh api graphql -f query='query { repository(owner:"vellum-ai", name:"vellum-assistant") { pullRequest(number:<original-PR-number>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { body author { login } } } } } } } }'`
+     - For each unresolved thread from a reviewer bot, reply and resolve it:
+       ```
+       gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in <new-PR-URL>"}) { comment { id } } }'
+       gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'
+       ```
+     - Only reply to and resolve threads from `chatgpt-codex-connector[bot]` and `devin-ai-integration[bot]`. Leave human review threads untouched.
 
 After you've handled the item:
 


### PR DESCRIPTION
## Summary
- Adds a new `/check-reviews-and-swarm` command that chains review triage into swarm execution in one step
- Enhances `/work` and `/swarm` agent prompts to reply to each bot review thread with a link to the followup PR, then resolve the thread via GitHub GraphQL API
- Only resolves threads from `chatgpt-codex-connector[bot]` and `devin-ai-integration[bot]` — human threads are left untouched

## Test plan
- [ ] Run `/check-reviews-and-swarm` and verify it triages reviews then swarms on feedback items
- [ ] Verify that when addressing feedback, the agent replies to review threads and resolves them
- [ ] Verify human review threads are not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
