### PR TITLE
Scope confirmation requests to active session and verify IPC send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -554,7 +554,12 @@ final class ChatViewModel: ObservableObject {
             }
 
         case .confirmationRequest(let msg):
-            guard belongsToSession(nil) else { return }
+            // ConfirmationRequestMessage doesn't include a sessionId, so we
+            // can't use belongsToSession. Instead, only accept the request
+            // when this ChatViewModel is actively sending (has an active
+            // session and is mid-generation). This ensures only the thread
+            // that triggered the tool call displays the confirmation.
+            guard isSending, sessionId != nil else { return }
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,
@@ -704,15 +709,19 @@ final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation request displayed inline in the chat.
     func respondToConfirmation(requestId: String, decision: String) {
-        // Update the message state
-        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
-            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
-        }
-        // Send the response to the daemon
+        // Send the response to the daemon first, then update UI state only on success.
+        // This prevents the UI from showing a finalized decision when the IPC
+        // message was never delivered (e.g. daemon disconnected).
         do {
             try daemonClient.sendConfirmationResponse(requestId: requestId, decision: decision)
         } catch {
             log.error("Failed to send confirmation response: \(error.localizedDescription)")
+            errorText = "Failed to send confirmation response."
+            return
+        }
+        // IPC send succeeded — update the message state
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            messages[index].confirmation?.state = decision == "allow" ? .approved : .denied
         }
         // Dismiss the corresponding floating panel if one exists
         onInlineConfirmationResponse?(requestId)


### PR DESCRIPTION
## Summary
- **Fix confirmation request scoping**: `belongsToSession(nil)` always returned `true`, causing confirmation messages to appear in every ChatViewModel thread. Now checks `isSending && sessionId != nil` so only the thread that triggered the tool call displays the confirmation.
- **Fix optimistic state update**: `respondToConfirmation` previously updated UI state before verifying the IPC send. Now sends first and only updates the UI on success, with an early return and error message on failure.

Addresses review feedback from PR #1278.

## Test plan
- [ ] Open multiple chat threads, trigger a tool confirmation in one — verify it only appears in the active thread
- [ ] Disconnect daemon, click approve/deny on a pending confirmation — verify error message appears and state remains unchanged
- [ ] Normal flow: approve/deny with daemon connected — verify UI updates and daemon receives response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
