### PR TITLE
Fix JIT permission backdrop hit-testing and initial appearance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -12,6 +12,7 @@ struct JITPermissionView: View {
             // Dimmed backdrop
             Color.black.opacity(showContent ? 0.5 : 0)
                 .ignoresSafeArea()
+                .allowsHitTesting(manager.activePermissionRequest != nil)
                 .onTapGesture {
                     dismiss()
                 }
@@ -27,6 +28,16 @@ struct JITPermissionView: View {
             }
         }
         .animation(VAnimation.panel, value: manager.activePermissionRequest != nil)
+        .onAppear {
+            if manager.activePermissionRequest != nil {
+                showContent = false
+                iconScale = 1.0
+                withAnimation(.easeOut(duration: 0.4).delay(0.1)) {
+                    showContent = true
+                }
+                startIconBreathing()
+            }
+        }
         .onChange(of: manager.activePermissionRequest) { _, newValue in
             if newValue != nil {
                 showContent = false


### PR DESCRIPTION
## Summary
- Gate backdrop `.allowsHitTesting()` on `activePermissionRequest != nil` so the transparent `Color` overlay does not intercept taps when no permission card is shown
- Add `.onAppear` handler that mirrors the `onChange` logic, fixing the case where `activePermissionRequest` is already non-nil when the view first appears (since `onChange` does not fire for the initial value)

Addresses review feedback from #1351.

## Test plan
- [ ] Verify taps pass through the backdrop when no permission card is shown
- [ ] Verify permission card appears correctly when `activePermissionRequest` is set before the view appears
- [ ] Verify permission card still animates in correctly when `activePermissionRequest` changes after the view is visible
- [ ] Verify dismissing the permission card via backdrop tap still works when card is shown
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
