### PR TITLE
Trigger macOS build on push to main

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -2,8 +2,11 @@ name: Build and Release macOS App
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 */4 * * *'
+  push:
+    branches: [main]
+    paths:
+      - 'clients/macos/**'
+      - 'assistant/**'
 
 concurrency:
   group: build-release


### PR DESCRIPTION
## Summary
- Replace 4-hour cron schedule with push-to-main trigger
- Only builds when `clients/macos/` or `assistant/` files change
- Manual dispatch still available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
