### PR TITLE
Computer usage slider: range 1-100 with step-of-10 snapping

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
@@ -50,8 +50,8 @@ struct VSlider: View {
                         let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
-                        value = range.lowerBound + round((rawValue - range.lowerBound) / step) * step
-                        value = min(max(value, range.lowerBound), range.upperBound)
+                        let snapped = round(rawValue / step) * step
+                        value = min(max(snapped, range.lowerBound), range.upperBound)
                     }
                     .onEnded { _ in
                         isDragging = false
@@ -109,17 +109,21 @@ struct VSlider: View {
     // MARK: - Tick Marks
 
     private func tickMarksView(trackWidth: CGFloat, fraction: Double) -> some View {
-        let totalSteps = Int((range.upperBound - range.lowerBound) / step)
+        // Build tick values as multiples of step within the range
+        let firstTick = ceil(range.lowerBound / step) * step
+        let lastTick = floor(range.upperBound / step) * step
+        let tickValues = stride(from: firstTick, through: lastTick, by: step).map { $0 }
         let maxTicks = 20
-        let tickStep = totalSteps > maxTicks ? totalSteps / maxTicks : 1
+        let tickStep = tickValues.count > maxTicks ? tickValues.count / maxTicks : 1
+        let rangeSpan = range.upperBound - range.lowerBound
 
         return ZStack(alignment: .leading) {
-            ForEach(0...totalSteps, id: \.self) { i in
-                if i % tickStep == 0 {
-                    let tickFraction = Double(i) / Double(totalSteps)
+            ForEach(Array(tickValues.enumerated()), id: \.offset) { index, tickValue in
+                if index % tickStep == 0 {
+                    let tickFraction = (tickValue - range.lowerBound) / rangeSpan
 
                     // Only render tick marks in the unfilled portion, excluding the rightmost
-                    if tickFraction > fraction && i < totalSteps {
+                    if tickFraction > fraction && tickValue < range.upperBound {
                         let tickX = trackWidth * tickFraction + thumbWidth / 2
 
                         RoundedRectangle(cornerRadius: 0.5)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -153,7 +153,7 @@ struct ControlPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
+                VSlider(value: $maxSteps, range: 1...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
- VSlider snap formula changed to zero-based rounding (`round(rawValue / step) * step`) so values land on exact multiples of step (e.g., 10, 20, 30...), clamped to range bounds
- VSlider tick marks now position at multiples of step within range instead of evenly dividing from lowerBound
- ControlPanel computer usage slider range changed from `10...100` to `1...100` so the minimum is 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
