### PR TITLE
Validate Telegram API ok field in deleteWebhook response

### DIFF
--- a/web/src/app/api/assistants/[id]/kill/route.ts
+++ b/web/src/app/api/assistants/[id]/kill/route.ts
@@ -62,7 +62,12 @@ export async function POST(request: Request, { params }: RouteParams) {
           { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ drop_pending_updates: false }) },
         );
         if (!res.ok) {
-          console.warn(`Telegram deleteWebhook returned ${res.status}, continuing`);
+          console.warn(`Telegram deleteWebhook returned HTTP ${res.status}, continuing`);
+        } else {
+          const body = await res.json().catch(() => null) as { ok?: boolean; description?: string } | null;
+          if (body && !body.ok) {
+            console.warn(`Telegram deleteWebhook returned ok:false: ${body.description ?? "unknown error"}, continuing`);
+          }
         }
       }
     } catch (telegramError: unknown) {


### PR DESCRIPTION
## Summary
- Parse the JSON response body from Telegram's `deleteWebhook` endpoint after a successful HTTP response
- Log a warning when the Telegram API returns `ok: false` (which can happen even with HTTP 200)
- Prevents silently treating a failed webhook teardown as successful during assistant deletion

Addresses review feedback on #1224.

## Test plan
- [ ] Verify warning is logged when Telegram returns `{ ok: false, description: "..." }` with HTTP 200
- [ ] Verify no warning when response is `{ ok: true }`
- [ ] Verify JSON parse failure is handled gracefully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
