### PR TITLE
Add safe plan execution commands

### DIFF
--- a/.claude/commands/resume-plan.md
+++ b/.claude/commands/resume-plan.md
@@ -1,0 +1,164 @@
+Merge the current plan PR and continue to the next one.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, check `.private/safe-plan-state/` for state files. If exactly one exists, use that plan. If multiple exist, list them and ask the user to specify. If none exist, tell the user:
+
+> No active plan PR. Run `/safe-execute-plan <plan file>` to start.
+
+Then stop.
+
+## Steps
+
+### 1. Read state
+
+Sanitize `$ARGUMENTS` by stripping any path separators (use `basename -- "$ARGUMENTS"`). Derive the **plan slug** from the filename (e.g. `BROWSER_PLAN.md` → `browser-plan`).
+
+Read `.private/safe-plan-state/<plan-slug>.md`. If it doesn't exist or has no active PR, tell the user:
+
+> No active PR for this plan. Run `/safe-execute-plan <plan file>` to start.
+
+Then stop.
+
+### 2. Merge the current PR
+
+```bash
+gh pr merge <number> --squash
+```
+
+### 3. Clean up worktree
+
+Change back to the main repo directory, then remove the worktree:
+
+```bash
+cd <main-repo>
+.claude/worktree remove safe-plan/<plan-slug>/<pr-slug> --delete-branch
+```
+
+### 4. Remove from unreviewed list
+
+Read `.private/UNREVIEWED_PRS.md`, remove the merged PR link, write it back.
+
+### 5. Pull main
+
+```bash
+git checkout main && git pull origin main
+```
+
+### 6. Report what was merged
+
+Tell the user:
+> **Merged PR <X> of <total>:** <PR link>
+
+### 7. Check if plan is complete
+
+Read the plan file from `.private/plans/<plan filename>`. If all PRs are done:
+
+1. Archive the plan:
+   ```bash
+   PLAN_FILE="$(basename -- "<plan filename>")"
+   mkdir -p .private/plans/archived
+   mv ".private/plans/$PLAN_FILE" ".private/plans/archived/$PLAN_FILE"
+   ```
+2. Delete `.private/safe-plan-state/<plan-slug>.md`.
+3. Tell the user:
+   > **Plan complete!** All <total> PRs have been merged.
+4. Stop.
+
+### 8. Implement the next PR
+
+If there are remaining PRs, follow the same implementation workflow as `/safe-execute-plan`:
+
+#### 8a. Create worktree
+
+```bash
+git fetch origin main
+.claude/worktree create safe-plan/<plan-slug>/<pr-slug> origin/main
+```
+
+#### 8b. Implement
+
+Read the next PR section from the plan. Implement all changes in the worktree.
+- Follow the project conventions.
+- Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+
+#### 8c. Validate
+
+```bash
+cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
+```
+
+Fix any failures before proceeding.
+
+#### 8d. Commit and push
+
+```bash
+cd <worktree>
+git add -A
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+git push -u origin HEAD
+```
+
+#### 8e. Create PR (do NOT merge)
+
+```bash
+gh pr create --base main --title "<title from plan>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+Part of plan: <plan filename> (PR <X> of <total>)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+#### 8f. Add to unreviewed list
+
+Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
+
+### 9. Save state
+
+Update `.private/safe-plan-state/<plan-slug>.md` with the new PR info:
+
+```markdown
+# Safe Plan State
+
+- **Plan**: <plan filename>
+- **Current PR**: <X> of <total>
+- **PR URL**: <github PR URL>
+- **PR Number**: <number>
+- **Branch**: <branch name>
+- **Worktree**: <absolute path to worktree>
+```
+
+### 10. Notify the user and stop
+
+Tell the user:
+
+> **PR <X> of <total> is ready for review:** <PR link>
+>
+> - <brief summary of what was implemented>
+> - Files changed: <list>
+>
+> **Next steps:**
+> - `/safe-check-review <plan file>` — check for reviewer feedback and address it
+> - `/resume-plan <plan file>` — merge this PR and continue to the next one
+
+Then **stop**. Do NOT continue to the next PR.
+
+## Repo-specific gotchas
+
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- **Imports**: All imports use `.js` extensions (NodeNext module resolution).
+- **Project structure**: Bun + TypeScript project. Code is in `assistant/`.
+
+## Important
+
+- .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing. This file is gitignored.
+- .private/safe-plan-state/ is gitignored.

--- a/.claude/commands/safe-check-review.md
+++ b/.claude/commands/safe-check-review.md
@@ -1,0 +1,115 @@
+Check the active plan PR for review feedback and address it.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, check `.private/safe-plan-state/` for state files. If exactly one exists, use that plan. If multiple exist, list them and ask the user to specify. If none exist, tell the user:
+
+> No active plan PR. Run `/safe-execute-plan <plan file>` to start.
+
+Then stop.
+
+## Steps
+
+### 1. Read state
+
+Sanitize `$ARGUMENTS` by stripping any path separators (use `basename -- "$ARGUMENTS"`). Derive the **plan slug** from the filename (e.g. `BROWSER_PLAN.md` → `browser-plan`).
+
+Read `.private/safe-plan-state/<plan-slug>.md`. If it doesn't exist or has no active PR, tell the user:
+
+> No active PR for this plan. Run `/safe-execute-plan <plan file>` to start.
+
+Then stop.
+
+### 2. Fetch review data
+
+Using the PR number from the state file, run these commands in parallel:
+
+1. **Reviews and comments:** `gh pr view <number> --json comments,reviews,createdAt`
+2. **PR description reactions:** `gh api repos/vellum-ai/vellum-assistant/issues/<number>/reactions --jq '[.[] | {user: .user.login, content: .content}]'`
+3. **Review threads (with resolution status):**
+   ```
+   gh api graphql -f query='query { repository(owner:"vellum-ai", name:"vellum-assistant") { pullRequest(number:<number>) { reviewThreads(first:100) { nodes { id isResolved comments(first:5) { nodes { body author { login } path line } } } } } } }'
+   ```
+
+### 3. Determine review status
+
+Check for feedback from any reviewer — bots (chatgpt-codex-connector[bot], devin-ai-integration[bot]) and humans alike.
+
+**Important:** Only **unresolved** review threads count as "requested changes". Resolved threads represent already-addressed feedback and must be ignored. This ensures re-running `/safe-check-review` after addressing feedback can reach the "all approved" state.
+
+#### chatgpt-codex-connector (appears as `chatgpt-codex-connector[bot]`)
+
+- **Approved:** Left a `+1` reaction on the PR description
+- **Requested changes:** Has **unresolved** review threads with comments
+- **Pending:** Neither of the above (no reaction and no review threads)
+
+#### devin-ai-integration (appears as `devin-ai-integration[bot]`)
+
+- **Approved:** Left a PR review containing "No Issues Found"
+- **Requested changes:** Has **unresolved** review threads with comments
+- **Pending:** No review from this user
+
+#### Human reviewers
+
+- **Requested changes:** Has **unresolved** review threads
+- **Approved:** Left an approving PR review with no unresolved threads
+- **Commented:** Left comments but all threads are resolved
+
+### 4. Display status
+
+Show a summary table:
+
+| Reviewer | Status | Details |
+| --- | --- | --- |
+| codex | Approved / Changes requested / Pending | brief summary |
+| devin | Approved / Changes requested / Pending | brief summary |
+| <human> | Commented / Approved / Changes requested | brief summary |
+
+### 5. Address feedback (if any)
+
+If any reviewer requested changes:
+
+1. Read the worktree path and branch from the state file.
+2. Pull latest changes in the worktree:
+   ```bash
+   cd <worktree> && git pull origin <branch>
+   ```
+3. Read the **unresolved** review threads from step 2. Implement the requested fixes in the worktree.
+4. Validate:
+   ```bash
+   cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
+   ```
+5. Commit and push:
+   ```bash
+   cd <worktree>
+   git add -A
+   git commit -m "$(cat <<'EOF'
+Address review feedback
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+   )"
+   git push origin HEAD
+   ```
+6. For each unresolved thread from step 2, reply and resolve:
+   ```
+   gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<thread-id>", body:"Addressed in latest push."}) { comment { id } } }'
+   gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<thread-id>"}) { thread { isResolved } } }'
+   ```
+7. Tell the user what feedback was addressed and what changes were made.
+
+If any reviewer is still **Pending** (no response yet), tell the user:
+
+> Still waiting on reviews from: <list of pending reviewers>. Check back in a few minutes with `/safe-check-review <plan file>`.
+
+Do NOT suggest running `/resume-plan` while reviews are pending.
+
+If all reviewers have responded and none requested changes (all approved), tell the user:
+
+> All reviews are in — no actionable feedback. Run `/resume-plan <plan file>` to merge and continue.
+
+## Repo-specific gotchas
+
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- **Imports**: All imports use `.js` extensions (NodeNext module resolution).
+- **Project structure**: Bun + TypeScript project. Code is in `assistant/`.

--- a/.claude/commands/safe-execute-plan.md
+++ b/.claude/commands/safe-execute-plan.md
@@ -1,0 +1,140 @@
+Execute a multi-PR rollout plan one PR at a time, pausing after each for human review.
+
+The user passed: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, stop and tell the user to provide the plan filename. Example: `/safe-execute-plan BROWSER_PLAN.md`.
+
+## Repo-specific gotchas
+
+- **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+- **Imports**: All imports use `.js` extensions (NodeNext module resolution).
+- **Project structure**: Bun + TypeScript project. Code is in `assistant/`.
+
+## Steps
+
+### 1. Read the plan
+
+Sanitize `$ARGUMENTS` by stripping any path separators (use `basename -- "$ARGUMENTS"`). Then read `.private/plans/<sanitized name>`. If the file doesn't exist, stop and tell the user.
+
+Parse the plan to identify the ordered list of PRs. Plans typically have numbered PR sections (e.g. "## PR 1", "## PR 2") each describing: branch name, title, scope, files to modify, implementation steps, tests to run, and acceptance criteria.
+
+Derive a **plan slug** from the filename (e.g. `BROWSER_PLAN.md` → `browser-plan`). This is used to namespace state and worktrees.
+
+### 2. Check for existing state
+
+Read `.private/safe-plan-state/<plan-slug>.md` if it exists. If it has an active PR, tell the user:
+
+> This plan already has an active PR: <PR link>
+> Run `/safe-check-review <plan file>` to check for feedback, or `/resume-plan <plan file>` to merge and continue.
+
+Then stop.
+
+### 3. Determine starting point
+
+Check which PRs have already been completed. Look at:
+- The git log for commits/PRs that match earlier PR titles or branch names from the plan.
+- Whether the files/changes described in earlier PRs already exist in the codebase.
+
+Skip any PRs that are already done. Tell the user which PRs you're skipping and why.
+
+### 4. Implement the next PR
+
+#### 4a. Create worktree
+
+Derive a branch name from the plan's PR section (or from the PR title). Fetch latest main and create a worktree:
+
+```bash
+git fetch origin main
+.claude/worktree create safe-plan/<plan-slug>/<pr-slug> origin/main
+```
+
+ALL work happens in the worktree — do NOT modify files in the main repo.
+
+#### 4b. Implement
+
+Read the PR section carefully. Implement all the changes described:
+- Create/modify the listed files according to the steps.
+- Follow the project conventions.
+- Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
+
+#### 4c. Validate
+
+Run the tests and type-checks specified in the PR section:
+
+```bash
+cd <worktree>/assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
+```
+
+Fix any failures before proceeding.
+
+#### 4d. Commit and push
+
+```bash
+cd <worktree>
+git add -A
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+git push -u origin HEAD
+```
+
+#### 4e. Create PR (do NOT merge)
+
+```bash
+gh pr create --base main --title "<title from plan>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+Part of plan: <plan filename> (PR <X> of <total>)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+#### 4f. Add to unreviewed list
+
+Read `.private/UNREVIEWED_PRS.md`, append the new PR link, write it back.
+
+### 5. Save state
+
+```bash
+mkdir -p .private/safe-plan-state
+```
+
+Write `.private/safe-plan-state/<plan-slug>.md` with this format:
+
+```markdown
+# Safe Plan State
+
+- **Plan**: <plan filename>
+- **Current PR**: <X> of <total>
+- **PR URL**: <github PR URL>
+- **PR Number**: <number>
+- **Branch**: <branch name>
+- **Worktree**: <absolute path to worktree>
+```
+
+### 6. Notify the user and stop
+
+Tell the user:
+
+> **PR <X> of <total> is ready for review:** <PR link>
+>
+> - <brief summary of what was implemented>
+> - Files changed: <list>
+>
+> **Next steps:**
+> - `/safe-check-review <plan file>` — check for reviewer feedback and address it
+> - `/resume-plan <plan file>` — merge this PR and continue to the next one
+
+Then **stop**. Do NOT continue to the next PR.
+
+## Important
+
+- .private/UNREVIEWED_PRS.md is written to by other processes. Read before writing, verify after writing. This file is gitignored.
+- .private/safe-plan-state/ is gitignored.
+- Multiple plans can run concurrently — each has its own state file and worktree namespace.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 | `/safe-blitz-done [PR\|branch]` | Finalize a safe-blitz — squash-merges the feature branch PR into main, sets the project issue to Done, closes the issue, and deletes the local branch. Auto-detects the PR from current branch, open `feature/*` PRs, or project board "In Review" items. |
 | `/execute-plan <file>` | Sequential multi-PR rollout — reads a plan file from `.private/plans/`, executes each PR in order, mainlining each before moving to the next. |
 
