### PR TITLE
Add PDF/document and photo support to gateway Telegram integration

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -124,9 +124,14 @@ export class AnthropicProvider implements Provider {
         };
       case "file":
         return {
-          type: "text",
-          text: this.fileBlockToText(block),
-        };
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: block.source.media_type,
+            data: block.source.data,
+          },
+          ...(block.source.filename ? { title: block.source.filename } : {}),
+        } as unknown as Anthropic.ContentBlockParam;
       case "tool_use":
         return {
           type: "tool_use",
@@ -170,11 +175,4 @@ export class AnthropicProvider implements Provider {
     }
   }
 
-  private fileBlockToText(block: Extract<ContentBlock, { type: "file" }>): string {
-    const header = `[Attached file: ${block.source.filename} (${block.source.media_type})]`;
-    if (block.extracted_text?.trim()) {
-      return `${header}\n${block.extracted_text}`;
-    }
-    return `${header}\nNo extracted text available.`;
-  }
 }

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "vellum-gateway",
       "dependencies": {
+        "file-type": "^21.3.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.1.3",
         "zod": "^4.3.6",
@@ -16,7 +17,13 @@
     },
   },
   "packages": {
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
@@ -30,17 +37,25 @@
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
+
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
@@ -72,9 +87,15 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -8,6 +8,7 @@
     "start": "bun run src/index.ts"
   },
   "dependencies": {
+    "file-type": "^21.3.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.1.3",
     "zod": "^4.3.6"

--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -41,7 +41,7 @@ describe("normalizeTelegramUpdate", () => {
     expect(result!.raw).toEqual(validPayload);
   });
 
-  test("returns null for non-text messages", () => {
+  test("returns null for unsupported message types (e.g. sticker-only)", () => {
     const payload = {
       update_id: 1,
       message: {
@@ -51,6 +51,106 @@ describe("normalizeTelegramUpdate", () => {
       },
     };
     expect(normalizeTelegramUpdate(payload)).toBeNull();
+  });
+
+  test("normalizes a photo message", () => {
+    const payload = {
+      update_id: 100,
+      message: {
+        message_id: 10,
+        chat: { id: 200, type: "private" },
+        from: { id: 300, is_bot: false, username: "photouser", first_name: "Photo" },
+        photo: [
+          { file_id: "small_id", file_unique_id: "s1", width: 90, height: 90 },
+          { file_id: "medium_id", file_unique_id: "s2", width: 320, height: 320 },
+          { file_id: "large_id", file_unique_id: "s3", width: 800, height: 800 },
+        ],
+        caption: "Check this out",
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("Check this out");
+    expect(result!.message.attachments).toHaveLength(1);
+    expect(result!.message.attachments![0]).toEqual({
+      type: "photo",
+      fileId: "large_id",
+    });
+  });
+
+  test("normalizes a photo message without caption", () => {
+    const payload = {
+      update_id: 101,
+      message: {
+        message_id: 11,
+        chat: { id: 200, type: "private" },
+        from: { id: 300, is_bot: false },
+        photo: [
+          { file_id: "only_id", file_unique_id: "s1", width: 800, height: 800 },
+        ],
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("");
+    expect(result!.message.attachments).toHaveLength(1);
+    expect(result!.message.attachments![0].fileId).toBe("only_id");
+  });
+
+  test("normalizes a document message", () => {
+    const payload = {
+      update_id: 102,
+      message: {
+        message_id: 12,
+        chat: { id: 200, type: "private" },
+        from: { id: 300, is_bot: false, username: "docuser" },
+        document: {
+          file_id: "doc_file_id",
+          file_unique_id: "du1",
+          file_name: "report.pdf",
+          mime_type: "application/pdf",
+          file_size: 12345,
+        },
+        caption: "Here is the report",
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("Here is the report");
+    expect(result!.message.attachments).toHaveLength(1);
+    expect(result!.message.attachments![0]).toEqual({
+      type: "document",
+      fileId: "doc_file_id",
+      fileName: "report.pdf",
+      mimeType: "application/pdf",
+    });
+  });
+
+  test("normalizes a document message without caption", () => {
+    const payload = {
+      update_id: 103,
+      message: {
+        message_id: 13,
+        chat: { id: 200, type: "private" },
+        from: { id: 300, is_bot: false },
+        document: {
+          file_id: "doc_id_2",
+          file_unique_id: "du2",
+          file_name: "data.csv",
+          mime_type: "text/csv",
+        },
+      },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("");
+    expect(result!.message.attachments).toHaveLength(1);
+  });
+
+  test("text-only messages have no attachments field", () => {
+    const result = normalizeTelegramUpdate(validPayload);
+    expect(result).not.toBeNull();
+    expect(result!.message.attachments).toBeUndefined();
   });
 
   test("returns null for group messages", () => {

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -17,6 +17,7 @@ export type InboundResult = {
 export async function handleInbound(
   config: GatewayConfig,
   event: Omit<GatewayInboundEventV1, "routing">,
+  options?: { attachmentIds?: string[] },
 ): Promise<InboundResult> {
   const routing = resolveAssistant(
     config,
@@ -50,6 +51,7 @@ export async function handleInbound(
         languageCode: event.sender.languageCode,
         isBot: event.sender.isBot,
       },
+      ...(options?.attachmentIds?.length ? { attachmentIds: options.attachmentIds } : {}),
     });
 
     log.info(

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -3,7 +3,10 @@ import type { GatewayConfig } from "../../config.js";
 import type { GatewayInboundEventV1 } from "../../types.js";
 import { verifyWebhookSecret } from "../../telegram/verify.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
+import { downloadTelegramFile } from "../../telegram/download.js";
 import { handleInbound, type InboundResult } from "../../handlers/handle-inbound.js";
+import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
+import { uploadAttachment } from "../../runtime/client.js";
 
 const log = pino({ name: "gateway:telegram-webhook" });
 
@@ -41,10 +44,42 @@ export function createTelegramWebhookHandler(
       return Response.json({ ok: true });
     }
 
+    // Download and upload attachments if present
+    let attachmentIds: string[] | undefined;
+    const eventAttachments = normalized.message.attachments;
+    if (eventAttachments && eventAttachments.length > 0) {
+      const routing = resolveAssistant(
+        config,
+        normalized.message.externalChatId,
+        normalized.sender.externalUserId,
+      );
+
+      if (!isRejection(routing)) {
+        try {
+          attachmentIds = [];
+          for (const att of eventAttachments) {
+            const downloaded = await downloadTelegramFile(config, att.fileId, {
+              fileName: att.fileName,
+              mimeType: att.mimeType,
+            });
+            const uploaded = await uploadAttachment(config, routing.assistantId, downloaded);
+            attachmentIds.push(uploaded.id);
+          }
+          log.info(
+            { count: attachmentIds.length, assistantId: routing.assistantId },
+            "Attachments downloaded and uploaded",
+          );
+        } catch (err) {
+          log.error({ err }, "Failed to process attachments");
+          return Response.json({ error: "Failed to process attachments" }, { status: 500 });
+        }
+      }
+    }
+
     // Process inbound and only acknowledge after successful delivery
     let result: InboundResult;
     try {
-      result = await handleInbound(config, normalized);
+      result = await handleInbound(config, normalized, { attachmentIds });
     } catch (err) {
       log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       return Response.json({ error: "Internal error" }, { status: 500 });

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -15,6 +15,7 @@ export type RuntimeInboundPayload = {
   senderExternalUserId?: string;
   senderUsername?: string;
   sourceMetadata?: Record<string, unknown>;
+  attachmentIds?: string[];
 };
 
 export type RuntimeInboundResponse = {
@@ -94,4 +95,35 @@ export async function forwardToRuntime(
   }
 
   throw lastError ?? new Error("Runtime forward failed after retries");
+}
+
+export type UploadAttachmentInput = {
+  filename: string;
+  mimeType: string;
+  data: string; // base64-encoded
+};
+
+export type UploadAttachmentResponse = {
+  id: string;
+};
+
+export async function uploadAttachment(
+  config: GatewayConfig,
+  assistantId: string,
+  input: UploadAttachmentInput,
+): Promise<UploadAttachmentResponse> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Attachment upload failed (${response.status}): ${body}`);
+  }
+
+  return (await response.json()) as UploadAttachmentResponse;
 }

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -1,0 +1,61 @@
+import { fileTypeFromBuffer } from "file-type";
+import type { GatewayConfig } from "../config.js";
+import { callTelegramApi } from "./api.js";
+
+interface TelegramFile {
+  file_id: string;
+  file_unique_id: string;
+  file_size?: number;
+  file_path?: string;
+}
+
+export interface DownloadedFile {
+  filename: string;
+  mimeType: string;
+  data: string; // base64-encoded
+}
+
+/**
+ * Download a file from Telegram by its file_id.
+ * Calls the getFile API to resolve the file path, then fetches the binary.
+ */
+export async function downloadTelegramFile(
+  config: GatewayConfig,
+  fileId: string,
+  hint?: { fileName?: string; mimeType?: string },
+): Promise<DownloadedFile> {
+  const file = await callTelegramApi<TelegramFile>(config, "getFile", {
+    file_id: fileId,
+  });
+
+  if (!file.file_path) {
+    throw new Error(`Telegram getFile returned no file_path for ${fileId}`);
+  }
+
+  const downloadUrl = `${config.telegramApiBaseUrl}/file/bot${config.telegramBotToken}/${file.file_path}`;
+  const response = await fetch(downloadUrl);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download Telegram file: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const filename =
+    hint?.fileName ||
+    file.file_path.split("/").pop() ||
+    `file_${fileId}`;
+
+  const buffer = await response.arrayBuffer();
+  const detected = await fileTypeFromBuffer(new Uint8Array(buffer));
+
+  const mimeType =
+    hint?.mimeType ||
+    detected?.mime ||
+    response.headers.get("Content-Type")?.split(";")[0].trim() ||
+    "application/octet-stream";
+
+  const data = Buffer.from(buffer).toString("base64");
+
+  return { filename, mimeType, data };
+}

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -49,7 +49,7 @@ export function normalizeTelegramUpdate(
   const message = update.message;
   const updateId = update.update_id;
 
-  const hasContent = !!(message?.text || message?.caption || message?.photo || message?.document);
+  const hasContent = !!(message?.text || message?.photo || message?.document);
   if (!hasContent || !message?.chat?.id || updateId == null) {
     return null;
   }

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -1,5 +1,21 @@
 import type { GatewayInboundEventV1 } from "../types.js";
 
+interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+interface TelegramDocument {
+  file_id: string;
+  file_unique_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
 interface TelegramMessage {
   message_id?: number;
   text?: string;
@@ -13,6 +29,8 @@ interface TelegramMessage {
     last_name?: string;
     language_code?: string;
   };
+  photo?: TelegramPhotoSize[];
+  document?: TelegramDocument;
 }
 
 interface TelegramUpdate {
@@ -31,7 +49,8 @@ export function normalizeTelegramUpdate(
   const message = update.message;
   const updateId = update.update_id;
 
-  if (!message?.text || !message?.chat?.id || updateId == null) {
+  const hasContent = !!(message?.text || message?.caption || message?.photo || message?.document);
+  if (!hasContent || !message?.chat?.id || updateId == null) {
     return null;
   }
 
@@ -49,14 +68,32 @@ export function normalizeTelegramUpdate(
     .join(" ")
     .trim();
 
+  const content = message.text || message.caption || "";
+
+  const attachments: { type: "photo" | "document"; fileId: string; fileName?: string; mimeType?: string }[] = [];
+  if (message.photo && message.photo.length > 0) {
+    // Telegram sends multiple sizes; pick the largest (last in array)
+    const largest = message.photo[message.photo.length - 1];
+    attachments.push({ type: "photo", fileId: largest.file_id });
+  }
+  if (message.document) {
+    attachments.push({
+      type: "document",
+      fileId: message.document.file_id,
+      fileName: message.document.file_name,
+      mimeType: message.document.mime_type,
+    });
+  }
+
   return {
     version: "v1",
     sourceChannel: "telegram",
     receivedAt: new Date().toISOString(),
     message: {
-      content: message.text,
+      content,
       externalChatId: String(message.chat.id),
       externalMessageId: String(updateId),
+      ...(attachments.length > 0 ? { attachments } : {}),
     },
     sender: {
       externalUserId,

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -10,6 +10,12 @@ export type GatewayInboundEventV1 = {
     content: string;
     externalChatId: string;
     externalMessageId: string;
+    attachments?: {
+      type: "photo" | "document";
+      fileId: string;
+      fileName?: string;
+      mimeType?: string;
+    }[];
   };
   sender: {
     externalUserId: string;


### PR DESCRIPTION
## Summary
- **Gateway normalize**: Accept Telegram `photo` and `document` messages (not just `text`), use `caption` as content fallback, return attachment metadata
- **File download**: New `downloadTelegramFile()` function that calls Telegram's `getFile` API, downloads binary, detects MIME type via `file-type` magic bytes
- **Attachment upload**: New `uploadAttachment()` function that POSTs base64 file data to the runtime's `/v1/assistants/{id}/attachments` endpoint
- **Webhook handler**: Downloads files from Telegram, uploads to runtime, passes attachment IDs through `handleInbound` → `forwardToRuntime`
- **Anthropic provider fix**: Send file attachments as native `type: "document"` content blocks instead of converting to plain text (was causing "No extracted text available" errors)
- **Tests**: 6 new tests for photo messages, document messages, caption handling

## Test plan
- [x] Send a PDF to the Telegram bot — downloaded, uploaded to runtime, and summarized by AI
- [x] Send a photo — same flow, correctly identified as `image/jpeg`
- [x] Send a text message — still works as before
- [x] `bun test` in gateway/ — all 16 normalize tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
