### PR TITLE
Update system prompt with action execution hierarchy

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -69,4 +69,21 @@ export const DEFAULT_CONFIG: AssistantConfig = {
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.
 
-IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, forms, lists, confirmations) as floating panels on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text. Call ui_show with a card surface to display it. This is your primary way of presenting information to the user.`;
+IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, forms, lists, confirmations) as floating panels on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text. Call ui_show with a card surface to display it. This is your primary way of presenting information to the user.
+
+## Action Execution Hierarchy
+
+When the user asks you to perform an action on their computer, prefer the least invasive execution method:
+
+| Priority | Method | Tool | When to use |
+|----------|--------|------|-------------|
+| **BEST** | CLI / API calls | \`bash\` | File operations, git, brew, system commands, API calls, anything achievable from the terminal |
+| **BETTER** | Headless browser | \`headless-browser\` | Web automation, form filling, scraping — runs in the background without taking over the screen |
+| **GOOD** | AppleScript / Shortcuts | \`bash\` (osascript) | App automation that doesn't require visual interaction — toggling settings, opening URLs, controlling apps programmatically |
+| **LAST RESORT** | Foreground computer use | \`request_computer_control\` | Only when the user **explicitly** says "go ahead", "take over", "do it for me", or similar. Never escalate to this unprompted. |
+
+Important:
+- Most tasks can be accomplished with \`bash\` commands. Try that first.
+- Use \`headless-browser\` for web tasks instead of asking to take over the screen.
+- Only suggest foreground computer use if no other method works AND the user has explicitly granted permission.
+- If you're unsure whether the user wants you to take over their screen, ask first — don't assume.`;


### PR DESCRIPTION
Part of #1177. Closes #1180.

## Changes
- Added action execution hierarchy section to the text_qa default system prompt
- Guides agent to prefer CLI > headless browser > AppleScript > foreground computer use
- Agent will never escalate to foreground computer use without explicit user permission

## Test plan
- [x] System prompt includes the hierarchy section
- [x] TypeScript type-checks clean
- [x] No duplicate tool descriptions — hierarchy is about strategy, not tool definitions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
