### PR TITLE
Forward normalized inbound events directly to assistant runtime

### DIFF
--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { forwardToRuntime } from "../runtime/client.js";
+import type { GatewayConfig } from "../config.js";
+
+const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
+  telegramBotToken: "tok",
+  telegramWebhookSecret: "wh-ver",
+  telegramApiBaseUrl: "https://api.telegram.org",
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  routingEntries: [],
+  defaultAssistantId: undefined,
+  unmappedPolicy: "reject",
+  port: 7830,
+  ...overrides,
+});
+
+const payload = {
+  sourceChannel: "telegram",
+  externalChatId: "99001",
+  externalMessageId: "123",
+  content: "Hello",
+  senderName: "Test User",
+};
+
+const successBody = {
+  accepted: true,
+  duplicate: false,
+  eventId: "evt-1",
+  assistantMessage: {
+    id: "msg-1",
+    role: "assistant" as const,
+    content: "Hi there!",
+    timestamp: new Date().toISOString(),
+    attachments: [],
+  },
+};
+
+function mockFetch(fn: () => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
+
+describe("forwardToRuntime", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("successful forward returns runtime response", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig();
+    const result = await forwardToRuntime(config, "assistant-a", payload);
+    expect(result.accepted).toBe(true);
+    expect(result.eventId).toBe("evt-1");
+    expect(result.assistantMessage?.content).toBe("Hi there!");
+  });
+
+  test("4xx error throws immediately without retry", async () => {
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(new Response("Bad request", { status: 400 })),
+    );
+
+    const config = makeConfig();
+    await expect(
+      forwardToRuntime(config, "assistant-a", payload),
+    ).rejects.toThrow("Runtime returned 400");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("5xx error retries and eventually succeeds", async () => {
+    let callCount = 0;
+    mockFetch(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.resolve(
+          new Response("Internal error", { status: 500 }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      );
+    });
+
+    const config = makeConfig();
+    const result = await forwardToRuntime(config, "assistant-a", payload);
+    expect(result.accepted).toBe(true);
+    expect(callCount).toBe(3);
+  });
+
+  test("5xx error exhausts retries and throws", async () => {
+    mockFetch(() =>
+      Promise.resolve(new Response("Server error", { status: 500 })),
+    );
+
+    const config = makeConfig();
+    await expect(
+      forwardToRuntime(config, "assistant-a", payload),
+    ).rejects.toThrow("Runtime returned 500");
+  });
+});

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,0 +1,65 @@
+import pino from "pino";
+import type { GatewayConfig } from "../config.js";
+import type { GatewayInboundEventV1 } from "../types.js";
+import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import { forwardToRuntime } from "../runtime/client.js";
+import type { RuntimeInboundResponse } from "../runtime/client.js";
+
+const log = pino({ name: "gateway:handle-inbound" });
+
+export type InboundResult = {
+  forwarded: boolean;
+  rejected: boolean;
+  runtimeResponse?: RuntimeInboundResponse;
+  rejectionReason?: string;
+};
+
+export async function handleInbound(
+  config: GatewayConfig,
+  event: Omit<GatewayInboundEventV1, "routing">,
+): Promise<InboundResult> {
+  const routing = resolveAssistant(
+    config,
+    event.message.externalChatId,
+    event.sender.externalUserId,
+  );
+
+  if (isRejection(routing)) {
+    log.info(
+      { externalChatId: event.message.externalChatId, reason: routing.reason },
+      "Inbound event rejected by routing",
+    );
+    return { forwarded: false, rejected: true, rejectionReason: routing.reason };
+  }
+
+  const displayName = event.sender.displayName || event.sender.username;
+
+  try {
+    const response = await forwardToRuntime(config, routing.assistantId, {
+      sourceChannel: event.sourceChannel,
+      externalChatId: event.message.externalChatId,
+      externalMessageId: event.message.externalMessageId,
+      content: event.message.content,
+      senderName: displayName,
+    });
+
+    log.info(
+      {
+        assistantId: routing.assistantId,
+        routeSource: routing.routeSource,
+        eventId: response.eventId,
+        duplicate: response.duplicate,
+        hasReply: !!response.assistantMessage,
+      },
+      "Inbound event forwarded to runtime",
+    );
+
+    return { forwarded: true, rejected: false, runtimeResponse: response };
+  } catch (err) {
+    log.error(
+      { err, assistantId: routing.assistantId },
+      "Failed to forward inbound event to runtime",
+    );
+    return { forwarded: false, rejected: false };
+  }
+}

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,17 +1,20 @@
 import pino from "pino";
 import type { GatewayConfig } from "../../config.js";
+import type { GatewayInboundEventV1 } from "../../types.js";
 import { verifyWebhookSecret } from "../../telegram/verify.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
