### PR TITLE
Fix introduction view: guard double completion, stale name, session filtering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
@@ -10,6 +10,7 @@ struct FirstMeetingIntroductionView: View {
     @State private var showControls = false
     @State private var streamingMessageId = UUID()
     @State private var isRecording = false
+    @State private var hasCompleted = false
 
     @State private var voiceInputManager = VoiceInputManager()
     private let profileExtractor: ProfileExtractor
@@ -163,8 +164,10 @@ struct FirstMeetingIntroductionView: View {
     // MARK: - Conversation Completion
 
     private func completeConversation() {
+        guard !hasCompleted else { return }
+        hasCompleted = true
+
         let messages = viewModel.messages
-        let assistantName = state.assistantName
 
         // Extract conversation data (name, first task candidate).
         viewModel.extractConversationData()
@@ -179,6 +182,9 @@ struct FirstMeetingIntroductionView: View {
 
         state.conversationCompleted = true
         viewModel.endConversation()
+
+        // Capture the assistant name AFTER extraction so profile uses the updated name.
+        let assistantName = state.assistantName
 
         // Run profile extraction in the background.
         Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -161,6 +161,10 @@ final class FirstMeetingIntroductionViewModel {
                     }
 
                 case .assistantTextDelta(let delta) where self.sessionId != nil:
+                    // Filter by session to prevent contamination from concurrent sessions.
+                    if let deltaSessionId = delta.sessionId, deltaSessionId != self.sessionId {
+                        break
+                    }
                     accumulated += delta.text
                     self.isThinking = false
                     self.streamingText = accumulated
@@ -285,6 +289,10 @@ final class FirstMeetingIntroductionViewModel {
 
                 switch message {
                 case .assistantTextDelta(let delta):
+                    // Filter by session to prevent contamination from concurrent sessions.
+                    if let deltaSessionId = delta.sessionId, deltaSessionId != sessionId {
+                        break
+                    }
                     accumulated += delta.text
                     self.isThinking = false
                     self.streamingText = accumulated


### PR DESCRIPTION
## Summary
- Guard `completeConversation()` against double invocation via `@State private var hasCompleted` flag, preventing `state.advance()` from being called twice when both `onChange` and Skip button fire
- Capture assistant name **after** `extractConversationData()` runs and saves to state, so profile extraction uses the newly extracted name instead of the stale default
- Filter `assistantTextDelta` streaming messages by `sessionId` in both `startConversation()` and `sendMessage()` to prevent contamination from concurrent daemon sessions

Addresses review feedback from #1353.

## Test plan
- [ ] Verify that clicking Skip while conversation auto-completes does not cause a double advance
- [ ] Verify that naming the assistant during conversation results in the correct name being passed to profile extraction
- [ ] Verify that concurrent daemon sessions do not bleed text deltas into the onboarding conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
