### PR TITLE
Fix attachment size validation and blank bubble display

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -451,6 +451,14 @@ private struct ChatBubble: View {
         !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    private var attachmentSummary: String {
+        let count = message.attachments.count
+        if count == 1 {
+            return "Sent \(message.attachments[0].filename)"
+        }
+        return "Sent \(count) attachments"
+    }
+
     private var imageAttachments: [ChatAttachment] {
         message.attachments.filter { $0.mimeType.hasPrefix("image/") }
     }
@@ -467,6 +475,11 @@ private struct ChatBubble: View {
                     .foregroundColor(isUser ? .white : VColor.textPrimary)
                     .tint(isUser ? .white : VColor.accent)
                     .textSelection(.enabled)
+            } else if !message.attachments.isEmpty {
+                // Show attachment summary when no text is provided
+                Text(attachmentSummary)
+                    .font(VFont.caption)
+                    .foregroundColor(isUser ? .white.opacity(0.8) : VColor.textSecondary)
             }
 
             if !imageAttachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -61,17 +61,26 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
+        // Check file size via metadata before reading into memory to avoid
+        // loading very large files synchronously (which could freeze the UI).
+        do {
+            let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+            if let fileSize = resourceValues.fileSize, fileSize > Self.maxFileSize {
+                errorText = "File exceeds 20 MB limit."
+                return
+            }
+        } catch {
+            log.error("Failed to read file attributes: \(error.localizedDescription)")
+            errorText = "Could not read file."
+            return
+        }
+
         let data: Data
         do {
             data = try Data(contentsOf: url)
         } catch {
             log.error("Failed to read attachment: \(error.localizedDescription)")
             errorText = "Could not read file."
-            return
-        }
-
-        guard data.count <= Self.maxFileSize else {
-            errorText = "File exceeds 20 MB limit."
             return
         }
 


### PR DESCRIPTION
## Summary
- **Pre-read size check**: Validate attachment file size via `URL.resourceValues(forKeys: [.fileSizeKey])` before calling `Data(contentsOf:)`, preventing synchronous memory reads of very large files that could freeze the UI or crash
- **Attachment-only bubble text**: Show "Sent <filename>" or "Sent N attachments" in chat bubbles when a message has attachments but no text, so attachment-only sends no longer produce blank entries

Addresses feedback from #1287.

## Test plan
- [ ] Attach a file >20 MB and verify the error appears instantly without a visible delay
- [ ] Send a message with only an image attachment (no text) and verify the bubble shows "Sent <filename>"
- [ ] Send a message with multiple file attachments (no text) and verify "Sent N attachments" appears
- [ ] Send a normal text+attachment message and verify it still renders text (not the summary)
- [ ] Build succeeds: `swift build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
