### PR TITLE
M4: Support provider-aware pricing catalog and custom model overrides

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -1,0 +1,236 @@
+import { describe, test, expect } from 'bun:test';
+import { estimateCost, resolvePricing, resolvePricingWithOverrides } from '../util/pricing.js';
+import type { ModelPricingOverride } from '../config/schema.js';
+
+describe('resolvePricing', () => {
+  describe('Anthropic models', () => {
+    test('returns priced for claude-opus-4', () => {
+      const result = resolvePricing('anthropic', 'claude-opus-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(15 + 75);
+    });
+
+    test('returns priced for claude-sonnet-4', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(3 + 15);
+    });
+
+    test('returns priced for claude-haiku-4', () => {
+      const result = resolvePricing('anthropic', 'claude-haiku-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.80 + 4);
+    });
+  });
+
+  describe('OpenAI models', () => {
+    test('returns priced for gpt-4o', () => {
+      const result = resolvePricing('openai', 'gpt-4o', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.50 + 10);
+    });
+
+    test('returns priced for gpt-4o-mini', () => {
+      const result = resolvePricing('openai', 'gpt-4o-mini', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('returns priced for gpt-4.1', () => {
+      const result = resolvePricing('openai', 'gpt-4.1', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.00 + 8.00);
+    });
+
+    test('returns priced for o3', () => {
+      const result = resolvePricing('openai', 'o3', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.00 + 8.00);
+    });
+
+    test('returns priced for o4-mini', () => {
+      const result = resolvePricing('openai', 'o4-mini', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.10 + 4.40);
+    });
+  });
+
+  describe('Gemini models', () => {
+    test('returns priced for gemini-2.5-pro', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-pro', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.25 + 10);
+    });
+
+    test('returns priced for gemini-2.5-flash', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-flash', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('returns priced for gemini-2.0-flash', () => {
+      const result = resolvePricing('gemini', 'gemini-2.0-flash', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.10 + 0.40);
+    });
+  });
+
+  describe('unknown models', () => {
+    test('returns unpriced with null cost for unknown model', () => {
+      const result = resolvePricing('anthropic', 'unknown-model-xyz', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+
+    test('returns unpriced for unknown provider', () => {
+      const result = resolvePricing('unknown-provider', 'some-model', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+  });
+
+  describe('Ollama (local) models', () => {
+    test('returns unpriced for ollama models', () => {
+      const result = resolvePricing('ollama', 'llama3:latest', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+
+    test('returns unpriced for ollama with any model name', () => {
+      const result = resolvePricing('ollama', 'mistral:7b', 500_000, 500_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+  });
+
+  describe('prefix matching', () => {
+    test('matches claude-sonnet-4-5-20250929 via claude-sonnet-4 prefix', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(3 + 15);
+    });
+
+    test('matches claude-opus-4-5-20250929 via claude-opus-4 prefix', () => {
+      const result = resolvePricing('anthropic', 'claude-opus-4-5-20250929', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(15 + 75);
+    });
+
+    test('matches gpt-4o-mini-2024-07-18 via gpt-4o-mini prefix', () => {
+      const result = resolvePricing('openai', 'gpt-4o-mini-2024-07-18', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('matches gemini-2.5-pro-preview via gemini-2.5-pro prefix', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-pro-preview', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.25 + 10);
+    });
+  });
+
+  describe('cost calculation', () => {
+    test('calculates correctly with fractional token counts', () => {
+      // 500k input, 200k output with claude-sonnet-4 pricing (3/15 per 1M)
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 500_000, 200_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBeCloseTo(0.5 * 3 + 0.2 * 15, 10);
+    });
+
+    test('returns 0 cost for zero tokens', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 0, 0);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0);
+    });
+  });
+});
+
+describe('resolvePricingWithOverrides', () => {
+  test('uses override when matching provider and modelPattern', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 5, outputPer1M: 25 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test('override prefix matching works with version suffixes', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 5, outputPer1M: 25 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test('falls back to built-in catalog when no override matches', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'openai', modelPattern: 'gpt-4o', inputPer1M: 99, outputPer1M: 99 },
+    ];
+    // Different provider, so override should not match
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('falls back to built-in catalog with empty overrides array', () => {
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, []);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('falls back to built-in catalog with no overrides argument', () => {
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('override can price a previously unpriced provider/model', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'ollama', modelPattern: 'llama3', inputPer1M: 0, outputPer1M: 0 },
+    ];
+    const result = resolvePricingWithOverrides('ollama', 'llama3:latest', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(0);
+  });
+
+  test('longest modelPattern prefix wins among overrides', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet', inputPer1M: 1, outputPer1M: 1 },
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 99, outputPer1M: 99 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(99 + 99);
+  });
+});
+
+describe('estimateCost (backward compatibility)', () => {
+  test('returns a number for known Claude model', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-sonnet-4-5-20250929');
+    expect(typeof cost).toBe('number');
+    expect(cost).toBe(3 + 15);
+  });
+
+  test('returns 0 for unknown model', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'unknown-model');
+    expect(cost).toBe(0);
+  });
+
+  test('returns correct cost for claude-opus-4 via prefix match', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-opus-4-5-20250929');
+    expect(cost).toBe(15 + 75);
+  });
+
+  test('returns correct cost for claude-haiku-4 via prefix match', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-haiku-4-5-20251001');
+    expect(cost).toBe(0.80 + 4);
+  });
+
+  test('always returns number type, never null', () => {
+    const cost = estimateCost(500_000, 500_000, 'nonexistent-model');
+    expect(typeof cost).toBe('number');
+    expect(cost).toBe(0);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -65,6 +65,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   auditLog: {
     retentionDays: 0,
   },
+  pricingOverrides: [],
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -207,6 +207,17 @@ export const MemoryConfigSchema = z.object({
   }),
 });
 
+export const ModelPricingOverrideSchema = z.object({
+  provider: z.string({ error: 'pricingOverrides[].provider must be a string' }),
+  modelPattern: z.string({ error: 'pricingOverrides[].modelPattern must be a string' }),
+  inputPer1M: z
+    .number({ error: 'pricingOverrides[].inputPer1M must be a number' })
+    .nonnegative('pricingOverrides[].inputPer1M must be a non-negative number'),
+  outputPer1M: z
+    .number({ error: 'pricingOverrides[].outputPer1M must be a number' })
+    .nonnegative('pricingOverrides[].outputPer1M must be a non-negative number'),
+});
+
 export const AssistantConfigSchema = z.object({
   provider: z
     .enum(VALID_PROVIDERS, {
@@ -288,6 +299,9 @@ export const AssistantConfigSchema = z.object({
   auditLog: AuditLogConfigSchema.default({
     retentionDays: 0,
   }),
+  pricingOverrides: z
+    .array(ModelPricingOverrideSchema)
+    .default([]),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -319,3 +333,4 @@ export type MemorySegmentationConfig = z.infer<typeof MemorySegmentationConfigSc
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
+export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -13,4 +13,5 @@ export type {
   MemoryJobsConfig,
   MemoryRetentionConfig,
   MemoryConfig,
+  ModelPricingOverride,
 } from './schema.js';

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -1,8 +1,15 @@
+import type { PricingResult } from '../usage/types.js';
+import type { ModelPricingOverride } from '../config/schema.js';
+
 interface ModelPricing {
   inputPer1M: number;  // USD per 1M input tokens
   outputPer1M: number; // USD per 1M output tokens
 }
 
+/**
+ * Legacy pricing table keyed by exact model string.
+ * Kept for backward compatibility with estimateCost().
+ */
 const PRICING: Record<string, ModelPricing> = {
   'claude-opus-4-5-20250929':   { inputPer1M: 15, outputPer1M: 75 },
   'claude-sonnet-4-5-20250929': { inputPer1M: 3, outputPer1M: 15 },
@@ -10,17 +17,147 @@ const PRICING: Record<string, ModelPricing> = {
 };
 
 /**
+ * Multi-provider pricing catalog keyed by provider then model pattern.
+ * Model patterns are matched by exact match first, then by prefix.
+ */
+const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
+  anthropic: {
+    'claude-opus-4': { inputPer1M: 15, outputPer1M: 75 },
+    'claude-sonnet-4': { inputPer1M: 3, outputPer1M: 15 },
+    'claude-haiku-4': { inputPer1M: 0.80, outputPer1M: 4 },
+  },
+  openai: {
+    'gpt-4o': { inputPer1M: 2.50, outputPer1M: 10 },
+    'gpt-4o-mini': { inputPer1M: 0.15, outputPer1M: 0.60 },
+    'gpt-4.1': { inputPer1M: 2.00, outputPer1M: 8.00 },
+    'gpt-4.1-mini': { inputPer1M: 0.40, outputPer1M: 1.60 },
+    'gpt-4.1-nano': { inputPer1M: 0.10, outputPer1M: 0.40 },
+    'o3': { inputPer1M: 2.00, outputPer1M: 8.00 },
+    'o3-mini': { inputPer1M: 1.10, outputPer1M: 4.40 },
+    'o3-pro': { inputPer1M: 20, outputPer1M: 80 },
+    'o4-mini': { inputPer1M: 1.10, outputPer1M: 4.40 },
+  },
+  gemini: {
+    'gemini-2.5-pro': { inputPer1M: 1.25, outputPer1M: 10 },
+    'gemini-2.5-flash': { inputPer1M: 0.15, outputPer1M: 0.60 },
+    'gemini-2.0-flash': { inputPer1M: 0.10, outputPer1M: 0.40 },
+  },
+};
+
+/**
+ * Look up pricing for a model within a provider's catalog.
+ * Tries exact match first, then longest prefix match.
+ */
+function findPricing(catalog: Record<string, ModelPricing>, model: string): ModelPricing | undefined {
+  // Exact match
+  if (catalog[model]) return catalog[model];
+
+  // Prefix match: find the longest matching prefix
+  let bestMatch: ModelPricing | undefined;
+  let bestLen = 0;
+  for (const [pattern, pricing] of Object.entries(catalog)) {
+    if (model.startsWith(pattern) && pattern.length > bestLen) {
+      bestMatch = pricing;
+      bestLen = pattern.length;
+    }
+  }
+  return bestMatch;
+}
+
+/**
+ * Calculate cost from pricing and token counts.
+ */
+function calculateCost(pricing: ModelPricing, inputTokens: number, outputTokens: number): number {
+  return (inputTokens / 1_000_000) * pricing.inputPer1M
+       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+}
+
+/**
+ * Resolve pricing for a provider/model combination using the built-in catalog.
+ * Returns a PricingResult with explicit priced/unpriced status.
+ */
+export function resolvePricing(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): PricingResult {
+  const providerCatalog = PROVIDER_PRICING[provider];
+  if (!providerCatalog) {
+    return { estimatedCostUsd: null, pricingStatus: 'unpriced' };
+  }
+
+  const pricing = findPricing(providerCatalog, model);
+  if (!pricing) {
+    return { estimatedCostUsd: null, pricingStatus: 'unpriced' };
+  }
+
+  return {
+    estimatedCostUsd: calculateCost(pricing, inputTokens, outputTokens),
+    pricingStatus: 'priced',
+  };
+}
+
+/**
+ * Resolve pricing with optional custom model overrides checked first.
+ * Overrides are matched by provider (exact) and modelPattern (prefix match).
+ * Falls back to the built-in catalog if no override matches.
+ */
+export function resolvePricingWithOverrides(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  overrides?: ModelPricingOverride[],
+): PricingResult {
+  if (overrides && overrides.length > 0) {
+    // Find matching overrides for this provider, use longest modelPattern prefix match
+    let bestOverride: ModelPricingOverride | undefined;
+    let bestLen = 0;
+    for (const override of overrides) {
+      if (override.provider !== provider) continue;
+      // Exact match or prefix match on modelPattern
+      if (model === override.modelPattern || model.startsWith(override.modelPattern)) {
+        if (override.modelPattern.length > bestLen) {
+          bestOverride = override;
+          bestLen = override.modelPattern.length;
+        }
+      }
+    }
+    if (bestOverride) {
+      const cost = calculateCost(
+        { inputPer1M: bestOverride.inputPer1M, outputPer1M: bestOverride.outputPer1M },
+        inputTokens,
+        outputTokens,
+      );
+      return { estimatedCostUsd: cost, pricingStatus: 'priced' };
+    }
+  }
+
+  return resolvePricing(provider, model, inputTokens, outputTokens);
+}
+
+/**
  * Estimate cost in USD for the given token counts and model.
  * Returns 0 if the model is not in the pricing table.
+ *
+ * @deprecated Prefer resolvePricing() or resolvePricingWithOverrides() for
+ * provider-aware pricing with explicit priced/unpriced status.
  */
 export function estimateCost(
   inputTokens: number,
   outputTokens: number,
   model: string,
 ): number {
+  // Try the new provider-aware catalog first (default to anthropic for backward compat)
+  const result = resolvePricing('anthropic', model, inputTokens, outputTokens);
+  if (result.pricingStatus === 'priced' && result.estimatedCostUsd !== null) {
+    return result.estimatedCostUsd;
+  }
+
+  // Fall back to legacy exact/prefix matching on the old PRICING table
   const pricing = PRICING[model]
     ?? Object.entries(PRICING).find(([key]) => model.startsWith(key))?.[1];
   if (!pricing) return 0;
-  return (inputTokens / 1_000_000) * pricing.inputPer1M
-       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+  return calculateCost(pricing, inputTokens, outputTokens);
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded Claude-only pricing in `pricing.ts` with a multi-provider `PROVIDER_PRICING` catalog covering Anthropic, OpenAI, and Gemini models
- Add `resolvePricing()` and `resolvePricingWithOverrides()` functions that return `PricingResult` with explicit `priced`/`unpriced` status and nullable cost
- Add `ModelPricingOverrideSchema` to config schema and `pricingOverrides: []` default so users can define custom per-model pricing
- Preserve backward-compatible `estimateCost()` API unchanged (returns `number`, 0 for unknown)
- Prefix matching handles versioned model strings (e.g. `claude-sonnet-4-5-20250929` matches `claude-sonnet-4`)

## Test plan
- [x] `resolvePricing` returns priced for known Anthropic models
- [x] `resolvePricing` returns priced for known OpenAI models
- [x] `resolvePricing` returns priced for known Gemini models
- [x] `resolvePricing` returns unpriced with null cost for unknown models
- [x] `resolvePricing` returns unpriced for Ollama (local) models
- [x] `resolvePricingWithOverrides` uses overrides when matching
- [x] Prefix matching works with version suffixes
- [x] `estimateCost()` backward compat: still returns number (0 for unknown)
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
