### PR TITLE
Fix tool event session filtering and cancel spinner

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -277,6 +277,7 @@ export interface ToolUseStart {
   type: 'tool_use_start';
   toolName: string;
   input: Record<string, unknown>;
+  sessionId?: string;
 }
 
 export interface ToolOutputChunk {
@@ -291,6 +292,7 @@ export interface ToolResult {
   isError?: boolean;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
   status?: string;
+  sessionId?: string;
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -472,13 +472,13 @@ export class Session {
             onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
             break;
           case 'tool_use':
-            onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input });
+            onEvent({ type: 'tool_use_start', toolName: event.name, input: event.input, sessionId: this.conversationId });
             break;
           case 'tool_output_chunk':
             onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
             break;
           case 'tool_result':
-            onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status });
+            onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError });
             break;
           case 'error':

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -679,6 +679,9 @@ final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
+                    messages[index].toolCalls[j].isComplete = true
+                }
             }
             currentAssistantMessageId = nil
             pendingQueuedCount = 0
@@ -708,6 +711,9 @@ final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
+                for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
+                    messages[index].toolCalls[j].isComplete = true
+                }
             }
             currentAssistantMessageId = nil
             pendingQueuedCount = 0
@@ -731,10 +737,14 @@ final class ChatViewModel: ObservableObject {
         isCancelling = true
         isThinking = false
 
-        // Mark current assistant message as stopped
+        // Mark current assistant message as stopped and complete any in-progress tool calls
+        // so their chips don't show an endless spinner.
         if let existingId = currentAssistantMessageId,
            let index = messages.firstIndex(where: { $0.id == existingId }) {
             messages[index].isStreaming = false
+            for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
+                messages[index].toolCalls[j].isComplete = true
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `sessionId` to `tool_use_start` and `tool_result` IPC events so the Swift client can properly filter cross-session tool events via `belongsToSession`. Previously these events were emitted without `sessionId`, making the session guard a no-op.
- When the user cancels generation, mark any in-progress tool calls as complete so their `ToolCallChip` stops showing an endless spinner. Applied to all three cancel paths (main, daemon-disconnected, send-failed).

Addresses feedback on #1321.

## Test plan
- [ ] Open two chat threads, send a message in each — verify tool call chips only appear in the correct thread
- [ ] While a tool is executing, press Stop — verify the chip transitions to completed state (no spinner)
- [ ] Disconnect daemon, press Stop while tool is mid-flight — verify chip resolves
- [ ] TypeScript type check passes (`bunx tsc --noEmit`)
- [ ] Swift build passes (`swift build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
