### PR TITLE
Fix undo DB cleanup to handle merged user messages

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -797,13 +797,14 @@ export class Session {
     // deleteLastExchange only finds the last role='user' row — which may be a
     // tool_result message, leaving the real user message orphaned.
     //
-    // Strategy: first peel back any tool_result user messages, then delete
-    // the real user message exchange. This ensures the DB cleanup matches
-    // the in-memory cleanup.
-    while (conversationStore.isLastUserMessageToolResult(this.conversationId)) {
+    // Strategy: delete the last exchange, then continue deleting any trailing
+    // tool_result user messages. Using a do-while ensures we clean up orphaned
+    // tool_result rows that may appear both before AND after the real user
+    // message (e.g. when repairHistory merges them in memory but the DB still
+    // stores them as separate rows).
+    do {
       conversationStore.deleteLastExchange(this.conversationId);
-    }
-    conversationStore.deleteLastExchange(this.conversationId);
+    } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
 
     return removed;
   }


### PR DESCRIPTION
## Summary
- Restructure undo DB cleanup to a do-while loop so orphaned tool_result rows left by repairHistory merging are properly deleted

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
