### PR TITLE
Wrap ThreadTabBar @Previewable preview in #if DEBUG

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -45,6 +45,7 @@ struct ThreadTabBar: View {
     }
 }
 
+#if DEBUG
 #Preview("ThreadTabBar") {
     @Previewable @State var threads = [
         ThreadModel(title: "New Thread"),
@@ -62,3 +63,4 @@ struct ThreadTabBar: View {
     }
     .frame(width: 600, height: 60)
 }
+#endif


### PR DESCRIPTION
## Summary
- Wrap `#Preview` block in ThreadTabBar.swift with `#if DEBUG` since `@Previewable` isn't available at macOS 14 deployment target on CI's Xcode 16.2

Same pattern as the other views fixed in #1057.

## Test plan
- [ ] CI build-sign-release passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
