### PR TITLE
M6: Expose usage summary endpoint on runtime + web API

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -16,6 +16,7 @@ import * as attachmentsStore from '../memory/attachments-store.js';
 import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import { getConfig } from '../config/loader.js';
+import { getUsageSummary } from '../usage/summary.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 
 const log = getLogger('runtime-http');
@@ -154,6 +155,10 @@ export class RuntimeHttpServer {
 
       if (endpoint === 'channels/delivery-ack' && req.method === 'POST') {
         return await this.handleChannelDeliveryAck(assistantId, req);
+      }
+
+      if (endpoint === 'usage' && req.method === 'GET') {
+        return this.handleGetUsage(assistantId, url);
       }
 
       return Response.json({ error: 'Not found' }, { status: 404 });
@@ -729,6 +734,66 @@ export class RuntimeHttpServer {
       eventId: result.eventId,
       ...(assistantMessage ? { assistantMessage } : {}),
     });
+  }
+
+  // ── Usage endpoint ──────────────────────────────────────────────────
+
+  private handleGetUsage(assistantId: string, url: URL): Response {
+    const preset = url.searchParams.get('preset');
+    const startParam = url.searchParams.get('start');
+    const endParam = url.searchParams.get('end');
+
+    let startAt: number;
+    let endAt: number;
+
+    if (preset) {
+      const now = Date.now();
+      endAt = now;
+      switch (preset) {
+        case '24h':
+          startAt = now - 24 * 60 * 60 * 1000;
+          break;
+        case '7d':
+          startAt = now - 7 * 24 * 60 * 60 * 1000;
+          break;
+        case '30d':
+          startAt = now - 30 * 24 * 60 * 60 * 1000;
+          break;
+        default:
+          return Response.json(
+            { error: 'Invalid preset. Must be one of: 24h, 7d, 30d' },
+            { status: 400 },
+          );
+      }
+    } else if (startParam && endParam) {
+      startAt = Number(startParam);
+      endAt = Number(endParam);
+      if (isNaN(startAt) || isNaN(endAt)) {
+        return Response.json(
+          { error: 'start and end must be valid epoch milliseconds' },
+          { status: 400 },
+        );
+      }
+      if (startAt >= endAt) {
+        return Response.json(
+          { error: 'start must be before end' },
+          { status: 400 },
+        );
+      }
+    } else {
+      return Response.json(
+        { error: 'Either preset (24h|7d|30d) or start+end (epoch ms) query params are required' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const summary = getUsageSummary({ startAt, endAt, assistantId });
+      return Response.json(summary);
+    } catch (err) {
+      log.error({ err, assistantId }, 'Failed to fetch usage summary');
+      return Response.json({ error: 'Failed to fetch usage summary' }, { status: 500 });
+    }
   }
 
   private async handleChannelDeliveryAck(assistantId: string, req: Request): Promise<Response> {

--- a/web/src/app/api/assistants/[id]/usage/route.ts
+++ b/web/src/app/api/assistants/[id]/usage/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAssistantOwner, toAuthErrorResponse } from "@/lib/auth/server-session";
+import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
+import { resolveRuntime } from "@/lib/runtime/resolver";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: assistantId } = await params;
+    await requireAssistantOwner(request, assistantId);
+
+    const { baseUrl } = resolveRuntime(assistantId);
+    const client = createRuntimeClient(baseUrl, assistantId);
+
+    const preset = request.nextUrl.searchParams.get("preset") ?? undefined;
+    const startParam = request.nextUrl.searchParams.get("start");
+    const endParam = request.nextUrl.searchParams.get("end");
+
+    const result = await client.getUsage({
+      preset: preset as "24h" | "7d" | "30d" | undefined,
+      start: startParam != null ? Number(startParam) : undefined,
+      end: endParam != null ? Number(endParam) : undefined,
+    });
+
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    if (error instanceof RuntimeClientError) {
+      return NextResponse.json(
+        { error: "Failed to fetch usage" },
+        { status: error.httpStatus },
+      );
+    }
+    if (error instanceof Error && ["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN"].includes(error.message)) {
+      return toAuthErrorResponse(error);
+    }
+    console.error("Error fetching usage:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch usage" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -25,6 +25,8 @@ import type {
   RunResponse,
   RunDecisionParams,
   RunDecisionResponse,
+  GetUsageParams,
+  UsageSummaryResponse,
 } from "./types";
 
 function sanitizeUrl(url: string): string {
@@ -164,6 +166,14 @@ export function createRuntimeClient(
         method: "POST",
         body: JSON.stringify(params),
       });
+    },
+
+    getUsage(params: GetUsageParams) {
+      const qs = new URLSearchParams();
+      if (params.preset) qs.set("preset", params.preset);
+      if (params.start != null) qs.set("start", String(params.start));
+      if (params.end != null) qs.set("end", String(params.end));
+      return request<UsageSummaryResponse>(`/usage?${qs.toString()}`);
     },
   };
 }

--- a/web/src/lib/runtime/types.ts
+++ b/web/src/lib/runtime/types.ts
@@ -158,6 +158,45 @@ export interface RunDecisionResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+export interface GetUsageParams {
+  preset?: "24h" | "7d" | "30d";
+  start?: number; // epoch ms
+  end?: number;   // epoch ms
+}
+
+export interface UsageBreakdownEntry {
+  key: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number | null;
+  eventCount: number;
+}
+
+export interface UsageDailyBucket {
+  date: string; // YYYY-MM-DD
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number | null;
+  eventCount: number;
+}
+
+export interface UsageSummaryResponse {
+  totalPricedCostUsd: number;
+  totalUnpricedInputTokens: number;
+  totalUnpricedOutputTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  eventCount: number;
+  byProvider: UsageBreakdownEntry[];
+  byModel: UsageBreakdownEntry[];
+  byActor: UsageBreakdownEntry[];
+  dailyBuckets: UsageDailyBucket[];
+}
+
+// ---------------------------------------------------------------------------
 // Client interface
 // ---------------------------------------------------------------------------
 
@@ -178,4 +217,6 @@ export interface RuntimeClient {
   createRun(params: CreateRunParams): Promise<RunResponse>;
   getRun(runId: string): Promise<RunResponse>;
   submitRunDecision(runId: string, params: RunDecisionParams): Promise<RunDecisionResponse>;
+
+  getUsage(params: GetUsageParams): Promise<UsageSummaryResponse>;
 }


### PR DESCRIPTION
## Summary
- Add `GET /v1/assistants/:id/usage` runtime HTTP endpoint that accepts `preset` (`24h`|`7d`|`30d`) or explicit `start`+`end` (epoch ms) query params and returns the `UsageSummary` from `getUsageSummary()`
- Add web API proxy route at `web/src/app/api/assistants/[id]/usage/route.ts` following existing proxy patterns
- Add `UsageSummaryResponse`, `UsageBreakdownEntry`, `UsageDailyBucket`, and `GetUsageParams` types to `web/src/lib/runtime/types.ts`
- Add `getUsage()` client method to `web/src/lib/runtime/client.ts`

Closes #1241

## Test plan
- [x] `bunx tsc --noEmit` passes in `assistant/`
- [x] All usage-summary, pricing, and server-history-render tests pass
- [ ] Manual: `curl localhost:7821/v1/assistants/<id>/usage?preset=24h` returns JSON summary
- [ ] Manual: `curl localhost:7821/v1/assistants/<id>/usage?start=0&end=9999999999999` returns JSON summary
- [ ] Manual: Missing/invalid params return 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
