### PR TITLE
Fix generation_handoff busy state and session-id filtering on messageComplete

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -400,13 +400,11 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
 
       case 'generation_handoff': {
         // The current request's generation is done; show usage and re-prompt.
-        // However, only clear `generating` when no queued work remains —
-        // otherwise SIGINT should still send `cancel` to stop the next
-        // queued generation instead of detaching.
+        // Always clear `generating` — this CLI client's generation is finished
+        // when it receives a handoff. If other work is queued, those completions
+        // go to other request callbacks, not this CLI socket.
         spinner.stop();
-        if (msg.queuedCount === 0) {
-          generating = false;
-        }
+        generating = false;
         if (lastUsage) {
           const cost = lastUsage.estimatedCost > 0
             ? ` ~$${lastUsage.estimatedCost.toFixed(4)}`

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -107,7 +107,7 @@ final class TextSession: ObservableObject {
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_) where self.daemonSessionId != nil:
+                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     // Set state before appending to messages — the $state Combine sink
                     // triggers a layout pass, and if state is still .streaming when the
@@ -182,7 +182,7 @@ final class TextSession: ObservableObject {
                 case .assistantThinkingDelta(let delta):
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(_):
+                case .messageComplete(let complete) where complete.sessionId == sessionId:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -150,7 +150,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete where self.sessionId != nil:
+                case .messageComplete(let complete) where complete.sessionId == self.sessionId:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -273,7 +273,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete:
+                case .messageComplete(let complete) where complete.sessionId == sessionId:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated


### PR DESCRIPTION
## Summary
- **cli.ts**: Always set `generating = false` on `generation_handoff` regardless of `queuedCount`. The CLI client's own generation is done when it receives a handoff; queued work completions go to other request callbacks, not this CLI socket. This prevents `generating` from getting stuck true.
- **TextSession.swift**: Add session-id filtering to `messageComplete` in both the initial message handler and `sendFollowUp`. Without this, a `messageComplete` from a concurrent daemon session could prematurely finalize the response.
- **InterviewViewModel.swift**: Add session-id filtering to `messageComplete` in both `sendGreeting` and `sendMessage`, matching the pattern used by `ChatViewModel` (`belongsToSession`) and `ProfileExtractor` (`where complete.sessionId == sessionId`).

Addresses review feedback from PR #1094.

## Test plan
- [ ] Verify CLI does not get stuck in generating state after `generation_handoff` with queued work
- [ ] Verify TextSession does not prematurely finalize on messageComplete from a different session
- [ ] Verify InterviewViewModel does not prematurely finalize on messageComplete from a different session
- [ ] TypeScript type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
