### PR TITLE
Add /safe-blitz-merge command and improve /safe-blitz

### DIFF
--- a/.claude/commands/safe-blitz-merge.md
+++ b/.claude/commands/safe-blitz-merge.md
@@ -1,0 +1,185 @@
+Merge a safe-blitz feature branch PR into main, close out the project, and clean up.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, auto-detect the feature branch PR (see Step 1). Example usage: `/safe-blitz-merge`, `/safe-blitz-merge 1136`, `/safe-blitz-merge feature/vslider-restyle`.
+
+## Parsing arguments
+
+`$ARGUMENTS` can be:
+- A PR number (e.g., `1136`)
+- A branch name (e.g., `feature/vslider-restyle`)
+- Empty (auto-detect)
+
+## Step 1: Identify the PR
+
+Use the following detection cascade. Stop at the first step that finds a match.
+
+### 1a. Explicit argument
+
+```bash
+# If PR number provided:
+gh pr view <number> --json number,title,url,headRefName,body,state
+
+# If branch name provided:
+gh pr list --head <branch-name> --base main --json number,title,url,headRefName,body,state
+```
+
+### 1b. Current branch
+
+```bash
+gh pr list --head $(git branch --show-current) --base main --json number,title,url,headRefName,body,state
+```
+
+### 1c. Open feature/* PRs targeting main
+
+```bash
+gh pr list --base main --state open --json number,title,url,headRefName,body,state
+```
+
+Filter to PRs whose `headRefName` starts with `feature/`.
+
+### 1d. Project board — issues in "In Review" status
+
+If no open feature PRs were found, check the project board for issues in "In Review" status. Safe-blitz sets the epic to "In Review" in Phase 6, so this catches cases where the PR might have been missed.
+
+```bash
+source .private/project-config.env
+
+gh api graphql -f query='{
+  node(id: "'"$GH_PROJECT_ID"'") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              optionId
+              name
+            }
+          }
+          content {
+            ... on Issue {
+              number
+              title
+              body
+              state
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Filter to items where the status `optionId` matches `$GH_STATUS_IN_REVIEW_ID` and the issue is still open. These are safe-blitz epics awaiting merge. Look at the issue body for the `Feature branch` section to extract the branch name, then find the corresponding PR.
+
+### Resolution
+
+- If exactly **one** candidate is found (from any step), use it automatically.
+- If **multiple** candidates are found, list them and ask the user to pick one.
+- If **none** are found, stop and tell the user there are no open safe-blitz PRs or in-review project items.
+
+Extract the **feature branch name** and **PR number** for later steps.
+
+## Step 2: Find the project issue
+
+Look at the PR body for a `Closes #<number>` reference — that's the project-level (epic) issue.
+
+If not found, ask the user for the project issue number.
+
+## Step 3: Merge the PR
+
+```bash
+gh pr merge <pr-number> --squash
+```
+
+Wait for the merge to complete. Confirm with:
+
+```bash
+gh pr view <pr-number> --json state,mergedAt
+```
+
+## Step 4: Update project board status to Done
+
+Source project config:
+
+```bash
+source .private/project-config.env
+```
+
+Find the project item for the epic issue and set status to Done:
+
+```bash
+ITEM_ID=""
+CURSOR=""
+while [ -z "$ITEM_ID" ]; do
+  if [ -z "$CURSOR" ]; then
+    AFTER_ARG=""
+  else
+    AFTER_ARG=", after: \"$CURSOR\""
+  fi
+  RESULT=$(gh api graphql -f query='{
+    node(id: "'"$GH_PROJECT_ID"'") {
+      ... on ProjectV2 {
+        items(first: 100'"$AFTER_ARG"') {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            content { ... on Issue { number } }
+          }
+        }
+      }
+    }
+  }')
+  ITEM_ID=$(echo "$RESULT" | jq -r '.data.node.items.nodes[] | select(.content.number == <issue-number>) | .id')
+  HAS_NEXT=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.hasNextPage')
+  CURSOR=$(echo "$RESULT" | jq -r '.data.node.items.pageInfo.endCursor')
+  if [ "$HAS_NEXT" != "true" ]; then break; fi
+done
+
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "'"$GH_PROJECT_ID"'"
+    itemId: "'"$ITEM_ID"'"
+    fieldId: "'"$GH_STATUS_FIELD_ID"'"
+    value: {singleSelectOptionId: "'"$GH_STATUS_DONE_ID"'"}
+  }) { projectV2Item { id } }
+}'
+```
+
+## Step 5: Close the project issue
+
+```bash
+gh issue close <project-issue-number>
+```
+
+## Step 6: Clean up local branch
+
+```bash
+git checkout main
+git pull origin main
+git branch -d <feature-branch-name>
+```
+
+If `-d` fails (unmerged warning), use `-D` since the PR was already squash-merged.
+
+## Step 7: Report
+
+Print a summary:
+
+```
+## Safe Blitz Merged
+
+**PR:** #<number> — <title> (<url>)
+**Project issue:** #<epic-number> — closed
+**Branch:** `<feature-branch-name>` — deleted locally
+
+You're now on `main` with the latest changes.
+```
+
+## Repo-specific gotchas
+
+- **gh pr view fields**: `merged` is NOT a valid --json field. Use `state` and `mergedAt`: `gh pr view <N> --json state,mergedAt,title,url`
+- **Merge strategy**: This repo does NOT allow merge commits. Always use `gh pr merge <N> --squash`.

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -71,13 +71,15 @@ This is the key difference from `/blitz`. All milestone work merges into this br
    - If `--branch NAME` was passed, use that.
    - Otherwise, generate one from the feature description: `feature/<kebab-case-summary>` (e.g., `feature/websocket-ipc-transport`). Keep it under 50 characters.
 
