### PR TITLE
Remove unused phone button from chat composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -172,9 +172,6 @@ struct ChatView: View {
             }
 
             HStack(spacing: VSpacing.sm) {
-                // Leading chat icon
-                VCircleButton(icon: "phone.fill", label: "Phone") { }
-
                 // Text field with ghost suffix overlay
                 ZStack(alignment: .leading) {
                     TextField("", text: $inputText, axis: .vertical)


### PR DESCRIPTION
## Summary
- Remove the placeholder phone button from the chat input area — it had an empty action and no functionality wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
