### PR TITLE
Fix tool event session filtering, cancel guard, and input summary ordering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -323,17 +323,31 @@ final class ChatViewModel: ObservableObject {
         return messageSessionId == sessionId
     }
 
-    /// Summarize tool input for display, showing the first value truncated to 80 chars.
+    /// Priority list of input keys whose values are most useful as a tool call summary.
+    private static let toolInputPriorityKeys = [
+        "command", "file_path", "path", "query", "url", "pattern", "glob"
+    ]
+
+    /// Summarize tool input for display, picking the most relevant value truncated to 80 chars.
     private func summarizeToolInput(_ input: [String: AnyCodable]) -> String {
-        guard let firstValue = input.values.first else { return "" }
+        // Pick the first matching priority key, falling back to the first sorted key.
+        let value: AnyCodable
+        if let match = Self.toolInputPriorityKeys.first(where: { input[$0] != nil }),
+           let v = input[match] {
+            value = v
+        } else if let firstKey = input.keys.sorted().first, let v = input[firstKey] {
+            value = v
+        } else {
+            return ""
+        }
         let str: String
-        if let s = firstValue.value as? String {
+        if let s = value.value as? String {
             str = s
-        } else if let encoder = try? JSONEncoder().encode(firstValue),
+        } else if let encoder = try? JSONEncoder().encode(value),
                   let json = String(data: encoder, encoding: .utf8) {
             str = json
         } else {
-            str = String(describing: firstValue.value ?? "")
+            str = String(describing: value.value ?? "")
         }
         return str.count > 80 ? String(str.prefix(77)) + "..." : str
     }
@@ -576,6 +590,8 @@ final class ChatViewModel: ObservableObject {
             }
 
         case .toolUseStart(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            guard !isCancelling else { return }
             isThinking = false
             let toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
@@ -596,6 +612,8 @@ final class ChatViewModel: ObservableObject {
             break
 
         case .toolResult(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            guard !isCancelling else { return }
             // Find the most recent pending (incomplete) tool call and mark it complete
             if let existingId = currentAssistantMessageId,
                let msgIndex = messages.firstIndex(where: { $0.id == existingId }),

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -405,6 +405,7 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
 struct ToolUseStartMessage: Decodable, Sendable {
     let toolName: String
     let input: [String: AnyCodable]
+    let sessionId: String?
 }
 
 /// Streaming tool output chunk.
@@ -421,6 +422,7 @@ struct ToolResultMessage: Decodable, Sendable {
     let isError: Bool?
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let status: String?
+    let sessionId: String?
 }
 
 /// Follow-up suggestion response from daemon.


### PR DESCRIPTION
## Summary
- Add `belongsToSession` guard to `toolUseStart` and `toolResult` handlers to prevent cross-session tool event contamination when multiple chat subscribers are active
- Add `isCancelling` guard to both handlers (matching `assistantTextDelta` behavior) so late-arriving tool events after Stop are suppressed
- Replace non-deterministic `input.values.first` in `summarizeToolInput` with a priority key list (`command`, `file_path`, `path`, `query`, `url`, `pattern`, `glob`), falling back to sorted keys for deterministic output
- Add optional `sessionId` field to `ToolUseStartMessage` and `ToolResultMessage` IPC types to support session filtering

Addresses feedback on #1307.

## Test plan
- [ ] Build succeeds (verified locally with `swift build`)
- [ ] Multiple chat sessions don't show each other's tool call chips
- [ ] Clicking Stop suppresses subsequent tool use and tool result events
- [ ] Tool call summaries consistently show the most relevant input value (e.g. command text for bash, file path for file operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
