### PR TITLE
Send assistant replies back to Telegram from gateway

### DIFF
--- a/gateway/src/__tests__/reply-path.test.ts
+++ b/gateway/src/__tests__/reply-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "bun:test";
+import { splitText } from "../telegram/send.js";
+
+describe("splitText", () => {
+  test("returns single chunk for short text", () => {
+    const chunks = splitText("Hello!");
+    expect(chunks).toEqual(["Hello!"]);
+  });
+
+  test("returns single chunk for exactly max length", () => {
+    const text = "x".repeat(4000);
+    const chunks = splitText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
+  });
+
+  test("splits text exceeding max length", () => {
+    const text = "x".repeat(8500);
+    const chunks = splitText(text);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toHaveLength(4000);
+    expect(chunks[1]).toHaveLength(4000);
+    expect(chunks[2]).toHaveLength(500);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("handles empty string", () => {
+    const chunks = splitText("");
+    expect(chunks).toEqual([""]);
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,6 +1,7 @@
 import pino from "pino";
 import { loadConfig } from "./config.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
+import { sendTelegramReply } from "./telegram/send.js";
 
 const log = pino({ name: "gateway" });
 
@@ -9,7 +10,19 @@ function main() {
 
   const config = loadConfig();
 
-  const handleTelegramWebhook = createTelegramWebhookHandler(config);
+  const handleTelegramWebhook = createTelegramWebhookHandler(
+    config,
+    async (chatId, result) => {
+      const content = result.runtimeResponse?.assistantMessage?.content;
+      if (!content) return;
+
+      try {
+        await sendTelegramReply(config, chatId, content);
+      } catch (err) {
+        log.error({ err, chatId }, "Failed to send Telegram reply");
+      }
+    },
+  );
 
   const server = Bun.serve({
     port: config.port,

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,0 +1,40 @@
+import pino from "pino";
+import type { GatewayConfig } from "../config.js";
+import { callTelegramApi } from "./api.js";
+
+const log = pino({ name: "gateway:telegram-send" });
+
+const TELEGRAM_MAX_MESSAGE_LEN = 4000;
+
+function splitText(text: string): string[] {
+  if (text.length <= TELEGRAM_MAX_MESSAGE_LEN) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    chunks.push(text.slice(cursor, cursor + TELEGRAM_MAX_MESSAGE_LEN));
+    cursor += TELEGRAM_MAX_MESSAGE_LEN;
+  }
+  return chunks;
+}
+
+export async function sendTelegramReply(
+  config: GatewayConfig,
+  chatId: string,
+  text: string,
+): Promise<void> {
+  const chunks = splitText(text);
+
+  for (const chunk of chunks) {
+    await callTelegramApi(config, "sendMessage", {
+      chat_id: chatId,
+      text: chunk,
+    });
+  }
+
+  log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
+}
+
+export { splitText };


### PR DESCRIPTION
## Summary
- Complete end-to-end flow: Telegram inbound -> assistant runtime -> Telegram outbound
- Send runtime response content back to originating Telegram chat via `sendMessage`
- Preserve message chunking for Telegram's 4000 character limit
- Wire reply callback into the webhook handler

## Test plan
- [x] Short text returns single chunk
- [x] Text at exactly max length returns single chunk
- [x] Long text correctly split into multiple chunks that rejoin to original
- [x] Empty string handled gracefully
- [x] `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
