### PR TITLE
Add macOS model + routing for inline chat surfaces

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -47,6 +47,19 @@ struct ToolCallData: Identifiable, Equatable {
     }
 }
 
+/// Data for an inline UI surface rendered within a chat message.
+struct InlineSurfaceData: Identifiable, Equatable {
+    let id: String
+    let surfaceType: SurfaceType
+    let title: String?
+    let data: SurfaceData
+    let actions: [SurfaceActionButton]
+
+    static func == (lhs: InlineSurfaceData, rhs: InlineSurfaceData) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 /// A file or image attachment associated with a chat message.
 struct ChatAttachment: Identifiable {
     let id: String
@@ -69,8 +82,9 @@ struct ChatMessage: Identifiable {
     var confirmation: ToolConfirmationData?
     var attachments: [ChatAttachment]
     var toolCalls: [ToolCallData]
+    var inlineSurfaces: [InlineSurfaceData]
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = []) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
         self.id = id
         self.role = role
         self.text = text
@@ -80,5 +94,6 @@ struct ChatMessage: Identifiable {
         self.confirmation = confirmation
         self.attachments = attachments
         self.toolCalls = toolCalls
+        self.inlineSurfaces = inlineSurfaces
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -629,6 +629,10 @@ final class ChatViewModel: ObservableObject {
             guard !isCancelling else { return }
             lastToolUseReceivedAt = Date()
             isThinking = false
+            // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
+            if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" || msg.toolName == "request_file" {
+                break
+            }
             let toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
                 inputSummary: summarizeToolInput(msg.input)
@@ -660,9 +664,40 @@ final class ChatViewModel: ObservableObject {
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
             }
 
+        case .uiSurfaceShow(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            guard msg.display == "inline" else { break }
+            guard let surface = Surface.from(msg) else { break }
+            let inlineSurface = InlineSurfaceData(
+                id: surface.id,
+                surfaceType: surface.type,
+                title: surface.title,
+                data: surface.data,
+                actions: surface.actions
+            )
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].inlineSurfaces.append(inlineSurface)
+            } else {
+                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
+                currentAssistantMessageId = newMsg.id
+                messages.append(newMsg)
+            }
+
         default:
             break
         }
+    }
+
+    func sendSurfaceAction(surfaceId: String, actionId: String, data: [String: AnyCodable]? = nil) {
+        guard let sessionId = sessionId else { return }
+        let msg = UiSurfaceActionMessage(
+            sessionId: sessionId,
+            surfaceId: surfaceId,
+            actionId: actionId,
+            data: data
+        )
+        try? daemonClient.send(msg)
     }
 
     func stopGenerating() {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -90,6 +90,9 @@ struct SurfaceContainerView: View {
                         viewModel.onAction("cancel", ["files": [Any]()])
                     }
                 )
+            case .table:
+                // Table surfaces are rendered inline in chat, not in floating panels.
+                EmptyView()
             }
 
             // Action buttons for card/list surfaces
