### PR TITLE
Add version module and wire Sentry release/environment

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -1,6 +1,9 @@
 import * as Sentry from "@sentry/node";
+import { APP_VERSION } from "./version.js";
 
 Sentry.init({
   dsn: "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992",
+  release: `vellum-assistant@${APP_VERSION}`,
+  environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
   sendDefaultPii: true,
 });

--- a/assistant/src/version.ts
+++ b/assistant/src/version.ts
@@ -1,0 +1,3 @@
+// Version is embedded at compile time via --define in CI.
+// Falls back to "0.0.0-dev" for local development.
+export const APP_VERSION: string = process.env.APP_VERSION ?? "0.0.0-dev";


### PR DESCRIPTION
## Summary
- Create `assistant/src/version.ts` with compile-time `APP_VERSION` constant (falls back to `0.0.0-dev` locally)
- Wire version into `Sentry.init()` as release identifier (`vellum-assistant@<version>`)
- Set Sentry environment based on version (`production` for tagged builds, `development` for dev)

Part of GTM release readiness.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
