### PR TITLE
Fix resource bundle loading for .app bundles

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -79,15 +79,6 @@ swift build $SWIFT_FLAGS
 
 BIN_PATH=$(swift build $SWIFT_FLAGS --show-bin-path)
 
-# Patch SPM's generated resource_bundle_accessor to use Bundle.main.resourceURL
-# (points to Contents/Resources/) instead of Bundle.main.bundleURL (points to .app root).
-# macOS codesigning requires all contents inside Contents/.
-ACCESSOR=$(find "$BIN_PATH" -path "*/VellumAssistantLib.build/DerivedSources/resource_bundle_accessor.swift" 2>/dev/null | head -1)
-if [ -n "$ACCESSOR" ] && grep -q 'Bundle.main.bundleURL' "$ACCESSOR"; then
-    sed -i '' 's/Bundle\.main\.bundleURL/Bundle.main.resourceURL!/' "$ACCESSOR"
-    echo "Patched resource_bundle_accessor.swift for .app bundle layout"
-    swift build $SWIFT_FLAGS
-fi
 
 EXECUTABLE="$BIN_PATH/$APP_NAME"
 
@@ -173,12 +164,15 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# 4. Copy SPM resource bundle (contains Recipes, processed assets)
-# SPM names the bundle as <product>_<target>.bundle
-SPM_BUNDLE="$BIN_PATH/${APP_NAME}_VellumAssistantLib.bundle"
-if [ -d "$SPM_BUNDLE" ]; then
-    cp -R "$SPM_BUNDLE" "$RESOURCES_DIR/"
-fi
+# 4. Copy SPM resource bundles into Contents/Resources/
+# ResourceBundle.swift checks Bundle.main.resourceURL (Contents/Resources/) first,
+# then falls back to Bundle.main.bundleURL (for direct `swift run`).
+for SPM_BUNDLE in "$BIN_PATH"/*.bundle; do
+    if [ -d "$SPM_BUNDLE" ]; then
+        echo "Bundling $(basename "$SPM_BUNDLE")"
+        cp -R "$SPM_BUNDLE" "$RESOURCES_DIR/"
+    fi
+done
 
 # 5. Compile asset catalog (if actool is available)
 XCASSETS="$SCRIPT_DIR/vellum-assistant/Resources/Assets.xcassets"

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -609,7 +609,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func registerBundledFonts() {
         for name in ["Silkscreen-Regular", "Silkscreen-Bold"] {
-            guard let url = Bundle.module.url(forResource: name, withExtension: "ttf") else {
+            guard let url = ResourceBundle.bundle.url(forResource: name, withExtension: "ttf") else {
                 log.warning("Font file \(name).ttf not found in bundle")
                 continue
             }

--- a/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/RecipeExecutor.swift
@@ -146,8 +146,8 @@ final class RecipeExecutor {
 
     private func loadRecipeMarkdown(_ name: String) -> String? {
         #if SWIFT_PACKAGE
-            // SPM builds: recipes are copied into Bundle.module via .copy("Resources/Recipes")
-            if let url = Bundle.module.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {
+            // SPM builds: recipes are copied into the resource bundle via .copy("Resources/Recipes")
+            if let url = ResourceBundle.bundle.url(forResource: name, withExtension: "md", subdirectory: "Recipes") {
                 return try? String(contentsOf: url, encoding: .utf8)
             }
         #endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -47,7 +47,7 @@ struct OnboardingStageImage: View {
                     .blur(radius: 8)
 
                 // Stage sprite
-                if let url = Bundle.module.url(forResource: "stage-\(displayedStage)", withExtension: "png"),
+                if let url = ResourceBundle.bundle.url(forResource: "stage-\(displayedStage)", withExtension: "png"),
                    let nsImage = NSImage(contentsOf: url) {
                     Image(nsImage: nsImage)
                         .interpolation(.none)

--- a/clients/macos/vellum-assistant/Features/Onboarding/MeadowBackground.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/MeadowBackground.swift
@@ -6,7 +6,7 @@ struct MeadowBackground: View {
         ZStack {
             VColor.background
 
-            if let url = Bundle.module.url(forResource: "meadow", withExtension: "svg"),
+            if let url = ResourceBundle.bundle.url(forResource: "meadow", withExtension: "svg"),
                let nsImage = NSImage(contentsOf: url) {
                 Image(nsImage: nsImage)
                     .resizable()

--- a/clients/macos/vellum-assistant/ResourceBundle.swift
+++ b/clients/macos/vellum-assistant/ResourceBundle.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Provides access to the SPM resource bundle in both .app bundles and direct SPM builds.
+///
+/// SPM's auto-generated `Bundle.module` uses `Bundle.main.bundleURL` which resolves
+/// to the `.app` root. macOS codesigning requires resources inside `Contents/Resources/`,
+/// so SPM's accessor fails in `.app` bundles. This helper checks `resourceURL` first
+/// (correct for .app), then falls back to `bundleURL` (correct for `swift run`).
+enum ResourceBundle {
+    static let bundle: Bundle = {
+        let bundleName = "vellum-assistant_VellumAssistantLib"
+
+        // .app bundle: Contents/Resources/
+        if let url = Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
+           let bundle = Bundle(url: url) {
+            return bundle
+        }
+
+        // SPM direct build: alongside the executable
+        if let bundle = Bundle(url: Bundle.main.bundleURL.appendingPathComponent("\(bundleName).bundle")) {
+            return bundle
+        }
+
+        fatalError("Could not find resource bundle '\(bundleName).bundle'")
+    }()
+}


### PR DESCRIPTION
## Summary
- SPM's auto-generated `Bundle.module` uses `Bundle.main.bundleURL` (→ `.app` root), but macOS codesigning requires resources inside `Contents/`
- The previous sed-patching approach didn't work because SPM **regenerates** `resource_bundle_accessor.swift` on every `swift build`, undoing the patch
- Added `ResourceBundle.swift` helper that checks `Bundle.main.resourceURL` (`Contents/Resources/`) first, falls back to `bundleURL` for direct `swift run`
- Replaced all 4 `Bundle.module` usages with `ResourceBundle.bundle`
- Build script now copies all SPM resource bundles (not just one) into `Contents/Resources/`

## Test plan
- [x] Clean release build succeeds locally (`./build.sh clean && ./build.sh release`)
- [x] Codesigning passes (no "unsealed contents" error)
- [x] App launches successfully from release build
- [ ] CI build produces a working release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
