### PR TITLE
Skip publish steps on branch builds and upload DMG as artifact

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -213,7 +213,15 @@ jobs:
           xcrun stapler validate "$DMG_PATH"
           echo "Notarization ticket stapled and validated"
 
+      - name: Upload DMG artifact
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: vellum-assistant.dmg
+          path: clients/macos/${{ env.DMG_PATH }}
+
       - name: Build ZIP for Sparkle auto-update
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         run: |
           cd dist
           ditto -c -k --keepParent Vellum.app vellum-assistant.zip
@@ -221,6 +229,7 @@ jobs:
           ls -lh vellum-assistant.zip
 
       - name: Install Sparkle sign_update tool
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         run: |
           brew install sparkle
           SPARKLE_BIN=$(find /opt/homebrew/Caskroom/sparkle -name sign_update -type f 2>/dev/null | head -1)
@@ -231,6 +240,7 @@ jobs:
           echo "$(dirname "$SPARKLE_BIN")" >> "$GITHUB_PATH"
 
       - name: Generate appcast.xml
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
@@ -272,6 +282,7 @@ jobs:
           echo "Appcast generated with signature"
 
       - name: Create GitHub Release on public repo
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_PAT }}
         run: |


### PR DESCRIPTION
The purpose of this PR is to prevent `workflow_dispatch` runs on feature branches from overwriting the live public release.

## Changes Made
- Gate Sparkle ZIP, appcast generation, and public repo release behind `main`/tag ref checks
- Upload the signed+notarized DMG as a GitHub Actions artifact on branch builds for testing
- Build, sign, notarize, and staple steps still run on all branches for full pipeline validation

## Testing
- Verified YAML is valid
- Branch builds will produce a downloadable DMG artifact without publishing to the public repo

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
