### PR TITLE
Restore VFont.caption to 11pt (address PR #1165 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
@@ -14,8 +14,8 @@ enum VFont {
     static let headline   = Font.system(size: 13, weight: .bold)
     static let body       = Font.system(size: 13)
     static let bodyMedium = Font.system(size: 13, weight: .medium)
-    static let caption    = Font.system(size: 10)
-    static let captionMedium = Font.system(size: 10, weight: .medium)
+    static let caption    = Font.system(size: 11)
+    static let captionMedium = Font.system(size: 11, weight: .medium)
     static let small      = Font.system(size: 10)
 
     // MARK: - Specialized


### PR DESCRIPTION
## Summary
- Restores `VFont.caption` from 10pt back to 11pt and `VFont.captionMedium` from 10pt back to 11pt medium
- Addresses review feedback on PR #1165 where caption and small tokens were collapsed to the same 10pt size
- 11pt aligns with macOS HIG Subheadline and preserves the type scale: body (13pt) > caption (11pt) > small (10pt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
