### PR TITLE
Fix escalation handler: error on missing handler, pass task text, handle socket rebind

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -36,17 +36,42 @@ const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
 /**
+ * Find the current socket bound to a given session by reversing the
+ * `socketToSession` map. Returns `undefined` if no socket is bound.
+ */
+function findSocketForSession(
+  sessionId: string,
+  ctx: HandlerContext,
+): net.Socket | undefined {
+  for (const [sock, id] of ctx.socketToSession) {
+    if (id === sessionId) return sock;
+  }
+  return undefined;
+}
+
+/**
  * Wire the escalation handler on a text_qa session so that invoking
  * `request_computer_control` creates a CU session and notifies the client.
+ *
+ * Instead of closing over the original `socket`, the handler looks up the
+ * current socket for the session at call time via `ctx.socketToSession`.
+ * This ensures the handler targets the correct socket even after a
+ * disconnect-and-rebind cycle.
  */
 function wireEscalationHandler(
   session: Session,
-  socket: net.Socket,
+  _socket: net.Socket,
   ctx: HandlerContext,
   screenWidth: number,
   screenHeight: number,
 ): void {
   session.setEscalationHandler((task: string, sourceSessionId: string) => {
+    const currentSocket = findSocketForSession(sourceSessionId, ctx);
+    if (!currentSocket) {
+      log.warn({ sourceSessionId }, 'Escalation handler: no active socket found for session');
+      return;
+    }
+
     const cuSessionId = uuid();
     const cuMsg: CuSessionCreate = {
       type: 'cu_session_create',
@@ -56,12 +81,13 @@ function wireEscalationHandler(
       screenHeight,
       interactionType: 'computer_use',
     };
-    handleCuSessionCreate(cuMsg, socket, ctx);
+    handleCuSessionCreate(cuMsg, currentSocket, ctx);
 
-    ctx.send(socket, {
+    ctx.send(currentSocket, {
       type: 'task_routed',
       sessionId: cuSessionId,
       interactionType: 'computer_use',
+      task,
       escalatedFrom: sourceSessionId,
     });
   });

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -448,6 +448,8 @@ export interface TaskRouted {
   type: 'task_routed';
   sessionId: string;
   interactionType: 'computer_use' | 'text_qa';
+  /** The task text passed to the escalated session. */
+  task?: string;
   /** Set when a text_qa session escalates to computer_use via request_computer_control. */
   escalatedFrom?: string;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -924,9 +924,13 @@ export class Session {
 
     if (toolName === 'request_computer_control') {
       const task = typeof input.task === 'string' ? input.task : 'Perform the requested task';
-      if (this.onEscalateToComputerUse) {
-        this.onEscalateToComputerUse(task, this.conversationId);
+      if (!this.onEscalateToComputerUse) {
+        return {
+          content: 'Computer control escalation is not available in this session.',
+          isError: true,
+        };
       }
+      this.onEscalateToComputerUse(task, this.conversationId);
       return {
         content: 'Computer control activated. The task has been handed off to foreground computer use.',
         isError: false,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -98,7 +98,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let storedMaxSteps = UserDefaults.standard.integer(forKey: "maxStepsPerSession")
         let maxSteps = storedMaxSteps > 0 ? storedMaxSteps : 50
         let session = ComputerUseSession(
-            task: "",
+            task: routed.task ?? "Escalated task",
             daemonClient: self.daemonClient,
             maxSteps: maxSteps,
             sessionId: routed.sessionId,

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -289,6 +289,8 @@ struct SessionInfoMessage: Decodable, Sendable {
 struct TaskRoutedMessage: Decodable, Sendable {
     let sessionId: String
     let interactionType: String
+    /// The task text passed to the escalated session.
+    let task: String?
     /// Set when a text_qa session escalates to computer_use via request_computer_control.
     let escalatedFrom: String?
 }


### PR DESCRIPTION
Addresses review feedback on #1188.

## Changes
- Return error when escalation handler is not wired (prevents misleading success)
- Pass task text through TaskRouted IPC to Swift client (fixes empty overlay/logs)
- Use session-to-socket lookup instead of closed-over socket (handles reconnection)

## Test plan
- [ ] request_computer_control returns error in sessions without handler
- [ ] Escalated CU sessions show correct task in overlay
- [ ] TypeScript type-checks clean
- [ ] Swift builds clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
