### PR TITLE
Guard extra deleteLastExchange in undo to prevent data loss

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -798,14 +798,22 @@ export class Session {
     // tool_result message, leaving the real user message orphaned.
     //
     // Strategy: peel back any trailing tool_result exchanges first, then
-    // unconditionally delete the real user message exchange. The do-while
-    // handles the case where the last DB exchange is a tool_result row, and
-    // the final call after the loop ensures the original user message is
-    // always removed.
+    // delete the real user message exchange only if tool_result rows were
+    // actually encountered. The do-while handles the case where the last DB
+    // exchange is a tool_result row; the flag ensures we only issue the extra
+    // deleteLastExchange when the loop peeled back tool_result messages.
+    let hadToolResult = false;
     do {
       conversationStore.deleteLastExchange(this.conversationId);
-    } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
-    conversationStore.deleteLastExchange(this.conversationId);
+      if (conversationStore.isLastUserMessageToolResult(this.conversationId)) {
+        hadToolResult = true;
+      } else {
+        break;
+      }
+    } while (true);
+    if (hadToolResult) {
+      conversationStore.deleteLastExchange(this.conversationId);
+    }
 
     return removed;
   }


### PR DESCRIPTION
## Summary
- Follow-up to #1265 addressing review feedback from Codex and Devin.
- The unconditional `deleteLastExchange` call after the do-while loop in `undo()` deleted the **previous** exchange when the undo target had no trailing `tool_result` rows, causing data loss.
- Introduced a `hadToolResult` flag so the extra `deleteLastExchange` only fires when the loop actually peeled back `tool_result` messages.

## Test plan
- [ ] Verify undo with a normal `user/assistant` conversation (`u1/a1, u2/a2`) only removes the last exchange
- [ ] Verify undo with trailing `tool_result` rows still correctly removes the entire tool-use turn including the real user message
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
