### PR TITLE
Coordinate inline and floating confirmation panels

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -179,10 +179,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupToolConfirmationManager() {
         daemonClient.onConfirmationRequest = { [weak self] msg in
-            self?.toolConfirmationManager.showConfirmation(msg)
+            // Only show floating panel if app is NOT focused
+            if !NSApp.isActive {
+                self?.toolConfirmationManager.showConfirmation(msg)
+            }
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
+            // Send the response to daemon
             try? self?.daemonClient.sendConfirmationResponse(
+                requestId: requestId,
+                decision: decision
+            )
+            // Sync the inline message state in the active ChatViewModel
+            self?.mainWindow?.activeViewModel?.updateConfirmationState(
                 requestId: requestId,
                 decision: decision
             )
@@ -478,6 +487,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent)
+        // Wire inline confirmation dismiss to close the corresponding floating panel
+        main.threadManager.confirmationDismissHandler = { [weak self] requestId in
+            self?.toolConfirmationManager.dismissConfirmation(requestId: requestId)
+        }
         main.show()
         mainWindow = main
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,9 @@ final class ChatViewModel: ObservableObject {
     /// Tracks the current in-flight suggestion request so stale responses are ignored.
     private var pendingSuggestionRequestId: String?
 
+    /// Called when an inline confirmation is responded to, so the floating panel can be dismissed.
+    var onInlineConfirmationResponse: ((String) -> Void)?
+
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
         // Add initial greeting
@@ -600,6 +603,23 @@ final class ChatViewModel: ObservableObject {
             try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
         } catch {
             log.error("Failed to send confirmation response: \(error.localizedDescription)")
+        }
+        // Dismiss the corresponding floating panel if one exists
+        onInlineConfirmationResponse?(requestId)
+    }
+
+    /// Update the inline confirmation message state without sending a response to the daemon.
+    /// Used when the floating panel handles the response.
+    func updateConfirmationState(requestId: String, decision: String) {
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            switch decision {
+            case "allow":
+                messages[index].confirmation?.state = .approved
+            case "deny":
+                messages[index].confirmation?.state = .denied
+            default:
+                break
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -15,6 +15,9 @@ final class ThreadManager: ObservableObject {
     private let daemonClient: DaemonClient
     private var viewModelCancellable: AnyCancellable?
 
+    /// Called when an inline confirmation response should dismiss the floating panel.
+    var confirmationDismissHandler: ((String) -> Void)?
+
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil }
         return chatViewModels[activeThreadId]
@@ -29,6 +32,9 @@ final class ThreadManager: ObservableObject {
     func createThread() {
         let thread = ThreadModel()
         let viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.onInlineConfirmationResponse = { [weak self] requestId in
+            self?.confirmationDismissHandler?(requestId)
+        }
         threads.append(thread)
         chatViewModels[thread.id] = viewModel
         activeThreadId = thread.id


### PR DESCRIPTION
## Summary
- Shows floating confirmation panel only when the app is **not focused** (`NSApp.isActive` is false); when focused, only the inline chat bubble is shown
- When the user responds via the **floating panel**, the inline chat message state is synced to show "Allowed"/"Denied"
- When the user responds **inline**, the corresponding floating panel is dismissed via a callback chain through ThreadManager

## Files changed
- `App/AppDelegate.swift` — Gate floating panel on `!NSApp.isActive`, sync inline state on panel response, wire dismiss handler after main window creation
- `Features/Chat/ChatViewModel.swift` — Add `onInlineConfirmationResponse` callback, `updateConfirmationState()` method, modify `respondToConfirmation()` to dismiss floating panel
- `Features/MainWindow/ThreadManager.swift` — Add `confirmationDismissHandler` property, propagate to new ChatViewModels on creation

## Test plan
- [ ] Verify that when the app is focused and a confirmation request arrives, only the inline bubble appears (no floating panel)
- [ ] Verify that when the app is unfocused and a confirmation request arrives, both inline bubble and floating panel appear
- [ ] Respond via floating panel and verify inline bubble updates to "Allowed"/"Denied"
- [ ] Respond via inline bubble and verify floating panel is dismissed
- [ ] Open multiple threads, verify callback wiring works for all ChatViewModels