### PR TITLE
Route voice to ChatView when main window is visible

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -289,16 +289,34 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         voiceInput?.onTranscription = { [weak self] text in
             self?.voiceTranscriptionWindow?.close()
             self?.voiceTranscriptionWindow = nil
-            // Route to active conversation if one exists and is ready
+
+            // Priority 1: Route to main window ChatView if visible
+            if let mainWindow = self?.mainWindow, mainWindow.isVisible,
+               let viewModel = mainWindow.activeViewModel {
+                viewModel.inputText = text
+                viewModel.sendMessage()
+                return
+            }
+
+            // Priority 2: Route to active TextResponseWindow conversation
             if let textSession = self?.currentTextSession, textSession.state == .ready {
                 textSession.sendFollowUp(text: text)
                 self?.textResponseWindow?.updatePartialTranscription("")
-            } else {
-                self?.startSession(task: text, source: "voice")
+                return
             }
+
+            // Priority 3: Fall back to creating a new session
+            self?.startSession(task: text, source: "voice")
         }
         voiceInput?.onPartialTranscription = { [weak self] text in
-            // Route partial text to active conversation's input field if available
+            // Priority 1: Route partial text to main window ChatView input if visible
+            if let mainWindow = self?.mainWindow, mainWindow.isVisible,
+               let viewModel = mainWindow.activeViewModel {
+                viewModel.inputText = text
+                return
+            }
+
+            // Priority 2: Route to active TextResponseWindow conversation
             if let textSession = self?.currentTextSession, textSession.state == .ready {
                 self?.textResponseWindow?.updatePartialTranscription(text)
             } else {
@@ -306,6 +324,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
+            // Check if main window ChatView is the target
+            let mainWindowVisible = self?.mainWindow?.isVisible ?? false
             // If there's an active conversation in ready state, route recording state there
             let hasActiveConvo = self?.currentTextSession?.state == .ready
 
@@ -314,7 +334,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     systemSymbolName: "mic.fill",
                     accessibilityDescription: "Vellum"
                 )
-                if !hasActiveConvo {
+                if !mainWindowVisible && !hasActiveConvo {
                     let window = VoiceTranscriptionWindow()
                     window.show()
                     self?.voiceTranscriptionWindow = window

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -6,10 +6,22 @@ final class MainWindow {
     private let daemonClient: DaemonClient
     private let ambientAgent: AmbientAgent
     private var window: NSWindow?
+    let threadManager: ThreadManager
+
+    /// Whether the main window is currently visible on screen.
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    /// The active ChatViewModel from the current thread, if any.
+    var activeViewModel: ChatViewModel? {
+        threadManager.activeViewModel
+    }
 
     init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
         self.daemonClient = daemonClient
         self.ambientAgent = ambientAgent
+        self.threadManager = ThreadManager(daemonClient: daemonClient)
     }
 
     func show() {
@@ -17,14 +29,14 @@ final class MainWindow {
         if let existing = window {
             // Rebuild the SwiftUI view hierarchy so it picks up any
             // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient, ambientAgent: ambientAgent))
+            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent))
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(daemonClient: daemonClient, ambientAgent: ambientAgent))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent))
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 struct MainWindowView: View {
-    @StateObject private var threadManager: ThreadManager
+    @ObservedObject var threadManager: ThreadManager
     @State private var activePanel: SidePanelType?
     let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
 
-    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
+    init(threadManager: ThreadManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
+        self.threadManager = threadManager
         self.daemonClient = daemonClient
-        _threadManager = StateObject(wrappedValue: ThreadManager(daemonClient: daemonClient))
         self.ambientAgent = ambientAgent
     }
 
@@ -75,5 +75,6 @@ struct MainWindowView: View {
 }
 
 #Preview {
-    MainWindowView(daemonClient: DaemonClient(), ambientAgent: AmbientAgent())
+    let dc = DaemonClient()
+    MainWindowView(threadManager: ThreadManager(daemonClient: dc), daemonClient: dc, ambientAgent: AmbientAgent())
 }


### PR DESCRIPTION
Part of #1177. Closes #1181.

## Changes
- Move `ThreadManager` ownership from `MainWindowView` (`@StateObject`) to `MainWindow` class, so `AppDelegate` can access the active `ChatViewModel`
- Add `isVisible` and `activeViewModel` computed properties to `MainWindow`
- Update `MainWindowView` to accept `ThreadManager` via `@ObservedObject` instead of creating its own
- Voice transcription (`onTranscription`) now routes to ChatView when main window is visible, setting `inputText` and calling `sendMessage()` on the active `ChatViewModel`
- Partial transcription (`onPartialTranscription`) updates the ChatView input field in real-time when main window is visible
- Recording state (`onRecordingStateChanged`) skips showing `VoiceTranscriptionWindow` when main window is visible
- Falls back to existing TextResponseWindow / `startSession()` behavior when main window is not visible

## Test plan
- [ ] Voice input with main window open routes to ChatView
- [ ] Voice input with main window closed creates TextResponseWindow
- [ ] Partial transcription shows in ChatView input when main window visible
- [ ] Partial transcription shows in VoiceTranscriptionWindow when main window not visible
- [ ] Swift builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
