### PR TITLE
Fix safe-blitz Phase 2 text and update AGENTS.md TLDR table

### DIFF
--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -88,7 +88,7 @@ This keeps your current branch unchanged so safe-blitz doesn't block your main w
 **If `--skip-plan` was passed**, skip issue creation. Instead:
 
 1. Fetch existing "Ready" issues from the project board and use those as the milestones.
-2. Identify the project-level issue (the epic). Look for an open issue in "In Progress" status that references milestones, or ask the user to provide the project issue number. This is required — Phase 6 needs it to close out the project.
+2. Identify the project-level issue (the epic). Look for an open issue in "In Progress" status that references milestones, or ask the user to provide the project issue number. This is required — Phase 6 needs it to set the project status and reference it in the final PR.
 3. Proceed to Phase 3 with the fetched milestones.
 
 **Otherwise:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/do <description>` | Implement a described change in an isolated worktree, ship it to main via a squash-merged PR, and clean up. |
 | `/swarm [workers] [max-tasks]` | Process `.private/TODO.md` in parallel — one worktree per agent, auto-merge PRs (auto-assigned to the current user), respawn agents until the list is empty. |
 | `/blitz <feature>` | End-to-end feature delivery: plan, create GitHub issues on a project board, swarm-execute in parallel, sweep for review feedback, and report. |
+| `/safe-blitz <feature>` | Like `/blitz` but merges milestone PRs into a feature branch instead of main, then opens a final PR for manual review. Supports `--auto`, `--workers N`, `--skip-plan`, `--branch NAME`. |
+| `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merge the feature branch PR into main, set the project issue to Done, close the issue, and clean up locally. Auto-detects from current branch, open `feature/*` PRs, or project board. |
 | `/mainline [title]` | Ship the current uncommitted changes to main via a squash-merged PR. |
 | `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
 | `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |


### PR DESCRIPTION
## Summary
- Fix copy-paste error in safe-blitz.md: Phase 2 --skip-plan text incorrectly said Phase 6 "closes out the project" when it actually sets status to "In Review" and creates a final PR
- Add /safe-blitz and /safe-blitz-done entries to AGENTS.md slash commands TLDR table

Addresses review feedback from PR #1122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
