### PR TITLE
Update README scrub command docs to reflect non-fatal kills (#1253)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,4 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the first PR, creates it (without merging), and stops to wait for human review. |
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. |
-| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 | Command | Purpose |
 |---------|---------|
-| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
 
 ### Review
 


### PR DESCRIPTION
## Summary
- Updates the `/scrub` command description in both `README.md` and `AGENTS.md` to note that process kills are non-fatal (won't fail if Vellum processes aren't running).
- Addresses documentation sync feedback from PR #1253 where `|| true` was added to `pkill` commands in `.claude/commands/scrub.md` but the README was not updated.
- Fulfills the `AGENTS.md` requirement that any modification to `.claude/commands/` must be reflected in the README's Slash Commands section.

## Test plan
- [x] Verify README.md scrub description mentions non-fatal behavior
- [x] Verify AGENTS.md scrub TLDR matches README.md
- [x] Confirm descriptions are consistent with actual scrub.md command behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