@@ -106,7 +109,7 @@ struct SurfaceContainerView: View {
         switch surface.data {
         case .form, .confirmation, .dynamicPage, .fileUpload:
             return true
-        case .card, .list:
+        case .card, .list, .table:
             return false
         }
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -6,6 +6,7 @@ enum SurfaceType: String, Codable, Sendable {
     case card
     case form
     case list
+    case table
     case confirmation
     case dynamicPage = "dynamic_page"
     case fileUpload = "file_upload"
@@ -129,10 +130,31 @@ struct FileUploadSurfaceData: Sendable {
     let maxSizeBytes: Int
 }
 
+struct TableColumn: Identifiable, Sendable {
+    let id: String
+    let label: String
+    let width: Int?
+}
+
+struct TableRow: Identifiable, Sendable {
+    let id: String
+    let cells: [String: String]
+    let selectable: Bool
+    let selected: Bool
+}
+
+struct TableSurfaceData: Sendable {
+    let columns: [TableColumn]
+    let rows: [TableRow]
+    let selectionMode: SelectionMode
+    let caption: String?
+}
+
 enum SurfaceData: Sendable {
     case card(CardSurfaceData)
     case form(FormSurfaceData)
     case list(ListSurfaceData)
+    case table(TableSurfaceData)
     case confirmation(ConfirmationSurfaceData)
     case dynamicPage(DynamicPageSurfaceData)
     case fileUpload(FileUploadSurfaceData)
@@ -216,6 +238,8 @@ extension Surface {
             return parseFormData(dict).map { .form($0) }
         case .list:
             return parseListData(dict).map { .list($0) }
+        case .table:
+            return parseTableData(dict).map { .table($0) }
         case .confirmation:
             return parseConfirmationData(dict).map { .confirmation($0) }
         case .dynamicPage:
@@ -240,6 +264,8 @@ extension Surface {
             return .list(mergeListData(existing: list, update: update))
         case .confirmation(let confirmation):
             return .confirmation(mergeConfirmationData(existing: confirmation, update: update))
+        case .table(let table):
+            return .table(mergeTableData(existing: table, update: update))
         case .dynamicPage(let dp):
             return .dynamicPage(mergeDynamicPageData(existing: dp, update: update))
         case .fileUpload(let fu):
@@ -461,6 +487,76 @@ extension Surface {
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String
         )
+    }
+
+    private static func parseTableData(_ dict: [String: Any?]) -> TableSurfaceData? {
+        guard let columnsArray = dict["columns"] as? [[String: Any?]],
+              let rowsArray = dict["rows"] as? [[String: Any?]] else {
+            return nil
+        }
+
+        let columns: [TableColumn] = columnsArray.compactMap { colDict in
+            guard let id = colDict["id"] as? String,
+                  let label = colDict["label"] as? String else { return nil }
+            return TableColumn(id: id, label: label, width: colDict["width"] as? Int)
+        }
+
+        let rows: [TableRow] = rowsArray.compactMap { rowDict in
+            guard let id = rowDict["id"] as? String,
+                  let cellsRaw = rowDict["cells"] as? [String: Any?] else { return nil }
+            let cells = cellsRaw.compactMapValues { $0 as? String }
+            return TableRow(
+                id: id,
+                cells: cells,
+                selectable: rowDict["selectable"] as? Bool ?? false,
+                selected: rowDict["selected"] as? Bool ?? false
+            )
+        }
+
+        let selectionModeStr = dict["selectionMode"] as? String ?? "none"
+        let selectionMode = SelectionMode(rawValue: selectionModeStr) ?? .none
+        let caption = dict["caption"] as? String
+
+        return TableSurfaceData(columns: columns, rows: rows, selectionMode: selectionMode, caption: caption)
+    }
+
+    private static func mergeTableData(existing: TableSurfaceData, update: [String: Any?]) -> TableSurfaceData {
+        var columns = existing.columns
+        if let columnsArray = update["columns"] as? [[String: Any?]] {
+            columns = columnsArray.compactMap { colDict in
+                guard let id = colDict["id"] as? String,
+                      let label = colDict["label"] as? String else { return nil }
+                return TableColumn(id: id, label: label, width: colDict["width"] as? Int)
+            }
+        }
+
+        var rows = existing.rows
+        if let rowsArray = update["rows"] as? [[String: Any?]] {
+            rows = rowsArray.compactMap { rowDict in
+                guard let id = rowDict["id"] as? String,
+                      let cellsRaw = rowDict["cells"] as? [String: Any?] else { return nil }
+                let cells = cellsRaw.compactMapValues { $0 as? String }
+                return TableRow(
+                    id: id,
+                    cells: cells,
+                    selectable: rowDict["selectable"] as? Bool ?? false,
+                    selected: rowDict["selected"] as? Bool ?? false
+                )
+            }
+        }
+
+        let selectionMode: SelectionMode
+        if let modeStr = update["selectionMode"] as? String,
+           let mode = SelectionMode(rawValue: modeStr) {
+            selectionMode = mode
+        } else {
+            selectionMode = existing.selectionMode
+        }
+
+        let caption: String? = update.keys.contains("caption")
+            ? (update["caption"] as? String) : existing.caption
+
+        return TableSurfaceData(columns: columns, rows: rows, selectionMode: selectionMode, caption: caption)
     }
 
     private static func parseFileUploadData(_ dict: [String: Any?]) -> FileUploadSurfaceData? {

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -398,7 +398,10 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // Forward surface messages to registered callbacks.
         switch message {
         case .uiSurfaceShow(let msg):
-            onSurfaceShow?(msg)
+            // Inline surfaces are rendered in-chat by ChatViewModel; skip the floating panel.
+            if msg.display != "inline" {
+                onSurfaceShow?(msg)
+            }
         case .uiSurfaceUpdate(let msg):
             onSurfaceUpdate?(msg)
         case .uiSurfaceDismiss(let msg):

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -312,6 +312,8 @@ struct UiSurfaceShowMessage: Decodable, Sendable {
     let title: String?
     let data: AnyCodable
     let actions: [SurfaceActionData]?
+    /// `"inline"` embeds in chat, `"panel"` shows a floating window.
+    let display: String?
 }
 
 struct SurfaceActionData: Decodable, Sendable {


### PR DESCRIPTION
## Summary
- Add `display` field to `UiSurfaceShowMessage` and route inline surfaces to `ChatViewModel` instead of floating `SurfaceManager` panels
- Add table surface type (`TableColumn`, `TableRow`, `TableSurfaceData`) with full parse and merge helpers
- Add `InlineSurfaceData` model to `ChatMessage` and `sendSurfaceAction` to `ChatViewModel` for widget interactions
- Suppress `ToolCallChip` for `ui_show`/`ui_update`/`ui_dismiss`/`request_file` tool calls (they show truncated JSON that's never useful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
