### PR TITLE
Launch macOS windows at full visible screen size

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -40,8 +40,12 @@ final class MainWindow {
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
 
-        window.setContentSize(NSSize(width: 1366, height: 849))
-        window.center()
+        if let visibleFrame = Self.visibleScreenFrame() {
+            window.setFrame(visibleFrame, display: true)
+        } else {
+            window.setContentSize(NSSize(width: 1366, height: 849))
+            window.center()
+        }
 
         // Keep regular activation policy — the main window should appear in Dock and Cmd+Tab
         NSApp.setActivationPolicy(.regular)
@@ -55,5 +59,12 @@ final class MainWindow {
     func close() {
         window?.close()
         window = nil
+    }
+
+    private static func visibleScreenFrame() -> NSRect? {
+        if let screen = NSScreen.main {
+            return screen.visibleFrame
+        }
+        return NSScreen.screens.first?.visibleFrame
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -40,7 +40,7 @@ final class OnboardingWindow {
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),
-            styleMask: [.titled, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -52,20 +52,14 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
 
-        // Set preferred size, clamped to screen
-        let preferredSize = NSSize(width: 1366, height: 849)
-        let minSize = NSSize(width: 800, height: 600)
-        window.contentMinSize = minSize
+        window.contentMinSize = NSSize(width: 800, height: 600)
 
-        if let screen = NSScreen.main {
-            let visibleFrame = screen.visibleFrame
-            let clampedWidth = min(preferredSize.width, visibleFrame.width)
-            let clampedHeight = min(preferredSize.height, visibleFrame.height)
-            window.setContentSize(NSSize(width: clampedWidth, height: clampedHeight))
+        if let visibleFrame = Self.visibleScreenFrame() {
+            window.setFrame(visibleFrame, display: true)
         } else {
-            window.setContentSize(preferredSize)
+            window.setContentSize(NSSize(width: 1366, height: 849))
+            window.center()
         }
-        window.center()
 
         // Make the app a regular app so the window gets focus
         NSApp.setActivationPolicy(.regular)
@@ -79,5 +73,12 @@ final class OnboardingWindow {
     func close() {
         window?.close()
         window = nil
+    }
+
+    private static func visibleScreenFrame() -> NSRect? {
+        if let screen = NSScreen.main {
+            return screen.visibleFrame
+        }
+        return NSScreen.screens.first?.visibleFrame
     }
 }


### PR DESCRIPTION
## Summary
- launch MainWindow using the active screen visible frame so it fills available desktop area on open
- make OnboardingWindow use a resizable/closable window mask and launch it at visible frame size
- keep fallback centered 1366x849 sizing when a visible screen frame is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
