### PR TITLE
Fix progress dots mapping, persist variant, clamp restored step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
@@ -91,7 +91,7 @@ struct FirstMeetingFlowView: View {
                     )
                     .id("\(state.currentStep)-\(observationPhase)")
 
-                    OnboardingProgressDots(currentStep: state.currentStep)
+                    OnboardingProgressDots(currentStep: state.currentStep, totalSteps: 5)
                         .padding(.top, VSpacing.xs)
                 }
                 .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingProgressDots.swift
@@ -1,20 +1,27 @@
 import SwiftUI
 
-/// Five cumulative progress dots for the onboarding flow (steps 0-6).
+/// Five cumulative progress dots for the onboarding flow.
+///
+/// By default maps 7 steps (0-6) to 5 dots. Pass a custom `totalSteps`
+/// for flows with a different number of steps (e.g. `totalSteps: 5` for
+/// the first-meeting flow).
 struct OnboardingProgressDots: View {
     let currentStep: Int
+    let totalSteps: Int
 
     private let totalDots = 5
 
-    /// Maps onboarding step (0-6) to active dot index (0-4).
+    init(currentStep: Int, totalSteps: Int = 7) {
+        self.currentStep = currentStep
+        self.totalSteps = totalSteps
+    }
+
+    /// Maps the current step to the active dot index (0 ..< totalDots)
+    /// by evenly distributing `totalSteps` across `totalDots`.
     private var activeDotIndex: Int {
-        switch currentStep {
-        case 0, 1: return 0
-        case 2:    return 1
-        case 3:    return 2
-        case 4:    return 3
-        default:   return 4
-        }
+        guard totalSteps > 1 else { return 0 }
+        let fraction = Double(currentStep) / Double(totalSteps - 1)
+        return min(Int(fraction * Double(totalDots - 1) + 0.5), totalDots - 1)
     }
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -83,6 +83,14 @@ final class OnboardingState {
             onboardingVariant = variant
         }
         firstMeetingCrackProgress = CGFloat(UserDefaults.standard.double(forKey: "onboarding.firstMeetingCrackProgress"))
+
+        // Clamp restored step to the variant's maximum to prevent out-of-range
+        // rendering (e.g. a step saved from the 7-step default flow would be
+        // invalid for the 5-step first-meeting flow).
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : 6
+        if currentStep > maxStep {
+            currentStep = maxStep
+        }
     }
 
     func advance() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -21,6 +21,7 @@ final class OnboardingWindow {
            idx + 1 < CommandLine.arguments.count,
            CommandLine.arguments[idx + 1] == "first_meeting" {
             state.onboardingVariant = .firstMeeting
+            UserDefaults.standard.set(OnboardingVariant.firstMeeting.rawValue, forKey: "onboarding.variant")
         }
         #endif
 


### PR DESCRIPTION
## Summary
- Add `totalSteps` parameter to `OnboardingProgressDots` (default 7) with dynamic step-to-dot mapping, and pass `totalSteps: 5` from `FirstMeetingFlowView` so all 5 dots are correctly used across the 5-step flow
- Persist CLI-selected onboarding variant (`--onboarding-variant first_meeting`) to `UserDefaults` immediately in `OnboardingWindow.show()` so it survives app restarts
- Clamp restored step to variant-specific max (4 for firstMeeting, 6 for default) in `OnboardingState.init()` to prevent out-of-range rendering when the saved step exceeds the variant's step count

Addresses review feedback from #1350.

## Test plan
- [ ] Launch with `--onboarding-variant first_meeting` and verify all 5 progress dots light up sequentially across steps 0-4
- [ ] Launch default onboarding and verify dots still map correctly across steps 0-6
- [ ] Kill app mid-onboarding with `--onboarding-variant first_meeting`, relaunch, and verify variant persists
- [ ] Manually set `onboarding.step` to 6 in UserDefaults, launch with first-meeting variant, and verify step is clamped to 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
