### PR TITLE
Add /release command for cutting tagged releases

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,80 @@
+Cut a new macOS desktop app release by creating a tagged GitHub Release, which triggers the CI build pipeline.
+
+The user may pass `$ARGUMENTS` as the version (e.g. `0.2.0` or `v0.2.0`). If not provided, auto-increment the patch version from the latest tag.
+
+## Steps
+
+### 1. Pull latest main
+
+```bash
+git checkout main && git pull
+```
+
+### 2. Determine the version
+
+If the user provided `$ARGUMENTS`, use it as the version (strip leading `v` if present, then re-add it for the tag).
+
+If no version was provided, find the latest tag and auto-increment the patch version:
+
+```bash
+git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0"
+```
+
+For example: `v0.1.1` → `v0.1.2`, `v1.2.3` → `v1.2.4`.
+
+Show the user the version you're about to release and ask for confirmation before proceeding.
+
+### 3. Check for existing tag
+
+```bash
+git tag -l "v<version>"
+```
+
+If the tag already exists, stop and tell the user.
+
+### 4. Generate release notes
+
+Look at the commits since the last tag to build release notes:
+
+```bash
+git log <previous-tag>..HEAD --oneline
+```
+
+Group changes into categories:
+- **Features**: new functionality
+- **Fixes**: bug fixes
+- **Infrastructure**: CI, build, tooling changes
+- **Other**: anything else
+
+Write concise, user-facing descriptions (not raw commit messages).
+
+### 5. Create the GitHub Release
+
+```bash
+gh release create v<version> \
+  --repo vellum-ai/vellum-assistant \
+  --title "v<version>" \
+  --notes "<release notes>"
+```
+
+This automatically:
+- Creates the git tag
+- Triggers the `Build and Release macOS App` workflow via `on: release`
+- The workflow builds, signs, notarizes, and publishes the DMG to the public updates repo
+
+### 6. Verify the workflow started
+
+```bash
+gh run list --repo vellum-ai/vellum-assistant --workflow="Build and Release macOS App" --limit 1
+```
+
+Confirm the build was triggered.
+
+### 7. Report
+
+Output:
+- The release URL
+- The version number
+- The release notes
+- A link to the running workflow
+- Remind the user that the build takes ~15-20 minutes and will auto-publish to `alex-nork/vellum-assistant-macos-updates` when done


### PR DESCRIPTION
## Summary
- Adds a `/release` slash command that automates cutting a new macOS desktop app release
- Accepts an optional version argument (e.g. `/release 0.2.0`), or auto-increments patch version from latest tag
- Creates a GitHub Release which triggers the CI build pipeline via `on: release`
- Generates release notes from commits since the last tag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
