### PR TITLE
M2: First Meeting egg & uninterrupted hatch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingEggView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingEggView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+@MainActor
+struct FirstMeetingEggView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showButton = false
+    @State private var isHatching = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxl) {
+            TypewriterText(
+                fullText: "Something is waiting for you...",
+                speed: 0.06,
+                font: VFont.onboardingTitle
+            ) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        showButton = true
+                    }
+                }
+            }
+
+            OnboardingButton(title: "Wake it up", style: .primary) {
+                guard !isHatching else { return }
+                isHatching = true
+                state.hasHatched = true
+                state.firstMeetingCrackProgress = 0.15
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    state.advance()
+                }
+            }
+            .opacity(showButton ? 1 : 0)
+            .offset(y: showButton ? 0 : 8)
+            .disabled(isHatching)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        FirstMeetingEggView(state: {
+            let s = OnboardingState()
+            s.onboardingVariant = .firstMeeting
+            return s
+        }())
+    }
+    .frame(width: 640, height: 400)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
@@ -1,3 +1,4 @@
+import SpriteKit
 import SwiftUI
 
 @MainActor
@@ -6,6 +7,15 @@ struct FirstMeetingFlowView: View {
     let daemonClient: DaemonClientProtocol
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
+
+    /// Shared SpriteKit scene for the egg/hatch animation across steps 0-1.
+    @State private var eggScene: EggHatchScene = {
+        let s = EggHatchScene()
+        s.size = CGSize(width: 280, height: 480)
+        s.scaleMode = .resizeFill
+        s.backgroundColor = .clear
+        return s
+    }()
 
     var body: some View {
         ZStack {
@@ -23,25 +33,34 @@ struct FirstMeetingFlowView: View {
 
             // Vertical card layout
             VStack(spacing: 0) {
-                // TOP: Meadow background
+                // TOP: Meadow background + egg scene
                 ZStack {
                     MeadowBackground()
+
+                    if state.currentStep <= 1 {
+                        SpriteView(scene: eggScene, options: [.allowsTransparency])
+                            .frame(width: 280, height: 350)
+                            .allowsHitTesting(false)
+                    }
                 }
                 .frame(height: 350)
                 .clipped()
+                .onAppear {
+                    // Set initial crack progress without animation for restored sessions
+                    let progress = state.firstMeetingCrackProgress
+                    if progress > 0 {
+                        eggScene.setCrackProgress(progress, animated: false)
+                    }
+                }
 
                 // BOTTOM: Dark content panel
                 VStack(spacing: VSpacing.lg) {
                     Group {
                         switch state.currentStep {
                         case 0:
-                            Text("Egg step — coming soon")
-                                .font(VFont.headline)
-                                .foregroundColor(VColor.textPrimary)
+                            FirstMeetingEggView(state: state)
                         case 1:
-                            Text("Hatch step — coming soon")
-                                .font(VFont.headline)
-                                .foregroundColor(VColor.textPrimary)
+                            FirstMeetingHatchView(state: state, scene: eggScene)
                         case 2:
                             Text("Introduction — coming soon")
                                 .font(VFont.headline)

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingHatchView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingHatchView.swift
@@ -1,0 +1,136 @@
+import SpriteKit
+import SwiftUI
+
+@MainActor
+struct FirstMeetingHatchView: View {
+    @Bindable var state: OnboardingState
+    let scene: EggHatchScene
+
+    @State private var hatchTimer: Timer?
+    @State private var hasTriggeredDramaticCrack = false
+    @State private var hasTriggeredFullHatch = false
+    @State private var hatchCompleted = false
+    @State private var statusText = "Your velly is hatching..."
+    @State private var delegateAdapter: HatchDelegateAdapter?
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxl) {
+            TypewriterText(
+                fullText: statusText,
+                speed: 0.05,
+                font: VFont.onboardingTitle
+            )
+            .id(statusText)
+        }
+        .onAppear {
+            setupDelegate()
+            startHatchTimer()
+        }
+        .onDisappear {
+            hatchTimer?.invalidate()
+            hatchTimer = nil
+        }
+    }
+
+    // MARK: - Timer-Driven Hatch Sequence
+
+    private func startHatchTimer() {
+        // Drive crackProgress from current value to 1.0 over ~8 seconds.
+        let startProgress = state.firstMeetingCrackProgress
+        let totalDuration: CGFloat = 8.0
+        let tickInterval: CGFloat = 0.1
+        let progressRange = 1.0 - startProgress
+        let increment = progressRange * (tickInterval / totalDuration)
+
+        hatchTimer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { _ in
+            Task { @MainActor in
+                guard !hasTriggeredFullHatch else {
+                    hatchTimer?.invalidate()
+                    hatchTimer = nil
+                    return
+                }
+
+                let newProgress = min(state.firstMeetingCrackProgress + increment, 1.0)
+                state.firstMeetingCrackProgress = newProgress
+                scene.setCrackProgress(newProgress, animated: true)
+
+                // At ~0.5 progress, trigger dramatic crack effects
+                if newProgress >= 0.5 && !hasTriggeredDramaticCrack {
+                    hasTriggeredDramaticCrack = true
+                    scene.triggerDramaticCrack(for: 3)
+                }
+
+                // At 1.0 progress, trigger full hatch
+                if newProgress >= 1.0 && !hasTriggeredFullHatch {
+                    hasTriggeredFullHatch = true
+                    hatchTimer?.invalidate()
+                    hatchTimer = nil
+                    scene.triggerFullHatch()
+                }
+            }
+        }
+    }
+
+    // MARK: - Delegate
+
+    private func setupDelegate() {
+        let adapter = HatchDelegateAdapter { event in
+            Task { @MainActor in
+                if event == .fullHatchDone {
+                    hatchCompleted = true
+                    statusText = "Say hello!"
+                    // Wait a moment then auto-advance to step 2
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        state.advance()
+                    }
+                }
+            }
+        }
+        delegateAdapter = adapter
+        scene.hatchDelegate = adapter
+    }
+}
+
+/// Bridges the EggHatchSceneDelegate protocol to a closure for use in SwiftUI.
+private final class HatchDelegateAdapter: EggHatchSceneDelegate {
+    let handler: @Sendable (HatchEvent) -> Void
+
+    init(handler: @escaping @Sendable (HatchEvent) -> Void) {
+        self.handler = handler
+    }
+
+    func sceneDidComplete(_ event: HatchEvent) {
+        handler(event)
+    }
+}
+
+private struct FirstMeetingHatchPreview: View {
+    let scene: EggHatchScene = {
+        let s = EggHatchScene()
+        s.size = CGSize(width: 280, height: 480)
+        s.scaleMode = .resizeFill
+        s.backgroundColor = .clear
+        return s
+    }()
+
+    var body: some View {
+        ZStack {
+            MeadowBackground()
+            FirstMeetingHatchView(
+                state: {
+                    let s = OnboardingState()
+                    s.onboardingVariant = .firstMeeting
+                    s.firstMeetingCrackProgress = 0.15
+                    s.currentStep = 1
+                    return s
+                }(),
+                scene: scene
+            )
+        }
+        .frame(width: 640, height: 400)
+    }
+}
+
+#Preview {
+    FirstMeetingHatchPreview()
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -34,6 +34,7 @@ final class OnboardingState {
     var onboardingVariant: OnboardingVariant = .default
 
     // First-meeting-specific state
+    var firstMeetingCrackProgress: CGFloat = 0.0
     var conversationCompleted: Bool = false
     var capabilitiesBriefingShown: Bool = false
     var observationCompleted: Bool = false
@@ -44,7 +45,11 @@ final class OnboardingState {
     }
 
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
+    /// For the first meeting variant, uses a timer-driven stored property instead.
     var crackProgress: CGFloat {
+        if onboardingVariant == .firstMeeting {
+            return firstMeetingCrackProgress
+        }
         switch currentStep {
         case 0: return hasHatched ? 0.15 : 0.0
         case 1: return 0.25


### PR DESCRIPTION
## Summary
- Add `FirstMeetingEggView` — egg step with typewriter text ("Something is waiting for you...") and "Wake it up" button that sets initial crack progress and advances
- Add `FirstMeetingHatchView` — timer-driven hatch that auto-progresses crack from 0.15 to 1.0 over ~8 seconds, triggers dramatic crack effects at 0.5 and full hatch at 1.0, then auto-advances after the SpriteKit hatch animation completes
- Add `firstMeetingCrackProgress` stored property to `OnboardingState` with variant-aware `crackProgress` computed property
- Wire up steps 0-1 in `FirstMeetingFlowView` with shared `EggHatchScene` in the meadow area

Part of #1340. Closes #1342.

## Test plan
- [ ] Launch with first meeting variant and verify egg view shows typewriter text followed by "Wake it up" button
- [ ] Tap "Wake it up" and verify transition to hatch step with egg crack animation auto-progressing
- [ ] Verify dramatic crack effects trigger around 50% progress
- [ ] Verify full hatch animation triggers at 100% with creature reveal
- [ ] Verify text changes from "Your velly is hatching..." to "Say hello!" after hatch completes
- [ ] Verify auto-advance to step 2 after ~1.5s delay post-hatch
- [ ] Verify steps 2-4 still show placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
