### PR TITLE
Add inline confirmation data model and ViewModel routing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -11,6 +11,23 @@ enum ChatMessageStatus: Equatable {
     case processing
 }
 
+/// Tracks the state of an inline tool confirmation request.
+enum ToolConfirmationState: Equatable {
+    case pending
+    case approved
+    case denied
+    case timedOut
+}
+
+/// Data for an inline tool confirmation message displayed in chat.
+struct ToolConfirmationData: Equatable {
+    let requestId: String
+    let toolName: String
+    let riskLevel: String
+    let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    var state: ToolConfirmationState = .pending
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
@@ -18,13 +35,16 @@ struct ChatMessage: Identifiable {
     let timestamp: Date
     var isStreaming: Bool
     var status: ChatMessageStatus
+    /// Non-nil when this message is an inline tool confirmation request.
+    var confirmation: ToolConfirmationData?
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil) {
         self.id = id
         self.role = role
         self.text = text
         self.timestamp = timestamp
         self.isStreaming = isStreaming
         self.status = status
+        self.confirmation = confirmation
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -391,6 +391,21 @@ final class ChatViewModel: ObservableObject {
                 requestIdToMessageId = [:]
             }
 
+        case .confirmationRequest(let msg):
+            guard belongsToSession(nil) else { return }
+            let confirmation = ToolConfirmationData(
+                requestId: msg.requestId,
+                toolName: msg.toolName,
+                riskLevel: msg.riskLevel,
+                diff: msg.diff
+            )
+            let confirmMsg = ChatMessage(
+                role: .assistant,
+                text: "",
+                confirmation: confirmation
+            )
+            messages.append(confirmMsg)
+
         default:
             break
         }
@@ -484,6 +499,20 @@ final class ChatViewModel: ObservableObject {
 
     func dismissError() {
         errorText = nil
+    }
+
+    /// Respond to a tool confirmation request displayed inline in the chat.
+    func respondToConfirmation(requestId: String, decision: String) {
+        // Update the message state
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
+        }
+        // Send the response to the daemon
+        do {
+            try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
+        } catch {
+            log.error("Failed to send confirmation response: \(error.localizedDescription)")
+        }
     }
 
     /// Ask the daemon for a follow-up suggestion for the current session.

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -420,15 +420,15 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
     let diff: ConfirmationDiffInfo?
     let sandboxed: Bool?
 
-    struct ConfirmationAllowlistOption: Decodable, Sendable {
+    struct ConfirmationAllowlistOption: Decodable, Sendable, Equatable {
         let label: String
         let pattern: String
     }
-    struct ConfirmationScopeOption: Decodable, Sendable {
+    struct ConfirmationScopeOption: Decodable, Sendable, Equatable {
         let label: String
         let scope: String
     }
-    struct ConfirmationDiffInfo: Decodable, Sendable {
+    struct ConfirmationDiffInfo: Decodable, Sendable, Equatable {
         let filePath: String
         let oldContent: String
         let newContent: String


### PR DESCRIPTION
## Summary
- Extends `ChatMessage` with `ToolConfirmationData` and `ToolConfirmationState` enums for inline tool permission approval in the chat message list
- Handles `confirmation_request` messages in `ChatViewModel.handleServerMessage` so they appear as chat messages
- Adds `respondToConfirmation()` method for sending allow/deny decisions back to the daemon via IPC
- Adds `Equatable` conformance to `ConfirmationDiffInfo`, `ConfirmationAllowlistOption`, and `ConfirmationScopeOption`

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Manual: trigger a tool confirmation and verify the message appears in the chat list
- [ ] M2 will add the UI rendering for these confirmation messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
