### PR TITLE
Fix data race on urls array in onDrop handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -259,8 +259,10 @@ struct ChatView: View {
             for provider in providers {
                 group.enter()
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    if let url { urls.append(url) }
-                    group.leave()
+                    DispatchQueue.main.async {
+                        if let url { urls.append(url) }
+                        group.leave()
+                    }
                 }
             }
             group.notify(queue: .main) {


### PR DESCRIPTION
## Summary
- Fixes thread safety issue in `ChatView.onDrop` where `loadObject(ofClass:completionHandler:)` callbacks run on arbitrary background queues, causing concurrent unsynchronized writes to a shared `var urls: [URL]` array
- Wraps the `urls.append(url)` and `group.leave()` calls in `DispatchQueue.main.async` to serialize all mutations on the main thread, which `group.notify` already uses

Addresses review feedback from PR #1302.

## Test plan
- [ ] Drop multiple files simultaneously onto the composer area — verify all files appear as attachments without crashes
- [ ] Drop a single file — verify it still works correctly
- [ ] Verify no data race warnings in Thread Sanitizer (`swift build -c debug -Xswiftc -sanitize=thread`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
