### PR TITLE
Fix undo do-while loop to delete real user message exchange (#1257)

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -797,14 +797,15 @@ export class Session {
     // deleteLastExchange only finds the last role='user' row — which may be a
     // tool_result message, leaving the real user message orphaned.
     //
-    // Strategy: delete the last exchange, then continue deleting any trailing
-    // tool_result user messages. Using a do-while ensures we clean up orphaned
-    // tool_result rows that may appear both before AND after the real user
-    // message (e.g. when repairHistory merges them in memory but the DB still
-    // stores them as separate rows).
+    // Strategy: peel back any trailing tool_result exchanges first, then
+    // unconditionally delete the real user message exchange. The do-while
+    // handles the case where the last DB exchange is a tool_result row, and
+    // the final call after the loop ensures the original user message is
+    // always removed.
     do {
       conversationStore.deleteLastExchange(this.conversationId);
     } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
+    conversationStore.deleteLastExchange(this.conversationId);
 
     return removed;
   }


### PR DESCRIPTION
## Summary
- Adds back the final `deleteLastExchange` call after the do-while loop in the `undo()` method so the real user message exchange is properly cleaned up from the DB.
- Both Codex and Devin identified that the do-while refactor in PR #1257 exits without deleting the original user message + assistant response pair when tool_result rows precede it.
- Updates the comment to accurately describe the corrected strategy.

## Context
Given this DB state after a multi-tool-use turn:
```
user("Do two things")       rowid=1
assistant(tool_use tu1)     rowid=2
user(tool_result tu1)       rowid=3
assistant(tool_use tu2)     rowid=4
user(tool_result tu2)       rowid=5
assistant("Done both")      rowid=6
```

The do-while loop correctly peels back rows 5+6, then 3+4, but then exits because row 1 is not a tool_result. Without the extra `deleteLastExchange` call, rows 1+2 are orphaned.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] Existing `conversation-store.test.ts` tests pass (10/10), including the "looping pattern handles multiple tool uses in sequence" test that exercises exactly this scenario

Addresses feedback from PR #1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
