### PR TITLE
Fix confirmation panel issues from PR #1292 feedback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -186,16 +186,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.toolConfirmationManager.showConfirmation(msg)
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
-            // Send the response to daemon
-            try? self?.daemonClient.sendConfirmationResponse(
+            // Send the response to daemon; return false on failure so
+            // the floating panel stays visible for retry.
+            do {
+                try self?.daemonClient.sendConfirmationResponse(
+                    requestId: requestId,
+                    decision: decision
+                )
+            } catch {
+                log.error("Failed to send confirmation response: \(error.localizedDescription)")
+                return false
+            }
+            // Sync the inline message state across ALL ChatViewModels so the
+            // originating thread is updated even if the user switched threads.
+            self?.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
                 requestId: requestId,
                 decision: decision
             )
-            // Sync the inline message state in the active ChatViewModel
-            self?.mainWindow?.activeViewModel?.updateConfirmationState(
-                requestId: requestId,
-                decision: decision
-            )
+            return true
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -72,6 +72,15 @@ final class ThreadManager: ObservableObject {
         activeThreadId = id
     }
 
+    /// Update confirmation state across ALL chat view models, not just the active one.
+    /// This ensures that when the floating panel responds, the originating thread's
+    /// inline confirmation is updated even if the user switched threads.
+    func updateConfirmationStateAcrossThreads(requestId: String, decision: String) {
+        for viewModel in chatViewModels.values {
+            viewModel.updateConfirmationState(requestId: requestId, decision: decision)
+        }
+    }
+
     // MARK: - Private
 
     /// Subscribe to the active ChatViewModel's objectWillChange so that

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -16,7 +16,10 @@ final class ToolConfirmationManager {
     private let panelWidth: CGFloat = 420
     private let panelMargin: CGFloat = 20
 
-    var onResponse: ((String, String) -> Void)?
+    /// Called when the user responds to a floating confirmation panel.
+    /// Returns `true` if the IPC send succeeded, `false` otherwise.
+    /// The panel is only dismissed on success.
+    var onResponse: ((String, String) -> Bool)?
 
     func showConfirmation(_ message: ConfirmationRequestMessage) {
         // Dismiss existing panel for same request, if any
@@ -75,14 +78,18 @@ final class ToolConfirmationManager {
     func dismissAll() {
         for (requestId, panel) in panels {
             panel.close()
-            onResponse?(requestId, "deny")
+            _ = onResponse?(requestId, "deny")
         }
         panels.removeAll()
     }
 
     private func respond(requestId: String, decision: String) {
-        dismissConfirmation(requestId: requestId)
-        onResponse?(requestId, decision)
+        // Only dismiss the panel if the IPC send succeeds. If it fails,
+        // the panel stays visible so the user can retry.
+        let success = onResponse?(requestId, decision) ?? true
+        if success {
+            dismissConfirmation(requestId: requestId)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **Cross-thread state sync**: Floating panel response now updates ALL ChatViewModels via `ThreadManager.updateConfirmationStateAcrossThreads`, not just the active thread. Fixes stale `.pending` state when the user switches threads before responding.
- **Window visibility check**: Show floating confirmation panel when the main chat window is not visible (minimized, closed, or app not focused), instead of only checking `NSApp.isActive`. Ensures confirmations aren't suppressed when the app is active but the window is minimized.
- **Conditional panel dismiss**: Floating panel is only dismissed after successful IPC send. On failure, the panel stays visible so the user can retry. Changed `onResponse` callback to return `Bool` success indicator.

Addresses review feedback on #1292.

## Test plan
- [ ] Open multiple chat threads, trigger tool confirmation, switch to a different thread, respond via floating panel — verify originating thread's inline confirmation updates
- [ ] Minimize main window while app is active, trigger tool confirmation — verify floating panel appears
- [ ] Close main window, trigger tool confirmation — verify floating panel appears
- [ ] With main window visible and focused, trigger tool confirmation — verify floating panel does NOT appear (inline confirmation handles it)
- [ ] Disconnect daemon, click Allow/Deny on floating panel — verify panel stays visible for retry

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
