### PR TITLE
Fix ToolCallChip preview to use mapped display names

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -89,18 +89,18 @@ struct ToolCallChip: View {
 #Preview("ToolCallChip") {
     VStack(alignment: .leading, spacing: VSpacing.md) {
         ToolCallChip(toolCall: ToolCallData(
-            toolName: "bash",
+            toolName: "Run Command",
             inputSummary: "ls -la /Users/test/project",
             result: "total 42\ndrwxr-xr-x  10 user  staff  320 Jan  1 12:00 .\ndrwxr-xr-x   5 user  staff  160 Jan  1 11:00 ..",
             isComplete: true
         ))
         ToolCallChip(toolCall: ToolCallData(
-            toolName: "file_read",
+            toolName: "Read File",
             inputSummary: "/src/main.swift",
             isComplete: false
         ))
         ToolCallChip(toolCall: ToolCallData(
-            toolName: "bash",
+            toolName: "Run Command",
             inputSummary: "rm -rf /important",
             result: "Permission denied",
             isError: true,


### PR DESCRIPTION
## Summary
- Updated `#Preview` block in `ToolCallChip.swift` to use already-mapped display names (`"Run Command"`, `"Read File"`) instead of raw tool identifiers (`"bash"`, `"file_read"`)
- Since `ToolCallChip.toolDisplayName` now returns `toolCall.toolName` directly, and `ChatViewModel.toolDisplayName()` maps names before passing them to `ToolCallData`, the preview should reflect what production displays

Addresses feedback from PR #1318.

## Test plan
- [ ] Verify Xcode Preview renders "Run Command" and "Read File" instead of "bash" and "file_read"
- [ ] Build succeeds with `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
