### PR TITLE
Fix --define quoting for APP_VERSION in CI workflow

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -82,7 +82,7 @@ jobs:
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}"
           bun build --compile --target=bun-darwin-arm64 src/daemon/main.ts \
             --external electron --external "chromium-bidi/*" \
-            --define "process.env.APP_VERSION='\"$DISPLAY_VERSION\"'" \
+            --define "process.env.APP_VERSION='$DISPLAY_VERSION'" \
             --outfile ../clients/macos/daemon-bin/vellum-daemon
           chmod +x ../clients/macos/daemon-bin/vellum-daemon
           echo "Daemon binary built:"


### PR DESCRIPTION
## Summary
- Fixes double-quote characters being embedded in the `APP_VERSION` compile-time constant
- The `--define` value was over-quoted, producing `'"1.0.0"'` instead of `'1.0.0'`
- Addresses review feedback on #1186

## Test plan
- [ ] Verify CI build produces correct `APP_VERSION` value without embedded quote characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
