### PR TITLE
M2: Add llm_usage_events table and store

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'llm-usage-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { recordUsageEvent, listUsageEvents } from '../memory/llm-usage-store.js';
+import type { UsageEventInput, PricingResult } from '../usage/types.js';
+
+// Initialize db once before all tests
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    actor: 'main_agent',
+    assistantId: null,
+    conversationId: null,
+    runId: null,
+    requestId: null,
+    ...overrides,
+  };
+}
+
+const pricedResult: PricingResult = {
+  estimatedCostUsd: 0.0045,
+  pricingStatus: 'priced',
+};
+
+const unpricedResult: PricingResult = {
+  estimatedCostUsd: null,
+  pricingStatus: 'unpriced',
+};
+
+describe('recordUsageEvent', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test('persists an event and returns it with id and createdAt', () => {
+    const input = makeInput();
+    const event = recordUsageEvent(input, pricedResult);
+
+    expect(event.id).toBeDefined();
+    expect(typeof event.id).toBe('string');
+    expect(event.id.length).toBeGreaterThan(0);
+    expect(event.createdAt).toBeDefined();
+    expect(typeof event.createdAt).toBe('number');
+    expect(event.provider).toBe('anthropic');
+    expect(event.model).toBe('claude-sonnet-4-20250514');
+    expect(event.inputTokens).toBe(1000);
+    expect(event.outputTokens).toBe(500);
+    expect(event.actor).toBe('main_agent');
+    expect(event.estimatedCostUsd).toBe(0.0045);
+    expect(event.pricingStatus).toBe('priced');
+  });
+
+  test('persists a priced event that can be retrieved', () => {
+    const input = makeInput({ assistantId: 'a1', conversationId: 'c1' });
+    const event = recordUsageEvent(input, pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(event.id);
+    expect(events[0].estimatedCostUsd).toBe(0.0045);
+    expect(events[0].pricingStatus).toBe('priced');
+    expect(events[0].assistantId).toBe('a1');
+    expect(events[0].conversationId).toBe('c1');
+  });
+
+  test('persists an unpriced event', () => {
+    const input = makeInput({ provider: 'ollama', model: 'llama3' });
+    const event = recordUsageEvent(input, unpricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(event.id);
+    expect(events[0].estimatedCostUsd).toBeNull();
+    expect(events[0].pricingStatus).toBe('unpriced');
+    expect(events[0].provider).toBe('ollama');
+    expect(events[0].model).toBe('llama3');
+  });
+
+  test('handles null optional fields', () => {
+    const input = makeInput({
+      assistantId: null,
+      conversationId: null,
+      runId: null,
+      requestId: null,
+      cacheCreationInputTokens: null,
+      cacheReadInputTokens: null,
+    });
+    const event = recordUsageEvent(input, unpricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].assistantId).toBeNull();
+    expect(events[0].conversationId).toBeNull();
+    expect(events[0].runId).toBeNull();
+    expect(events[0].requestId).toBeNull();
+    expect(events[0].cacheCreationInputTokens).toBeNull();
+    expect(events[0].cacheReadInputTokens).toBeNull();
+  });
+
+  test('handles populated optional fields', () => {
+    const input = makeInput({
+      assistantId: 'assistant-1',
+      conversationId: 'conv-1',
+      runId: 'run-1',
+      requestId: 'req-1',
+      cacheCreationInputTokens: 200,
+      cacheReadInputTokens: 300,
+    });
+    const event = recordUsageEvent(input, pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].assistantId).toBe('assistant-1');
+    expect(events[0].conversationId).toBe('conv-1');
+    expect(events[0].runId).toBe('run-1');
+    expect(events[0].requestId).toBe('req-1');
+    expect(events[0].cacheCreationInputTokens).toBe(200);
+    expect(events[0].cacheReadInputTokens).toBe(300);
+  });
+});
+
+describe('listUsageEvents', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test('returns events in descending createdAt order', () => {
+    // Insert events with small delays to ensure different timestamps
+    const event1 = recordUsageEvent(makeInput({ model: 'model-a' }), pricedResult);
+    // Manually adjust createdAt for deterministic ordering
+    const db = getDb();
+    db.run(`UPDATE llm_usage_events SET created_at = 1000 WHERE id = '${event1.id}'`);
+
+    const event2 = recordUsageEvent(makeInput({ model: 'model-b' }), pricedResult);
+    db.run(`UPDATE llm_usage_events SET created_at = 2000 WHERE id = '${event2.id}'`);
+
+    const event3 = recordUsageEvent(makeInput({ model: 'model-c' }), pricedResult);
+    db.run(`UPDATE llm_usage_events SET created_at = 3000 WHERE id = '${event3.id}'`);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(3);
+    expect(events[0].model).toBe('model-c');
+    expect(events[1].model).toBe('model-b');
+    expect(events[2].model).toBe('model-a');
+  });
+
+  test('respects the limit option', () => {
+    recordUsageEvent(makeInput({ model: 'model-a' }), pricedResult);
+    recordUsageEvent(makeInput({ model: 'model-b' }), pricedResult);
+    recordUsageEvent(makeInput({ model: 'model-c' }), pricedResult);
+
+    const events = listUsageEvents({ limit: 2 });
+    expect(events).toHaveLength(2);
+  });
+
+  test('defaults to limit of 100', () => {
+    // Just verify it returns without error when no limit is specified
+    const events = listUsageEvents();
+    expect(Array.isArray(events)).toBe(true);
+  });
+
+  test('returns empty array when no events exist', () => {
+    const events = listUsageEvents();
+    expect(events).toHaveLength(0);
+  });
+
+  test('returns events with correct types', () => {
+    recordUsageEvent(makeInput({
+      cacheCreationInputTokens: 100,
+      cacheReadInputTokens: 200,
+    }), pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0];
+
+    // Verify all fields have correct types
+    expect(typeof event.id).toBe('string');
+    expect(typeof event.createdAt).toBe('number');
+    expect(typeof event.actor).toBe('string');
+    expect(typeof event.provider).toBe('string');
+    expect(typeof event.model).toBe('string');
+    expect(typeof event.inputTokens).toBe('number');
+    expect(typeof event.outputTokens).toBe('number');
+    expect(typeof event.cacheCreationInputTokens).toBe('number');
+    expect(typeof event.cacheReadInputTokens).toBe('number');
+    expect(typeof event.estimatedCostUsd).toBe('number');
+    expect(typeof event.pricingStatus).toBe('string');
+  });
+});

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -262,6 +262,27 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      assistant_id TEXT,
+      conversation_id TEXT,
+      run_id TEXT,
+      request_id TEXT,
+      actor TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      cache_creation_input_tokens INTEGER,
+      cache_read_input_tokens INTEGER,
+      estimated_cost_usd REAL,
+      pricing_status TEXT NOT NULL,
+      metadata_json TEXT
+    )
+  `);
+
   // FTS table for lexical retrieval over memory_segments.text.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
@@ -343,6 +364,13 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_service ON accounts(service)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_created_at ON llm_usage_events(created_at)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_assistant_id ON llm_usage_events(assistant_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_provider ON llm_usage_events(provider)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_model ON llm_usage_events(model)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_actor ON llm_usage_events(actor)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -1,0 +1,62 @@
+import { desc } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { llmUsageEvents } from './schema.js';
+import type { UsageEventInput, UsageEvent, PricingResult } from '../usage/types.js';
+
+export function recordUsageEvent(input: UsageEventInput, pricing: PricingResult): UsageEvent {
+  const db = getDb();
+  const event: UsageEvent = {
+    id: uuid(),
+    createdAt: Date.now(),
+    ...input,
+    estimatedCostUsd: pricing.estimatedCostUsd,
+    pricingStatus: pricing.pricingStatus,
+  };
+  db.insert(llmUsageEvents).values({
+    id: event.id,
+    createdAt: event.createdAt,
+    assistantId: event.assistantId,
+    conversationId: event.conversationId,
+    runId: event.runId,
+    requestId: event.requestId,
+    actor: event.actor,
+    provider: event.provider,
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    cacheCreationInputTokens: event.cacheCreationInputTokens,
+    cacheReadInputTokens: event.cacheReadInputTokens,
+    estimatedCostUsd: event.estimatedCostUsd,
+    pricingStatus: event.pricingStatus,
+    metadataJson: null,
+  }).run();
+  return event;
+}
+
+export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(llmUsageEvents)
+    .orderBy(desc(llmUsageEvents.createdAt))
+    .limit(options?.limit ?? 100)
+    .all();
+  return rows.map(row => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    assistantId: row.assistantId,
+    conversationId: row.conversationId,
+    runId: row.runId,
+    requestId: row.requestId,
+    actor: row.actor as UsageEvent['actor'],
+    provider: row.provider,
+    model: row.model,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheCreationInputTokens: row.cacheCreationInputTokens,
+    cacheReadInputTokens: row.cacheReadInputTokens,
+    estimatedCostUsd: row.estimatedCostUsd,
+    pricingStatus: row.pricingStatus as 'priced' | 'unpriced',
+  }));
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -233,3 +233,24 @@ export const cronRuns = sqliteTable('cron_runs', {
   conversationId: text('conversation_id'),
   createdAt: integer('created_at').notNull(),
 });
+
+// ── LLM Usage Events (cost tracking ledger) ─────────────────────────
+
+export const llmUsageEvents = sqliteTable('llm_usage_events', {
+  id: text('id').primaryKey(),
+  createdAt: integer('created_at').notNull(),
+  assistantId: text('assistant_id'),
+  conversationId: text('conversation_id'),
+  runId: text('run_id'),
+  requestId: text('request_id'),
+  actor: text('actor').notNull(),
+  provider: text('provider').notNull(),
+  model: text('model').notNull(),
+  inputTokens: integer('input_tokens').notNull(),
+  outputTokens: integer('output_tokens').notNull(),
+  cacheCreationInputTokens: integer('cache_creation_input_tokens'),
+  cacheReadInputTokens: integer('cache_read_input_tokens'),
+  estimatedCostUsd: real('estimated_cost_usd'),
+  pricingStatus: text('pricing_status').notNull(),
+  metadataJson: text('metadata_json'),
+});


### PR DESCRIPTION
## Summary
- Add `llm_usage_events` Drizzle schema table definition for tracking LLM token consumption and estimated costs per actor/provider/model
- Add idempotent `CREATE TABLE IF NOT EXISTS` migration with 5 performance indexes (created_at, assistant_id, provider, model, actor)
- Add `recordUsageEvent()` and `listUsageEvents()` store functions following existing store patterns
- Add comprehensive test suite (10 tests) covering priced/unpriced events, null optional fields, descending order, and limit behavior

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 10 tests pass (`bun test src/__tests__/llm-usage-store.test.ts`)
- [x] Verified priced and unpriced event persistence
- [x] Verified null optional fields (assistantId, conversationId, runId, requestId, cache tokens)
- [x] Verified populated optional fields round-trip correctly
- [x] Verified descending createdAt ordering
- [x] Verified limit option is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
