### PR TITLE
Add About section to ControlPanel showing app version

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -203,6 +203,35 @@ struct ControlPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard()
+
+            // ABOUT section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("ABOUT")
+                    .font(VFont.display)
+                    .foregroundColor(VColor.textPrimary)
+
+                HStack {
+                    Text("Version")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+
+                HStack {
+                    Text("Build")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard()
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds an "ABOUT" section at the bottom of the ControlPanel settings tab
- Displays app version (from `CFBundleShortVersionString`) and build number (from `CFBundleVersion`)
- In release builds these come from Info.plist (stamped by CI); in dev builds they show "dev"/"-"
- Follows the existing section design pattern (VStack + VFont.display header + .vCard())

Part of GTM release readiness.

## Test plan
- [ ] Build succeeds (`swift build` verified locally)
- [ ] Open ControlPanel > Settings tab and confirm the ABOUT section appears after PERMISSIONS
- [ ] Verify Version and Build rows display correctly with right-aligned mono text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
