### PR TITLE
Fix build warnings in VToast and SurfaceManager

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Feedback/VToast.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Feedback/VToast.swift
@@ -24,7 +24,7 @@ struct VToast: View {
         )
         .vShadow(VShadow.md)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(style): \(message)")
+        .accessibilityLabel(Text("\(String(describing: style)): \(message)"))
         .onAppear {
             NSAccessibility.post(
                 element: NSApp as Any,

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -198,7 +198,7 @@ final class SurfaceManager: ObservableObject {
 
         if isDynamicPage {
             let surfaceId = surface.id
-            weak var observedPanel = panel
+            weak let observedPanel = panel
             let observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.willCloseNotification,
                 object: panel,


### PR DESCRIPTION
## Summary
- Fix deprecated `appendInterpolation` warning in VToast by wrapping enum interpolation in `Text(String(describing:))`
- Fix `weak var` mutability warning in SurfaceManager by changing to `weak let`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
