### PR TITLE
Add sessionId to confirmation_request for cross-thread routing

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -262,6 +262,7 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
       "scope": "/tmp",
     },
   ],
+  "sessionId": "sess-001",
   "toolName": "bash",
   "type": "confirmation_request",
 }

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -188,6 +188,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       isNewFile: false,
     },
     sandboxed: false,
+    sessionId: 'sess-001',
   },
   message_complete: {
     type: 'message_complete',

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -305,6 +305,7 @@ export interface ConfirmationRequest {
   scopeOptions: Array<{ label: string; scope: string }>;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
   sandboxed?: boolean;
+  sessionId?: string;
 }
 
 export interface MessageComplete {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -33,6 +33,7 @@ export class PermissionPrompter {
     scopeOptions: ScopeOption[],
     diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean },
     sandboxed?: boolean,
+    sessionId?: string,
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -56,6 +57,7 @@ export class PermissionPrompter {
         scopeOptions: scopeOptions.map((o) => ({ label: o.label, scope: o.scope })),
         diff,
         sandboxed,
+        sessionId,
       });
     });
   }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -130,6 +130,7 @@ export class ToolExecutor {
           scopeOptions,
           previewDiff,
           sandboxed,
+          context.conversationId,
         );
 
         decision = response.decision;

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -594,16 +594,16 @@ final class ChatViewModel: ObservableObject {
             }
 
         case .confirmationRequest(let msg):
-            // ConfirmationRequestMessage doesn't include a sessionId, so we
-            // can't use belongsToSession. Delegate routing to ThreadManager
-            // via the shouldAcceptConfirmation closure, which picks the
-            // ChatViewModel that most recently received a toolUseStart event.
-            // This avoids false negatives from gating on isSending (which
-            // isn't set for flows like handleSurfaceAction) and false
-            // positives when multiple threads are sending simultaneously.
-            guard sessionId != nil,
-                  lastToolUseReceivedAt != nil,
-                  shouldAcceptConfirmation?() ?? false else { return }
+            // Route using sessionId when available (daemon >= v1.x includes
+            // the conversationId). Fall back to the timestamp-based heuristic
+            // via shouldAcceptConfirmation for older daemons that omit sessionId.
+            if let msgSessionId = msg.sessionId {
+                guard belongsToSession(msgSessionId) else { return }
+            } else {
+                guard sessionId != nil,
+                      lastToolUseReceivedAt != nil,
+                      shouldAcceptConfirmation?() ?? false else { return }
+            }
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -444,6 +444,7 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
     let scopeOptions: [ConfirmationScopeOption]
     let diff: ConfirmationDiffInfo?
     let sandboxed: Bool?
+    let sessionId: String?
 
     struct ConfirmationAllowlistOption: Decodable, Sendable, Equatable {
         let label: String


### PR DESCRIPTION
## Summary
- Adds `sessionId` field to the `confirmation_request` IPC message, threading the session's `conversationId` from `ToolExecutor` through `PermissionPrompter.prompt()` into the wire message.
- Updates the Swift `ConfirmationRequestMessage` to decode `sessionId` and routes confirmations via `belongsToSession()` when present, falling back to the timestamp-based `isLatestToolUseRecipient` heuristic for backward compatibility.
- Fixes a bug where `confirmation_request` UI could appear in the wrong chat thread when multiple threads had active subscriptions, because the message lacked a session identifier and relied on a racy timestamp comparison.

Addresses review feedback from #1330.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass (`bun test ipc-snapshot.test.ts` — 61/61)
- [ ] Manual: open two chat threads, send messages in both, verify confirmation prompts appear in the correct thread
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
