### PR TITLE
Fix CI node_modules path and sign_update stderr corruption

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Free disk space
         run: |
           rm -rf .build daemon-bin
-          rm -rf ../assistant/node_modules
+          rm -rf ../../assistant/node_modules
           # Clear Xcode caches
           rm -rf ~/Library/Developer/Xcode/DerivedData 2>/dev/null || true
           rm -rf ~/Library/Caches/org.swift.swiftpm 2>/dev/null || true
@@ -239,9 +239,8 @@ jobs:
           echo "sign_update location: $(which sign_update || echo 'NOT FOUND')"
           ED_KEY_FILE=$(mktemp)
           echo "$SPARKLE_ED_PRIVATE_KEY" > "$ED_KEY_FILE"
-          SIGNATURE=$(sign_update dist/vellum-assistant.zip --ed-key-file "$ED_KEY_FILE" 2>&1) || {
+          SIGNATURE=$(sign_update dist/vellum-assistant.zip --ed-key-file "$ED_KEY_FILE") || {
             echo "sign_update failed with exit code $?"
-            echo "Output: $SIGNATURE"
             rm -f "$ED_KEY_FILE"
             exit 1
           }


### PR DESCRIPTION
## Summary
Addresses review feedback from #1057:

- **Fix node_modules cleanup path (line 109):** The "Free disk space" step runs with `working-directory: clients/macos`, so `../assistant/node_modules` incorrectly resolves to `clients/assistant/node_modules` (which doesn't exist). Changed to `../../assistant/node_modules` to correctly target the repo-root `assistant/node_modules`. Without this fix, `rm -rf` silently succeeds on the non-existent path and the intended disk space savings (~hundreds of MB) never happen.

- **Remove `2>&1` from sign_update capture (line 242):** The `2>&1` redirect mixed stderr into the `SIGNATURE` variable. If `sign_update` emits any warnings or informational output to stderr, it would corrupt the `edSignature` in `appcast.xml`, silently breaking Sparkle auto-update verification for all users. Stderr now flows directly to CI logs for visibility. Also removed the `echo "Output: $SIGNATURE"` from the error handler since stderr is no longer captured.

## Test plan
- [ ] CI build-sign-release workflow passes
- [ ] Verify `appcast.xml` contains a clean EdDSA signature (no stderr noise)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
