### PR TITLE
Await inbound processing before acknowledging Telegram webhook

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -41,20 +41,17 @@ export function createTelegramWebhookHandler(
       return Response.json({ ok: true });
     }
 
-    // Return 200 immediately, process async
-    const processAsync = async () => {
-      try {
-        const result = await handleInbound(config, normalized);
+    // Process inbound and only acknowledge after successful delivery
+    try {
+      const result = await handleInbound(config, normalized);
 
-        if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
-          await onReply(normalized.message.externalChatId, result);
-        }
-      } catch (err) {
-        log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
+        await onReply(normalized.message.externalChatId, result);
       }
-    };
-
-    processAsync();
+    } catch (err) {
+      log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
+      return Response.json({ error: "Internal error" }, { status: 500 });
+    }
 
     return Response.json({ ok: true });
   };


### PR DESCRIPTION
## Summary
- Remove fire-and-forget pattern in the Telegram webhook handler so it waits for `handleInbound` to complete before returning 200
- If processing fails, return 500 so Telegram retries delivery instead of silently dropping the message
- Prevents permanent message loss when runtime forwarding fails

Addresses review feedback on #1210 (P1).

## Test plan
- [ ] Verify webhook returns 200 only after successful processing
- [ ] Verify webhook returns 500 on processing failure, enabling Telegram retries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
