### PR TITLE
Add accessibility label to chat composer TextField

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -179,6 +179,7 @@ struct ChatView: View {
                         .font(VFont.mono)
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1...3)
+                        .accessibilityLabel("Message")
                         .onKeyPress(.tab, phases: .down) { keyPress in
                             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                                 onAcceptSuggestion()


### PR DESCRIPTION
## Summary
- Adds `.accessibilityLabel("Message")` to the chat composer `TextField` in `ChatView.swift`
- The placeholder text was previously removed (PR #1284), leaving the `TextField` without a built-in label, causing VoiceOver to announce it as an unlabeled text field
- This restores a descriptive label for assistive technology users

## Test plan
- [ ] Enable VoiceOver (System Settings > Accessibility > VoiceOver) and verify the composer TextField is announced as "Message" 
- [ ] Verify `swift build` succeeds with no warnings

Addresses feedback from #1284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
