### PR TITLE
Fix API key gating to respect daemon credentials

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -258,7 +258,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let contentView = TaskInputView(onSubmit: { [weak self] submission in
             self?.startSession(submission: submission)
-        })
+        }, daemonClient: daemonClient)
 
         popover = NSPopover()
         popover.contentSize = NSSize(width: 320, height: 200)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -76,6 +76,9 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
+        .onReceive(daemonClient.$isConnected) { _ in
+            refreshAPIKeyState()
+        }
     }
 
     @MainActor
@@ -110,7 +113,7 @@ struct MainWindowView: View {
     }
 
     private func refreshAPIKeyState() {
-        hasAPIKey = APIKeyManager.getKey() != nil
+        hasAPIKey = APIKeyManager.getKey() != nil || daemonClient.isConnected
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -6,6 +6,7 @@ struct TaskInputView: View {
     private static let maxAttachmentCount = 10
     private static let maxTotalAttachmentBytes = 50 * 1024 * 1024
     let onSubmit: (TaskSubmission) -> Void
+    @ObservedObject var daemonClient: DaemonClient
     @State private var taskText = ""
     @State private var hasAPIKey = APIKeyManager.getKey() != nil
     @State private var attachments: [TaskAttachment] = []
@@ -139,6 +140,9 @@ struct TaskInputView: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
+        .onReceive(daemonClient.$isConnected) { _ in
+            refreshAPIKeyState()
+        }
     }
 
     private func submitTask() {
@@ -156,7 +160,7 @@ struct TaskInputView: View {
     }
 
     private func refreshAPIKeyState() {
-        hasAPIKey = APIKeyManager.getKey() != nil
+        hasAPIKey = APIKeyManager.getKey() != nil || daemonClient.isConnected
     }
 
     private func pickerTypes() -> [UTType] {
@@ -327,7 +331,7 @@ struct TaskInputView: View {
 }
 
 #Preview {
-    TaskInputView(onSubmit: { _ in })
+    TaskInputView(onSubmit: { _ in }, daemonClient: DaemonClient())
 }
 
 private extension NSImage {


### PR DESCRIPTION
## Summary
- Update `refreshAPIKeyState()` in `MainWindowView` and `TaskInputView` to check `daemonClient.isConnected` alongside the keychain lookup
- Add `.onReceive(daemonClient.$isConnected)` listeners so the UI updates reactively when the daemon connects/disconnects
- Pass `DaemonClient` into `TaskInputView` (matching the existing pattern in `MainWindowView`)

This prevents blocking chat use in valid configurations where the daemon has credentials via environment variables (`ANTHROPIC_API_KEY`) or non-Anthropic providers that the keychain check doesn't know about.

Addresses review feedback from PR #1309.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
