### PR TITLE
Flush Sentry before process.exit on startup failure

### DIFF
--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -3,8 +3,9 @@ import '../instrument.js';
 import * as Sentry from '@sentry/node';
 import { runDaemon } from './lifecycle.js';
 
-runDaemon().catch((err) => {
+runDaemon().catch(async (err) => {
   Sentry.captureException(err);
+  await Sentry.flush(2000);
   console.error('Failed to start daemon:', err);
   console.error('Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/data/logs/');
   process.exit(1);


### PR DESCRIPTION
## Summary
- Add `await Sentry.flush(2000)` before `process.exit(1)` in daemon startup error handler to ensure crash reports are delivered

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
