### PR TITLE
Clear llm_usage_events on conversation data wipe

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -8,8 +8,8 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 1. Kill any running Vellum processes (including the legacy process name):
    ```bash
-   pkill -x "Vellum"
-   pkill -x "vellum-assistant"
+   pkill -x "Vellum" || true
+   pkill -x "vellum-assistant" || true
    ```
 
 2. Remove session logs and knowledge store:

--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Generate DMG background
         run: |
           mkdir -p build
-          swift dmg/generate-background.swift build/dmg-background.png
+          swift dmg/generate-background.swift build/dmg-background@2x.png
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -138,7 +138,7 @@ jobs:
           # Create styled DMG with background, icon layout, and Applications drop link
           create-dmg \
             --volname "Vellum" \
-            --background "build/dmg-background.png" \
+            --background "build/dmg-background@2x.png" \
             --window-pos 200 120 \
             --window-size 660 400 \
             --icon-size 128 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,7 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/brainstorm` | Read through the codebase and `.private/TODO.md`, generate a prioritized list of improvements, and update the TODO after user approval. |
 | `/check-reviews` | Check every PR in `.private/UNREVIEWED_PRS.md` for Codex and Devin reviews; add feedback items to TODO and remove fully-reviewed PRs. |
 | `/execute-plan <plan-file>` | Execute a multi-PR rollout plan from `.private/plans/` sequentially — implement, validate, and mainline each PR in order. |
+| `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the first PR, creates it (without merging), and stops to wait for human review. |
+| `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
+| `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. |
 | `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,4 @@ These are the most commonly used slash commands defined in `.claude/commands/`:
 | `/safe-execute-plan <file>` | Start a plan from `.private/plans/` — implements the first PR, creates it (without merging), and stops to wait for human review. |
 | `/safe-check-review [file]` | Check the active plan PR for review feedback from codex/devin/humans. Addresses requested changes, waits if reviews are pending. |
 | `/resume-plan [file]` | Merge the current plan PR, implement the next one, create it, and stop again. Repeats until the plan is complete. |
-| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 | Command | Purpose |
 |---------|---------|
-| `/scrub` | Kill the running Vellum app, wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
+| `/scrub` | Kill the running Vellum app (non-fatal if not running), wipe all persistent data, and relaunch the daemon and macOS app for a clean first-run experience. |
 
 ### Review
 

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -176,6 +176,14 @@ exports[`IPC message snapshots ClientMessage types skill_detail serializes to ex
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types suggestion_request serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "sessionId": "sess-001",
+  "type": "suggestion_request",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",
@@ -559,6 +567,15 @@ Do the thing."
 ,
   "skillId": "my-skill",
   "type": "skill_detail_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
+{
+  "requestId": "req-suggest-001",
+  "source": "llm",
+  "suggestion": "Tell me more about that",
+  "type": "suggestion_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -125,6 +125,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skill_detail',
     skillId: 'my-skill',
   },
