### PR TITLE
M10: Persist usage events from computer-use session loop

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -18,6 +18,8 @@ import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
 import { getLogger } from '../util/logger.js';
+import { recordUsageEvent } from '../memory/llm-usage-store.js';
+import { resolvePricing } from '../util/pricing.js';
 
 const log = getLogger('computer-use-session');
 
@@ -449,6 +451,32 @@ export class ComputerUseSession {
                 outputTokens: event.outputTokens,
                 model: event.model,
               }, 'Usage');
+              try {
+                const pricing = resolvePricing(
+                  this.provider.name,
+                  event.model,
+                  event.inputTokens,
+                  event.outputTokens,
+                );
+                recordUsageEvent(
+                  {
+                    actor: 'computer_use_agent',
+                    provider: this.provider.name,
+                    model: event.model,
+                    inputTokens: event.inputTokens,
+                    outputTokens: event.outputTokens,
+                    cacheCreationInputTokens: event.cacheCreationInputTokens ?? null,
+                    cacheReadInputTokens: event.cacheReadInputTokens ?? null,
+                    assistantId: null,
+                    conversationId: this.sessionId,
+                    runId: null,
+                    requestId: null,
+                  },
+                  pricing,
+                );
+              } catch (err) {
+                log.warn({ err, sessionId: this.sessionId }, 'Failed to persist usage event (non-fatal)');
+              }
               break;
             // Other events (text_delta, thinking_delta, etc.) are not surfaced to the CU client
           }


### PR DESCRIPTION
## Summary
- Instruments the `ComputerUseSession` class to persist LLM usage events to the usage ledger
- Each usage event from the AgentLoop is recorded via `recordUsageEvent()` with actor `computer_use_agent`, provider/model from the session, and the sessionId as conversationId
- Recording is wrapped in try/catch to remain non-fatal, matching the pattern established in M3 for `Session.recordUsage()`

## Test plan
- [x] TypeScript type checking passes (`bunx tsc --noEmit`)
- [x] Existing computer-use session lifecycle tests pass
- [x] Existing computer-use session compaction tests pass
- [x] Existing pricing and usage summary tests pass
- [x] Verified try/catch handles missing table gracefully (logs warning, does not break session)

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