+import { handleInbound, type InboundResult } from "../../handlers/handle-inbound.js";
 
 const log = pino({ name: "gateway:telegram-webhook" });
 
-export type InboundHandler = (
-  event: import("../../types.js").GatewayInboundEventV1,
+export type OnReply = (
+  chatId: string,
+  result: InboundResult,
 ) => Promise<void>;
 
 export function createTelegramWebhookHandler(
   config: GatewayConfig,
-  onInbound: InboundHandler,
+  onReply?: OnReply,
 ) {
   return async (req: Request): Promise<Response> => {
     if (req.method !== "POST") {
@@ -39,16 +42,13 @@ export function createTelegramWebhookHandler(
     }
 
     // Return 200 immediately, process async
-    // We need routing to build the full event, but that's wired up in PR 3.
-    // For now, fire-and-forget the processing.
     const processAsync = async () => {
       try {
-        // Routing placeholder — will be filled in PR 3
-        const event = {
-          ...normalized,
-          routing: { assistantId: "", routeSource: "default" as const },
-        };
-        await onInbound(event);
+        const result = await handleInbound(config, normalized);
+
+        if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
+          await onReply(normalized.message.externalChatId, result);
+        }
       } catch (err) {
         log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,7 +1,6 @@
 import pino from "pino";
 import { loadConfig } from "./config.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
-import type { GatewayInboundEventV1 } from "./types.js";
 
 const log = pino({ name: "gateway" });
 
@@ -10,16 +9,7 @@ function main() {
 
   const config = loadConfig();
 
-  const handleTelegramWebhook = createTelegramWebhookHandler(
-    config,
-    async (event: GatewayInboundEventV1) => {
-      // Will be wired to routing + runtime forwarding in subsequent PRs
-      log.info(
-        { externalChatId: event.message.externalChatId },
-        "Received inbound event",
-      );
-    },
-  );
+  const handleTelegramWebhook = createTelegramWebhookHandler(config);
 
   const server = Bun.serve({
     port: config.port,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -1,0 +1,94 @@
+import pino from "pino";
+import type { GatewayConfig } from "../config.js";
+
+const log = pino({ name: "gateway:runtime-client" });
+
+const MAX_RETRIES = 2;
+const INITIAL_BACKOFF_MS = 500;
+
+export type RuntimeInboundPayload = {
+  sourceChannel: string;
+  externalChatId: string;
+  externalMessageId: string;
+  content: string;
+  senderName?: string;
+};
+
+export type RuntimeInboundResponse = {
+  accepted: boolean;
+  duplicate: boolean;
+  eventId: string;
+  assistantMessage?: {
+    id: string;
+    role: "assistant";
+    content: string;
+    timestamp: string;
+    attachments: unknown[];
+  };
+};
+
+export async function forwardToRuntime(
+  config: GatewayConfig,
+  assistantId: string,
+  payload: RuntimeInboundPayload,
+): Promise<RuntimeInboundResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/channels/inbound`;
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delay = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+      log.debug({ attempt, delay, assistantId }, "Retrying runtime forward");
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.status >= 400 && response.status < 500) {
+        const body = await response.text();
+        log.warn(
+          { status: response.status, body, assistantId },
+          "Runtime returned client error, not retrying",
+        );
+        throw new Error(`Runtime returned ${response.status}: ${body}`);
+      }
+
+      if (response.status >= 500) {
+        const body = await response.text();
+        lastError = new Error(`Runtime returned ${response.status}: ${body}`);
+        log.warn(
+          { status: response.status, attempt, assistantId },
+          "Runtime returned server error",
+        );
+        continue;
+      }
+
+      const result = (await response.json()) as RuntimeInboundResponse;
+      log.debug(
+        { assistantId, eventId: result.eventId, duplicate: result.duplicate },
+        "Runtime forward succeeded",
+      );
+      return result;
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith("Runtime returned 4")
+      ) {
+        throw err;
+      }
+      lastError = err instanceof Error ? err : new Error(String(err));
+      log.warn(
+        { err: lastError, attempt, assistantId },
+        "Runtime forward attempt failed",
+      );
+    }
+  }
+
+  throw lastError ?? new Error("Runtime forward failed after retries");
+}


### PR DESCRIPTION
## Summary
- Add runtime client for `POST /v1/assistants/:assistantId/channels/inbound` with bounded retries and exponential backoff for 5xx errors
- Wire routing + forwarding into a single `handleInbound` orchestrator
- 4xx errors fail immediately (no retries); 5xx errors retry up to 2 times
- Update webhook handler to use the new orchestrator

## Test plan
- [x] Successful forward returns runtime response
- [x] 4xx error throws immediately without retry
- [x] 5xx error retries and eventually succeeds
- [x] 5xx error exhausts retries and throws
- [x] `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
