### PR TITLE
Fix error handler: mark streaming message complete and reset queue state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -337,11 +337,21 @@ final class ChatViewModel: ObservableObject {
             isThinking = false
             isSending = false
             isCancelling = false
+            // Mark current assistant message as no longer streaming
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
             currentAssistantMessageId = nil
+            pendingQueuedCount = 0
+            pendingMessageIds = []
+            requestIdToMessageId = [:]
             errorText = err.message
-            // Reset processing messages to sent
+            // Reset processing/queued messages to sent
             for i in messages.indices {
-                if messages[i].role == .user && messages[i].status == .processing {
+                if case .queued = messages[i].status, messages[i].role == .user {
+                    messages[i].status = .sent
+                } else if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
             }
@@ -379,8 +389,13 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            pendingQueuedCount = 0
+            pendingMessageIds = []
+            requestIdToMessageId = [:]
             for i in messages.indices {
-                if messages[i].role == .user && messages[i].status == .processing {
+                if case .queued = messages[i].status, messages[i].role == .user {
+                    messages[i].status = .sent
+                } else if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
             }
@@ -402,9 +417,14 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            // Reset processing messages to sent
+            pendingQueuedCount = 0
+            pendingMessageIds = []
+            requestIdToMessageId = [:]
+            // Reset processing/queued messages to sent
             for i in messages.indices {
-                if messages[i].role == .user && messages[i].status == .processing {
+                if case .queued = messages[i].status, messages[i].role == .user {
+                    messages[i].status = .sent
+                } else if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
             }


### PR DESCRIPTION
## Summary
- **Issue 1**: The `.error` handler in `ChatViewModel` now marks the current assistant message as `isStreaming = false` before clearing `currentAssistantMessageId`. Previously, the error path skipped this step, leaving the message permanently stuck with a blinking streaming cursor.
- **Issue 2**: The `.error` handler and both `stopGenerating()` failure paths (daemon disconnected + cancel send failure) now reset `pendingQueuedCount`, `pendingMessageIds`, and `requestIdToMessageId` to prevent stale "N messages queued" banners and corrupted queue state. The message status reset loop also clears `.queued` messages (not just `.processing`) back to `.sent`.

## Test plan
- [ ] Trigger a server error while an assistant message is streaming; verify the cursor stops blinking
- [ ] Trigger a server error while messages are queued; verify the queue banner disappears and queued messages show as sent
- [ ] Stop generation while daemon is disconnected; verify queue state is fully reset
- [ ] Stop generation when cancel message fails to send; verify queue state is fully reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
