### PR TITLE
Restyle VToggle: pill/circle to rounded-rect/rounded-square

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
@@ -38,16 +38,16 @@ struct VToggle: View {
     private var toggleTrack: some View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
-            RoundedRectangle(cornerRadius: VRadius.pill)
+            RoundedRectangle(cornerRadius: VRadius.sm + 2)
                 .fill(isOn ? Emerald._500 : Slate._700)
                 .frame(width: trackWidth, height: trackHeight)
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.pill)
+                    RoundedRectangle(cornerRadius: VRadius.sm + 2)
                         .stroke(Slate._600, lineWidth: 1)
                 )
 
             // Knob
-            Circle()
+            RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(Color.white)
                 .frame(width: knobSize, height: knobSize)
                 .padding(.horizontal, knobPadding)


### PR DESCRIPTION
## Summary
- Track corner radius changed from `VRadius.pill` (999pt, fully rounded) to `VRadius.sm + 2` (6pt, squared)
- Knob shape changed from `Circle` to `RoundedRectangle(cornerRadius: VRadius.sm)` (4pt, squared)

This completes the VToggle UI restyle that was part of M2 (#1262) but couldn't be applied due to worktree file permission restrictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
