### PR TITLE
M2: Add VCircleButton and integrate in ChatView + OnboardingFlowView

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Buttons/VCircleButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Buttons/VCircleButton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct VCircleButton: View {
+    let icon: String              // SF Symbol name
+    var fillColor: Color = Emerald._600
+    var iconColor: Color = .white
+    var size: CGFloat = 36
+    var iconSize: CGFloat = 14
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Circle()
+                .fill(fillColor)
+                .frame(width: size, height: size)
+                .overlay(
+                    Image(systemName: icon)
+                        .foregroundColor(iconColor)
+                        .font(.system(size: iconSize))
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            NSCursor.pointingHand.set()
+            if !hovering { NSCursor.arrow.set() }
+        }
+        .accessibilityLabel(icon)
+    }
+}
+
+#Preview("VCircleButton") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 12) {
+            VCircleButton(icon: "phone.fill") {}
+            VCircleButton(icon: "phone.fill", fillColor: Emerald._600.opacity(0.5)) {}
+            VCircleButton(icon: "plus", fillColor: Violet._500, size: 28, iconSize: 12) {}
+        }
+        .padding()
+    }
+    .frame(width: 200, height: 80)
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -136,9 +136,7 @@ struct ChatView: View {
     private var composerArea: some View {
         HStack(spacing: VSpacing.sm) {
             // Leading chat icon
-            Image(systemName: "phone.fill")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(VColor.accent)
+            VCircleButton(icon: "phone.fill") { }
 
             // Text field
             TextField("What you need chef?", text: $inputText, axis: .vertical)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -150,14 +150,7 @@ struct OnboardingFlowView: View {
 
     private var mockInputBar: some View {
         HStack(spacing: VSpacing.md) {
-            Circle()
-                .fill(Emerald._600.opacity(0.5))
-                .frame(width: 36, height: 36)
-                .overlay(
-                    Image(systemName: "phone.fill")
-                        .foregroundColor(.white)
-                        .font(.system(size: 14))
-                )
+            VCircleButton(icon: "phone.fill", fillColor: Emerald._600.opacity(0.5)) { }
 
             Text("What you need chef?")
                 .font(VFont.body)


### PR DESCRIPTION
Add VCircleButton primitive — a filled circular button with an SF Symbol icon. Defaults to green (Emerald._600) background with white icon.

Replace inline phone icon code in ChatView composer and OnboardingFlowView mock input bar with the new VCircleButton component.

Part of #1189. Closes #1191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
