### PR TITLE
Remove divider under navigation toolbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -36,8 +36,6 @@ struct NavigationToolbar: View {
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.sm)
             .background(VColor.background)
-
-            Divider()
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the `Divider()` under the NavigationToolbar in the main window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
