### PR TITLE
Reset isCancelling in disconnected-cancel cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -384,6 +384,7 @@ final class ChatViewModel: ObservableObject {
             log.warning("Cannot send cancel: daemon not connected")
             isSending = false
             isThinking = false
+            isCancelling = false
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false


### PR DESCRIPTION
## Summary
- Fixes a bug where `isCancelling` is not reset in the disconnected-daemon early-return branch of `stopGenerating()`, causing assistant text deltas to be permanently suppressed after a cancel-while-offline sequence.

## Problem
The `stopGenerating()` method has a `guard daemonClient.isConnected` early-return branch that resets `isSending` and `isThinking` but leaves `isCancelling` unchanged. This creates a reproducible stuck state:
1. User cancels generation (`isCancelling = true`)
2. Daemon disconnects before `generation_cancelled`/`message_complete` arrives
3. User cancels again while offline — the disconnected branch runs and returns with `isCancelling` still `true`
4. Later `assistantTextDelta` events are dropped by the `guard !isCancelling` check in `handleServerMessage`

## Fix
Added `isCancelling = false` to the disconnected-cancel early-return branch, consistent with how `isCancelling` is already reset in the `cancel-send-failed` catch block, the `.error` handler, `.messageComplete`, and `.generationCancelled`.

## Test plan
- [ ] Verify the app builds successfully
- [ ] Confirm that cancelling while daemon is disconnected properly resets all transient state
- [ ] Confirm that subsequent assistant messages are not suppressed after the cancel-while-offline sequence

Addresses review feedback from PR #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
