### PR TITLE
Fix stale ghost text and older-turn suggestion fallback

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -819,7 +819,9 @@ async function handleSuggestionRequest(
   const rawMessages = conversationStore.getMessages(msg.sessionId);
   if (rawMessages.length === 0) { noSuggestion(); return; }
 
-  // Walk backwards to find the last assistant message with text content
+  // Find the most recent assistant message — only use it if it has text content.
+  // Do NOT fall back to older turns; if the latest assistant message is tool-only,
+  // return no suggestion rather than reusing stale text from a previous turn.
   for (let i = rawMessages.length - 1; i >= 0; i--) {
     const m = rawMessages[i];
     if (m.role !== 'assistant') continue;
@@ -828,7 +830,7 @@ async function handleSuggestionRequest(
     try { content = JSON.parse(m.content); } catch { content = m.content; }
     const rendered = renderHistoryContent(content);
     const text = rendered.text.trim();
-    if (!text) continue;
+    if (!text) { noSuggestion(); return; }
 
     // Return cached suggestion
     const cached = suggestionCache.get(m.id);

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -768,6 +768,7 @@ final class ChatViewModel: ObservableObject {
         } else if inputText.isEmpty {
             inputText = suggestion
         }
+        self.suggestion = nil
     }
 
     deinit {


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #1275:

- **Clear suggestion after Tab-accept**: `acceptSuggestion()` now sets `self.suggestion = nil` after setting `inputText`, preventing stale ghost text from reappearing.
- **Stop falling back to older turns**: When the most recent assistant message has no rendered text (tool-only message), the suggestion handler now returns `null` immediately instead of scanning older messages for stale text.

## Test plan
- [ ] Verify Tab-accepting a suggestion clears the ghost text overlay
- [ ] Verify that after a tool-only assistant turn, no stale suggestion from a previous turn appears
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
