### PR TITLE
Fix ambiguous #Preview macro in MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -76,5 +76,5 @@ struct MainWindowView: View {
 
 #Preview {
     let dc = DaemonClient()
-    MainWindowView(threadManager: ThreadManager(daemonClient: dc), daemonClient: dc, ambientAgent: AmbientAgent())
+    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), daemonClient: dc, ambientAgent: AmbientAgent())
 }


### PR DESCRIPTION
## Summary
- Add explicit `return` in `#Preview` block to disambiguate between AppKit (NSView/NSViewController) and SwiftUI (View) preview initializers
- Fixes release build failure on CI (Xcode 16.2 treats this as an error in release mode)

One-line fix in `MainWindowView.swift:79`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
