### PR TITLE
Add inline display mode for ui_show and table surface type

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -70,7 +70,14 @@ export const DEFAULT_CONFIG: AssistantConfig = {
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running locally on the user's machine. You have access to tools that let you interact with the computer, filesystem, and terminal. Be concise and helpful.
 
-IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, forms, lists, confirmations) as floating panels on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text. Call ui_show with a card surface to display it. This is your primary way of presenting information to the user.
+IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, tables, forms, lists, confirmations) on the user's screen. You MUST use ui_show instead of plain text whenever your response contains structured information — weather, summaries, data, options, confirmations, or anything that benefits from visual layout. Do NOT stream structured data as text.
+
+- Use display: "inline" (default) to embed widgets directly in chat — best for informational cards, tables, and data summaries that are part of the conversation flow.
+- Use display: "panel" for interactive forms, confirmations, and workflows that need dedicated focus.
+- Use surface_type "table" for tabular data with optional row selection and action buttons (e.g. email declutter, file lists, search results).
+- Use surface_type "card" for structured info like weather, summaries, status reports.
+
+This is your primary way of presenting information to the user.
 
 ## Action Execution Hierarchy
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -157,7 +157,7 @@ export interface SuggestionRequest {
 
 // === Surface types ===
 
-export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
+export type SurfaceType = 'card' | 'form' | 'list' | 'table' | 'confirmation' | 'dynamic_page' | 'file_upload';
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = ['form', 'confirmation', 'dynamic_page', 'file_upload'];
 
@@ -225,7 +225,27 @@ export interface FileUploadSurfaceData {
   maxSizeBytes?: number;
 }
 
-export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
+export interface TableColumn {
+  id: string;
+  label: string;
+  width?: number;
+}
+
+export interface TableRow {
+  id: string;
+  cells: Record<string, string>;
+  selectable?: boolean;
+  selected?: boolean;
+}
+
+export interface TableSurfaceData {
+  columns: TableColumn[];
+  rows: TableRow[];
+  selectionMode?: 'none' | 'single' | 'multiple';
+  caption?: string;
+}
+
+export type SurfaceData = CardSurfaceData | FormSurfaceData | ListSurfaceData | TableSurfaceData | ConfirmationSurfaceData | DynamicPageSurfaceData | FileUploadSurfaceData;
 
 export interface UiSurfaceAction {
   type: 'ui_surface_action';
@@ -534,6 +554,7 @@ interface UiSurfaceShowBase {
   surfaceId: string;
   title?: string;
   actions?: SurfaceAction[];
+  display?: 'inline' | 'panel';
 }
 
 export interface UiSurfaceShowCard extends UiSurfaceShowBase {
@@ -561,6 +582,11 @@ export interface UiSurfaceShowDynamicPage extends UiSurfaceShowBase {
   data: DynamicPageSurfaceData;
 }
 
+export interface UiSurfaceShowTable extends UiSurfaceShowBase {
+  surfaceType: 'table';
+  data: TableSurfaceData;
+}
+
 export interface UiSurfaceShowFileUpload extends UiSurfaceShowBase {
   surfaceType: 'file_upload';
   data: FileUploadSurfaceData;
@@ -570,6 +596,7 @@ export type UiSurfaceShow =
   | UiSurfaceShowCard
   | UiSurfaceShowForm
   | UiSurfaceShowList
+  | UiSurfaceShowTable
   | UiSurfaceShowConfirmation
   | UiSurfaceShowDynamicPage
   | UiSurfaceShowFileUpload;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -878,6 +878,8 @@ export class Session {
       // Track surface state for ui_update merging
       this.surfaceState.set(surfaceId, { surfaceType, data });
 
+      const display = (input.display as string) === 'panel' ? 'panel' : 'inline';
+
       this.sendToClient({
         type: 'ui_surface_show',
         sessionId: this.conversationId,
@@ -886,6 +888,7 @@ export class Session {
         title,
         data,
         actions: actions?.map(a => ({ id: a.id, label: a.label, style: (a.style ?? 'secondary') as 'primary' | 'secondary' | 'destructive' })),
+        display,
       } as unknown as UiSurfaceShow);
 
       if (awaitAction) {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -26,9 +26,12 @@ function proxyExecute(): Promise<ToolExecutionResult> {
 export const uiShowTool: Tool = {
   name: 'ui_show',
   description:
-    'Show a UI surface to the user. Supported surface types:\n' +
+    'Show a UI surface to the user. Use display: "inline" (default) to embed in chat, or "panel" for a floating window.\n\n' +
+    'Supported surface types:\n' +
     '- card: Informational card with title, subtitle, body text, and optional metadata key-value pairs. ' +
     'data shape: { title: string, subtitle?: string, body: string, metadata?: Array<{ label: string, value: string }> }\n' +
+    '- table: Data table with columns, selectable rows, and action buttons. ' +
+    'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
     '- form: Input form with typed fields. ' +
     'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }\n' +
     '- list: Selectable list of items. ' +
@@ -52,7 +55,7 @@ export const uiShowTool: Tool = {
         properties: {
           surface_type: {
             type: 'string',
-            enum: ['card', 'form', 'list', 'confirmation', 'dynamic_page', 'file_upload'],
+            enum: ['card', 'form', 'list', 'table', 'confirmation', 'dynamic_page', 'file_upload'],
             description: 'The type of surface to display',
           },
           title: {
@@ -79,6 +82,11 @@ export const uiShowTool: Tool = {
               required: ['id', 'label'],
             },
             description: 'Optional action buttons to display on the surface',
+          },
+          display: {
+            type: 'string',
+            enum: ['inline', 'panel'],
+            description: 'Where to render the surface. "inline" embeds it in the chat message. "panel" shows a floating window. Defaults to "inline".',
           },
           await_action: {
             type: 'boolean',

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -187,7 +187,7 @@ struct ChatView: View {
             HStack(spacing: VSpacing.sm) {
                 // Text field with ghost suffix overlay
                 ZStack(alignment: .leading) {
-                    TextField("Message...", text: $inputText, axis: .vertical)
+                    TextField("", text: $inputText, axis: .vertical)
                         .textFieldStyle(.plain)
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)


### PR DESCRIPTION
## Summary
- Add `display` parameter to `ui_show` tool (`"inline"` default, `"panel"` for floating windows) so surfaces can render directly in chat
- Add `table` surface type with columns, rows, selection modes, and captions for tabular data (email lists, search results, etc.)
- Pass `display` field through `surfaceProxyResolver` → IPC message pipeline
- Update system prompt to guide the LLM on when to use inline vs panel display
- Fix composer placeholder text overlapping ghost suggestion overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
