### PR TITLE
M2: Composer attachment preview UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ChatView: View {
     let messages: [ChatMessage]
@@ -14,6 +15,9 @@ struct ChatView: View {
     let onDismissError: () -> Void
     let onAcceptSuggestion: () -> Void
     let onAttach: () -> Void
+    let onRemoveAttachment: (String) -> Void
+    let onDropFiles: ([URL]) -> Void
+    let onPaste: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
 
@@ -161,69 +165,82 @@ struct ChatView: View {
     // MARK: - Composer Area
 
     private var composerArea: some View {
-        HStack(spacing: VSpacing.sm) {
-            // Leading chat icon
-            VCircleButton(icon: "phone.fill", label: "Phone") { }
-
-            // Text field with ghost suffix overlay
-            ZStack(alignment: .leading) {
-                TextField("", text: $inputText, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-                    .lineLimit(1...3)
-                    .onKeyPress(.tab, phases: .down) { keyPress in
-                        if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
-                            onAcceptSuggestion()
-                            return .handled
-                        }
-                        return .ignored
-                    }
-                    .onKeyPress(.return, phases: .down) { keyPress in
-                        if keyPress.modifiers.contains(.shift) { return .ignored }
-                        if canSend { onSend() }
-                        return .handled
-                    }
-                    .onSubmit { if canSend { onSend() } }
-
-                if let ghostSuffix {
-                    Text(inputText + ghostSuffix)
-                        .font(VFont.mono)
-                        .foregroundColor(.clear)
-                        .lineLimit(1...3)
-                        .overlay(alignment: .leading) {
-                            HStack(spacing: 0) {
-                                Text(inputText)
-                                    .font(VFont.mono)
-                                    .foregroundColor(.clear)
-                                Text(ghostSuffix)
-                                    .font(VFont.mono)
-                                    .foregroundColor(VColor.textMuted.opacity(0.5))
-                            }
-                        }
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
+        VStack(spacing: 0) {
+            if !pendingAttachments.isEmpty {
+                attachmentStrip
             }
 
-            // Attachment / Stop button
-            if isSending {
-                Button(action: onStop) {
-                    Image(systemName: "stop.circle.fill")
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundColor(VColor.error)
+            HStack(spacing: VSpacing.sm) {
+                // Leading chat icon
+                VCircleButton(icon: "phone.fill", label: "Phone") { }
+
+                // Text field with ghost suffix overlay
+                ZStack(alignment: .leading) {
+                    TextField("", text: $inputText, axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1...3)
+                        .onKeyPress(.tab, phases: .down) { keyPress in
+                            if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
+                                onAcceptSuggestion()
+                                return .handled
+                            }
+                            return .ignored
+                        }
+                        .onKeyPress(.return, phases: .down) { keyPress in
+                            if keyPress.modifiers.contains(.shift) { return .ignored }
+                            if canSend { onSend() }
+                            return .handled
+                        }
+                        .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
+                            if keyPress.modifiers.contains(.command) {
+                                onPaste()
+                                return .ignored
+                            }
+                            return .ignored
+                        }
+                        .onSubmit { if canSend { onSend() } }
+
+                    if let ghostSuffix {
+                        Text(inputText + ghostSuffix)
+                            .font(VFont.mono)
+                            .foregroundColor(.clear)
+                            .lineLimit(1...3)
+                            .overlay(alignment: .leading) {
+                                HStack(spacing: 0) {
+                                    Text(inputText)
+                                        .font(VFont.mono)
+                                        .foregroundColor(.clear)
+                                    Text(ghostSuffix)
+                                        .font(VFont.mono)
+                                        .foregroundColor(VColor.textMuted.opacity(0.5))
+                                }
+                            }
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Stop generation")
-            } else {
-                Button(action: onAttach) {
-                    Image(systemName: "paperclip")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(VColor.textSecondary)
-                        .padding(10)
+
+                // Attachment / Stop button
+                if isSending {
+                    Button(action: onStop) {
+                        Image(systemName: "stop.circle.fill")
+                            .font(.system(size: 20, weight: .medium))
+                            .foregroundColor(VColor.error)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Stop generation")
+                } else {
+                    Button(action: onAttach) {
+                        Image(systemName: "paperclip")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(VColor.textSecondary)
+                            .padding(10)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Attach file")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Attach file")
             }
         }
         .padding(VSpacing.xs)
@@ -237,6 +254,132 @@ struct ChatView: View {
         .padding(.vertical, VSpacing.lg)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            var urls: [URL] = []
+            let group = DispatchGroup()
+            for provider in providers {
+                group.enter()
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    if let url { urls.append(url) }
+                    group.leave()
+                }
+            }
+            group.notify(queue: .main) {
+                if !urls.isEmpty { onDropFiles(urls) }
+            }
+            return true
+        }
+    }
+
+    // MARK: - Attachment Preview Strip
+
+    private var attachmentStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: VSpacing.sm) {
+                ForEach(pendingAttachments) { attachment in
+                    attachmentChip(attachment)
+                }
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.top, VSpacing.sm)
+            .padding(.bottom, VSpacing.xs)
+        }
+    }
+
+    private func attachmentChip(_ attachment: ChatAttachment) -> some View {
+        let fileSize = formattedFileSize(base64Length: attachment.data.count)
+        let isImage = attachment.mimeType.hasPrefix("image/")
+
+        return VStack(spacing: VSpacing.xxs) {
+            ZStack(alignment: .topTrailing) {
+                if isImage, let thumbnailData = attachment.thumbnailData,
+                   let nsImage = NSImage(data: thumbnailData) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                } else {
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.surfaceBorder.opacity(0.5))
+                        .frame(width: 48, height: 48)
+                        .overlay {
+                            VStack(spacing: VSpacing.xxs) {
+                                Image(systemName: iconForMimeType(attachment.mimeType, filename: attachment.filename))
+                                    .font(.system(size: 16))
+                                    .foregroundColor(VColor.textSecondary)
+                                Text(fileExtension(attachment.filename))
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                                    .lineLimit(1)
+                            }
+                        }
+                }
+
+                Button {
+                    onRemoveAttachment(attachment.id)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(VColor.textSecondary)
+                        .background(Circle().fill(VColor.surface))
+                }
+                .buttonStyle(.plain)
+                .offset(x: 4, y: -4)
+                .accessibilityLabel("Remove \(attachment.filename)")
+            }
+
+            Text(truncatedFilename(attachment.filename))
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+                .lineLimit(1)
+                .frame(width: 56)
+
+            Text(fileSize)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+
+    // MARK: - Attachment Helpers
+
+    private func formattedFileSize(base64Length: Int) -> String {
+        let bytes = base64Length * 3 / 4
+        if bytes < 1024 {
+            return "\(bytes) B"
+        } else if bytes < 1024 * 1024 {
+            return "\(bytes / 1024) KB"
+        } else {
+            let mb = Double(bytes) / (1024 * 1024)
+            return String(format: "%.1f MB", mb)
+        }
+    }
+
+    private func truncatedFilename(_ name: String) -> String {
+        if name.count <= 8 { return name }
+        let ext = fileExtension(name)
+        let base = String(name.prefix(name.count - ext.count - (ext.isEmpty ? 0 : 1)))
+        let truncBase = String(base.prefix(5))
+        return ext.isEmpty ? truncBase + "..." : truncBase + "..." + ext
+    }
+
+    private func fileExtension(_ filename: String) -> String {
+        let parts = filename.split(separator: ".")
+        guard parts.count > 1, let last = parts.last else { return "" }
+        return String(last).uppercased()
+    }
+
+    private func iconForMimeType(_ mimeType: String, filename: String) -> String {
+        if mimeType == "application/pdf" { return "doc.fill" }
+        if mimeType.hasPrefix("text/") { return "doc.text.fill" }
+        if mimeType.hasPrefix("image/") { return "photo" }
+        let ext = filename.split(separator: ".").last.map(String.init) ?? ""
+        switch ext.lowercased() {
+        case "pdf": return "doc.fill"
+        case "csv": return "tablecells"
+        case "md", "txt": return "doc.text.fill"
+        default: return "doc.fill"
+        }
     }
 
     private var canSend: Bool {
@@ -418,6 +561,9 @@ private struct ThinkingIndicator: View {
             onDismissError: {},
             onAcceptSuggestion: {},
             onAttach: {},
+            onRemoveAttachment: { _ in },
+            onDropFiles: { _ in },
+            onPaste: {},
             onConfirmationAllow: { _ in },
             onConfirmationDeny: { _ in }
         )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -98,6 +98,48 @@ final class ChatViewModel: ObservableObject {
         pendingAttachments.removeAll { $0.id == id }
     }
 
+    func addAttachmentFromPasteboard() {
+        let pasteboard = NSPasteboard.general
+        guard let imageData = pasteboard.data(forType: .png) ?? pasteboard.data(forType: .tiff) else {
+            return
+        }
+
+        guard pendingAttachments.count < Self.maxAttachments else {
+            errorText = "Maximum \(Self.maxAttachments) attachments per message."
+            return
+        }
+
+        // Convert to PNG if needed
+        let pngData: Data
+        if pasteboard.data(forType: .png) != nil {
+            pngData = imageData
+        } else if let bitmapRep = NSBitmapImageRep(data: imageData),
+                  let converted = bitmapRep.representation(using: .png, properties: [:]) {
+            pngData = converted
+        } else {
+            log.error("Failed to convert pasted image to PNG")
+            errorText = "Could not process pasted image."
+            return
+        }
+
+        guard pngData.count <= Self.maxFileSize else {
+            errorText = "Pasted image exceeds 20 MB limit."
+            return
+        }
+
+        let base64 = pngData.base64EncodedString()
+        let thumbnail = Self.generateThumbnail(from: pngData, maxDimension: 120)
+
+        let attachment = ChatAttachment(
+            id: UUID().uuidString,
+            filename: "Pasted Image.png",
+            mimeType: "image/png",
+            data: base64,
+            thumbnailData: thumbnail
+        )
+        pendingAttachments.append(attachment)
+    }
+
     /// Resize image data to fit within `maxDimension` and return PNG data.
     private static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
         guard let image = NSImage(data: data) else { return nil }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -48,6 +48,9 @@ struct MainWindowView: View {
                             onDismissError: viewModel.dismissError,
                             onAcceptSuggestion: viewModel.acceptSuggestion,
                             onAttach: { Self.openFilePicker(viewModel: viewModel) },
+                            onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+                            onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
+                            onPaste: { viewModel.addAttachmentFromPasteboard() },
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
                         )


### PR DESCRIPTION
## Summary
- Add horizontal scroll attachment preview strip above composer text field with image thumbnails and document file icons
- Each attachment chip displays truncated filename, estimated file size, and an x remove button
- Drag-drop files from Finder onto the composer area to add as attachments
- CMD+V pastes images from clipboard as attachments (text paste still works normally)
- Wire new callbacks (onRemoveAttachment, onDropFiles, onPaste) through MainWindowView to ChatViewModel

Part of #1279. Closes #1281.

## Test plan
- [ ] Add attachments via paperclip -> preview strip appears above composer
- [ ] Image attachments show thumbnail preview (48x48)
- [ ] Document attachments show file type icon + extension label
- [ ] Click x removes attachment from strip
- [ ] Drag files from Finder onto chat -> adds attachments
- [ ] CMD+V with image in clipboard -> adds as attachment
- [ ] CMD+V with text in clipboard -> pastes text normally
- [ ] Strip disappears when all attachments removed
- [ ] File size labels display correctly (B, KB, MB)
- [ ] Long filenames are truncated with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