+### Human-in-the-loop plan execution
+
+A three-command workflow for executing plans one PR at a time with human review between each step. Each plan gets its own state file in `.private/safe-plan-state/`, so multiple plans can run concurrently in separate sessions.
+
+| Command | Purpose |
+|---------|---------|
+| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the first PR, creates it (without merging), and stops to wait for review. |
+| `/safe-check-review [file]` | Check the active plan PR for feedback from codex/devin/humans. Addresses requested changes by pushing fixes. Waits if reviews are still pending — only recommends merging once all reviewers have responded. Auto-detects the plan if only one is active. |
+| `/resume-plan [file]` | Merge the current PR, implement the next one, create it, and stop again. Repeats until the plan is complete. Auto-detects the plan if only one is active. |
+
+**Typical flow:**
+
+1. **`/safe-execute-plan MY_PLAN.md`** — starts the plan, creates PR 1, stops
+2. **`/safe-check-review MY_PLAN.md`** — run periodically; waits for pending reviews, addresses feedback, or gives the all-clear to merge
+3. **`/resume-plan MY_PLAN.md`** — merge PR 1, create PR 2, stop (only after `/safe-check-review` confirms all reviews are in)
+4. Repeat steps 2–3 until the plan is complete
+
+Multiple plans can run in parallel — just specify the plan name to disambiguate.
+
 ### Utility
 
 | Command | Purpose |
