### PR TITLE
Add auto_open to app_create for JIT app presentation

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -149,18 +149,14 @@ async function deleteItem(recordId) {
 
 ### 4. Create and Open the App
 
-After building the schema and HTML, call the tools in sequence:
+Call `app_create` with:
+- `name`: A short, descriptive name for the app
+- `description`: A one-sentence summary of what the app does
+- `schema_json`: The JSON schema as a string (use `JSON.stringify` formatting)
+- `html`: The complete HTML document as a string
+- `auto_open`: (optional, defaults to `true`) When true, the app is automatically opened in a dynamic_page surface immediately after creation -- no separate `app_open` call is needed
 
-1. Call `app_create` with:
-   - `name`: A short, descriptive name for the app
-   - `description`: A one-sentence summary of what the app does
-   - `schema_json`: The JSON schema as a string (use `JSON.stringify` formatting)
-   - `html`: The complete HTML document as a string
-
-2. Immediately call `app_open` with:
-   - `app_id`: The `id` field from the `app_create` response
-
-Always open the app right after creating it so the user can see and use it immediately.
+Since `auto_open` defaults to `true`, the app will be displayed to the user as soon as it is created. You do **not** need to call `app_open` separately after `app_create` unless `auto_open` was explicitly set to `false`.
 
 ### 5. Handle Iteration
 

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -55,19 +55,53 @@ export const appCreateTool: Tool = {
             type: 'string',
             description: 'HTML definition for rendering the app',
           },
+          auto_open: {
+            type: 'boolean',
+            description:
+              'Automatically open the app after creation. Defaults to true. ' +
+              'When true, the app is immediately displayed in a dynamic_page surface ' +
+              'without needing a separate app_open call.',
+          },
         },
         required: ['name', 'schema_json', 'html'],
       },
     };
   },
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
     const name = input.name as string;
     const description = input.description as string | undefined;
     const schemaJson = input.schema_json as string;
     const htmlDefinition = input.html as string;
+    const autoOpen = input.auto_open !== false; // default true
 
     const app = appStore.createApp({ name, description, schemaJson, htmlDefinition });
+
+    // Auto-open the app via the proxy resolver if available
+    if (autoOpen && context.proxyToolResolver) {
+      try {
+        const openResult = await context.proxyToolResolver('app_open', { app_id: app.id });
+        return {
+          content: JSON.stringify({
+            ...app,
+            auto_opened: true,
+            open_result: openResult.content,
+          }),
+          isError: false,
+        };
+      } catch {
+        // App was created successfully but auto-open failed; return creation result with a note
+        return {
+          content: JSON.stringify({
+            ...app,
+            auto_opened: false,
+            auto_open_error: 'Failed to auto-open app. Use app_open to open it manually.',
+          }),
+          isError: false,
+        };
+      }
+    }
+
     return { content: JSON.stringify(app), isError: false };
   },
 };


### PR DESCRIPTION
## Summary
- Adds an optional `auto_open` boolean parameter (defaults to `true`) to the `app_create` tool
- When `auto_open` is true and a proxy resolver is available, the tool automatically calls `app_open` after creating the app, so the user sees it immediately without a separate tool call
- Gracefully handles auto-open failures: app creation still succeeds, and a note indicates manual `app_open` is needed
- Updates the App Builder skill documentation to reflect the new parameter and streamlined workflow

## Test plan
- [ ] Create an app with `auto_open: true` (or omitted) — app should be created and immediately displayed
- [ ] Create an app with `auto_open: false` — app should be created but not opened
- [ ] Create an app when no proxy resolver is available — app should be created without error, auto-open silently skipped
- [ ] Verify type-check passes: `bunx tsc --noEmit`

Part of #1127. Closes #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
