### PR TITLE
Align typography to Apple macOS HIG and fix VTab/VIconButton height mismatch

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VTab.swift
@@ -33,7 +33,7 @@ struct VTab: View {
                         .font(.system(size: 12))
                 }
                 Text(label)
-                    .font(VFont.body)
+                    .font(VFont.caption)
                     .lineLimit(1)
             }
             .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))

--- a/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
@@ -9,13 +9,13 @@ enum VFont {
 
     // MARK: - Standard Scale
 
-    static let largeTitle = Font.system(size: 24, weight: .bold)
-    static let title      = Font.system(size: 18, weight: .semibold)
-    static let headline   = Font.system(size: 14, weight: .semibold)
+    static let largeTitle = Font.system(size: 26, weight: .bold)
+    static let title      = Font.system(size: 22, weight: .semibold)
+    static let headline   = Font.system(size: 13, weight: .bold)
     static let body       = Font.system(size: 13)
     static let bodyMedium = Font.system(size: 13, weight: .medium)
-    static let caption    = Font.system(size: 11)
-    static let captionMedium = Font.system(size: 11, weight: .medium)
+    static let caption    = Font.system(size: 10)
+    static let captionMedium = Font.system(size: 10, weight: .medium)
     static let small      = Font.system(size: 10)
 
     // MARK: - Specialized


### PR DESCRIPTION
## Summary
- Align VFont typography tokens to Apple's macOS Human Interface Guidelines (largeTitle 26pt, title 22pt, headline 13pt bold, caption 10pt)
- Fix VTab using VFont.caption to match VIconButton height in NavigationToolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
