### PR TITLE
M2: Fix ControlPanel UI — nav button, ambient toggle, permission rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -78,7 +78,7 @@ struct ControlPanel: View {
                 .padding(.vertical, VSpacing.xs)
         }
         .buttonStyle(.plain)
-        .background(selected ? VColor.surface : Color.clear)
+        .background(selected ? Slate._700 : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         .vHover()
     }
@@ -164,11 +164,15 @@ struct ControlPanel: View {
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack(spacing: VSpacing.xs) {
-                    VToggle(isOn: $ambientEnabled, label: "Enable ambient screen watching")
+                HStack {
+                    Text("Enable ambient screen watching")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
                     Image(systemName: "info.circle")
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
+                    Spacer()
+                    VToggle(isOn: $ambientEnabled)
                 }
                 .onChange(of: ambientEnabled) { _, newValue in
                     ambientAgent.isEnabled = newValue
@@ -188,18 +192,24 @@ struct ControlPanel: View {
                     label: "Accessibility",
                     granted: PermissionManager.accessibilityStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard()
 
                 permissionRow(
                     icon: "record.circle",
                     label: "Screen Recording",
                     granted: PermissionManager.screenRecordingStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard()
 
                 permissionRow(
                     icon: "key",
                     label: "API Key",
                     granted: APIKeyManager.getKey() != nil
                 )
+                .padding(VSpacing.md)
+                .vCard()
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
- **Nav button selected state**: Changed background from `VColor.surface` to `Slate._700` so the selected chip is visible against the `backgroundSubtle` panel background (both were `Slate._800`)
- **Ambient Agent toggle position**: Moved label + info icon to the left with a `Spacer`, toggle to the right, using a label-less `VToggle`
- **Permission row borders**: Wrapped each permission row in `.padding(VSpacing.md).vCard()` for bordered card styling

## Note
The VToggle restyle (change 2 — squared track and knob) could not be applied from this worktree due to file permission restrictions on `DesignSystem/Primitives/Inputs/VToggle.swift`. That change should be applied separately.

## Test plan
- [ ] Verify nav button selected state shows a visible `Slate._700` chip against the panel background
- [ ] Verify ambient agent toggle label is on the left and toggle is on the right
- [ ] Verify each permission row has card borders (`.vCard()` styling)
- [ ] Build succeeds: `cd clients/macos && swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
