### PR TITLE
Restyle ControlPanel to match design mockup

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -12,10 +12,6 @@ struct VSplitView<Main: View, Panel: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if showPanel, let panel = panel {
-                Divider()
-                    .background(VColor.surfaceBorder)
-                    .transition(.move(edge: .trailing))
-
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -19,6 +19,8 @@ struct VSplitView<Main: View, Panel: View>: View {
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .padding(VSpacing.sm)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct CardModifier: ViewModifier {
     var radius: CGFloat = VRadius.md
+    var background: Color = VColor.surface
 
     func body(content: Content) -> some View {
         content
-            .background(VColor.surface)
+            .background(background)
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
@@ -15,8 +16,8 @@ struct CardModifier: ViewModifier {
 }
 
 extension View {
-    func vCard(radius: CGFloat = VRadius.md) -> some View {
-        modifier(CardModifier(radius: radius))
+    func vCard(radius: CGFloat = VRadius.md, background: Color = VColor.surface) -> some View {
+        modifier(CardModifier(radius: radius, background: background))
     }
 }
 

--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
@@ -38,16 +38,16 @@ struct VToggle: View {
     private var toggleTrack: some View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
-            RoundedRectangle(cornerRadius: VRadius.pill)
+            RoundedRectangle(cornerRadius: VRadius.sm + 2)
                 .fill(isOn ? Emerald._500 : Slate._700)
                 .frame(width: trackWidth, height: trackHeight)
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.pill)
+                    RoundedRectangle(cornerRadius: VRadius.sm + 2)
                         .stroke(Slate._600, lineWidth: 1)
                 )
 
             // Knob
-            Circle()
+            RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(Color.white)
                 .frame(width: knobSize, height: knobSize)
                 .padding(.horizontal, knobPadding)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -13,43 +13,45 @@ struct MainWindowView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Row 1 — thread tab bar
-            ThreadTabBar(
-                threads: threadManager.threads,
-                activeThreadId: threadManager.activeThreadId,
-                onSelect: { threadManager.selectThread(id: $0) },
-                onClose: { threadManager.closeThread(id: $0) },
-                onCreate: { threadManager.createThread() }
-            )
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                // Row 1 — thread tab bar
+                ThreadTabBar(
+                    threads: threadManager.threads,
+                    activeThreadId: threadManager.activeThreadId,
+                    onSelect: { threadManager.selectThread(id: $0) },
+                    onClose: { threadManager.closeThread(id: $0) },
+                    onCreate: { threadManager.createThread() }
+                )
 
-            // Row 2 — navigation toolbar
-            NavigationToolbar(activePanel: $activePanel)
+                // Row 2 — navigation toolbar
+                NavigationToolbar(activePanel: $activePanel)
 
-            // Row 3 — chat content with optional side panel
-            VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
-                if let viewModel = threadManager.activeViewModel {
-                    ChatView(
-                        messages: viewModel.messages,
-                        inputText: Binding(
-                            get: { viewModel.inputText },
-                            set: { viewModel.inputText = $0 }
-                        ),
-                        isThinking: viewModel.isThinking,
-                        isSending: viewModel.isSending,
-                        errorText: viewModel.errorText,
-                        pendingQueuedCount: viewModel.pendingQueuedCount,
-                        onSend: viewModel.sendMessage,
-                        onStop: viewModel.stopGenerating,
-                        onDismissError: viewModel.dismissError
-                    )
-                }
-            }, panel: {
-                panelContent
-            })
+                // Row 3 — chat content with optional side panel
+                VSplitView(panelWidth: geometry.size.width * 0.5, showPanel: activePanel != nil, main: {
+                    if let viewModel = threadManager.activeViewModel {
+                        ChatView(
+                            messages: viewModel.messages,
+                            inputText: Binding(
+                                get: { viewModel.inputText },
+                                set: { viewModel.inputText = $0 }
+                            ),
+                            isThinking: viewModel.isThinking,
+                            isSending: viewModel.isSending,
+                            errorText: viewModel.errorText,
+                            pendingQueuedCount: viewModel.pendingQueuedCount,
+                            onSend: viewModel.sendMessage,
+                            onStop: viewModel.stopGenerating,
+                            onDismissError: viewModel.dismissError
+                        )
+                    }
+                }, panel: {
+                    panelContent
+                })
+            }
+            .ignoresSafeArea(edges: .top)
+            .background(VColor.background.ignoresSafeArea())
         }
