### PR TITLE
Fix Xcode Preview crash for views using ResourceBundle

### DIFF
--- a/clients/macos/vellum-assistant/ResourceBundle.swift
+++ b/clients/macos/vellum-assistant/ResourceBundle.swift
@@ -21,6 +21,12 @@ enum ResourceBundle {
             return bundle
         }
 
+        #if DEBUG
+        // Xcode Previews — resource bundle isn't at either path.
+        // Fall back to Bundle.main so previews render without crashing.
+        return Bundle.main
+        #else
         fatalError("Could not find resource bundle '\(bundleName).bundle'")
+        #endif
     }()
 }


### PR DESCRIPTION
## Summary
- ResourceBundle.bundle's fatalError crashes XCPreviewAgent because the SPM resource bundle isn't available in the preview sandbox
- Added `#if DEBUG` fallback to `Bundle.main` so previews render gracefully (images/fonts simply missing)
- Release builds retain the fatalError for immediate diagnosis of misconfigured bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
