### PR TITLE
Restrict ResourceBundle fallback to Xcode Previews only

### DIFF
--- a/clients/macos/vellum-assistant/ResourceBundle.swift
+++ b/clients/macos/vellum-assistant/ResourceBundle.swift
@@ -24,9 +24,11 @@ enum ResourceBundle {
         #if DEBUG
         // Xcode Previews — resource bundle isn't at either path.
         // Fall back to Bundle.main so previews render without crashing.
-        return Bundle.main
-        #else
-        fatalError("Could not find resource bundle '\(bundleName).bundle'")
+        // Gate on XCODE_RUNNING_FOR_PREVIEWS so regular debug builds still fail fast.
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+            return Bundle.main
+        }
         #endif
+        fatalError("Could not find resource bundle '\(bundleName).bundle'")
     }()
 }


### PR DESCRIPTION
## Summary
- Gate the `Bundle.main` fallback on `XCODE_RUNNING_FOR_PREVIEWS` environment variable instead of `#if DEBUG` alone
- Regular debug builds now fail fast on missing resource bundles instead of silently falling back to `Bundle.main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
