### PR TITLE
Match chat message list width to composer input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -53,8 +53,10 @@ struct ChatView: View {
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
                 }
-                .padding(.horizontal, VSpacing.lg)
+                .padding(.horizontal, VSpacing.xl)
                 .padding(.vertical, VSpacing.md)
+                .frame(maxWidth: 700)
+                .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
             .onChange(of: messages.count) {


### PR DESCRIPTION
## Summary
- Apply the same `maxWidth: 700` and `VSpacing.xl` horizontal padding to the message list as the composer area so chat messages and input are aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
