### PR TITLE
Slider snaps to multiples of 10 with minimum of 1

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -148,12 +148,15 @@ struct ControlPanel: View {
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
                     Spacer()
-                    Text("\(Int(maxSteps))")
+                    Text("\(max(1, Int(maxSteps)))")
                         .font(VFont.mono)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 1...100, step: 10, showTickMarks: true)
+                VSlider(value: $maxSteps, range: 0...100, step: 10, showTickMarks: true)
+                    .onChange(of: maxSteps) { _, newValue in
+                        if newValue < 1 { maxSteps = 1 }
+                    }
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
- Changed Computer Usage slider range from 1...100 to 0...100 with step 10, so snap points are multiples of 10
- Added onChange clamp so the minimum effective value is 1 (not 0)
- Effective snap points: 1, 10, 20, 30, ..., 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
