### PR TITLE
Fix timing-safe secret comparison and falsy API result handling

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -19,7 +19,7 @@ export async function callTelegramApi<T>(
   });
 
   const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
-  if (!response.ok || !data.ok || !data.result) {
+  if (!response.ok || !data.ok || data.result === undefined) {
     throw new Error(
       data.description
         ? `Telegram ${method} failed: ${data.description}`

--- a/gateway/src/telegram/verify.ts
+++ b/gateway/src/telegram/verify.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "crypto";
+
 export function verifyWebhookSecret(
   headers: Headers,
   expectedSecret: string,
@@ -6,5 +8,10 @@ export function verifyWebhookSecret(
   if (!provided || !expectedSecret) {
     return false;
   }
-  return provided === expectedSecret;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expectedSecret);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
 }


### PR DESCRIPTION
## Summary
- Use `crypto.timingSafeEqual` for webhook secret verification in `gateway/src/telegram/verify.ts` to prevent timing side-channel attacks
- Check `data.result === undefined` instead of `!data.result` in `gateway/src/telegram/api.ts` so that legitimate falsy Telegram API responses (0, false, empty string) are not incorrectly treated as errors

Addresses review feedback on #1206.

## Test plan
- [ ] Verify webhook secret verification still works correctly
- [ ] Verify Telegram API calls with falsy results are handled properly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
