### PR TITLE
Fix DMG arrow seam

### DIFF
--- a/clients/macos/dmg/generate-background.swift
+++ b/clients/macos/dmg/generate-background.swift
@@ -98,23 +98,20 @@ let arrowLineWidth: CGFloat = 4.0
 
 // Arrow color: muted purple-white
 let arrowColor = CGColor(colorSpace: colorSpace, components: rgb(168, 140, 210, 0.7))!
-ctx.setStrokeColor(arrowColor)
 ctx.setFillColor(arrowColor)
-ctx.setLineWidth(arrowLineWidth)
-ctx.setLineCap(.round)
-ctx.setLineJoin(.round)
 
-// Arrow shaft
-ctx.beginPath()
-ctx.move(to: CGPoint(x: arrowStartX, y: arrowY))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize, y: arrowY))
-ctx.strokePath()
+// Single filled polygon: shaft rectangle merging into arrowhead triangle
+let shaftHalf: CGFloat = arrowLineWidth / 2
+let neckX = arrowEndX - arrowHeadSize * 1.5  // Where shaft meets head
 
-// Arrowhead (filled triangle)
 ctx.beginPath()
-ctx.move(to: CGPoint(x: arrowEndX, y: arrowY))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY - arrowHeadSize))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY + arrowHeadSize))
+ctx.move(to: CGPoint(x: arrowStartX, y: arrowY - shaftHalf))          // top-left of shaft
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY - shaftHalf))             // top-right of shaft
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY - arrowHeadSize))         // top of arrowhead
+ctx.addLine(to: CGPoint(x: arrowEndX, y: arrowY))                     // tip
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY + arrowHeadSize))         // bottom of arrowhead
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY + shaftHalf))             // bottom-right of shaft
+ctx.addLine(to: CGPoint(x: arrowStartX, y: arrowY + shaftHalf))       // bottom-left of shaft
 ctx.closePath()
 ctx.fillPath()
 


### PR DESCRIPTION
## Summary
- Draw the DMG background arrow as a single filled polygon instead of a separate stroked line + filled triangle, eliminating the visible seam at the junction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
