### PR TITLE
Fix isCancelling and queue bookkeeping in ChatViewModel error paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -335,7 +335,6 @@ final class ChatViewModel: ObservableObject {
         case .error(let err):
             log.error("Server error: \(err.message)")
             isThinking = false
-            isSending = false
             isCancelling = false
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -343,17 +342,21 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            pendingQueuedCount = 0
-            pendingMessageIds = []
-            requestIdToMessageId = [:]
             errorText = err.message
-            // Reset processing/queued messages to sent
+            // Reset processing messages to sent
             for i in messages.indices {
-                if case .queued = messages[i].status, messages[i].role == .user {
-                    messages[i].status = .sent
-                } else if messages[i].role == .user && messages[i].status == .processing {
+                if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
+            }
+            // The daemon drains queued work after an error, so preserve
+            // queue bookkeeping (pendingQueuedCount, pendingMessageIds,
+            // requestIdToMessageId) when messages are still queued.
+            // Only clear everything when the queue is empty.
+            if pendingQueuedCount == 0 {
+                isSending = false
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
             }
 
         default:
@@ -412,6 +415,7 @@ final class ChatViewModel: ObservableObject {
             // all transient state now to avoid stuck UI.
             isSending = false
             isThinking = false
+            isCancelling = false
             // Mark current assistant message as stopped
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {


### PR DESCRIPTION
## Summary
- Add `isCancelling = false` in the catch block of `stopGenerating()` so a failed cancel send doesn't permanently suppress assistant deltas. The disconnected guard path already had this reset.
- Preserve `pendingQueuedCount`, `pendingMessageIds`, and `requestIdToMessageId` in `handleServerMessage(.error)` when messages are still queued. The daemon drains queued work after an error (`drainQueue` in the `finally` block of `runAgentLoop`), so clearing these fields prematurely caused subsequent `messageDequeued` events to lose their requestId-to-message mapping and left queue state inconsistent.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/1112

## Test plan
- [x] All 115 existing tests pass
- [x] Swift build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
