### PR TITLE
M3: Add design system structure docs to macOS CLAUDE.md

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -84,6 +84,33 @@ The package is split into two targets for Xcode Preview support:
 
 `UI/Onboarding/` — multi-step flow (`OnboardingFlowView` → `OnboardingState`) covering wake-up animation, naming, permissions (screen recording, microphone), Fn key setup, and an alive-check step. Shown on first launch; skip with `--skip-onboarding` in debug.
 
+## Design System (`DesignSystem/`)
+
+The design system uses a two-tier architecture with functional subgrouping:
+
+```
+DesignSystem/
+├── Tokens/              (VColor, VFont, VSpacing, VRadius, VShadow, VAnimation)
+├── Primitives/          (atomic, single-element wrappers)
+│   ├── Buttons/         (VButton, VIconButton, VCircleButton)
+│   ├── Inputs/          (VSlider, VTextEditor, VTextField, VToggle)
+│   ├── Feedback/        (VBadge, VLoadingIndicator, VToast)
+│   ├── Display/         (VEmptyState, VListRow)
+│   └── Navigation/      (VTab)
+├── Components/          (composed from primitives, feature-aware)
+│   ├── Navigation/      (VTabBar, VSegmentedControl)
+│   ├── Layout/          (VSidePanel, VSplitView, VToolbar)
+│   └── Display/         (VCard)
+├── Modifiers/           (ViewModifier extensions: .vShadow, .hoverEffect, etc.)
+└── Gallery/             (ComponentGalleryView — visual catalog of all tokens/components)
+```
+
+**Classification rule:**
+- **Primitive** = wraps a single native SwiftUI element (Button, Toggle, Slider, TextField, Circle). Place in `Primitives/`.
+- **Component** = composes multiple primitives or has internal layout logic (VTabBar arranges VTabs, VCard has header/body slots). Place in `Components/`.
+
+All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Always use design tokens instead of raw values — `VFont.body` not `Font.system(size: 13)`, `VColor.accent` not `Color.purple`.
+
 ## Key Constraints
 
 - **LSUIElement app** — no dock icon; uses `.accessory` activation policy. Must temporarily switch to `.regular` when showing Settings window.


### PR DESCRIPTION
Document the two-tier Primitives + Components design system architecture in the macOS CLAUDE.md:

- Directory layout showing both tiers with functional subgroups
- Classification rule (Primitive = single element, Component = composed)
- V-prefix naming convention and token usage guidance

Part of #1189. Closes #1192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
