### PR TITLE
Make legacy process kill non-fatal in /scrub

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -8,8 +8,8 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 1. Kill any running Vellum processes (including the legacy process name):
    ```bash
-   pkill -x "Vellum"
-   pkill -x "vellum-assistant"
+   pkill -x "Vellum" || true
+   pkill -x "vellum-assistant" || true
    ```
 
 2. Remove session logs and knowledge store:


### PR DESCRIPTION
## Summary
- Append `|| true` to pkill commands in /scrub so they don't fail when no matching process is found

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
