### PR TITLE
Add typing indicator to Telegram webhook handler

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -4,6 +4,7 @@ import { verifyWebhookSecret } from "../../telegram/verify.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
 import { downloadTelegramFile } from "../../telegram/download.js";
 import { handleInbound, type InboundResult } from "../../handlers/handle-inbound.js";
+import { sendTypingIndicator } from "../../telegram/send.js";
 import { resolveAssistant, isRejection } from "../../routing/resolve-assistant.js";
 import { uploadAttachment } from "../../runtime/client.js";
 
@@ -111,6 +112,11 @@ export function createTelegramWebhookHandler(
       }
     }
 
+    // Start typing indicator
+    const chatId = normalized.message.externalChatId;
+    sendTypingIndicator(config, chatId);
+    const typingInterval = setInterval(() => sendTypingIndicator(config, chatId), 5000);
+
     // Process inbound and only acknowledge after successful delivery
     let result: InboundResult;
     try {
@@ -118,6 +124,8 @@ export function createTelegramWebhookHandler(
     } catch (err) {
       log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       return Response.json({ error: "Internal error" }, { status: 500 });
+    } finally {
+      clearInterval(typingInterval);
     }
 
     if (!result.forwarded && !result.rejected) {

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -63,59 +63,62 @@ export function createTelegramWebhookHandler(
       return Response.json({ ok: true });
     }
 
+    // Check routing early so we can gate attachments and typing indicator
+    const chatId = normalized.message.externalChatId;
+    const routing = resolveAssistant(
+      config,
+      chatId,
+      normalized.sender.externalUserId,
+    );
+    const routable = !isRejection(routing);
+
     // Download and upload attachments if present
     let attachmentIds: string[] | undefined;
     const eventAttachments = normalized.message.attachments;
-    if (eventAttachments && eventAttachments.length > 0) {
-      const routing = resolveAssistant(
-        config,
-        normalized.message.externalChatId,
-        normalized.sender.externalUserId,
-      );
+    if (eventAttachments && eventAttachments.length > 0 && routable) {
+      try {
+        attachmentIds = [];
 
-      if (!isRejection(routing)) {
-        try {
-          attachmentIds = [];
-
-          // Filter oversized attachments
-          const eligible = eventAttachments.filter((att) => {
-            if (att.fileSize !== undefined && att.fileSize > config.maxAttachmentBytes) {
-              log.warn(
-                { fileId: att.fileId, fileSize: att.fileSize, limit: config.maxAttachmentBytes },
-                "Skipping oversized attachment",
-              );
-              return false;
-            }
-            return true;
-          });
-
-          // Process with bounded concurrency
-          for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
-            const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
-            const results = await Promise.all(
-              batch.map(async (att) => {
-                const downloaded = await downloadTelegramFile(config, att.fileId, {
-                  fileName: att.fileName,
-                  mimeType: att.mimeType,
-                });
-                return uploadAttachment(config, routing.assistantId, downloaded);
-              }),
+        // Filter oversized attachments
+        const eligible = eventAttachments.filter((att) => {
+          if (att.fileSize !== undefined && att.fileSize > config.maxAttachmentBytes) {
+            log.warn(
+              { fileId: att.fileId, fileSize: att.fileSize, limit: config.maxAttachmentBytes },
+              "Skipping oversized attachment",
             );
-            for (const uploaded of results) {
-              attachmentIds.push(uploaded.id);
-            }
+            return false;
           }
-        } catch (err) {
-          log.error({ err }, "Failed to process attachments");
-          return Response.json({ error: "Failed to process attachments" }, { status: 500 });
+          return true;
+        });
+
+        // Process with bounded concurrency
+        for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
+          const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
+          const results = await Promise.all(
+            batch.map(async (att) => {
+              const downloaded = await downloadTelegramFile(config, att.fileId, {
+                fileName: att.fileName,
+                mimeType: att.mimeType,
+              });
+              return uploadAttachment(config, routing.assistantId, downloaded);
+            }),
+          );
+          for (const uploaded of results) {
+            attachmentIds.push(uploaded.id);
+          }
         }
+      } catch (err) {
+        log.error({ err }, "Failed to process attachments");
+        return Response.json({ error: "Failed to process attachments" }, { status: 500 });
       }
     }
 
-    // Start typing indicator
-    const chatId = normalized.message.externalChatId;
-    sendTypingIndicator(config, chatId);
-    const typingInterval = setInterval(() => sendTypingIndicator(config, chatId), 5000);
+    // Start typing indicator only for routable chats
+    let typingInterval: ReturnType<typeof setInterval> | undefined;
+    if (routable) {
+      sendTypingIndicator(config, chatId);
+      typingInterval = setInterval(() => sendTypingIndicator(config, chatId), 5000);
+    }
 
     // Process inbound and only acknowledge after successful delivery
     let result: InboundResult;

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -10,6 +10,8 @@ import { uploadAttachment } from "../../runtime/client.js";
 
 const log = pino({ name: "gateway:telegram-webhook" });
 
+const MAX_TYPING_DURATION_MS = 60_000;
+
 export type OnReply = (
   chatId: string,
   result: InboundResult,
@@ -113,11 +115,18 @@ export function createTelegramWebhookHandler(
       }
     }
 
-    // Start typing indicator only for routable chats
+    // Start typing indicator only for routable chats.
+    // A safety timeout ensures the interval is cleared even if handleInbound hangs.
     let typingInterval: ReturnType<typeof setInterval> | undefined;
+    let typingTimeout: ReturnType<typeof setTimeout> | undefined;
+    const clearTyping = () => {
+      clearInterval(typingInterval);
+      clearTimeout(typingTimeout);
+    };
     if (routable) {
       sendTypingIndicator(config, chatId);
       typingInterval = setInterval(() => sendTypingIndicator(config, chatId), 5000);
+      typingTimeout = setTimeout(clearTyping, MAX_TYPING_DURATION_MS);
     }
 
     // Process inbound and only acknowledge after successful delivery
@@ -128,7 +137,7 @@ export function createTelegramWebhookHandler(
       log.error({ err, updateId: payload.update_id }, "Failed to process inbound event");
       return Response.json({ error: "Internal error" }, { status: 500 });
     } finally {
-      clearInterval(typingInterval);
+      clearTyping();
     }
 
     if (!result.forwarded && !result.rejected) {

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -42,4 +42,12 @@ export async function sendTelegramReply(
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
 }
 
+export async function sendTypingIndicator(config: GatewayConfig, chatId: string): Promise<void> {
+  try {
+    await callTelegramApi(config, "sendChatAction", { chat_id: chatId, action: "typing" });
+  } catch (err) {
+    log.debug({ err, chatId }, "Failed to send typing indicator");
+  }
+}
+
 export { splitText };


### PR DESCRIPTION
## Summary
- Add `sendTypingIndicator` helper to `gateway/src/telegram/send.ts` that calls Telegram's `sendChatAction` API (fire-and-forget, errors logged at debug level)
- Wire it into the webhook handler: fires immediately before `handleInbound()` and repeats every 5s via `setInterval` so the indicator persists during long AI responses
- `finally` block ensures the interval is cleared on both success and error paths

## Test plan
- [ ] Send a message to the Telegram bot and observe "typing..." appears immediately
- [ ] Indicator persists until the reply arrives
- [ ] If the runtime errors, the indicator stops (no infinite typing)
- [ ] `bun test` in `gateway/` passes (30/30 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
