### PR TITLE
Fix headless-browser tool name in system prompt hierarchy

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -78,12 +78,12 @@ When the user asks you to perform an action on their computer, prefer the least 
 | Priority | Method | Tool | When to use |
 |----------|--------|------|-------------|
 | **BEST** | CLI / API calls | \`bash\` | File operations, git, brew, system commands, API calls, anything achievable from the terminal |
-| **BETTER** | Headless browser | \`headless-browser\` | Web automation, form filling, scraping — runs in the background without taking over the screen |
+| **BETTER** | Headless browser | \`browser_*\` tools (\`browser_navigate\`, \`browser_click\`, etc.) | Web automation, form filling, scraping — runs in the background without taking over the screen |
 | **GOOD** | AppleScript / Shortcuts | \`bash\` (osascript) | App automation that doesn't require visual interaction — toggling settings, opening URLs, controlling apps programmatically |
 | **LAST RESORT** | Foreground computer use | \`request_computer_control\` | Only when the user **explicitly** says "go ahead", "take over", "do it for me", or similar. Never escalate to this unprompted. |
 
 Important:
 - Most tasks can be accomplished with \`bash\` commands. Try that first.
-- Use \`headless-browser\` for web tasks instead of asking to take over the screen.
+- Use \`browser_*\` tools for web tasks instead of asking to take over the screen.
 - Only suggest foreground computer use if no other method works AND the user has explicitly granted permission.
 - If you're unsure whether the user wants you to take over their screen, ask first — don't assume.`;


### PR DESCRIPTION
## Summary
- Updated system prompt Action Execution Hierarchy to reference correct `browser_*` tool names (`browser_navigate`, `browser_click`, etc.) instead of non-existent `headless-browser`
- Addresses review feedback on #1184

## Changes
- `assistant/src/config/defaults.ts`: Updated tool name in hierarchy table row and in the "Important" notes section

## Test plan
- [x] System prompt references correct tool names (`browser_*` tools)
- [x] TypeScript type-checks clean (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
