### PR TITLE
Enable tick marks on Computer Usage slider

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -153,7 +153,7 @@ struct ControlPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 1...100, step: 1)
+                VSlider(value: $maxSteps, range: 1...100, step: 1, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
- Enable `showTickMarks: true` on the VSlider in ControlPanel's Computer Usage section so the slider displays visual tick marks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
