### PR TITLE
Fix skill icons: non-blocking list + resilient caching

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -462,6 +462,21 @@ async function generateSkillIcon(name: string, description: string): Promise<str
   return svgMatch[0];
 }
 
+/**
+ * Synchronously read a cached icon if it exists on disk. Returns undefined if not cached yet.
+ */
+export function readCachedSkillIcon(directoryPath: string): string | undefined {
+  const iconPath = join(directoryPath, 'icon.svg');
+  if (existsSync(iconPath)) {
+    try {
+      return readFileSync(iconPath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 export async function ensureSkillIcon(directoryPath: string, name: string, description: string): Promise<string | undefined> {
   const iconPath = join(directoryPath, 'icon.svg');
 
@@ -476,8 +491,12 @@ export async function ensureSkillIcon(directoryPath: string, name: string, descr
 
   try {
     const svg = await generateSkillIcon(name, description);
-    writeFileSync(iconPath, svg, 'utf-8');
-    log.info({ iconPath }, 'Generated skill icon');
+    try {
+      writeFileSync(iconPath, svg, 'utf-8');
+      log.info({ iconPath }, 'Generated skill icon');
+    } catch (writeErr) {
+      log.warn({ err: writeErr, iconPath }, 'Failed to cache icon.svg (returning generated icon anyway)');
+    }
     return svg;
   } catch (err) {
     log.warn({ err, iconPath }, 'Failed to generate skill icon');

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -27,7 +27,7 @@ import type {
   AppDataRequest,
   SkillDetailRequest,
 } from './ipc-protocol.js';
-import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../config/skills.js';
+import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
@@ -575,15 +575,20 @@ function handleUsageRequest(
 
 // ─── Skills handlers ─────────────────────────────────────────────────────────
 
-async function handleSkillsList(socket: net.Socket, ctx: HandlerContext): Promise<void> {
+function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const catalog = loadSkillCatalog();
-  const skills = await Promise.all(
-    catalog.map(async (s) => {
-      const icon = await ensureSkillIcon(s.directoryPath, s.name, s.description);
-      return { id: s.id, name: s.name, description: s.description, ...(icon ? { icon } : {}) };
-    }),
-  );
+  // Respond immediately with cached icons (sync reads only)
+  const skills = catalog.map((s) => {
+    const icon = readCachedSkillIcon(s.directoryPath);
+    return { id: s.id, name: s.name, description: s.description, ...(icon ? { icon } : {}) };
+  });
   ctx.send(socket, { type: 'skills_list_response', skills });
+
+  // Generate missing icons in the background (fire-and-forget)
+  const missing = catalog.filter((s) => !readCachedSkillIcon(s.directoryPath));
+  if (missing.length > 0) {
+    Promise.all(missing.map((s) => ensureSkillIcon(s.directoryPath, s.name, s.description))).catch(() => {});
+  }
 }
 
 async function handleSkillDetail(


### PR DESCRIPTION
## Summary
- **P1 fix**: `handleSkillsList` now responds immediately with cached icons (sync reads only), then generates missing icons in the background — no more blocking on Anthropic API calls when opening the Agent panel
- **P2 fix**: When icon generation succeeds but `writeFileSync` fails (e.g., read-only directory), the generated SVG is still returned instead of being discarded

Addresses review feedback on #1061.

## Test plan
- [ ] Open Agent panel with no cached icons — skills list loads instantly, icons appear on next open
- [ ] Open Agent panel with cached icons — icons display immediately
- [ ] Verify icon generation still works and caches to disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
