### PR TITLE
M11: Add day/week/month budget schema and evaluator

### DIFF
--- a/assistant/src/__tests__/budget-policy.test.ts
+++ b/assistant/src/__tests__/budget-policy.test.ts
@@ -1,0 +1,264 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'budget-policy-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { recordUsageEvent } from '../memory/llm-usage-store.js';
+import { evaluateBudgets } from '../usage/budget-policy.js';
+import type { BudgetEvaluation } from '../usage/budget-policy.js';
+import type { CostControlsConfig } from '../config/types.js';
+import type { UsageEventInput, PricingResult } from '../usage/types.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    actor: 'main_agent',
+    assistantId: null,
+    conversationId: null,
+    runId: null,
+    requestId: null,
+    ...overrides,
+  };
+}
+
+const pricedResult: PricingResult = {
+  estimatedCostUsd: 0.50,
+  pricingStatus: 'priced',
+};
+
+/** Insert an event and override its createdAt timestamp. */
+function insertEventAt(
+  createdAt: number,
+  pricing: PricingResult = pricedResult,
+): void {
+  const event = recordUsageEvent(makeInput(), pricing);
+  const db = getDb();
+  db.run(`UPDATE llm_usage_events SET created_at = ${createdAt} WHERE id = '${event.id}'`);
+}
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const BASE_DATE = new Date('2025-01-15T12:00:00Z').getTime();
+
+describe('evaluateBudgets', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM llm_usage_events');
+  });
+
+  test('returns empty violations when costControls is disabled', () => {
+    const config: CostControlsConfig = {
+      enabled: false,
+      budgets: [{ period: 'day', amountUsd: 1.0, action: 'block' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(0);
+    expect(result.hasWarnings).toBe(false);
+    expect(result.hasBlocks).toBe(false);
+  });
+
+  test('returns empty violations when no budget rules defined', () => {
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(0);
+    expect(result.hasWarnings).toBe(false);
+    expect(result.hasBlocks).toBe(false);
+  });
+
+  test('reports no exceeded when spend is under budget', () => {
+    // Insert $0.50 spend, budget is $5.00
+    insertEventAt(BASE_DATE - HOUR_MS);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'day', amountUsd: 5.0, action: 'warn' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(false);
+    expect(result.violations[0].currentSpend).toBe(0.50);
+    expect(result.violations[0].amountUsd).toBe(5.0);
+    expect(result.violations[0].action).toBe('warn');
+    expect(result.hasWarnings).toBe(false);
+    expect(result.hasBlocks).toBe(false);
+  });
+
+  test('detects exceeded warn budget', () => {
+    // Insert 3 events ($0.50 each = $1.50), budget is $1.00
+    insertEventAt(BASE_DATE - HOUR_MS);
+    insertEventAt(BASE_DATE - HOUR_MS * 2);
+    insertEventAt(BASE_DATE - HOUR_MS * 3);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'day', amountUsd: 1.0, action: 'warn' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(true);
+    expect(result.violations[0].currentSpend).toBe(1.50);
+    expect(result.violations[0].action).toBe('warn');
+    expect(result.hasWarnings).toBe(true);
+    expect(result.hasBlocks).toBe(false);
+  });
+
+  test('detects exceeded block budget', () => {
+    // Insert 3 events ($0.50 each = $1.50), budget is $1.00
+    insertEventAt(BASE_DATE - HOUR_MS);
+    insertEventAt(BASE_DATE - HOUR_MS * 2);
+    insertEventAt(BASE_DATE - HOUR_MS * 3);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'day', amountUsd: 1.0, action: 'block' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(true);
+    expect(result.violations[0].action).toBe('block');
+    expect(result.hasWarnings).toBe(false);
+    expect(result.hasBlocks).toBe(true);
+  });
+
+  test('evaluates multiple periods independently', () => {
+    // Insert 1 event 2 hours ago ($0.50) — within day and week windows
+    insertEventAt(BASE_DATE - HOUR_MS * 2);
+
+    // Insert 1 event 3 days ago ($0.50) — within week window only
+    insertEventAt(BASE_DATE - DAY_MS * 3);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [
+        { period: 'day', amountUsd: 0.40, action: 'warn' },
+        { period: 'week', amountUsd: 0.80, action: 'block' },
+      ],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(2);
+
+    const dayViolation = result.violations.find((v) => v.period === 'day')!;
+    expect(dayViolation.exceeded).toBe(true);
+    expect(dayViolation.currentSpend).toBe(0.50);
+    expect(dayViolation.action).toBe('warn');
+
+    const weekViolation = result.violations.find((v) => v.period === 'week')!;
+    expect(weekViolation.exceeded).toBe(true);
+    expect(weekViolation.currentSpend).toBe(1.0);
+    expect(weekViolation.action).toBe('block');
+
+    expect(result.hasWarnings).toBe(true);
+    expect(result.hasBlocks).toBe(true);
+  });
+
+  test('month period covers last 30 days', () => {
+    // Insert event 25 days ago — within 30-day month window
+    insertEventAt(BASE_DATE - DAY_MS * 25);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'month', amountUsd: 0.40, action: 'warn' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(true);
+    expect(result.violations[0].currentSpend).toBe(0.50);
+    expect(result.violations[0].period).toBe('month');
+  });
+
+  test('events outside the window are not counted', () => {
+    // Insert event 2 days ago — outside the day window
+    insertEventAt(BASE_DATE - DAY_MS * 2);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'day', amountUsd: 0.10, action: 'block' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(false);
+    expect(result.violations[0].currentSpend).toBe(0);
+  });
+
+  test('exact budget amount counts as exceeded', () => {
+    // Insert exactly $0.50, budget is $0.50
+    insertEventAt(BASE_DATE - HOUR_MS);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [{ period: 'day', amountUsd: 0.50, action: 'warn' }],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].exceeded).toBe(true);
+  });
+
+  test('mixed warn and block with partial exceedance', () => {
+    // Insert $0.50 within last day
+    insertEventAt(BASE_DATE - HOUR_MS);
+
+    const config: CostControlsConfig = {
+      enabled: true,
+      budgets: [
+        { period: 'day', amountUsd: 0.40, action: 'warn' },   // exceeded
+        { period: 'day', amountUsd: 1.00, action: 'block' },  // not exceeded
+      ],
+    };
+
+    const result = evaluateBudgets(config, BASE_DATE);
+    expect(result.violations).toHaveLength(2);
+
+    const warnViolation = result.violations.find((v) => v.action === 'warn')!;
+    expect(warnViolation.exceeded).toBe(true);
+
+    const blockViolation = result.violations.find((v) => v.action === 'block')!;
+    expect(blockViolation.exceeded).toBe(false);
+
+    expect(result.hasWarnings).toBe(true);
+    expect(result.hasBlocks).toBe(false);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -66,6 +66,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     retentionDays: 0,
   },
   pricingOverrides: [],
+  costControls: {
+    enabled: false,
+    budgets: [],
+  },
 };
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -207,6 +207,33 @@ export const MemoryConfigSchema = z.object({
   }),
 });
 
