### PR TITLE
Add tab-complete suggestions to desktop app

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -176,6 +176,14 @@ exports[`IPC message snapshots ClientMessage types skill_detail serializes to ex
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types suggestion_request serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "sessionId": "sess-001",
+  "type": "suggestion_request",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",
@@ -559,6 +567,15 @@ Do the thing."
 ,
   "skillId": "my-skill",
   "type": "skill_detail_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "source": "llm",
+  "suggestion": "Tell me more about that",
+  "type": "suggestion_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -125,6 +125,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skill_detail',
     skillId: 'my-skill',
   },
+  suggestion_request: {
+    type: 'suggestion_request',
+    sessionId: 'sess-001',
+    requestId: 'req-suggest-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -354,6 +359,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'skill_detail_response',
     skillId: 'my-skill',
     body: '# Skill content\n\nDo the thing.',
+  },
+  suggestion_response: {
+    type: 'suggestion_response',
+    requestId: 'req-suggest-001',
+    suggestion: 'Tell me more about that',
+    source: 'llm',
   },
   message_queued: {
     type: 'message_queued',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,5 +1,6 @@
 import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
+import Anthropic from '@anthropic-ai/sdk';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -26,6 +27,7 @@ import type {
   TaskSubmit,
   AppDataRequest,
   SkillDetailRequest,
+  SuggestionRequest,
 } from './ipc-protocol.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
@@ -287,6 +289,7 @@ const handlers: DispatchMap = {
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
+  suggestion_request: handleSuggestionRequest,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -788,6 +791,117 @@ async function handleTaskSubmit(
     rlog.error({ err }, 'Error handling task_submit');
     ctx.send(socket, { type: 'error', message: `Failed to route task: ${message}` });
   }
+}
+
+// ─── Suggestion handler ─────────────────────────────────────────────────────
+
+const SUGGESTION_CACHE_MAX = 100;
+const suggestionCache = new Map<string, string>();
+const suggestionInFlight = new Map<string, Promise<string | null>>();
+
+async function handleSuggestionRequest(
+  msg: SuggestionRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const noSuggestion = () => {
+    ctx.send(socket, {
+      type: 'suggestion_response',
+      requestId: msg.requestId,
+      suggestion: null,
+      source: 'none' as const,
+    });
+  };
+
+  const rawMessages = conversationStore.getMessages(msg.sessionId);
+  if (rawMessages.length === 0) { noSuggestion(); return; }
+
+  // Walk backwards to find the last assistant message with text content
+  for (let i = rawMessages.length - 1; i >= 0; i--) {
+    const m = rawMessages[i];
+    if (m.role !== 'assistant') continue;
+
+    let content: unknown;
+    try { content = JSON.parse(m.content); } catch { content = m.content; }
+    const rendered = renderHistoryContent(content);
+    const text = rendered.text.trim();
+    if (!text) continue;
+
+    // Return cached suggestion
+    const cached = suggestionCache.get(m.id);
+    if (cached !== undefined) {
+      ctx.send(socket, {
+        type: 'suggestion_response',
+        requestId: msg.requestId,
+        suggestion: cached,
+        source: 'llm' as const,
+      });
+      return;
+    }
+
+    // Try LLM suggestion if an Anthropic API key is configured
+    const apiKey = getConfig().apiKeys.anthropic;
+    if (apiKey) {
+      try {
+        let promise = suggestionInFlight.get(m.id);
+        if (!promise) {
+          promise = generateSuggestion(apiKey, text);
+          suggestionInFlight.set(m.id, promise);
+        }
+        const llmSuggestion = await promise;
+        suggestionInFlight.delete(m.id);
+
+        if (llmSuggestion) {
+          if (suggestionCache.size >= SUGGESTION_CACHE_MAX) {
+            const oldest = suggestionCache.keys().next().value!;
+            suggestionCache.delete(oldest);
+          }
+          suggestionCache.set(m.id, llmSuggestion);
+
+          ctx.send(socket, {
+            type: 'suggestion_response',
+            requestId: msg.requestId,
+            suggestion: llmSuggestion,
+            source: 'llm' as const,
+          });
+          return;
+        }
+      } catch (err) {
+        suggestionInFlight.delete(m.id);
+        log.warn({ err }, 'LLM suggestion failed');
+      }
+    }
+
+    noSuggestion();
+    return;
+  }
+
+  noSuggestion();
+}
+
+async function generateSuggestion(apiKey: string, assistantText: string): Promise<string | null> {
+  const client = new Anthropic({ apiKey });
+  const truncated = assistantText.length > 2000
+    ? assistantText.slice(-2000)
+    : assistantText;
+
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 60,
+    messages: [
+      {
+        role: 'user',
+        content: `The AI assistant just said the following to the user. Suggest a single short follow-up message (max 200 chars) the user might want to send next. Reply with ONLY the suggested message text, nothing else.\n\nAssistant's message:\n${truncated}`,
+      },
+    ],
+  });
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+  if (!raw || raw.length > 200) return null;
+
+  const firstLine = raw.split('\n')[0].trim();
+  return firstLine || null;
 }
 
 // ─── Computer-use handlers ──────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -149,6 +149,12 @@ export interface SkillDetailRequest {
   skillId: string;
 }
 
