### PR TITLE
Fix safe-blitz worktree command to use .claude/worktree helper

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -211,7 +211,7 @@ For each task being handed off:
 1. Create a worktree **from the feature branch** (not main):
 
 ```bash
-git worktree add .worktrees/swarm/task-<counter> -b swarm/task-<counter> origin/<feature-branch-name>
+.claude/worktree create swarm/task-<counter> origin/<feature-branch-name>
 ```
 
 2. Create a `TaskCreate` entry for tracking.


### PR DESCRIPTION
## Summary
- Fixed Phase 4 worktree creation to use `.claude/worktree create` instead of raw `git worktree add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
