### PR TITLE
Remove dividers, use Slate._900 section backgrounds

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -12,10 +12,6 @@ struct VSplitView<Main: View, Panel: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if showPanel, let panel = panel {
-                Divider()
-                    .background(VColor.surfaceBorder)
-                    .transition(.move(edge: .trailing))
-
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct CardModifier: ViewModifier {
     var radius: CGFloat = VRadius.md
+    var background: Color = VColor.surface
 
     func body(content: Content) -> some View {
         content
-            .background(VColor.surface)
+            .background(background)
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
@@ -15,8 +16,8 @@ struct CardModifier: ViewModifier {
 }
 
 extension View {
-    func vCard(radius: CGFloat = VRadius.md) -> some View {
-        modifier(CardModifier(radius: radius))
+    func vCard(radius: CGFloat = VRadius.md, background: Color = VColor.surface) -> some View {
+        modifier(CardModifier(radius: radius, background: background))
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -29,8 +29,6 @@ struct ControlPanel: View {
                 .frame(width: 100)
                 .padding(.top, VSpacing.md)
 
-                Divider()
-
                 // Right content
                 ScrollView {
                     Group {
@@ -132,7 +130,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // COMPUTER USAGE section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -156,7 +154,7 @@ struct ControlPanel: View {
                 VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // AMBIENT AGENT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -179,7 +177,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // PERMISSIONS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -193,7 +191,7 @@ struct ControlPanel: View {
                     granted: PermissionManager.accessibilityStatus() == .granted
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "record.circle",
@@ -201,7 +199,7 @@ struct ControlPanel: View {
                     granted: PermissionManager.screenRecordingStatus() == .granted
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "key",
@@ -209,10 +207,10 @@ struct ControlPanel: View {
                     granted: APIKeyManager.getKey() != nil
                 )
                 .padding(VSpacing.md)
-                .vCard()
+                .vCard(background: Slate._900)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // ABOUT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -241,7 +239,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove vertical divider between chat content and side panel (VSplitView)
- Remove vertical divider between Settings nav tabs and content area (ControlPanel)
- ControlPanel section cards use `Slate._900` (`0x0F172A`) background instead of default `VColor.surface` (`Slate._800`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
