### PR TITLE
Add bundled skills infrastructure to daemon

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -13,6 +13,7 @@ export interface SkillSummary {
   description: string;
   directoryPath: string;
   skillFilePath: string;
+  bundled?: boolean;
 }
 
 export interface SkillDefinition extends SkillSummary {
@@ -31,6 +32,10 @@ export interface SkillSelectorResult {
 
 export function getSkillsDir(): string {
   return join(getDataDir(), 'skills');
+}
+
+export function getBundledSkillsDir(): string {
+  return join(import.meta.dir, 'bundled-skills');
 }
 
 function getSkillsIndexPath(skillsDir: string): string {
@@ -138,6 +143,81 @@ function readSkillFromDirectory(directoryPath: string, skillsDir: string): Skill
   }
 }
 
+function readBundledSkillFromDirectory(directoryPath: string): SkillDefinition | null {
+  const skillFilePath = join(directoryPath, 'SKILL.md');
+  if (!existsSync(skillFilePath)) {
+    log.warn({ directoryPath }, 'Skipping bundled skill directory without SKILL.md');
+    return null;
+  }
+
+  try {
+    const stat = statSync(skillFilePath);
+    if (!stat.isFile()) {
+      log.warn({ skillFilePath }, 'Skipping bundled skill path because SKILL.md is not a file');
+      return null;
+    }
+
+    const content = readFileSync(skillFilePath, 'utf-8');
+    const parsed = parseFrontmatter(content, skillFilePath);
+    if (!parsed) return null;
+
+    return {
+      id: basename(directoryPath),
+      name: parsed.name,
+      description: parsed.description,
+      directoryPath,
+      skillFilePath,
+      body: parsed.body,
+    };
+  } catch (err) {
+    log.warn({ err, skillFilePath }, 'Failed to read bundled skill file');
+    return null;
+  }
+}
+
+function discoverBundledSkillDirectories(): string[] {
+  const bundledDir = getBundledSkillsDir();
+  if (!existsSync(bundledDir)) return [];
+
+  const dirs: string[] = [];
+  try {
+    const entries = readdirSync(bundledDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const directoryPath = join(bundledDir, entry.name);
+      if (existsSync(join(directoryPath, 'SKILL.md'))) {
+        dirs.push(directoryPath);
+      }
+    }
+  } catch (err) {
+    log.warn({ err, bundledDir }, 'Failed to discover bundled skill directories');
+    return [];
+  }
+
+  return dirs.sort((a, b) => a.localeCompare(b));
+}
+
+function loadBundledSkills(): SkillSummary[] {
+  const directories = discoverBundledSkillDirectories();
+  const skills: SkillSummary[] = [];
+
+  for (const directory of directories) {
+    const skill = readBundledSkillFromDirectory(directory);
+    if (!skill) continue;
+
+    skills.push({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      directoryPath: skill.directoryPath,
+      skillFilePath: skill.skillFilePath,
+      bundled: true,
+    });
+  }
+
+  return skills;
+}
+
 function parseIndexEntry(line: string): string | null {
   const bulletMatch = line.trim().match(/^[-*]\s+(.+)$/);
   if (!bulletMatch) return null;
@@ -233,18 +313,43 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 }
 
 export function loadSkillCatalog(): SkillSummary[] {
+  const catalog: SkillSummary[] = [];
+  const seenIds = new Set<string>();
+
+  // Load bundled skills first
+  const bundledSkills = loadBundledSkills();
+  for (const skill of bundledSkills) {
+    if (seenIds.has(skill.id)) {
+      log.warn({ id: skill.id, directory: skill.directoryPath }, 'Skipping duplicate bundled skill id');
+      continue;
+    }
+    seenIds.add(skill.id);
+    catalog.push(skill);
+  }
+
+  // Load user skills, which take precedence over bundled skills with the same ID
   const skillsDir = getSkillsDir();
   const indexedDirectories = getIndexedSkillDirectories(skillsDir);
   const directories = indexedDirectories ?? discoverSkillDirectories(skillsDir);
-
-  const catalog: SkillSummary[] = [];
-  const seenIds = new Set<string>();
 
   for (const directory of directories) {
     const skill = readSkillFromDirectory(directory, skillsDir);
     if (!skill) continue;
 
     if (seenIds.has(skill.id)) {
+      // If the existing entry is bundled, the user skill overrides it
+      const existingIndex = catalog.findIndex((s) => s.id === skill.id);
+      if (existingIndex !== -1 && catalog[existingIndex].bundled) {
+        log.info({ id: skill.id, directory }, 'User skill overrides bundled skill');
+        catalog[existingIndex] = {
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+          directoryPath: skill.directoryPath,
+          skillFilePath: skill.skillFilePath,
+        };
+        continue;
+      }
       log.warn({ id: skill.id, directory }, 'Skipping duplicate skill id');
       continue;
     }
@@ -263,7 +368,9 @@ export function loadSkillCatalog(): SkillSummary[] {
 }
 
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
-  const loaded = readSkillFromDirectory(skill.directoryPath, getSkillsDir());
+  const loaded = skill.bundled
+    ? readBundledSkillFromDirectory(skill.directoryPath)
+    : readSkillFromDirectory(skill.directoryPath, getSkillsDir());
   if (!loaded) {
     return { error: `Failed to load SKILL.md for "${skill.id}"` };
   }


### PR DESCRIPTION
Part of #1127. Adds support for bundled skills that ship with the daemon source code alongside user-created skills from ~/.vellum/skills/. Closes #1128.

## Changes

- **`getBundledSkillsDir()`** — resolves the `bundled-skills/` directory relative to the source using `import.meta.dir`
- **`readBundledSkillFromDirectory()`** — reads bundled skill SKILL.md files without path-escape validation (trusted source code)
- **`discoverBundledSkillDirectories()` / `loadBundledSkills()`** — scans the bundled-skills directory for skill subdirectories
- **`loadSkillCatalog()`** — now merges bundled skills + user skills, with user skills overriding bundled skills on ID conflicts
- **`SkillSummary.bundled?: boolean`** — flag to distinguish bundled from user-created skills
- **`loadSkillDefinition()`** — uses the correct reader based on whether a skill is bundled
- **`assistant/src/config/bundled-skills/.gitkeep`** — placeholder directory for future bundled skill definitions (M2 will add the first actual skill)

## How it works

1. `loadSkillCatalog()` first discovers bundled skills from `assistant/src/config/bundled-skills/`
2. Then loads user skills from `~/.vellum/skills/`
3. If a user skill has the same ID as a bundled skill, the user skill replaces it (override)
4. The `bundled` flag lets downstream code distinguish the source

## Test plan

- [x] All 8 existing skills tests pass (no regressions)
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [ ] M2 will add an actual bundled skill to verify end-to-end functionality
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
