### PR TITLE
Return boolean from escalation handler to signal failure

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -65,11 +65,11 @@ function wireEscalationHandler(
   screenWidth: number,
   screenHeight: number,
 ): void {
-  session.setEscalationHandler((task: string, sourceSessionId: string) => {
+  session.setEscalationHandler((task: string, sourceSessionId: string): boolean => {
     const currentSocket = findSocketForSession(sourceSessionId, ctx);
     if (!currentSocket) {
       log.warn({ sourceSessionId }, 'Escalation handler: no active socket found for session');
-      return;
+      return false;
     }
 
     const cuSessionId = uuid();
@@ -90,6 +90,8 @@ function wireEscalationHandler(
       task,
       escalatedFrom: sourceSessionId,
     });
+
+    return true;
   });
 }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -87,7 +87,7 @@ export class Session {
     surfaceType: SurfaceType;
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
-  private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => void;
+  private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
 
   constructor(
     conversationId: string,
@@ -205,7 +205,7 @@ export class Session {
    * Set a callback for when a text_qa session escalates to computer use
    * via the `request_computer_control` tool.
    */
-  setEscalationHandler(handler: (task: string, sourceSessionId: string) => void): void {
+  setEscalationHandler(handler: (task: string, sourceSessionId: string) => boolean): void {
     this.onEscalateToComputerUse = handler;
   }
 
@@ -930,7 +930,13 @@ export class Session {
           isError: true,
         };
       }
-      this.onEscalateToComputerUse(task, this.conversationId);
+      const success = this.onEscalateToComputerUse(task, this.conversationId);
+      if (!success) {
+        return {
+          content: 'Computer control escalation failed — no active connection.',
+          isError: true,
+        };
+      }
       return {
         content: 'Computer control activated. The task has been handed off to foreground computer use.',
         isError: false,


### PR DESCRIPTION
Addresses review feedback on #1198.

## Changes
- Changed escalation handler type from `void` to `boolean`
- Handler returns `false` when `findSocketForSession` returns `undefined`
- `session.ts` checks the return value and returns `isError: true` to the LLM when the handler returns `false`

## Test plan
- [ ] Escalation with no socket returns error to LLM
- [ ] Escalation with valid socket still succeeds
- [ ] TypeScript type-checks clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
