### PR TITLE
Fix composer input padding to align with pill shape

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -247,7 +247,8 @@ struct ChatView: View {
                 }
             }
         }
-        .padding(VSpacing.xs)
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.sm)
         .background(VColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
         .overlay(


### PR DESCRIPTION
## Summary
- Replaced uniform `VSpacing.xs` padding with `VSpacing.xl` horizontal and `VSpacing.sm` vertical padding on the composer input
- Text now starts where the pill shape's curve flattens into the straight edge, matching standard input field aesthetics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
