### PR TITLE
Fix DaemonClient.send() to throw when disconnected

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -243,12 +243,25 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Send
 
-    /// Send a message to the daemon. Fire-and-forget.
+    enum SendError: Error, LocalizedError {
+        case notConnected
+
+        var errorDescription: String? {
+            switch self {
+            case .notConnected:
+                return "Cannot send: not connected to daemon"
+            }
+        }
+    }
+
+    /// Send a message to the daemon.
     /// Encodes the message as JSON, appends a newline, and writes to the connection.
+    /// Throws `SendError.notConnected` when the connection is nil so callers can
+    /// distinguish a silently-dropped message from a successful write.
     func send<T: Encodable>(_ message: T) throws {
         guard let conn = connection else {
             log.warning("Cannot send: not connected")
-            return
+            throw SendError.notConnected
         }
 
         var data = try encoder.encode(message)


### PR DESCRIPTION
## Summary
- `DaemonClient.send()` previously returned early (without throwing) when `connection` was `nil`, causing callers using `do/catch` to treat the silent return as success.
- The floating confirmation panel's response handler in `AppDelegate` relied on `do/catch` around `sendConfirmationResponse`, so when the daemon was disconnected, it never caught the error and returned `true` — dismissing the panel even though no IPC message was sent, removing the user's retry path.
- Changed `send()` to throw `SendError.notConnected` instead of silently returning, so the floating panel's catch block correctly returns `false` and keeps the panel visible for retry.
- All existing `try?` callers (fire-and-forget sends) continue to work unchanged.

Addresses review feedback on #1323.

## Test plan
- [ ] Disconnect daemon, click Allow/Deny on floating confirmation panel — verify panel stays visible for retry
- [ ] With daemon connected, click Allow/Deny on floating panel — verify panel dismisses normally
- [ ] Verify `try?` fire-and-forget sends (surface actions, task submit, etc.) continue to work silently when disconnected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
