### PR TITLE
Reduce NavigationToolbar top padding (#1100)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -34,7 +34,8 @@ struct NavigationToolbar: View {
                 }
             }
             .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
+            .padding(.top, VSpacing.xs)
+            .padding(.bottom, VSpacing.sm)
             .background(VColor.backgroundSubtle)
 
             Divider()


### PR DESCRIPTION
## Summary
- Reduce top padding of NavigationToolbar from `VSpacing.sm` (8px) to `VSpacing.xs` (4px) to close the gap between ThreadTabBar and NavigationToolbar
- Bottom padding remains `VSpacing.sm` (8px)

Closes #1100

## Test plan
- [ ] Verify the gap between ThreadTabBar and NavigationToolbar is reduced
- [ ] Verify NavigationToolbar buttons still have adequate vertical spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
