### PR TITLE
Implement Telegram webhook verify + normalize in gateway

### DIFF
--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from "bun:test";
+import { normalizeTelegramUpdate } from "../telegram/normalize.js";
+import { verifyWebhookSecret } from "../telegram/verify.js";
+
+describe("normalizeTelegramUpdate", () => {
+  const validPayload = {
+    update_id: 123456,
+    message: {
+      message_id: 42,
+      text: "Hello bot",
+      chat: { id: 99001, type: "private" },
+      from: {
+        id: 55001,
+        is_bot: false,
+        username: "testuser",
+        first_name: "Test",
+        last_name: "User",
+        language_code: "en",
+      },
+    },
+  };
+
+  test("normalizes a valid private text message", () => {
+    const result = normalizeTelegramUpdate(validPayload);
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe("v1");
+    expect(result!.sourceChannel).toBe("telegram");
+    expect(result!.message.content).toBe("Hello bot");
+    expect(result!.message.externalChatId).toBe("99001");
+    expect(result!.message.externalMessageId).toBe("123456");
+    expect(result!.sender.externalUserId).toBe("55001");
+    expect(result!.sender.username).toBe("testuser");
+    expect(result!.sender.displayName).toBe("Test User");
+    expect(result!.sender.firstName).toBe("Test");
+    expect(result!.sender.lastName).toBe("User");
+    expect(result!.sender.languageCode).toBe("en");
+    expect(result!.sender.isBot).toBe(false);
+    expect(result!.source.updateId).toBe("123456");
+    expect(result!.source.messageId).toBe("42");
+    expect(result!.source.chatType).toBe("private");
+    expect(result!.raw).toEqual(validPayload);
+  });
+
+  test("returns null for non-text messages", () => {
+    const payload = {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: 1, type: "private" },
+        sticker: { file_id: "abc" },
+      },
+    };
+    expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+
+  test("returns null for group messages", () => {
+    const payload = {
+      ...validPayload,
+      message: { ...validPayload.message, chat: { id: 99001, type: "group" } },
+    };
+    expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+
+  test("returns null for payloads without update_id", () => {
+    const { update_id: _, ...rest } = validPayload;
+    expect(normalizeTelegramUpdate(rest)).toBeNull();
+  });
+
+  test("returns null for payloads without chat id", () => {
+    const payload = {
+      update_id: 1,
+      message: { message_id: 1, text: "hello", chat: {} },
+    };
+    expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+
+  test("uses chat.id as fallback for sender when from.id is missing", () => {
+    const payload = {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        text: "hello",
+        chat: { id: 12345, type: "private" },
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.sender.externalUserId).toBe("12345");
+  });
+
+  test("returns null for non-message updates (e.g. callback_query)", () => {
+    const payload = {
+      update_id: 1,
+      callback_query: { id: "abc", data: "some_data" },
+    };
+    expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+});
+
+describe("verifyWebhookSecret", () => {
+  test("returns true for matching secret", () => {
+    const headers = new Headers({ "x-telegram-bot-api-secret-token": "my-secret" });
+    expect(verifyWebhookSecret(headers, "my-secret")).toBe(true);
+  });
+
+  test("returns false for mismatched secret", () => {
+    const headers = new Headers({ "x-telegram-bot-api-secret-token": "wrong" });
+    expect(verifyWebhookSecret(headers, "my-secret")).toBe(false);
+  });
+
+  test("returns false when header is missing", () => {
+    const headers = new Headers();
+    expect(verifyWebhookSecret(headers, "my-secret")).toBe(false);
+  });
+
+  test("returns false when expected secret is empty", () => {
+    const headers = new Headers({ "x-telegram-bot-api-secret-token": "something" });
+    expect(verifyWebhookSecret(headers, "")).toBe(false);
+  });
+});

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,0 +1,61 @@
+import pino from "pino";
+import type { GatewayConfig } from "../../config.js";
+import { verifyWebhookSecret } from "../../telegram/verify.js";
+import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
+
+const log = pino({ name: "gateway:telegram-webhook" });
+
+export type InboundHandler = (
+  event: import("../../types.js").GatewayInboundEventV1,
+) => Promise<void>;
+
+export function createTelegramWebhookHandler(
+  config: GatewayConfig,
+  onInbound: InboundHandler,
+) {
+  return async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    // Verify webhook secret
+    if (!verifyWebhookSecret(req.headers, config.telegramWebhookSecret)) {
+      log.warn("Telegram webhook request failed secret verification");
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = (await req.json()) as Record<string, unknown>;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Normalize the update
+    const normalized = normalizeTelegramUpdate(payload);
+    if (!normalized) {
+      log.debug({ updateId: payload.update_id }, "Unsupported Telegram update, ignoring");
+      return Response.json({ ok: true });
+    }
+
+    // Return 200 immediately, process async
+    // We need routing to build the full event, but that's wired up in PR 3.
+    // For now, fire-and-forget the processing.
+    const processAsync = async () => {
+      try {
+        // Routing placeholder — will be filled in PR 3
+        const event = {
+          ...normalized,
+          routing: { assistantId: "", routeSource: "default" as const },
+        };
+        await onInbound(event);
+      } catch (err) {
+        log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      }
+    };
+
+    processAsync();
+
+    return Response.json({ ok: true });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,7 @@
 import pino from "pino";
 import { loadConfig } from "./config.js";
+import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
+import type { GatewayInboundEventV1 } from "./types.js";
 
 const log = pino({ name: "gateway" });
 
@@ -8,9 +10,26 @@ function main() {
 
   const config = loadConfig();
 
+  const handleTelegramWebhook = createTelegramWebhookHandler(
+    config,
+    async (event: GatewayInboundEventV1) => {
+      // Will be wired to routing + runtime forwarding in subsequent PRs
+      log.info(
+        { externalChatId: event.message.externalChatId },
+        "Received inbound event",
+      );
+    },
+  );
+
   const server = Bun.serve({
     port: config.port,
-    fetch(_req) {
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/webhooks/telegram") {
+        return handleTelegramWebhook(req);
+      }
+
       return Response.json({ error: "Not found" }, { status: 404 });
     },
   });

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -1,0 +1,31 @@
+import type { GatewayConfig } from "../config.js";
+
+interface TelegramApiResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+export async function callTelegramApi<T>(
+  config: GatewayConfig,
+  method: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const url = `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
+  if (!response.ok || !data.ok || !data.result) {
+    throw new Error(
+      data.description
+        ? `Telegram ${method} failed: ${data.description}`
+        : `Telegram ${method} failed with status ${response.status}`,
+    );
+  }
+
+  return data.result;
+}

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -1,0 +1,77 @@
+import type { GatewayInboundEventV1 } from "../types.js";
+
+interface TelegramMessage {
+  message_id?: number;
+  text?: string;
+  caption?: string;
+  chat?: { id?: number; type?: string };
+  from?: {
+    id?: number;
+    is_bot?: boolean;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+    language_code?: string;
+  };
+}
+
+interface TelegramUpdate {
+  update_id?: number;
+  message?: TelegramMessage;
+}
+
+/**
+ * Normalize a Telegram webhook payload into a GatewayInboundEventV1.
+ * Returns null if the payload is unsupported (non-text, non-private, etc.).
+ */
+export function normalizeTelegramUpdate(
+  payload: Record<string, unknown>,
+): Omit<GatewayInboundEventV1, "routing"> | null {
+  const update = payload as TelegramUpdate;
+  const message = update.message;
+  const updateId = update.update_id;
+
+  if (!message?.text || !message?.chat?.id || updateId == null) {
+    return null;
+  }
+
+  // v1 is DM-only
+  if (message.chat.type !== "private") {
+    return null;
+  }
+
+  const externalUserId = message.from?.id
+    ? String(message.from.id)
+    : String(message.chat.id);
+
+  const displayName = [message.from?.first_name, message.from?.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return {
+    version: "v1",
+    sourceChannel: "telegram",
+    receivedAt: new Date().toISOString(),
+    message: {
+      content: message.text,
+      externalChatId: String(message.chat.id),
+      externalMessageId: String(updateId),
+    },
+    sender: {
+      externalUserId,
+      username: message.from?.username,
+      displayName: displayName || undefined,
+      firstName: message.from?.first_name,
+      lastName: message.from?.last_name,
+      languageCode: message.from?.language_code,
+      isBot: message.from?.is_bot,
+    },
+    source: {
+      updateId: String(updateId),
+      messageId: message.message_id != null ? String(message.message_id) : undefined,
+      chatType: message.chat.type,
+    },
+    raw: payload,
+  };
+}

--- a/gateway/src/telegram/verify.ts
+++ b/gateway/src/telegram/verify.ts
@@ -1,0 +1,10 @@
+export function verifyWebhookSecret(
+  headers: Headers,
+  expectedSecret: string,
+): boolean {
+  const provided = headers.get("x-telegram-bot-api-secret-token");
+  if (!provided || !expectedSecret) {
+    return false;
+  }
+  return provided === expectedSecret;
+}


### PR DESCRIPTION
## Summary
- Add `/webhooks/telegram` endpoint with `x-telegram-bot-api-secret-token` verification
- Normalize supported inbound messages (private DM text for v1) into `GatewayInboundEventV1` envelope
- Return 200 immediately and process inbound events asynchronously
- Add comprehensive test suite for normalization and secret verification

## Test plan
- [x] Valid secret + valid payload accepted and normalized correctly
- [x] Invalid secret rejected with 401
- [x] Unsupported payloads (groups, non-text, missing fields) safely ignored
- [x] `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
