### PR TITLE
Introduce IpcConnection abstraction layer

### DIFF
--- a/assistant/src/daemon/ambient-handler.ts
+++ b/assistant/src/daemon/ambient-handler.ts
@@ -1,6 +1,6 @@
-import type * as net from 'node:net';
 import type { HandlerContext } from './handlers.js';
 import type { AmbientObservation } from './ipc-protocol.js';
+import type { IpcConnection } from './connection.js';
 import { analyzeAndIndexAmbientObservation } from '../memory/ambient-indexer.js';
 import { getLogger } from '../util/logger.js';
 
@@ -8,7 +8,7 @@ const log = getLogger('ambient-handler');
 
 export async function handleAmbientObservation(
   msg: AmbientObservation,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   try {
@@ -18,7 +18,7 @@ export async function handleAmbientObservation(
       msg.windowTitle,
     );
 
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'ambient_result',
       requestId: msg.requestId,
       decision: result.decision,
@@ -27,7 +27,7 @@ export async function handleAmbientObservation(
     });
   } catch (err) {
     log.error({ err }, 'Error processing ambient observation');
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'ambient_result',
       requestId: msg.requestId,
       decision: 'ignore',

--- a/assistant/src/daemon/connection.ts
+++ b/assistant/src/daemon/connection.ts
@@ -1,0 +1,76 @@
+import * as net from 'node:net';
+import type { ServerMessage } from './ipc-protocol.js';
+import { serialize } from './ipc-protocol.js';
+
+/**
+ * Generic IPC connection interface that abstracts the transport layer.
+ * Allows the daemon to support both Unix sockets and HTTP-based connections
+ * without changing handler logic.
+ */
+export interface IpcConnection {
+  /** Unique identifier for this connection */
+  readonly id: string;
+
+  /** Whether the connection has been destroyed/closed */
+  readonly isDestroyed: boolean;
+
+  /** Send a message to the client */
+  send(msg: ServerMessage): void;
+
+  /** Register a handler to be called when the connection closes */
+  onClose(handler: () => void): void;
+
+  /** Destroy/close the connection */
+  destroy(): void;
+}
+
+/**
+ * IPC connection implementation backed by a Unix domain socket.
+ */
+export class SocketIpcConnection implements IpcConnection {
+  private closeHandlers: Array<() => void> = [];
+  private closed = false;
+
+  constructor(
+    private socket: net.Socket,
+    public readonly id: string,
+  ) {
+    // Wire up the close event
+    this.socket.on('close', () => {
+      this.closed = true;
+      for (const handler of this.closeHandlers) {
+        handler();
+      }
+    });
+  }
+
+  get isDestroyed(): boolean {
+    return this.socket.destroyed || this.closed;
+  }
+
+  send(msg: ServerMessage): void {
+    if (!this.isDestroyed) {
+      this.socket.write(serialize(msg));
+    }
+  }
+
+  onClose(handler: () => void): void {
+    this.closeHandlers.push(handler);
+    // If already closed, call immediately
+    if (this.closed) {
+      handler();
+    }
+  }
+
+  destroy(): void {
+    this.socket.destroy();
+  }
+
+  /**
+   * Get the underlying socket for operations that still need direct access.
+   * This is a temporary bridge during the transition to full abstraction.
+   */
+  getSocket(): net.Socket {
+    return this.socket;
+  }
+}

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,4 +1,3 @@
-import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import Anthropic from '@anthropic-ai/sdk';
 import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
@@ -33,20 +32,21 @@ import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkill
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
+import type { IpcConnection } from './connection.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
 /**
- * Find the current socket bound to a given session by reversing the
- * `socketToSession` map. Returns `undefined` if no socket is bound.
+ * Find the current connection bound to a given session by reversing the
+ * `connectionToSession` map. Returns `undefined` if no connection is bound.
  */
-function findSocketForSession(
+function findConnectionForSession(
   sessionId: string,
   ctx: HandlerContext,
-): net.Socket | undefined {
-  for (const [sock, id] of ctx.socketToSession) {
-    if (id === sessionId) return sock;
+): IpcConnection | undefined {
+  for (const [conn, id] of ctx.connectionToSession) {
+    if (id === sessionId) return conn;
   }
   return undefined;
 }
@@ -55,22 +55,22 @@ function findSocketForSession(
  * Wire the escalation handler on a text_qa session so that invoking
  * `request_computer_control` creates a CU session and notifies the client.
  *
- * Instead of closing over the original `socket`, the handler looks up the
- * current socket for the session at call time via `ctx.socketToSession`.
- * This ensures the handler targets the correct socket even after a
+ * Instead of closing over the original `connection`, the handler looks up the
+ * current connection for the session at call time via `ctx.connectionToSession`.
+ * This ensures the handler targets the correct connection even after a
  * disconnect-and-rebind cycle.
  */
 function wireEscalationHandler(
   session: Session,
-  _socket: net.Socket,
+  _connection: IpcConnection,
   ctx: HandlerContext,
   screenWidth: number,
   screenHeight: number,
 ): void {
   session.setEscalationHandler((task: string, sourceSessionId: string): boolean => {
-    const currentSocket = findSocketForSession(sourceSessionId, ctx);
-    if (!currentSocket) {
-      log.warn({ sourceSessionId }, 'Escalation handler: no active socket found for session');
+    const currentConnection = findConnectionForSession(sourceSessionId, ctx);
+    if (!currentConnection) {
+      log.warn({ sourceSessionId }, 'Escalation handler: no active connection found for session');
       return false;
     }
 
@@ -83,9 +83,9 @@ function wireEscalationHandler(
       screenHeight,
       interactionType: 'computer_use',
     };
-    handleCuSessionCreate(cuMsg, currentSocket, ctx);
+    handleCuSessionCreate(cuMsg, currentConnection, ctx);
 
-    ctx.send(currentSocket, {
+    ctx.send(currentConnection, {
       type: 'task_routed',
       sessionId: cuSessionId,
       interactionType: 'computer_use',
@@ -240,19 +240,19 @@ export interface SessionCreateOptions {
  */
 export interface HandlerContext {
   sessions: Map<string, Session>;
-  socketToSession: Map<net.Socket, string>;
+  connectionToSession: Map<IpcConnection, string>;
   cuSessions: Map<string, ComputerUseSession>;
-  socketToCuSession: Map<net.Socket, Set<string>>;
-  socketSandboxOverride: Map<net.Socket, boolean>;
+  connectionToCuSession: Map<IpcConnection, Set<string>>;
+  connectionSandboxOverride: Map<IpcConnection, boolean>;
   sharedRequestTimestamps: number[];
   debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
   suppressConfigReload: boolean;
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
-  send(socket: net.Socket, msg: ServerMessage): void;
+  send(connection: IpcConnection, msg: ServerMessage): void;
   getOrCreateSession(
     conversationId: string,
-    socket?: net.Socket,
+    connection?: IpcConnection,
     rebindClient?: boolean,
     options?: SessionCreateOptions,
   ): Promise<Session>;
@@ -264,7 +264,7 @@ type MessageType = ClientMessage['type'];
 type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
 type MessageHandler<T extends MessageType> = (
   msg: MessageOfType<T>,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ) => void | Promise<void>;
 type DispatchMap = { [T in MessageType]: MessageHandler<T> };
@@ -272,11 +272,11 @@ type DispatchMap = { [T in MessageType]: MessageHandler<T> };
 const handlers: DispatchMap = {
   user_message: handleUserMessage,
   confirmation_response: handleConfirmationResponse,
-  session_list: (_msg, socket, ctx) => handleSessionList(socket, ctx),
+  session_list: (_msg, connection, ctx) => handleSessionList(connection, ctx),
   session_create: handleSessionCreate,
   session_switch: handleSessionSwitch,
   cancel: handleCancel,
-  model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
+  model_get: (_msg, connection, ctx) => handleModelGet(connection, ctx),
   model_set: handleModelSet,
   history_request: handleHistoryRequest,
   undo: handleUndo,
@@ -288,11 +288,11 @@ const handlers: DispatchMap = {
   ambient_observation: handleAmbientObservation,
   task_submit: handleTaskSubmit,
   app_data_request: handleAppDataRequest,
-  skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
+  skills_list: (_msg, connection, ctx) => handleSkillsList(connection, ctx),
   skill_detail: handleSkillDetail,
   suggestion_request: handleSuggestionRequest,
-  ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
-  ui_surface_action: (msg, _socket, ctx) => {
+  ping: (_msg, connection, ctx) => { ctx.send(connection, { type: 'pong' }); },
+  ui_surface_action: (msg, _connection, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
     if (cuSession) {
       cuSession.handleSurfaceAction(msg.surfaceId, msg.actionId, msg.data);
@@ -309,43 +309,43 @@ const handlers: DispatchMap = {
 
 export function handleMessage(
   msg: ClientMessage,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const handler = handlers[msg.type] as
-    | ((msg: ClientMessage, socket: net.Socket, ctx: HandlerContext) => void)
+    | ((msg: ClientMessage, connection: IpcConnection, ctx: HandlerContext) => void)
     | undefined;
   if (!handler) {
     log.warn({ type: msg.type }, 'Unknown message type, ignoring');
     return;
   }
-  handler(msg, socket, ctx);
+  handler(msg, connection, ctx);
 }
 
 // ─── Individual handlers ─────────────────────────────────────────────────────
 
 async function handleUserMessage(
   msg: UserMessage,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const requestId = uuid();
   const rlog = log.child({ sessionId: msg.sessionId, requestId });
   try {
-    ctx.socketToSession.set(socket, msg.sessionId);
-    const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+    ctx.connectionToSession.set(connection, msg.sessionId);
+    const session = await ctx.getOrCreateSession(msg.sessionId, connection, true);
 
-    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+    const sendEvent = (event: ServerMessage) => ctx.send(connection, event);
 
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
-      ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
+      ctx.send(connection, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
       return;
     }
     if (result.queued) {
       rlog.info({ position: session.getQueueDepth() }, 'Message queued (session busy)');
-      ctx.send(socket, {
+      ctx.send(connection, {
         type: 'message_queued',
         sessionId: msg.sessionId,
         requestId,
@@ -361,21 +361,21 @@ async function handleUserMessage(
     session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
-      ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+      ctx.send(connection, { type: 'error', message: `Failed to process message: ${message}` });
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');
-    ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+    ctx.send(connection, { type: 'error', message: `Failed to process message: ${message}` });
   }
 }
 
 function handleConfirmationResponse(
   msg: ConfirmationResponse,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
-  const sessionId = ctx.socketToSession.get(socket);
+  const sessionId = ctx.connectionToSession.get(connection);
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
@@ -389,9 +389,9 @@ function handleConfirmationResponse(
   }
 }
 
-function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
+function handleSessionList(connection: IpcConnection, ctx: HandlerContext): void {
   const conversations = conversationStore.listConversations(50);
-  ctx.send(socket, {
+  ctx.send(connection, {
     type: 'session_list_response',
     sessions: conversations.map((c) => ({
       id: c.id,
@@ -403,17 +403,17 @@ function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
 
 async function handleSessionCreate(
   msg: SessionCreateRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const conversation = conversationStore.createConversation(
     msg.title ?? 'New Conversation',
   );
-  await ctx.getOrCreateSession(conversation.id, socket, true, {
+  await ctx.getOrCreateSession(conversation.id, connection, true, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
   });
-  ctx.send(socket, {
+  ctx.send(connection, {
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'New Conversation',
@@ -423,25 +423,25 @@ async function handleSessionCreate(
 
 async function handleSessionSwitch(
   msg: SessionSwitchRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const conversation = conversationStore.getConversation(msg.sessionId);
   if (!conversation) {
-    ctx.send(socket, { type: 'error', message: `Session ${msg.sessionId} not found` });
+    ctx.send(connection, { type: 'error', message: `Session ${msg.sessionId} not found` });
     return;
   }
-  ctx.socketToSession.set(socket, msg.sessionId);
-  await ctx.getOrCreateSession(msg.sessionId, socket, true);
-  ctx.send(socket, {
+  ctx.connectionToSession.set(connection, msg.sessionId);
+  await ctx.getOrCreateSession(msg.sessionId, connection, true);
+  ctx.send(connection, {
     type: 'session_info',
     sessionId: conversation.id,
     title: conversation.title ?? 'Untitled',
   });
 }
 
-function handleCancel(msg: CancelRequest, socket: net.Socket, ctx: HandlerContext): void {
-  const sessionId = msg.sessionId || ctx.socketToSession.get(socket);
+function handleCancel(msg: CancelRequest, connection: IpcConnection, ctx: HandlerContext): void {
+  const sessionId = msg.sessionId || ctx.connectionToSession.get(connection);
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
@@ -450,9 +450,9 @@ function handleCancel(msg: CancelRequest, socket: net.Socket, ctx: HandlerContex
   }
 }
 
-function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
+function handleModelGet(connection: IpcConnection, ctx: HandlerContext): void {
   const config = getConfig();
-  ctx.send(socket, {
+  ctx.send(connection, {
     type: 'model_info',
     model: config.model,
     provider: config.provider,
@@ -461,9 +461,9 @@ function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
 
 function handleModelSet(
   msg: ModelSetRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
-): void {
+): void{
   try {
     // Use raw config to avoid persisting env-var API keys to disk
     const raw = loadRawConfig();
@@ -500,26 +500,26 @@ function handleModelSet(
 
     ctx.updateConfigFingerprint();
 
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'model_info',
       model: config.model,
       provider: config.provider,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, { type: 'error', message: `Failed to set model: ${message}` });
+    ctx.send(connection, { type: 'error', message: `Failed to set model: ${message}` });
   }
 }
 
 function handleSandboxSet(
   msg: SandboxSetRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
-  // Per-socket override: store the sandbox preference for this client only.
+  // Per-connection override: store the sandbox preference for this client only.
   // The override is applied to the session so it doesn't affect other clients.
-  ctx.socketSandboxOverride.set(socket, msg.enabled);
-  const sessionId = ctx.socketToSession.get(socket);
+  ctx.connectionSandboxOverride.set(connection, msg.enabled);
+  const sessionId = ctx.connectionToSession.get(connection);
   if (sessionId) {
     const session = ctx.sessions.get(sessionId);
     if (session) {
@@ -539,7 +539,7 @@ export interface ParsedHistoryMessage {
 
 function handleHistoryRequest(
   msg: HistoryRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const dbMessages = conversationStore.getMessages(msg.sessionId);
@@ -569,7 +569,7 @@ function handleHistoryRequest(
     timestamp: m.timestamp,
     ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
   }));
-  ctx.send(socket, { type: 'history_response', messages: historyMessages });
+  ctx.send(connection, { type: 'history_response', messages: historyMessages });
 }
 
 export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistoryMessage[] {
@@ -607,30 +607,30 @@ export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistor
 
 function handleUndo(
   msg: UndoRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const session = ctx.sessions.get(msg.sessionId);
   if (!session) {
-    ctx.send(socket, { type: 'error', message: 'No active session' });
+    ctx.send(connection, { type: 'error', message: 'No active session' });
     return;
   }
   const removedCount = session.undo();
-  ctx.send(socket, { type: 'undo_complete', removedCount });
+  ctx.send(connection, { type: 'undo_complete', removedCount });
 }
 
 function handleUsageRequest(
   msg: UsageRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const conversation = conversationStore.getConversation(msg.sessionId);
   if (!conversation) {
-    ctx.send(socket, { type: 'error', message: 'No active session' });
+    ctx.send(connection, { type: 'error', message: 'No active session' });
     return;
   }
   const config = getConfig();
-  ctx.send(socket, {
+  ctx.send(connection, {
     type: 'usage_response',
     totalInputTokens: conversation.totalInputTokens,
     totalOutputTokens: conversation.totalOutputTokens,
@@ -641,14 +641,14 @@ function handleUsageRequest(
 
 // ─── Skills handlers ─────────────────────────────────────────────────────────
 
-function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
+function handleSkillsList(connection: IpcConnection, ctx: HandlerContext): void {
   const catalog = loadSkillCatalog();
   // Respond immediately with cached icons (sync reads only)
   const skills = catalog.map((s) => {
     const icon = readCachedSkillIcon(s.directoryPath);
     return { id: s.id, name: s.name, description: s.description, ...(icon ? { icon } : {}) };
   });
-  ctx.send(socket, { type: 'skills_list_response', skills });
+  ctx.send(connection, { type: 'skills_list_response', skills });
 
   // Generate missing icons in the background (fire-and-forget)
   const missing = catalog.filter((s) => !readCachedSkillIcon(s.directoryPath));
@@ -659,20 +659,20 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
 
 async function handleSkillDetail(
   msg: SkillDetailRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = loadSkillBySelector(msg.skillId);
   if (result.skill) {
     const icon = await ensureSkillIcon(result.skill.directoryPath, result.skill.name, result.skill.description);
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'skill_detail_response',
       skillId: result.skill.id,
       body: result.skill.body,
       ...(icon ? { icon } : {}),
     });
   } else {
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'skill_detail_response',
       skillId: msg.skillId,
       body: '',
@@ -685,9 +685,9 @@ async function handleSkillDetail(
 
 function handleAppDataRequest(
   msg: AppDataRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
-): void {
+): void{
   const { surfaceId, callId, method, appId, recordId, data } = msg;
   try {
     let result: unknown = null;
@@ -712,7 +712,7 @@ function handleAppDataRequest(
       default:
         throw new Error(`Unknown app data method: ${method}`);
     }
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'app_data_response',
       surfaceId,
       callId,
@@ -722,7 +722,7 @@ function handleAppDataRequest(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, method, appId, recordId }, 'Error handling app_data_request');
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'app_data_response',
       surfaceId,
       callId,
@@ -736,7 +736,7 @@ function handleAppDataRequest(
 
 async function handleTaskSubmit(
   msg: TaskSubmit,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const requestId = uuid();
@@ -758,9 +758,9 @@ async function handleTaskSubmit(
         attachments: msg.attachments,
         interactionType: 'computer_use',
       };
-      handleCuSessionCreate(cuMsg, socket, ctx);
+      handleCuSessionCreate(cuMsg, connection, ctx);
 
-      ctx.send(socket, {
+      ctx.send(connection, {
         type: 'task_routed',
         sessionId,
         interactionType: 'computer_use',
@@ -768,13 +768,13 @@ async function handleTaskSubmit(
     } else {
       // Create text QA session and immediately start processing
       const conversation = conversationStore.createConversation(msg.task);
-      ctx.socketToSession.set(socket, conversation.id);
-      const session = await ctx.getOrCreateSession(conversation.id, socket, true);
+      ctx.connectionToSession.set(connection, conversation.id);
+      const session = await ctx.getOrCreateSession(conversation.id, connection, true);
 
       // Wire escalation handler so the agent can call request_computer_control
-      wireEscalationHandler(session, socket, ctx, msg.screenWidth, msg.screenHeight);
+      wireEscalationHandler(session, connection, ctx, msg.screenWidth, msg.screenHeight);
 
-      ctx.send(socket, {
+      ctx.send(connection, {
         type: 'task_routed',
         sessionId: conversation.id,
         interactionType: 'text_qa',
@@ -782,17 +782,17 @@ async function handleTaskSubmit(
 
       // Start streaming immediately — client doesn't need to send user_message
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
-        ctx.send(socket, event);
+        ctx.send(connection, event);
       }, requestId).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
-        ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+        ctx.send(connection, { type: 'error', message: `Failed to process message: ${message}` });
       });
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error handling task_submit');
-    ctx.send(socket, { type: 'error', message: `Failed to route task: ${message}` });
+    ctx.send(connection, { type: 'error', message: `Failed to route task: ${message}` });
   }
 }
 
@@ -804,11 +804,11 @@ const suggestionInFlight = new Map<string, Promise<string | null>>();
 
 async function handleSuggestionRequest(
   msg: SuggestionRequest,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): Promise<void> {
   const noSuggestion = () => {
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'suggestion_response',
       requestId: msg.requestId,
       suggestion: null,
@@ -835,7 +835,7 @@ async function handleSuggestionRequest(
     // Return cached suggestion
     const cached = suggestionCache.get(m.id);
     if (cached !== undefined) {
-      ctx.send(socket, {
+      ctx.send(connection, {
         type: 'suggestion_response',
         requestId: msg.requestId,
         suggestion: cached,
@@ -863,7 +863,7 @@ async function handleSuggestionRequest(
           }
           suggestionCache.set(m.id, llmSuggestion);
 
-          ctx.send(socket, {
+          ctx.send(connection, {
             type: 'suggestion_response',
             requestId: msg.requestId,
             suggestion: llmSuggestion,
@@ -921,18 +921,18 @@ function removeCuSessionReferences(
     return;
   }
   ctx.cuSessions.delete(sessionId);
-  for (const [sock, ids] of ctx.socketToCuSession) {
+  for (const [conn, ids] of ctx.connectionToCuSession) {
     if (ids.delete(sessionId) && ids.size === 0) {
-      ctx.socketToCuSession.delete(sock);
+      ctx.connectionToCuSession.delete(conn);
     }
   }
 }
 
 function handleCuSessionCreate(
   msg: CuSessionCreate,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
-): void {
+): void{
   // Abort any existing session with the same ID to prevent zombies,
   // and remove it from the previous owner's socket set so disconnect
   // cleanup doesn't accidentally abort the replacement session.
@@ -950,7 +950,7 @@ function handleCuSessionCreate(
   }
 
   const sendToClient = (serverMsg: ServerMessage) => {
-    ctx.send(socket, serverMsg);
+    ctx.send(connection, serverMsg);
   };
 
   const sessionRef: { current?: ComputerUseSession } = {};
@@ -973,11 +973,11 @@ function handleCuSessionCreate(
 
   ctx.cuSessions.set(msg.sessionId, session);
 
-  // Track all CU sessions per socket so disconnect cleans up all of them
-  let sessionIds = ctx.socketToCuSession.get(socket);
+  // Track all CU sessions per connection so disconnect cleans up all of them
+  let sessionIds = ctx.connectionToCuSession.get(connection);
   if (!sessionIds) {
     sessionIds = new Set();
-    ctx.socketToCuSession.set(socket, sessionIds);
+    ctx.connectionToCuSession.set(connection, sessionIds);
   }
   sessionIds.add(msg.sessionId);
 
@@ -986,7 +986,7 @@ function handleCuSessionCreate(
 
 function handleCuSessionAbort(
   msg: CuSessionAbort,
-  _socket: net.Socket,
+  _connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const session = ctx.cuSessions.get(msg.sessionId);
@@ -1001,12 +1001,12 @@ function handleCuSessionAbort(
 
 function handleCuObservation(
   msg: CuObservation,
-  socket: net.Socket,
+  connection: IpcConnection,
   ctx: HandlerContext,
 ): void {
   const session = ctx.cuSessions.get(msg.sessionId);
   if (!session) {
-    ctx.send(socket, {
+    ctx.send(connection, {
       type: 'cu_error',
       sessionId: msg.sessionId,
       message: `No computer-use session found for id ${msg.sessionId}`,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -22,17 +22,18 @@ import {
 } from './ipc-protocol.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import { type IpcConnection, SocketIpcConnection } from './connection.js';
 
 const log = getLogger('server');
 
 export class DaemonServer {
   private server: net.Server | null = null;
   private sessions = new Map<string, Session>();
-  private socketToSession = new Map<net.Socket, string>();
+  private connectionToSession = new Map<IpcConnection, string>();
   private cuSessions = new Map<string, ComputerUseSession>();
-  private socketToCuSession = new Map<net.Socket, Set<string>>();
-  private connectedSockets = new Set<net.Socket>();
-  private socketSandboxOverride = new Map<net.Socket, boolean>();
+  private connectionToCuSession = new Map<IpcConnection, Set<string>>();
+  private connections = new Set<IpcConnection>();
+  private connectionSandboxOverride = new Map<IpcConnection, boolean>();
   // Persisted session options (e.g. systemPromptOverride, maxResponseTokens)
   // so that evicted sessions can be recreated with the same overrides.
   private sessionOptions = new Map<string, SessionCreateOptions>();
@@ -116,7 +117,7 @@ export class DaemonServer {
       }
     });
 
-    // 2. Now abort sessions and destroy sockets. This lets server.close()
+    // 2. Now abort sessions and destroy connections. This lets server.close()
     //    finish promptly since all connections will be ended.
     for (const session of this.sessions.values()) {
       session.abort();
@@ -127,14 +128,14 @@ export class DaemonServer {
       cuSession.abort();
     }
     this.cuSessions.clear();
-    this.socketToCuSession.clear();
+    this.connectionToCuSession.clear();
 
-    for (const socket of this.connectedSockets) {
-      socket.destroy();
+    for (const connection of this.connections) {
+      connection.destroy();
     }
-    this.connectedSockets.clear();
-    this.socketToSession.clear();
-    this.socketSandboxOverride.clear();
+    this.connections.clear();
+    this.connectionToSession.clear();
+    this.connectionSandboxOverride.clear();
 
     await serverClosed;
     log.info('Daemon server stopped');
@@ -339,11 +340,14 @@ export class DaemonServer {
 
   private handleConnection(socket: net.Socket): void {
     log.info('Client connected');
-    this.connectedSockets.add(socket);
+
+    // Wrap the socket in an IpcConnection abstraction
+    const connection = new SocketIpcConnection(socket, crypto.randomUUID());
+    this.connections.add(connection);
     const parser = createMessageParser({ maxLineSize: MAX_LINE_SIZE });
 
     // Send initial session info
-    this.sendInitialSession(socket).catch((err) => {
+    this.sendInitialSession(connection).catch((err) => {
       log.error({ err }, 'Failed to send initial session info to client on connect');
     });
 
@@ -358,22 +362,22 @@ export class DaemonServer {
         return;
       }
       for (const msg of messages) {
-        this.dispatchMessage(msg as ClientMessage, socket);
+        this.dispatchMessage(msg as ClientMessage, connection);
       }
     });
 
-    socket.on('close', () => {
-      this.connectedSockets.delete(socket);
-      this.socketSandboxOverride.delete(socket);
-      const sessionId = this.socketToSession.get(socket);
+    connection.onClose(() => {
+      this.connections.delete(connection);
+      this.connectionSandboxOverride.delete(connection);
+      const sessionId = this.connectionToSession.get(connection);
       if (sessionId) {
         const session = this.sessions.get(sessionId);
         if (session) {
           session.abort();
         }
       }
-      this.socketToSession.delete(socket);
-      const cuSessionIds = this.socketToCuSession.get(socket);
+      this.connectionToSession.delete(connection);
+      const cuSessionIds = this.connectionToCuSession.get(connection);
       if (cuSessionIds) {
         for (const cuSessionId of cuSessionIds) {
           const cuSession = this.cuSessions.get(cuSessionId);
@@ -383,7 +387,7 @@ export class DaemonServer {
           }
         }
       }
-      this.socketToCuSession.delete(socket);
+      this.connectionToCuSession.delete(connection);
       log.info('Client disconnected');
     });
 
@@ -392,13 +396,11 @@ export class DaemonServer {
     });
   }
 
-  private send(socket: net.Socket, msg: ServerMessage): void {
-    if (!socket.destroyed) {
-      socket.write(serialize(msg));
-    }
+  private send(connection: IpcConnection, msg: ServerMessage): void {
+    connection.send(msg);
   }
 
-  private async sendInitialSession(socket: net.Socket): Promise<void> {
+  private async sendInitialSession(connection: IpcConnection): Promise<void> {
     // Get or create a session
     let conversation = conversationStore.getLatestConversation();
     if (!conversation) {
@@ -406,10 +408,10 @@ export class DaemonServer {
     }
 
     // Warm session state for commands like undo/usage after reconnect without
-    // rebinding the active IPC output client to this passive socket.
+    // rebinding the active IPC output client to this passive connection.
     await this.getOrCreateSession(conversation.id, undefined, false);
 
-    this.send(socket, {
+    this.send(connection, {
       type: 'session_info',
       sessionId: conversation.id,
       title: conversation.title ?? 'New Conversation',
@@ -418,18 +420,18 @@ export class DaemonServer {
 
   private async getOrCreateSession(
     conversationId: string,
-    socket?: net.Socket,
+    connection?: IpcConnection,
     rebindClient = true,
     options?: SessionCreateOptions,
   ): Promise<Session> {
     let session = this.sessions.get(conversationId);
-    const sendToClient = socket
-      ? (msg: ServerMessage) => this.send(socket, msg)
+    const sendToClient = connection
+      ? (msg: ServerMessage) => this.send(connection, msg)
       : () => {};
     const maybeBindClient = (target: Session): void => {
-      if (!rebindClient || !socket) return;
+      if (!rebindClient || !connection) return;
       target.updateClient(sendToClient);
-      target.setSandboxOverride(this.socketSandboxOverride.get(socket));
+      target.setSandboxOverride(this.connectionSandboxOverride.get(connection));
     };
 
     // Persist session options so they survive eviction/recreation.
@@ -476,8 +478,8 @@ export class DaemonServer {
           workingDir,
         );
         await newSession.loadFromDb();
-        if (rebindClient && socket) {
-          newSession.setSandboxOverride(this.socketSandboxOverride.get(socket));
+        if (rebindClient && connection) {
+          newSession.setSandboxOverride(this.connectionSandboxOverride.get(connection));
         }
         this.sessions.set(conversationId, newSession);
         return newSession;
@@ -490,7 +492,7 @@ export class DaemonServer {
         this.sessionCreating.delete(conversationId);
       }
     } else {
-      // Rebind to the new socket so IPC goes to the current client.
+      // Rebind to the new connection so IPC goes to the current client.
       maybeBindClient(session);
     }
     return session;
@@ -499,10 +501,10 @@ export class DaemonServer {
   private handlerContext(): HandlerContext {
     return {
       sessions: this.sessions,
-      socketToSession: this.socketToSession,
+      connectionToSession: this.connectionToSession,
       cuSessions: this.cuSessions,
-      socketToCuSession: this.socketToCuSession,
-      socketSandboxOverride: this.socketSandboxOverride,
+      connectionToCuSession: this.connectionToCuSession,
+      connectionSandboxOverride: this.connectionSandboxOverride,
       sharedRequestTimestamps: this.sharedRequestTimestamps,
       debounceTimers: this.debounceTimers,
       suppressConfigReload: this.suppressConfigReload,
@@ -511,13 +513,13 @@ export class DaemonServer {
         this.lastConfigFingerprint = this.configFingerprint(getConfig());
         this.lastConfigRefreshTime = Date.now();
       },
-      send: (socket, msg) => this.send(socket, msg),
-      getOrCreateSession: (id, socket?, rebind?, options?) =>
-        this.getOrCreateSession(id, socket, rebind, options),
+      send: (connection, msg) => this.send(connection, msg),
+      getOrCreateSession: (id, connection?, rebind?, options?) =>
+        this.getOrCreateSession(id, connection, rebind, options),
     };
   }
 
-  private dispatchMessage(msg: ClientMessage, socket: net.Socket): void {
+  private dispatchMessage(msg: ClientMessage, connection: IpcConnection): void{
     if (msg.type !== 'ping') {
       const now = Date.now();
       if (now - this.lastConfigRefreshTime >= DaemonServer.CONFIG_REFRESH_INTERVAL_MS) {
@@ -529,7 +531,7 @@ export class DaemonServer {
         }
       }
     }
-    handleMessage(msg, socket, this.handlerContext());
+    handleMessage(msg, connection, this.handlerContext());
   }
 
   /**


### PR DESCRIPTION
## Summary
- Created `IpcConnection` interface to abstract transport layer
- Implemented `SocketIpcConnection` as wrapper around `net.Socket`
- Refactored `HandlerContext` and all handlers to use `IpcConnection` instead of `net.Socket`
- Updated `DaemonServer` to manage `IpcConnection` objects

This change decouples message handling from the Unix socket transport, enabling future HTTP-based connections without modifying handler logic.

Part of plan: UNIFY.md (PR 1 of 5)

## Test plan
- [x] Type checking passes
- [ ] Manual testing: Verify IPC still works via Unix socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
