### PR TITLE
Validate routing JSON type and strictly parse gateway port

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ AI-powered assistant platform by Vellum.
 
 ## Architecture
 
-The platform has two main components:
+The platform has three main components:
 
-- **Assistant runtime** (`assistant/`): Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes an HTTP API consumed by the web app.
+- **Assistant runtime** (`assistant/`): Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes an HTTP API consumed by the web app and gateway.
 - **Web app** (`web/`): Next.js frontend and API layer. Stores assistant metadata, auth, and channel config in Postgres. All chat operations proxy through the assistant runtime via a unified `RuntimeClient`.
+- **Gateway** (`gateway/`): Standalone Bun + TypeScript service that owns Telegram integration end-to-end. Receives Telegram webhooks, routes to the correct assistant via static settings, forwards to the assistant runtime, and sends replies back to Telegram.
 
 ## Repository Structure
 
@@ -15,6 +16,7 @@ The platform has two main components:
 /
 ├── web/               # Next.js web application
 ├── assistant/         # Bun-based assistant runtime
+├── gateway/           # Telegram gateway service
 ├── platform/          # Terraform infrastructure
 ├── vel/               # Development toolkit CLI
 └── .github/           # GitHub Actions workflows

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,70 @@
+# Vellum Gateway
+
+Standalone service that owns Telegram integration end-to-end. Receives Telegram webhooks, routes messages to the correct assistant runtime, and sends replies back to Telegram.
+
+## Architecture
+
+```
+Telegram → gateway/ → Assistant Runtime (/v1/assistants/:id/channels/inbound) → gateway/ → Telegram
+```
+
+The web app is **not** in the Telegram request path.
+
+## Setup
+
+```bash
+cd gateway
+bun install
+cp .env.example .env
+# Edit .env with your configuration
+bun run dev
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TELEGRAM_BOT_TOKEN` | Yes | — | Bot token from @BotFather |
+| `TELEGRAM_WEBHOOK_SECRET` | Yes | — | Secret for verifying webhook requests |
+| `TELEGRAM_API_BASE_URL` | No | `https://api.telegram.org` | Override Telegram API base URL |
+| `ASSISTANT_RUNTIME_BASE_URL` | Yes | — | Base URL of the assistant runtime HTTP server |
+| `GATEWAY_ASSISTANT_ROUTING_JSON` | No | `{}` | JSON mapping of Telegram identities to assistant IDs |
+| `GATEWAY_DEFAULT_ASSISTANT_ID` | No | — | Default assistant ID for unmapped users |
+| `GATEWAY_UNMAPPED_POLICY` | No | `reject` | Policy for unmapped users: `reject` or `default` |
+| `GATEWAY_PORT` | No | `7830` | Port for the gateway HTTP server |
+
+## Routing
+
+v1 uses deterministic settings-based routing (no database):
+
+1. **chat_id match** — explicit `chat:<chat_id>` entry in routing JSON
+2. **user_id match** — explicit `user:<user_id>` entry in routing JSON
+3. **Unmapped policy** — `reject` (drop with message) or `default` (forward to `GATEWAY_DEFAULT_ASSISTANT_ID`)
+
+### Routing JSON format
+
+```json
+{
+  "chat:12345": "assistant-id-a",
+  "user:67890": "assistant-id-b"
+}
+```
+
+## Setting up the Telegram webhook
+
+After deploying the gateway, register the webhook with Telegram using the `setWebhook` API method. Pass:
+- `url` — your gateway URL, e.g. `https://your-host/webhooks/telegram`
+- The verify value matching your `TELEGRAM_WEBHOOK_SECRET` env var
+- `allowed_updates` — `["message"]`
+
+See the [Telegram Bot API docs](https://core.telegram.org/bots/api#setwebhook) for the full API reference.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| Telegram messages not arriving | Is the webhook registered? `curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo` |
+| 401 on webhook | Does `TELEGRAM_WEBHOOK_SECRET` match the `secret_token` in setWebhook? |
+| "No route configured" replies | Add a routing entry or set `GATEWAY_UNMAPPED_POLICY=default` with a default assistant |
+| Runtime errors | Is `ASSISTANT_RUNTIME_BASE_URL` reachable? Check runtime logs. |
+| No reply from assistant | Is the assistant runtime processing messages? Check for `RUNTIME_HTTP_PORT` env var. |

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -28,6 +28,9 @@ function parseRoutingJson(raw: string): RoutingEntry[] {
   }
 
   const entries: RoutingEntry[] = [];
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("GATEWAY_ASSISTANT_ROUTING_JSON must be a JSON object");
+  }
   for (const [key, assistantId] of Object.entries(parsed)) {
     if (typeof assistantId !== "string" || !assistantId) {
       throw new Error(`Invalid assistant ID for routing key "${key}"`);
@@ -84,8 +87,9 @@ export function loadConfig(): GatewayConfig {
     );
   }
 
-  const port = parseInt(process.env.GATEWAY_PORT || "7830", 10);
-  if (isNaN(port) || port < 1 || port > 65535) {
+  const portRaw = process.env.GATEWAY_PORT || "7830";
+  const port = Number(portRaw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error("GATEWAY_PORT must be a valid port number");
   }
 


### PR DESCRIPTION
## Summary
- Add runtime validation that `GATEWAY_ASSISTANT_ROUTING_JSON` parses to a non-null, non-array object before iterating entries in `gateway/src/config.ts`
- Use `Number()` instead of `parseInt()` for `GATEWAY_PORT` to reject malformed values with trailing characters (e.g. "7830abc")

Addresses review feedback on #1205.

## Test plan
- [ ] Verify gateway config rejects `null`, arrays, and non-object JSON for routing
- [ ] Verify gateway config rejects malformed port values like "7830abc"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