@@ -169,6 +188,8 @@ This repo includes Claude Code slash commands (in `.claude/commands/`) for agent
 4. **`/swarm`** again — address the feedback
 
 Or for a focused feature: **`/blitz <feature>`** handles all of the above in one shot (plan, issues, swarm, sweep, report). Use **`/safe-blitz <feature>`** for the same workflow but with a feature branch and a final PR for manual review, then **`/safe-blitz-done`** to merge it when ready.
+
+For controlled, sequential plan execution with human review at every step: **`/safe-execute-plan <file>`** → **`/safe-check-review`** → **`/resume-plan`** → repeat.
 
 All workflows use squash-merge (no merge commits), worktree isolation for parallel work, and track state in `.private/TODO.md`, `.private/DONE.md`, and `.private/UNREVIEWED_PRS.md`.
 


### PR DESCRIPTION
## Summary
- Add `/safe-execute-plan` command that executes a plan one PR at a time, pausing after each for human review
- Add `/safe-check-review` command that checks the active PR for reviewer feedback (codex/devin/humans) and addresses it
- Add `/resume-plan` command that merges the current PR and continues to the next task in the plan

State is tracked in `.private/SAFE_PLAN_STATE.md` between invocations. The workflow loop is:
`/safe-execute-plan` → `/safe-check-review` (as needed) → `/resume-plan` → repeat

## Test plan
- [ ] Run `/safe-execute-plan` with a test plan and verify it creates a PR and stops
- [ ] Run `/safe-check-review` and verify it reads review status correctly
- [ ] Run `/resume-plan` and verify it merges, cleans up, and creates the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
