### PR TITLE
Add request_computer_control tool for explicit CU escalation

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -35,6 +35,38 @@ import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } fr
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
+/**
+ * Wire the escalation handler on a text_qa session so that invoking
+ * `request_computer_control` creates a CU session and notifies the client.
+ */
+function wireEscalationHandler(
+  session: Session,
+  socket: net.Socket,
+  ctx: HandlerContext,
+  screenWidth: number,
+  screenHeight: number,
+): void {
+  session.setEscalationHandler((task: string, sourceSessionId: string) => {
+    const cuSessionId = uuid();
+    const cuMsg: CuSessionCreate = {
+      type: 'cu_session_create',
+      sessionId: cuSessionId,
+      task,
+      screenWidth,
+      screenHeight,
+      interactionType: 'computer_use',
+    };
+    handleCuSessionCreate(cuMsg, socket, ctx);
+
+    ctx.send(socket, {
+      type: 'task_routed',
+      sessionId: cuSessionId,
+      interactionType: 'computer_use',
+      escalatedFrom: sourceSessionId,
+    });
+  });
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -704,6 +736,9 @@ async function handleTaskSubmit(
       const conversation = conversationStore.createConversation(msg.task);
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(conversation.id, socket, true);
+
+      // Wire escalation handler so the agent can call request_computer_control
+      wireEscalationHandler(session, socket, ctx, msg.screenWidth, msg.screenHeight);
 
       ctx.send(socket, {
         type: 'task_routed',

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -448,6 +448,8 @@ export interface TaskRouted {
   type: 'task_routed';
   sessionId: string;
   interactionType: 'computer_use' | 'text_qa';
+  /** Set when a text_qa session escalates to computer_use via request_computer_control. */
+  escalatedFrom?: string;
 }
 
 export interface AmbientResult {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -16,6 +16,7 @@ import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/ty
 import { getAllToolDefinitions } from '../tools/registry.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { allAppTools } from '../tools/apps/definitions.js';
+import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost } from '../util/pricing.js';
@@ -86,6 +87,7 @@ export class Session {
     surfaceType: SurfaceType;
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
+  private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => void;
 
   constructor(
     conversationId: string,
@@ -113,6 +115,8 @@ export class Session {
       ...getAllToolDefinitions(),
       ...allUiSurfaceTools.map((t) => t.getDefinition()),
       ...allAppTools.filter((t) => t.executionMode === 'proxy').map((t) => t.getDefinition()),
+      // Escalation tool: allows text_qa sessions to hand off to computer use
+      requestComputerControlTool.getDefinition(),
     ];
     const toolExecutor = async (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => {
       return this.executor.execute(name, input, {
@@ -195,6 +199,14 @@ export class Session {
 
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
+  }
+
+  /**
+   * Set a callback for when a text_qa session escalates to computer use
+   * via the `request_computer_control` tool.
+   */
+  setEscalationHandler(handler: (task: string, sourceSessionId: string) => void): void {
+    this.onEscalateToComputerUse = handler;
   }
 
   isProcessing(): boolean {
@@ -908,6 +920,17 @@ export class Session {
       this.pendingSurfaceActions.delete(surfaceId);
       this.surfaceState.delete(surfaceId);
       return { content: 'Surface dismissed', isError: false };
+    }
+
+    if (toolName === 'request_computer_control') {
+      const task = typeof input.task === 'string' ? input.task : 'Perform the requested task';
+      if (this.onEscalateToComputerUse) {
+        this.onEscalateToComputerUse(task, this.conversationId);
+      }
+      return {
+        content: 'Computer control activated. The task has been handed off to foreground computer use.',
+        isError: false,
+      };
     }
 
     if (toolName === 'app_open') {

--- a/assistant/src/tools/computer-use/registry.ts
+++ b/assistant/src/tools/computer-use/registry.ts
@@ -7,9 +7,13 @@
 
 import { registerTool } from '../registry.js';
 import { allComputerUseTools } from './definitions.js';
+import { requestComputerControlTool } from './request-computer-control.js';
 
 export function registerComputerUseTools(): void {
   for (const tool of allComputerUseTools) {
     registerTool(tool);
   }
+  // Register the escalation tool separately — it is only added to text_qa
+  // sessions (not CU sessions) to avoid recursive escalation.
+  registerTool(requestComputerControlTool);
 }

--- a/assistant/src/tools/computer-use/request-computer-control.ts
+++ b/assistant/src/tools/computer-use/request-computer-control.ts
@@ -1,0 +1,49 @@
+/**
+ * request_computer_control tool definition.
+ *
+ * This tool allows a text_qa session to escalate to foreground computer use
+ * when the user explicitly requests it (e.g. "go ahead and do it", "take over
+ * for 20 seconds"). It is a proxy tool — execution is handled by the session's
+ * surfaceProxyResolver, which creates a CU session and sends a task_routed
+ * message to the client.
+ *
+ * This tool is only available to text_qa sessions. It must NOT be added to
+ * CU sessions (that would be recursive).
+ */
+
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+
+export const requestComputerControlTool: Tool = {
+  name: 'request_computer_control',
+  description:
+    'Escalate to foreground computer use. Call this when the user explicitly asks you to ' +
+    'take control of their computer to perform a task (e.g. "go ahead and do it", ' +
+    '"take over", "open that for me"). Provide a concise description of the task ' +
+    'that computer use should accomplish.',
+  category: 'computer-use',
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: 'proxy',
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          task: {
+            type: 'string',
+            description: 'Concise description of what computer use should accomplish',
+          },
+        },
+        required: ['task'],
+      },
+    };
+  },
+
+  execute(): Promise<ToolExecutionResult> {
+    throw new Error('Proxy tool: execution must be forwarded via surfaceProxyResolver');
+  },
+};

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -71,6 +71,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupDaemonClient() {
+        // Handle escalation: text_qa -> computer_use via request_computer_control
+        daemonClient.onTaskRouted = { [weak self] routed in
+            guard let self else { return }
+            // Only handle escalation messages (those with escalatedFrom set)
+            guard routed.escalatedFrom != nil,
+                  routed.interactionType == "computer_use" else { return }
+            self.handleEscalationToComputerUse(routed: routed)
+        }
+
         Task {
             // Launch the bundled daemon if present (release builds)
             try? await daemonLauncher.launchIfNeeded()
@@ -79,6 +88,42 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             if daemonClient.isConnected {
                 setupAmbientAgent()
             }
+        }
+    }
+
+    /// Handle escalation from an active text_qa session to foreground computer use.
+    private func handleEscalationToComputerUse(routed: TaskRoutedMessage) {
+        guard ActionExecutor.checkAccessibilityPermission(prompt: true) else { return }
+
+        let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
+        let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
+        let session = ComputerUseSession(
+            task: "",
+            daemonClient: self.daemonClient,
+            maxSteps: maxSteps,
+            sessionId: routed.sessionId,
+            skipSessionCreate: true
+        )
+        self.currentSession = session
+
+        let overlay = SessionOverlayWindow(session: session)
+        overlay.show()
+        self.overlayWindow = overlay
+        self.ambientAgent.pause()
+
+        // Close the text response window but keep the text session reference
+        // (no de-escalation for MVP — text session is effectively done)
+        self.textResponseWindow?.close()
+        self.textResponseWindow = nil
+
+        Task { @MainActor in
+            await session.run()
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            overlay.close()
+            self.overlayWindow = nil
+            self.currentSession = nil
+            self.currentTextSession = nil
+            self.ambientAgent.resume()
         }
     }
 

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -53,6 +53,9 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `confirmation_request` message for tool permission approval.
     var onConfirmationRequest: ((ConfirmationRequestMessage) -> Void)?
 
+    /// Called when the daemon sends a `task_routed` message (e.g. escalation from text_qa to CU).
+    var onTaskRouted: ((TaskRoutedMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -410,6 +413,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onGenerationHandoff?(msg)
         case .confirmationRequest(let msg):
             onConfirmationRequest?(msg)
+        case .taskRouted(let msg):
+            onTaskRouted?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -289,6 +289,8 @@ struct SessionInfoMessage: Decodable, Sendable {
 struct TaskRoutedMessage: Decodable, Sendable {
     let sessionId: String
     let interactionType: String
+    /// Set when a text_qa session escalates to computer_use via request_computer_control.
+    let escalatedFrom: String?
 }
 
 /// Result from ambient observation analysis.


### PR DESCRIPTION
Part of #1177. Closes #1179.

## Changes
- Added `request_computer_control` tool for text_qa sessions to escalate to foreground computer use
- Tool creates a CU session and sends task_routed with escalatedFrom field
- Swift client handles escalated task_routed during active text sessions

## Test plan
- [ ] Text session agent can call request_computer_control
- [ ] Calling the tool sends task_routed with computer_use to the client
- [ ] Swift client creates CU session when escalation received
- [ ] TypeScript type-checks clean
- [ ] Swift builds clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
