### PR TITLE
Add multi-assistant routing via static settings (no DB)

### DIFF
--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "bun:test";
+import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    ...overrides,
+  };
+}
+
+describe("resolveAssistant", () => {
+  test("resolves by chat_id match", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "chat_id", key: "99001", assistantId: "assistant-a" },
+        { type: "user_id", key: "55001", assistantId: "assistant-b" },
+      ],
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.assistantId).toBe("assistant-a");
+      expect(result.routeSource).toBe("chat_id");
+    }
+  });
+
+  test("falls back to user_id when chat_id does not match", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "chat_id", key: "99999", assistantId: "assistant-a" },
+        { type: "user_id", key: "55001", assistantId: "assistant-b" },
+      ],
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.assistantId).toBe("assistant-b");
+      expect(result.routeSource).toBe("user_id");
+    }
+  });
+
+  test("falls back to default policy when no explicit match", () => {
+    const config = makeConfig({
+      unmappedPolicy: "default",
+      defaultAssistantId: "assistant-default",
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.assistantId).toBe("assistant-default");
+      expect(result.routeSource).toBe("default");
+    }
+  });
+
+  test("rejects when policy is reject and no match", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) {
+      expect(result.reason).toContain("No route configured");
+    }
+  });
+
+  test("chat_id takes priority over user_id for same assistant", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "user_id", key: "55001", assistantId: "assistant-user" },
+        { type: "chat_id", key: "99001", assistantId: "assistant-chat" },
+      ],
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.assistantId).toBe("assistant-chat");
+      expect(result.routeSource).toBe("chat_id");
+    }
+  });
+
+  test("rejects with default policy but no default assistant configured", () => {
+    const config = makeConfig({
+      unmappedPolicy: "default",
+      defaultAssistantId: undefined,
+    });
+
+    const result = resolveAssistant(config, "99001", "55001");
+    expect(isRejection(result)).toBe(true);
+  });
+});

--- a/gateway/src/routing/resolve-assistant.ts
+++ b/gateway/src/routing/resolve-assistant.ts
@@ -1,0 +1,45 @@
+import pino from "pino";
+import type { GatewayConfig } from "../config.js";
+import type { RoutingOutcome } from "./types.js";
+
+const log = pino({ name: "gateway:routing" });
+
+export function resolveAssistant(
+  config: GatewayConfig,
+  chatId: string,
+  userId: string,
+): RoutingOutcome {
+  // Priority 1: explicit chat_id route
+  for (const entry of config.routingEntries) {
+    if (entry.type === "chat_id" && entry.key === chatId) {
+      log.debug({ chatId, assistantId: entry.assistantId }, "Resolved by chat_id");
+      return { assistantId: entry.assistantId, routeSource: "chat_id" };
+    }
+  }
+
+  // Priority 2: explicit user_id route
+  for (const entry of config.routingEntries) {
+    if (entry.type === "user_id" && entry.key === userId) {
+      log.debug({ userId, assistantId: entry.assistantId }, "Resolved by user_id");
+      return { assistantId: entry.assistantId, routeSource: "user_id" };
+    }
+  }
+
+  // Priority 3: apply unmapped policy
+  if (config.unmappedPolicy === "default" && config.defaultAssistantId) {
+    log.debug(
+      { chatId, userId, assistantId: config.defaultAssistantId },
+      "Resolved by default policy",
+    );
+    return { assistantId: config.defaultAssistantId, routeSource: "default" };
+  }
+
+  log.info({ chatId, userId }, "No route matched, rejecting");
+  return { rejected: true, reason: "No route configured for this chat" };
+}
+
+export function isRejection(
+  outcome: RoutingOutcome,
+): outcome is { rejected: true; reason: string } {
+  return "rejected" in outcome && outcome.rejected === true;
+}

--- a/gateway/src/routing/types.ts
+++ b/gateway/src/routing/types.ts
@@ -1,0 +1,11 @@
+export type RouteResult = {
+  assistantId: string;
+  routeSource: "chat_id" | "user_id" | "default";
+};
+
+export type RouteRejection = {
+  rejected: true;
+  reason: string;
+};
+
+export type RoutingOutcome = RouteResult | RouteRejection;


### PR DESCRIPTION
## Summary
- Implement deterministic routing: resolve assistant by `chat_id`, then `user_id`, then configurable unmapped policy
- Support `reject` (drop unmatched) and `default` (forward to default assistant) policies
- Keep v1 fully stateless with no persistence layer required

## Test plan
- [x] `chat_id` match resolves correctly
- [x] `user_id` fallback when no chat_id match
- [x] Default policy fallback for unresolved routes
- [x] Reject policy returns rejection for unresolved routes
- [x] `chat_id` takes priority over `user_id`
- [x] All tests pass: `bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
