### PR TITLE
Remove placeholder text from chat composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -153,7 +153,7 @@ struct ChatView: View {
 
             // Text field with ghost suffix overlay
             ZStack(alignment: .leading) {
-                TextField("What you need chef?", text: $inputText, axis: .vertical)
+                TextField("", text: $inputText, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)


### PR DESCRIPTION
## Summary
- Remove the "What you need chef?" placeholder text from the desktop app chat input field, which was clashing with the new ghost suggestion overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
