### PR TITLE
Suppress error banner on intentional cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -445,7 +445,9 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            errorText = err.message
+            if !wasCancelling {
+                errorText = err.message
+            }
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {


### PR DESCRIPTION
## Summary
- Guard `errorText` assignment with `!wasCancelling` in the `.error` case handler so users don't see "Session aborted — queued message discarded" error banners after intentionally cancelling queued messages.
- Follow-up to #1266 addressing Devin's review feedback.

## Test plan
- [ ] Trigger intentional cancellation while messages are queued; verify no error banner appears.
- [ ] Trigger a real (non-cancellation) error; verify the error banner still appears as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
