### PR TITLE
Add Qdrant vector store and local embedding backend

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@google/genai": "^1.40.0",
+        "@huggingface/transformers": "^3.8.1",
+        "@qdrant/js-client-rest": "^1.16.2",
         "@sentry/node": "^10.38.0",
         "commander": "^13.1.0",
         "drizzle-orm": "^0.38.4",
@@ -41,6 +43,8 @@
     "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.3.1", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.8.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -108,6 +112,10 @@
 
     "@google/genai": ["@google/genai@1.40.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-fhIww8smT0QYRX78qWOiz/nIQhHMF5wXOrlXvj33HBrz3vKDBb+wibLcEmTA+L9dmPD4KmfNr7UF3LDQVTXNjA=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -116,11 +124,63 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -214,6 +274,10 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
+    "@qdrant/js-client-rest": ["@qdrant/js-client-rest@1.16.2", "", { "dependencies": { "@qdrant/openapi-typescript-fetch": "1.2.6", "undici": "^6.0.0" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-Zm4wEZURrZ24a+Hmm4l1QQYjiz975Ep3vF0yzWR7ICGcxittNz47YK2iBOk8kb8qseCu8pg7WmO1HOIsO8alvw=="],
+
+    "@qdrant/openapi-typescript-fetch": ["@qdrant/openapi-typescript-fetch@1.2.6", "", {}, "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA=="],
+
     "@sentry/core": ["@sentry/core@10.38.0", "", {}, "sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g=="],
 
     "@sentry/node": ["@sentry/node@10.38.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^2.5.0", "@opentelemetry/core": "^2.5.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/instrumentation-amqplib": "0.58.0", "@opentelemetry/instrumentation-connect": "0.54.0", "@opentelemetry/instrumentation-dataloader": "0.28.0", "@opentelemetry/instrumentation-express": "0.59.0", "@opentelemetry/instrumentation-fs": "0.30.0", "@opentelemetry/instrumentation-generic-pool": "0.54.0", "@opentelemetry/instrumentation-graphql": "0.58.0", "@opentelemetry/instrumentation-hapi": "0.57.0", "@opentelemetry/instrumentation-http": "0.211.0", "@opentelemetry/instrumentation-ioredis": "0.59.0", "@opentelemetry/instrumentation-kafkajs": "0.20.0", "@opentelemetry/instrumentation-knex": "0.55.0", "@opentelemetry/instrumentation-koa": "0.59.0", "@opentelemetry/instrumentation-lru-memoizer": "0.55.0", "@opentelemetry/instrumentation-mongodb": "0.64.0", "@opentelemetry/instrumentation-mongoose": "0.57.0", "@opentelemetry/instrumentation-mysql": "0.57.0", "@opentelemetry/instrumentation-mysql2": "0.57.0", "@opentelemetry/instrumentation-pg": "0.63.0", "@opentelemetry/instrumentation-redis": "0.59.0", "@opentelemetry/instrumentation-tedious": "0.30.0", "@opentelemetry/instrumentation-undici": "0.21.0", "@opentelemetry/resources": "^2.5.0", "@opentelemetry/sdk-trace-base": "^2.5.0", "@opentelemetry/semantic-conventions": "^1.39.0", "@prisma/instrumentation": "7.2.0", "@sentry/core": "10.38.0", "@sentry/node-core": "10.38.0", "@sentry/opentelemetry": "10.38.0", "import-in-the-middle": "^2.0.6", "minimatch": "^9.0.0" } }, "sha512-wriyDtWDAoatn8EhOj0U4PJR1WufiijTsCGALqakOHbFiadtBJANLe6aSkXoXT4tegw59cz1wY4NlzHjYksaPw=="],
@@ -294,6 +358,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
@@ -303,6 +369,8 @@
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
@@ -326,7 +394,15 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
@@ -351,6 +427,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
@@ -400,6 +478,8 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -434,6 +514,10 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
     "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -441,6 +525,10 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -480,6 +568,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
@@ -494,6 +584,8 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -505,6 +597,8 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -520,9 +614,17 @@
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
 
     "openai": ["openai@6.18.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw=="],
 
@@ -555,6 +657,8 @@
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
@@ -592,6 +696,8 @@
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
@@ -599,6 +705,12 @@
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -616,6 +728,8 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -625,6 +739,8 @@
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "tar": ["tar@7.5.7", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
@@ -636,11 +752,17 @@
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.54.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.54.0", "@typescript-eslint/parser": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0", "@typescript-eslint/utils": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ=="],
+
+    "undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -669,6 +791,8 @@
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -703,6 +827,8 @@
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@google/genai": "^1.40.0",
+    "@huggingface/transformers": "^3.8.1",
+    "@qdrant/js-client-rest": "^1.16.2",
     "@sentry/node": "^10.38.0",
     "commander": "^13.1.0",
     "drizzle-orm": "^0.38.4",

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -24,14 +24,22 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     embeddings: {
       required: true,
       provider: 'auto',
+      localModel: 'Xenova/bge-small-en-v1.5',
       openaiModel: 'text-embedding-3-small',
       geminiModel: 'gemini-embedding-001',
       ollamaModel: 'nomic-embed-text',
     },
+    qdrant: {
+      url: 'http://127.0.0.1:6333',
+      collection: 'memory',
+      vectorSize: 384,
+      onDisk: true,
+      quantization: 'scalar',
+    },
     retrieval: {
       lexicalTopK: 80,
       semanticTopK: 40,
-      maxInjectTokens: 1800,
+      maxInjectTokens: 10000,
     },
     segmentation: {
       targetTokens: 450,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,7 +3,7 @@ import { getDataDir } from '../util/platform.js';
 
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
-const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'openai', 'gemini', 'ollama'] as const;
+const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -123,6 +123,9 @@ export const MemoryEmbeddingsConfigSchema = z.object({
       error: `memory.embeddings.provider must be one of: ${VALID_MEMORY_EMBEDDING_PROVIDERS.join(', ')}`,
     })
     .default('auto'),
+  localModel: z
+    .string({ error: 'memory.embeddings.localModel must be a string' })
+    .default('Xenova/bge-small-en-v1.5'),
   openaiModel: z
     .string({ error: 'memory.embeddings.openaiModel must be a string' })
     .default('text-embedding-3-small'),
@@ -132,6 +135,30 @@ export const MemoryEmbeddingsConfigSchema = z.object({
   ollamaModel: z
     .string({ error: 'memory.embeddings.ollamaModel must be a string' })
     .default('nomic-embed-text'),
+});
+
+const VALID_QDRANT_QUANTIZATION = ['scalar', 'none'] as const;
+
+export const QdrantConfigSchema = z.object({
+  url: z
+    .string({ error: 'memory.qdrant.url must be a string' })
+    .default('http://127.0.0.1:6333'),
+  collection: z
+    .string({ error: 'memory.qdrant.collection must be a string' })
+    .default('memory'),
+  vectorSize: z
+    .number({ error: 'memory.qdrant.vectorSize must be a number' })
+    .int('memory.qdrant.vectorSize must be an integer')
+    .positive('memory.qdrant.vectorSize must be a positive integer')
+    .default(384),
+  onDisk: z
+    .boolean({ error: 'memory.qdrant.onDisk must be a boolean' })
+    .default(true),
+  quantization: z
+    .enum(VALID_QDRANT_QUANTIZATION, {
+      error: `memory.qdrant.quantization must be one of: ${VALID_QDRANT_QUANTIZATION.join(', ')}`,
+    })
+    .default('scalar'),
 });
 
 export const MemoryRetrievalConfigSchema = z.object({
@@ -186,14 +213,22 @@ export const MemoryConfigSchema = z.object({
   embeddings: MemoryEmbeddingsConfigSchema.default({
     required: true,
     provider: 'auto',
+    localModel: 'Xenova/bge-small-en-v1.5',
     openaiModel: 'text-embedding-3-small',
     geminiModel: 'gemini-embedding-001',
     ollamaModel: 'nomic-embed-text',
   }),
+  qdrant: QdrantConfigSchema.default({
+    url: 'http://127.0.0.1:6333',
+    collection: 'memory',
+    vectorSize: 384,
+    onDisk: true,
+    quantization: 'scalar',
+  }),
   retrieval: MemoryRetrievalConfigSchema.default({
     lexicalTopK: 80,
     semanticTopK: 40,
-    maxInjectTokens: 1800,
+    maxInjectTokens: 10000,
   }),
   segmentation: MemorySegmentationConfigSchema.default({
     targetTokens: 450,
@@ -256,14 +291,22 @@ export const AssistantConfigSchema = z.object({
     embeddings: {
       required: true,
       provider: 'auto',
+      localModel: 'Xenova/bge-small-en-v1.5',
       openaiModel: 'text-embedding-3-small',
       geminiModel: 'gemini-embedding-001',
       ollamaModel: 'nomic-embed-text',
     },
+    qdrant: {
+      url: 'http://127.0.0.1:6333',
+      collection: 'memory',
+      vectorSize: 384,
+      onDisk: true,
+      quantization: 'scalar',
+    },
     retrieval: {
       lexicalTopK: 80,
       semanticTopK: 40,
-      maxInjectTokens: 1800,
+      maxInjectTokens: 10000,
     },
     segmentation: {
       targetTokens: 450,
@@ -333,4 +376,5 @@ export type MemorySegmentationConfig = z.infer<typeof MemorySegmentationConfigSc
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
+export type QdrantConfig = z.infer<typeof QdrantConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -14,4 +14,5 @@ export type {
   MemoryRetentionConfig,
   MemoryConfig,
   ModelPricingOverride,
+  QdrantConfig,
 } from './schema.js';

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,6 +18,8 @@ import { DaemonServer } from './server.js';
 import { getLogger } from '../util/logger.js';
 import { DaemonError } from '../util/errors.js';
 import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
+import { QdrantManager } from '../memory/qdrant-manager.js';
+import { initQdrantClient } from '../memory/qdrant-client.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 
@@ -175,6 +177,25 @@ export async function runDaemon(): Promise<void> {
   initializeProviders(config);
   await initializeTools();
 
+  // Initialize Qdrant vector store
+  const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
+  const qdrantManager = new QdrantManager({
+    url: qdrantUrl,
+  });
+  try {
+    await qdrantManager.start();
+    initQdrantClient({
+      url: qdrantUrl,
+      collection: config.memory.qdrant.collection,
+      vectorSize: config.memory.qdrant.vectorSize,
+      onDisk: config.memory.qdrant.onDisk,
+      quantization: config.memory.qdrant.quantization,
+    });
+    log.info('Qdrant vector store initialized');
+  } catch (err) {
+    log.warn({ err }, 'Failed to initialize Qdrant vector store, memory semantic search will be degraded');
+  }
+
   const server = new DaemonServer();
   await server.start();
   const memoryWorker = startMemoryJobsWorker();
@@ -235,6 +256,7 @@ export async function runDaemon(): Promise<void> {
     if (runtimeHttp) await runtimeHttp.stop();
     await browserManager.closeAllPages();
     memoryWorker.stop();
+    await qdrantManager.stop();
     await Sentry.flush(2000);
     cleanupPidFile();
     process.exit(0);

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -1,12 +1,13 @@
 import type { AssistantConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { GeminiEmbeddingBackend } from './embedding-gemini.js';
+import { LocalEmbeddingBackend } from './embedding-local.js';
 import { OllamaEmbeddingBackend } from './embedding-ollama.js';
 import { OpenAIEmbeddingBackend } from './embedding-openai.js';
 
 const log = getLogger('memory-embeddings');
 
-export type EmbeddingProviderName = 'openai' | 'gemini' | 'ollama';
+export type EmbeddingProviderName = 'local' | 'openai' | 'gemini' | 'ollama';
 
 export interface EmbeddingRequestOptions {
   signal?: AbortSignal;
@@ -25,6 +26,12 @@ export interface EmbeddingBackendSelection {
 
 export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBackendSelection {
   const requested = config.memory.embeddings.provider;
+  if (requested === 'local') {
+    return {
+      backend: new LocalEmbeddingBackend(config.memory.embeddings.localModel),
+      reason: null,
+    };
+  }
   if (requested === 'ollama') {
     return {
       backend: new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
@@ -33,12 +40,20 @@ export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBacken
       reason: null,
     };
   }
+
+  // Auto order: local → openai → gemini → ollama
   const order: EmbeddingProviderName[] = requested === 'auto'
-    ? ['openai', 'gemini', 'ollama']
+    ? ['local', 'openai', 'gemini', 'ollama']
     : [requested];
 
   for (const provider of order) {
     switch (provider) {
+      case 'local':
+        // Local embeddings are always available (model downloaded on first use)
+        return {
+          backend: new LocalEmbeddingBackend(config.memory.embeddings.localModel),
+          reason: null,
+        };
       case 'openai':
         if (!config.apiKeys.openai) continue;
         return {
@@ -63,7 +78,7 @@ export function selectEmbeddingBackend(config: AssistantConfig): EmbeddingBacken
   }
 
   const reason = requested === 'auto'
-    ? 'No embedding backend configured (openai/gemini keys missing and ollama not configured)'
+    ? 'No embedding backend configured'
     : `Embedding backend "${requested}" is not configured`;
   return { backend: null, reason };
 }

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -1,0 +1,75 @@
+import type { EmbeddingBackend, EmbeddingRequestOptions } from './embedding-backend.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('memory-embedding-local');
+
+type FeatureExtractionPipeline = (
+  texts: string | string[],
+  options?: { pooling?: string; normalize?: boolean },
+) => Promise<{ tolist: () => number[][] }>;
+
+/**
+ * Local embedding backend using @huggingface/transformers (ONNX Runtime).
+ * Runs BAAI/bge-small-en-v1.5 locally — no API calls, no network required.
+ *
+ * The model is downloaded on first use and cached by the transformers library.
+ * Produces 384-dimensional embeddings.
+ */
+export class LocalEmbeddingBackend implements EmbeddingBackend {
+  readonly provider = 'local' as const;
+  readonly model: string;
+  private extractor: FeatureExtractionPipeline | null = null;
+  private initPromise: Promise<void> | null = null;
+
+  constructor(model: string) {
+    this.model = model;
+  }
+
+  async embed(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    if (options?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+
+    await this.ensureInitialized();
+
+    const results: number[][] = [];
+    // Process in batches of 32 to avoid OOM with large inputs
+    const batchSize = 32;
+    for (let i = 0; i < texts.length; i += batchSize) {
+      if (options?.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      const batch = texts.slice(i, i + batchSize);
+      const output = await this.extractor!(batch, {
+        pooling: 'cls',
+        normalize: true,
+      });
+      const vectors = output.tolist();
+      results.push(...vectors);
+    }
+
+    return results;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.extractor) return;
+    if (this.initPromise) {
+      await this.initPromise;
+      return;
+    }
+
+    this.initPromise = this.initialize();
+    try {
+      await this.initPromise;
+    } catch (err) {
+      this.initPromise = null;
+      throw err;
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    log.info({ model: this.model }, 'Loading local embedding model (first load downloads the model)');
+    const { pipeline } = await import('@huggingface/transformers');
+    this.extractor = await pipeline('feature-extraction', this.model, {
+      dtype: 'fp32',
+    }) as unknown as FeatureExtractionPipeline;
+    log.info({ model: this.model }, 'Local embedding model loaded');
+  }
+}

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -17,6 +17,7 @@ import {
 } from './jobs-store.js';
 import { indexMessageNow } from './indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
+import { getQdrantClient } from './qdrant-client.js';
 import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries, messages } from './schema.js';
 
 const log = getLogger('memory-jobs-worker');
@@ -120,12 +121,21 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
   }
 }
 
-async function embedSegmentJob(job: MemoryJob, _config: AssistantConfig): Promise<void> {
+async function embedSegmentJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
   const segmentId = asString(job.payload.segmentId);
   if (!segmentId) return;
-  // Segment embeddings are intentionally disabled: retrieval only consumes
-  // semantic vectors for items and summaries.
-  log.debug({ segmentId }, 'Skipping segment embedding job');
+  const db = getDb();
+  const segment = db
+    .select()
+    .from(memorySegments)
+    .where(eq(memorySegments.id, segmentId))
+    .get();
+  if (!segment) return;
+  await embedAndUpsert(config, 'segment', segment.id, segment.text, {
+    conversation_id: segment.conversationId,
+    message_id: segment.messageId,
+    created_at: segment.createdAt,
+  });
 }
 
 async function embedItemJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
@@ -139,7 +149,14 @@ async function embedItemJob(job: MemoryJob, config: AssistantConfig): Promise<vo
     .get();
   if (!item || item.status !== 'active') return;
   const text = `[${item.kind}] ${item.subject}: ${item.statement}`;
-  await embedAndUpsert(config, 'item', item.id, text);
+  await embedAndUpsert(config, 'item', item.id, text, {
+    kind: item.kind,
+    subject: item.subject,
+    status: item.status,
+    confidence: item.confidence,
+    created_at: item.firstSeenAt,
+    last_seen_at: item.lastSeenAt,
+  });
 }
 
 async function embedSummaryJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
@@ -152,7 +169,11 @@ async function embedSummaryJob(job: MemoryJob, config: AssistantConfig): Promise
     .where(eq(memorySummaries.id, summaryId))
     .get();
   if (!summary) return;
-  await embedAndUpsert(config, 'summary', summary.id, `[${summary.scope}] ${summary.summary}`);
+  await embedAndUpsert(config, 'summary', summary.id, `[${summary.scope}] ${summary.summary}`, {
+    kind: summary.scope,
+    created_at: summary.startAt,
+    last_seen_at: summary.endAt,
+  });
 }
 
 function extractItemsJob(job: MemoryJob): void {
@@ -350,6 +371,7 @@ async function embedAndUpsert(
   targetType: 'segment' | 'item' | 'summary',
   targetId: string,
   text: string,
+  extraPayload?: Record<string, unknown>,
 ): Promise<void> {
   const status = getMemoryBackendStatus(config);
   if (!status.provider) {
@@ -364,42 +386,17 @@ async function embedAndUpsert(
   const vector = embedded.vectors[0];
   if (!vector) return;
 
-  const db = getDb();
-  const now = Date.now();
-  const existing = db
-    .select()
-    .from(memoryEmbeddings)
-    .where(and(
-      eq(memoryEmbeddings.targetType, targetType),
-      eq(memoryEmbeddings.targetId, targetId),
-      eq(memoryEmbeddings.provider, embedded.provider),
-      eq(memoryEmbeddings.model, embedded.model),
-    ))
-    .get();
-
-  if (existing) {
-    db.update(memoryEmbeddings)
-      .set({
-        dimensions: vector.length,
-        vectorJson: JSON.stringify(vector),
-        updatedAt: now,
-      })
-      .where(eq(memoryEmbeddings.id, existing.id))
-      .run();
-    return;
+  try {
+    const qdrant = getQdrantClient();
+    const now = Date.now();
+    await qdrant.upsert(targetType, targetId, vector, {
+      text,
+      created_at: (extraPayload?.created_at as number) ?? now,
+      ...(extraPayload as Record<string, unknown> | undefined),
+    });
+  } catch (err) {
+    log.warn({ err, targetType, targetId }, 'Failed to upsert embedding to Qdrant');
   }
-
-  db.insert(memoryEmbeddings).values({
-    id: uuid(),
-    targetType,
-    targetId,
-    provider: embedded.provider,
-    model: embedded.model,
-    dimensions: vector.length,
-    vectorJson: JSON.stringify(vector),
-    createdAt: now,
-    updatedAt: now,
-  }).run();
 }
 
 function asString(value: unknown): string | null {

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -1,0 +1,269 @@
+import { QdrantClient as QdrantRestClient } from '@qdrant/js-client-rest';
+import { v4 as uuid } from 'uuid';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('qdrant-client');
+
+export interface QdrantClientConfig {
+  url: string;
+  collection: string;
+  vectorSize: number;
+  onDisk: boolean;
+  quantization: 'scalar' | 'none';
+}
+
+export interface QdrantPointPayload {
+  target_type: 'segment' | 'item' | 'summary';
+  target_id: string;
+  text: string;
+  kind?: string;
+  subject?: string;
+  status?: string;
+  importance?: number;
+  confidence?: number;
+  created_at: number;
+  last_seen_at?: number;
+  conversation_id?: string;
+  message_id?: string;
+  entity_ids?: string[];
+}
+
+export interface QdrantSearchResult {
+  id: string;
+  score: number;
+  payload: QdrantPointPayload;
+}
+
+let _instance: VellumQdrantClient | null = null;
+
+export function getQdrantClient(): VellumQdrantClient {
+  if (!_instance) {
+    throw new Error('Qdrant client not initialized. Call initQdrantClient() first.');
+  }
+  return _instance;
+}
+
+export function initQdrantClient(config: QdrantClientConfig): VellumQdrantClient {
+  _instance = new VellumQdrantClient(config);
+  return _instance;
+}
+
+export class VellumQdrantClient {
+  private readonly client: QdrantRestClient;
+  private readonly collection: string;
+  private readonly vectorSize: number;
+  private readonly onDisk: boolean;
+  private readonly quantization: 'scalar' | 'none';
+  private collectionReady = false;
+
+  constructor(config: QdrantClientConfig) {
+    this.client = new QdrantRestClient({ url: config.url });
+    this.collection = config.collection;
+    this.vectorSize = config.vectorSize;
+    this.onDisk = config.onDisk;
+    this.quantization = config.quantization;
+  }
+
+  async ensureCollection(): Promise<void> {
+    if (this.collectionReady) return;
+
+    try {
+      const exists = await this.client.collectionExists(this.collection);
+      if (exists.exists) {
+        this.collectionReady = true;
+        return;
+      }
+    } catch {
+      // Collection doesn't exist, create it
+    }
+
+    log.info({ collection: this.collection, vectorSize: this.vectorSize }, 'Creating Qdrant collection');
+
+    await this.client.createCollection(this.collection, {
+      vectors: {
+        size: this.vectorSize,
+        distance: 'Cosine',
+        on_disk: this.onDisk,
+      },
+      hnsw_config: {
+        on_disk: this.onDisk,
+        m: 16,
+        ef_construct: 100,
+      },
+      quantization_config: this.quantization === 'scalar'
+        ? {
+          scalar: {
+            type: 'int8',
+            quantile: 0.99,
+            always_ram: true,
+          },
+        }
+        : undefined,
+      on_disk_payload: this.onDisk,
+    });
+
+    // Create payload indexes for efficient filtering
+    await Promise.all([
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'target_type',
+        field_schema: 'keyword',
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'target_id',
+        field_schema: 'keyword',
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'kind',
+        field_schema: 'keyword',
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'status',
+        field_schema: 'keyword',
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'created_at',
+        field_schema: 'integer',
+      }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: 'conversation_id',
+        field_schema: 'keyword',
+      }),
+    ]);
+
+    this.collectionReady = true;
+    log.info({ collection: this.collection }, 'Qdrant collection created with payload indexes');
+  }
+
+  async upsert(
+    targetType: 'segment' | 'item' | 'summary',
+    targetId: string,
+    vector: number[],
+    payload: Omit<QdrantPointPayload, 'target_type' | 'target_id'>,
+  ): Promise<string> {
+    await this.ensureCollection();
+
+    // Deterministic point ID: look up existing point by target_type + target_id
+    const existing = await this.findByTarget(targetType, targetId);
+    const pointId = existing ?? uuid();
+
+    await this.client.upsert(this.collection, {
+      wait: true,
+      points: [
+        {
+          id: pointId,
+          vector,
+          payload: {
+            target_type: targetType,
+            target_id: targetId,
+            ...payload,
+          },
+        },
+      ],
+    });
+
+    return pointId;
+  }
+
+  async search(
+    vector: number[],
+    limit: number,
+    filter?: Record<string, unknown>,
+  ): Promise<QdrantSearchResult[]> {
+    await this.ensureCollection();
+
+    const results = await this.client.search(this.collection, {
+      vector,
+      limit,
+      with_payload: true,
+      score_threshold: 0.0,
+      filter: filter as Parameters<QdrantRestClient['search']>[1]['filter'],
+    });
+
+    return results.map((result) => ({
+      id: typeof result.id === 'string' ? result.id : String(result.id),
+      score: result.score,
+      payload: result.payload as unknown as QdrantPointPayload,
+    }));
+  }
+
+  async searchWithFilter(
+    vector: number[],
+    limit: number,
+    targetTypes: Array<'segment' | 'item' | 'summary'>,
+    excludeMessageIds?: string[],
+  ): Promise<QdrantSearchResult[]> {
+    const mustConditions: Array<Record<string, unknown>> = [
+      {
+        key: 'target_type',
+        match: { any: targetTypes },
+      },
+    ];
+
+    if (excludeMessageIds && excludeMessageIds.length > 0) {
+      mustConditions.push({
+        key: 'status',
+        match: { value: 'active' },
+      });
+    }
+
+    const mustNotConditions: Array<Record<string, unknown>> = [];
+    if (excludeMessageIds && excludeMessageIds.length > 0) {
+      mustNotConditions.push({
+        key: 'message_id',
+        match: { any: excludeMessageIds },
+      });
+    }
+
+    const filter: Record<string, unknown> = {
+      must: mustConditions,
+    };
+    if (mustNotConditions.length > 0) {
+      filter.must_not = mustNotConditions;
+    }
+
+    return this.search(vector, limit, filter);
+  }
+
+  async deleteByTarget(targetType: string, targetId: string): Promise<void> {
+    await this.ensureCollection();
+
+    await this.client.delete(this.collection, {
+      wait: true,
+      filter: {
+        must: [
+          { key: 'target_type', match: { value: targetType } },
+          { key: 'target_id', match: { value: targetId } },
+        ],
+      },
+    });
+  }
+
+  async count(): Promise<number> {
+    await this.ensureCollection();
+    const result = await this.client.count(this.collection, { exact: false });
+    return result.count;
+  }
+
+  private async findByTarget(targetType: string, targetId: string): Promise<string | null> {
+    try {
+      const results = await this.client.scroll(this.collection, {
+        filter: {
+          must: [
+            { key: 'target_type', match: { value: targetType } },
+            { key: 'target_id', match: { value: targetId } },
+          ],
+        },
+        limit: 1,
+        with_payload: false,
+        with_vector: false,
+      });
+      if (results.points.length > 0) {
+        const id = results.points[0].id;
+        return typeof id === 'string' ? id : String(id);
+      }
+    } catch {
+      // Not found
+    }
+    return null;
+  }
+}

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -1,0 +1,187 @@
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Subprocess } from 'bun';
+import { getLogger } from '../util/logger.js';
+import { getDataDir } from '../util/platform.js';
+
+const log = getLogger('qdrant-manager');
+
+const READYZ_POLL_INTERVAL_MS = 200;
+const READYZ_TIMEOUT_MS = 30_000;
+const SHUTDOWN_GRACE_MS = 5_000;
+
+export interface QdrantManagerConfig {
+  url: string;
+  storagePath?: string;
+}
+
+/**
+ * Manages the Qdrant sidecar process lifecycle.
+ *
+ * Desktop: spawns ~/.vellum/bin/qdrant as a child process.
+ * K8s / external: connects to an existing Qdrant at the configured URL.
+ *
+ * Detection logic:
+ * - If QDRANT_URL env var is set → external mode (don't spawn)
+ * - If qdrant binary exists at ~/.vellum/bin/qdrant → local spawn mode
+ * - Otherwise → external mode (assume sidecar or remote)
+ */
+export class QdrantManager {
+  private process: Subprocess | null = null;
+  private readonly url: string;
+  private readonly host: string;
+  private readonly port: number;
+  private readonly storagePath: string;
+  private readonly pidPath: string;
+  private readonly isExternal: boolean;
+
+  constructor(config: QdrantManagerConfig) {
+    this.url = config.url;
+    const parsed = new URL(config.url);
+    this.host = parsed.hostname;
+    this.port = parseInt(parsed.port || '6333', 10);
+    this.storagePath = config.storagePath ?? join(getDataDir(), 'data', 'qdrant');
+    this.pidPath = join(getDataDir(), 'qdrant.pid');
+
+    // External mode if QDRANT_URL is explicitly set or no local binary exists
+    const hasEnvUrl = Boolean(process.env.QDRANT_URL?.trim());
+    const localBinaryPath = this.getBinaryPath();
+    this.isExternal = hasEnvUrl || !existsSync(localBinaryPath);
+  }
+
+  async start(): Promise<void> {
+    if (this.isExternal) {
+      log.info({ url: this.url }, 'Qdrant running in external mode, verifying connectivity');
+      await this.waitForReady();
+      return;
+    }
+
+    // Check for stale process
+    this.cleanupStaleProcess();
+
+    const binaryPath = this.getBinaryPath();
+    if (!existsSync(binaryPath)) {
+      throw new Error(
+        `Qdrant binary not found at ${binaryPath}. ` +
+        'Install it or set QDRANT_URL to use an external Qdrant instance.',
+      );
+    }
+
+    log.info({ binaryPath, storagePath: this.storagePath, port: this.port }, 'Starting Qdrant');
+
+    this.process = Bun.spawn({
+      cmd: [binaryPath],
+      env: {
+        ...process.env,
+        QDRANT__SERVICE__HOST: this.host,
+        QDRANT__SERVICE__HTTP_PORT: String(this.port),
+        QDRANT__SERVICE__GRPC_PORT: '0', // disable gRPC
+        QDRANT__TELEMETRY_DISABLED: 'true',
+        QDRANT__STORAGE__STORAGE_PATH: this.storagePath,
+        QDRANT__LOG_LEVEL: 'WARN',
+      },
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+
+    if (this.process.pid) {
+      this.writePid(this.process.pid);
+    }
+
+    try {
+      await this.waitForReady();
+      log.info({ pid: this.process.pid, port: this.port }, 'Qdrant is ready');
+    } catch (err) {
+      // If startup fails, clean up
+      await this.stop();
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.process) {
+      this.cleanupPid();
+      return;
+    }
+
+    log.info('Stopping Qdrant');
+    this.process.kill('SIGTERM');
+
+    // Wait for graceful shutdown
+    const graceful = await Promise.race([
+      this.process.exited.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), SHUTDOWN_GRACE_MS)),
+    ]);
+
+    if (!graceful) {
+      log.warn('Qdrant did not exit gracefully, sending SIGKILL');
+      this.process.kill('SIGKILL');
+      await this.process.exited;
+    }
+
+    this.process = null;
+    this.cleanupPid();
+    log.info('Qdrant stopped');
+  }
+
+  getUrl(): string {
+    return this.url;
+  }
+
+  private async waitForReady(): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < READYZ_TIMEOUT_MS) {
+      try {
+        const res = await fetch(`${this.url}/readyz`);
+        if (res.ok) return;
+      } catch {
+        // Not ready yet
+      }
+      await Bun.sleep(READYZ_POLL_INTERVAL_MS);
+    }
+    throw new Error(`Qdrant did not become ready within ${READYZ_TIMEOUT_MS}ms at ${this.url}`);
+  }
+
+  private getBinaryPath(): string {
+    return join(getDataDir(), 'bin', 'qdrant');
+  }
+
+  private cleanupStaleProcess(): void {
+    const pid = this.readPid();
+    if (pid === null) return;
+
+    try {
+      process.kill(pid, 0); // Check if process exists
+      // Process is still running — kill it
+      log.warn({ pid }, 'Found stale Qdrant process, killing it');
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Process doesn't exist, just clean up PID file
+    }
+    this.cleanupPid();
+  }
+
+  private readPid(): number | null {
+    if (!existsSync(this.pidPath)) return null;
+    try {
+      const pid = parseInt(readFileSync(this.pidPath, 'utf-8').trim(), 10);
+      return isNaN(pid) ? null : pid;
+    } catch {
+      return null;
+    }
+  }
+
+  private writePid(pid: number): void {
+    writeFileSync(this.pidPath, String(pid));
+  }
+
+  private cleanupPid(): void {
+    if (existsSync(this.pidPath)) {
+      try {
+        unlinkSync(this.pidPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -4,7 +4,8 @@ import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
-import { memoryEmbeddings, memoryItems, memoryItemSources, memorySegments, memorySummaries, messages } from './schema.js';
+import { getQdrantClient } from './qdrant-client.js';
+import { memoryItems, memorySegments } from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_MARKER = '[Memory Recall v1]';
@@ -313,132 +314,74 @@ function lexicalSearch(query: string, limit: number, excludedMessageIds: string[
 
 async function semanticSearch(
   queryVector: number[],
-  provider: string,
-  model: string,
+  _provider: string,
+  _model: string,
   limit: number,
   excludedMessageIds: string[] = [],
 ): Promise<Candidate[]> {
   if (limit <= 0) return [];
-  const db = getDb();
-  const excludedMessageSet = new Set(excludedMessageIds);
-  const rows = db
-    .select()
-    .from(memoryEmbeddings)
-    .where(and(
-      eq(memoryEmbeddings.provider, provider),
-      eq(memoryEmbeddings.model, model),
-      inArray(memoryEmbeddings.targetType, ['item', 'summary']),
-    ))
-    .orderBy(desc(memoryEmbeddings.updatedAt))
-    .limit(5000)
-    .all();
 
-  type Scored = { row: typeof memoryEmbeddings.$inferSelect; score: number };
-  const scored: Scored[] = [];
-  for (const row of rows) {
-    const vector = parseVector(row.vectorJson);
-    if (!vector) continue;
-    const score = cosineSimilarity(queryVector, vector);
-    scored.push({ row, score });
+  let qdrant: ReturnType<typeof getQdrantClient>;
+  try {
+    qdrant = getQdrantClient();
+  } catch {
+    log.warn('Qdrant client not initialized, skipping semantic search');
+    return [];
   }
 
-  scored.sort((a, b) => b.score - a.score);
-  const top = scored.slice(0, limit);
-  const itemIds = top
-    .filter((entry) => entry.row.targetType === 'item')
-    .map((entry) => entry.row.targetId);
-  const summaryIds = top
-    .filter((entry) => entry.row.targetType === 'summary')
-    .map((entry) => entry.row.targetId);
-
-  const itemRows = itemIds.length > 0
-    ? db.select().from(memoryItems).where(inArray(memoryItems.id, itemIds)).all()
-    : [];
-  const itemSourceRows = itemIds.length > 0
-    ? db
-      .select({
-        memoryItemId: memoryItemSources.memoryItemId,
-        messageId: memoryItemSources.messageId,
-      })
-      .from(memoryItemSources)
-      .where(inArray(memoryItemSources.memoryItemId, itemIds))
-      .all()
-    : [];
-  const summaryRows = summaryIds.length > 0
-    ? db.select().from(memorySummaries).where(inArray(memorySummaries.id, summaryIds)).all()
-    : [];
-  const excludedMessagesByConversation = summaryIds.length > 0 && excludedMessageSet.size > 0
-    ? db
-      .select({
-        conversationId: messages.conversationId,
-        createdAt: messages.createdAt,
-      })
-      .from(messages)
-      .where(inArray(messages.id, [...excludedMessageSet]))
-      .all()
-    : [];
-  const itemMap = new Map(itemRows.map((item) => [item.id, item]));
-  const summaryMap = new Map(summaryRows.map((summary) => [summary.id, summary]));
-  const itemEvidenceStats = new Map<string, { total: number; nonExcluded: number }>();
-  for (const source of itemSourceRows) {
-    const existing = itemEvidenceStats.get(source.memoryItemId) ?? { total: 0, nonExcluded: 0 };
-    existing.total += 1;
-    if (!excludedMessageSet.has(source.messageId)) {
-      existing.nonExcluded += 1;
-    }
-    itemEvidenceStats.set(source.memoryItemId, existing);
-  }
-  const excludedSummaryTimestampsByConversation = new Map<string, number[]>();
-  for (const row of excludedMessagesByConversation) {
-    const existing = excludedSummaryTimestampsByConversation.get(row.conversationId) ?? [];
-    existing.push(row.createdAt);
-    excludedSummaryTimestampsByConversation.set(row.conversationId, existing);
-  }
+  const results = await qdrant.searchWithFilter(
+    queryVector,
+    limit,
+    ['item', 'summary', 'segment'],
+    excludedMessageIds,
+  );
 
   const candidates: Candidate[] = [];
-  for (const entry of top) {
-    const semantic = mapCosineToUnit(entry.score);
-    if (entry.row.targetType === 'item') {
-      const item = itemMap.get(entry.row.targetId);
-      if (!item || item.status !== 'active') continue;
-      const evidence = itemEvidenceStats.get(item.id);
-      if (!evidence || evidence.total <= 0) continue;
-      if (excludedMessageSet.size > 0 && evidence.nonExcluded <= 0) continue;
+  for (const result of results) {
+    const { payload, score } = result;
+    const semantic = mapCosineToUnit(score);
+    const createdAt = payload.created_at ?? Date.now();
+
+    if (payload.target_type === 'item') {
       candidates.push({
-        key: `item:${item.id}`,
+        key: `item:${payload.target_id}`,
         type: 'item',
-        id: item.id,
-        text: `[${item.kind}] ${item.subject}: ${item.statement}`,
-        confidence: item.confidence,
-        createdAt: item.lastSeenAt,
+        id: payload.target_id,
+        text: payload.text,
+        confidence: payload.confidence ?? 0.6,
+        createdAt: payload.last_seen_at ?? createdAt,
         lexical: 0,
         semantic,
-        recency: computeRecencyScore(item.lastSeenAt),
+        recency: computeRecencyScore(payload.last_seen_at ?? createdAt),
         finalScore: 0,
       });
-      continue;
+    } else if (payload.target_type === 'summary') {
+      candidates.push({
+        key: `summary:${payload.target_id}`,
+        type: 'summary',
+        id: payload.target_id,
+        text: payload.text,
+        confidence: 0.6,
+        createdAt: payload.last_seen_at ?? createdAt,
+        lexical: 0,
+        semantic,
+        recency: computeRecencyScore(payload.last_seen_at ?? createdAt),
+        finalScore: 0,
+      });
+    } else {
+      candidates.push({
+        key: `segment:${payload.target_id}`,
+        type: 'segment',
+        id: payload.target_id,
+        text: payload.text,
+        confidence: 0.55,
+        createdAt,
+        lexical: 0,
+        semantic,
+        recency: computeRecencyScore(createdAt),
+        finalScore: 0,
+      });
     }
-    const summary = summaryMap.get(entry.row.targetId);
-    if (!summary) continue;
-    if (summary.scope === 'conversation' && excludedMessageSet.size > 0) {
-      const excludedTimestamps = excludedSummaryTimestampsByConversation.get(summary.scopeKey) ?? [];
-      const overlapsExcludedMessage = excludedTimestamps.some((timestamp) => (
-        timestamp >= summary.startAt && timestamp <= summary.endAt
-      ));
-      if (overlapsExcludedMessage) continue;
-    }
-    candidates.push({
-      key: `summary:${summary.id}`,
-      type: 'summary',
-      id: summary.id,
-      text: `[${summary.scope}] ${summary.summary}`,
-      confidence: 0.6,
-      createdAt: summary.endAt,
-      lexical: 0,
-      semantic,
-      recency: computeRecencyScore(summary.endAt),
-      finalScore: 0,
-    });
   }
   return candidates;
 }
@@ -564,32 +507,6 @@ function computeRecencyScore(createdAt: number): number {
 
 function mapCosineToUnit(value: number): number {
   return Math.max(0, Math.min(1, (value + 1) / 2));
-}
-
-function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length !== b.length || a.length === 0) return -1;
-  let dot = 0;
-  let normA = 0;
-  let normB = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    normA += a[i] * a[i];
-    normB += b[i] * b[i];
-  }
-  if (normA === 0 || normB === 0) return -1;
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
-
-function parseVector(raw: string): number[] | null {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return null;
-    if (parsed.length === 0) return null;
-    if (!parsed.every((value) => typeof value === 'number')) return null;
-    return parsed as number[];
-  } catch {
-    return null;
-  }
 }
 
 function emptyResult(


### PR DESCRIPTION
## Summary
- Add Qdrant as the vector store for memory semantic search, replacing in-memory SQLite vector loading (scales to 100M+ vectors with HNSW + scalar quantization)
- Add local ONNX embedding backend via `@huggingface/transformers` with `BAAI/bge-small-en-v1.5` (384d), making it the default in auto-selection order
- Re-enable segment embedding (now practical with Qdrant's scalable indexing)
- Wire Qdrant lifecycle into daemon startup/shutdown with PID-based orphan detection
- Raise `maxInjectTokens` from 1,800 to 10,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
