### PR TITLE
Fix ControlPanel slider range to align with step 10

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -148,15 +148,12 @@ struct ControlPanel: View {
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
                     Spacer()
-                    Text("\(max(1, Int(maxSteps)))")
+                    Text("\(Int(maxSteps))")
                         .font(VFont.mono)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 0...100, step: 10, showTickMarks: true)
-                    .onChange(of: maxSteps) { _, newValue in
-                        if newValue < 1 { maxSteps = 1 }
-                    }
+                VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
- Change max-steps slider range from `0...100` to `10...100` to produce clean round values (10, 20, ..., 100), matching SettingsView
- Remove unnecessary `max(1, ...)` display guard and `onChange` clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