-2. Create and push the feature branch from the current main:
+2. Create and push the feature branch from the latest main **without switching your working tree**:
 
 ```bash
-git checkout main && git pull origin main
-git checkout -b <feature-branch-name>
+git fetch origin main
+git branch <feature-branch-name> origin/main
 git push -u origin <feature-branch-name>
 ```
+
+This keeps your current branch unchanged so safe-blitz doesn't block your main working tree.
 
 3. Store the feature branch name for later phases. All agents will use `--base <feature-branch-name>` instead of `--base main`.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/brainstorm` | Deep-read the codebase, generate a prioritized list of improvements, and update `.private/TODO.md` after approval. |
 | `/swarm [workers] [max-tasks]` | Parallel execution — spawns a pool of agents (default 3) that work through `.private/TODO.md` concurrently, each in its own worktree. PRs are auto-assigned to the current user. |
 | `/blitz <feature>` | End-to-end feature delivery — plans the feature, creates GitHub issues on a project board, swarm-executes them in parallel, sweeps for review feedback, addresses it, and reports. Merges directly to main. |
-| `/safe-blitz <feature>` | Same as `/blitz` but merges milestone PRs into a feature branch instead of main. Creates a final PR from the feature branch into main for manual review. Supports `--branch NAME` for custom branch names. |
+| `/safe-blitz <feature>` | Same as `/blitz` but merges milestone PRs into a feature branch instead of main. Creates a final PR from the feature branch into main for manual review. Does not switch your working tree — all work happens in worktrees. Supports `--branch NAME` for custom branch names. |
+| `/safe-blitz-merge [PR\|branch]` | Finalize a safe-blitz: squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
 | `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
 
 ### Utility
@@ -165,7 +166,7 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 3. **`/check-reviews`** — sweep for reviewer feedback
 4. **`/swarm`** again — address the feedback
 
-Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review before merging to main.
+Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-merge`** to merge it when ready.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
 


### PR DESCRIPTION
## Summary
- Add `/safe-blitz-merge` command that finalizes a safe-blitz: squash-merges the feature branch PR into main, sets the project issue to Done, closes it, and cleans up the local branch. Auto-detects the PR via a 4-layer cascade (current branch, open `feature/*` PRs, or project board "In Review" items).
- Update `/safe-blitz` Phase 1.5 to create the feature branch without switching the working tree (`git branch` + `git push` instead of `git checkout`), so it doesn't block the user's main thread.
- Update README with new command documentation.

## Test plan
- [ ] Run `/safe-blitz-merge` on an open safe-blitz PR and verify it merges, closes the issue, and cleans up
- [ ] Run `/safe-blitz` and verify it no longer switches the working tree during feature branch creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
