### PR TITLE
Fix VCircleButton accessibility label to use human-readable text

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Buttons/VCircleButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Buttons/VCircleButton.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct VCircleButton: View {
     let icon: String              // SF Symbol name
+    let label: String             // Human-readable accessibility label
     var fillColor: Color = Emerald._600
     var iconColor: Color = .white
     var size: CGFloat = 36
@@ -24,7 +25,7 @@ struct VCircleButton: View {
             NSCursor.pointingHand.set()
             if !hovering { NSCursor.arrow.set() }
         }
-        .accessibilityLabel(icon)
+        .accessibilityLabel(label)
     }
 }
 
@@ -32,9 +33,9 @@ struct VCircleButton: View {
     ZStack {
         VColor.background.ignoresSafeArea()
         HStack(spacing: 12) {
-            VCircleButton(icon: "phone.fill") {}
-            VCircleButton(icon: "phone.fill", fillColor: Emerald._600.opacity(0.5)) {}
-            VCircleButton(icon: "plus", fillColor: Violet._500, size: 28, iconSize: 12) {}
+            VCircleButton(icon: "phone.fill", label: "Phone") {}
+            VCircleButton(icon: "phone.fill", label: "Phone", fillColor: Emerald._600.opacity(0.5)) {}
+            VCircleButton(icon: "plus", label: "Add", fillColor: Violet._500, size: 28, iconSize: 12) {}
         }
         .padding()
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -136,7 +136,7 @@ struct ChatView: View {
     private var composerArea: some View {
         HStack(spacing: VSpacing.sm) {
             // Leading chat icon
-            VCircleButton(icon: "phone.fill") { }
+            VCircleButton(icon: "phone.fill", label: "Phone") { }
 
             // Text field
             TextField("What you need chef?", text: $inputText, axis: .vertical)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -149,7 +149,7 @@ struct OnboardingFlowView: View {
 
     private var mockInputBar: some View {
         HStack(spacing: VSpacing.md) {
-            VCircleButton(icon: "phone.fill", fillColor: Emerald._600.opacity(0.5)) { }
+            VCircleButton(icon: "phone.fill", label: "Phone", fillColor: Emerald._600.opacity(0.5)) { }
 
             Text("What you need chef?")
                 .font(VFont.body)


### PR DESCRIPTION
## Summary
- Added a required `label: String` parameter to `VCircleButton` for human-readable accessibility labels
- Changed `.accessibilityLabel(icon)` to `.accessibilityLabel(label)` so VoiceOver reads meaningful text instead of raw SF Symbol names like "phone.fill"
- Updated all call sites (ChatView, OnboardingFlowView, and preview code) with appropriate labels

## Context
Addresses PR #1197 feedback from both Codex and Devin reviewers, who flagged that VoiceOver users hear raw SF Symbol identifiers (e.g. "phone.fill") instead of human-readable labels. This follows the same pattern already established by `VIconButton`, which has a `label` parameter.

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] VoiceOver reads "Phone" for the circle button in the chat composer
- [ ] VoiceOver reads "Phone" for the circle button in the onboarding mock input bar

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
