### PR TITLE
Fix bundled flag lost in readBundledSkillFromDirectory

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -168,6 +168,7 @@ function readBundledSkillFromDirectory(directoryPath: string): SkillDefinition |
       directoryPath,
       skillFilePath,
       body: parsed.body,
+      bundled: true,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, 'Failed to read bundled skill file');


### PR DESCRIPTION
## Summary
- Adds `bundled: true` to the return object in `readBundledSkillFromDirectory()` so the flag is preserved when `loadSkillDefinition()` dispatches to this function for bundled skills.
- Previously, the `bundled` flag set on the `SkillSummary` in the catalog was lost when loading the full `SkillDefinition`.

Addresses review feedback on #1135.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] Existing test failures are pre-existing (bundled `app-builder` skill not accounted for in test expectations), not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
