### PR TITLE
Kill legacy vellum-assistant process in /scrub command

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -6,9 +6,10 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 ## Steps
 
-1. Kill any running Vellum processes:
+1. Kill any running Vellum processes (including the legacy process name):
    ```bash
    pkill -x "Vellum"
+   pkill -x "vellum-assistant"
    ```
 
 2. Remove session logs and knowledge store:


### PR DESCRIPTION
## Summary
- The `/scrub` command's kill step only killed processes named `Vellum` (`pkill -x "Vellum"`) but did not kill the legacy `vellum-assistant` process.
- Added `pkill -x "vellum-assistant"` alongside the existing kill command, matching the behavior already present in `build.sh` (updated in PR #1091).

## Test plan
- [ ] Run `/scrub` and verify both `Vellum` and `vellum-assistant` processes are killed before wiping data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
