### PR TITLE
Support receiving PDF and document files from Telegram

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -123,6 +123,16 @@ export class AnthropicProvider implements Provider {
           },
         };
       case "file":
+        if (block.source.media_type === "application/pdf") {
+          return {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: block.source.data,
+            },
+          };
+        }
         return {
           type: "text",
           text: this.fileBlockToText(block),

--- a/web/src/lib/channels/plugins/__tests__/telegram.test.ts
+++ b/web/src/lib/channels/plugins/__tests__/telegram.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect } from "bun:test";
-import { telegramPlugin } from "@/lib/channels/plugins/telegram";
+import { describe, test, expect, afterEach, mock } from "bun:test";
+import { telegramPlugin, downloadTelegramPhoto, downloadTelegramDocument } from "@/lib/channels/plugins/telegram";
+import type { TelegramPhoto, TelegramDocument } from "@/lib/channels/plugins/telegram";
 
 // ---------------------------------------------------------------------------
 // Helpers — Telegram webhook payload builders
@@ -29,6 +30,25 @@ function makePhotoPayload(overrides?: Record<string, unknown>) {
         { file_id: "medium_id", file_unique_id: "m1", width: 320, height: 320 },
         { file_id: "large_id", file_unique_id: "l1", width: 800, height: 800 },
       ],
+      chat: { id: 42, type: "private" },
+      from: { id: 99, username: "alice", first_name: "Alice" },
+      ...overrides,
+    },
+  };
+}
+
+function makeDocumentPayload(overrides?: Record<string, unknown>) {
+  return {
+    update_id: 300,
+    message: {
+      message_id: 3,
+      document: {
+        file_id: "doc_id",
+        file_unique_id: "du1",
+        file_name: "report.pdf",
+        mime_type: "application/pdf",
+        file_size: 12345,
+      },
       chat: { id: 42, type: "private" },
       from: { id: 99, username: "alice", first_name: "Alice" },
       ...overrides,
@@ -70,6 +90,32 @@ describe("telegramPlugin.inbound.normalizeMessage", () => {
 
     expect(result).not.toBeNull();
     expect(result!.text).toBe("");
+  });
+
+  test("normalizes a document message", () => {
+    const result = telegramPlugin.inbound.normalizeMessage(makeDocumentPayload());
+
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("");
+    expect(result!.externalChatId).toBe("42");
+    expect(result!.externalMessageId).toBe("300");
+  });
+
+  test("normalizes a document message with caption", () => {
+    const result = telegramPlugin.inbound.normalizeMessage(
+      makeDocumentPayload({ caption: "here is the report" }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("here is the report");
+  });
+
+  test("returns null for document without file_id", () => {
+    const payload = makeDocumentPayload();
+    (payload.message as Record<string, unknown>).document = { file_unique_id: "du1" };
+
+    const result = telegramPlugin.inbound.normalizeMessage(payload);
+    expect(result).toBeNull();
   });
 
   test("returns null for group messages", () => {
@@ -173,5 +219,107 @@ describe("telegramPlugin.inbound.verifyWebhook", () => {
 describe("telegramPlugin.capabilities", () => {
   test("media is enabled", () => {
     expect(telegramPlugin.capabilities.media).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadTelegramPhoto
+// ---------------------------------------------------------------------------
+
+describe("downloadTelegramPhoto", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  test("downloads the largest photo size", async () => {
+    globalThis.fetch = mock((url: string) => {
+      if (url.includes("/getFile")) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ ok: true, result: { file_id: "big", file_path: "photos/file_1.jpg" } }),
+          { headers: { "content-type": "application/json" } },
+        ));
+      }
+      return Promise.resolve(new Response(
+        new Uint8Array([0xFF, 0xD8, 0xFF]),
+        { headers: { "content-type": "image/jpeg" } },
+      ));
+    }) as unknown as typeof fetch;
+
+    const photos: TelegramPhoto[] = [
+      { file_id: "small", file_unique_id: "s1", width: 100, height: 100 },
+      { file_id: "big", file_unique_id: "s2", width: 800, height: 600 },
+    ];
+
+    const result = await downloadTelegramPhoto("bot-token", photos);
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe("file_1.jpg");
+    expect(result!.mimeType).toBe("image/jpeg");
+    expect(result!.data).toBe(Buffer.from([0xFF, 0xD8, 0xFF]).toString("base64"));
+  });
+
+  test("returns null for empty photo array", async () => {
+    const result = await downloadTelegramPhoto("bot-token", []);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadTelegramDocument
+// ---------------------------------------------------------------------------
+
+describe("downloadTelegramDocument", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  test("downloads a document using hint metadata", async () => {
+    globalThis.fetch = mock((url: string) => {
+      if (url.includes("/getFile")) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ ok: true, result: { file_id: "doc1", file_path: "documents/file_2.pdf" } }),
+          { headers: { "content-type": "application/json" } },
+        ));
+      }
+      return Promise.resolve(new Response(
+        new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+        { headers: { "content-type": "application/pdf" } },
+      ));
+    }) as unknown as typeof fetch;
+
+    const doc: TelegramDocument = {
+      file_id: "doc1",
+      file_unique_id: "du1",
+      file_name: "report.pdf",
+      mime_type: "application/pdf",
+    };
+
+    const result = await downloadTelegramDocument("bot-token", doc);
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe("report.pdf");
+    expect(result!.mimeType).toBe("application/pdf");
+    expect(result!.data).toBe(Buffer.from([0x25, 0x50, 0x44, 0x46]).toString("base64"));
+  });
+
+  test("falls back to content-type and file_path when no hints", async () => {
+    globalThis.fetch = mock((url: string) => {
+      if (url.includes("/getFile")) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ ok: true, result: { file_id: "doc2", file_path: "documents/file_3.bin" } }),
+          { headers: { "content-type": "application/json" } },
+        ));
+      }
+      return Promise.resolve(new Response(
+        new Uint8Array([0x00]),
+        { headers: { "content-type": "application/octet-stream" } },
+      ));
+    }) as unknown as typeof fetch;
+
+    const doc: TelegramDocument = {
+      file_id: "doc2",
+      file_unique_id: "du2",
+    };
+
+    const result = await downloadTelegramDocument("bot-token", doc);
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe("file_3.bin");
+    expect(result!.mimeType).toBe("application/octet-stream");
   });
 });

