### PR TITLE
Suppress floating confirmation panel when main window is visible

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -179,10 +179,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupToolConfirmationManager() {
         daemonClient.onConfirmationRequest = { [weak self] msg in
-            // Only show floating panel if app is NOT focused
-            if !NSApp.isActive {
-                self?.toolConfirmationManager.showConfirmation(msg)
-            }
+            // Only show floating panel when the main chat window is not visible.
+            // When the main window is visible, the inline ToolConfirmationBubble
+            // handles the confirmation to avoid duplicate UIs for the same request.
+            guard self?.mainWindow?.isVisible != true else { return }
+            self?.toolConfirmationManager.showConfirmation(msg)
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
             // Send the response to daemon


### PR DESCRIPTION
## Summary
- Fixes duplicate confirmation UI issue from PR #1286 feedback: when the main chat window is visible, suppress the floating `ToolConfirmationManager` panel so only the inline `ToolConfirmationBubble` handles confirmation requests.
- Changed `!NSApp.isActive` to `mainWindow?.isVisible == true` for a more precise check — ensures the floating panel only appears when the user can't see the inline confirmation bubble.
- Issue 2 (P1, IPC send verification) was already resolved by PR #1316, which reordered `respondToConfirmation` to send IPC before updating UI state.

## Test plan
- [ ] Open the main chat window, trigger a tool confirmation request — verify only the inline bubble appears (no floating panel)
- [ ] Close/hide the main window, trigger a tool confirmation request — verify the floating panel appears
- [ ] Respond via inline bubble — verify floating panel (if somehow shown) is dismissed
- [ ] Respond via floating panel — verify inline bubble state updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
