### PR TITLE
Defer idle-bob start to prevent repeatForever leak on resumed onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -78,13 +78,15 @@ struct OnboardingStageImage: View {
         }
         .onAppear {
             displayedStage = stageNumber
-            // Kick off the idle bob by setting the target offset.
-            // The actual animation is driven by the value-based
-            // .animation() modifier on the offset below, NOT by
-            // withAnimation — using withAnimation(.repeatForever())
-            // in onAppear leaks the repeating animation to ancestor
-            // views and makes the whole card bob.
-            bobOffset = -4
+            // Defer the bob animation start to the next run-loop iteration
+            // so the repeatForever .animation() modifier doesn't infect
+            // the displayedStage change above. When onboarding resumes
+            // from persisted progress, both assignments would otherwise
+            // happen in the same SwiftUI update cycle, letting the
+            // repeat-forever animation leak to the stage transition.
+            DispatchQueue.main.async {
+                bobOffset = -4
+            }
         }
         .onChange(of: stageNumber) { oldStage, newStage in
             guard oldStage != newStage, !isTransitioning else { return }


### PR DESCRIPTION
## Summary
- Follow-up to #1283. When onboarding resumes from persisted progress (`OnboardingState.init` sets `currentStep > 1`), `displayedStage` and `bobOffset` were both set in the same `onAppear` update cycle. The value-scoped `.animation(.repeatForever, value: bobOffset)` modifier would then infect the `displayedStage` change, causing unintended flickering stage transitions.
- Move `bobOffset = -4` into `DispatchQueue.main.async` so the two state changes happen in separate SwiftUI update cycles -- `displayedStage` commits without animation, then `bobOffset` triggers only the idle bob.

## Test plan
- [ ] Launch app fresh (no persisted onboarding state) -- egg should idle-bob normally, no flickering
- [ ] Launch app with persisted onboarding progress (currentStep > 1) -- stage image should display without flickering, idle bob still works
- [ ] Progress through onboarding stages -- hatch transitions should animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
