### PR TITLE
Add post-read size guard for attachment validation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -84,6 +84,14 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
+        // Belt-and-suspenders: the pre-read metadata check above may report
+        // nil (e.g. symlinks, certain file systems) so always validate the
+        // actual byte count after reading.
+        guard data.count <= Self.maxFileSize else {
+            errorText = "File exceeds 20 MB limit."
+            return
+        }
+
         let filename = url.lastPathComponent
         let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
         let base64 = data.base64EncodedString()


### PR DESCRIPTION
## Summary
- Addresses reviewer feedback from PR #1320: the pre-read `resourceValues(forKeys: [.fileSizeKey])` check silently skips validation when `fileSize` is nil (e.g. symlinks, certain file systems), and the original post-read `data.count` guard was removed
- Re-adds a belt-and-suspenders `guard data.count <= Self.maxFileSize` after `Data(contentsOf:)` so oversized files are always rejected regardless of metadata availability
- Keeps the pre-read metadata check as a fast-path rejection to avoid loading large files into memory

## Test plan
- [ ] Verify build succeeds (`swift build` passes)
- [ ] Test attaching a file > 20 MB — should be rejected
- [ ] Test attaching a symlink to a large file — should now be caught by the post-read guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
