### PR TITLE
Add voice source to IPC protocol and force voice to text_qa

### DIFF
--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -10,7 +10,12 @@ export type InteractionType = 'computer_use' | 'text_qa';
  * Classify a user task as computer_use or text_qa using a Haiku tool-use call,
  * falling back to a heuristic if the API call fails or no API key is available.
  */
-export async function classifyInteraction(task: string): Promise<InteractionType> {
+export async function classifyInteraction(task: string, source?: 'voice' | 'text'): Promise<InteractionType> {
+  if (source === 'voice') {
+    log.info({ source }, 'Voice source detected, skipping classification — routing to text_qa');
+    return 'text_qa';
+  }
+
   const config = getConfig();
   const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -677,7 +677,7 @@ async function handleTaskSubmit(
   const rlog = log.child({ requestId });
 
   try {
-    const interactionType = await classifyInteraction(msg.task);
+    const interactionType = await classifyInteraction(msg.task, msg.source);
     rlog.info({ interactionType, task: msg.task }, 'Task classified');
 
     if (interactionType === 'computer_use') {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -118,6 +118,7 @@ export interface TaskSubmit {
   screenWidth: number;
   screenHeight: number;
   attachments?: UserMessageAttachment[];
+  source?: 'voice' | 'text';
 }
 
 export interface AmbientObservation {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -294,7 +294,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 textSession.sendFollowUp(text: text)
                 self?.textResponseWindow?.updatePartialTranscription("")
             } else {
-                self?.startSession(task: text)
+                self?.startSession(task: text, source: "voice")
             }
         }
         voiceInput?.onPartialTranscription = { [weak self] text in
@@ -431,8 +431,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Session
 
-    func startSession(task: String) {
-        startSession(submission: TaskSubmission(task: task, attachments: []))
+    func startSession(task: String, source: String? = nil) {
+        startSession(submission: TaskSubmission(task: task, attachments: [], source: source))
     }
 
     func startSession(submission: TaskSubmission) {
@@ -481,7 +481,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 task: effectiveTask,
                 screenWidth: Int(screenBounds.width),
                 screenHeight: Int(screenBounds.height),
-                attachments: ipcAttachments
+                attachments: ipcAttachments,
+                source: submission.source
             ))
 
             // 3. Wait for task_routed response (or error)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -251,9 +251,10 @@ private struct ChatBubble: View {
     }
 
     private var bubbleContent: some View {
-        Text(message.text)
+        Text(markdownText)
             .font(VFont.mono)
             .foregroundColor(isUser ? .white : VColor.textPrimary)
+            .tint(isUser ? .white : VColor.accent)
             .textSelection(.enabled)
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
@@ -263,6 +264,14 @@ private struct ChatBubble: View {
             )
             .frame(maxWidth: 500, alignment: isUser ? .trailing : .leading)
             .opacity(bubbleOpacity)
+    }
+
+    private var markdownText: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: message.text, options: options))
+            ?? AttributedString(message.text)
     }
 
     private func ordinal(_ n: Int) -> String {

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -128,7 +128,7 @@ struct TextResponseView: View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             assistantAvatar
 
-            Text(text)
+            Text(Self.markdownString(text))
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
                 .textSelection(.enabled)
@@ -229,6 +229,16 @@ struct TextResponseView: View {
             .clipShape(Circle())
     }
 
+    // MARK: - Markdown
+
+    static func markdownString(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options))
+            ?? AttributedString(text)
+    }
+
     // MARK: - Helpers
 
     private func sendMessage() {
@@ -254,9 +264,10 @@ private struct ConversationBubble: View {
                 Spacer(minLength: 0)
             }
 
-            Text(message.text)
+            Text(Self.markdownString(message.text))
                 .font(VFont.body)
                 .foregroundColor(isAssistant ? VColor.textPrimary : .white)
+                .tint(isAssistant ? VColor.accent : .white)
                 .if(isAssistant) { view in
                     view.textSelection(.enabled)
                 }
@@ -275,6 +286,10 @@ private struct ConversationBubble: View {
                 Spacer(minLength: 0)
             }
         }
+    }
+
+    static func markdownString(_ text: String) -> AttributedString {
+        TextResponseView.markdownString(text)
     }
 
     private var bubbleFill: some ShapeStyle {

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -162,6 +162,7 @@ struct TaskSubmitMessage: Encodable, Sendable {
     let screenWidth: Int
     let screenHeight: Int
     let attachments: [IPCAttachment]?
+    let source: String?
 }
 
 /// Sent to cancel the active generation.

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -226,4 +226,11 @@ struct TaskAttachment: Identifiable {
 struct TaskSubmission {
     let task: String
     let attachments: [TaskAttachment]
+    let source: String?
+
+    init(task: String, attachments: [TaskAttachment], source: String? = nil) {
+        self.task = task
+        self.attachments = attachments
+        self.source = source
+    }
 }


### PR DESCRIPTION
Part of #1177. Closes #1178.

## Changes
- Added `source` field to TaskSubmit IPC message (`'voice' | 'text'`)
- Classifier returns text_qa immediately for voice-sourced tasks (skips Haiku API call)
- Swift client sends source='voice' for voice-initiated tasks
- Threaded source through TaskSubmission -> TaskSubmitMessage -> handler

## Test plan
- [ ] Voice input routes to text_qa (no classification API call)
- [ ] Non-voice input still goes through normal classification
- [ ] TypeScript type-checks clean
- [ ] Swift builds clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
