### PR TITLE
Return 500 on forwarding failure and decouple reply from webhook ack

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -42,15 +42,24 @@ export function createTelegramWebhookHandler(
     }
 
     // Process inbound and only acknowledge after successful delivery
+    let result: InboundResult;
     try {
-      const result = await handleInbound(config, normalized);
-
-      if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
-        await onReply(normalized.message.externalChatId, result);
-      }
+      result = await handleInbound(config, normalized);
     } catch (err) {
       log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       return Response.json({ error: "Internal error" }, { status: 500 });
+    }
+
+    if (!result.forwarded && !result.rejected) {
+      log.error({ updateId: payload.update_id }, "Failed to forward inbound event");
+      return Response.json({ error: "Internal error" }, { status: 500 });
+    }
+
+    // Fire reply asynchronously so webhook ack is not blocked by outbound send
+    if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
+      onReply(normalized.message.externalChatId, result).catch((err) => {
+        log.error({ err, updateId: payload.update_id }, "Failed to send reply");
+      });
     }
 
     return Response.json({ ok: true });


### PR DESCRIPTION
## Summary
- Check `result.forwarded` after `handleInbound` returns; return 500 when forwarding failed (but not rejected) so Telegram retries delivery. The previous `catch` block was dead code because `handleInbound` catches forwarding errors internally and returns `{ forwarded: false }` instead of re-throwing.
- Fire `onReply` asynchronously so webhook acknowledgement is not blocked by outbound Telegram API latency, preventing stale webhook retries for messages that were already forwarded.

Addresses review feedback on #1220 (P1).

## Test plan
- [ ] Verify webhook returns 500 when runtime forwarding fails (handleInbound returns forwarded: false)
- [ ] Verify webhook returns 200 when forwarding succeeds, even if reply send is slow
- [ ] Verify rejected messages still return 200 (intentional rejection, not an error)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
