### PR TITLE
Add observation mode views for First Meeting onboarding (step 4)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
@@ -8,6 +8,14 @@ struct FirstMeetingFlowView: View {
     var onComplete: () -> Void
     var onOpenSettings: () -> Void
 
+    /// Tracks sub-phase within the observation step (step 4).
+    enum ObservationPhase {
+        case pitch
+        case session
+        case summary
+    }
+    @State private var observationPhase: ObservationPhase = .pitch
+
     /// Shared SpriteKit scene for the egg/hatch animation across steps 0-1.
     @State private var eggScene: EggHatchScene = {
         let s = EggHatchScene()
@@ -70,9 +78,7 @@ struct FirstMeetingFlowView: View {
                         case 3:
                             CapabilitiesBriefingView(state: state, onComplete: { state.advance() })
                         case 4:
-                            Text("Observation mode — coming soon")
-                                .font(VFont.headline)
-                                .foregroundColor(VColor.textPrimary)
+                            observationStep
                         default:
                             EmptyView()
                         }
@@ -83,7 +89,7 @@ struct FirstMeetingFlowView: View {
                             removal: .opacity.combined(with: .offset(y: -8))
                         )
                     )
-                    .id(state.currentStep)
+                    .id("\(state.currentStep)-\(observationPhase)")
 
                     OnboardingProgressDots(currentStep: state.currentStep)
                         .padding(.top, VSpacing.xs)
@@ -111,6 +117,55 @@ struct FirstMeetingFlowView: View {
             .padding(.vertical, VSpacing.xxxl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Observation Step
+
+    @ViewBuilder
+    private var observationStep: some View {
+        switch observationPhase {
+        case .pitch:
+            ObservationModeView(
+                state: state,
+                onStartObserving: {
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        observationPhase = .session
+                    }
+                },
+                onSkip: {
+                    completeOnboarding()
+                }
+            )
+        case .session:
+            ObservationSessionView(
+                state: state,
+                onComplete: {
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        observationPhase = .summary
+                    }
+                },
+                onStopEarly: {
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        observationPhase = .summary
+                    }
+                }
+            )
+        case .summary:
+            ObservationSummaryView(
+                state: state,
+                onAccept: {
+                    completeOnboarding()
+                },
+                onDecline: {
+                    completeOnboarding()
+                }
+            )
+        }
+    }
+
+    private func completeOnboarding() {
+        state.observationCompleted = true
+        onComplete()
     }
 
     // MARK: - Mock Chrome

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationModeView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Observation mode pitch view — step 4 of the first meeting flow.
+/// Proposes that the assistant observe the user working for a few minutes
+/// before offering autonomous help.
+@MainActor
+struct ObservationModeView: View {
+    @Bindable var state: OnboardingState
+    var onStartObserving: () -> Void
+    var onSkip: () -> Void
+
+    @State private var pitchDone = false
+    @State private var showDurationPicker = false
+    @State private var showButtons = false
+    @State private var selectedMinutes: Int = 5
+
+    private var pitchText: String {
+        let task = state.firstTaskCandidate ?? "getting things done"
+        return "You mentioned \(task). I can definitely help with that. But since we just met, can I ride along while you do it for a few minutes first? Like \(selectedMinutes) minutes \u{2014} I\u{2019}ll watch and learn how you work, then I\u{2019}ll know how to actually help the way you\u{2019}d want."
+    }
+
+    private let durationOptions = [3, 5, 10]
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.xxxl) {
+            CreatureView(visible: true, animated: false)
+                .scaleEffect(0.5)
+                .frame(width: 200, height: 200)
+
+            OnboardingPanel {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    TypewriterText(
+                        fullText: pitchText,
+                        speed: 0.03,
+                        font: VFont.body,
+                        onComplete: {
+                            pitchDone = true
+                            withAnimation(.easeOut(duration: 0.4)) {
+                                showDurationPicker = true
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                withAnimation(.easeOut(duration: 0.5)) {
+                                    showButtons = true
+                                }
+                            }
+                        }
+                    )
+
+                    // Duration selector
+                    if showDurationPicker {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            Text("\(selectedMinutes) minutes okay?")
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textSecondary)
+
+                            HStack(spacing: VSpacing.sm) {
+                                ForEach(durationOptions, id: \.self) { minutes in
+                                    durationChip(minutes)
+                                }
+                            }
+                        }
+                        .transition(.opacity.combined(with: .offset(y: 6)))
+                    }
+
+                    // Action buttons
+                    if showButtons {
+                        VStack(spacing: VSpacing.md) {
+                            OnboardingButton(
+                                title: "Start observing",
+                                style: .primary,
+                                fadeIn: true,
+                                fadeDelay: 0.1
+                            ) {
+                                state.observationDurationMinutes = selectedMinutes
+                                onStartObserving()
+                            }
+
+                            OnboardingButton(
+                                title: "Skip for now",
+                                style: .ghost,
+                                fadeIn: true,
+                                fadeDelay: 0.3
+                            ) {
+                                onSkip()
+                            }
+                        }
+                        .transition(.opacity.combined(with: .offset(y: 8)))
+                    }
+                }
+            }
+            .frame(maxWidth: 420)
+        }
+    }
+
+    private func durationChip(_ minutes: Int) -> some View {
+        Button {
+            withAnimation(VAnimation.fast) {
+                selectedMinutes = minutes
+            }
+        } label: {
+            Text("\(minutes) min")
+                .font(VFont.captionMedium)
+                .foregroundColor(
+                    minutes == selectedMinutes
+                        ? VColor.textPrimary
+                        : VColor.textSecondary
+                )
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(
+                            minutes == selectedMinutes
+                                ? VColor.accent.opacity(0.3)
+                                : VColor.surface
+                        )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(
+                            minutes == selectedMinutes
+                                ? VColor.accent.opacity(0.6)
+                                : VColor.surfaceBorder.opacity(0.5),
+                            lineWidth: 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        ObservationModeView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 4
+                s.assistantName = "Velly"
+                s.firstTaskCandidate = "organizing my project files"
+                return s
+            }(),
+            onStartObserving: {},
+            onSkip: {}
+        )
+    }
+    .frame(width: 1366, height: 849)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+
+/// Active observation session view — shows a timer countdown and running narration
+/// of what the assistant "sees" while observing the user work.
+/// Screen capture is stubbed; narration uses placeholder messages.
+@MainActor
+struct ObservationSessionView: View {
+    @Bindable var state: OnboardingState
+    var onComplete: () -> Void
+    var onStopEarly: () -> Void
+
+    @State private var remainingSeconds: Int = 0
+    @State private var totalSeconds: Int = 0
+    @State private var timer: Timer?
+    @State private var narrationMessages: [InterviewMessage] = []
+    @State private var narrationIndex: Int = 0
+
+    /// Stub narration messages that simulate the assistant describing what it sees.
+    private static let stubNarrations: [String] = [
+        "Okay, I\u{2019}m watching\u{2026} I see you have a few apps open. Interesting workflow.",
+        "You seem to switch between your browser and editor a lot \u{2014} I can help streamline that.",
+        "I notice you tend to organize things in a specific way. I\u{2019}ll remember that.",
+        "Got it \u{2014} you like to keep things tidy. I can work with that style.",
+        "Almost done! I\u{2019}m getting a good picture of how you work.",
+    ]
+
+    private var progress: Double {
+        guard totalSeconds > 0 else { return 0 }
+        return 1.0 - (Double(remainingSeconds) / Double(totalSeconds))
+    }
+
+    private var timeDisplay: String {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.xxxl) {
+            // Creature on the left with "watching" indicator
+            VStack(spacing: VSpacing.md) {
+                CreatureView(visible: true, animated: false)
+                    .scaleEffect(0.5)
+                    .frame(width: 200, height: 200)
+
+                HStack(spacing: VSpacing.xs) {
+                    Circle()
+                        .fill(VColor.success)
+                        .frame(width: 8, height: 8)
+                        .opacity(pulseOpacity)
+
+                    Text("Observing")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.success)
+                }
+            }
+
+            OnboardingPanel {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Timer header
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                            Text("Observation in progress")
+                                .font(VFont.headline)
+                                .foregroundColor(VColor.textPrimary)
+
+                            Text("\(timeDisplay) remaining")
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+
+                        Spacer()
+
+                        // Circular progress indicator
+                        ZStack {
+                            Circle()
+                                .stroke(VColor.surfaceBorder, lineWidth: 3)
+                                .frame(width: 40, height: 40)
+
+                            Circle()
+                                .trim(from: 0, to: progress)
+                                .stroke(VColor.accent, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                                .frame(width: 40, height: 40)
+                                .rotationEffect(.degrees(-90))
+                                .animation(VAnimation.standard, value: progress)
+
+                            Image(systemName: "eye")
+                                .font(.system(size: 14))
+                                .foregroundColor(VColor.accent)
+                        }
+                    }
+
+                    // Progress bar
+                    GeometryReader { geometry in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: VRadius.xs)
+                                .fill(VColor.surfaceBorder)
+                                .frame(height: 4)
+
+                            RoundedRectangle(cornerRadius: VRadius.xs)
+                                .fill(VColor.accent)
+                                .frame(width: geometry.size.width * progress, height: 4)
+                                .animation(VAnimation.standard, value: progress)
+                        }
+                    }
+                    .frame(height: 4)
+
+                    // Narration messages
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            LazyVStack(spacing: VSpacing.md) {
+                                ForEach(narrationMessages) { message in
+                                    NarrationBubble(text: message.text)
+                                        .id(message.id)
+                                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                }
+                            }
+                            .padding(.vertical, VSpacing.xs)
+                        }
+                        .frame(maxHeight: 200)
+                        .onChange(of: narrationMessages.count) {
+                            withAnimation(VAnimation.standard) {
+                                if let last = narrationMessages.last {
+                                    proxy.scrollTo(last.id, anchor: .bottom)
+                                }
+                            }
+                        }
+                    }
+
+                    // Stop early button
+                    OnboardingButton(
+                        title: "Stop early",
+                        style: .ghost
+                    ) {
+                        stopObservation()
+                        onStopEarly()
+                    }
+                }
+            }
+            .frame(maxWidth: 420)
+        }
+        .onAppear {
+            startObservation()
+        }
+        .onDisappear {
+            timer?.invalidate()
+        }
+    }
+
+    // MARK: - Pulse Animation
+
+    @State private var pulseOpacity: Double = 1.0
+
+    private func startPulse() {
+        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+            pulseOpacity = 0.3
+        }
+    }
+
+    // MARK: - Observation Logic
+
+    private func startObservation() {
+        let minutes = state.observationDurationMinutes
+        totalSeconds = minutes * 60
+        remainingSeconds = totalSeconds
+
+        startPulse()
+
+        // Add initial narration after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            addNextNarration()
+        }
+
+        // Start countdown timer
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            if remainingSeconds > 0 {
+                remainingSeconds -= 1
+            } else {
+                stopObservation()
+                onComplete()
+            }
+        }
+
+        // Schedule narration messages at intervals
+        let narrationInterval = max(Double(totalSeconds) / Double(Self.stubNarrations.count), 15.0)
+        for i in 1..<Self.stubNarrations.count {
+            DispatchQueue.main.asyncAfter(deadline: .now() + narrationInterval * Double(i) + 2.0) {
+                addNextNarration()
+            }
+        }
+    }
+
+    private func addNextNarration() {
+        guard narrationIndex < Self.stubNarrations.count else { return }
+        let text = Self.stubNarrations[narrationIndex]
+        narrationIndex += 1
+
+        withAnimation(VAnimation.standard) {
+            narrationMessages.append(
+                InterviewMessage(role: .assistant, text: text)
+            )
+        }
+
+        // Store as observation insight
+        state.observationInsights.append(text)
+    }
+
+    private func stopObservation() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+// MARK: - Narration Bubble
+
+private struct NarrationBubble: View {
+    let text: String
+
+    var body: some View {
+        HStack {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "eye")
+                    .font(.system(size: 11))
+                    .foregroundColor(VColor.accent)
+
+                Text(text)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surface.opacity(0.5))
+            )
+
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        ObservationSessionView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 4
+                s.assistantName = "Velly"
+                s.observationDurationMinutes = 1
+                return s
+            }(),
+            onComplete: {},
+            onStopEarly: {}
+        )
+    }
+    .frame(width: 1366, height: 849)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSummaryView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+/// Post-observation summary view — shown after the observation session completes.
+/// Displays key observations and proposes a first autonomous action.
+@MainActor
+struct ObservationSummaryView: View {
+    @Bindable var state: OnboardingState
+    var onAccept: () -> Void
+    var onDecline: () -> Void
+
+    @State private var summaryDone = false
+    @State private var showInsights = false
+    @State private var showProposal = false
+    @State private var showButtons = false
+
+    private let summaryText = "Okay, I think I\u{2019}ve got a good read on how you work. Here\u{2019}s what I noticed:"
+
+    /// Stub observations — in production these would come from ambient analysis.
+    private var displayInsights: [String] {
+        if state.observationInsights.isEmpty {
+            return [
+                "You switch between apps frequently \u{2014} I can help keep context across windows.",
+                "You tend to organize files methodically \u{2014} I\u{2019}ll match that style.",
+                "You like keyboard shortcuts \u{2014} I\u{2019}ll suggest efficient workflows.",
+            ]
+        }
+        // Use a curated subset of the collected insights
+        return Array(state.observationInsights.prefix(3))
+    }
+
+    private var proposalText: String {
+        let task = state.firstTaskCandidate ?? "your next task"
+        return "Based on what I saw, I think I could help with \(task) right away. Want me to give it a try?"
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.xxxl) {
+            CreatureView(visible: true, animated: false)
+                .scaleEffect(0.5)
+                .frame(width: 200, height: 200)
+
+            OnboardingPanel {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Summary introduction
+                    TypewriterText(
+                        fullText: summaryText,
+                        speed: 0.03,
+                        font: VFont.body,
+                        onComplete: {
+                            summaryDone = true
+                            withAnimation(.easeOut(duration: 0.4)) {
+                                showInsights = true
+                            }
+                        }
+                    )
+
+                    // Key observations
+                    if showInsights {
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            ForEach(Array(displayInsights.enumerated()), id: \.offset) { index, insight in
+                                InsightRow(text: insight, index: index)
+                                    .transition(.opacity.combined(with: .offset(y: 6)))
+                            }
+                        }
+                        .transition(.opacity.combined(with: .offset(y: 6)))
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                                withAnimation(.easeOut(duration: 0.4)) {
+                                    showProposal = true
+                                }
+                            }
+                        }
+                    }
+
+                    // Proposal
+                    if showProposal {
+                        Text(proposalText)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                            .transition(.opacity.combined(with: .offset(y: 6)))
+                            .onAppear {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                    withAnimation(.easeOut(duration: 0.5)) {
+                                        showButtons = true
+                                    }
+                                }
+                            }
+                    }
+
+                    // Action buttons
+                    if showButtons {
+                        VStack(spacing: VSpacing.md) {
+                            OnboardingButton(
+                                title: "Let\u{2019}s try it",
+                                style: .primary,
+                                fadeIn: true,
+                                fadeDelay: 0.1
+                            ) {
+                                state.observationCompleted = true
+                                onAccept()
+                            }
+
+                            OnboardingButton(
+                                title: "Maybe later",
+                                style: .ghost,
+                                fadeIn: true,
+                                fadeDelay: 0.3
+                            ) {
+                                state.observationCompleted = true
+                                onDecline()
+                            }
+                        }
+                        .transition(.opacity.combined(with: .offset(y: 8)))
+                    }
+                }
+            }
+            .frame(maxWidth: 420)
+        }
+    }
+}
+
+// MARK: - Insight Row
+
+private struct InsightRow: View {
+    let text: String
+    let index: Int
+
+    @State private var appeared = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: "sparkle")
+                .font(.system(size: 12))
+                .foregroundColor(VColor.accent)
+                .padding(.top, 2)
+
+            Text(text)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+        }
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 4)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(index) * 0.2) {
+                withAnimation(.easeOut(duration: 0.4)) {
+                    appeared = true
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        MeadowBackground()
+        ObservationSummaryView(
+            state: {
+                let s = OnboardingState()
+                s.currentStep = 4
+                s.assistantName = "Velly"
+                s.firstTaskCandidate = "organizing my project files"
+                s.observationInsights = [
+                    "You switch between VS Code and Terminal frequently.",
+                    "You organize files into clearly named directories.",
+                    "You prefer keyboard shortcuts over mouse clicks.",
+                ]
+                return s
+            }(),
+            onAccept: {},
+            onDecline: {}
+        )
+    }
+    .frame(width: 1366, height: 849)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -39,6 +39,8 @@ final class OnboardingState {
     var capabilitiesBriefingShown: Bool = false
     var observationCompleted: Bool = false
     var firstTaskCandidate: String? = nil
+    var observationDurationMinutes: Int = 5
+    var observationInsights: [String] = []
 
     var anyPermissionDenied: Bool {
         !speechGranted || !accessibilityGranted || !screenGranted


### PR DESCRIPTION
## Summary
- Create three new observation mode views (ObservationModeView, ObservationSessionView, ObservationSummaryView) as step 4 of the First Meeting onboarding flow
- Wire the observation sub-flow into FirstMeetingFlowView with pitch -> session -> summary phase transitions
- Add `observationDurationMinutes` and `observationInsights` properties to OnboardingState

Closes #1346

## Test plan
- [ ] Verify ObservationModeView displays the pitch message with the user's first task candidate
- [ ] Verify duration selector chips (3/5/10 min) toggle correctly
- [ ] Verify "Start observing" transitions to ObservationSessionView
- [ ] Verify "Skip for now" completes onboarding without observation
- [ ] Verify ObservationSessionView shows timer countdown and narration bubbles
- [ ] Verify "Stop early" transitions to ObservationSummaryView
- [ ] Verify ObservationSummaryView displays insights and proposal
- [ ] Verify both "Let's try it" and "Maybe later" set observationCompleted and complete onboarding
- [ ] Verify all Previews render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
