### PR TITLE
Fix notification observer leak in showSettingsWindow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -41,6 +41,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var galleryWindow: ComponentGalleryWindow?
     #endif
     private var windowObserver: Any?
+    private var settingsWindowObserver: Any?
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
@@ -531,7 +532,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         window.isReleasedWhenClosed = false
         window.center()
 
-        NotificationCenter.default.addObserver(
+        if let existing = settingsWindowObserver {
+            NotificationCenter.default.removeObserver(existing)
+            settingsWindowObserver = nil
+        }
+
+        settingsWindowObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: window,
             queue: .main
@@ -539,6 +545,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             Task { @MainActor [weak self] in
                 self?.settingsWindow = nil
+                if let observer = self?.settingsWindowObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                self?.settingsWindowObserver = nil
             }
         }
 


### PR DESCRIPTION
## Summary
- Store the NotificationCenter observer token returned by addObserver in showSettingsWindow
- Remove existing observer before adding a new one on repeated calls
- Clean up observer when settings window closes
- Mirrors the existing pattern used for windowObserver

Addresses review feedback from PR #1309.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