+export interface SuggestionRequest {
+  type: 'suggestion_request';
+  sessionId: string;
+  requestId: string;
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -251,7 +257,8 @@ export type ClientMessage =
   | UiSurfaceAction
   | AppDataRequest
   | SkillsListRequest
-  | SkillDetailRequest;
+  | SkillDetailRequest
+  | SuggestionRequest;
 
 // === Server → Client messages ===
 
@@ -497,6 +504,13 @@ export interface SkillDetailResponse {
   error?: string;
 }
 
+export interface SuggestionResponse {
+  type: 'suggestion_response';
+  requestId: string;
+  suggestion: string | null;
+  source: 'llm' | 'none';
+}
+
 export interface MessageQueued {
   type: 'message_queued';
   sessionId: string;
@@ -604,6 +618,7 @@ export type ServerMessage =
   | AppDataResponse
   | SkillsListResponse
   | SkillDetailResponse
+  | SuggestionResponse
   | MessageQueued
   | MessageDequeued;
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -7,9 +7,22 @@ struct ChatView: View {
     let isSending: Bool
     let errorText: String?
     let pendingQueuedCount: Int
+    let suggestion: String?
     let onSend: () -> Void
     let onStop: () -> Void
     let onDismissError: () -> Void
+    let onAcceptSuggestion: () -> Void
+
+    /// The portion of the suggestion that extends beyond the current input.
+    private var ghostSuffix: String? {
+        guard let suggestion else { return nil }
+        if suggestion.hasPrefix(inputText) {
+            let suffix = String(suggestion.dropFirst(inputText.count))
+            return suffix.isEmpty ? nil : suffix
+        }
+        if inputText.isEmpty { return suggestion }
+        return nil
+    }
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -138,18 +151,46 @@ struct ChatView: View {
             // Leading chat icon
             VCircleButton(icon: "phone.fill", label: "Phone") { }
 
-            // Text field
-            TextField("What you need chef?", text: $inputText, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(VFont.mono)
-                .foregroundColor(VColor.textPrimary)
-                .lineLimit(1...3)
-                .onKeyPress(.return, phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.shift) { return .ignored }
-                    if canSend { onSend() }
-                    return .handled
+            // Text field with ghost suffix overlay
+            ZStack(alignment: .leading) {
+                TextField("What you need chef?", text: $inputText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1...3)
+                    .onKeyPress(.tab, phases: .down) { keyPress in
+                        if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
+                            onAcceptSuggestion()
+                            return .handled
+                        }
+                        return .ignored
+                    }
+                    .onKeyPress(.return, phases: .down) { keyPress in
+                        if keyPress.modifiers.contains(.shift) { return .ignored }
+                        if canSend { onSend() }
+                        return .handled
+                    }
+                    .onSubmit { if canSend { onSend() } }
+
+                if let ghostSuffix {
+                    Text(inputText + ghostSuffix)
+                        .font(VFont.mono)
+                        .foregroundColor(.clear)
+                        .lineLimit(1...3)
+                        .overlay(alignment: .leading) {
+                            HStack(spacing: 0) {
+                                Text(inputText)
+                                    .font(VFont.mono)
+                                    .foregroundColor(.clear)
+                                Text(ghostSuffix)
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textMuted.opacity(0.5))
+                            }
+                        }
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
                 }
-                .onSubmit { if canSend { onSend() } }
+            }
 
             // Attachment / Stop button
             if isSending {
@@ -353,9 +394,11 @@ private struct ThinkingIndicator: View {
             isSending: false,
             errorText: nil,
             pendingQueuedCount: 0,
+            suggestion: "That sounds great, thanks!",
             onSend: {},
             onStop: {},
-            onDismissError: {}
+            onDismissError: {},
+            onAcceptSuggestion: {}
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -11,6 +11,7 @@ final class ChatViewModel: ObservableObject {
     @Published var isSending: Bool = false
     @Published var errorText: String?
     @Published var pendingQueuedCount: Int = 0
+    @Published var suggestion: String?
 
     private let daemonClient: DaemonClient
     var sessionId: String?
@@ -30,6 +31,8 @@ final class ChatViewModel: ObservableObject {
     private var requestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
     private var pendingMessageIds: [UUID] = []
+    /// Tracks the current in-flight suggestion request so stale responses are ignored.
+    private var pendingSuggestionRequestId: String?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -58,6 +61,8 @@ final class ChatViewModel: ObservableObject {
             pendingMessageIds.append(userMessage.id)
         }
         inputText = ""
+        suggestion = nil
+        pendingSuggestionRequestId = nil
         errorText = nil
 
         if sessionId == nil {
@@ -246,6 +251,12 @@ final class ChatViewModel: ObservableObject {
                 messages.append(msg)
             }
 
+        case .suggestionResponse(let resp):
+            // Only accept if this response matches our current request
+            guard resp.requestId == pendingSuggestionRequestId else { return }
+            pendingSuggestionRequestId = nil
+            suggestion = resp.suggestion
+
         case .messageComplete(let complete):
             guard belongsToSession(complete.sessionId) else { return }
             isCancelling = false
@@ -265,6 +276,10 @@ final class ChatViewModel: ObservableObject {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
+            }
+            // Fetch a follow-up suggestion when the turn is fully complete
+            if !isSending {
+                fetchSuggestion()
             }
 
         case .generationCancelled(let cancelled):
@@ -452,6 +467,34 @@ final class ChatViewModel: ObservableObject {
 
     func dismissError() {
         errorText = nil
+    }
+
+    /// Ask the daemon for a follow-up suggestion for the current session.
+    private func fetchSuggestion() {
+        guard let sessionId, daemonClient.isConnected else { return }
+
+        let requestId = UUID().uuidString
+        pendingSuggestionRequestId = requestId
+
+        do {
+            try daemonClient.send(SuggestionRequestMessage(
+                sessionId: sessionId,
+                requestId: requestId
+            ))
+        } catch {
+            log.error("Failed to send suggestion_request: \(error.localizedDescription)")
+            pendingSuggestionRequestId = nil
+        }
+    }
+
+    /// Accept the current suggestion, appending the ghost suffix to input.
+    func acceptSuggestion() {
+        guard let suggestion else { return }
+        if suggestion.hasPrefix(inputText) {
+            inputText = suggestion
+        } else if inputText.isEmpty {
+            inputText = suggestion
+        }
     }
 
     deinit {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -39,9 +39,11 @@ struct MainWindowView: View {
                         isSending: viewModel.isSending,
                         errorText: viewModel.errorText,
                         pendingQueuedCount: viewModel.pendingQueuedCount,
+                        suggestion: viewModel.suggestion,
                         onSend: viewModel.sendMessage,
                         onStop: viewModel.stopGenerating,
-                        onDismissError: viewModel.dismissError
+                        onDismissError: viewModel.dismissError,
+                        onAcceptSuggestion: viewModel.acceptSuggestion
                     )
                 }
             }, panel: {

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -400,6 +400,14 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Follow-up suggestion response from daemon.
+/// Wire type: `"suggestion_response"`
+struct SuggestionResponseMessage: Decodable, Sendable {
+    let requestId: String
+    let suggestion: String?
+    let source: String
+}
+
 /// Permission confirmation request from daemon.
 /// Wire type: `"confirmation_request"`
 struct ConfirmationRequestMessage: Decodable, Sendable {
@@ -426,6 +434,14 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
         let newContent: String
         let isNewFile: Bool
     }
+}
+
+/// Request a follow-up suggestion for the current session.
+/// Wire type: `"suggestion_request"`
+struct SuggestionRequestMessage: Encodable, Sendable {
+    let type: String = "suggestion_request"
+    let sessionId: String
+    let requestId: String
 }
 
 /// Client response to a permission confirmation request.
@@ -462,6 +478,7 @@ enum ServerMessage: Decodable, Sendable {
     case messageDequeued(MessageDequeuedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
+    case suggestionResponse(SuggestionResponseMessage)
     case pong
     case unknown(String)
 
@@ -537,6 +554,9 @@ enum ServerMessage: Decodable, Sendable {
         case "skill_detail_response":
             let message = try SkillDetailResponseMessage(from: decoder)
             self = .skillDetailResponse(message)
+        case "suggestion_response":
+            let message = try SuggestionResponseMessage(from: decoder)
+            self = .suggestionResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Port the web app's LLM-powered tab completion to the macOS desktop app
- Add `suggestion_request` / `suggestion_response` IPC messages so the daemon generates follow-up suggestions via Claude Haiku after each assistant turn
- Render ghost text in the chat composer and accept it with Tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
