### PR TITLE
Decode tool IPC messages and track tool calls in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -28,6 +28,25 @@ struct ToolConfirmationData: Equatable {
     var state: ToolConfirmationState = .pending
 }
 
+/// Data for a tool call displayed inline in an assistant message.
+struct ToolCallData: Identifiable, Equatable {
+    let id: UUID
+    let toolName: String
+    let inputSummary: String
+    var result: String?
+    var isError: Bool
+    var isComplete: Bool
+
+    init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false) {
+        self.id = id
+        self.toolName = toolName
+        self.inputSummary = inputSummary
+        self.result = result
+        self.isError = isError
+        self.isComplete = isComplete
+    }
+}
+
 /// A file or image attachment associated with a chat message.
 struct ChatAttachment: Identifiable {
     let id: String
@@ -49,8 +68,9 @@ struct ChatMessage: Identifiable {
     /// Non-nil when this message is an inline tool confirmation request.
     var confirmation: ToolConfirmationData?
     var attachments: [ChatAttachment]
+    var toolCalls: [ToolCallData]
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = []) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = []) {
         self.id = id
         self.role = role
         self.text = text
@@ -59,5 +79,6 @@ struct ChatMessage: Identifiable {
         self.status = status
         self.confirmation = confirmation
         self.attachments = attachments
+        self.toolCalls = toolCalls
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -323,6 +323,34 @@ final class ChatViewModel: ObservableObject {
         return messageSessionId == sessionId
     }
 
+    /// Summarize tool input for display, showing the first value truncated to 80 chars.
+    private func summarizeToolInput(_ input: [String: AnyCodable]) -> String {
+        guard let firstValue = input.values.first else { return "" }
+        let str: String
+        if let s = firstValue.value as? String {
+            str = s
+        } else if let encoder = try? JSONEncoder().encode(firstValue),
+                  let json = String(data: encoder, encoding: .utf8) {
+            str = json
+        } else {
+            str = String(describing: firstValue.value ?? "")
+        }
+        return str.count > 80 ? String(str.prefix(77)) + "..." : str
+    }
+
+    private func toolDisplayName(_ name: String) -> String {
+        switch name {
+        case "file_write": return "Write File"
+        case "file_edit": return "Edit File"
+        case "bash": return "Run Command"
+        case "web_fetch": return "Fetch URL"
+        case "file_read": return "Read File"
+        case "glob": return "Find Files"
+        case "grep": return "Search Files"
+        default: return name.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
     func handleServerMessage(_ message: ServerMessage) {
         switch message {
         case .sessionInfo(let info):
@@ -545,6 +573,37 @@ final class ChatViewModel: ObservableObject {
                 messages.insert(confirmMsg, at: index)
             } else {
                 messages.append(confirmMsg)
+            }
+
+        case .toolUseStart(let msg):
+            isThinking = false
+            let toolCall = ToolCallData(
+                toolName: toolDisplayName(msg.toolName),
+                inputSummary: summarizeToolInput(msg.input)
+            )
+            // Add to existing assistant message or create one
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].toolCalls.append(toolCall)
+            } else {
+                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [toolCall])
+                currentAssistantMessageId = newMsg.id
+                messages.append(newMsg)
+            }
+
+        case .toolOutputChunk:
+            // Streaming output — ignore for now, we show the final result
+            break
+
+        case .toolResult(let msg):
+            // Find the most recent pending (incomplete) tool call and mark it complete
+            if let existingId = currentAssistantMessageId,
+               let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
+               let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                let truncatedResult = msg.result.count > 2000 ? String(msg.result.prefix(2000)) + "...[truncated]" : msg.result
+                messages[msgIndex].toolCalls[tcIndex].result = truncatedResult
+                messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
+                messages[msgIndex].toolCalls[tcIndex].isComplete = true
             }
 
         default:

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -400,6 +400,29 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Tool execution started.
+/// Wire type: `"tool_use_start"`
+struct ToolUseStartMessage: Decodable, Sendable {
+    let toolName: String
+    let input: [String: AnyCodable]
+}
+
+/// Streaming tool output chunk.
+/// Wire type: `"tool_output_chunk"`
+struct ToolOutputChunkMessage: Decodable, Sendable {
+    let chunk: String
+}
+
+/// Tool execution completed.
+/// Wire type: `"tool_result"`
+struct ToolResultMessage: Decodable, Sendable {
+    let toolName: String
+    let result: String
+    let isError: Bool?
+    let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    let status: String?
+}
+
 /// Follow-up suggestion response from daemon.
 /// Wire type: `"suggestion_response"`
 struct SuggestionResponseMessage: Decodable, Sendable {
@@ -479,6 +502,9 @@ enum ServerMessage: Decodable, Sendable {
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
+    case toolUseStart(ToolUseStartMessage)
+    case toolOutputChunk(ToolOutputChunkMessage)
+    case toolResult(ToolResultMessage)
     case pong
     case unknown(String)
 
@@ -557,6 +583,15 @@ enum ServerMessage: Decodable, Sendable {
         case "suggestion_response":
             let message = try SuggestionResponseMessage(from: decoder)
             self = .suggestionResponse(message)
+        case "tool_use_start":
+            let message = try ToolUseStartMessage(from: decoder)
+            self = .toolUseStart(message)
+        case "tool_output_chunk":
+            let message = try ToolOutputChunkMessage(from: decoder)
+            self = .toolOutputChunk(message)
+        case "tool_result":
+            let message = try ToolResultMessage(from: decoder)
+            self = .toolResult(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Adds `ToolUseStartMessage`, `ToolOutputChunkMessage`, and `ToolResultMessage` Decodable structs to the IPC decoder so `tool_use_start`, `tool_output_chunk`, and `tool_result` wire types are properly decoded instead of falling through to `unknown`.
- Adds `ToolCallData` struct to `ChatMessage` to track tool calls inline with assistant messages, including tool name, input summary, result, error state, and completion state.
- Handles `toolUseStart` and `toolResult` in `ChatViewModel.handleServerMessage` to build tool call history on the current assistant message, with input summarization and display-friendly tool names.

## Test plan
- [ ] Verify the project builds without errors via `./build.sh`
- [ ] Confirm tool IPC messages (`tool_use_start`, `tool_output_chunk`, `tool_result`) no longer hit the `unknown` case in `ServerMessage` decoder
- [ ] Verify `ToolCallData` entries accumulate on assistant messages when the daemon sends tool events
- [ ] Confirm tool results are truncated at 2000 chars with `...[truncated]` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
