### PR TITLE
Make macOS release workflow manual-only

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -2,11 +2,6 @@ name: Build and Release macOS App
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'clients/macos/**'
-      - 'assistant/**'
 
 concurrency:
   group: build-release


### PR DESCRIPTION
## Summary
- Remove push-to-main trigger from macOS build workflow
- Releases now only run via manual workflow_dispatch (GitHub Actions UI or `gh workflow run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
