### PR TITLE
Fix remaining Bundle.module crash in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -18,7 +18,7 @@ struct ChatView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            Image("bg", bundle: .module)
+            Image("bg", bundle: ResourceBundle.bundle)
                 .resizable()
                 .scaledToFit()
                 .opacity(0.3)


### PR DESCRIPTION
## Summary
- Follow-up to #1160 — missed `Image("bg", bundle: .module)` in ChatView which still triggered SPM's generated accessor
- This was the direct cause of the launch crash (crash report shows `ChatView.body.getter` → `NSBundle.module` → `fatalError`)
- Replaced with `ResourceBundle.bundle`

## Test plan
- [x] Clean release build succeeds
- [x] App launches without crashing
- [x] No remaining `.module` references in Swift source (verified with grep)
- [ ] CI build produces working release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
