### PR TITLE
Fix task_routed ordering in architecture sequence diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,14 +288,16 @@ sequenceDiagram
         AD->>DC: send(SessionCreate + UserMessage)
         Note over DC: Unix socket<br/>~/.vellum/vellum.sock
         DC->>Daemon: IPC
-        Note over Daemon: Creates conversation in SQLite<br/>Wires escalation handler<br/>Starts streaming immediately
+        Note over Daemon: Creates conversation in SQLite<br/>Wires escalation handler
+        Daemon-->>DC: task_routed(text_qa)
+        DC-->>AD: route to text_qa UI
+        Note over Daemon: Starts streaming immediately
         Daemon->>Claude: API call with text prompt
         Claude-->>Daemon: streaming text response
         Daemon-->>DC: assistant_text_delta (stream)
         DC-->>TextSess: text deltas
         TextSess-->>TW: display streaming response
         Daemon-->>DC: message_complete
-        DC-->>AD: task_routed(text_qa)
 
     else source === 'text' or nil → computer_use path
         Note over CLS: Haiku-4.5 direct call<br/>5s timeout, heuristic fallback


### PR DESCRIPTION
Addresses review feedback on #1199.

## Changes
- Moved `task_routed(text_qa)` before streaming events in the sequence diagram to match runtime behavior in `handleTaskSubmit`
- In the actual code, `task_routed` is sent first (line 771-775 of handlers.ts), then `processMessage()` starts streaming `assistant_text_delta` events, and finally `message_complete` is sent

## Test plan
- [ ] Diagram matches actual runtime message ordering in `handleTaskSubmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
