### PR TITLE
Fix image decode fallback in chat bubble attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -453,11 +453,11 @@ private struct ChatBubble: View {
     }
 
     private var imageAttachments: [ChatAttachment] {
-        message.attachments.filter { $0.mimeType.hasPrefix("image/") }
+        message.attachments.filter { $0.mimeType.hasPrefix("image/") && nsImage(for: $0) != nil }
     }
 
     private var fileAttachments: [ChatAttachment] {
-        message.attachments.filter { !$0.mimeType.hasPrefix("image/") }
+        message.attachments.filter { !$0.mimeType.hasPrefix("image/") || nsImage(for: $0) == nil }
     }
 
     private var bubbleContent: some View {


### PR DESCRIPTION
## Summary
- When an attachment has an `image/*` MIME type but `NSImage(data:)` cannot decode it (mismatched extension, unsupported format), it previously disappeared entirely from the chat bubble
- Now undecodable image attachments fall back to rendering as file chips instead of being hidden
- `imageAttachments` only includes attachments where `nsImage(for:)` succeeds; `fileAttachments` catches everything else

Fixes review feedback on #1303 (P2)

## Test plan
- [ ] Send a message with a file that has an image MIME type but invalid/unsupported image data — verify it shows as a file chip
- [ ] Send a message with a valid image attachment — verify it still renders as an inline image
- [ ] Send a message with a non-image file attachment — verify it still shows as a file chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
