### PR TITLE
Rename /safe-blitz-merge to /safe-blitz-done

### DIFF
--- a/.claude/commands/safe-blitz-done.md
+++ b/.claude/commands/safe-blitz-done.md
@@ -1,8 +1,8 @@
-Merge a safe-blitz feature branch PR into main, close out the project, and clean up.
+Finalize a safe-blitz: merge the feature branch PR into main, close out the project issue, and clean up locally.
 
 The user passed: `$ARGUMENTS`
 
-If `$ARGUMENTS` is empty, auto-detect the feature branch PR (see Step 1). Example usage: `/safe-blitz-merge`, `/safe-blitz-merge 1136`, `/safe-blitz-merge feature/vslider-restyle`.
+If `$ARGUMENTS` is empty, auto-detect the feature branch PR (see Step 1). Example usage: `/safe-blitz-done`, `/safe-blitz-done 1136`, `/safe-blitz-done feature/vslider-restyle`.
 
 ## Parsing arguments
 
@@ -170,7 +170,7 @@ If `-d` fails (unmerged warning), use `-D` since the PR was already squash-merge
 Print a summary:
 
 ```
-## Safe Blitz Merged
+## Safe Blitz Done
 
 **PR:** #<number> — <title> (<url>)
 **Project issue:** #<epic-number> — closed

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/brainstorm` | Deep-read the codebase, generate a prioritized list of improvements, and update `.private/TODO.md` after approval. |
 | `/swarm [workers] [max-tasks]` | Parallel execution — spawns a pool of agents (default 3) that work through `.private/TODO.md` concurrently, each in its own worktree. PRs are auto-assigned to the current user. |
 | `/blitz <feature>` | End-to-end feature delivery — plans the feature, creates GitHub issues on a project board, swarm-executes them in parallel, sweeps for review feedback, addresses it, and reports. Merges directly to main. |
-| `/safe-blitz <feature>` | Same as `/blitz` but merges milestone PRs into a feature branch instead of main. Creates a final PR from the feature branch into main for manual review. Does not switch your working tree — all work happens in worktrees. Supports `--branch NAME` for custom branch names. |
-| `/safe-blitz-merge [PR\|branch]` | Finalize a safe-blitz: squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
+| `/safe-blitz <feature>` | End-to-end feature delivery on a feature branch — plans, creates issues, swarm-executes in parallel, sweeps for review feedback. All milestone PRs merge into a feature branch (not main). Creates a final PR for manual review. Does not switch your working tree. Supports `--auto`, `--workers N`, `--skip-plan`, `--branch NAME`. |
+| `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
 | `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
 
 ### Utility
@@ -166,7 +166,7 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 3. **`/check-reviews`** — sweep for reviewer feedback
 4. **`/swarm`** again — address the feedback
 
-Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-merge`** to merge it when ready.
+Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-done`** to merge it when ready.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
 


### PR DESCRIPTION
## Summary
- Rename `/safe-blitz-merge` command to `/safe-blitz-done`
- Improve `/safe-blitz` description in README with supported flags
- Update all references in README typical flow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