--- a/web/src/lib/channels/plugins/telegram.ts
+++ b/web/src/lib/channels/plugins/telegram.ts
@@ -67,24 +67,32 @@ export interface TelegramPhoto {
   height: number;
 }
 
+export interface TelegramDocument {
+  file_id: string;
+  file_unique_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
 interface TelegramGetFileResult {
   file_id: string;
   file_path?: string;
 }
 
-export async function downloadTelegramPhoto(
+/**
+ * Download a file from Telegram by file_id, returning base64 data.
+ */
+async function downloadTelegramFile(
   botToken: string,
-  photos: TelegramPhoto[]
+  fileId: string,
+  hint?: { filename?: string; mimeType?: string },
 ): Promise<InboundAttachment | null> {
-  // Pick the largest resolution (last in the array).
-  const best = photos[photos.length - 1];
-  if (!best) return null;
-
   try {
     const fileInfo = await callTelegramApi<TelegramGetFileResult>(
       botToken,
       "getFile",
-      { file_id: best.file_id }
+      { file_id: fileId }
     );
 
     if (!fileInfo.file_path) return null;
@@ -96,23 +104,34 @@ export async function downloadTelegramPhoto(
     const buffer = await response.arrayBuffer();
     const base64 = Buffer.from(buffer).toString("base64");
 
-    // Derive mime type from the file extension.
-    const ext = fileInfo.file_path.split(".").pop()?.toLowerCase();
-    const mimeMap: Record<string, string> = {
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      png: "image/png",
-      gif: "image/gif",
-      webp: "image/webp",
-      bmp: "image/bmp",
-    };
-    const mimeType = (ext && mimeMap[ext]) || "image/jpeg";
-    const filename = fileInfo.file_path.split("/").pop() ?? `photo.${ext || "jpg"}`;
+    const contentType = response.headers.get("content-type")?.split(";")[0].trim();
+    const mimeType = hint?.mimeType || contentType || "application/octet-stream";
+    const filename = hint?.filename || fileInfo.file_path.split("/").pop()!;
 
     return { filename, mimeType, data: base64 };
-  } catch {
+  } catch (err) {
+    console.error("[TG] Failed to download file:", err);
     return null;
   }
+}
+
+export async function downloadTelegramPhoto(
+  botToken: string,
+  photos: TelegramPhoto[]
+): Promise<InboundAttachment | null> {
+  const best = photos[photos.length - 1];
+  if (!best) return null;
+  return downloadTelegramFile(botToken, best.file_id);
+}
+
+export async function downloadTelegramDocument(
+  botToken: string,
+  doc: TelegramDocument
+): Promise<InboundAttachment | null> {
+  return downloadTelegramFile(botToken, doc.file_id, {
+    filename: doc.file_name,
+    mimeType: doc.mime_type,
+  });
 }
 
 function parseTelegramInbound(payload: Record<string, unknown>): NormalizedInboundMessage | null {
@@ -122,6 +141,7 @@ function parseTelegramInbound(payload: Record<string, unknown>): NormalizedInbou
         text?: string;
         caption?: string;
         photo?: TelegramPhoto[];
+        document?: TelegramDocument;
         chat?: { id?: number; type?: string };
         from?: { id?: number; username?: string; first_name?: string; last_name?: string };
       }
@@ -130,8 +150,9 @@ function parseTelegramInbound(payload: Record<string, unknown>): NormalizedInbou
   const updateId = payload.update_id as number | undefined;
   const hasText = Boolean(message?.text);
   const hasPhoto = Array.isArray(message?.photo) && message!.photo!.length > 0;
+  const hasDocument = Boolean(message?.document?.file_id);
 
-  if ((!hasText && !hasPhoto) || !message?.chat?.id || !updateId) {
+  if ((!hasText && !hasPhoto && !hasDocument) || !message?.chat?.id || !updateId) {
     return null;
   }
 

--- a/web/src/lib/channels/service.ts
+++ b/web/src/lib/channels/service.ts
@@ -15,7 +15,7 @@ import {
   upsertAssistantChannelContact,
 } from "@/lib/channels/db";
 import { getChannelPlugin } from "@/lib/channels/plugins";
-import { downloadTelegramPhoto } from "@/lib/channels/plugins/telegram";
+import { downloadTelegramPhoto, downloadTelegramDocument } from "@/lib/channels/plugins/telegram";
 import { DomainError } from "@/lib/auth/server-session";
 import { createRuntimeClient } from "@/lib/runtime/client";
 import { resolveRuntime } from "@/lib/runtime/resolver";
@@ -404,20 +404,26 @@ export async function handleTelegramWebhook(params: {
 
   const client = getRuntimeClient(account.assistant_id);
 
-  // Upload any photo attachments from the Telegram payload.
+  // Upload any file attachments from the Telegram payload.
   const attachmentIds: string[] = [];
   const rawMessage = params.payload.message as Record<string, unknown> | undefined;
   const photos = rawMessage?.photo as Array<{ file_id: string; file_unique_id: string; file_size?: number; width: number; height: number }> | undefined;
+  const document = rawMessage?.document as { file_id: string; file_unique_id: string; file_name?: string; mime_type?: string; file_size?: number } | undefined;
+
+  let attachment = null;
   if (Array.isArray(photos) && photos.length > 0 && config.botToken) {
-    const attachment = await downloadTelegramPhoto(config.botToken, photos);
-    if (attachment) {
-      const uploaded = await client.uploadAttachment({
-        filename: attachment.filename,
-        mimeType: attachment.mimeType,
-        data: attachment.data,
-      });
-      attachmentIds.push(uploaded.id);
-    }
+    attachment = await downloadTelegramPhoto(config.botToken, photos);
+  } else if (document?.file_id && config.botToken) {
+    attachment = await downloadTelegramDocument(config.botToken, document);
+  }
+
+  if (attachment) {
+    const uploaded = await client.uploadAttachment({
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      data: attachment.data,
+    });
+    attachmentIds.push(uploaded.id);
   }
 
   // If there is no text and no attachments (e.g. photo download failed),


### PR DESCRIPTION
## Summary
- Add Telegram document/PDF download support alongside existing photo support
- Send PDFs as native Anthropic `document` blocks instead of discarding the binary data and converting to a text placeholder
- Refactor Telegram file download into a shared helper (`downloadTelegramFile`) used by both `downloadTelegramPhoto` and `downloadTelegramDocument`
- Use `Content-Type` response header for MIME type detection instead of file extension lookup
- Add tests for document message normalization, photo download, and document download

## Test plan
- [ ] Send a PDF via Telegram and verify the AI can read its contents
- [ ] Send a photo via Telegram and verify it still works as before
- [ ] Send a document with no caption and verify it's processed
- [ ] Run `bun test web/src/lib/channels/plugins/__tests__/telegram.test.ts` (22 tests pass)
- [ ] Run `bun test assistant/src/__tests__/anthropic-provider.test.ts` (4 tests pass)
- [ ] Run `bunx tsc --noEmit` in both `web/` and `assistant/` directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
