### PR TITLE
Add polished DMG installer with branded background

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -115,35 +115,49 @@ jobs:
           df -h .
           echo "Disk space freed"
 
+      - name: Generate DMG background
+        run: |
+          mkdir -p build
+          swift dmg/generate-background.swift build/dmg-background.png
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
       - name: Create DMG
         run: |
           APP_PATH="dist/Vellum.app"
-          APP_NAME="Vellum.app"
 
-          # Create staging directory for DMG contents
+          # Stage just the .app (create-dmg adds the Applications symlink)
           DMG_STAGING="build/dmg-staging"
           mkdir -p "$DMG_STAGING"
           cp -R "$APP_PATH" "$DMG_STAGING/"
-          ln -s /Applications "$DMG_STAGING/Applications"
 
           echo "Staging directory size:"
           du -sh "$DMG_STAGING"
 
-          # Two-step DMG creation to avoid auto-sizing issues:
-          # 1. Create read-write image (auto-sizes more generously)
-          hdiutil create \
-            -volname "Vellum" \
-            -srcfolder "$DMG_STAGING" \
-            -ov \
-            -format UDRW \
-            "build/temp.dmg"
-
-          # 2. Convert to compressed UDZO
-          hdiutil convert "build/temp.dmg" \
-            -format UDZO \
-            -ov \
-            -o "$DMG_PATH"
-          rm "build/temp.dmg"
+          # Create styled DMG with background, icon layout, and Applications drop link
+          create-dmg \
+            --volname "Vellum" \
+            --background "build/dmg-background.png" \
+            --window-pos 200 120 \
+            --window-size 660 400 \
+            --icon-size 128 \
+            --icon "Vellum.app" 175 190 \
+            --app-drop-link 485 190 \
+            --hide-extension "Vellum.app" \
+            --no-internet-enable \
+            "$DMG_PATH" \
+            "$DMG_STAGING/" \
+          || {
+            # create-dmg exits 2 on non-fatal warnings (e.g. Finder scripting delays)
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 2 ] && [ -f "$DMG_PATH" ]; then
+              echo "create-dmg exited with warning (code 2), but DMG was created successfully"
+            else
+              echo "create-dmg failed with exit code $EXIT_CODE"
+              exit $EXIT_CODE
+            fi
+          }
 
           echo "DMG created at $DMG_PATH"
           ls -lh "$DMG_PATH"

