### PR TITLE
Fix confirmation routing: isConnected guard, tool-use-based routing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -43,8 +43,17 @@ final class ChatViewModel: ObservableObject {
     /// Tracks the current in-flight suggestion request so stale responses are ignored.
     private var pendingSuggestionRequestId: String?
 
+    /// Timestamp of the most recent `toolUseStart` event received by this view model.
+    /// Used by ThreadManager to route `confirmationRequest` messages to the correct
+    /// ChatViewModel when multiple threads have active sessions.
+    var lastToolUseReceivedAt: Date?
+
     /// Called when an inline confirmation is responded to, so the floating panel can be dismissed.
     var onInlineConfirmationResponse: ((String) -> Void)?
+
+    /// Called to determine whether this ChatViewModel should accept a `confirmationRequest`.
+    /// Set by ThreadManager to coordinate routing when multiple ChatViewModels are active.
+    var shouldAcceptConfirmation: (() -> Bool)?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -578,11 +587,15 @@ final class ChatViewModel: ObservableObject {
 
         case .confirmationRequest(let msg):
             // ConfirmationRequestMessage doesn't include a sessionId, so we
-            // can't use belongsToSession. Instead, only accept the request
-            // when this ChatViewModel is actively sending (has an active
-            // session and is mid-generation). This ensures only the thread
-            // that triggered the tool call displays the confirmation.
-            guard isSending, sessionId != nil else { return }
+            // can't use belongsToSession. Delegate routing to ThreadManager
+            // via the shouldAcceptConfirmation closure, which picks the
+            // ChatViewModel that most recently received a toolUseStart event.
+            // This avoids false negatives from gating on isSending (which
+            // isn't set for flows like handleSurfaceAction) and false
+            // positives when multiple threads are sending simultaneously.
+            guard sessionId != nil,
+                  lastToolUseReceivedAt != nil,
+                  shouldAcceptConfirmation?() ?? false else { return }
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,
@@ -606,6 +619,7 @@ final class ChatViewModel: ObservableObject {
         case .toolUseStart(let msg):
             guard belongsToSession(msg.sessionId) else { return }
             guard !isCancelling else { return }
+            lastToolUseReceivedAt = Date()
             isThinking = false
             let toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
@@ -736,6 +750,14 @@ final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation request displayed inline in the chat.
     func respondToConfirmation(requestId: String, decision: String) {
+        // DaemonClient.send silently returns when connection is nil (it does
+        // not throw), so we must check connectivity explicitly before calling
+        // sendConfirmationResponse. Without this guard the UI would show the
+        // decision as finalized even though the daemon never received it.
+        guard daemonClient.isConnected else {
+            errorText = "Failed to send confirmation response."
+            return
+        }
         // Send the response to the daemon first, then update UI state only on success.
         // This prevents the UI from showing a finalized decision when the IPC
         // message was never delivered (e.g. daemon disconnected).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -35,6 +35,10 @@ final class ThreadManager: ObservableObject {
         viewModel.onInlineConfirmationResponse = { [weak self] requestId in
             self?.confirmationDismissHandler?(requestId)
         }
+        viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
+            guard let self, let viewModel else { return false }
+            return self.isLatestToolUseRecipient(viewModel)
+        }
         threads.append(thread)
         chatViewModels[thread.id] = viewModel
         activeThreadId = thread.id
@@ -79,6 +83,21 @@ final class ThreadManager: ObservableObject {
         for viewModel in chatViewModels.values {
             viewModel.updateConfirmationState(requestId: requestId, decision: decision)
         }
+    }
+
+    /// Returns true if the given ChatViewModel is the one that most recently
+    /// received a `toolUseStart` event across all threads. Used to route
+    /// `confirmationRequest` messages (which lack a sessionId) to exactly
+    /// one ChatViewModel, preventing duplicates and ensuring confirmations
+    /// are accepted even in flows that don't go through `sendMessage()`.
+    func isLatestToolUseRecipient(_ viewModel: ChatViewModel) -> Bool {
+        guard let timestamp = viewModel.lastToolUseReceivedAt else { return false }
+        for other in chatViewModels.values where other !== viewModel {
+            if let otherTimestamp = other.lastToolUseReceivedAt, otherTimestamp > timestamp {
+                return false
+            }
+        }
+        return true
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Summary

Addresses 3 review issues from PR #1316:

- **(P0) isConnected guard in respondToConfirmation**: `DaemonClient.send` silently returns when `connection` is nil (does not throw), so `respondToConfirmation` would update the UI as if the decision was delivered even when the daemon was disconnected. Added an explicit `guard daemonClient.isConnected` check before the send call.
- **(P1) Tool-use-based confirmation routing**: Replaced the `isSending` gate in the `confirmationRequest` handler with a `lastToolUseReceivedAt` timestamp set on each `toolUseStart` event. ThreadManager coordinates via a `shouldAcceptConfirmation` closure that checks `isLatestToolUseRecipient`, ensuring exactly one ChatViewModel accepts each confirmation -- even when multiple threads are sending simultaneously.
- **(P1) Remove isSending dependency**: Flows like `handleSurfaceAction` call `processMessage()` directly without setting `isSending`, so gating on it dropped legitimate confirmation requests. The new routing mechanism is independent of `isSending`.

## Test plan

- [ ] Open two chat threads, send messages in both, trigger a tool confirmation -- verify it appears in only the thread that issued the tool call
- [ ] Disconnect daemon, click approve/deny on a pending confirmation -- verify error message appears and state remains unchanged
- [ ] Trigger a confirmation via a surface action (non-sendMessage flow) -- verify the confirmation UI appears
- [ ] Single thread with active session -- verify confirmations still work normally

Closes feedback on #1316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
