### PR TITLE
Restore Telegram webhook teardown on assistant deletion

### DIFF
--- a/web/src/app/api/assistants/[id]/kill/route.ts
+++ b/web/src/app/api/assistants/[id]/kill/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
 import { deleteAssistantMailInbox, deleteAssistantMailWebhook } from "@/lib/agentmail";
+import { getAssistantChannelAccount } from "@/lib/channels/db";
 import { getDb } from "@/lib/db";
 import { deleteInstance } from "@/lib/gcp";
 
@@ -49,6 +50,23 @@ export async function POST(request: Request, { params }: RouteParams) {
       } catch (mailError: unknown) {
         console.warn("Failed to delete AgentMail resources, continuing:", mailError);
       }
+    }
+
+    // Tear down Telegram webhook before deleting the assistant record
+    try {
+      const telegramAccount = await getAssistantChannelAccount(assistantId, "telegram");
+      const botToken = (telegramAccount?.config as Record<string, unknown>)?.botToken as string | undefined;
+      if (botToken) {
+        const res = await fetch(
+          `https://api.telegram.org/bot${botToken}/deleteWebhook`,
+          { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ drop_pending_updates: false }) },
+        );
+        if (!res.ok) {
+          console.warn(`Telegram deleteWebhook returned ${res.status}, continuing`);
+        }
+      }
+    } catch (telegramError: unknown) {
+      console.warn("Failed to tear down Telegram webhook, continuing:", telegramError);
     }
 
     await sql`DELETE FROM assistants WHERE id = ${assistantId}`;


### PR DESCRIPTION
## Summary
- Restore the Telegram `deleteWebhook` API call in the assistant kill route that was removed in #1213
- Before deleting the assistant record, looks up the Telegram channel account and calls `deleteWebhook` using the stored bot token
- Prevents orphaned remote webhooks that would continue posting updates to a dead endpoint

Addresses review feedback on #1213.

## Test plan
- [ ] Verify deleting an assistant with Telegram configured calls deleteWebhook
- [ ] Verify deleting an assistant without Telegram configured still works
- [ ] Verify failures in webhook teardown are caught and don't block deletion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
