### PR TITLE
M1: Panel 50% width + rounded corners

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -19,6 +19,8 @@ struct VSplitView<Main: View, Panel: View>: View {
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .padding(VSpacing.sm)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -13,43 +13,45 @@ struct MainWindowView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Row 1 — thread tab bar
-            ThreadTabBar(
-                threads: threadManager.threads,
-                activeThreadId: threadManager.activeThreadId,
-                onSelect: { threadManager.selectThread(id: $0) },
-                onClose: { threadManager.closeThread(id: $0) },
-                onCreate: { threadManager.createThread() }
-            )
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                // Row 1 — thread tab bar
+                ThreadTabBar(
+                    threads: threadManager.threads,
+                    activeThreadId: threadManager.activeThreadId,
+                    onSelect: { threadManager.selectThread(id: $0) },
+                    onClose: { threadManager.closeThread(id: $0) },
+                    onCreate: { threadManager.createThread() }
+                )
 
-            // Row 2 — navigation toolbar
-            NavigationToolbar(activePanel: $activePanel)
+                // Row 2 — navigation toolbar
+                NavigationToolbar(activePanel: $activePanel)
 
-            // Row 3 — chat content with optional side panel
-            VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
-                if let viewModel = threadManager.activeViewModel {
-                    ChatView(
-                        messages: viewModel.messages,
-                        inputText: Binding(
-                            get: { viewModel.inputText },
-                            set: { viewModel.inputText = $0 }
-                        ),
-                        isThinking: viewModel.isThinking,
-                        isSending: viewModel.isSending,
-                        errorText: viewModel.errorText,
-                        pendingQueuedCount: viewModel.pendingQueuedCount,
-                        onSend: viewModel.sendMessage,
-                        onStop: viewModel.stopGenerating,
-                        onDismissError: viewModel.dismissError
-                    )
-                }
-            }, panel: {
-                panelContent
-            })
+                // Row 3 — chat content with optional side panel
+                VSplitView(panelWidth: geometry.size.width * 0.5, showPanel: activePanel != nil, main: {
+                    if let viewModel = threadManager.activeViewModel {
+                        ChatView(
+                            messages: viewModel.messages,
+                            inputText: Binding(
+                                get: { viewModel.inputText },
+                                set: { viewModel.inputText = $0 }
+                            ),
+                            isThinking: viewModel.isThinking,
+                            isSending: viewModel.isSending,
+                            errorText: viewModel.errorText,
+                            pendingQueuedCount: viewModel.pendingQueuedCount,
+                            onSend: viewModel.sendMessage,
+                            onStop: viewModel.stopGenerating,
+                            onDismissError: viewModel.dismissError
+                        )
+                    }
+                }, panel: {
+                    panelContent
+                })
+            }
+            .ignoresSafeArea(edges: .top)
+            .background(VColor.background.ignoresSafeArea())
         }
-        .ignoresSafeArea(edges: .top)
-        .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }
 


### PR DESCRIPTION
## Summary
- **VSplitView**: Add `clipShape(RoundedRectangle(cornerRadius: VRadius.lg))` and `.padding(VSpacing.sm)` to panel for rounded corners with margin
- **MainWindowView**: Wrap body in `GeometryReader`, use `geometry.size.width * 0.5` for panel width instead of fixed 420pt

## Test plan
- [ ] Panel opens at 50% of window width
- [ ] Panel has rounded corners with subtle padding/margin
- [ ] Build succeeds: `cd clients/macos && swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
