### PR TITLE
Avoid splitting surrogate pairs in Telegram message chunking

### DIFF
--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -14,8 +14,13 @@ function splitText(text: string): string[] {
   const chunks: string[] = [];
   let cursor = 0;
   while (cursor < text.length) {
-    chunks.push(text.slice(cursor, cursor + TELEGRAM_MAX_MESSAGE_LEN));
-    cursor += TELEGRAM_MAX_MESSAGE_LEN;
+    let end = Math.min(cursor + TELEGRAM_MAX_MESSAGE_LEN, text.length);
+    // Avoid splitting a surrogate pair
+    if (end < text.length && text.charCodeAt(end - 1) >= 0xd800 && text.charCodeAt(end - 1) <= 0xdbff) {
+      end--;
+    }
+    chunks.push(text.slice(cursor, end));
+    cursor = end;
   }
   return chunks;
 }


### PR DESCRIPTION
## Summary
- Fix `splitText` to check for high surrogates at chunk boundaries before slicing
- If the last character of a chunk is a high surrogate (0xD800-0xDBFF), back up one position to keep the surrogate pair intact
- Prevents emoji and other astral characters from being corrupted when splitting long messages

Addresses review feedback on #1211.

## Test plan
- [ ] Verify long messages with emoji near the 4000-char boundary are split correctly
- [ ] Verify surrogate pairs are never split across chunks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
