### PR TITLE
Remove NavigationToolbar top padding and match background (#1114)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -34,9 +34,8 @@ struct NavigationToolbar: View {
                 }
             }
             .padding(.horizontal, VSpacing.lg)
-            .padding(.top, VSpacing.xs)
             .padding(.bottom, VSpacing.sm)
-            .background(VColor.backgroundSubtle)
+            .background(VColor.background)
 
             Divider()
         }


### PR DESCRIPTION
## Summary
- Remove top padding from NavigationToolbar to eliminate gap with ThreadTabBar
- Change background from `VColor.backgroundSubtle` to `VColor.background` for seamless dark appearance

Closes #1114

## Test plan
- [ ] Verify no visible gap between ThreadTabBar and NavigationToolbar
- [ ] Verify both bars share the same dark background color
- [ ] Verify toolbar buttons still have adequate bottom spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
