### PR TITLE
M1: Restyle VSlider track, thumb, and tick marks (#1133)

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -8,19 +8,13 @@ struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 10
+    private let trackHeight: CGFloat = 14
     private let thumbWidth: CGFloat = 20
-    private let thumbHeight: CGFloat = 10
-    private let tickMarkHeight: CGFloat = 14
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 6
+    private let gripLineHeight: CGFloat = 8
     private let gripLineSpacing: CGFloat = 2.5
-
-    private var sliderHeight: CGFloat {
-        showTickMarks ? max(thumbHeight, tickMarkHeight) : thumbHeight
-    }
 
     // MARK: - State
 
@@ -35,19 +29,19 @@ struct VSlider: View {
             let thumbOffset = trackWidth * fraction
 
             ZStack(alignment: .leading) {
-                // Tick marks (behind track)
-                if showTickMarks {
-                    tickMarksView(trackWidth: trackWidth)
-                }
-
                 // Track
                 trackView(thumbOffset: thumbOffset, trackWidth: trackWidth)
+
+                // Tick marks (on top of unfilled track)
+                if showTickMarks {
+                    tickMarksView(trackWidth: trackWidth, fraction: fraction)
+                }
 
                 // Thumb
                 thumbView
                     .offset(x: thumbOffset)
             }
-            .frame(height: sliderHeight)
+            .frame(height: trackHeight)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
@@ -64,21 +58,23 @@ struct VSlider: View {
                     }
             )
         }
-        .frame(height: sliderHeight)
+        .frame(height: trackHeight)
     }
 
     // MARK: - Track
 
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
-        ZStack(alignment: .leading) {
+        let cornerRadius = trackHeight / 2
+
+        return ZStack(alignment: .leading) {
             // Unfilled track
-            RoundedRectangle(cornerRadius: VRadius.sm)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(Slate._800)
                 .frame(height: trackHeight)
                 .padding(.horizontal, thumbWidth / 2)
 
             // Filled track
-            RoundedRectangle(cornerRadius: VRadius.sm)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(VColor.accent)
                 .frame(width: thumbOffset, height: trackHeight)
                 .padding(.leading, thumbWidth / 2)
@@ -91,7 +87,7 @@ struct VSlider: View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.xs)
                 .fill(Slate._600)
-                .frame(width: thumbWidth, height: thumbHeight)
+                .frame(width: thumbWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.xs)
                         .stroke(Slate._700, lineWidth: 1)
@@ -112,22 +108,25 @@ struct VSlider: View {
 
     // MARK: - Tick Marks
 
-    private func tickMarksView(trackWidth: CGFloat) -> some View {
+    private func tickMarksView(trackWidth: CGFloat, fraction: Double) -> some View {
         let totalSteps = Int((range.upperBound - range.lowerBound) / step)
         let maxTicks = 20
         let tickStep = totalSteps > maxTicks ? totalSteps / maxTicks : 1
-        let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
 
         return ZStack(alignment: .leading) {
             ForEach(0...totalSteps, id: \.self) { i in
                 if i % tickStep == 0 {
                     let tickFraction = Double(i) / Double(totalSteps)
-                    let tickX = trackWidth * tickFraction + thumbWidth / 2
 
-                    RoundedRectangle(cornerRadius: 0.5)
-                        .fill(tickFraction <= fraction ? VColor.accent.opacity(0.4) : Slate._600)
-                        .frame(width: tickMarkWidth, height: tickMarkHeight)
-                        .offset(x: tickX - tickMarkWidth / 2)
+                    // Only render tick marks in the unfilled portion
+                    if tickFraction > fraction {
+                        let tickX = trackWidth * tickFraction + thumbWidth / 2
+
+                        RoundedRectangle(cornerRadius: 0.5)
+                            .fill(Slate._600)
+                            .frame(width: tickMarkWidth, height: trackHeight)
+                            .offset(x: tickX - tickMarkWidth / 2)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Restyle VSlider to match the UI mockup with a continuous pill-shaped track, flush thumb, and internal tick marks as segment dividers in the unfilled portion only.

## Changes
- **Track height**: Increased from 10px to 14px for the chunkier appearance shown in the mockup
- **Pill-shaped track**: Changed corner radius from `VRadius.sm` (4pt) to `trackHeight / 2` (7pt) for true pill-shaped ends
- **Thumb height**: Now matches `trackHeight` (14px) so the thumb sits flush with the track
- **Tick marks rendering order**: Moved from behind the track (ZStack layer 0) to on top of the track (after trackView in ZStack) so they appear as visible segment dividers
- **Tick marks limited to unfilled portion**: Only tick marks where `tickFraction > fraction` are rendered, so they appear only in the dark unfilled area (right of thumb)
- **Tick mark color**: Simplified to a single `Slate._600` color for all visible ticks (removed the `VColor.accent.opacity(0.4)` tint for filled-side ticks since they no longer exist)
- **Tick mark height**: Changed from separate `tickMarkHeight` (14px) to use `trackHeight` directly, making them flush with the track as internal dividers
- **Removed `sliderHeight`**: The computed property `sliderHeight` is no longer needed since tick marks are the same height as the track; both `.frame(height:)` calls now use `trackHeight`
- **Grip line height**: Increased from 6px to 8px to better proportion with the taller thumb

## File modified
- `clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift`

## Verification
- Build passes: `cd clients/macos && ./build.sh`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
