### PR TITLE
Create standalone gateway/ service skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -1,0 +1,24 @@
+# Required: Telegram bot token from @BotFather
+TELEGRAM_BOT_TOKEN=
+
+# Required: Secret token for verifying Telegram webhook requests
+TELEGRAM_WEBHOOK_SECRET=
+
+# Optional: Override Telegram API base URL (default: https://api.telegram.org)
+# TELEGRAM_API_BASE_URL=https://api.telegram.org
+
+# Required: Base URL of the assistant runtime HTTP server
+ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
+
+# Optional: JSON mapping of Telegram identities to assistant IDs
+# Format: { "chat:<chat_id>": "<assistant_id>", "user:<user_id>": "<assistant_id>" }
+# GATEWAY_ASSISTANT_ROUTING_JSON={}
+
+# Optional: Default assistant ID when no explicit route matches
+# GATEWAY_DEFAULT_ASSISTANT_ID=
+
+# Optional: Policy for unmapped Telegram users ("reject" | "default"). Default: "reject"
+# GATEWAY_UNMAPPED_POLICY=reject
+
+# Optional: Port for the gateway HTTP server (default: 7830)
+# GATEWAY_PORT=7830

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -1,0 +1,87 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "vellum-gateway",
+      "dependencies": {
+        "pino": "^9.6.0",
+        "pino-pretty": "^13.1.3",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.4",
+        "typescript": "^5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+  }
+}

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vellum-gateway",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist --target bun",
+    "start": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "pino": "^9.6.0",
+    "pino-pretty": "^13.1.3",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,0 +1,114 @@
+import pino from "pino";
+
+const log = pino({ name: "gateway:config" });
+
+export type RoutingEntry = {
+  type: "chat_id" | "user_id";
+  key: string;
+  assistantId: string;
+};
+
+export type GatewayConfig = {
+  telegramBotToken: string;
+  telegramWebhookSecret: string;
+  telegramApiBaseUrl: string;
+  assistantRuntimeBaseUrl: string;
+  routingEntries: RoutingEntry[];
+  defaultAssistantId: string | undefined;
+  unmappedPolicy: "reject" | "default";
+  port: number;
+};
+
+function parseRoutingJson(raw: string): RoutingEntry[] {
+  let parsed: Record<string, string>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("GATEWAY_ASSISTANT_ROUTING_JSON is not valid JSON");
+  }
+
+  const entries: RoutingEntry[] = [];
+  for (const [key, assistantId] of Object.entries(parsed)) {
+    if (typeof assistantId !== "string" || !assistantId) {
+      throw new Error(`Invalid assistant ID for routing key "${key}"`);
+    }
+    if (key.startsWith("chat:")) {
+      entries.push({ type: "chat_id", key: key.slice(5), assistantId });
+    } else if (key.startsWith("user:")) {
+      entries.push({ type: "user_id", key: key.slice(5), assistantId });
+    } else {
+      throw new Error(
+        `Invalid routing key "${key}": must start with "chat:" or "user:"`,
+      );
+    }
+  }
+  return entries;
+}
+
+export function loadConfig(): GatewayConfig {
+  const telegramBotToken = process.env.TELEGRAM_BOT_TOKEN;
+  if (!telegramBotToken) {
+    throw new Error("TELEGRAM_BOT_TOKEN is required");
+  }
+
+  const telegramWebhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (!telegramWebhookSecret) {
+    throw new Error("TELEGRAM_WEBHOOK_SECRET is required");
+  }
+
+  const telegramApiBaseUrl =
+    process.env.TELEGRAM_API_BASE_URL || "https://api.telegram.org";
+
+  const assistantRuntimeBaseUrl = process.env.ASSISTANT_RUNTIME_BASE_URL;
+  if (!assistantRuntimeBaseUrl) {
+    throw new Error("ASSISTANT_RUNTIME_BASE_URL is required");
+  }
+
+  const routingJson = process.env.GATEWAY_ASSISTANT_ROUTING_JSON || "{}";
+  const routingEntries = parseRoutingJson(routingJson);
+
+  const defaultAssistantId =
+    process.env.GATEWAY_DEFAULT_ASSISTANT_ID || undefined;
+
+  const unmappedPolicyRaw = process.env.GATEWAY_UNMAPPED_POLICY || "reject";
+  if (unmappedPolicyRaw !== "reject" && unmappedPolicyRaw !== "default") {
+    throw new Error(
+      `GATEWAY_UNMAPPED_POLICY must be "reject" or "default", got "${unmappedPolicyRaw}"`,
+    );
+  }
+  const unmappedPolicy = unmappedPolicyRaw;
+
+  if (unmappedPolicy === "default" && !defaultAssistantId) {
+    throw new Error(
+      'GATEWAY_DEFAULT_ASSISTANT_ID is required when GATEWAY_UNMAPPED_POLICY is "default"',
+    );
+  }
+
+  const port = parseInt(process.env.GATEWAY_PORT || "7830", 10);
+  if (isNaN(port) || port < 1 || port > 65535) {
+    throw new Error("GATEWAY_PORT must be a valid port number");
+  }
+
+  log.info(
+    {
+      telegramApiBaseUrl,
+      assistantRuntimeBaseUrl,
+      routingEntryCount: routingEntries.length,
+      unmappedPolicy,
+      hasDefaultAssistant: !!defaultAssistantId,
+      port,
+    },
+    "Configuration loaded",
+  );
+
+  return {
+    telegramBotToken,
+    telegramWebhookSecret,
+    telegramApiBaseUrl,
+    assistantRuntimeBaseUrl,
+    routingEntries,
+    defaultAssistantId,
+    unmappedPolicy,
+    port,
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,21 @@
+import pino from "pino";
+import { loadConfig } from "./config.js";
+
+const log = pino({ name: "gateway" });
+
+function main() {
+  log.info("Starting Vellum Gateway...");
+
+  const config = loadConfig();
+
+  const server = Bun.serve({
+    port: config.port,
+    fetch(_req) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    },
+  });
+
+  log.info({ port: server.port }, "Gateway HTTP server listening");
+}
+
+main();

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -1,0 +1,29 @@
+export type GatewayInboundEventV1 = {
+  version: "v1";
+  sourceChannel: "telegram";
+  receivedAt: string;
+  routing: {
+    assistantId: string;
+    routeSource: "chat_id" | "user_id" | "default";
+  };
+  message: {
+    content: string;
+    externalChatId: string;
+    externalMessageId: string;
+  };
+  sender: {
+    externalUserId: string;
+    username?: string;
+    displayName?: string;
+    firstName?: string;
+    lastName?: string;
+    languageCode?: string;
+    isBot?: boolean;
+  };
+  source: {
+    updateId: string;
+    messageId?: string;
+    chatType?: string;
+  };
+  raw: Record<string, unknown>;
+};

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add independent Bun/TypeScript `gateway/` service package with `dev`, `build`, and `start` scripts
- Implement config loading/validation for all required env vars: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `ASSISTANT_RUNTIME_BASE_URL`, routing JSON, unmapped policy, and port
- Add startup-time config sanity checks with clear error messages
- Add `.env.example` with documentation for all configuration options

## Test plan
- [x] `cd gateway && bunx tsc --noEmit` passes
- [x] Config validation rejects missing required env vars
- [x] Routing JSON parsing handles chat: and user: prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
