### PR TITLE
Extend MainWindowView into top safe area

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -48,6 +48,7 @@ struct MainWindowView: View {
                 panelContent
             })
         }
+        .ignoresSafeArea(edges: .top)
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }


### PR DESCRIPTION
## Summary
- Add `.ignoresSafeArea(edges: .top)` to MainWindowView's outer VStack to eliminate the titlebar gap in previews and push the navigation bar closer to the top of the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
