### PR TITLE
Add nil guard to session-id filters in TextSession and InterviewViewModel

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -107,7 +107,7 @@ final class TextSession: ObservableObject {
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId:
+                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     // Set state before appending to messages — the $state Combine sink
                     // triggers a layout pass, and if state is still .streaming when the
@@ -117,13 +117,13 @@ final class TextSession: ObservableObject {
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
-                case .generationHandoff(let handoff) where handoff.sessionId == self.daemonSessionId:
+                case .generationHandoff(let handoff) where handoff.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
-                case .cuError(let error) where error.sessionId == self.daemonSessionId:
+                case .cuError(let error) where error.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     self.state = .failed(reason: error.message)
                     return
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -150,7 +150,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete(let complete) where complete.sessionId == self.sessionId:
+                case .messageComplete(let complete) where complete.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -161,7 +161,7 @@ final class InterviewViewModel {
                     log.info("Interview greeting complete (\(accumulated.count) chars)")
                     return
 
-                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId:
+                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -172,7 +172,7 @@ final class InterviewViewModel {
                     log.info("Interview greeting complete via handoff (\(accumulated.count) chars)")
                     return
 
-                case .cuError(let error) where error.sessionId == self.sessionId:
+                case .cuError(let error) where error.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     log.error("Interview start failed: \(error.message)")


### PR DESCRIPTION
## Summary
- Add `&& self.daemonSessionId != nil` / `&& self.sessionId != nil` guards to `messageComplete`, `generationHandoff`, and `cuError` `where` clauses to prevent nil==nil matches before session establishment
- Follows the existing defensive pattern established in `ProfileExtractor.swift`

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1111

## Test plan
- [ ] Verify that `messageComplete`, `generationHandoff`, and `cuError` messages with nil session IDs are no longer matched before session establishment
- [ ] Verify normal session flow (session established, then messages matched) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
