### PR TITLE
Fix CI build: @Previewable, #Preview ambiguity, and missing resource bundle

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -78,6 +78,17 @@ echo "Building ($CONFIG)..."
 swift build $SWIFT_FLAGS
 
 BIN_PATH=$(swift build $SWIFT_FLAGS --show-bin-path)
+
+# Patch SPM's generated resource_bundle_accessor to use Bundle.main.resourceURL
+# (points to Contents/Resources/) instead of Bundle.main.bundleURL (points to .app root).
+# macOS codesigning requires all contents inside Contents/.
+ACCESSOR=$(find "$BIN_PATH" -path "*/VellumAssistantLib.build/DerivedSources/resource_bundle_accessor.swift" 2>/dev/null | head -1)
+if [ -n "$ACCESSOR" ] && grep -q 'Bundle.main.bundleURL' "$ACCESSOR"; then
+    sed -i '' 's/Bundle\.main\.bundleURL/Bundle.main.resourceURL!/' "$ACCESSOR"
+    echo "Patched resource_bundle_accessor.swift for .app bundle layout"
+    swift build $SWIFT_FLAGS
+fi
+
 EXECUTABLE="$BIN_PATH/$APP_NAME"
 
 if [ ! -f "$EXECUTABLE" ]; then
@@ -163,8 +174,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 PLIST
 
 # 4. Copy SPM resource bundle (contains Recipes, processed assets)
-LIB_TARGET="VellumAssistantLib"
-SPM_BUNDLE="$BIN_PATH/${LIB_TARGET}_${LIB_TARGET}.bundle"
+# SPM names the bundle as <product>_<target>.bundle
+SPM_BUNDLE="$BIN_PATH/${APP_NAME}_VellumAssistantLib.bundle"
 if [ -d "$SPM_BUNDLE" ]; then
     cp -R "$SPM_BUNDLE" "$RESOURCES_DIR/"
 fi

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -50,7 +50,7 @@ struct ThreadTabBar: View {
         ThreadModel(title: "New Thread"),
     ]
 
-    ZStack {
+    return ZStack {
         VColor.background.ignoresSafeArea()
         ThreadTabBar(
             threads: threads,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -46,7 +46,7 @@ struct ThreadTabBar: View {
 }
 
 #Preview("ThreadTabBar") {
-    @Previewable @State var threads = [
+    let threads = [
         ThreadModel(title: "New Thread"),
     ]
 


### PR DESCRIPTION
## Summary

Three issues preventing the CI build-and-release workflow from succeeding:

1. **`@Previewable` unavailable** — `@Previewable` requires macOS 15+ but the project deploys to macOS 14. Replaced with plain `let` binding since the preview doesn't need mutable state.

2. **`#Preview` ambiguity** — With a multi-statement closure (`let` + `ZStack`), Swift doesn't auto-return the last expression, so the compiler sees a `Void` return and can't disambiguate between `NSView`, `NSViewController`, and `View` overloads. Fixed with explicit `return`.

3. **Resource bundle missing at runtime** — Two sub-bugs:
   - The bundle name in `build.sh` was wrong (`VellumAssistantLib_VellumAssistantLib.bundle` vs the actual `vellum-assistant_VellumAssistantLib.bundle`), so the copy silently did nothing.
   - SPM's generated `resource_bundle_accessor.swift` looks for the bundle at `Bundle.main.bundleURL` (the `.app` root), but macOS codesigning requires all contents inside `Contents/`. Fixed by patching the generated accessor during build to use `Bundle.main.resourceURL` (`Contents/Resources/`) instead.

## Test plan
- [x] Local `./build.sh` succeeds (build + codesign)
- [x] App launches without resource bundle crash
- [ ] CI workflow passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)