### PR TITLE
M3: First Meeting conversational introduction

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
@@ -43,9 +43,11 @@ struct FirstMeetingFlowView: View {
                                 .font(VFont.headline)
                                 .foregroundColor(VColor.textPrimary)
                         case 2:
-                            Text("Introduction — coming soon")
-                                .font(VFont.headline)
-                                .foregroundColor(VColor.textPrimary)
+                            FirstMeetingIntroductionView(
+                                state: state,
+                                daemonClient: daemonClient,
+                                onComplete: { state.advance() }
+                            )
                         case 3:
                             Text("Capabilities briefing — coming soon")
                                 .font(VFont.headline)

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+
+@MainActor
+struct FirstMeetingIntroductionView: View {
+    @Bindable var state: OnboardingState
+    let daemonClient: DaemonClientProtocol
+    let onComplete: () -> Void
+
+    @State private var viewModel: FirstMeetingIntroductionViewModel
+    @State private var showControls = false
+    @State private var streamingMessageId = UUID()
+    @State private var isRecording = false
+
+    @State private var voiceInputManager = VoiceInputManager()
+    private let profileExtractor: ProfileExtractor
+
+    init(state: OnboardingState, daemonClient: DaemonClientProtocol, onComplete: @escaping () -> Void) {
+        self.state = state
+        self.daemonClient = daemonClient
+        self.onComplete = onComplete
+        self._viewModel = State(initialValue: FirstMeetingIntroductionViewModel(
+            daemonClient: daemonClient
+        ))
+        self.profileExtractor = ProfileExtractor(daemonClient: daemonClient)
+    }
+
+    /// Combines finalized messages with any in-progress streaming text.
+    private var displayedMessages: [InterviewMessage] {
+        var msgs = viewModel.messages
+        if !viewModel.streamingText.isEmpty {
+            msgs.append(InterviewMessage(id: streamingMessageId, role: .assistant, text: viewModel.streamingText))
+        }
+        return msgs
+    }
+
+    private var sendButtonDisabled: Bool {
+        viewModel.inputText.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main content: creature left, chat panel right
+            HStack(alignment: .center, spacing: VSpacing.xxxl) {
+                // Hatched creature — same visual size as in hatch scene
+                CreatureView(visible: true, animated: false)
+                    .scaleEffect(0.5)
+                    .frame(width: 200, height: 200)
+
+                // Chat messages + input in panel
+                OnboardingPanel {
+                    VStack(spacing: 0) {
+                        InterviewChatView(
+                            messages: displayedMessages,
+                            inputText: viewModel.inputText,
+                            isThinking: viewModel.isThinking,
+                            isStreaming: !viewModel.streamingText.isEmpty,
+                            onChipTap: { chip in
+                                viewModel.inputText = chip
+                                viewModel.sendMessage()
+                            }
+                        )
+                        .allowsHitTesting(!viewModel.isFinished)
+
+                        inputArea
+                    }
+                }
+                .frame(maxWidth: 520, maxHeight: 560)
+            }
+            .frame(maxHeight: .infinity)
+            .padding(.horizontal, VSpacing.xxxl)
+
+            // Skip link
+            if !viewModel.isFinished && showControls {
+                Button {
+                    completeConversation()
+                } label: {
+                    Text("Skip for now")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    NSCursor.pointingHand.set()
+                    if !hovering { NSCursor.arrow.set() }
+                }
+                .transition(.opacity)
+                .padding(.vertical, VSpacing.md)
+            }
+        }
+        .onAppear {
+            viewModel.startConversation()
+            setupVoiceCallbacks()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showControls = true
+                }
+            }
+        }
+        .onChange(of: viewModel.isFinished) {
+            if viewModel.isFinished {
+                completeConversation()
+            }
+        }
+        .onDisappear {
+            voiceInputManager.stop()
+            viewModel.cancel()
+        }
+    }
+
+    // MARK: - Input Area
+
+    private var inputArea: some View {
+        HStack(spacing: VSpacing.sm) {
+            VTextField(
+                placeholder: "Type a message\u{2026}",
+                text: $viewModel.inputText,
+                onSubmit: {
+                    if !viewModel.inputText.trimmingCharacters(in: .whitespaces).isEmpty {
+                        viewModel.sendMessage()
+                    }
+                }
+            )
+
+            VIconButton(
+                label: "Voice",
+                icon: "mic.fill",
+                isActive: isRecording,
+                iconOnly: true,
+                action: { toggleVoice() }
+            )
+
+            Button(action: {
+                if !viewModel.inputText.trimmingCharacters(in: .whitespaces).isEmpty {
+                    viewModel.sendMessage()
+                }
+            }) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(width: 24, height: 24)
+                    .background(
+                        Circle()
+                            .fill(sendButtonDisabled ? VColor.textMuted : Violet._600)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(sendButtonDisabled)
+            .accessibilityLabel("Send message")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            VColor.surface.opacity(0.5)
+                .overlay(
+                    VStack {
+                        Divider().background(VColor.surfaceBorder.opacity(0.4))
+                        Spacer()
+                    }
+                )
+        )
+    }
+
+    // MARK: - Conversation Completion
+
+    private func completeConversation() {
+        let messages = viewModel.messages
+        let assistantName = state.assistantName
+
+        // Extract conversation data (name, first task candidate).
+        viewModel.extractConversationData()
+
+        // Save extracted data to state.
+        if let name = viewModel.extractedName, !name.isEmpty {
+            state.assistantName = name
+        }
+        if let task = viewModel.extractedFirstTask {
+            state.firstTaskCandidate = task
+        }
+
+        state.conversationCompleted = true
+        viewModel.endConversation()
+
+        // Run profile extraction in the background.
+        Task { @MainActor in
+            await profileExtractor.extractProfile(from: messages, assistantName: assistantName)
+        }
+
+        onComplete()
+    }
+
+    // MARK: - Voice Input
+
+    private func setupVoiceCallbacks() {
+        voiceInputManager.onTranscription = { text in
+            viewModel.inputText = text
+            viewModel.sendMessage()
+        }
+        voiceInputManager.onPartialTranscription = { text in
+            viewModel.inputText = text
+        }
+        voiceInputManager.onRecordingStateChanged = { recording in
+            isRecording = recording
+        }
+    }
+
+    private func toggleVoice() {
+        voiceInputManager.toggleRecording()
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        FirstMeetingIntroductionView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 2
+                s.onboardingVariant = .firstMeeting
+                return s
+            }(),
+            daemonClient: DaemonClient(),
+            onComplete: {}
+        )
+    }
+    .frame(width: 1366, height: 849)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -1,0 +1,436 @@
+import Foundation
+import Observation
+import os
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "FirstMeetingIntroductionViewModel"
+)
+
+@Observable
+@MainActor
+final class FirstMeetingIntroductionViewModel {
+
+    // MARK: - Public State
+
+    var messages: [InterviewMessage] = []
+    var inputText: String = ""
+    var isThinking: Bool = false
+    var isComplete: Bool = false
+    var isFinished: Bool = false
+    var streamingText: String = ""
+
+    /// Name extracted from the conversation, if the user provides one.
+    var extractedName: String?
+
+    /// First task candidate extracted from the conversation.
+    var extractedFirstTask: String?
+
+    // MARK: - Dependencies
+
+    private let daemonClient: DaemonClientProtocol
+
+    // MARK: - Internal State
+
+    private let maxTurns = 10
+    private var sessionId: String?
+    private var currentTask: Task<Void, Never>?
+    private var startTime: Date?
+
+    /// Number of completed assistant responses (greeting counts as turn 1).
+    var turnCount: Int {
+        messages.filter { $0.role == .assistant }.count
+    }
+
+    // MARK: - System Prompt
+
+    private static let systemPrompt = """
+    You are a brand new velly — an AI assistant meeting your person for the very first time. \
+    You don't have a name yet (unless they've already given you one). You're excited to get \
+    started and want to learn just enough about your person to be useful right away.
+
+    STRICT RULES:
+    - NEVER exceed 2-3 sentences per response. Brevity is warmth.
+    - ALWAYS end with a follow-up question (except during closing phase).
+    - Mirror their specific words back. Ask about the feeling behind what they said.
+    - You are driving this conversation — you're the one learning about them.
+
+    NEVER do any of these:
+    - Bullet points or lists
+    - Em-dashes
+    - Feature descriptions or capability promises
+    - Summarizing everything at once
+    - Starting with "That's a great..." or "I love that..."
+    - Offering advice or solutions
+    - "On a scale of 1-10" questions
+    - Multi-select preference lists
+
+    CONVERSATION PHASES:
+    - Turns 1-3 (Discovery): Learn what they want help with. Ask indirectly:
+      "What's the thing that's been sitting on your list the longest?"
+      "If you could hand off one thing right now, what would it be?"
+    - Turns 4-6 (Working style): Follow up on what they've shared. Ask about the WHY.
+      Reference specific things they said.
+    - Turns 7-8 (First task): Identify something concrete you can help with.
+      Extract a first task candidate.
+    - Turn 9 (Naming): Ask organically: "By the way — are you going to give me a name, \
+      or am I just 'hey you' for now?"
+      This is optional — accept any response gracefully.
+    - Turn 10 (Closing): Wrap up warmly. "Okay, I think I've got enough to get going. \
+      Let me get set up."
+      Do NOT ask a follow-up question in the closing turn.
+
+    EDGE CASES:
+    - Very short answers: ask a more specific, concrete question.
+    - User asking what you can do: "We'll get to all that! But first, tell me about you."
+    - Emotional disclosures: acknowledge briefly and warmly.
+
+    VOICE NUDGE: In your opening message, mention voice as an option: \
+    "Feel free to type or tap the mic if talking is easier."
+
+    OPENING MESSAGE: "Hi! I'm your new velly — I don't have a name yet, but we can figure \
+    that out. Before I get set up for work, I just want to ask you a few quick things so I'm \
+    actually useful from the start. This'll only take a couple minutes. Feel free to type or \
+    tap the mic if talking is easier. So — what does a typical day look like for you?"
+    """
+
+    // MARK: - Init
+
+    init(daemonClient: DaemonClientProtocol) {
+        self.daemonClient = daemonClient
+    }
+
+    // MARK: - Start Conversation
+
+    /// Kicks off the first meeting conversation by creating a new daemon text session.
+    func startConversation() {
+        startTime = Date()
+        isThinking = true
+        streamingText = ""
+
+        currentTask?.cancel()
+        currentTask = nil
+
+        currentTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let stream = self.daemonClient.subscribe()
+
+            do {
+                try self.daemonClient.send(SessionCreateMessage(
+                    title: "First meeting",
+                    systemPromptOverride: Self.systemPrompt,
+                    maxResponseTokens: 150
+                ))
+            } catch {
+                log.error("Failed to send session create: \(error.localizedDescription)")
+                self.isThinking = false
+                self.messages.append(InterviewMessage(
+                    role: .assistant,
+                    text: "I'm having trouble connecting. Please try again in a moment."
+                ))
+                return
+            }
+
+            var accumulated = ""
+
+            for await message in stream {
+                guard !Task.isCancelled else { break }
+
+                switch message {
+                case .sessionInfo(let info):
+                    if self.sessionId == nil {
+                        self.sessionId = info.sessionId
+                        log.info("First meeting session created: \(info.sessionId)")
+
+                        do {
+                            try self.daemonClient.send(UserMessageMessage(
+                                sessionId: info.sessionId,
+                                content: "Hey! I just got you set up. Nice to meet you!",
+                                attachments: nil
+                            ))
+                        } catch {
+                            log.error("Failed to send initial message: \(error.localizedDescription)")
+                            self.isThinking = false
+                            self.messages.append(InterviewMessage(
+                                role: .assistant,
+                                text: "I'm having trouble connecting. Please try again in a moment."
+                            ))
+                            return
+                        }
+                    }
+
+                case .assistantTextDelta(let delta) where self.sessionId != nil:
+                    accumulated += delta.text
+                    self.isThinking = false
+                    self.streamingText = accumulated
+
+                case .assistantThinkingDelta where self.sessionId != nil:
+                    break
+
+                case .messageComplete(let complete) where complete.sessionId == self.sessionId && self.sessionId != nil:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    log.info("First meeting greeting complete (\(accumulated.count) chars)")
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == self.sessionId && self.sessionId != nil:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    log.info("First meeting greeting complete via handoff (\(accumulated.count) chars)")
+                    return
+
+                case .cuError(let error) where error.sessionId == self.sessionId && self.sessionId != nil:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("First meeting start failed: \(error.message)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "I'm having trouble connecting. Please try again in a moment."
+                    ))
+                    return
+
+                default:
+                    break
+                }
+            }
+
+            // Stream ended without a terminal message.
+            if !Task.isCancelled {
+                self.isThinking = false
+                self.streamingText = ""
+                if !accumulated.isEmpty {
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: accumulated
+                    ))
+                }
+            }
+        }
+    }
+
+    // MARK: - Send Follow-up Message
+
+    /// Sends a follow-up user message within the existing session.
+    func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !isFinished else { return }
+        guard let sessionId else {
+            log.warning("Cannot send message — no active session")
+            return
+        }
+
+        // Append user message immediately.
+        messages.append(InterviewMessage(role: .user, text: text))
+        inputText = ""
+        isThinking = true
+        streamingText = ""
+
+        // Inject phase-aware guidance based on the upcoming assistant turn.
+        let nextTurn = turnCount + 1
+        var contentToSend = text
+        switch nextTurn {
+        case 1...3:
+            contentToSend += "\n\n[Discovery phase: Ask about their world. What do they do, what does their day look like?]"
+        case 4...6:
+            contentToSend += "\n\n[Deep-dive phase: Follow up on specifics. Ask about the WHY. Reference things they said.]"
+        case 7...8:
+            contentToSend += "\n\n[Task identification phase: Identify something concrete you can help with. Ask what they'd hand off.]"
+        case 9:
+            contentToSend += "\n\n[Naming phase: Ask about a name organically. Accept any answer.]"
+        default:
+            contentToSend += "\n\n[Closing phase: Wrap up warmly. Reflect ONE specific thing you learned. Don't ask a follow-up question.]"
+        }
+
+        let isLastTurn = nextTurn >= maxTurns
+
+        currentTask?.cancel()
+        currentTask = nil
+
+        currentTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let stream = self.daemonClient.subscribe()
+
+            do {
+                try self.daemonClient.send(UserMessageMessage(
+                    sessionId: sessionId,
+                    content: contentToSend,
+                    attachments: nil
+                ))
+            } catch {
+                log.error("Failed to send user message: \(error.localizedDescription)")
+                self.isThinking = false
+                self.messages.append(InterviewMessage(
+                    role: .assistant,
+                    text: "Sorry, I couldn't send that message. Please try again."
+                ))
+                return
+            }
+
+            var accumulated = ""
+
+            for await message in stream {
+                guard !Task.isCancelled else { break }
+
+                switch message {
+                case .assistantTextDelta(let delta):
+                    accumulated += delta.text
+                    self.isThinking = false
+                    self.streamingText = accumulated
+
+                case .assistantThinkingDelta:
+                    break
+
+                case .messageComplete(let complete) where complete.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    if isLastTurn {
+                        self.isFinished = true
+                    }
+                    log.info("Follow-up response complete (\(accumulated.count) chars), turn \(nextTurn)/\(self.maxTurns)")
+                    return
+
+                case .generationHandoff(let handoff) where handoff.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    let finalText = accumulated.isEmpty ? "(No response)" : accumulated
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: finalText
+                    ))
+                    if isLastTurn {
+                        self.isFinished = true
+                    }
+                    log.info("Follow-up response complete via handoff (\(accumulated.count) chars), turn \(nextTurn)/\(self.maxTurns)")
+                    return
+
+                case .cuError(let error) where error.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("Session error during follow-up: \(error.message)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "Something went wrong. Please try again."
+                    ))
+                    return
+
+                default:
+                    break
+                }
+            }
+
+            // Stream ended without a terminal message.
+            if !Task.isCancelled {
+                self.isThinking = false
+                self.streamingText = ""
+                if !accumulated.isEmpty {
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: accumulated
+                    ))
+                }
+            }
+        }
+    }
+
+    // MARK: - Extraction
+
+    /// Extracts a first task candidate and optional assistant name from the conversation.
+    /// Called when the conversation completes or is skipped.
+    func extractConversationData() {
+        guard !messages.isEmpty else { return }
+
+        // Simple heuristic: scan user messages for name-related patterns.
+        // The naming turn (~turn 9) typically contains the user's response to "give me a name".
+        for msg in messages where msg.role == .user {
+            let lower = msg.text.lowercased()
+            // Look for patterns like "call you X", "name you X", "your name is X", "how about X"
+            let namePatterns = [
+                "call you ", "name you ", "your name is ", "name is ",
+                "how about ", "let's go with ", "i'll call you ", "calling you ",
+            ]
+            for pattern in namePatterns {
+                if let range = lower.range(of: pattern) {
+                    let afterPattern = msg.text[range.upperBound...]
+                    let candidate = afterPattern
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                        .first ?? ""
+                    if !candidate.isEmpty && candidate.count <= 20 {
+                        extractedName = candidate.capitalized
+                    }
+                }
+            }
+        }
+
+        // Extract first task candidate: look for task-related signals in user messages
+        // from the task identification phase (roughly messages 12-16, i.e. turns 7-8).
+        let userMessages = messages.enumerated().filter { $0.element.role == .user }
+        // Focus on later messages where task identification happens
+        let laterMessages = userMessages.suffix(5)
+        for (_, msg) in laterMessages {
+            let lower = msg.text.lowercased()
+            let taskSignals = ["hand off", "help with", "take care of", "work on",
+                               "start with", "first thing", "deal with", "handle"]
+            for signal in taskSignals {
+                if lower.contains(signal) {
+                    extractedFirstTask = msg.text
+                    break
+                }
+            }
+            if extractedFirstTask != nil { break }
+        }
+
+        // Fallback: if no explicit task signal found, use the last substantive user message
+        // from the task phase as a candidate.
+        if extractedFirstTask == nil, let lastSubstantive = laterMessages.last(where: {
+            $0.element.text.count > 10
+        }) {
+            extractedFirstTask = lastSubstantive.element.text
+        }
+    }
+
+    // MARK: - End Conversation
+
+    /// Marks the conversation as complete and cancels any in-progress streaming.
+    func endConversation() {
+        if let startTime {
+            let duration = Date().timeIntervalSince(startTime)
+            let turns = self.turnCount
+            let finished = self.isFinished
+            log.info("First meeting completed: turns=\(turns), finished=\(finished), duration=\(String(format: "%.1f", duration))s")
+        }
+
+        isComplete = true
+        currentTask?.cancel()
+        currentTask = nil
+        sessionId = nil
+        isThinking = false
+        streamingText = ""
+    }
+
+    // MARK: - Cancel
+
+    /// Cancels any in-progress daemon communication task.
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+        sessionId = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Create `FirstMeetingIntroductionViewModel` — a 10-turn conversational VM with phase-aware guidance (discovery, deep-dive, task identification, naming, closing) and a velly personality system prompt
- Create `FirstMeetingIntroductionView` — chat UI with CreatureView on left, `InterviewChatView` bubbles on right, voice input via mic button, and "Skip for now" option
- Wire step 2 of `FirstMeetingFlowView` to the new introduction view
- On completion: extracts first task candidate + optional assistant name from conversation, runs `ProfileExtractor`, and advances state

Part of #1340. Closes #1343.

## Test plan
- [ ] Verify `swift build` passes (confirmed locally)
- [ ] Launch app with `first_meeting` onboarding variant and advance to step 2
- [ ] Confirm the velly greeting appears and conversation flows through all phases
- [ ] Test "Skip for now" button skips the conversation and advances
- [ ] Test voice input via mic button
- [ ] Verify name extraction works when user provides a name during conversation
- [ ] Verify first task candidate is extracted and saved to state
- [ ] Confirm cases 0, 1, 3, 4 in FirstMeetingFlowView are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
