### PR TITLE
Fix onboarding card bobbing by isolating idle-bob animation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -64,6 +64,10 @@ struct OnboardingStageImage: View {
                 }
             }
             .offset(x: shakeOffset, y: bobOffset - 40)
+            .animation(
+                .easeInOut(duration: 2.5).repeatForever(autoreverses: true),
+                value: bobOffset
+            )
             .rotationEffect(.degrees(shakeRotation))
 
             // White flash overlay
@@ -74,7 +78,13 @@ struct OnboardingStageImage: View {
         }
         .onAppear {
             displayedStage = stageNumber
-            startIdleBob()
+            // Kick off the idle bob by setting the target offset.
+            // The actual animation is driven by the value-based
+            // .animation() modifier on the offset below, NOT by
+            // withAnimation — using withAnimation(.repeatForever())
+            // in onAppear leaks the repeating animation to ancestor
+            // views and makes the whole card bob.
+            bobOffset = -4
         }
         .onChange(of: stageNumber) { oldStage, newStage in
             guard oldStage != newStage, !isTransitioning else { return }
@@ -83,15 +93,6 @@ struct OnboardingStageImage: View {
     }
 
     // MARK: - Animations
-
-    private func startIdleBob() {
-        withAnimation(
-            .easeInOut(duration: 2.5)
-            .repeatForever(autoreverses: true)
-        ) {
-            bobOffset = -4
-        }
-    }
 
     private func playHatchTransition(to newStage: Int) {
         isTransitioning = true


### PR DESCRIPTION
## Summary
- Replace `withAnimation(.repeatForever())` in `onAppear` with a value-scoped `.animation(_, value: bobOffset)` modifier on the egg sprite's offset
- `withAnimation(.repeatForever())` in `onAppear` is a known SwiftUI pitfall — the repeating animation transaction leaks to ancestor views during the initial layout pass, causing the entire onboarding card to bob up and down instead of just the egg sprite
- Removes the now-unused `startIdleBob()` method

## Test plan
- [x] Scrubbed and launched — onboarding card stays still, egg bobs gently as intended
- [ ] Step through all onboarding steps to confirm hatch transitions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
