### PR TITLE
M1: Add provider/model-aware usage domain types

### DIFF
--- a/assistant/src/usage/actors.ts
+++ b/assistant/src/usage/actors.ts
@@ -1,0 +1,24 @@
+/**
+ * Identifiers for the different agents/subsystems that consume LLM tokens.
+ */
+export type UsageActor =
+  | 'main_agent'
+  | 'context_compactor'
+  | 'task_classifier'
+  | 'title_generator'
+  | 'ambient_analyzer'
+  | 'suggestion_generator'
+  | 'computer_use_agent'
+  | 'memory_embedding';
+
+/** All valid actor identifiers (useful for runtime validation). */
+export const USAGE_ACTORS: readonly UsageActor[] = [
+  'main_agent',
+  'context_compactor',
+  'task_classifier',
+  'title_generator',
+  'ambient_analyzer',
+  'suggestion_generator',
+  'computer_use_agent',
+  'memory_embedding',
+] as const;

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -1,0 +1,38 @@
+import type { UsageActor } from './actors.js';
+
+/**
+ * Input data required to record a single LLM usage event.
+ * Matches the token fields from `ProviderResponse.usage`.
+ */
+export interface UsageEventInput {
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
+  actor: UsageActor;
+  assistantId: string | null;
+  conversationId: string | null;
+  runId: string | null;
+  requestId: string | null;
+}
+
+/**
+ * Result of resolving pricing for a usage event.
+ */
+export interface PricingResult {
+  estimatedCostUsd: number | null;
+  pricingStatus: 'priced' | 'unpriced';
+}
+
+/**
+ * A persisted usage event, combining the original input with
+ * storage metadata and resolved pricing.
+ */
+export interface UsageEvent extends UsageEventInput {
+  id: string;
+  createdAt: number;
+  estimatedCostUsd: number | null;
+  pricingStatus: 'priced' | 'unpriced';
+}


### PR DESCRIPTION
## Summary
Add typed primitives for the new usage tracking system: `UsageActor` actor identifiers, `UsageEventInput` for recording usage, `PricingResult` for pricing resolution, and `UsageEvent` for persisted records.

## Changes
- New `assistant/src/usage/types.ts` with core usage types
- New `assistant/src/usage/actors.ts` with actor constants

No runtime behavior changes. Foundation types for #1236.

Part of #1235: Cost Tracking and Limits
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
