### PR TITLE
Fix floating confirmation panel suppressed when app is in background

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -180,10 +180,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupToolConfirmationManager() {
         daemonClient.onConfirmationRequest = { [weak self] msg in
-            // Only show floating panel when the main chat window is not visible.
-            // When the main window is visible, the inline ToolConfirmationBubble
-            // handles the confirmation to avoid duplicate UIs for the same request.
-            guard self?.mainWindow?.isVisible != true else { return }
+            // Only suppress the floating panel when the main chat window is visible
+            // AND the app is active (frontmost). NSWindow.isVisible returns true even
+            // when the window is behind other apps, so we must also check NSApp.isActive
+            // to avoid silently dropping confirmations when the user can't see the inline UI.
+            guard self?.mainWindow?.isVisible != true || !NSApp.isActive else { return }
             self?.toolConfirmationManager.showConfirmation(msg)
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in


### PR DESCRIPTION
## Summary
- Fixes the guard in `setupToolConfirmationManager` to check **both** `mainWindow.isVisible` and `NSApp.isActive` before suppressing the floating confirmation panel.
- `NSWindow.isVisible` returns `true` even when the window is behind other apps, so the previous guard silently dropped confirmations when the user couldn't see the inline UI.
- Addresses review feedback from both Devin and Codex on PR #1322.

## Test plan
- [ ] Open main chat window, keep app focused -- confirm inline bubble appears and floating panel does NOT appear
- [ ] Open main chat window, switch to another app -- confirm floating panel DOES appear (since user can't see inline UI)
- [ ] Close main chat window entirely -- confirm floating panel appears regardless of app focus

Closes feedback on #1322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
