### PR TITLE
Force-clear queue state when cancelling with queued messages (#1259)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -335,6 +335,7 @@ final class ChatViewModel: ObservableObject {
         case .error(let err):
             log.error("Server error: \(err.message)")
             isThinking = false
+            let wasCancelling = isCancelling
             isCancelling = false
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -349,11 +350,27 @@ final class ChatViewModel: ObservableObject {
                     messages[i].status = .sent
                 }
             }
-            // The daemon drains queued work after an error, so preserve
-            // queue bookkeeping (pendingQueuedCount, pendingMessageIds,
-            // requestIdToMessageId) when messages are still queued.
-            // Only clear everything when the queue is empty.
-            if pendingQueuedCount == 0 {
+            // When cancelling, the daemon's abort() emits error events for
+            // queued messages but drops the queue without sending
+            // message_dequeued events, so pendingQueuedCount never drains
+            // on its own. Force-clear all queue state to prevent isSending
+            // from staying true permanently. Also reset queued message
+            // statuses since the daemon will not process them.
+            if wasCancelling {
+                isSending = false
+                pendingQueuedCount = 0
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
+            } else if pendingQueuedCount == 0 {
+                // The daemon drains queued work after a non-cancellation
+                // error, so preserve queue bookkeeping when messages are
+                // still queued. Only clear everything when the queue is
+                // empty.
                 isSending = false
                 pendingMessageIds = []
                 requestIdToMessageId = [:]


### PR DESCRIPTION
## Summary
- When the user cancels while messages are queued, the daemon's `abort()` emits `error` events for each queued message but drops `messageQueue` without sending `message_dequeued` events. This left `pendingQueuedCount` stranded above zero, keeping `isSending` permanently true and locking the chat in a stuck sending/queued state.
- Capture `isCancelling` into `wasCancelling` before clearing it in the `.error` handler. When the error arrived during a cancellation flow, force-drain all queue bookkeeping (`pendingQueuedCount`, `pendingMessageIds`, `requestIdToMessageId`) and reset queued message statuses to `.sent`.
- Non-cancellation errors continue to preserve queue state so the daemon can drain normally via `message_dequeued` events.

## Test plan
- [ ] Build succeeds (`swift build` verified)
- [ ] Send multiple messages rapidly so some get queued, then cancel — verify `isSending` resets and queued messages show `.sent` status
- [ ] Trigger a non-cancellation server error while messages are queued — verify queue bookkeeping is preserved and the daemon drains correctly
- [ ] Cancel with no queued messages — verify behavior unchanged from before

Addresses feedback from PR #1259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
