### PR TITLE
Initialize providers at daemon startup to prevent ConfigError

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -55,6 +55,12 @@ export class DaemonServer {
     // Clean up stale socket (only if it's actually a Unix socket)
     removeSocketFile(this.socketPath);
 
+    // Initialize providers from config so they're available before any
+    // session is created. Without this, getProvider() throws because the
+    // registry is empty until a config file change triggers a reload.
+    const config = getConfig();
+    initializeProviders(config);
+
     this.startFileWatchers();
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- The provider registry was never populated during `DaemonServer.start()`, causing `getProvider()` to throw `ConfigError: Provider "anthropic" not found` on first session creation
- `initializeProviders()` was only called reactively (config file watcher, `model_set` handler), never at boot
- Added `initializeProviders(getConfig())` at the top of `start()` so providers are ready before any client connects

Fixes VELLUM-ASSISTANT-BRAIN-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
