### PR TITLE
Restyle VSlider to match dark-theme mockup

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -8,12 +8,12 @@ struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 14
+    private let trackHeight: CGFloat = 24
     private let thumbWidth: CGFloat = 20
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 8
+    private let gripLineHeight: CGFloat = 12
     private let gripLineSpacing: CGFloat = 2.5
 
     // MARK: - State
@@ -64,7 +64,7 @@ struct VSlider: View {
     // MARK: - Track
 
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
-        let cornerRadius = trackHeight / 2
+        let cornerRadius: CGFloat = VRadius.md
 
         return ZStack(alignment: .leading) {
             // Unfilled track
@@ -86,18 +86,18 @@ struct VSlider: View {
     private var thumbView: some View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.xs)
-                .fill(Slate._600)
+                .fill(Violet._700)
                 .frame(width: thumbWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.xs)
-                        .stroke(Slate._700, lineWidth: 1)
+                        .stroke(Violet._800, lineWidth: 1)
                 )
 
             // Grip lines
             HStack(spacing: gripLineSpacing) {
                 ForEach(0..<gripLineCount, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 0.5)
-                        .fill(Slate._400)
+                        .fill(Violet._300)
                         .frame(width: gripLineWidth, height: gripLineHeight)
                 }
             }
@@ -118,8 +118,8 @@ struct VSlider: View {
                 if i % tickStep == 0 {
                     let tickFraction = Double(i) / Double(totalSteps)
 
-                    // Only render tick marks in the unfilled portion
-                    if tickFraction > fraction {
+                    // Only render tick marks in the unfilled portion, excluding the rightmost
+                    if tickFraction > fraction && i < totalSteps {
                         let tickX = trackWidth * tickFraction + thumbWidth / 2
 
                         RoundedRectangle(cornerRadius: 0.5)

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Inputs/VSlider.swift
@@ -8,19 +8,13 @@ struct VSlider: View {
 
     // MARK: - Layout Constants
 
-    private let trackHeight: CGFloat = 10
+    private let trackHeight: CGFloat = 14
     private let thumbWidth: CGFloat = 20
-    private let thumbHeight: CGFloat = 10
-    private let tickMarkHeight: CGFloat = 14
     private let tickMarkWidth: CGFloat = 1
     private let gripLineCount: Int = 3
     private let gripLineWidth: CGFloat = 1
-    private let gripLineHeight: CGFloat = 6
+    private let gripLineHeight: CGFloat = 8
     private let gripLineSpacing: CGFloat = 2.5
-
-    private var sliderHeight: CGFloat {
-        showTickMarks ? max(thumbHeight, tickMarkHeight) : thumbHeight
-    }
 
     // MARK: - State
 
@@ -35,19 +29,19 @@ struct VSlider: View {
             let thumbOffset = trackWidth * fraction
 
             ZStack(alignment: .leading) {
-                // Tick marks (behind track)
-                if showTickMarks {
-                    tickMarksView(trackWidth: trackWidth)
-                }
-
                 // Track
                 trackView(thumbOffset: thumbOffset, trackWidth: trackWidth)
+
+                // Tick marks (on top of unfilled track)
+                if showTickMarks {
+                    tickMarksView(trackWidth: trackWidth, fraction: fraction)
+                }
 
                 // Thumb
                 thumbView
                     .offset(x: thumbOffset)
             }
-            .frame(height: sliderHeight)
+            .frame(height: trackHeight)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
@@ -64,21 +58,23 @@ struct VSlider: View {
                     }
             )
         }
-        .frame(height: sliderHeight)
+        .frame(height: trackHeight)
     }
 
     // MARK: - Track
 
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
-        ZStack(alignment: .leading) {
+        let cornerRadius = trackHeight / 2
+
+        return ZStack(alignment: .leading) {
             // Unfilled track
-            RoundedRectangle(cornerRadius: VRadius.sm)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(Slate._800)
                 .frame(height: trackHeight)
                 .padding(.horizontal, thumbWidth / 2)
 
             // Filled track
-            RoundedRectangle(cornerRadius: VRadius.sm)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(VColor.accent)
                 .frame(width: thumbOffset, height: trackHeight)
                 .padding(.leading, thumbWidth / 2)
@@ -91,7 +87,7 @@ struct VSlider: View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.xs)
                 .fill(Slate._600)
-                .frame(width: thumbWidth, height: thumbHeight)
+                .frame(width: thumbWidth, height: trackHeight)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.xs)
                         .stroke(Slate._700, lineWidth: 1)
@@ -112,22 +108,25 @@ struct VSlider: View {
 
     // MARK: - Tick Marks
 
-    private func tickMarksView(trackWidth: CGFloat) -> some View {
+    private func tickMarksView(trackWidth: CGFloat, fraction: Double) -> some View {
         let totalSteps = Int((range.upperBound - range.lowerBound) / step)
         let maxTicks = 20
         let tickStep = totalSteps > maxTicks ? totalSteps / maxTicks : 1
-        let fraction = (value - range.lowerBound) / (range.upperBound - range.lowerBound)
 
         return ZStack(alignment: .leading) {
             ForEach(0...totalSteps, id: \.self) { i in
                 if i % tickStep == 0 {
                     let tickFraction = Double(i) / Double(totalSteps)
-                    let tickX = trackWidth * tickFraction + thumbWidth / 2
 
-                    RoundedRectangle(cornerRadius: 0.5)
-                        .fill(tickFraction <= fraction ? VColor.accent.opacity(0.4) : Slate._600)
-                        .frame(width: tickMarkWidth, height: tickMarkHeight)
-                        .offset(x: tickX - tickMarkWidth / 2)
+                    // Only render tick marks in the unfilled portion
+                    if tickFraction > fraction {
+                        let tickX = trackWidth * tickFraction + thumbWidth / 2
+
+                        RoundedRectangle(cornerRadius: 0.5)
+                            .fill(Slate._600)
+                            .frame(width: tickMarkWidth, height: trackHeight)
+                            .offset(x: tickX - tickMarkWidth / 2)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Refactors the VSlider design system component to match the dark-theme UI mockup with tick marks as internal segment dividers, pill-shaped track, and flush thumb.

## Changes
- Increased track height from 10→14px for chunkier appearance
- Changed track corners to pill-shaped (trackHeight/2 radius)
- Thumb now flush with track height (was 10px, now matches 14px track)
- Tick marks render ON TOP of unfilled track as segment dividers (were behind track)
- Tick marks only appear in unfilled portion (right of thumb)
- Tick marks same height as track (were taller at 14px)
- Simplified tick mark color to single Slate._600
- Removed unused sliderHeight computed property, thumbHeight and tickMarkHeight constants
- Grip line height increased from 6→8px for proportion

## Milestone PRs (merged into feature branch)
- #1134: M1: Restyle VSlider track, thumb, and tick marks (#1133)

## Project issue
Closes #1132

## Test plan
- [ ] Build succeeds: `cd clients/macos && ./build.sh`
- [ ] Preview slider with and without tick marks in Xcode Previews
- [ ] Verify ControlPanel "Max Steps per Session" slider renders correctly
- [ ] Verify InputsGallerySection slider variants render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<img width="407" height="332" alt="image" src="https://github.com/user-attachments/assets/7dda63e8-04f3-4afe-a4a0-76accafd8191" />

