### PR TITLE
Fix token table name in architecture diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,7 @@ graph TB
             PG_CHAN["assistant_channel_accounts"]
             PG_CONTACT["assistant_channel_contacts"]
             PG_USER["user / session / account"]
-            PG_TOKENS["assistant_api_tokens"]
+            PG_TOKENS["assistant_auth_tokens"]
             PG_APIKEYS["api_keys"]
         end
 


### PR DESCRIPTION
## Summary
- Fix `assistant_api_tokens` → `assistant_auth_tokens` in ARCHITECTURE.md to match the actual schema in `web/src/lib/schema.ts`

Addresses review feedback on #1215.

## Test plan
- [x] Verified table name matches schema definition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
