### PR TITLE
Persist firstMeetingCrackProgress across app restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -82,6 +82,7 @@ final class OnboardingState {
            let variant = OnboardingVariant(rawValue: rawVariant) {
             onboardingVariant = variant
         }
+        firstMeetingCrackProgress = CGFloat(UserDefaults.standard.double(forKey: "onboarding.firstMeetingCrackProgress"))
     }
 
     func advance() {
@@ -99,10 +100,11 @@ final class OnboardingState {
         UserDefaults.standard.set(hasHatched, forKey: "onboarding.hatched")
         UserDefaults.standard.set(interviewCompleted, forKey: "onboarding.interviewCompleted")
         UserDefaults.standard.set(onboardingVariant.rawValue, forKey: "onboarding.variant")
+        UserDefaults.standard.set(Double(firstMeetingCrackProgress), forKey: "onboarding.firstMeetingCrackProgress")
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }


### PR DESCRIPTION
## Summary
- Save `firstMeetingCrackProgress` to UserDefaults in `persist()` so the value survives app kills
- Restore `firstMeetingCrackProgress` from UserDefaults in `init()` so the hatch animation resumes at the correct position on restart
- Clear `onboarding.firstMeetingCrackProgress` key in `clearPersistedState()`

Addresses review feedback from #1354.

## Test plan
- [ ] Launch app in first-meeting onboarding variant
- [ ] Advance crack progress partway through the hatch animation
- [ ] Force-quit the app
- [ ] Relaunch and verify the egg shows the correct crack progress (not reset to 0)
- [ ] Complete onboarding and verify `clearPersistedState()` removes the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
