### PR TITLE
Restyle Chat button to match design mock

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -19,7 +19,7 @@ struct VTab: View {
     private var background: Color {
         switch style {
         case .pill:
-            return isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+            return isSelected ? Slate._200 : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
         case .flat:
             return .clear
         }
@@ -36,11 +36,16 @@ struct VTab: View {
                     .font(VFont.body)
                     .lineLimit(1)
             }
-            .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
+            .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
             .background(background)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.pill)
+                    .stroke(Slate._300, lineWidth: 1)
+                    .opacity(style == .pill && isSelected ? 1 : 0)
+            )
         }
         .buttonStyle(.plain)
         .onHover { hovering in isHovered = hovering }

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -7,7 +7,7 @@ struct NavigationToolbar: View {
         VStack(spacing: 0) {
             HStack(spacing: VSpacing.sm) {
                 // Left group
-                VTab(label: "Chat", icon: "bubble.left.fill", isSelected: true, isCloseable: false, onSelect: {})
+                VTab(label: "Chat", icon: "bubble.left", isSelected: true, isCloseable: false, onSelect: {})
 
                 Spacer()
 


### PR DESCRIPTION
## Summary
Restyles the Chat button in the NavigationToolbar to match the design mockup — light pill background with subtle border, outlined chat icon, and dark text instead of the previous dark filled background with white text.

## Changes
- VTab pill selected state: background `Slate._200` (light), foreground `Slate._900` (dark), `Slate._300` border stroke
- NavigationToolbar Chat icon: `bubble.left.fill` → `bubble.left` (outlined)

## Milestone PRs (merged into feature branch)
- #1124: Restyle VTab pill selected state to match light-background mock

## Project issue
Closes #1120

## Test plan
- [ ] Verify Chat button in NavigationToolbar matches the design mock (light background, dark text, outlined icon, subtle border)
- [ ] Verify non-selected VTab pill state still shows transparent background
- [ ] Verify flat-style tabs (ThreadTabBar) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
