### PR TITLE
Fix typography gallery 'small' sample using wrong font token

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -102,7 +102,7 @@ struct TokensGallerySection: View {
                     typographySample("bodyBold", font: VFont.bodyBold)
                     typographySample("caption", font: VFont.caption)
                     typographySample("captionMedium", font: VFont.captionMedium)
-                    typographySample("small", font: VFont.caption)
+                    typographySample("small", font: VFont.small)
                     typographySample("mono", font: VFont.mono)
                     typographySample("monoSmall", font: VFont.monoSmall)
                     typographySample("display", font: VFont.display)


### PR DESCRIPTION
## Summary
- Fixed a copy-paste bug in `TokensGallerySection.swift` where the "small" typography sample was using `VFont.caption` (11pt) instead of `VFont.small` (10pt)

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Open the Component Gallery and verify the "small" typography sample renders at 10pt (smaller than "caption" at 11pt)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
