### PR TITLE
Restyle VTab pill selected state to match light-background mock

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -19,7 +19,7 @@ struct VTab: View {
     private var background: Color {
         switch style {
         case .pill:
-            return isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+            return isSelected ? Slate._200 : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
         case .flat:
             return .clear
         }
@@ -36,11 +36,16 @@ struct VTab: View {
                     .font(VFont.body)
                     .lineLimit(1)
             }
-            .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
+            .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
             .background(background)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.pill)
+                    .stroke(Slate._300, lineWidth: 1)
+                    .opacity(style == .pill && isSelected ? 1 : 0)
+            )
         }
         .buttonStyle(.plain)
         .onHover { hovering in isHovered = hovering }

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -7,7 +7,7 @@ struct NavigationToolbar: View {
         VStack(spacing: 0) {
             HStack(spacing: VSpacing.sm) {
                 // Left group
-                VTab(label: "Chat", icon: "bubble.left.fill", isSelected: true, isCloseable: false, onSelect: {})
+                VTab(label: "Chat", icon: "bubble.left", isSelected: true, isCloseable: false, onSelect: {})
 
                 Spacer()
 


### PR DESCRIPTION
## Summary
- Changed selected pill background from dark (`VColor.surfaceBorder` / `Slate._700`) to light (`Slate._200`)
- Changed selected pill text color from white (`VColor.textPrimary` / `Slate._50`) to dark (`Slate._900`)
- Added subtle `Slate._300` border stroke around the pill when selected
- Switched Chat button icon from filled (`bubble.left.fill`) to outlined (`bubble.left`)

## Test plan
- [ ] Build succeeds (`swift build` passes)
- [ ] Launch app and verify Chat pill has light/white background with dark text
- [ ] Verify the outlined (not filled) chat bubble icon appears
- [ ] Verify a thin subtle border is visible around the selected pill
- [ ] Verify hover state on unselected tabs still works correctly
- [ ] Verify flat-style tabs (if any) are unaffected by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
