### PR TITLE
Extend runtime inbound payload with optional sender/source metadata

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -639,6 +639,9 @@ export class RuntimeHttpServer {
       content?: string;
       senderName?: string;
       attachmentIds?: string[];
+      senderExternalUserId?: string;
+      senderUsername?: string;
+      sourceMetadata?: Record<string, unknown>;
     };
 
     const { sourceChannel, externalChatId, externalMessageId, content, attachmentIds } = body;

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -41,6 +41,15 @@ export async function handleInbound(
       externalMessageId: event.message.externalMessageId,
       content: event.message.content,
       senderName: displayName,
+      senderExternalUserId: event.sender.externalUserId,
+      senderUsername: event.sender.username,
+      sourceMetadata: {
+        updateId: event.source.updateId,
+        messageId: event.source.messageId,
+        chatType: event.source.chatType,
+        languageCode: event.sender.languageCode,
+        isBot: event.sender.isBot,
+      },
     });
 
     log.info(

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -12,6 +12,9 @@ export type RuntimeInboundPayload = {
   externalMessageId: string;
   content: string;
   senderName?: string;
+  senderExternalUserId?: string;
+  senderUsername?: string;
+  sourceMetadata?: Record<string, unknown>;
 };
 
 export type RuntimeInboundResponse = {


### PR DESCRIPTION
## Summary
- Add optional `senderExternalUserId`, `senderUsername`, and `sourceMetadata` fields to assistant runtime's channel inbound handler
- Forward these fields from gateway for improved downstream observability
- Fully backward compatible: old payloads without these fields still work

## Test plan
- [x] `bunx tsc --noEmit` passes in both `assistant/` and `gateway/`
- [x] All gateway tests pass
- [x] Old payload format still accepted (existing fields unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
