### PR TITLE
M4: JIT permission system mapped to hatch body parts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Speech
+
+@Observable
+@MainActor
+final class JITPermissionManager {
+    // Track what's been requested/granted
+    var microphoneRequested = false
+    var accessibilityRequested = false
+    var screenCaptureRequested = false
+
+    // Whether JIT mode is active (true when first_meeting variant was used)
+    var isActive = false
+
+    // Currently showing permission sheet
+    var activePermissionRequest: JITPermissionType? = nil
+
+    enum JITPermissionType {
+        case microphone    // ears
+        case accessibility // arms
+        case screenCapture // eyes
+
+        var bodyPart: String {
+            switch self {
+            case .microphone: return "ears"
+            case .accessibility: return "arms"
+            case .screenCapture: return "eyes"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .microphone: return "Turn on my ears?"
+            case .accessibility: return "Use my hands?"
+            case .screenCapture: return "Turn on my eyes?"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .microphone: return "Want to try talking? I just need to turn my ears on."
+            case .accessibility: return "I can do that for you \u{2014} just need to use my hands. That okay?"
+            case .screenCapture: return "Mind if I watch? I just need to turn my eyes on for a few minutes."
+            }
+        }
+
+        var explanation: String {
+            switch self {
+            case .microphone: return "This lets me hear you when you hold the activation key. Audio is processed on-device and never stored."
+            case .accessibility: return "This lets me click, type, and interact with apps on your behalf."
+            case .screenCapture: return "This lets me see your screen so I can understand what you're working on."
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .microphone: return "ear"
+            case .accessibility: return "hand.raised"
+            case .screenCapture: return "eye"
+            }
+        }
+    }
+
+    // Check if permission is needed and show JIT request if so
+    func requestIfNeeded(_ type: JITPermissionType) -> Bool {
+        guard isActive else { return true } // Not in JIT mode, skip
+
+        switch type {
+        case .microphone:
+            if SFSpeechRecognizer.authorizationStatus() == .authorized { return true }
+            activePermissionRequest = .microphone
+            return false
+        case .accessibility:
+            if PermissionManager.accessibilityStatus(prompt: false) == .granted { return true }
+            activePermissionRequest = .accessibility
+            return false
+        case .screenCapture:
+            if CGPreflightScreenCaptureAccess() { return true }
+            activePermissionRequest = .screenCapture
+            return false
+        }
+    }
+
+    // Grant the currently active permission
+    func grantActivePermission() {
+        guard let type = activePermissionRequest else { return }
+        switch type {
+        case .microphone:
+            SFSpeechRecognizer.requestAuthorization { _ in }
+            microphoneRequested = true
+        case .accessibility:
+            _ = PermissionManager.accessibilityStatus(prompt: true)
+            accessibilityRequested = true
+        case .screenCapture:
+            CGRequestScreenCaptureAccess()
+            screenCaptureRequested = true
+        }
+        activePermissionRequest = nil
+    }
+
+    func dismissActivePermission() {
+        activePermissionRequest = nil
+    }
+}
+
+#Preview {
+    @Previewable @State var manager = JITPermissionManager()
+
+    VStack(spacing: VSpacing.xl) {
+        Text("JIT Permission Manager")
+            .font(VFont.headline)
+            .foregroundColor(VColor.textPrimary)
+
+        Text("Active: \(manager.isActive ? "Yes" : "No")")
+            .font(VFont.body)
+            .foregroundColor(VColor.textSecondary)
+
+        HStack(spacing: VSpacing.md) {
+            OnboardingButton(title: "Request Mic", style: .ghost) {
+                manager.isActive = true
+                _ = manager.requestIfNeeded(.microphone)
+            }
+            OnboardingButton(title: "Request A11y", style: .ghost) {
+                manager.isActive = true
+                _ = manager.requestIfNeeded(.accessibility)
+            }
+            OnboardingButton(title: "Request Screen", style: .ghost) {
+                manager.isActive = true
+                _ = manager.requestIfNeeded(.screenCapture)
+            }
+        }
+
+        if let request = manager.activePermissionRequest {
+            Text("Active request: \(request.title)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.success)
+        }
+    }
+    .padding(VSpacing.xxl)
+    .frame(width: 500, height: 300)
+    .background(VColor.background)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+@MainActor
+struct JITPermissionView: View {
+    @Bindable var manager: JITPermissionManager
+
+    @State private var showContent = false
+    @State private var iconScale: CGFloat = 1.0
+
+    var body: some View {
+        ZStack {
+            // Dimmed backdrop
+            Color.black.opacity(showContent ? 0.5 : 0)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    dismiss()
+                }
+
+            if let request = manager.activePermissionRequest {
+                permissionCard(for: request)
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.combined(with: .scale(scale: 0.92)),
+                            removal: .opacity.combined(with: .scale(scale: 0.95))
+                        )
+                    )
+            }
+        }
+        .animation(VAnimation.panel, value: manager.activePermissionRequest != nil)
+        .onChange(of: manager.activePermissionRequest) { _, newValue in
+            if newValue != nil {
+                showContent = false
+                iconScale = 1.0
+                withAnimation(.easeOut(duration: 0.4).delay(0.1)) {
+                    showContent = true
+                }
+                startIconBreathing()
+            } else {
+                withAnimation(VAnimation.fast) {
+                    showContent = false
+                }
+            }
+        }
+    }
+
+    // MARK: - Permission Card
+
+    private func permissionCard(for request: JITPermissionManager.JITPermissionType) -> some View {
+        VStack(spacing: VSpacing.xl) {
+            // Body part icon with breathing animation
+            ZStack {
+                // Glow behind icon
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [
+                                VColor.accent.opacity(0.3),
+                                VColor.accent.opacity(0.0)
+                            ],
+                            center: .center,
+                            startRadius: 0,
+                            endRadius: 40
+                        )
+                    )
+                    .frame(width: 80, height: 80)
+                    .scaleEffect(iconScale)
+
+                Image(systemName: request.icon)
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundColor(VColor.accent)
+                    .scaleEffect(iconScale)
+            }
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 8)
+
+            // Title
+            VStack(spacing: VSpacing.sm) {
+                Text(request.title)
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(request.message)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
+            }
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 6)
+
+            // Explanation card
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "lock.shield")
+                        .font(.system(size: 11))
+                        .foregroundColor(VColor.textMuted)
+                    Text("Privacy")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Text(request.explanation)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(VSpacing.lg)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surface.opacity(0.3))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.surfaceBorder.opacity(0.4), lineWidth: 1)
+                    )
+            )
+            .opacity(showContent ? 1 : 0)
+
+            // Buttons
+            VStack(spacing: VSpacing.md) {
+                OnboardingButton(title: "Allow", style: .primary) {
+                    manager.grantActivePermission()
+                }
+
+                Button("Not now") {
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+            }
+            .opacity(showContent ? 1 : 0)
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.vertical, VSpacing.xxxl)
+        .frame(maxWidth: 420)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .fill(Meadow.panelBackground)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(Meadow.panelBorder, lineWidth: 1)
+                )
+        )
+        .shadow(color: .black.opacity(0.5), radius: 32, y: 16)
+    }
+
+    // MARK: - Helpers
+
+    private func dismiss() {
+        manager.dismissActivePermission()
+    }
+
+    private func startIconBreathing() {
+        withAnimation(
+            .easeInOut(duration: 2.0)
+            .repeatForever(autoreverses: true)
+        ) {
+            iconScale = 1.08
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Microphone") {
+    @Previewable @State var manager: JITPermissionManager = {
+        let m = JITPermissionManager()
+        m.isActive = true
+        m.activePermissionRequest = .microphone
+        return m
+    }()
+
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        JITPermissionView(manager: manager)
+    }
+    .frame(width: 640, height: 560)
+}
+
+#Preview("Accessibility") {
+    @Previewable @State var manager: JITPermissionManager = {
+        let m = JITPermissionManager()
+        m.isActive = true
+        m.activePermissionRequest = .accessibility
+        return m
+    }()
+
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        JITPermissionView(manager: manager)
+    }
+    .frame(width: 640, height: 560)
+}
+
+#Preview("Screen Capture") {
+    @Previewable @State var manager: JITPermissionManager = {
+        let m = JITPermissionManager()
+        m.isActive = true
+        m.activePermissionRequest = .screenCapture
+        return m
+    }()
+
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        JITPermissionView(manager: manager)
+    }
+    .frame(width: 640, height: 560)
+}


### PR DESCRIPTION
## Summary
- Add `JITPermissionManager` that tracks permission state and shows contextual just-in-time permission requests instead of upfront onboarding prompts
- Add `JITPermissionView` overlay with frosted-glass card, body-part SF Symbol icons (ear/hand.raised/eye), conversational messaging, and breathing icon animation
- Each permission maps to a hatch body part: microphone -> ears, accessibility -> arms, screen capture -> eyes

## Test plan
- [ ] Preview all three permission variants (Microphone, Accessibility, Screen Capture) in Xcode Previews
- [ ] Verify JITPermissionManager preview shows state transitions when tapping request buttons
- [ ] Verify overlay appears/disappears with panel animation
- [ ] Verify breathing icon animation runs continuously while card is visible
- [ ] Verify "Allow" calls system permission prompt and dismisses card
- [ ] Verify "Not now" dismisses card without requesting permission
- [ ] Verify tapping backdrop dismisses card

Part of #1340. Closes #1344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