-        .ignoresSafeArea(edges: .top)
-        .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -29,8 +29,6 @@ struct ControlPanel: View {
                 .frame(width: 100)
                 .padding(.top, VSpacing.md)
 
-                Divider()
-
                 // Right content
                 ScrollView {
                     Group {
@@ -132,7 +130,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // COMPUTER USAGE section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -156,7 +154,7 @@ struct ControlPanel: View {
                 VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // AMBIENT AGENT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -179,7 +177,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // PERMISSIONS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -193,7 +191,7 @@ struct ControlPanel: View {
                     granted: PermissionManager.accessibilityStatus() == .granted
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "record.circle",
@@ -201,7 +199,7 @@ struct ControlPanel: View {
                     granted: PermissionManager.screenRecordingStatus() == .granted
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "key",
@@ -209,10 +207,10 @@ struct ControlPanel: View {
                     granted: APIKeyManager.getKey() != nil
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // ABOUT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -241,7 +239,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -78,7 +78,7 @@ struct ControlPanel: View {
                 .padding(.vertical, VSpacing.xs)
         }
         .buttonStyle(.plain)
-        .background(selected ? VColor.surface : Color.clear)
+        .background(selected ? Slate._700 : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         .vHover()
     }
@@ -164,11 +164,15 @@ struct ControlPanel: View {
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack(spacing: VSpacing.xs) {
-                    VToggle(isOn: $ambientEnabled, label: "Enable ambient screen watching")
+                HStack {
+                    Text("Enable ambient screen watching")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
                     Image(systemName: "info.circle")
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
+                    Spacer()
+                    VToggle(isOn: $ambientEnabled)
                 }
                 .onChange(of: ambientEnabled) { _, newValue in
                     ambientAgent.isEnabled = newValue
@@ -188,18 +192,24 @@ struct ControlPanel: View {
                     label: "Accessibility",
                     granted: PermissionManager.accessibilityStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard()
 
                 permissionRow(
                     icon: "record.circle",
                     label: "Screen Recording",
                     granted: PermissionManager.screenRecordingStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard()
 
                 permissionRow(
                     icon: "key",
                     label: "API Key",
                     granted: APIKeyManager.getKey() != nil
                 )
+                .padding(VSpacing.md)
+                .vCard()
             }
             .padding(VSpacing.lg)
             .vCard()


### PR DESCRIPTION
## Summary
Restyled the ControlPanel side panel to match the UI design mockup, including panel dimensions, navigation, toggle, and permission row styling.

## Changes
- Panel takes 50% of viewport width (via GeometryReader) with rounded corners and padding
- Nav button selected state uses Slate._700 background (was invisible since VColor.surface = VColor.backgroundSubtle = Slate._800)
- VToggle restyled from pill track + circle knob to rounded-rect track + rounded-square knob
- Ambient Agent toggle: label+info on left, toggle on right
- Permission rows: each wrapped in individual .vCard() bordered containers

## Milestone PRs (merged into feature branch)
- #1267: M1: Panel 50% width + rounded corners
- #1263: M2: Fix ControlPanel UI — nav button, ambient toggle, permission rows
- #1272: Restyle VToggle: pill/circle to rounded-rect/rounded-square

## Project issue
Closes #1255

## Test plan
- [ ] Panel opens at 50% window width with rounded corners
- [ ] Nav button "Settings" shows visible selected chip (Slate._700)
- [ ] VToggle has squared track and knob shape
- [ ] Ambient Agent: label on left, toggle on right
- [ ] Each permission row has its own bordered card
- [ ] Build succeeds: `cd clients/macos && swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
