### PR TITLE
Fix inline confirmation bubble ordering in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -538,7 +538,14 @@ final class ChatViewModel: ObservableObject {
                 text: "",
                 confirmation: confirmation
             )
-            messages.append(confirmMsg)
+            // Insert before the current streaming assistant message so the
+            // confirmation appears between the user message and the response.
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages.insert(confirmMsg, at: index)
+            } else {
+                messages.append(confirmMsg)
+            }
 
         default:
             break


### PR DESCRIPTION
## Summary
- Insert confirmation messages before the current streaming assistant message instead of appending after it
- Confirmation bubbles now appear between the user message and the assistant's response, matching the natural conversation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
