### PR TITLE
Add inline widget views and ChatBubble integration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -22,6 +22,7 @@ struct ChatView: View {
     let onPaste: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
+    let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -37,7 +38,7 @@ struct ChatView: View {
     /// Triggers auto-scroll when the last message's text length changes (e.g. during streaming).
     private var streamingScrollTrigger: Int {
         let last = messages.last
-        return (last?.text.count ?? 0) + (last?.toolCalls.count ?? 0)
+        return (last?.text.count ?? 0) + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 
     var body: some View {
@@ -86,7 +87,7 @@ struct ChatView: View {
                             .id(message.id)
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                         } else {
-                            ChatBubble(message: message)
+                            ChatBubble(message: message, onSurfaceAction: onSurfaceAction)
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
@@ -428,6 +429,7 @@ struct ChatView: View {
 
 private struct ChatBubble: View {
     let message: ChatMessage
+    let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
 
     private var isUser: Bool { message.role == .user }
 
@@ -482,8 +484,16 @@ private struct ChatBubble: View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
-            VStack(alignment: isUser ? .trailing : .leading, spacing: 2) {
+            VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
                 bubbleContent
+
+                // Inline surfaces render below the bubble as separate cards
+                if !message.inlineSurfaces.isEmpty {
+                    ForEach(message.inlineSurfaces) { surface in
+                        InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                            .frame(maxWidth: 560, alignment: .leading)
+                    }
+                }
 
                 if let label = statusLabel {
                     Text(label)
@@ -788,7 +798,8 @@ private struct TimestampDivider: View {
             onDropFiles: { _ in },
             onPaste: {},
             onConfirmationAllow: { _ in },
-            onConfirmationDeny: { _ in }
+            onConfirmationDeny: { _ in },
+            onSurfaceAction: { _, _, _ in }
         )
     }
     .frame(width: 600, height: 500)

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Inline card widget for displaying structured information in chat.
+struct InlineCardWidget: View {
+    let data: CardSurfaceData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Title + subtitle
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(data.title)
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                if let subtitle = data.subtitle {
+                    Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+
+            // Body text
+            Text(markdownBody)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .textSelection(.enabled)
+
+            // Metadata grid
+            if let metadata = data.metadata, !metadata.isEmpty {
+                metadataGrid(metadata)
+            }
+        }
+    }
+
+    private func metadataGrid(_ metadata: [(label: String, value: String)]) -> some View {
+        let columns = [
+            GridItem(.flexible(), spacing: VSpacing.md),
+            GridItem(.flexible(), spacing: VSpacing.md),
+        ]
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: VSpacing.sm) {
+            ForEach(Array(metadata.enumerated()), id: \.offset) { _, item in
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(item.label)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text(item.value)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle.opacity(0.5))
+        )
+    }
+
+    private var markdownBody: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: data.body, options: options))
+            ?? AttributedString(data.body)
+    }
+}
+
+#if DEBUG
+#Preview("InlineCardWidget") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        InlineCardWidget(data: CardSurfaceData(
+            title: "Weather in New York",
+            subtitle: "Next 7 days",
+            body: "Partly cloudy with temperatures ranging from 45°F to 62°F. Rain expected on Wednesday.",
+            metadata: [
+                (label: "High", value: "62°F"),
+                (label: "Low", value: "45°F"),
+                (label: "Humidity", value: "65%"),
+                (label: "Wind", value: "12 mph NW"),
+            ]
+        ))
+        .padding()
+    }
+    .frame(width: 400, height: 300)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineFallbackChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineFallbackChip.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Fallback view for unsupported inline surface types.
+struct InlineFallbackChip: View {
+    let surfaceType: SurfaceType
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "square.on.square")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            Text("Interactive \(surfaceType.rawValue) surface")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.backgroundSubtle.opacity(0.5))
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineListWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineListWidget.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Inline list widget for selectable items in chat.
+struct InlineListWidget: View {
+    let data: ListSurfaceData
+
+    @State private var selectedIds: Set<String> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            ForEach(data.items) { item in
+                itemRow(item)
+            }
+        }
+        .onAppear {
+            selectedIds = Set(data.items.filter(\.selected).map(\.id))
+        }
+    }
+
+    private func itemRow(_ item: ListItemData) -> some View {
+        let isSelected = selectedIds.contains(item.id)
+        return HStack(spacing: VSpacing.sm) {
+            if let icon = item.icon {
+                Text(icon)
+                    .font(VFont.cardEmoji)
+                    .frame(width: 32, height: 32)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(item.title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if data.selectionMode != .none {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 14))
+                    .foregroundColor(isSelected ? VColor.accent : VColor.textMuted)
+            }
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard data.selectionMode != .none else { return }
+            if data.selectionMode == .single {
+                selectedIds = selectedIds.contains(item.id) ? [] : [item.id]
+            } else {
+                if selectedIds.contains(item.id) {
+                    selectedIds.remove(item.id)
+                } else {
+                    selectedIds.insert(item.id)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+#Preview("InlineListWidget") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        InlineListWidget(data: ListSurfaceData(
+            items: [
+                ListItemData(id: "1", title: "Option A", subtitle: "First choice", icon: nil, selected: false),
+                ListItemData(id: "2", title: "Option B", subtitle: "Second choice", icon: nil, selected: true),
+                ListItemData(id: "3", title: "Option C", subtitle: nil, icon: nil, selected: false),
+            ],
+            selectionMode: .single
+        ))
+        .padding()
+    }
+    .frame(width: 400, height: 250)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Routes an `InlineSurfaceData` to the correct inline widget view.
+struct InlineSurfaceRouter: View {
+    let surface: InlineSurfaceData
+    let onAction: (String, String, [String: AnyCodable]?) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            if let title = surface.title {
+                Text(title)
+                    .font(VFont.cardTitle)
+                    .foregroundColor(VColor.textPrimary)
+            }
+
+            surfaceContent
+
+            if !surface.actions.isEmpty {
+                actionButtons
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
+        )
+        .vShadow(VShadow.sm)
+    }
+
+    @ViewBuilder
+    private var surfaceContent: some View {
+        switch surface.data {
+        case .card(let data):
+            InlineCardWidget(data: data)
+        case .table(let data):
+            InlineTableWidget(data: data) { actionId, payload in
+                onAction(surface.id, actionId, payload)
+            }
+        case .list(let data):
+            InlineListWidget(data: data)
+        default:
+            InlineFallbackChip(surfaceType: surface.surfaceType)
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            Spacer()
+            ForEach(surface.actions) { action in
+                Button {
+                    onAction(surface.id, action.id, nil)
+                } label: {
+                    Text(action.label)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(buttonForeground(action.style))
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .fill(buttonBackground(action.style))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func buttonForeground(_ style: SurfaceActionStyle) -> Color {
+        switch style {
+        case .primary: return .white
+        case .destructive: return .white
+        case .secondary: return VColor.textPrimary
+        }
+    }
+
+    private func buttonBackground(_ style: SurfaceActionStyle) -> Color {
+        switch style {
+        case .primary: return VColor.accent
+        case .destructive: return VColor.error
+        case .secondary: return VColor.surfaceBorder.opacity(0.5)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+/// Inline table widget with selectable rows and action support.
+struct InlineTableWidget: View {
+    let data: TableSurfaceData
+    let onAction: (String, [String: AnyCodable]?) -> Void
+
+    @State private var selectedIds: Set<String> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Column headers
+            HStack(spacing: 0) {
+                if data.selectionMode != .none {
+                    // Checkbox column header
+                    Color.clear
+                        .frame(width: 28)
+                }
+                ForEach(data.columns) { column in
+                    Text(column.label)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.bottom, VSpacing.xxs)
+
+            Divider()
+                .background(VColor.surfaceBorder.opacity(0.3))
+
+            // Rows
+            ForEach(data.rows) { row in
+                rowView(row)
+            }
+
+            if let caption = data.caption {
+                Text(caption)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.top, VSpacing.xs)
+            }
+        }
+        .onAppear {
+            // Initialize selection from data
+            selectedIds = Set(data.rows.filter(\.selected).map(\.id))
+        }
+    }
+
+    private func rowView(_ row: TableRow) -> some View {
+        let isSelected = selectedIds.contains(row.id)
+        return HStack(spacing: 0) {
+            if data.selectionMode != .none && row.selectable {
+                Button {
+                    toggleSelection(row.id)
+                } label: {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 14))
+                        .foregroundColor(isSelected ? VColor.accent : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 28)
+            } else if data.selectionMode != .none {
+                Color.clear
+                    .frame(width: 28)
+            }
+
+            ForEach(data.columns) { column in
+                Text(row.cells[column.id] ?? "")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if row.selectable && data.selectionMode != .none {
+                toggleSelection(row.id)
+            }
+        }
+    }
+
+    private func toggleSelection(_ id: String) {
+        if data.selectionMode == .single {
+            if selectedIds.contains(id) {
+                selectedIds.removeAll()
+            } else {
+                selectedIds = [id]
+            }
+        } else {
+            if selectedIds.contains(id) {
+                selectedIds.remove(id)
+            } else {
+                selectedIds.insert(id)
+            }
+        }
+    }
+}
+
+#if DEBUG
+#Preview("InlineTableWidget") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        InlineTableWidget(
+            data: TableSurfaceData(
+                columns: [
+                    TableColumn(id: "sender", label: "Sender", width: nil),
+                    TableColumn(id: "count", label: "Emails", width: nil),
+                ],
+                rows: [
+                    TableRow(id: "1", cells: ["sender": "newsletter@tech.co", "count": "47"], selectable: true, selected: false),
+                    TableRow(id: "2", cells: ["sender": "deals@store.com", "count": "32"], selectable: true, selected: false),
+                    TableRow(id: "3", cells: ["sender": "updates@social.app", "count": "28"], selectable: true, selected: false),
+                ],
+                selectionMode: .multiple,
+                caption: "3 newsletters found from last 30 days"
+            ),
+            onAction: { _, _ in }
+        )
+        .padding()
+    }
+    .frame(width: 500, height: 300)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -59,7 +59,8 @@ struct MainWindowView: View {
                             onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
                             onPaste: { viewModel.addAttachmentFromPasteboard() },
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
-                            onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") }
+                            onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
+                            onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) }
                         )
                     }
                 }, panel: {


### PR DESCRIPTION
## Summary
- Create `InlineWidgets/` module with card, table, list, and fallback widget views
- `InlineSurfaceRouter` dispatches `InlineSurfaceData` to the correct widget based on surface type
- Inline surfaces render below chat bubbles as separate visual cards with action buttons
- Wire surface action callbacks through the view hierarchy to `ChatViewModel.sendSurfaceAction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
