### PR TITLE
Add inline ToolConfirmationBubble in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -12,6 +12,8 @@ struct ChatView: View {
     let onStop: () -> Void
     let onDismissError: () -> Void
     let onAcceptSuggestion: () -> Void
+    let onConfirmationAllow: (String) -> Void
+    let onConfirmationDeny: (String) -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -55,9 +57,19 @@ struct ChatView: View {
             ScrollView {
                 LazyVStack(spacing: VSpacing.md) {
                     ForEach(messages) { message in
-                        ChatBubble(message: message)
+                        if let confirmation = message.confirmation {
+                            ToolConfirmationBubble(
+                                confirmation: confirmation,
+                                onAllow: { onConfirmationAllow(confirmation.requestId) },
+                                onDeny: { onConfirmationDeny(confirmation.requestId) }
+                            )
                             .id(message.id)
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        } else {
+                            ChatBubble(message: message)
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        }
                     }
 
                     if isThinking {
@@ -398,7 +410,9 @@ private struct ThinkingIndicator: View {
             onSend: {},
             onStop: {},
             onDismissError: {},
-            onAcceptSuggestion: {}
+            onAcceptSuggestion: {},
+            onConfirmationAllow: { _ in },
+            onConfirmationDeny: { _ in }
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct ToolConfirmationBubble: View {
+    let confirmation: ToolConfirmationData
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+
+    private var isHighRisk: Bool { confirmation.riskLevel.lowercased() == "high" }
+
+    private var toolDisplayName: String {
+        switch confirmation.toolName {
+        case "file_write": return "Write File"
+        case "file_edit": return "Edit File"
+        case "bash": return "Run Command"
+        case "web_fetch": return "Fetch URL"
+        default: return confirmation.toolName.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Header row: icon + tool name + risk badge
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: isHighRisk ? "exclamationmark.triangle.fill" : "shield.checkered")
+                    .font(.system(size: 14))
+                    .foregroundStyle(isHighRisk ? VColor.error : VColor.warning)
+
+                Text(toolDisplayName)
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(confirmation.riskLevel.lowercased())
+                    .font(VFont.caption)
+                    .foregroundColor(isHighRisk ? VColor.error : VColor.warning)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill((isHighRisk ? VColor.error : VColor.warning).opacity(0.15))
+                    )
+
+                Spacer()
+            }
+
+            // Diff preview (if present)
+            if let diff = confirmation.diff {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(diff.filePath)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    if diff.isNewFile {
+                        Text("New file")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.success)
+                    }
+
+                    ScrollView {
+                        Text(String(diff.newContent.prefix(500)))
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 120)
+                    .padding(VSpacing.sm)
+                    .background(VColor.backgroundSubtle)
+                    .cornerRadius(VRadius.sm)
+                }
+            }
+
+            // Action buttons or decided state
+            switch confirmation.state {
+            case .pending:
+                HStack(spacing: VSpacing.md) {
+                    Spacer()
+                    VButton(label: "Deny", style: .ghost) {
+                        onDeny()
+                    }
+                    VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
+                        onAllow()
+                    }
+                }
+
+            case .approved:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("Allowed")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
+
+            case .denied:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(VColor.error)
+                    Text("Denied")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
+
+            case .timedOut:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(VColor.textMuted)
+                    Text("Timed out")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface.opacity(0.5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(isHighRisk ? VColor.error.opacity(0.3) : VColor.warning.opacity(0.3), lineWidth: 1)
+                )
+        )
+        .frame(maxWidth: 500)
+    }
+}
+
+#if DEBUG
+#Preview("ToolConfirmationBubble") {
+    VStack(spacing: VSpacing.lg) {
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                diff: nil
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-2",
+                toolName: "file_write",
+                riskLevel: "high",
+                diff: ConfirmationRequestMessage.ConfirmationDiffInfo(
+                    filePath: "/Users/test/project/src/main.swift",
+                    oldContent: "",
+                    newContent: "import Foundation\n\nfunc hello() {\n    print(\"Hello, World!\")\n}",
+                    isNewFile: true
+                )
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-3",
+                toolName: "bash",
+                riskLevel: "medium",
+                diff: nil,
+                state: .approved
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+    }
+    .padding(VSpacing.xl)
+    .background(VColor.background)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -43,7 +43,9 @@ struct MainWindowView: View {
                         onSend: viewModel.sendMessage,
                         onStop: viewModel.stopGenerating,
                         onDismissError: viewModel.dismissError,
-                        onAcceptSuggestion: viewModel.acceptSuggestion
+                        onAcceptSuggestion: viewModel.acceptSuggestion,
+                        onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
+                        onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
                     )
                 }
             }, panel: {


### PR DESCRIPTION
## Summary
- Created `ToolConfirmationBubble.swift` — a new SwiftUI view that renders inline confirmation cards in chat with risk-level badges (high/medium), tool name display, diff previews for file operations, and Allow/Deny action buttons
- Modified `ChatView.swift` to detect confirmation messages in the ForEach loop and render `ToolConfirmationBubble` instead of `ChatBubble`, with new `onConfirmationAllow`/`onConfirmationDeny` closure properties
- Updated `MainWindowView.swift` to wire the confirmation callbacks to `ChatViewModel.respondToConfirmation()`

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] Preview renders correctly for pending, approved, and high-risk confirmation states
- [ ] Allow/Deny buttons call through to ChatViewModel.respondToConfirmation()
- [ ] Confirmation bubble displays inline in chat message list with proper styling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
