### PR TITLE
Fix double-mapping of tool display name in ToolCallChip

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -5,16 +5,7 @@ struct ToolCallChip: View {
     @State private var isExpanded = false
 
     private var toolDisplayName: String {
-        switch toolCall.toolName {
-        case "file_write": return "Write File"
-        case "file_edit": return "Edit File"
-        case "bash": return "Run Command"
-        case "web_fetch": return "Fetch URL"
-        case "file_read": return "Read File"
-        case "glob": return "Find Files"
-        case "grep": return "Search Files"
-        default: return toolCall.toolName.replacingOccurrences(of: "_", with: " ").capitalized
-        }
+        toolCall.toolName
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Removed duplicate tool name mapping switch/case in `ToolCallChip.toolDisplayName` that was corrupting already-mapped display names (e.g., "Fetch URL" → "Fetch Url")
- `ChatViewModel` already maps raw tool names to display names before storing in `ToolCallData.toolName`, so the property now simply returns `toolCall.toolName`

Fixes feedback on #1310.

## Test plan
- [x] Build succeeds with no warnings
- [ ] Verify tool call chips display correct names ("Fetch URL", not "Fetch Url") in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
