### PR TITLE
Remove glossy border from download page icon

### DIFF
--- a/web/src/components/marketing/DownloadPage/DownloadBody.tsx
+++ b/web/src/components/marketing/DownloadPage/DownloadBody.tsx
@@ -127,9 +127,6 @@ export function DownloadBody() {
 .download-owl-img {
   position: relative;
   border-radius: 28px;
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 .download-heading {
   font-family: "Playfair Display", serif;


### PR DESCRIPTION
## Summary
- Remove the `box-shadow` on the owl icon that creates a glossy border/outline effect

## Test plan
- [ ] Visit `/download` and confirm the icon no longer has a visible border/shadow outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
