### PR TITLE
Fix onboarding diagonal animation on first appearance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -107,7 +107,6 @@ struct OnboardingFlowView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.spring(duration: 0.6, bounce: 0.15), value: state.currentStep)
     }
 
     // MARK: - Mock Chrome

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -62,7 +62,7 @@ final class OnboardingState {
     }
 
     func advance() {
-        withAnimation(.easeOut(duration: 0.8)) {
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
             currentStep += 1
         }
         persist()


### PR DESCRIPTION
## Summary
- Removed the blanket `.animation(.spring, value: currentStep)` modifier from the `OnboardingFlowView` ZStack, which could fire during the initial window layout pass and cause the onboarding card to spring-animate diagonally on first appearance
- Moved the spring animation into the explicit `withAnimation` call in `advance()`, preserving the same spring feel for step transitions while ensuring animations only trigger on deliberate step changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