+  suggestion_request: {
+    type: 'suggestion_request',
+    sessionId: 'sess-001',
+    requestId: 'req-suggest-001',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -354,6 +359,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'skill_detail_response',
     skillId: 'my-skill',
     body: '# Skill content\n\nDo the thing.',
+  },
+  suggestion_response: {
+    type: 'suggestion_response',
+    requestId: 'req-suggest-001',
+    suggestion: 'Tell me more about that',
+    source: 'llm',
   },
   message_queued: {
     type: 'message_queued',

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'llm-usage-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { recordUsageEvent, listUsageEvents } from '../memory/llm-usage-store.js';
+import type { UsageEventInput, PricingResult } from '../usage/types.js';
+
+// Initialize db once before all tests
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    actor: 'main_agent',
+    assistantId: null,
+    conversationId: null,
+    runId: null,
+    requestId: null,
+    ...overrides,
+  };
+}
+
+const pricedResult: PricingResult = {
+  estimatedCostUsd: 0.0045,
+  pricingStatus: 'priced',
+};
+
+const unpricedResult: PricingResult = {
+  estimatedCostUsd: null,
+  pricingStatus: 'unpriced',
+};
+
+describe('recordUsageEvent', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test('persists an event and returns it with id and createdAt', () => {
+    const input = makeInput();
+    const event = recordUsageEvent(input, pricedResult);
+
+    expect(event.id).toBeDefined();
+    expect(typeof event.id).toBe('string');
+    expect(event.id.length).toBeGreaterThan(0);
+    expect(event.createdAt).toBeDefined();
+    expect(typeof event.createdAt).toBe('number');
+    expect(event.provider).toBe('anthropic');
+    expect(event.model).toBe('claude-sonnet-4-20250514');
+    expect(event.inputTokens).toBe(1000);
+    expect(event.outputTokens).toBe(500);
+    expect(event.actor).toBe('main_agent');
+    expect(event.estimatedCostUsd).toBe(0.0045);
+    expect(event.pricingStatus).toBe('priced');
+  });
+
+  test('persists a priced event that can be retrieved', () => {
+    const input = makeInput({ assistantId: 'a1', conversationId: 'c1' });
+    const event = recordUsageEvent(input, pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(event.id);
+    expect(events[0].estimatedCostUsd).toBe(0.0045);
+    expect(events[0].pricingStatus).toBe('priced');
+    expect(events[0].assistantId).toBe('a1');
+    expect(events[0].conversationId).toBe('c1');
+  });
+
+  test('persists an unpriced event', () => {
+    const input = makeInput({ provider: 'ollama', model: 'llama3' });
+    const event = recordUsageEvent(input, unpricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(event.id);
+    expect(events[0].estimatedCostUsd).toBeNull();
+    expect(events[0].pricingStatus).toBe('unpriced');
+    expect(events[0].provider).toBe('ollama');
+    expect(events[0].model).toBe('llama3');
+  });
+
+  test('handles null optional fields', () => {
+    const input = makeInput({
+      assistantId: null,
+      conversationId: null,
+      runId: null,
+      requestId: null,
+      cacheCreationInputTokens: null,
+      cacheReadInputTokens: null,
+    });
+    const event = recordUsageEvent(input, unpricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].assistantId).toBeNull();
+    expect(events[0].conversationId).toBeNull();
+    expect(events[0].runId).toBeNull();
+    expect(events[0].requestId).toBeNull();
+    expect(events[0].cacheCreationInputTokens).toBeNull();
+    expect(events[0].cacheReadInputTokens).toBeNull();
+  });
+
+  test('handles populated optional fields', () => {
+    const input = makeInput({
+      assistantId: 'assistant-1',
+      conversationId: 'conv-1',
+      runId: 'run-1',
+      requestId: 'req-1',
+      cacheCreationInputTokens: 200,
+      cacheReadInputTokens: 300,
+    });
+    const event = recordUsageEvent(input, pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].assistantId).toBe('assistant-1');
+    expect(events[0].conversationId).toBe('conv-1');
+    expect(events[0].runId).toBe('run-1');
+    expect(events[0].requestId).toBe('req-1');
+    expect(events[0].cacheCreationInputTokens).toBe(200);
+    expect(events[0].cacheReadInputTokens).toBe(300);
+  });
+});
+
+describe('listUsageEvents', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test('returns events in descending createdAt order', () => {
+    // Insert events with small delays to ensure different timestamps
+    const event1 = recordUsageEvent(makeInput({ model: 'model-a' }), pricedResult);
+    // Manually adjust createdAt for deterministic ordering
+    const db = getDb();
+    db.run(`UPDATE llm_usage_events SET created_at = 1000 WHERE id = '${event1.id}'`);
+
+    const event2 = recordUsageEvent(makeInput({ model: 'model-b' }), pricedResult);
+    db.run(`UPDATE llm_usage_events SET created_at = 2000 WHERE id = '${event2.id}'`);
+
+    const event3 = recordUsageEvent(makeInput({ model: 'model-c' }), pricedResult);
+    db.run(`UPDATE llm_usage_events SET created_at = 3000 WHERE id = '${event3.id}'`);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(3);
+    expect(events[0].model).toBe('model-c');
+    expect(events[1].model).toBe('model-b');
+    expect(events[2].model).toBe('model-a');
+  });
+
+  test('respects the limit option', () => {
+    recordUsageEvent(makeInput({ model: 'model-a' }), pricedResult);
+    recordUsageEvent(makeInput({ model: 'model-b' }), pricedResult);
+    recordUsageEvent(makeInput({ model: 'model-c' }), pricedResult);
+
+    const events = listUsageEvents({ limit: 2 });
+    expect(events).toHaveLength(2);
+  });
+
+  test('defaults to limit of 100', () => {
+    // Just verify it returns without error when no limit is specified
+    const events = listUsageEvents();
+    expect(Array.isArray(events)).toBe(true);
+  });
+
+  test('returns empty array when no events exist', () => {
+    const events = listUsageEvents();
+    expect(events).toHaveLength(0);
+  });
+
+  test('returns events with correct types', () => {
+    recordUsageEvent(makeInput({
+      cacheCreationInputTokens: 100,
+      cacheReadInputTokens: 200,
+    }), pricedResult);
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0];
+
+    // Verify all fields have correct types
+    expect(typeof event.id).toBe('string');
+    expect(typeof event.createdAt).toBe('number');
+    expect(typeof event.actor).toBe('string');
+    expect(typeof event.provider).toBe('string');
+    expect(typeof event.model).toBe('string');
+    expect(typeof event.inputTokens).toBe('number');
+    expect(typeof event.outputTokens).toBe('number');
+    expect(typeof event.cacheCreationInputTokens).toBe('number');
+    expect(typeof event.cacheReadInputTokens).toBe('number');
+    expect(typeof event.estimatedCostUsd).toBe('number');
+    expect(typeof event.pricingStatus).toBe('string');
+  });
+});

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -1,0 +1,236 @@
+import { describe, test, expect } from 'bun:test';
+import { estimateCost, resolvePricing, resolvePricingWithOverrides } from '../util/pricing.js';
+import type { ModelPricingOverride } from '../config/schema.js';
+
+describe('resolvePricing', () => {
+  describe('Anthropic models', () => {
+    test('returns priced for claude-opus-4', () => {
+      const result = resolvePricing('anthropic', 'claude-opus-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(15 + 75);
+    });
+
+    test('returns priced for claude-sonnet-4', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(3 + 15);
+    });
+
+    test('returns priced for claude-haiku-4', () => {
+      const result = resolvePricing('anthropic', 'claude-haiku-4', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.80 + 4);
+    });
+  });
+
+  describe('OpenAI models', () => {
+    test('returns priced for gpt-4o', () => {
+      const result = resolvePricing('openai', 'gpt-4o', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.50 + 10);
+    });
+
+    test('returns priced for gpt-4o-mini', () => {
+      const result = resolvePricing('openai', 'gpt-4o-mini', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('returns priced for gpt-4.1', () => {
+      const result = resolvePricing('openai', 'gpt-4.1', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.00 + 8.00);
+    });
+
+    test('returns priced for o3', () => {
+      const result = resolvePricing('openai', 'o3', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(2.00 + 8.00);
+    });
+
+    test('returns priced for o4-mini', () => {
+      const result = resolvePricing('openai', 'o4-mini', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.10 + 4.40);
+    });
+  });
+
+  describe('Gemini models', () => {
+    test('returns priced for gemini-2.5-pro', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-pro', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.25 + 10);
+    });
+
+    test('returns priced for gemini-2.5-flash', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-flash', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('returns priced for gemini-2.0-flash', () => {
+      const result = resolvePricing('gemini', 'gemini-2.0-flash', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.10 + 0.40);
+    });
+  });
+
+  describe('unknown models', () => {
+    test('returns unpriced with null cost for unknown model', () => {
+      const result = resolvePricing('anthropic', 'unknown-model-xyz', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+
+    test('returns unpriced for unknown provider', () => {
+      const result = resolvePricing('unknown-provider', 'some-model', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+  });
+
+  describe('Ollama (local) models', () => {
+    test('returns unpriced for ollama models', () => {
+      const result = resolvePricing('ollama', 'llama3:latest', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+
+    test('returns unpriced for ollama with any model name', () => {
+      const result = resolvePricing('ollama', 'mistral:7b', 500_000, 500_000);
+      expect(result.pricingStatus).toBe('unpriced');
+      expect(result.estimatedCostUsd).toBeNull();
+    });
+  });
+
+  describe('prefix matching', () => {
+    test('matches claude-sonnet-4-5-20250929 via claude-sonnet-4 prefix', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(3 + 15);
+    });
+
+    test('matches claude-opus-4-5-20250929 via claude-opus-4 prefix', () => {
+      const result = resolvePricing('anthropic', 'claude-opus-4-5-20250929', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(15 + 75);
+    });
+
+    test('matches gpt-4o-mini-2024-07-18 via gpt-4o-mini prefix', () => {
+      const result = resolvePricing('openai', 'gpt-4o-mini-2024-07-18', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0.15 + 0.60);
+    });
+
+    test('matches gemini-2.5-pro-preview via gemini-2.5-pro prefix', () => {
+      const result = resolvePricing('gemini', 'gemini-2.5-pro-preview', 1_000_000, 1_000_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(1.25 + 10);
+    });
+  });
+
+  describe('cost calculation', () => {
+    test('calculates correctly with fractional token counts', () => {
+      // 500k input, 200k output with claude-sonnet-4 pricing (3/15 per 1M)
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 500_000, 200_000);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBeCloseTo(0.5 * 3 + 0.2 * 15, 10);
+    });
+
+    test('returns 0 cost for zero tokens', () => {
+      const result = resolvePricing('anthropic', 'claude-sonnet-4', 0, 0);
+      expect(result.pricingStatus).toBe('priced');
+      expect(result.estimatedCostUsd).toBe(0);
+    });
+  });
+});
+
+describe('resolvePricingWithOverrides', () => {
+  test('uses override when matching provider and modelPattern', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 5, outputPer1M: 25 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test('override prefix matching works with version suffixes', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 5, outputPer1M: 25 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test('falls back to built-in catalog when no override matches', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'openai', modelPattern: 'gpt-4o', inputPer1M: 99, outputPer1M: 99 },
+    ];
+    // Different provider, so override should not match
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('falls back to built-in catalog with empty overrides array', () => {
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000, []);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('falls back to built-in catalog with no overrides argument', () => {
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4', 1_000_000, 1_000_000);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(3 + 15);
+  });
+
+  test('override can price a previously unpriced provider/model', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'ollama', modelPattern: 'llama3', inputPer1M: 0, outputPer1M: 0 },
+    ];
+    const result = resolvePricingWithOverrides('ollama', 'llama3:latest', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(0);
+  });
+
+  test('longest modelPattern prefix wins among overrides', () => {
+    const overrides: ModelPricingOverride[] = [
+      { provider: 'anthropic', modelPattern: 'claude-sonnet', inputPer1M: 1, outputPer1M: 1 },
+      { provider: 'anthropic', modelPattern: 'claude-sonnet-4', inputPer1M: 99, outputPer1M: 99 },
+    ];
+    const result = resolvePricingWithOverrides('anthropic', 'claude-sonnet-4-5-20250929', 1_000_000, 1_000_000, overrides);
+    expect(result.pricingStatus).toBe('priced');
+    expect(result.estimatedCostUsd).toBe(99 + 99);
+  });
+});
+
+describe('estimateCost (backward compatibility)', () => {
+  test('returns a number for known Claude model', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-sonnet-4-5-20250929');
+    expect(typeof cost).toBe('number');
+    expect(cost).toBe(3 + 15);
+  });
+
+  test('returns 0 for unknown model', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'unknown-model');
+    expect(cost).toBe(0);
+  });
+
+  test('returns correct cost for claude-opus-4 via prefix match', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-opus-4-5-20250929');
+    expect(cost).toBe(15 + 75);
+  });
+
+  test('returns correct cost for claude-haiku-4 via prefix match', () => {
+    const cost = estimateCost(1_000_000, 1_000_000, 'claude-haiku-4-5-20251001');
+    expect(cost).toBe(0.80 + 4);
+  });
+
+  test('always returns number type, never null', () => {
+    const cost = estimateCost(500_000, 500_000, 'nonexistent-model');
+    expect(typeof cost).toBe('number');
+    expect(cost).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/usage-summary.test.ts
+++ b/assistant/src/__tests__/usage-summary.test.ts
@@ -1,0 +1,395 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'usage-summary-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { recordUsageEvent } from '../memory/llm-usage-store.js';
+import { getUsageSummary } from '../usage/summary.js';
+import type { UsageEventInput, PricingResult } from '../usage/types.js';
+
+// Initialize db once before all tests
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    actor: 'main_agent',
+    assistantId: null,
+    conversationId: null,
+    runId: null,
+    requestId: null,
+    ...overrides,
+  };
+}
+
+const pricedResult: PricingResult = {
+  estimatedCostUsd: 0.0045,
+  pricingStatus: 'priced',
+};
+
+const unpricedResult: PricingResult = {
+  estimatedCostUsd: null,
+  pricingStatus: 'unpriced',
+};
+
+/** Insert an event and override its createdAt timestamp. */
+function insertEventAt(
+  createdAt: number,
+  inputOverrides?: Partial<UsageEventInput>,
+  pricing: PricingResult = pricedResult,
+): void {
+  const event = recordUsageEvent(makeInput(inputOverrides), pricing);
+  const db = getDb();
+  db.run(`UPDATE llm_usage_events SET created_at = ${createdAt} WHERE id = '${event.id}'`);
+}
+
+// Time constants: use 2025-01-15 as the base date
+const DAY_MS = 86_400_000;
+const BASE_DATE = new Date('2025-01-15T12:00:00Z').getTime(); // noon UTC
+
+describe('getUsageSummary', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test('empty window returns zeroes', () => {
+    const summary = getUsageSummary({
+      startAt: BASE_DATE,
+      endAt: BASE_DATE + DAY_MS,
+    });
+
+    expect(summary.totalPricedCostUsd).toBe(0);
+    expect(summary.totalUnpricedInputTokens).toBe(0);
+    expect(summary.totalUnpricedOutputTokens).toBe(0);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.totalOutputTokens).toBe(0);
+    expect(summary.eventCount).toBe(0);
+    expect(summary.byProvider).toHaveLength(0);
+    expect(summary.byModel).toHaveLength(0);
+    expect(summary.byActor).toHaveLength(0);
+    expect(summary.dailyBuckets).toHaveLength(0);
+  });
+
+  test('single priced event returns correct totals', () => {
+    insertEventAt(BASE_DATE, {
+      inputTokens: 2000,
+      outputTokens: 800,
+    }, { estimatedCostUsd: 0.01, pricingStatus: 'priced' });
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + 1000,
+    });
+
+    expect(summary.totalPricedCostUsd).toBe(0.01);
+    expect(summary.totalUnpricedInputTokens).toBe(0);
+    expect(summary.totalUnpricedOutputTokens).toBe(0);
+    expect(summary.totalInputTokens).toBe(2000);
+    expect(summary.totalOutputTokens).toBe(800);
+    expect(summary.eventCount).toBe(1);
+  });
+
+  test('mixed priced/unpriced events separates costs correctly', () => {
+    // Priced event
+    insertEventAt(BASE_DATE, {
+      inputTokens: 1000,
+      outputTokens: 500,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+    }, { estimatedCostUsd: 0.005, pricingStatus: 'priced' });
+
+    // Unpriced event
+    insertEventAt(BASE_DATE + 1000, {
+      inputTokens: 3000,
+      outputTokens: 1500,
+      provider: 'ollama',
+      model: 'llama3',
+    }, unpricedResult);
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + DAY_MS,
+    });
+
+    expect(summary.totalPricedCostUsd).toBe(0.005);
+    expect(summary.totalUnpricedInputTokens).toBe(3000);
+    expect(summary.totalUnpricedOutputTokens).toBe(1500);
+    expect(summary.totalInputTokens).toBe(4000);
+    expect(summary.totalOutputTokens).toBe(2000);
+    expect(summary.eventCount).toBe(2);
+  });
+
+  test('breakdown by provider groups events correctly', () => {
+    insertEventAt(BASE_DATE, {
+      provider: 'anthropic',
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, { estimatedCostUsd: 0.005, pricingStatus: 'priced' });
+
+    insertEventAt(BASE_DATE + 1000, {
+      provider: 'anthropic',
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, { estimatedCostUsd: 0.01, pricingStatus: 'priced' });
+
+    insertEventAt(BASE_DATE + 2000, {
+      provider: 'openai',
+      inputTokens: 500,
+      outputTokens: 250,
+    }, { estimatedCostUsd: 0.003, pricingStatus: 'priced' });
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + DAY_MS,
+    });
+
+    expect(summary.byProvider).toHaveLength(2);
+
+    const anthropic = summary.byProvider.find(e => e.key === 'anthropic')!;
+    expect(anthropic).toBeDefined();
+    expect(anthropic.totalInputTokens).toBe(3000);
+    expect(anthropic.totalOutputTokens).toBe(1500);
+    expect(anthropic.totalCost).toBe(0.015);
+    expect(anthropic.eventCount).toBe(2);
+
+    const openai = summary.byProvider.find(e => e.key === 'openai')!;
+    expect(openai).toBeDefined();
+    expect(openai.totalInputTokens).toBe(500);
+    expect(openai.totalOutputTokens).toBe(250);
+    expect(openai.totalCost).toBe(0.003);
+    expect(openai.eventCount).toBe(1);
+  });
+
+  test('breakdown by model groups events correctly', () => {
+    insertEventAt(BASE_DATE, {
+      model: 'claude-sonnet-4-20250514',
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 1000, {
+      model: 'gpt-4o',
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 2000, {
+      model: 'gpt-4o',
+      inputTokens: 3000,
+      outputTokens: 1500,
+    }, pricedResult);
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + DAY_MS,
+    });
+
+    expect(summary.byModel).toHaveLength(2);
+
+    const sonnet = summary.byModel.find(e => e.key === 'claude-sonnet-4-20250514')!;
+    expect(sonnet).toBeDefined();
+    expect(sonnet.totalInputTokens).toBe(1000);
+    expect(sonnet.totalOutputTokens).toBe(500);
+    expect(sonnet.eventCount).toBe(1);
+
+    const gpt4o = summary.byModel.find(e => e.key === 'gpt-4o')!;
+    expect(gpt4o).toBeDefined();
+    expect(gpt4o.totalInputTokens).toBe(5000);
+    expect(gpt4o.totalOutputTokens).toBe(2500);
+    expect(gpt4o.eventCount).toBe(2);
+  });
+
+  test('breakdown by actor groups events correctly', () => {
+    insertEventAt(BASE_DATE, {
+      actor: 'main_agent',
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 1000, {
+      actor: 'context_compactor',
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 2000, {
+      actor: 'main_agent',
+      inputTokens: 3000,
+      outputTokens: 1500,
+    }, pricedResult);
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + DAY_MS,
+    });
+
+    expect(summary.byActor).toHaveLength(2);
+
+    const mainAgent = summary.byActor.find(e => e.key === 'main_agent')!;
+    expect(mainAgent).toBeDefined();
+    expect(mainAgent.totalInputTokens).toBe(4000);
+    expect(mainAgent.totalOutputTokens).toBe(2000);
+    expect(mainAgent.eventCount).toBe(2);
+
+    const compactor = summary.byActor.find(e => e.key === 'context_compactor')!;
+    expect(compactor).toBeDefined();
+    expect(compactor.totalInputTokens).toBe(2000);
+    expect(compactor.totalOutputTokens).toBe(1000);
+    expect(compactor.eventCount).toBe(1);
+  });
+
+  test('daily buckets assigns events to correct dates', () => {
+    // Day 1: 2025-01-15 noon UTC
+    insertEventAt(BASE_DATE, {
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, { estimatedCostUsd: 0.005, pricingStatus: 'priced' });
+
+    // Day 2: 2025-01-16 noon UTC
+    insertEventAt(BASE_DATE + DAY_MS, {
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, { estimatedCostUsd: 0.01, pricingStatus: 'priced' });
+
+    // Day 2: 2025-01-16 afternoon UTC (same day, second event)
+    insertEventAt(BASE_DATE + DAY_MS + 3_600_000, {
+      inputTokens: 500,
+      outputTokens: 250,
+    }, { estimatedCostUsd: 0.002, pricingStatus: 'priced' });
+
+    // Day 3: 2025-01-17 noon UTC
+    insertEventAt(BASE_DATE + 2 * DAY_MS, {
+      inputTokens: 3000,
+      outputTokens: 1500,
+    }, { estimatedCostUsd: 0.015, pricingStatus: 'priced' });
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + 3 * DAY_MS,
+    });
+
+    expect(summary.dailyBuckets).toHaveLength(3);
+
+    // Buckets should be in ascending date order
+    expect(summary.dailyBuckets[0].date).toBe('2025-01-15');
+    expect(summary.dailyBuckets[0].totalInputTokens).toBe(1000);
+    expect(summary.dailyBuckets[0].totalOutputTokens).toBe(500);
+    expect(summary.dailyBuckets[0].eventCount).toBe(1);
+
+    expect(summary.dailyBuckets[1].date).toBe('2025-01-16');
+    expect(summary.dailyBuckets[1].totalInputTokens).toBe(2500);
+    expect(summary.dailyBuckets[1].totalOutputTokens).toBe(1250);
+    expect(summary.dailyBuckets[1].eventCount).toBe(2);
+
+    expect(summary.dailyBuckets[2].date).toBe('2025-01-17');
+    expect(summary.dailyBuckets[2].totalInputTokens).toBe(3000);
+    expect(summary.dailyBuckets[2].totalOutputTokens).toBe(1500);
+    expect(summary.dailyBuckets[2].eventCount).toBe(1);
+  });
+
+  test('filter by assistantId works', () => {
+    insertEventAt(BASE_DATE, {
+      assistantId: 'assistant-1',
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 1000, {
+      assistantId: 'assistant-2',
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, pricedResult);
+
+    insertEventAt(BASE_DATE + 2000, {
+      assistantId: 'assistant-1',
+      inputTokens: 3000,
+      outputTokens: 1500,
+    }, pricedResult);
+
+    const summary = getUsageSummary({
+      startAt: BASE_DATE - 1000,
+      endAt: BASE_DATE + DAY_MS,
+      assistantId: 'assistant-1',
+    });
+
+    expect(summary.eventCount).toBe(2);
+    expect(summary.totalInputTokens).toBe(4000);
+    expect(summary.totalOutputTokens).toBe(2000);
+  });
+
+  test('time window boundaries exclude out-of-range events', () => {
+    const windowStart = BASE_DATE;
+    const windowEnd = BASE_DATE + DAY_MS;
+
+    // Before window
+    insertEventAt(windowStart - 1000, {
+      inputTokens: 100,
+      outputTokens: 50,
+    }, pricedResult);
+
+    // Inside window (at start boundary)
+    insertEventAt(windowStart, {
+      inputTokens: 1000,
+      outputTokens: 500,
+    }, pricedResult);
+
+    // Inside window
+    insertEventAt(windowStart + DAY_MS / 2, {
+      inputTokens: 2000,
+      outputTokens: 1000,
+    }, pricedResult);
+
+    // Inside window (at end boundary)
+    insertEventAt(windowEnd, {
+      inputTokens: 3000,
+      outputTokens: 1500,
+    }, pricedResult);
+
+    // After window
+    insertEventAt(windowEnd + 1000, {
+      inputTokens: 100,
+      outputTokens: 50,
+    }, pricedResult);
+
+    const summary = getUsageSummary({
+      startAt: windowStart,
+      endAt: windowEnd,
+    });
+
+    // Should include events at boundaries (gte/lte) and inside, exclude outside
+    expect(summary.eventCount).toBe(3);
+    expect(summary.totalInputTokens).toBe(6000);
+    expect(summary.totalOutputTokens).toBe(3000);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -65,6 +65,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   auditLog: {
     retentionDays: 0,
   },
+  pricingOverrides: [],
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -207,6 +207,17 @@ export const MemoryConfigSchema = z.object({
   }),
 });
 
+export const ModelPricingOverrideSchema = z.object({
+  provider: z.string({ error: 'pricingOverrides[].provider must be a string' }),
+  modelPattern: z.string({ error: 'pricingOverrides[].modelPattern must be a string' }),
+  inputPer1M: z
+    .number({ error: 'pricingOverrides[].inputPer1M must be a number' })
+    .nonnegative('pricingOverrides[].inputPer1M must be a non-negative number'),
+  outputPer1M: z
+    .number({ error: 'pricingOverrides[].outputPer1M must be a number' })
+    .nonnegative('pricingOverrides[].outputPer1M must be a non-negative number'),
+});
+
 export const AssistantConfigSchema = z.object({
   provider: z
     .enum(VALID_PROVIDERS, {
@@ -288,6 +299,9 @@ export const AssistantConfigSchema = z.object({
   auditLog: AuditLogConfigSchema.default({
     retentionDays: 0,
   }),
+  pricingOverrides: z
+    .array(ModelPricingOverrideSchema)
+    .default([]),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -319,3 +333,4 @@ export type MemorySegmentationConfig = z.infer<typeof MemorySegmentationConfigSc
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
+export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -13,4 +13,5 @@ export type {
   MemoryJobsConfig,
   MemoryRetentionConfig,
   MemoryConfig,
+  ModelPricingOverride,
 } from './schema.js';

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,5 +1,6 @@
 import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
+import Anthropic from '@anthropic-ai/sdk';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -26,6 +27,7 @@ import type {
   TaskSubmit,
   AppDataRequest,
   SkillDetailRequest,
+  SuggestionRequest,
 } from './ipc-protocol.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
@@ -287,6 +289,7 @@ const handlers: DispatchMap = {
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
+  suggestion_request: handleSuggestionRequest,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -788,6 +791,117 @@ async function handleTaskSubmit(
     rlog.error({ err }, 'Error handling task_submit');
     ctx.send(socket, { type: 'error', message: `Failed to route task: ${message}` });
   }
+}
+
+// ─── Suggestion handler ─────────────────────────────────────────────────────
+
+const SUGGESTION_CACHE_MAX = 100;
+const suggestionCache = new Map<string, string>();
+const suggestionInFlight = new Map<string, Promise<string | null>>();
+
+async function handleSuggestionRequest(
+  msg: SuggestionRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const noSuggestion = () => {
+    ctx.send(socket, {
+      type: 'suggestion_response',
+      requestId: msg.requestId,
+      suggestion: null,
+      source: 'none' as const,
+    });
+  };
+
+  const rawMessages = conversationStore.getMessages(msg.sessionId);
+  if (rawMessages.length === 0) { noSuggestion(); return; }
+
+  // Walk backwards to find the last assistant message with text content
+  for (let i = rawMessages.length - 1; i >= 0; i--) {
+    const m = rawMessages[i];
+    if (m.role !== 'assistant') continue;
+
+    let content: unknown;
+    try { content = JSON.parse(m.content); } catch { content = m.content; }
+    const rendered = renderHistoryContent(content);
+    const text = rendered.text.trim();
+    if (!text) continue;
+
+    // Return cached suggestion
+    const cached = suggestionCache.get(m.id);
+    if (cached !== undefined) {
+      ctx.send(socket, {
+        type: 'suggestion_response',
+        requestId: msg.requestId,
+        suggestion: cached,
+        source: 'llm' as const,
+      });
+      return;
+    }
+
+    // Try LLM suggestion if an Anthropic API key is configured
+    const apiKey = getConfig().apiKeys.anthropic;
+    if (apiKey) {
+      try {
+        let promise = suggestionInFlight.get(m.id);
+        if (!promise) {
+          promise = generateSuggestion(apiKey, text);
+          suggestionInFlight.set(m.id, promise);
+        }
+        const llmSuggestion = await promise;
+        suggestionInFlight.delete(m.id);
+
+        if (llmSuggestion) {
+          if (suggestionCache.size >= SUGGESTION_CACHE_MAX) {
+            const oldest = suggestionCache.keys().next().value!;
+            suggestionCache.delete(oldest);
+          }
+          suggestionCache.set(m.id, llmSuggestion);
+
+          ctx.send(socket, {
+            type: 'suggestion_response',
+            requestId: msg.requestId,
+            suggestion: llmSuggestion,
+            source: 'llm' as const,
+          });
+          return;
+        }
+      } catch (err) {
+        suggestionInFlight.delete(m.id);
+        log.warn({ err }, 'LLM suggestion failed');
+      }
+    }
+
+    noSuggestion();
+    return;
+  }
+
+  noSuggestion();
+}
+
+async function generateSuggestion(apiKey: string, assistantText: string): Promise<string | null> {
+  const client = new Anthropic({ apiKey });
+  const truncated = assistantText.length > 2000
+    ? assistantText.slice(-2000)
+    : assistantText;
+
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 60,
+    messages: [
+      {
+        role: 'user',
+        content: `The AI assistant just said the following to the user. Suggest a single short follow-up message (max 200 chars) the user might want to send next. Reply with ONLY the suggested message text, nothing else.\n\nAssistant's message:\n${truncated}`,
+      },
+    ],
+  });
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
+  if (!raw || raw.length > 200) return null;
+
+  const firstLine = raw.split('\n')[0].trim();
+  return firstLine || null;
 }
 
 // ─── Computer-use handlers ──────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -149,6 +149,12 @@ export interface SkillDetailRequest {
   skillId: string;
 }
 
+export interface SuggestionRequest {
+  type: 'suggestion_request';
+  sessionId: string;
+  requestId: string;
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -251,7 +257,8 @@ export type ClientMessage =
   | UiSurfaceAction
   | AppDataRequest
   | SkillsListRequest
-  | SkillDetailRequest;
+  | SkillDetailRequest
+  | SuggestionRequest;
 
 // === Server → Client messages ===
 
@@ -497,6 +504,13 @@ export interface SkillDetailResponse {
   error?: string;
 }
 
+export interface SuggestionResponse {
+  type: 'suggestion_response';
+  requestId: string;
+  suggestion: string | null;
+  source: 'llm' | 'none';
+}
+
 export interface MessageQueued {
   type: 'message_queued';
   sessionId: string;
@@ -604,6 +618,7 @@ export type ServerMessage =
   | AppDataResponse
   | SkillsListResponse
   | SkillDetailResponse
+  | SuggestionResponse
   | MessageQueued
   | MessageDequeued;
 

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -3,8 +3,9 @@ import '../instrument.js';
 import * as Sentry from '@sentry/node';
 import { runDaemon } from './lifecycle.js';
 
-runDaemon().catch((err) => {
+runDaemon().catch(async (err) => {
   Sentry.captureException(err);
+  await Sentry.flush(2000);
   console.error('Failed to start daemon:', err);
   console.error('Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/data/logs/');
   process.exit(1);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -19,7 +19,7 @@ import { allAppTools } from '../tools/apps/definitions.js';
 import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getConfig } from '../config/loader.js';
-import { estimateCost } from '../util/pricing.js';
+import { estimateCost, resolvePricing } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
@@ -37,6 +37,8 @@ import {
   injectMemoryRecallIntoUserMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
+import { recordUsageEvent } from '../memory/llm-usage-store.js';
+import type { UsageActor } from '../usage/actors.js';
 
 const log = getLogger('session');
 
@@ -67,6 +69,7 @@ export interface QueuePolicy {
 
 export class Session {
   public readonly conversationId: string;
+  private provider: Provider;
   private messages: Message[] = [];
   private agentLoop: AgentLoop;
   private processing = false;
@@ -98,6 +101,7 @@ export class Session {
     workingDir: string,
   ) {
     this.conversationId = conversationId;
+    this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
     this.prompter = new PermissionPrompter(sendToClient);
@@ -393,6 +397,7 @@ export class Session {
           compacted.summaryOutputTokens,
           compacted.summaryModel,
           onEvent,
+          'context_compactor',
         );
       }
 
@@ -618,7 +623,7 @@ export class Session {
       const restoredHistory = [...preRepairMessages, ...newMessages];
       this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText);
 
-      this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent);
+      this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent');
 
       if (yieldedForHandoff) {
         onEvent({
@@ -974,6 +979,7 @@ export class Session {
     outputTokens: number,
     model: string,
     onEvent: (msg: ServerMessage) => void,
+    actor: UsageActor,
   ): void {
     if (inputTokens <= 0 && outputTokens <= 0) return;
 
@@ -998,6 +1004,29 @@ export class Session {
       estimatedCost,
       model,
     });
+
+    // Dual-write: persist per-turn usage event to the new ledger table
+    try {
+      const pricing = resolvePricing(this.provider.name, model, inputTokens, outputTokens);
+      recordUsageEvent(
+        {
+          actor,
+          provider: this.provider.name,
+          model,
+          inputTokens,
+          outputTokens,
+          cacheCreationInputTokens: null,
+          cacheReadInputTokens: null,
+          assistantId: null,
+          conversationId: this.conversationId,
+          runId: null,
+          requestId: null,
+        },
+        pricing,
+      );
+    } catch (err) {
+      log.warn({ err, conversationId: this.conversationId }, 'Failed to persist usage event (non-fatal)');
+    }
   }
 
   private async generateTitle(userMessage: string, assistantResponse: string): Promise<void> {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -802,13 +802,14 @@ export class Session {
     // deleteLastExchange only finds the last role='user' row — which may be a
     // tool_result message, leaving the real user message orphaned.
     //
-    // Strategy: first peel back any tool_result user messages, then delete
-    // the real user message exchange. This ensures the DB cleanup matches
-    // the in-memory cleanup.
-    while (conversationStore.isLastUserMessageToolResult(this.conversationId)) {
+    // Strategy: delete the last exchange, then continue deleting any trailing
+    // tool_result user messages. Using a do-while ensures we clean up orphaned
+    // tool_result rows that may appear both before AND after the real user
+    // message (e.g. when repairHistory merges them in memory but the DB still
+    // stores them as separate rows).
+    do {
       conversationStore.deleteLastExchange(this.conversationId);
-    }
-    conversationStore.deleteLastExchange(this.conversationId);
+    } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
 
     return removed;
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -803,14 +803,22 @@ export class Session {
     // tool_result message, leaving the real user message orphaned.
     //
     // Strategy: peel back any trailing tool_result exchanges first, then
-    // unconditionally delete the real user message exchange. The do-while
-    // handles the case where the last DB exchange is a tool_result row, and
-    // the final call after the loop ensures the original user message is
-    // always removed.
+    // delete the real user message exchange only if tool_result rows were
+    // actually encountered. The do-while handles the case where the last DB
+    // exchange is a tool_result row; the flag ensures we only issue the extra
+    // deleteLastExchange when the loop peeled back tool_result messages.
+    let hadToolResult = false;
     do {
       conversationStore.deleteLastExchange(this.conversationId);
-    } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
-    conversationStore.deleteLastExchange(this.conversationId);
+      if (conversationStore.isLastUserMessageToolResult(this.conversationId)) {
+        hadToolResult = true;
+      } else {
+        break;
+      }
+    } while (true);
+    if (hadToolResult) {
+      conversationStore.deleteLastExchange(this.conversationId);
+    }
 
     return removed;
   }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -802,14 +802,15 @@ export class Session {
     // deleteLastExchange only finds the last role='user' row — which may be a
     // tool_result message, leaving the real user message orphaned.
     //
-    // Strategy: delete the last exchange, then continue deleting any trailing
-    // tool_result user messages. Using a do-while ensures we clean up orphaned
-    // tool_result rows that may appear both before AND after the real user
-    // message (e.g. when repairHistory merges them in memory but the DB still
-    // stores them as separate rows).
+    // Strategy: peel back any trailing tool_result exchanges first, then
+    // unconditionally delete the real user message exchange. The do-while
+    // handles the case where the last DB exchange is a tool_result row, and
+    // the final call after the loop ensures the original user message is
+    // always removed.
     do {
       conversationStore.deleteLastExchange(this.conversationId);
     } while (conversationStore.isLastUserMessageToolResult(this.conversationId));
+    conversationStore.deleteLastExchange(this.conversationId);
 
     return removed;
   }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -170,6 +170,7 @@ export function clearAll(): { conversations: number; messages: number } {
   raw.exec('DELETE FROM memory_embeddings');
   raw.exec('DELETE FROM memory_jobs');
   raw.exec('DELETE FROM memory_checkpoints');
+  raw.exec('DELETE FROM llm_usage_events');
   raw.exec('DELETE FROM tool_invocations');
   raw.exec('DELETE FROM messages');
   raw.exec('DELETE FROM conversations');

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -262,6 +262,27 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      assistant_id TEXT,
+      conversation_id TEXT,
+      run_id TEXT,
+      request_id TEXT,
+      actor TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL,
+      output_tokens INTEGER NOT NULL,
+      cache_creation_input_tokens INTEGER,
+      cache_read_input_tokens INTEGER,
+      estimated_cost_usd REAL,
+      pricing_status TEXT NOT NULL,
+      metadata_json TEXT
+    )
+  `);
+
   // FTS table for lexical retrieval over memory_segments.text.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
@@ -343,6 +364,13 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_service ON accounts(service)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_created_at ON llm_usage_events(created_at)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_assistant_id ON llm_usage_events(assistant_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_provider ON llm_usage_events(provider)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_model ON llm_usage_events(model)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_actor ON llm_usage_events(actor)`);
+
   migrateMemoryFtsBackfill(database);
 }
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -1,0 +1,62 @@
+import { desc } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { llmUsageEvents } from './schema.js';
+import type { UsageEventInput, UsageEvent, PricingResult } from '../usage/types.js';
+
+export function recordUsageEvent(input: UsageEventInput, pricing: PricingResult): UsageEvent {
+  const db = getDb();
+  const event: UsageEvent = {
+    id: uuid(),
+    createdAt: Date.now(),
+    ...input,
+    estimatedCostUsd: pricing.estimatedCostUsd,
+    pricingStatus: pricing.pricingStatus,
+  };
+  db.insert(llmUsageEvents).values({
+    id: event.id,
+    createdAt: event.createdAt,
+    assistantId: event.assistantId,
+    conversationId: event.conversationId,
+    runId: event.runId,
+    requestId: event.requestId,
+    actor: event.actor,
+    provider: event.provider,
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    cacheCreationInputTokens: event.cacheCreationInputTokens,
+    cacheReadInputTokens: event.cacheReadInputTokens,
+    estimatedCostUsd: event.estimatedCostUsd,
+    pricingStatus: event.pricingStatus,
+    metadataJson: null,
+  }).run();
+  return event;
+}
+
+export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(llmUsageEvents)
+    .orderBy(desc(llmUsageEvents.createdAt))
+    .limit(options?.limit ?? 100)
+    .all();
+  return rows.map(row => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    assistantId: row.assistantId,
+    conversationId: row.conversationId,
+    runId: row.runId,
+    requestId: row.requestId,
+    actor: row.actor as UsageEvent['actor'],
+    provider: row.provider,
+    model: row.model,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheCreationInputTokens: row.cacheCreationInputTokens,
+    cacheReadInputTokens: row.cacheReadInputTokens,
+    estimatedCostUsd: row.estimatedCostUsd,
+    pricingStatus: row.pricingStatus as 'priced' | 'unpriced',
+  }));
+}

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -233,3 +233,24 @@ export const cronRuns = sqliteTable('cron_runs', {
   conversationId: text('conversation_id'),
   createdAt: integer('created_at').notNull(),
 });
+
+// ── LLM Usage Events (cost tracking ledger) ─────────────────────────
+
+export const llmUsageEvents = sqliteTable('llm_usage_events', {
+  id: text('id').primaryKey(),
+  createdAt: integer('created_at').notNull(),
+  assistantId: text('assistant_id'),
+  conversationId: text('conversation_id'),
+  runId: text('run_id'),
+  requestId: text('request_id'),
+  actor: text('actor').notNull(),
+  provider: text('provider').notNull(),
+  model: text('model').notNull(),
+  inputTokens: integer('input_tokens').notNull(),
+  outputTokens: integer('output_tokens').notNull(),
+  cacheCreationInputTokens: integer('cache_creation_input_tokens'),
+  cacheReadInputTokens: integer('cache_read_input_tokens'),
+  estimatedCostUsd: real('estimated_cost_usd'),
+  pricingStatus: text('pricing_status').notNull(),
+  metadataJson: text('metadata_json'),
+});

--- a/assistant/src/usage/actors.ts
+++ b/assistant/src/usage/actors.ts
@@ -1,0 +1,24 @@
+/**
+ * Identifiers for the different agents/subsystems that consume LLM tokens.
+ */
+export type UsageActor =
+  | 'main_agent'
+  | 'context_compactor'
+  | 'task_classifier'
+  | 'title_generator'
+  | 'ambient_analyzer'
+  | 'suggestion_generator'
+  | 'computer_use_agent'
+  | 'memory_embedding';
+
+/** All valid actor identifiers (useful for runtime validation). */
+export const USAGE_ACTORS: readonly UsageActor[] = [
+  'main_agent',
+  'context_compactor',
+  'task_classifier',
+  'title_generator',
+  'ambient_analyzer',
+  'suggestion_generator',
+  'computer_use_agent',
+  'memory_embedding',
+] as const;

--- a/assistant/src/usage/summary.ts
+++ b/assistant/src/usage/summary.ts
@@ -1,0 +1,120 @@
+import { getDb } from '../memory/db.js';
+import { llmUsageEvents } from '../memory/schema.js';
+import { sql, and, gte, lte, eq } from 'drizzle-orm';
+
+export interface UsageSummaryOptions {
+  startAt: number;  // epoch ms
+  endAt: number;    // epoch ms
+  assistantId?: string;
+  provider?: string;
+  model?: string;
+  actor?: string;
+}
+
+export interface UsageBreakdownEntry {
+  key: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number | null;
+  eventCount: number;
+}
+
+export interface UsageDailyBucket {
+  date: string;  // YYYY-MM-DD
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number | null;
+  eventCount: number;
+}
+
+export interface UsageSummary {
+  totalPricedCostUsd: number;
+  totalUnpricedInputTokens: number;
+  totalUnpricedOutputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  eventCount: number;
+  byProvider: UsageBreakdownEntry[];
+  byModel: UsageBreakdownEntry[];
+  byActor: UsageBreakdownEntry[];
+  dailyBuckets: UsageDailyBucket[];
+}
+
+export function getUsageSummary(options: UsageSummaryOptions): UsageSummary {
+  const db = getDb();
+
+  // Build WHERE conditions
+  const conditions = [
+    gte(llmUsageEvents.createdAt, options.startAt),
+    lte(llmUsageEvents.createdAt, options.endAt),
+  ];
+  if (options.assistantId) conditions.push(eq(llmUsageEvents.assistantId, options.assistantId));
+  if (options.provider) conditions.push(eq(llmUsageEvents.provider, options.provider));
+  if (options.model) conditions.push(eq(llmUsageEvents.model, options.model));
+  if (options.actor) conditions.push(eq(llmUsageEvents.actor, options.actor));
+
+  const whereClause = and(...conditions);
+
+  // Total aggregation
+  const totals = db.select({
+    totalInputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+    totalOutputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+    totalPricedCost: sql<number>`coalesce(sum(case when ${llmUsageEvents.pricingStatus} = 'priced' then ${llmUsageEvents.estimatedCostUsd} else 0 end), 0)`,
+    totalUnpricedInputTokens: sql<number>`coalesce(sum(case when ${llmUsageEvents.pricingStatus} = 'unpriced' then ${llmUsageEvents.inputTokens} else 0 end), 0)`,
+    totalUnpricedOutputTokens: sql<number>`coalesce(sum(case when ${llmUsageEvents.pricingStatus} = 'unpriced' then ${llmUsageEvents.outputTokens} else 0 end), 0)`,
+    eventCount: sql<number>`count(*)`,
+  }).from(llmUsageEvents).where(whereClause).get()!;
+
+  // Breakdown by provider
+  const byProvider = db.select({
+    key: llmUsageEvents.provider,
+    totalInputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+    totalOutputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+    totalCost: sql<number | null>`sum(case when ${llmUsageEvents.pricingStatus} = 'priced' then ${llmUsageEvents.estimatedCostUsd} else null end)`,
+    eventCount: sql<number>`count(*)`,
+  }).from(llmUsageEvents).where(whereClause).groupBy(llmUsageEvents.provider).all();
+
+  // Breakdown by model
+  const byModel = db.select({
+    key: llmUsageEvents.model,
+    totalInputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+    totalOutputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+    totalCost: sql<number | null>`sum(case when ${llmUsageEvents.pricingStatus} = 'priced' then ${llmUsageEvents.estimatedCostUsd} else null end)`,
+    eventCount: sql<number>`count(*)`,
+  }).from(llmUsageEvents).where(whereClause).groupBy(llmUsageEvents.model).all();
+
+  // Breakdown by actor
+  const byActor = db.select({
+    key: llmUsageEvents.actor,
+    totalInputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+    totalOutputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+    totalCost: sql<number | null>`sum(case when ${llmUsageEvents.pricingStatus} = 'priced' then ${llmUsageEvents.estimatedCostUsd} else null end)`,
+    eventCount: sql<number>`count(*)`,
+  }).from(llmUsageEvents).where(whereClause).groupBy(llmUsageEvents.actor).all();
+
+  // Daily buckets using SQLite date function
+  // Convert epoch ms to seconds for SQLite date functions
+  const dailyBuckets = db.select({
+    date: sql<string>`date(${llmUsageEvents.createdAt} / 1000, 'unixepoch')`,
+    totalInputTokens: sql<number>`coalesce(sum(${llmUsageEvents.inputTokens}), 0)`,
+    totalOutputTokens: sql<number>`coalesce(sum(${llmUsageEvents.outputTokens}), 0)`,
+    totalCost: sql<number | null>`sum(case when ${llmUsageEvents.pricingStatus} = 'priced' then ${llmUsageEvents.estimatedCostUsd} else null end)`,
+    eventCount: sql<number>`count(*)`,
+  }).from(llmUsageEvents).where(whereClause)
+    .groupBy(sql`date(${llmUsageEvents.createdAt} / 1000, 'unixepoch')`)
+    .orderBy(sql`date(${llmUsageEvents.createdAt} / 1000, 'unixepoch')`)
+    .all();
+
+  return {
+    totalPricedCostUsd: totals.totalPricedCost,
+    totalUnpricedInputTokens: totals.totalUnpricedInputTokens,
+    totalUnpricedOutputTokens: totals.totalUnpricedOutputTokens,
+    totalInputTokens: totals.totalInputTokens,
+    totalOutputTokens: totals.totalOutputTokens,
+    eventCount: totals.eventCount,
+    byProvider,
+    byModel,
+    byActor,
+    dailyBuckets,
+  };
+}

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -1,0 +1,38 @@
+import type { UsageActor } from './actors.js';
+
+/**
+ * Input data required to record a single LLM usage event.
+ * Matches the token fields from `ProviderResponse.usage`.
+ */
+export interface UsageEventInput {
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
+  actor: UsageActor;
+  assistantId: string | null;
+  conversationId: string | null;
+  runId: string | null;
+  requestId: string | null;
+}
+
+/**
+ * Result of resolving pricing for a usage event.
+ */
+export interface PricingResult {
+  estimatedCostUsd: number | null;
+  pricingStatus: 'priced' | 'unpriced';
+}
+
+/**
+ * A persisted usage event, combining the original input with
+ * storage metadata and resolved pricing.
+ */
+export interface UsageEvent extends UsageEventInput {
+  id: string;
+  createdAt: number;
+  estimatedCostUsd: number | null;
+  pricingStatus: 'priced' | 'unpriced';
+}

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -1,8 +1,15 @@
+import type { PricingResult } from '../usage/types.js';
+import type { ModelPricingOverride } from '../config/schema.js';
+
 interface ModelPricing {
   inputPer1M: number;  // USD per 1M input tokens
   outputPer1M: number; // USD per 1M output tokens
 }
 
+/**
+ * Legacy pricing table keyed by exact model string.
+ * Kept for backward compatibility with estimateCost().
+ */
 const PRICING: Record<string, ModelPricing> = {
   'claude-opus-4-5-20250929':   { inputPer1M: 15, outputPer1M: 75 },
   'claude-sonnet-4-5-20250929': { inputPer1M: 3, outputPer1M: 15 },
@@ -10,17 +17,147 @@ const PRICING: Record<string, ModelPricing> = {
 };
 
 /**
+ * Multi-provider pricing catalog keyed by provider then model pattern.
+ * Model patterns are matched by exact match first, then by prefix.
+ */
+const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
+  anthropic: {
+    'claude-opus-4': { inputPer1M: 15, outputPer1M: 75 },
+    'claude-sonnet-4': { inputPer1M: 3, outputPer1M: 15 },
+    'claude-haiku-4': { inputPer1M: 0.80, outputPer1M: 4 },
+  },
+  openai: {
+    'gpt-4o': { inputPer1M: 2.50, outputPer1M: 10 },
+    'gpt-4o-mini': { inputPer1M: 0.15, outputPer1M: 0.60 },
+    'gpt-4.1': { inputPer1M: 2.00, outputPer1M: 8.00 },
+    'gpt-4.1-mini': { inputPer1M: 0.40, outputPer1M: 1.60 },
+    'gpt-4.1-nano': { inputPer1M: 0.10, outputPer1M: 0.40 },
+    'o3': { inputPer1M: 2.00, outputPer1M: 8.00 },
+    'o3-mini': { inputPer1M: 1.10, outputPer1M: 4.40 },
+    'o3-pro': { inputPer1M: 20, outputPer1M: 80 },
+    'o4-mini': { inputPer1M: 1.10, outputPer1M: 4.40 },
+  },
+  gemini: {
+    'gemini-2.5-pro': { inputPer1M: 1.25, outputPer1M: 10 },
+    'gemini-2.5-flash': { inputPer1M: 0.15, outputPer1M: 0.60 },
+    'gemini-2.0-flash': { inputPer1M: 0.10, outputPer1M: 0.40 },
+  },
+};
+
+/**
+ * Look up pricing for a model within a provider's catalog.
+ * Tries exact match first, then longest prefix match.
+ */
+function findPricing(catalog: Record<string, ModelPricing>, model: string): ModelPricing | undefined {
+  // Exact match
+  if (catalog[model]) return catalog[model];
+
+  // Prefix match: find the longest matching prefix
+  let bestMatch: ModelPricing | undefined;
+  let bestLen = 0;
+  for (const [pattern, pricing] of Object.entries(catalog)) {
+    if (model.startsWith(pattern) && pattern.length > bestLen) {
+      bestMatch = pricing;
+      bestLen = pattern.length;
+    }
+  }
+  return bestMatch;
+}
+
+/**
+ * Calculate cost from pricing and token counts.
+ */
+function calculateCost(pricing: ModelPricing, inputTokens: number, outputTokens: number): number {
+  return (inputTokens / 1_000_000) * pricing.inputPer1M
+       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+}
+
+/**
+ * Resolve pricing for a provider/model combination using the built-in catalog.
+ * Returns a PricingResult with explicit priced/unpriced status.
+ */
+export function resolvePricing(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): PricingResult {
+  const providerCatalog = PROVIDER_PRICING[provider];
+  if (!providerCatalog) {
+    return { estimatedCostUsd: null, pricingStatus: 'unpriced' };
+  }
+
+  const pricing = findPricing(providerCatalog, model);
+  if (!pricing) {
+    return { estimatedCostUsd: null, pricingStatus: 'unpriced' };
+  }
+
+  return {
+    estimatedCostUsd: calculateCost(pricing, inputTokens, outputTokens),
+    pricingStatus: 'priced',
+  };
+}
+
+/**
+ * Resolve pricing with optional custom model overrides checked first.
+ * Overrides are matched by provider (exact) and modelPattern (prefix match).
+ * Falls back to the built-in catalog if no override matches.
+ */
+export function resolvePricingWithOverrides(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  overrides?: ModelPricingOverride[],
+): PricingResult {
+  if (overrides && overrides.length > 0) {
+    // Find matching overrides for this provider, use longest modelPattern prefix match
+    let bestOverride: ModelPricingOverride | undefined;
+    let bestLen = 0;
+    for (const override of overrides) {
+      if (override.provider !== provider) continue;
+      // Exact match or prefix match on modelPattern
+      if (model === override.modelPattern || model.startsWith(override.modelPattern)) {
+        if (override.modelPattern.length > bestLen) {
+          bestOverride = override;
+          bestLen = override.modelPattern.length;
+        }
+      }
+    }
+    if (bestOverride) {
+      const cost = calculateCost(
+        { inputPer1M: bestOverride.inputPer1M, outputPer1M: bestOverride.outputPer1M },
+        inputTokens,
+        outputTokens,
+      );
+      return { estimatedCostUsd: cost, pricingStatus: 'priced' };
+    }
+  }
+
+  return resolvePricing(provider, model, inputTokens, outputTokens);
+}
+
+/**
  * Estimate cost in USD for the given token counts and model.
  * Returns 0 if the model is not in the pricing table.
+ *
+ * @deprecated Prefer resolvePricing() or resolvePricingWithOverrides() for
+ * provider-aware pricing with explicit priced/unpriced status.
  */
 export function estimateCost(
   inputTokens: number,
   outputTokens: number,
   model: string,
 ): number {
+  // Try the new provider-aware catalog first (default to anthropic for backward compat)
+  const result = resolvePricing('anthropic', model, inputTokens, outputTokens);
+  if (result.pricingStatus === 'priced' && result.estimatedCostUsd !== null) {
+    return result.estimatedCostUsd;
+  }
+
+  // Fall back to legacy exact/prefix matching on the old PRICING table
   const pricing = PRICING[model]
     ?? Object.entries(PRICING).find(([key]) => model.startsWith(key))?.[1];
   if (!pricing) return 0;
-  return (inputTokens / 1_000_000) * pricing.inputPer1M
-       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+  return calculateCost(pricing, inputTokens, outputTokens);
 }

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -8,7 +8,33 @@ A native macOS menu bar app that controls your Mac via accessibility APIs and CG
 - Xcode 15+ (for building)
 - Anthropic API key
 
+## Quick Run
+
+The fastest way to build and launch the app locally:
+
+```bash
+./build.sh run
+```
+
+This builds a debug `.app` bundle, codesigns it, and launches it immediately.
+
 ## Build
+
+```bash
+# Build debug .app bundle (→ dist/Vellum.app)
+./build.sh
+
+# Build + launch
+./build.sh run
+
+# Build release
+./build.sh release
+
+# Run all tests
+./build.sh test
+```
+
+The raw SwiftPM commands also work if you prefer:
 
 ```bash
 # Resolve dependencies
@@ -54,6 +80,22 @@ scripts/run-dev.sh --clean
 # Override team ID
 scripts/run-dev.sh --team YOUR_TEAM_ID
 ```
+
+## Daemon
+
+The macOS app is a frontend — all inference (chat, computer-use sessions, ambient analysis) goes through the **daemon**, a Node/Bun process that manages Claude API calls, conversation state, and tool execution. The app connects to the daemon via a Unix domain socket at `~/.vellum/vellum.sock`.
+
+**You must start the daemon before using the app.** Without it, the app will connect but get no responses.
+
+```bash
+# Start the daemon (from the repo root)
+cd assistant && bun run dev
+
+# Or use the CLI
+cd assistant && bun run src/index.ts daemon start
+```
+
+The app will auto-reconnect if the daemon restarts. For development, `bun run dev` runs in the foreground with auto-restart on file changes.
 
 ## Permissions
 

--- a/clients/macos/dmg/generate-background.swift
+++ b/clients/macos/dmg/generate-background.swift
@@ -98,23 +98,20 @@ let arrowLineWidth: CGFloat = 4.0
 
 // Arrow color: muted purple-white
 let arrowColor = CGColor(colorSpace: colorSpace, components: rgb(168, 140, 210, 0.7))!
-ctx.setStrokeColor(arrowColor)
 ctx.setFillColor(arrowColor)
-ctx.setLineWidth(arrowLineWidth)
-ctx.setLineCap(.round)
-ctx.setLineJoin(.round)
 
-// Arrow shaft
-ctx.beginPath()
-ctx.move(to: CGPoint(x: arrowStartX, y: arrowY))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize, y: arrowY))
-ctx.strokePath()
+// Single filled polygon: shaft rectangle merging into arrowhead triangle
+let shaftHalf: CGFloat = arrowLineWidth / 2
+let neckX = arrowEndX - arrowHeadSize * 1.5  // Where shaft meets head
 
-// Arrowhead (filled triangle)
 ctx.beginPath()
-ctx.move(to: CGPoint(x: arrowEndX, y: arrowY))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY - arrowHeadSize))
-ctx.addLine(to: CGPoint(x: arrowEndX - arrowHeadSize * 1.5, y: arrowY + arrowHeadSize))
+ctx.move(to: CGPoint(x: arrowStartX, y: arrowY - shaftHalf))          // top-left of shaft
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY - shaftHalf))             // top-right of shaft
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY - arrowHeadSize))         // top of arrowhead
+ctx.addLine(to: CGPoint(x: arrowEndX, y: arrowY))                     // tip
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY + arrowHeadSize))         // bottom of arrowhead
+ctx.addLine(to: CGPoint(x: neckX, y: arrowY + shaftHalf))             // bottom-right of shaft
+ctx.addLine(to: CGPoint(x: arrowStartX, y: arrowY + shaftHalf))       // bottom-left of shaft
 ctx.closePath()
 ctx.fillPath()
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -179,10 +179,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupToolConfirmationManager() {
         daemonClient.onConfirmationRequest = { [weak self] msg in
-            self?.toolConfirmationManager.showConfirmation(msg)
+            // Only show floating panel if app is NOT focused
+            if !NSApp.isActive {
+                self?.toolConfirmationManager.showConfirmation(msg)
+            }
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
+            // Send the response to daemon
             try? self?.daemonClient.sendConfirmationResponse(
+                requestId: requestId,
+                decision: decision
+            )
+            // Sync the inline message state in the active ChatViewModel
+            self?.mainWindow?.activeViewModel?.updateConfirmationState(
                 requestId: requestId,
                 decision: decision
             )
@@ -478,6 +487,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent)
+        // Wire inline confirmation dismiss to close the corresponding floating panel
+        main.threadManager.confirmationDismissHandler = { [weak self] requestId in
+            self?.toolConfirmationManager.dismissConfirmation(requestId: requestId)
+        }
         main.show()
         mainWindow = main
     }

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -107,7 +107,7 @@ final class TextSession: ObservableObject {
                     // Stay in thinking state while receiving thinking deltas
                     log.debug("Thinking: \(delta.thinking)")
 
-                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId:
+                case .messageComplete(let complete) where complete.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     // Set state before appending to messages — the $state Combine sink
                     // triggers a layout pass, and if state is still .streaming when the
@@ -117,13 +117,13 @@ final class TextSession: ObservableObject {
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
-                case .generationHandoff(let handoff) where handoff.sessionId == self.daemonSessionId:
+                case .generationHandoff(let handoff) where handoff.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     let responseText = self.accumulatedText.isEmpty ? "(No response)" : self.accumulatedText
                     self.state = .ready
                     self.messages.append(ConversationMessage(role: .assistant, text: responseText))
                     return
 
-                case .cuError(let error) where error.sessionId == self.daemonSessionId:
+                case .cuError(let error) where error.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
                     self.state = .failed(reason: error.message)
                     return
 

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -12,13 +12,11 @@ struct VSplitView<Main: View, Panel: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if showPanel, let panel = panel {
-                Divider()
-                    .background(VColor.surfaceBorder)
-                    .transition(.move(edge: .trailing))
-
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .padding(VSpacing.sm)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Modifiers/CardModifier.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct CardModifier: ViewModifier {
     var radius: CGFloat = VRadius.md
+    var background: Color = VColor.surface
 
     func body(content: Content) -> some View {
         content
-            .background(VColor.surface)
+            .background(background)
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
@@ -15,8 +16,8 @@ struct CardModifier: ViewModifier {
 }
 
 extension View {
-    func vCard(radius: CGFloat = VRadius.md) -> some View {
-        modifier(CardModifier(radius: radius))
+    func vCard(radius: CGFloat = VRadius.md, background: Color = VColor.surface) -> some View {
+        modifier(CardModifier(radius: radius, background: background))
     }
 }
 

--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
@@ -50,8 +50,8 @@ struct VSlider: View {
                         let newFraction = (drag.location.x - thumbWidth / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
-                        value = range.lowerBound + round((rawValue - range.lowerBound) / step) * step
-                        value = min(max(value, range.lowerBound), range.upperBound)
+                        let snapped = round(rawValue / step) * step
+                        value = min(max(snapped, range.lowerBound), range.upperBound)
                     }
                     .onEnded { _ in
                         isDragging = false
@@ -109,17 +109,21 @@ struct VSlider: View {
     // MARK: - Tick Marks
 
     private func tickMarksView(trackWidth: CGFloat, fraction: Double) -> some View {
-        let totalSteps = Int((range.upperBound - range.lowerBound) / step)
+        // Build tick values as multiples of step within the range
+        let firstTick = ceil(range.lowerBound / step) * step
+        let lastTick = floor(range.upperBound / step) * step
+        let tickValues = stride(from: firstTick, through: lastTick, by: step).map { $0 }
         let maxTicks = 20
-        let tickStep = totalSteps > maxTicks ? totalSteps / maxTicks : 1
+        let tickStep = tickValues.count > maxTicks ? tickValues.count / maxTicks : 1
+        let rangeSpan = range.upperBound - range.lowerBound
 
         return ZStack(alignment: .leading) {
-            ForEach(0...totalSteps, id: \.self) { i in
-                if i % tickStep == 0 {
-                    let tickFraction = Double(i) / Double(totalSteps)
+            ForEach(Array(tickValues.enumerated()), id: \.offset) { index, tickValue in
+                if index % tickStep == 0 {
+                    let tickFraction = (tickValue - range.lowerBound) / rangeSpan
 
                     // Only render tick marks in the unfilled portion, excluding the rightmost
-                    if tickFraction > fraction && i < totalSteps {
+                    if tickFraction > fraction && tickValue < range.upperBound {
                         let tickX = trackWidth * tickFraction + thumbWidth / 2
 
                         RoundedRectangle(cornerRadius: 0.5)

--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VToggle.swift
@@ -38,16 +38,16 @@ struct VToggle: View {
     private var toggleTrack: some View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
-            RoundedRectangle(cornerRadius: VRadius.pill)
+            RoundedRectangle(cornerRadius: VRadius.sm + 2)
                 .fill(isOn ? Emerald._500 : Slate._700)
                 .frame(width: trackWidth, height: trackHeight)
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.pill)
+                    RoundedRectangle(cornerRadius: VRadius.sm + 2)
                         .stroke(Slate._600, lineWidth: 1)
                 )
 
             // Knob
-            Circle()
+            RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(Color.white)
                 .frame(width: knobSize, height: knobSize)
                 .padding(.horizontal, knobPadding)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -28,6 +28,17 @@ struct ToolConfirmationData: Equatable {
     var state: ToolConfirmationState = .pending
 }
 
+/// A file or image attachment associated with a chat message.
+struct ChatAttachment: Identifiable {
+    let id: String
+    let filename: String
+    let mimeType: String
+    /// Base64-encoded file data.
+    let data: String
+    /// Pre-rendered thumbnail for image attachments (resized to 120px max dimension).
+    let thumbnailData: Data?
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
@@ -37,8 +48,9 @@ struct ChatMessage: Identifiable {
     var status: ChatMessageStatus
     /// Non-nil when this message is an inline tool confirmation request.
     var confirmation: ToolConfirmationData?
+    var attachments: [ChatAttachment]
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = []) {
         self.id = id
         self.role = role
         self.text = text
@@ -46,5 +58,6 @@ struct ChatMessage: Identifiable {
         self.isStreaming = isStreaming
         self.status = status
         self.confirmation = confirmation
+        self.attachments = attachments
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -11,6 +11,23 @@ enum ChatMessageStatus: Equatable {
     case processing
 }
 
+/// Tracks the state of an inline tool confirmation request.
+enum ToolConfirmationState: Equatable {
+    case pending
+    case approved
+    case denied
+    case timedOut
+}
+
+/// Data for an inline tool confirmation message displayed in chat.
+struct ToolConfirmationData: Equatable {
+    let requestId: String
+    let toolName: String
+    let riskLevel: String
+    let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    var state: ToolConfirmationState = .pending
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
@@ -18,13 +35,16 @@ struct ChatMessage: Identifiable {
     let timestamp: Date
     var isStreaming: Bool
     var status: ChatMessageStatus
+    /// Non-nil when this message is an inline tool confirmation request.
+    var confirmation: ToolConfirmationData?
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil) {
         self.id = id
         self.role = role
         self.text = text
         self.timestamp = timestamp
         self.isStreaming = isStreaming
         self.status = status
+        self.confirmation = confirmation
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -12,6 +12,8 @@ struct ChatView: View {
     let onStop: () -> Void
     let onDismissError: () -> Void
     let onAcceptSuggestion: () -> Void
+    let onConfirmationAllow: (String) -> Void
+    let onConfirmationDeny: (String) -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -55,9 +57,19 @@ struct ChatView: View {
             ScrollView {
                 LazyVStack(spacing: VSpacing.md) {
                     ForEach(messages) { message in
-                        ChatBubble(message: message)
+                        if let confirmation = message.confirmation {
+                            ToolConfirmationBubble(
+                                confirmation: confirmation,
+                                onAllow: { onConfirmationAllow(confirmation.requestId) },
+                                onDeny: { onConfirmationDeny(confirmation.requestId) }
+                            )
                             .id(message.id)
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        } else {
+                            ChatBubble(message: message)
+                                .id(message.id)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        }
                     }
 
                     if isThinking {
@@ -398,7 +410,9 @@ private struct ThinkingIndicator: View {
             onSend: {},
             onStop: {},
             onDismissError: {},
-            onAcceptSuggestion: {}
+            onAcceptSuggestion: {},
+            onConfirmationAllow: { _ in },
+            onConfirmationDeny: { _ in }
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -8,10 +8,12 @@ struct ChatView: View {
     let errorText: String?
     let pendingQueuedCount: Int
     let suggestion: String?
+    let pendingAttachments: [ChatAttachment]
     let onSend: () -> Void
     let onStop: () -> Void
     let onDismissError: () -> Void
     let onAcceptSuggestion: () -> Void
+    let onAttach: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
 
@@ -214,11 +216,14 @@ struct ChatView: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop generation")
             } else {
-                Image(systemName: "paperclip")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(10)
-                    .accessibilityHidden(true)
+                Button(action: onAttach) {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(10)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Attach file")
             }
         }
         .padding(VSpacing.xs)
@@ -235,7 +240,7 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty
     }
 }
 
@@ -407,10 +412,12 @@ private struct ThinkingIndicator: View {
             errorText: nil,
             pendingQueuedCount: 0,
             suggestion: "That sounds great, thanks!",
+            pendingAttachments: [],
             onSend: {},
             onStop: {},
             onDismissError: {},
             onAcceptSuggestion: {},
+            onAttach: {},
             onConfirmationAllow: { _ in },
             onConfirmationDeny: { _ in }
         )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -153,7 +153,7 @@ struct ChatView: View {
 
             // Text field with ghost suffix overlay
             ZStack(alignment: .leading) {
-                TextField("What you need chef?", text: $inputText, axis: .vertical)
+                TextField("", text: $inputText, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(VFont.mono)
                     .foregroundColor(VColor.textPrimary)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -7,9 +7,22 @@ struct ChatView: View {
     let isSending: Bool
     let errorText: String?
     let pendingQueuedCount: Int
+    let suggestion: String?
     let onSend: () -> Void
     let onStop: () -> Void
     let onDismissError: () -> Void
+    let onAcceptSuggestion: () -> Void
+
+    /// The portion of the suggestion that extends beyond the current input.
+    private var ghostSuffix: String? {
+        guard let suggestion else { return nil }
+        if suggestion.hasPrefix(inputText) {
+            let suffix = String(suggestion.dropFirst(inputText.count))
+            return suffix.isEmpty ? nil : suffix
+        }
+        if inputText.isEmpty { return suggestion }
+        return nil
+    }
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
@@ -138,18 +151,46 @@ struct ChatView: View {
             // Leading chat icon
             VCircleButton(icon: "phone.fill", label: "Phone") { }
 
-            // Text field
-            TextField("What you need chef?", text: $inputText, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(VFont.mono)
-                .foregroundColor(VColor.textPrimary)
-                .lineLimit(1...3)
-                .onKeyPress(.return, phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.shift) { return .ignored }
-                    if canSend { onSend() }
-                    return .handled
+            // Text field with ghost suffix overlay
+            ZStack(alignment: .leading) {
+                TextField("What you need chef?", text: $inputText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1...3)
+                    .onKeyPress(.tab, phases: .down) { keyPress in
+                        if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
+                            onAcceptSuggestion()
+                            return .handled
+                        }
+                        return .ignored
+                    }
+                    .onKeyPress(.return, phases: .down) { keyPress in
+                        if keyPress.modifiers.contains(.shift) { return .ignored }
+                        if canSend { onSend() }
+                        return .handled
+                    }
+                    .onSubmit { if canSend { onSend() } }
+
+                if let ghostSuffix {
+                    Text(inputText + ghostSuffix)
+                        .font(VFont.mono)
+                        .foregroundColor(.clear)
+                        .lineLimit(1...3)
+                        .overlay(alignment: .leading) {
+                            HStack(spacing: 0) {
+                                Text(inputText)
+                                    .font(VFont.mono)
+                                    .foregroundColor(.clear)
+                                Text(ghostSuffix)
+                                    .font(VFont.mono)
+                                    .foregroundColor(VColor.textMuted.opacity(0.5))
+                            }
+                        }
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
                 }
-                .onSubmit { if canSend { onSend() } }
+            }
 
             // Attachment / Stop button
             if isSending {
@@ -353,9 +394,11 @@ private struct ThinkingIndicator: View {
             isSending: false,
             errorText: nil,
             pendingQueuedCount: 0,
+            suggestion: "That sounds great, thanks!",
             onSend: {},
             onStop: {},
-            onDismissError: {}
+            onDismissError: {},
+            onAcceptSuggestion: {}
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -335,6 +335,7 @@ final class ChatViewModel: ObservableObject {
         case .error(let err):
             log.error("Server error: \(err.message)")
             isThinking = false
+            let wasCancelling = isCancelling
             isCancelling = false
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -349,11 +350,27 @@ final class ChatViewModel: ObservableObject {
                     messages[i].status = .sent
                 }
             }
-            // The daemon drains queued work after an error, so preserve
-            // queue bookkeeping (pendingQueuedCount, pendingMessageIds,
-            // requestIdToMessageId) when messages are still queued.
-            // Only clear everything when the queue is empty.
-            if pendingQueuedCount == 0 {
+            // When cancelling, the daemon's abort() emits error events for
+            // queued messages but drops the queue without sending
+            // message_dequeued events, so pendingQueuedCount never drains
+            // on its own. Force-clear all queue state to prevent isSending
+            // from staying true permanently. Also reset queued message
+            // statuses since the daemon will not process them.
+            if wasCancelling {
+                isSending = false
+                pendingQueuedCount = 0
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
+            } else if pendingQueuedCount == 0 {
+                // The daemon drains queued work after a non-cancellation
+                // error, so preserve queue bookkeeping when messages are
+                // still queued. Only clear everything when the queue is
+                // empty.
                 isSending = false
                 pendingMessageIds = []
                 requestIdToMessageId = [:]

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -335,7 +335,6 @@ final class ChatViewModel: ObservableObject {
         case .error(let err):
             log.error("Server error: \(err.message)")
             isThinking = false
-            isSending = false
             isCancelling = false
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -343,17 +342,21 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            pendingQueuedCount = 0
-            pendingMessageIds = []
-            requestIdToMessageId = [:]
             errorText = err.message
-            // Reset processing/queued messages to sent
+            // Reset processing messages to sent
             for i in messages.indices {
-                if case .queued = messages[i].status, messages[i].role == .user {
-                    messages[i].status = .sent
-                } else if messages[i].role == .user && messages[i].status == .processing {
+                if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
+            }
+            // The daemon drains queued work after an error, so preserve
+            // queue bookkeeping (pendingQueuedCount, pendingMessageIds,
+            // requestIdToMessageId) when messages are still queued.
+            // Only clear everything when the queue is empty.
+            if pendingQueuedCount == 0 {
+                isSending = false
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
             }
 
         default:
@@ -412,6 +415,7 @@ final class ChatViewModel: ObservableObject {
             // all transient state now to avoid stuck UI.
             isSending = false
             isThinking = false
+            isCancelling = false
             // Mark current assistant message as stopped
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -445,7 +445,9 @@ final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            errorText = err.message
+            if !wasCancelling {
+                errorText = err.message
+            }
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -11,6 +11,7 @@ final class ChatViewModel: ObservableObject {
     @Published var isSending: Bool = false
     @Published var errorText: String?
     @Published var pendingQueuedCount: Int = 0
+    @Published var suggestion: String?
 
     private let daemonClient: DaemonClient
     var sessionId: String?
@@ -30,6 +31,8 @@ final class ChatViewModel: ObservableObject {
     private var requestIdToMessageId: [String: UUID] = [:]
     /// FIFO queue of user message UUIDs awaiting requestId assignment from the daemon.
     private var pendingMessageIds: [UUID] = []
+    /// Tracks the current in-flight suggestion request so stale responses are ignored.
+    private var pendingSuggestionRequestId: String?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -58,6 +61,8 @@ final class ChatViewModel: ObservableObject {
             pendingMessageIds.append(userMessage.id)
         }
         inputText = ""
+        suggestion = nil
+        pendingSuggestionRequestId = nil
         errorText = nil
 
         if sessionId == nil {
@@ -246,6 +251,12 @@ final class ChatViewModel: ObservableObject {
                 messages.append(msg)
             }
 
+        case .suggestionResponse(let resp):
+            // Only accept if this response matches our current request
+            guard resp.requestId == pendingSuggestionRequestId else { return }
+            pendingSuggestionRequestId = nil
+            suggestion = resp.suggestion
+
         case .messageComplete(let complete):
             guard belongsToSession(complete.sessionId) else { return }
             isCancelling = false
@@ -265,6 +276,10 @@ final class ChatViewModel: ObservableObject {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent
                 }
+            }
+            // Fetch a follow-up suggestion when the turn is fully complete
+            if !isSending {
+                fetchSuggestion()
             }
 
         case .generationCancelled(let cancelled):
@@ -469,6 +484,34 @@ final class ChatViewModel: ObservableObject {
 
     func dismissError() {
         errorText = nil
+    }
+
+    /// Ask the daemon for a follow-up suggestion for the current session.
+    private func fetchSuggestion() {
+        guard let sessionId, daemonClient.isConnected else { return }
+
+        let requestId = UUID().uuidString
+        pendingSuggestionRequestId = requestId
+
+        do {
+            try daemonClient.send(SuggestionRequestMessage(
+                sessionId: sessionId,
+                requestId: requestId
+            ))
+        } catch {
+            log.error("Failed to send suggestion_request: \(error.localizedDescription)")
+            pendingSuggestionRequestId = nil
+        }
+    }
+
+    /// Accept the current suggestion, appending the ghost suffix to input.
+    func acceptSuggestion() {
+        guard let suggestion else { return }
+        if suggestion.hasPrefix(inputText) {
+            inputText = suggestion
+        } else if inputText.isEmpty {
+            inputText = suggestion
+        }
     }
 
     deinit {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 import os
+import UniformTypeIdentifiers
+import AppKit
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel")
 
@@ -12,10 +14,17 @@ final class ChatViewModel: ObservableObject {
     @Published var errorText: String?
     @Published var pendingQueuedCount: Int = 0
     @Published var suggestion: String?
+    @Published var pendingAttachments: [ChatAttachment] = []
+
+    /// Maximum file size per attachment (20 MB).
+    private static let maxFileSize = 20 * 1024 * 1024
+    /// Maximum number of attachments per message.
+    private static let maxAttachments = 5
 
     private let daemonClient: DaemonClient
     var sessionId: String?
     private var pendingUserMessage: String?
+    private var pendingUserAttachments: [IPCAttachment]?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     private var bootstrapCorrelationId: String?
@@ -41,17 +50,88 @@ final class ChatViewModel: ObservableObject {
         messages.append(ChatMessage(role: .assistant, text: "Hello! I'm \(name). How can I help you today?"))
     }
 
+    // MARK: - Attachments
+
+    func addAttachment(url: URL) {
+        guard pendingAttachments.count < Self.maxAttachments else {
+            errorText = "Maximum \(Self.maxAttachments) attachments per message."
+            return
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            log.error("Failed to read attachment: \(error.localizedDescription)")
+            errorText = "Could not read file."
+            return
+        }
+
+        guard data.count <= Self.maxFileSize else {
+            errorText = "File exceeds 20 MB limit."
+            return
+        }
+
+        let filename = url.lastPathComponent
+        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        let base64 = data.base64EncodedString()
+
+        var thumbnail: Data?
+        if let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .image) {
+            thumbnail = Self.generateThumbnail(from: data, maxDimension: 120)
+        }
+
+        let attachment = ChatAttachment(
+            id: UUID().uuidString,
+            filename: filename,
+            mimeType: mimeType,
+            data: base64,
+            thumbnailData: thumbnail
+        )
+        pendingAttachments.append(attachment)
+    }
+
+    func removeAttachment(id: String) {
+        pendingAttachments.removeAll { $0.id == id }
+    }
+
+    /// Resize image data to fit within `maxDimension` and return PNG data.
+    private static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
+        guard let image = NSImage(data: data) else { return nil }
+        let size = image.size
+        guard size.width > 0 && size.height > 0 else { return nil }
+        let scale = min(maxDimension / size.width, maxDimension / size.height, 1.0)
+        let newSize = NSSize(width: size.width * scale, height: size.height * scale)
+        let resized = NSImage(size: newSize)
+        resized.lockFocus()
+        image.draw(in: NSRect(origin: .zero, size: newSize),
+                   from: NSRect(origin: .zero, size: size),
+                   operation: .copy, fraction: 1.0)
+        resized.unlockFocus()
+        guard let tiffData = resized.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let png = bitmap.representation(using: .png, properties: [:]) else { return nil }
+        return png
+    }
+
+    // MARK: - Sending
+
     func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        let hasAttachments = !pendingAttachments.isEmpty
+        guard !text.isEmpty || hasAttachments else { return }
 
         // Block rapid-fire only when bootstrapping (no session yet)
         if isSending && sessionId == nil { return }
 
+        // Snapshot and clear pending attachments
+        let attachments = pendingAttachments
+        pendingAttachments = []
+
         // Append user message immediately for responsive UX
         let willBeQueued = isSending && sessionId != nil
         let status: ChatMessageStatus = willBeQueued ? .queued(position: 0) : .sent
-        let userMessage = ChatMessage(role: .user, text: text, status: status)
+        let userMessage = ChatMessage(role: .user, text: text, status: status, attachments: attachments)
         messages.append(userMessage)
         // Only track in pendingMessageIds when the message will actually be
         // queued by the daemon (i.e. sent while another message is processing).
@@ -65,19 +145,24 @@ final class ChatViewModel: ObservableObject {
         pendingSuggestionRequestId = nil
         errorText = nil
 
+        let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
+            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+        }
+
         if sessionId == nil {
             // First message: need to bootstrap session
-            bootstrapSession(userMessage: text)
+            bootstrapSession(userMessage: text, attachments: ipcAttachments)
         } else {
             // Subsequent messages: send directly (daemon queues if busy)
-            sendUserMessage(text, queuedMessageId: willBeQueued ? userMessage.id : nil)
+            sendUserMessage(text, attachments: ipcAttachments, queuedMessageId: willBeQueued ? userMessage.id : nil)
         }
     }
 
-    private func bootstrapSession(userMessage: String) {
+    private func bootstrapSession(userMessage: String, attachments: [IPCAttachment]?) {
         isSending = true
         isThinking = true
         pendingUserMessage = userMessage
+        pendingUserAttachments = attachments
 
         // Generate a unique correlation ID so this ChatViewModel only claims
         // the session_info response that belongs to its own session_create request.
@@ -115,7 +200,7 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func sendUserMessage(_ text: String, queuedMessageId: UUID? = nil) {
+    private func sendUserMessage(_ text: String, attachments: [IPCAttachment]? = nil, queuedMessageId: UUID? = nil) {
         guard let sessionId else { return }
 
         // Check connectivity before entering sending state so the UI
@@ -143,7 +228,7 @@ final class ChatViewModel: ObservableObject {
             try daemonClient.send(UserMessageMessage(
                 sessionId: sessionId,
                 content: text,
-                attachments: nil
+                attachments: attachments
             ))
         } catch {
             log.error("Failed to send user_message: \(error.localizedDescription)")
@@ -215,12 +300,14 @@ final class ChatViewModel: ObservableObject {
 
                 // Send the queued user message
                 if let pending = pendingUserMessage {
+                    let attachments = pendingUserAttachments
                     pendingUserMessage = nil
+                    pendingUserAttachments = nil
                     do {
                         try daemonClient.send(UserMessageMessage(
                             sessionId: info.sessionId,
                             content: pending,
-                            attachments: nil
+                            attachments: attachments
                         ))
                     } catch {
                         log.error("Failed to send queued user_message: \(error.localizedDescription)")
@@ -420,6 +507,7 @@ final class ChatViewModel: ObservableObject {
         // cancel on the daemon side.
         if sessionId == nil {
             pendingUserMessage = nil
+            pendingUserAttachments = nil
             bootstrapCorrelationId = nil
             isThinking = false
             isSending = false

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,9 @@ final class ChatViewModel: ObservableObject {
     /// Tracks the current in-flight suggestion request so stale responses are ignored.
     private var pendingSuggestionRequestId: String?
 
+    /// Called when an inline confirmation is responded to, so the floating panel can be dismissed.
+    var onInlineConfirmationResponse: ((String) -> Void)?
+
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
         // Add initial greeting
@@ -602,6 +605,23 @@ final class ChatViewModel: ObservableObject {
             try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
         } catch {
             log.error("Failed to send confirmation response: \(error.localizedDescription)")
+        }
+        // Dismiss the corresponding floating panel if one exists
+        onInlineConfirmationResponse?(requestId)
+    }
+
+    /// Update the inline confirmation message state without sending a response to the daemon.
+    /// Used when the floating panel handles the response.
+    func updateConfirmationState(requestId: String, decision: String) {
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            switch decision {
+            case "allow":
+                messages[index].confirmation?.state = .approved
+            case "deny":
+                messages[index].confirmation?.state = .denied
+            default:
+                break
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -391,6 +391,21 @@ final class ChatViewModel: ObservableObject {
                 requestIdToMessageId = [:]
             }
 
+        case .confirmationRequest(let msg):
+            guard belongsToSession(nil) else { return }
+            let confirmation = ToolConfirmationData(
+                requestId: msg.requestId,
+                toolName: msg.toolName,
+                riskLevel: msg.riskLevel,
+                diff: msg.diff
+            )
+            let confirmMsg = ChatMessage(
+                role: .assistant,
+                text: "",
+                confirmation: confirmation
+            )
+            messages.append(confirmMsg)
+
         default:
             break
         }
@@ -484,6 +499,20 @@ final class ChatViewModel: ObservableObject {
 
     func dismissError() {
         errorText = nil
+    }
+
+    /// Respond to a tool confirmation request displayed inline in the chat.
+    func respondToConfirmation(requestId: String, decision: String) {
+        // Update the message state
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
+        }
+        // Send the response to the daemon
+        do {
+            try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
+        } catch {
+            log.error("Failed to send confirmation response: \(error.localizedDescription)")
+        }
     }
 
     /// Ask the daemon for a follow-up suggestion for the current session.

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct ToolConfirmationBubble: View {
+    let confirmation: ToolConfirmationData
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+
+    private var isHighRisk: Bool { confirmation.riskLevel.lowercased() == "high" }
+
+    private var toolDisplayName: String {
+        switch confirmation.toolName {
+        case "file_write": return "Write File"
+        case "file_edit": return "Edit File"
+        case "bash": return "Run Command"
+        case "web_fetch": return "Fetch URL"
+        default: return confirmation.toolName.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Header row: icon + tool name + risk badge
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: isHighRisk ? "exclamationmark.triangle.fill" : "shield.checkered")
+                    .font(.system(size: 14))
+                    .foregroundStyle(isHighRisk ? VColor.error : VColor.warning)
+
+                Text(toolDisplayName)
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(confirmation.riskLevel.lowercased())
+                    .font(VFont.caption)
+                    .foregroundColor(isHighRisk ? VColor.error : VColor.warning)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.sm)
+                            .fill((isHighRisk ? VColor.error : VColor.warning).opacity(0.15))
+                    )
+
+                Spacer()
+            }
+
+            // Diff preview (if present)
+            if let diff = confirmation.diff {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(diff.filePath)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    if diff.isNewFile {
+                        Text("New file")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.success)
+                    }
+
+                    ScrollView {
+                        Text(String(diff.newContent.prefix(500)))
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 120)
+                    .padding(VSpacing.sm)
+                    .background(VColor.backgroundSubtle)
+                    .cornerRadius(VRadius.sm)
+                }
+            }
+
+            // Action buttons or decided state
+            switch confirmation.state {
+            case .pending:
+                HStack(spacing: VSpacing.md) {
+                    Spacer()
+                    VButton(label: "Deny", style: .ghost) {
+                        onDeny()
+                    }
+                    VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
+                        onAllow()
+                    }
+                }
+
+            case .approved:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("Allowed")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
+
+            case .denied:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(VColor.error)
+                    Text("Denied")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                }
+
+            case .timedOut:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(VColor.textMuted)
+                    Text("Timed out")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surface.opacity(0.5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(isHighRisk ? VColor.error.opacity(0.3) : VColor.warning.opacity(0.3), lineWidth: 1)
+                )
+        )
+        .frame(maxWidth: 500)
+    }
+}
+
+#if DEBUG
+#Preview("ToolConfirmationBubble") {
+    VStack(spacing: VSpacing.lg) {
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-1",
+                toolName: "bash",
+                riskLevel: "medium",
+                diff: nil
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-2",
+                toolName: "file_write",
+                riskLevel: "high",
+                diff: ConfirmationRequestMessage.ConfirmationDiffInfo(
+                    filePath: "/Users/test/project/src/main.swift",
+                    oldContent: "",
+                    newContent: "import Foundation\n\nfunc hello() {\n    print(\"Hello, World!\")\n}",
+                    isNewFile: true
+                )
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+        ToolConfirmationBubble(
+            confirmation: ToolConfirmationData(
+                requestId: "test-3",
+                toolName: "bash",
+                riskLevel: "medium",
+                diff: nil,
+                state: .approved
+            ),
+            onAllow: {},
+            onDeny: {}
+        )
+    }
+    .padding(VSpacing.xl)
+    .background(VColor.background)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
@@ -40,10 +41,12 @@ struct MainWindowView: View {
                         errorText: viewModel.errorText,
                         pendingQueuedCount: viewModel.pendingQueuedCount,
                         suggestion: viewModel.suggestion,
+                        pendingAttachments: viewModel.pendingAttachments,
                         onSend: viewModel.sendMessage,
                         onStop: viewModel.stopGenerating,
                         onDismissError: viewModel.dismissError,
                         onAcceptSuggestion: viewModel.acceptSuggestion,
+                        onAttach: { Self.openFilePicker(viewModel: viewModel) },
                         onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                         onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
                     )
@@ -55,6 +58,21 @@ struct MainWindowView: View {
         .ignoresSafeArea(edges: .top)
         .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
+    }
+
+    @MainActor
+    private static func openFilePicker(viewModel: ChatViewModel) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [
+            .png, .jpeg, .gif, .webP, .pdf, .plainText, .commaSeparatedText,
+            UTType("net.daringfireball.markdown") ?? .plainText,
+        ]
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            viewModel.addAttachment(url: url)
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -14,49 +14,51 @@ struct MainWindowView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Row 1 — thread tab bar
-            ThreadTabBar(
-                threads: threadManager.threads,
-                activeThreadId: threadManager.activeThreadId,
-                onSelect: { threadManager.selectThread(id: $0) },
-                onClose: { threadManager.closeThread(id: $0) },
-                onCreate: { threadManager.createThread() }
-            )
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                // Row 1 — thread tab bar
+                ThreadTabBar(
+                    threads: threadManager.threads,
+                    activeThreadId: threadManager.activeThreadId,
+                    onSelect: { threadManager.selectThread(id: $0) },
+                    onClose: { threadManager.closeThread(id: $0) },
+                    onCreate: { threadManager.createThread() }
+                )
 
-            // Row 2 — navigation toolbar
-            NavigationToolbar(activePanel: $activePanel)
+                // Row 2 — navigation toolbar
+                NavigationToolbar(activePanel: $activePanel)
 
-            // Row 3 — chat content with optional side panel
-            VSplitView(panelWidth: 420, showPanel: activePanel != nil, main: {
-                if let viewModel = threadManager.activeViewModel {
-                    ChatView(
-                        messages: viewModel.messages,
-                        inputText: Binding(
-                            get: { viewModel.inputText },
-                            set: { viewModel.inputText = $0 }
-                        ),
-                        isThinking: viewModel.isThinking,
-                        isSending: viewModel.isSending,
-                        errorText: viewModel.errorText,
-                        pendingQueuedCount: viewModel.pendingQueuedCount,
-                        suggestion: viewModel.suggestion,
-                        pendingAttachments: viewModel.pendingAttachments,
-                        onSend: viewModel.sendMessage,
-                        onStop: viewModel.stopGenerating,
-                        onDismissError: viewModel.dismissError,
-                        onAcceptSuggestion: viewModel.acceptSuggestion,
-                        onAttach: { Self.openFilePicker(viewModel: viewModel) },
-                        onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
-                        onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
-                    )
-                }
-            }, panel: {
-                panelContent
-            })
+                // Row 3 — chat content with optional side panel
+                VSplitView(panelWidth: geometry.size.width * 0.5, showPanel: activePanel != nil, main: {
+                    if let viewModel = threadManager.activeViewModel {
+                        ChatView(
+                            messages: viewModel.messages,
+                            inputText: Binding(
+                                get: { viewModel.inputText },
+                                set: { viewModel.inputText = $0 }
+                            ),
+                            isThinking: viewModel.isThinking,
+                            isSending: viewModel.isSending,
+                            errorText: viewModel.errorText,
+                            pendingQueuedCount: viewModel.pendingQueuedCount,
+                            suggestion: viewModel.suggestion,
+                            pendingAttachments: viewModel.pendingAttachments,
+                            onSend: viewModel.sendMessage,
+                            onStop: viewModel.stopGenerating,
+                            onDismissError: viewModel.dismissError,
+                            onAcceptSuggestion: viewModel.acceptSuggestion,
+                            onAttach: { Self.openFilePicker(viewModel: viewModel) },
+                            onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
+                            onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
+                        )
+                    }
+                }, panel: {
+                    panelContent
+                })
+            }
+            .ignoresSafeArea(edges: .top)
+            .background(VColor.background.ignoresSafeArea())
         }
-        .ignoresSafeArea(edges: .top)
-        .background(VColor.background.ignoresSafeArea())
         .frame(minWidth: 800, minHeight: 600)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -43,7 +43,9 @@ struct MainWindowView: View {
                         onSend: viewModel.sendMessage,
                         onStop: viewModel.stopGenerating,
                         onDismissError: viewModel.dismissError,
-                        onAcceptSuggestion: viewModel.acceptSuggestion
+                        onAcceptSuggestion: viewModel.acceptSuggestion,
+                        onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
+                        onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
                     )
                 }
             }, panel: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -39,9 +39,11 @@ struct MainWindowView: View {
                         isSending: viewModel.isSending,
                         errorText: viewModel.errorText,
                         pendingQueuedCount: viewModel.pendingQueuedCount,
+                        suggestion: viewModel.suggestion,
                         onSend: viewModel.sendMessage,
                         onStop: viewModel.stopGenerating,
-                        onDismissError: viewModel.dismissError
+                        onDismissError: viewModel.dismissError,
+                        onAcceptSuggestion: viewModel.acceptSuggestion
                     )
                 }
             }, panel: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -153,7 +153,7 @@ struct ControlPanel: View {
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
+                VSlider(value: $maxSteps, range: 1...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -148,15 +148,12 @@ struct ControlPanel: View {
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
                     Spacer()
-                    Text("\(max(1, Int(maxSteps)))")
+                    Text("\(Int(maxSteps))")
                         .font(VFont.mono)
                         .foregroundColor(VColor.textSecondary)
                 }
 
-                VSlider(value: $maxSteps, range: 0...100, step: 10, showTickMarks: true)
-                    .onChange(of: maxSteps) { _, newValue in
-                        if newValue < 1 { maxSteps = 1 }
-                    }
+                VSlider(value: $maxSteps, range: 10...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
             .vCard()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -29,8 +29,6 @@ struct ControlPanel: View {
                 .frame(width: 100)
                 .padding(.top, VSpacing.md)
 
-                Divider()
-
                 // Right content
                 ScrollView {
                     Group {
@@ -78,7 +76,7 @@ struct ControlPanel: View {
                 .padding(.vertical, VSpacing.xs)
         }
         .buttonStyle(.plain)
-        .background(selected ? VColor.surface : Color.clear)
+        .background(selected ? Slate._700 : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         .vHover()
     }
@@ -132,7 +130,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // COMPUTER USAGE section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -156,7 +154,7 @@ struct ControlPanel: View {
                 VSlider(value: $maxSteps, range: 1...100, step: 10, showTickMarks: true)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // AMBIENT AGENT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -164,18 +162,22 @@ struct ControlPanel: View {
                     .font(VFont.display)
                     .foregroundColor(VColor.textPrimary)
 
-                HStack(spacing: VSpacing.xs) {
-                    VToggle(isOn: $ambientEnabled, label: "Enable ambient screen watching")
+                HStack {
+                    Text("Enable ambient screen watching")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
                     Image(systemName: "info.circle")
                         .font(.system(size: 12))
                         .foregroundColor(VColor.textMuted)
+                    Spacer()
+                    VToggle(isOn: $ambientEnabled)
                 }
                 .onChange(of: ambientEnabled) { _, newValue in
                     ambientAgent.isEnabled = newValue
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // PERMISSIONS section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -188,21 +190,27 @@ struct ControlPanel: View {
                     label: "Accessibility",
                     granted: PermissionManager.accessibilityStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "record.circle",
                     label: "Screen Recording",
                     granted: PermissionManager.screenRecordingStatus() == .granted
                 )
+                .padding(VSpacing.md)
+                .vCard(background: Slate._900)
 
                 permissionRow(
                     icon: "key",
                     label: "API Key",
                     granted: APIKeyManager.getKey() != nil
                 )
+                .padding(VSpacing.md)
+                .vCard(background: Slate._900)
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
 
             // ABOUT section
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -231,7 +239,7 @@ struct ControlPanel: View {
                 }
             }
             .padding(VSpacing.lg)
-            .vCard()
+            .vCard(background: Slate._900)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -15,6 +15,9 @@ final class ThreadManager: ObservableObject {
     private let daemonClient: DaemonClient
     private var viewModelCancellable: AnyCancellable?
 
+    /// Called when an inline confirmation response should dismiss the floating panel.
+    var confirmationDismissHandler: ((String) -> Void)?
+
     var activeViewModel: ChatViewModel? {
         guard let activeThreadId else { return nil }
         return chatViewModels[activeThreadId]
@@ -29,6 +32,9 @@ final class ThreadManager: ObservableObject {
     func createThread() {
         let thread = ThreadModel()
         let viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.onInlineConfirmationResponse = { [weak self] requestId in
+            self?.confirmationDismissHandler?(requestId)
+        }
         threads.append(thread)
         chatViewModels[thread.id] = viewModel
         activeThreadId = thread.id

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -78,13 +78,15 @@ struct OnboardingStageImage: View {
         }
         .onAppear {
             displayedStage = stageNumber
-            // Kick off the idle bob by setting the target offset.
-            // The actual animation is driven by the value-based
-            // .animation() modifier on the offset below, NOT by
-            // withAnimation — using withAnimation(.repeatForever())
-            // in onAppear leaks the repeating animation to ancestor
-            // views and makes the whole card bob.
-            bobOffset = -4
+            // Defer the bob animation start to the next run-loop iteration
+            // so the repeatForever .animation() modifier doesn't infect
+            // the displayedStage change above. When onboarding resumes
+            // from persisted progress, both assignments would otherwise
+            // happen in the same SwiftUI update cycle, letting the
+            // repeat-forever animation leak to the stage transition.
+            DispatchQueue.main.async {
+                bobOffset = -4
+            }
         }
         .onChange(of: stageNumber) { oldStage, newStage in
             guard oldStage != newStage, !isTransitioning else { return }

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -64,6 +64,10 @@ struct OnboardingStageImage: View {
                 }
             }
             .offset(x: shakeOffset, y: bobOffset - 40)
+            .animation(
+                .easeInOut(duration: 2.5).repeatForever(autoreverses: true),
+                value: bobOffset
+            )
             .rotationEffect(.degrees(shakeRotation))
 
             // White flash overlay
@@ -74,7 +78,13 @@ struct OnboardingStageImage: View {
         }
         .onAppear {
             displayedStage = stageNumber
-            startIdleBob()
+            // Kick off the idle bob by setting the target offset.
+            // The actual animation is driven by the value-based
+            // .animation() modifier on the offset below, NOT by
+            // withAnimation — using withAnimation(.repeatForever())
+            // in onAppear leaks the repeating animation to ancestor
+            // views and makes the whole card bob.
+            bobOffset = -4
         }
         .onChange(of: stageNumber) { oldStage, newStage in
             guard oldStage != newStage, !isTransitioning else { return }
@@ -83,15 +93,6 @@ struct OnboardingStageImage: View {
     }
 
     // MARK: - Animations
-
-    private func startIdleBob() {
-        withAnimation(
-            .easeInOut(duration: 2.5)
-            .repeatForever(autoreverses: true)
-        ) {
-            bobOffset = -4
-        }
-    }
 
     private func playHatchTransition(to newStage: Int) {
         isTransitioning = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -150,7 +150,7 @@ final class InterviewViewModel {
                     // Stay in thinking state while the model reasons.
                     break
 
-                case .messageComplete(let complete) where complete.sessionId == self.sessionId:
+                case .messageComplete(let complete) where complete.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -161,7 +161,7 @@ final class InterviewViewModel {
                     log.info("Interview greeting complete (\(accumulated.count) chars)")
                     return
 
-                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId:
+                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     let finalText = accumulated.isEmpty ? "(No response)" : accumulated
@@ -172,7 +172,7 @@ final class InterviewViewModel {
                     log.info("Interview greeting complete via handoff (\(accumulated.count) chars)")
                     return
 
-                case .cuError(let error) where error.sessionId == self.sessionId:
+                case .cuError(let error) where error.sessionId == self.sessionId && self.sessionId != nil:
                     self.isThinking = false
                     self.streamingText = ""
                     log.error("Interview start failed: \(error.message)")

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -40,7 +40,7 @@ final class OnboardingWindow {
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -400,6 +400,14 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Follow-up suggestion response from daemon.
+/// Wire type: `"suggestion_response"`
+struct SuggestionResponseMessage: Decodable, Sendable {
+    let requestId: String
+    let suggestion: String?
+    let source: String
+}
+
 /// Permission confirmation request from daemon.
 /// Wire type: `"confirmation_request"`
 struct ConfirmationRequestMessage: Decodable, Sendable {
@@ -426,6 +434,14 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
         let newContent: String
         let isNewFile: Bool
     }
+}
+
+/// Request a follow-up suggestion for the current session.
+/// Wire type: `"suggestion_request"`
+struct SuggestionRequestMessage: Encodable, Sendable {
+    let type: String = "suggestion_request"
+    let sessionId: String
+    let requestId: String
 }
 
 /// Client response to a permission confirmation request.
@@ -462,6 +478,7 @@ enum ServerMessage: Decodable, Sendable {
     case messageDequeued(MessageDequeuedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
+    case suggestionResponse(SuggestionResponseMessage)
     case pong
     case unknown(String)
 
@@ -537,6 +554,9 @@ enum ServerMessage: Decodable, Sendable {
         case "skill_detail_response":
             let message = try SkillDetailResponseMessage(from: decoder)
             self = .skillDetailResponse(message)
+        case "suggestion_response":
+            let message = try SuggestionResponseMessage(from: decoder)
+            self = .suggestionResponse(message)
         case "pong":
             self = .pong
         default:

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -420,15 +420,15 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
     let diff: ConfirmationDiffInfo?
     let sandboxed: Bool?
 
-    struct ConfirmationAllowlistOption: Decodable, Sendable {
+    struct ConfirmationAllowlistOption: Decodable, Sendable, Equatable {
         let label: String
         let pattern: String
     }
-    struct ConfirmationScopeOption: Decodable, Sendable {
+    struct ConfirmationScopeOption: Decodable, Sendable, Equatable {
         let label: String
         let scope: String
     }
-    struct ConfirmationDiffInfo: Decodable, Sendable {
+    struct ConfirmationDiffInfo: Decodable, Sendable, Equatable {
         let filePath: String
         let oldContent: String
         let newContent: String

--- a/clients/macos/vellum-assistant/ResourceBundle.swift
+++ b/clients/macos/vellum-assistant/ResourceBundle.swift
@@ -24,9 +24,11 @@ enum ResourceBundle {
         #if DEBUG
         // Xcode Previews — resource bundle isn't at either path.
         // Fall back to Bundle.main so previews render without crashing.
-        return Bundle.main
-        #else
-        fatalError("Could not find resource bundle '\(bundleName).bundle'")
+        // Gate on XCODE_RUNNING_FOR_PREVIEWS so regular debug builds still fail fast.
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+            return Bundle.main
+        }
         #endif
+        fatalError("Could not find resource bundle '\(bundleName).bundle'")
     }()
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1271. The `clearAll()` function in `conversation-store.ts` deleted all conversations and related tables but missed the new `llm_usage_events` table, leaving orphaned usage event rows after a data wipe.
- Add `DELETE FROM llm_usage_events` to `clearAll()` so usage events are cleaned up alongside everything else.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify `clearAll()` removes llm_usage_events rows by running the scrub command and checking the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