--- a/clients/macos/dmg/generate-background.swift
+++ b/clients/macos/dmg/generate-background.swift
@@ -1,0 +1,179 @@
+#!/usr/bin/env swift
+// Generates the DMG installer background image using CoreGraphics.
+// Usage: swift generate-background.swift [output-path]
+// Output: A 1320x800 (Retina 2x) PNG suitable for a 660x400 DMG window.
+
+import AppKit
+import CoreGraphics
+import CoreText
+import ImageIO
+import UniformTypeIdentifiers
+
+let outputPath = CommandLine.arguments.count > 1
+    ? CommandLine.arguments[1]
+    : "dmg-background@2x.png"
+
+// --- Dimensions (2x Retina) ---
+let width = 1320
+let height = 800
+
+// Icon centers at 2x (matching Finder positions: Vellum at 175,190 / Applications at 485,190)
+let leftIconX = 175 * 2   // 350
+let rightIconX = 485 * 2  // 970
+let iconCenterY = 190 * 2 // 380
+
+// --- Colors (Vellum brand: dark purple theme) ---
+func rgb(_ r: CGFloat, _ g: CGFloat, _ b: CGFloat, _ a: CGFloat = 1.0) -> [CGFloat] {
+    [r / 255.0, g / 255.0, b / 255.0, a]
+}
+
+let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+guard let ctx = CGContext(
+    data: nil,
+    width: width,
+    height: height,
+    bitsPerComponent: 8,
+    bytesPerRow: 0,
+    space: colorSpace,
+    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+) else {
+    fatalError("Failed to create bitmap context")
+}
+
+// Flip coordinate system so (0,0) is top-left (matching Finder coordinates)
+ctx.translateBy(x: 0, y: CGFloat(height))
+ctx.scaleBy(x: 1, y: -1)
+
+// --- Background gradient ---
+let gradientColors = [
+    CGColor(colorSpace: colorSpace, components: rgb(22, 14, 36))!,   // Deep purple-black (top)
+    CGColor(colorSpace: colorSpace, components: rgb(15, 10, 26))!,   // Even darker (bottom)
+]
+let gradient = CGGradient(
+    colorsSpace: colorSpace,
+    colors: gradientColors as CFArray,
+    locations: [0.0, 1.0]
+)!
+
+ctx.drawLinearGradient(
+    gradient,
+    start: CGPoint(x: CGFloat(width) / 2, y: 0),
+    end: CGPoint(x: CGFloat(width) / 2, y: CGFloat(height)),
+    options: []
+)
+
+// --- Subtle radial glow behind each icon area ---
+func drawGlow(centerX: Int, centerY: Int, radius: CGFloat, color: CGColor) {
+    let clearColor = color.copy(alpha: 0)!
+    let glowGradient = CGGradient(
+        colorsSpace: colorSpace,
+        colors: [color, clearColor] as CFArray,
+        locations: [0.0, 1.0]
+    )!
+    ctx.drawRadialGradient(
+        glowGradient,
+        startCenter: CGPoint(x: CGFloat(centerX), y: CGFloat(centerY)),
+        startRadius: 0,
+        endCenter: CGPoint(x: CGFloat(centerX), y: CGFloat(centerY)),
+        endRadius: radius,
+        options: []
+    )
+}
+
+// Purple glow behind Vellum icon
+let purpleGlow = CGColor(colorSpace: colorSpace, components: rgb(88, 28, 135, 0.15))!
+drawGlow(centerX: leftIconX, centerY: iconCenterY, radius: 200, color: purpleGlow)
+
+// Lighter glow behind Applications icon
+let blueGlow = CGColor(colorSpace: colorSpace, components: rgb(59, 34, 112, 0.12))!
+drawGlow(centerX: rightIconX, centerY: iconCenterY, radius: 200, color: blueGlow)
+
+// --- Arrow between icons ---
+let arrowY = CGFloat(iconCenterY)
+let arrowStartX = CGFloat(leftIconX + 130)  // Right of left icon
+let arrowEndX = CGFloat(rightIconX - 130)    // Left of right icon
+let arrowHeadSize: CGFloat = 20
+let arrowLineWidth: CGFloat = 4.0
+
+// Arrow color: muted purple-white
+let arrowColor = CGColor(colorSpace: colorSpace, components: rgb(168, 140, 210, 0.7))!
+ctx.setStrokeColor(arrowColor)
+ctx.setFillColor(arrowColor)
+ctx.setLineWidth(arrowLineWidth)
+ctx.setLineCap(.round)
+ctx.setLineJoin(.round)
+
+// Arrow shaft
+ctx.beginPath()
+ctx.move(to: CGPoint(x: arrowStartX, y: arrowY))
+ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize, y: arrowY))
+ctx.strokePath()
+
+// Arrowhead (filled triangle)
+ctx.beginPath()
+ctx.move(to: CGPoint(x: arrowEndX, y: arrowY))
+ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY - arrowHeadSize))
+ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY + arrowHeadSize))
+ctx.closePath()
+ctx.fillPath()
+
+// --- "Drag to install" text ---
+let textY = CGFloat(iconCenterY + 150)  // Below the icons
+let textCenterX = CGFloat(width) / 2.0
+
+let textString = "Drag to Applications to install"
+let fontSize: CGFloat = 28.0
+let font = CTFontCreateWithName("Helvetica Neue" as CFString, fontSize, nil)
+let textColor = CGColor(colorSpace: colorSpace, components: rgb(168, 140, 210, 0.5))!
+
+let ctAttributes: [CFString: Any] = [
+    kCTFontAttributeName: font,
+    kCTForegroundColorAttributeName: textColor,
+]
+let attributedString = CFAttributedStringCreate(
+    kCFAllocatorDefault,
+    textString as CFString,
+    ctAttributes as CFDictionary
+)!
+let line = CTLineCreateWithAttributedString(attributedString)
+let textBounds = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
+
+// Position text centered horizontally
+// Core Text draws in bottom-left origin, so undo our flip for text
+ctx.saveGState()
+ctx.translateBy(x: 0, y: CGFloat(height))
+ctx.scaleBy(x: 1, y: -1)
+// Now (0,0) is bottom-left, y increases upward
+let textDrawY = CGFloat(height) - textY
+let textDrawX = textCenterX - textBounds.width / 2
+ctx.textPosition = CGPoint(x: textDrawX, y: textDrawY)
+CTLineDraw(line, ctx)
+ctx.restoreGState()
+
+// --- Generate output ---
+guard let image = ctx.makeImage() else {
+    fatalError("Failed to create CGImage")
+}
+
+let url = URL(fileURLWithPath: outputPath)
+guard let destination = CGImageDestinationCreateWithURL(
+    url as CFURL,
+    UTType.png.identifier as CFString,
+    1,
+    nil
+) else {
+    fatalError("Failed to create image destination at \(outputPath)")
+}
+
+let properties: [CFString: Any] = [
+    kCGImagePropertyDPIWidth: 144,
+    kCGImagePropertyDPIHeight: 144,
+]
+CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+
+guard CGImageDestinationFinalize(destination) else {
+    fatalError("Failed to write PNG")
+}
+
+print("Generated DMG background: \(outputPath) (\(width)x\(height) @2x)")


### PR DESCRIPTION
## Summary
- Adds a Swift script (`clients/macos/dmg/generate-background.swift`) that generates a Retina DMG background image using CoreGraphics — dark purple gradient with a directional arrow and "Drag to Applications to install" text
- Replaces the plain `hdiutil` DMG creation with `create-dmg`, which sets a custom background, positions the Vellum app icon on the left and Applications drop-link on the right, and configures 128px icon size in a 660x400 window
- Users now see a polished, branded installer experience when they open the disk image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
