### PR TITLE
Add ToolCallChip UI for inline tool call display in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -34,7 +34,8 @@ struct ChatView: View {
 
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
-        messages.last?.text.count ?? 0
+        let last = messages.last
+        return (last?.text.count ?? 0) + (last?.toolCalls.count ?? 0)
     }
 
     var body: some View {
@@ -462,7 +463,7 @@ private struct ChatBubble: View {
     }
 
     private var bubbleContent: some View {
-        VStack(alignment: .leading, spacing: hasText && !message.attachments.isEmpty ? VSpacing.sm : 0) {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
             if hasText {
                 Text(markdownText)
                     .font(VFont.mono)
@@ -479,6 +480,14 @@ private struct ChatBubble: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     ForEach(fileAttachments) { attachment in
                         fileAttachmentChip(attachment)
+                    }
+                }
+            }
+
+            if !message.toolCalls.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    ForEach(message.toolCalls) { toolCall in
+                        ToolCallChip(toolCall: toolCall)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct ToolCallChip: View {
+    let toolCall: ToolCallData
+    @State private var isExpanded = false
+
+    private var toolDisplayName: String {
+        switch toolCall.toolName {
+        case "file_write": return "Write File"
+        case "file_edit": return "Edit File"
+        case "bash": return "Run Command"
+        case "web_fetch": return "Fetch URL"
+        case "file_read": return "Read File"
+        case "glob": return "Find Files"
+        case "grep": return "Search Files"
+        default: return toolCall.toolName.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Chip header (always visible)
+            Button {
+                if toolCall.isComplete {
+                    withAnimation(VAnimation.fast) { isExpanded.toggle() }
+                }
+            } label: {
+                HStack(spacing: VSpacing.xs) {
+                    // Terminal icon
+                    Image(systemName: "terminal")
+                        .font(.system(size: 10))
+                        .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
+
+                    // Tool name
+                    Text(toolDisplayName)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
+
+                    // Input summary (truncated)
+                    if !toolCall.inputSummary.isEmpty {
+                        Text(toolCall.inputSummary)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+
+                    // Status indicator
+                    if !toolCall.isComplete {
+                        // Spinning indicator for in-progress
+                        ProgressView()
+                            .scaleEffect(0.5)
+                            .frame(width: 12, height: 12)
+                    } else if toolCall.result != nil {
+                        // Chevron for expandable result
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                }
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+            }
+            .buttonStyle(.plain)
+
+            // Expanded result
+            if isExpanded, let result = toolCall.result {
+                ScrollView {
+                    Text(result)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .frame(maxHeight: 200)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.bottom, VSpacing.sm)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(toolCall.isError
+                    ? VColor.error.opacity(0.08)
+                    : VColor.surfaceBorder.opacity(0.3))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .stroke(toolCall.isError
+                    ? VColor.error.opacity(0.3)
+                    : VColor.surfaceBorder.opacity(0.5), lineWidth: 0.5)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("ToolCallChip") {
+    VStack(alignment: .leading, spacing: VSpacing.md) {
+        ToolCallChip(toolCall: ToolCallData(
+            toolName: "bash",
+            inputSummary: "ls -la /Users/test/project",
+            result: "total 42\ndrwxr-xr-x  10 user  staff  320 Jan  1 12:00 .\ndrwxr-xr-x   5 user  staff  160 Jan  1 11:00 ..",
+            isComplete: true
+        ))
+        ToolCallChip(toolCall: ToolCallData(
+            toolName: "file_read",
+            inputSummary: "/src/main.swift",
+            isComplete: false
+        ))
+        ToolCallChip(toolCall: ToolCallData(
+            toolName: "bash",
+            inputSummary: "rm -rf /important",
+            result: "Permission denied",
+            isError: true,
+            isComplete: true
+        ))
+    }
+    .padding(VSpacing.xl)
+    .background(VColor.background)
+    .frame(width: 500)
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds `ToolCallChip` SwiftUI view: compact, collapsible chip showing tool name, input summary, spinner for in-progress calls, and expandable result text on click
- Integrates chips into `ChatBubble` in `ChatView.swift` below text and file attachments
- Updates `streamingScrollTrigger` to auto-scroll when new tool calls arrive
- Error styling (red tint) for failed tool calls

## Test plan
- [ ] Build succeeds (`./build.sh`)
- [ ] Send a message that triggers tool calls — verify chips appear inline in assistant bubbles
- [ ] In-progress tool calls show a spinner
- [ ] Completed tool calls with results show a chevron; clicking expands the result
- [ ] Error tool calls display with red-tinted background and border
- [ ] Auto-scroll works when tool calls stream in

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
