### PR TITLE
Fix DMG background @2x suffix for Retina displays

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Generate DMG background
         run: |
           mkdir -p build
-          swift dmg/generate-background.swift build/dmg-background.png
+          swift dmg/generate-background.swift build/dmg-background@2x.png
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -138,7 +138,7 @@ jobs:
           # Create styled DMG with background, icon layout, and Applications drop link
           create-dmg \
             --volname "Vellum" \
-            --background "build/dmg-background.png" \
+            --background "build/dmg-background@2x.png" \
             --window-pos 200 120 \
             --window-size 660 400 \
             --icon-size 128 \


### PR DESCRIPTION
## Summary
- Rename DMG background filename to include @2x suffix so create-dmg generates a multi-resolution TIFF for Retina displays

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