+const VALID_BUDGET_PERIODS = ['day', 'week', 'month'] as const;
+const VALID_BUDGET_ACTIONS = ['warn', 'block'] as const;
+
+export const BudgetRuleSchema = z.object({
+  period: z
+    .enum(VALID_BUDGET_PERIODS, {
+      error: `costControls.budgets[].period must be one of: ${VALID_BUDGET_PERIODS.join(', ')}`,
+    }),
+  amountUsd: z
+    .number({ error: 'costControls.budgets[].amountUsd must be a number' })
+    .finite('costControls.budgets[].amountUsd must be finite')
+    .positive('costControls.budgets[].amountUsd must be a positive number'),
+  action: z
+    .enum(VALID_BUDGET_ACTIONS, {
+      error: `costControls.budgets[].action must be one of: ${VALID_BUDGET_ACTIONS.join(', ')}`,
+    }),
+});
+
+export const CostControlsConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'costControls.enabled must be a boolean' })
+    .default(false),
+  budgets: z
+    .array(BudgetRuleSchema)
+    .default([]),
+});
+
 export const ModelPricingOverrideSchema = z.object({
   provider: z.string({ error: 'pricingOverrides[].provider must be a string' }),
   modelPattern: z.string({ error: 'pricingOverrides[].modelPattern must be a string' }),
@@ -302,6 +329,10 @@ export const AssistantConfigSchema = z.object({
   pricingOverrides: z
     .array(ModelPricingOverrideSchema)
     .default([]),
+  costControls: CostControlsConfigSchema.default({
+    enabled: false,
+    budgets: [],
+  }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -334,3 +365,5 @@ export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
+export type BudgetRule = z.infer<typeof BudgetRuleSchema>;
+export type CostControlsConfig = z.infer<typeof CostControlsConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -14,4 +14,6 @@ export type {
   MemoryRetentionConfig,
   MemoryConfig,
   ModelPricingOverride,
+  BudgetRule,
+  CostControlsConfig,
 } from './schema.js';

--- a/assistant/src/usage/budget-policy.ts
+++ b/assistant/src/usage/budget-policy.ts
@@ -1,0 +1,71 @@
+import type { BudgetRule, CostControlsConfig } from '../config/types.js';
+import { getUsageSummary } from './summary.js';
+
+export type { BudgetRule };
+
+export interface BudgetViolation {
+  period: BudgetRule['period'];
+  amountUsd: number;
+  currentSpend: number;
+  action: BudgetRule['action'];
+  exceeded: boolean;
+}
+
+export interface BudgetEvaluation {
+  violations: BudgetViolation[];
+  hasWarnings: boolean;
+  hasBlocks: boolean;
+}
+
+const PERIOD_DURATIONS_MS: Record<BudgetRule['period'], number> = {
+  day: 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Evaluate configured budget rules against current usage data.
+ *
+ * For each budget rule the function computes the appropriate time window
+ * (day = last 24h, week = last 7d, month = last 30d), queries usage via
+ * `getUsageSummary`, and compares `totalPricedCostUsd` against the budget
+ * threshold.
+ *
+ * @param config - The costControls config section
+ * @param now    - Optional epoch-ms timestamp to use as "now" (defaults to Date.now())
+ */
+export function evaluateBudgets(
+  config: CostControlsConfig,
+  now?: number,
+): BudgetEvaluation {
+  const currentTime = now ?? Date.now();
+  const violations: BudgetViolation[] = [];
+
+  if (!config.enabled) {
+    return { violations, hasWarnings: false, hasBlocks: false };
+  }
+
+  for (const rule of config.budgets) {
+    const windowMs = PERIOD_DURATIONS_MS[rule.period];
+    const startAt = currentTime - windowMs;
+    const endAt = currentTime;
+
+    const summary = getUsageSummary({ startAt, endAt });
+    const currentSpend = summary.totalPricedCostUsd;
+    const exceeded = currentSpend >= rule.amountUsd;
+
+    violations.push({
+      period: rule.period,
+      amountUsd: rule.amountUsd,
+      currentSpend,
+      action: rule.action,
+      exceeded,
+    });
+  }
+
+  return {
+    violations,
+    hasWarnings: violations.some((v) => v.exceeded && v.action === 'warn'),
+    hasBlocks: violations.some((v) => v.exceeded && v.action === 'block'),
+  };
+}


### PR DESCRIPTION
## Summary
- Add `costControls` config section to the Zod schema with `enabled` boolean and `budgets` array of rules (period: day/week/month, amountUsd, action: warn/block)
- Implement `evaluateBudgets()` function in `assistant/src/usage/budget-policy.ts` that evaluates budget rules against current usage by computing time windows and comparing spend
- Export `BudgetRule`, `BudgetViolation`, and `BudgetEvaluation` types
- Add 10 tests covering disabled config, under-budget, exceeded warn/block, multiple periods, boundary conditions, and mixed action types

## Test plan
- [x] `bunx tsc --noEmit` passes with no type errors
- [x] All 10 new budget-policy tests pass
- [x] All 34 existing config-schema tests still pass
- [x] Schema defaults applied correctly for empty costControls

Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
