### PR TITLE
Add entity graph layer for relationship-aware memory retrieval

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -282,6 +282,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     lexicalHits: 12,
     semanticHits: 8,
     recencyHits: 6,
+    entityHits: 3,
     injectedTokens: 480,
     latencyMs: 55,
   },

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -375,7 +375,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       case 'memory_recalled':
         spinner.stop();
         process.stdout.write(
-          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
+          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | entity ${msg.entityHits} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
         );
         spinner.start('Thinking...');
         break;

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -65,6 +65,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       useLLM: true,
       model: 'claude-haiku-4-5-20251001',
     },
+    entity: {
+      enabled: true,
+      model: 'claude-haiku-4-5-20251001',
+    },
   },
   dataDir: getDataDir(),
   timeouts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -237,6 +237,15 @@ export const MemoryExtractionConfigSchema = z.object({
     .default(true),
 });
 
+export const MemoryEntityConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.entity.enabled must be a boolean' })
+    .default(true),
+  model: z
+    .string({ error: 'memory.entity.model must be a string' })
+    .default('claude-haiku-4-5-20251001'),
+});
+
 export const MemorySummarizationConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.summarization.useLLM must be a boolean' })
@@ -292,6 +301,10 @@ export const MemoryConfigSchema = z.object({
   }),
   summarization: MemorySummarizationConfigSchema.default({
     useLLM: true,
+    model: 'claude-haiku-4-5-20251001',
+  }),
+  entity: MemoryEntityConfigSchema.default({
+    enabled: true,
     model: 'claude-haiku-4-5-20251001',
   }),
 });
@@ -386,6 +399,10 @@ export const AssistantConfigSchema = z.object({
       useLLM: true,
       model: 'claude-haiku-4-5-20251001',
     },
+    entity: {
+      enabled: true,
+      model: 'claude-haiku-4-5-20251001',
+    },
   }),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
@@ -446,6 +463,7 @@ export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryExtractionConfig = z.infer<typeof MemoryExtractionConfigSchema>;
 export type MemorySummarizationConfig = z.infer<typeof MemorySummarizationConfigSchema>;
+export type MemoryEntityConfig = z.infer<typeof MemoryEntityConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
 export type QdrantConfig = z.infer<typeof QdrantConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -15,6 +15,7 @@ export type {
   MemoryRetentionConfig,
   MemoryExtractionConfig,
   MemorySummarizationConfig,
+  MemoryEntityConfig,
   MemoryConfig,
   ModelPricingOverride,
   QdrantConfig,

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -438,6 +438,7 @@ export interface MemoryRecalled {
   lexicalHits: number;
   semanticHits: number;
   recencyHits: number;
+  entityHits: number;
   injectedTokens: number;
   latencyMs: number;
 }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -451,6 +451,7 @@ export class Session {
             lexicalHits: recall.lexicalHits,
             semanticHits: recall.semanticHits,
             recencyHits: recall.recencyHits,
+            entityHits: recall.entityHits,
             injectedTokens: recall.injectedTokens,
             latencyMs: recall.latencyMs,
           });

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -535,6 +535,7 @@ memory
     console.log(`Lexical hits: ${result.lexicalHits}`);
     console.log(`Semantic hits: ${result.semanticHits}`);
     console.log(`Recency hits: ${result.recencyHits}`);
+    console.log(`Entity hits: ${result.entityHits}`);
     console.log(`Injected tokens: ${result.injectedTokens}`);
     console.log(`Latency: ${result.latencyMs}ms`);
     if (result.injectedText.length > 0) {

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -283,6 +283,39 @@ export function initializeDb(): void {
     )
   `);
 
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_entities (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      aliases TEXT,
+      description TEXT,
+      first_seen_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL,
+      mention_count INTEGER NOT NULL DEFAULT 1
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_entity_relations (
+      id TEXT PRIMARY KEY,
+      source_entity_id TEXT NOT NULL,
+      target_entity_id TEXT NOT NULL,
+      relation TEXT NOT NULL,
+      evidence TEXT,
+      first_seen_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_item_entities (
+      memory_item_id TEXT NOT NULL,
+      entity_id TEXT NOT NULL,
+      PRIMARY KEY (memory_item_id, entity_id)
+    )
+  `);
+
   // FTS table for lexical retrieval over memory_segments.text.
   database.run(/*sql*/ `
     CREATE VIRTUAL TABLE IF NOT EXISTS memory_segment_fts USING fts5(
@@ -373,6 +406,13 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_provider ON llm_usage_events(provider)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_model ON llm_usage_events(model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_actor ON llm_usage_events(actor)`);
+
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_name ON memory_entities(name)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_type ON memory_entities(type)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entity_relations_source ON memory_entity_relations(source_entity_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entity_relations_target ON memory_entity_relations(target_entity_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_entities_memory_item ON memory_item_entities(memory_item_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_entities_entity ON memory_item_entities(entity_id)`);
 
   migrateMemoryFtsBackfill(database);
 }

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -1,0 +1,280 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { eq, or, sql } from 'drizzle-orm';
+import { getConfig } from '../config/loader.js';
+import type { MemoryEntityConfig } from '../config/types.js';
+import { getLogger } from '../util/logger.js';
+import { getDb } from './db.js';
+import { memoryEntities, memoryItemEntities } from './schema.js';
+
+const log = getLogger('memory-entity-extractor');
+
+export type EntityType =
+  | 'person'
+  | 'project'
+  | 'tool'
+  | 'company'
+  | 'concept'
+  | 'location'
+  | 'organization';
+
+const VALID_ENTITY_TYPES = new Set<string>([
+  'person', 'project', 'tool', 'company', 'concept', 'location', 'organization',
+]);
+
+export interface ExtractedEntity {
+  name: string;
+  type: EntityType;
+  aliases: string[];
+}
+
+interface LLMExtractedEntity {
+  name: string;
+  type: string;
+  aliases: string[];
+}
+
+const ENTITY_EXTRACTION_SYSTEM_PROMPT = `You are an entity extraction system. Given text from a conversation, extract named entities that are worth tracking across conversations.
+
+Extract entities in these categories:
+- person: People mentioned by name (users, colleagues, contacts)
+- project: Named projects, repositories, products, apps
+- tool: Software tools, libraries, frameworks, languages
+- company: Companies, organizations with commercial identity
+- concept: Technical concepts, methodologies, design patterns
+- location: Cities, offices, regions relevant to the user
+- organization: Non-commercial orgs, teams, groups, communities
+
+For each entity, provide:
+- name: The canonical name (proper casing, full name preferred)
+- type: One of the categories above
+- aliases: Array of alternate names, abbreviations, or nicknames (empty array if none)
+
+Rules:
+- Only extract concrete, named entities. Skip generic terms like "the project" or "that tool".
+- Prefer the most specific and complete name as the canonical name.
+- Include common abbreviations and nicknames as aliases.
+- Do NOT extract the assistant itself or generic conversation participants.
+- If there are no extractable entities, return an empty array.`;
+
+export async function extractEntitiesWithLLM(
+  text: string,
+  entityConfig: MemoryEntityConfig,
+): Promise<ExtractedEntity[]> {
+  const config = getConfig();
+  const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    log.debug('No Anthropic API key available for entity extraction');
+    return [];
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    const response = await Promise.race([
+      client.messages.create({
+        model: entityConfig.model,
+        max_tokens: 1024,
+        system: ENTITY_EXTRACTION_SYSTEM_PROMPT,
+        tools: [{
+          name: 'store_entities',
+          description: 'Store extracted entities from the text',
+          input_schema: {
+            type: 'object' as const,
+            properties: {
+              entities: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: {
+                      type: 'string',
+                      description: 'Canonical name of the entity',
+                    },
+                    type: {
+                      type: 'string',
+                      enum: [...VALID_ENTITY_TYPES],
+                      description: 'Category of the entity',
+                    },
+                    aliases: {
+                      type: 'array',
+                      items: { type: 'string' },
+                      description: 'Alternate names or abbreviations',
+                    },
+                  },
+                  required: ['name', 'type', 'aliases'],
+                },
+              },
+            },
+            required: ['entities'],
+          },
+        }],
+        tool_choice: { type: 'tool' as const, name: 'store_entities' },
+        messages: [{ role: 'user' as const, content: text }],
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Entity extraction LLM timeout')), 15000),
+      ),
+    ]);
+
+    const toolBlock = response.content.find((b) => b.type === 'tool_use');
+    if (!toolBlock || toolBlock.type !== 'tool_use') {
+      log.warn('No tool_use block in entity extraction response');
+      return [];
+    }
+
+    const input = toolBlock.input as { entities?: LLMExtractedEntity[] };
+    if (!Array.isArray(input.entities)) {
+      log.warn('Invalid entities in entity extraction response');
+      return [];
+    }
+
+    const entities: ExtractedEntity[] = [];
+    for (const raw of input.entities) {
+      if (!VALID_ENTITY_TYPES.has(raw.type)) continue;
+      if (!raw.name || raw.name.trim().length === 0) continue;
+      const name = String(raw.name).trim().slice(0, 200);
+      const aliases = Array.isArray(raw.aliases)
+        ? raw.aliases.map((a) => String(a).trim().slice(0, 200)).filter((a) => a.length > 0)
+        : [];
+      entities.push({
+        name,
+        type: raw.type as EntityType,
+        aliases,
+      });
+    }
+
+    return entities;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn({ err: message }, 'Entity extraction LLM call failed');
+    return [];
+  }
+}
+
+/**
+ * Resolve an extracted entity against existing entities in the database.
+ * Returns the existing entity ID if a match is found, or null if no match.
+ */
+export function resolveEntity(entity: ExtractedEntity): string | null {
+  const db = getDb();
+  const nameLower = entity.name.toLowerCase();
+
+  // Search by exact name match or alias match using LIKE on JSON aliases field
+  const candidates = db
+    .select()
+    .from(memoryEntities)
+    .where(
+      or(
+        sql`LOWER(${memoryEntities.name}) = ${nameLower}`,
+        sql`LOWER(${memoryEntities.aliases}) LIKE ${'%' + nameLower + '%'}`,
+      ),
+    )
+    .all();
+
+  if (candidates.length === 0) {
+    // Also check if any of the extracted aliases match an existing entity name
+    for (const alias of entity.aliases) {
+      const aliasLower = alias.toLowerCase();
+      const aliasCandidates = db
+        .select()
+        .from(memoryEntities)
+        .where(
+          or(
+            sql`LOWER(${memoryEntities.name}) = ${aliasLower}`,
+            sql`LOWER(${memoryEntities.aliases}) LIKE ${'%' + aliasLower + '%'}`,
+          ),
+        )
+        .all();
+      if (aliasCandidates.length > 0) {
+        // Return the first match — same type preferred
+        const sameType = aliasCandidates.find((c) => c.type === entity.type);
+        return sameType?.id ?? aliasCandidates[0].id;
+      }
+    }
+    return null;
+  }
+
+  // Prefer same-type matches
+  const sameType = candidates.find((c) => c.type === entity.type);
+  return sameType?.id ?? candidates[0].id;
+}
+
+/**
+ * Upsert an entity into the database: resolve against existing entities,
+ * update if found, or insert a new one.
+ * Returns the entity ID.
+ */
+export function upsertEntity(entity: ExtractedEntity): string {
+  const db = getDb();
+  const now = Date.now();
+  const existingId = resolveEntity(entity);
+
+  if (existingId) {
+    // Update existing entity: bump mention count, update lastSeenAt, merge aliases
+    const existing = db
+      .select()
+      .from(memoryEntities)
+      .where(eq(memoryEntities.id, existingId))
+      .get();
+
+    if (existing) {
+      const existingAliases: string[] = existing.aliases
+        ? (JSON.parse(existing.aliases) as string[])
+        : [];
+      const mergedAliases = mergeAliases(existingAliases, entity.aliases, existing.name);
+
+      db.update(memoryEntities)
+        .set({
+          lastSeenAt: now,
+          mentionCount: sql`${memoryEntities.mentionCount} + 1`,
+          aliases: JSON.stringify(mergedAliases),
+        })
+        .where(eq(memoryEntities.id, existingId))
+        .run();
+    }
+
+    return existingId;
+  }
+
+  // Insert new entity
+  const id = crypto.randomUUID();
+  db.insert(memoryEntities).values({
+    id,
+    name: entity.name,
+    type: entity.type,
+    aliases: entity.aliases.length > 0 ? JSON.stringify(entity.aliases) : null,
+    description: null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    mentionCount: 1,
+  }).run();
+
+  return id;
+}
+
+/**
+ * Link a memory item to an entity via the join table.
+ */
+export function linkMemoryItemToEntity(memoryItemId: string, entityId: string): void {
+  const db = getDb();
+  db.insert(memoryItemEntities).values({
+    memoryItemId,
+    entityId,
+  }).onConflictDoNothing().run();
+}
+
+/**
+ * Merge alias lists, deduplicating and excluding the canonical name.
+ */
+function mergeAliases(existing: string[], incoming: string[], canonicalName: string): string[] {
+  const seen = new Set<string>();
+  const canonicalLower = canonicalName.toLowerCase();
+  const merged: string[] = [];
+  for (const alias of [...existing, ...incoming]) {
+    const lower = alias.toLowerCase();
+    if (lower === canonicalLower) continue;
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    merged.push(alias);
+  }
+  return merged;
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -8,6 +8,7 @@ export type MemoryJobType =
   | 'embed_item'
   | 'embed_summary'
   | 'extract_items'
+  | 'extract_entities'
   | 'refresh_weekly_summary'
   | 'refresh_monthly_summary'
   | 'build_conversation_summary'

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -16,10 +16,20 @@ import {
   type MemoryJob,
   resetRunningJobsToPending,
 } from './jobs-store.js';
+import { extractEntitiesWithLLM, upsertEntity, linkMemoryItemToEntity } from './entity-extractor.js';
 import { indexMessageNow } from './indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
+import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getQdrantClient } from './qdrant-client.js';
-import { memoryEmbeddings, memoryItems, memorySegments, memorySummaries, messages } from './schema.js';
+import {
+  memoryEmbeddings,
+  memoryItemEntities,
+  memoryItems,
+  memoryItemSources,
+  memorySegments,
+  memorySummaries,
+  messages,
+} from './schema.js';
 
 const log = getLogger('memory-jobs-worker');
 const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';
@@ -129,6 +139,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
     case 'extract_items':
       await extractItemsJob(job);
       return;
+    case 'extract_entities':
+      await extractEntitiesJob(job, config);
+      return;
     case 'build_conversation_summary':
       await buildConversationSummaryJob(job, config);
       return;
@@ -208,6 +221,51 @@ async function extractItemsJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
   if (!messageId) return;
   await extractAndUpsertMemoryItemsForMessage(messageId);
+  // Queue entity extraction for this message after items are extracted
+  const config = getConfig();
+  if (config.memory.entity.enabled) {
+    enqueueMemoryJob('extract_entities', { messageId });
+  }
+}
+
+async function extractEntitiesJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  const messageId = asString(job.payload.messageId);
+  if (!messageId) return;
+
+  const db = getDb();
+  const message = db
+    .select({
+      id: messages.id,
+      content: messages.content,
+    })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (!message) return;
+
+  const text = extractTextFromStoredMessageContent(message.content);
+  if (text.trim().length < 15) return;
+
+  const entities = await extractEntitiesWithLLM(text, config.memory.entity);
+  if (entities.length === 0) return;
+
+  // Find all memory items linked to this message via memory_item_sources
+  const linkedItems = db
+    .select({ memoryItemId: memoryItemSources.memoryItemId })
+    .from(memoryItemSources)
+    .where(eq(memoryItemSources.messageId, messageId))
+    .all();
+  const itemIds = linkedItems.map((row) => row.memoryItemId);
+
+  for (const entity of entities) {
+    const entityId = upsertEntity(entity);
+    // Link all memory items from this message to the entity
+    for (const itemId of itemIds) {
+      linkMemoryItemToEntity(itemId, entityId);
+    }
+  }
+
+  log.debug({ messageId, entityCount: entities.length, linkedItems: itemIds.length }, 'Extracted entities from message');
 }
 
 async function buildConversationSummaryJob(job: MemoryJob, config: AssistantConfig): Promise<void> {

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -7,7 +7,7 @@ import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
-import { memoryItems, memorySegments } from './schema.js';
+import { memoryEntities, memoryItemEntities, memoryItems, memorySegments } from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_MARKER = '[Memory Recall v1]';
@@ -37,6 +37,7 @@ export interface MemoryRecallResult {
   lexicalHits: number;
   semanticHits: number;
   recencyHits: number;
+  entityHits: number;
   injectedTokens: number;
   injectedText: string;
   latencyMs: number;
@@ -115,6 +116,7 @@ export async function buildMemoryRecall(
   let lexicalCandidates: Candidate[] = [];
   let recencyCandidates: Candidate[] = [];
   let semanticCandidates: Candidate[] = [];
+  let entityCandidates: Candidate[] = [];
   try {
     lexicalCandidates = lexicalSearch(query, config.memory.retrieval.lexicalTopK, excludeMessageIds);
     recencyCandidates = recencySearch(
@@ -125,6 +127,9 @@ export async function buildMemoryRecall(
     semanticCandidates = queryVector
       ? await semanticSearch(queryVector, provider!, model!, config.memory.retrieval.semanticTopK, excludeMessageIds)
       : [];
+    if (config.memory.entity.enabled) {
+      entityCandidates = entitySearch(query);
+    }
   } catch (err) {
     if (signal?.aborted || isAbortError(err)) {
       return emptyResult({
@@ -147,7 +152,7 @@ export async function buildMemoryRecall(
     });
   }
 
-  let merged = mergeCandidates(lexicalCandidates, semanticCandidates, recencyCandidates);
+  let merged = mergeCandidates(lexicalCandidates, semanticCandidates, recencyCandidates, entityCandidates);
 
   // LLM re-ranking: send top candidates to Haiku for relevance scoring
   const rerankingConfig = config.memory.retrieval.reranking;
@@ -185,6 +190,7 @@ export async function buildMemoryRecall(
     lexicalHits: lexicalCandidates.length,
     semanticHits: semanticCandidates.length,
     recencyHits: recencyCandidates.length,
+    entityHits: entityCandidates.length,
     selected: selected.length,
     injectedTokens: estimateTextTokens(injectedText),
     latencyMs,
@@ -199,6 +205,7 @@ export async function buildMemoryRecall(
     lexicalHits: lexicalCandidates.length,
     semanticHits: semanticCandidates.length,
     recencyHits: recencyCandidates.length,
+    entityHits: entityCandidates.length,
     injectedTokens: estimateTextTokens(injectedText),
     injectedText,
     latencyMs,
@@ -451,6 +458,111 @@ function recencySearch(conversationId: string, limit: number, excludedMessageIds
 }
 
 /**
+ * Entity-based retrieval: extract entity names from the query,
+ * fuzzy match against known entities (name + aliases), and return
+ * all memory items linked to those entities.
+ */
+function entitySearch(query: string): Candidate[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+
+  // Tokenize query into words for entity matching
+  const tokens = trimmed
+    .toLowerCase()
+    .split(/[^a-z0-9_.-]+/g)
+    .filter((t) => t.length >= 2);
+  if (tokens.length === 0) return [];
+
+  // Build LIKE conditions for each token against entity name and aliases
+  const likeClauses = tokens.map((t) => `(LOWER(name) LIKE '%${escapeSqlLike(t)}%' OR LOWER(aliases) LIKE '%${escapeSqlLike(t)}%')`);
+  const entityQuery = `
+    SELECT id, name, type, aliases, mention_count
+    FROM memory_entities
+    WHERE ${likeClauses.join(' OR ')}
+    LIMIT 20
+  `;
+
+  let matchedEntities: Array<{
+    id: string;
+    name: string;
+    type: string;
+    aliases: string | null;
+    mention_count: number;
+  }> = [];
+  try {
+    matchedEntities = raw.query(entityQuery).all() as Array<{
+      id: string;
+      name: string;
+      type: string;
+      aliases: string | null;
+      mention_count: number;
+    }>;
+  } catch (err) {
+    log.warn({ err }, 'Entity search query failed');
+    return [];
+  }
+
+  if (matchedEntities.length === 0) return [];
+
+  // Get all entity IDs
+  const entityIds = matchedEntities.map((e) => e.id);
+
+  // Find all memory items linked to these entities
+  const placeholders = entityIds.map(() => '?').join(',');
+  let linkedRows: Array<{
+    memory_item_id: string;
+    entity_id: string;
+  }> = [];
+  try {
+    linkedRows = raw.query(`
+      SELECT memory_item_id, entity_id
+      FROM memory_item_entities
+      WHERE entity_id IN (${placeholders})
+    `).all(...entityIds) as Array<{
+      memory_item_id: string;
+      entity_id: string;
+    }>;
+  } catch (err) {
+    log.warn({ err }, 'Entity item link query failed');
+    return [];
+  }
+
+  if (linkedRows.length === 0) return [];
+
+  // Fetch the actual memory items
+  const itemIds = [...new Set(linkedRows.map((r) => r.memory_item_id))];
+  const items = db
+    .select()
+    .from(memoryItems)
+    .where(and(
+      inArray(memoryItems.id, itemIds),
+      eq(memoryItems.status, 'active'),
+    ))
+    .all();
+
+  return items.map((item) => ({
+    key: `item:${item.id}`,
+    type: 'item' as CandidateType,
+    id: item.id,
+    text: `[${item.kind}] ${item.subject}: ${item.statement}`,
+    confidence: item.confidence,
+    importance: item.importance ?? 0.5,
+    createdAt: item.lastSeenAt,
+    lexical: 0,
+    semantic: 0,
+    recency: computeRecencyScore(item.lastSeenAt),
+    finalScore: 0,
+  }));
+}
+
+function escapeSqlLike(s: string): string {
+  return s.replace(/'/g, "''").replace(/%/g, '').replace(/_/g, '');
+}
+
+/**
  * Reciprocal Rank Fusion (RRF) — merge candidates from independent ranking
  * lists without assuming comparable score scales.
  *
@@ -466,10 +578,11 @@ function mergeCandidates(
   lexical: Candidate[],
   semantic: Candidate[],
   recency: Candidate[],
+  entity: Candidate[] = [],
 ): Candidate[] {
   // Build merged candidate map (dedup by key, keep best metadata)
   const merged = new Map<string, Candidate>();
-  for (const candidate of [...lexical, ...semantic, ...recency]) {
+  for (const candidate of [...lexical, ...semantic, ...recency, ...entity]) {
     const existing = merged.get(candidate.key);
     if (!existing) {
       merged.set(candidate.key, { ...candidate });
@@ -489,6 +602,7 @@ function mergeCandidates(
   const lexicalRanks = buildRankMap(lexical, (c) => c.lexical);
   const semanticRanks = buildRankMap(semantic, (c) => c.semantic);
   const recencyRanks = buildRankMap(recency, (c) => c.recency);
+  const entityRanks = buildRankMap(entity, (c) => c.confidence);
 
   // Look up access_count for item-type candidates (retrieval reinforcement)
   const itemIds = [...merged.values()]
@@ -502,6 +616,7 @@ function mergeCandidates(
     if (lexicalRanks.has(row.key)) ranks.push(lexicalRanks.get(row.key)!);
     if (semanticRanks.has(row.key)) ranks.push(semanticRanks.get(row.key)!);
     if (recencyRanks.has(row.key)) ranks.push(recencyRanks.get(row.key)!);
+    if (entityRanks.has(row.key)) ranks.push(entityRanks.get(row.key)!);
 
     const rrfScore = rrf(ranks);
 
@@ -757,6 +872,7 @@ function emptyResult(
     lexicalHits: 0,
     semanticHits: 0,
     recencyHits: 0,
+    entityHits: 0,
     injectedTokens: 0,
     injectedText: '',
     latencyMs: init.latencyMs,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -239,6 +239,34 @@ export const cronRuns = sqliteTable('cron_runs', {
 
 // ── LLM Usage Events (cost tracking ledger) ─────────────────────────
 
+// ── Entity Graph ─────────────────────────────────────────────────────
+
+export const memoryEntities = sqliteTable('memory_entities', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  type: text('type').notNull(),
+  aliases: text('aliases'),
+  description: text('description'),
+  firstSeenAt: integer('first_seen_at').notNull(),
+  lastSeenAt: integer('last_seen_at').notNull(),
+  mentionCount: integer('mention_count').notNull().default(1),
+});
+
+export const memoryEntityRelations = sqliteTable('memory_entity_relations', {
+  id: text('id').primaryKey(),
+  sourceEntityId: text('source_entity_id').notNull(),
+  targetEntityId: text('target_entity_id').notNull(),
+  relation: text('relation').notNull(),
+  evidence: text('evidence'),
+  firstSeenAt: integer('first_seen_at').notNull(),
+  lastSeenAt: integer('last_seen_at').notNull(),
+});
+
+export const memoryItemEntities = sqliteTable('memory_item_entities', {
+  memoryItemId: text('memory_item_id').notNull(),
+  entityId: text('entity_id').notNull(),
+});
+
 export const llmUsageEvents = sqliteTable('llm_usage_events', {
   id: text('id').primaryKey(),
   createdAt: integer('created_at').notNull(),


### PR DESCRIPTION
## Summary
- Adds `memoryEntities`, `memoryEntityRelations`, and `memoryItemEntities` SQLite tables for entity graph storage
- Implements LLM-powered entity extraction (Claude Haiku) with resolution against existing entities by name/alias matching
- Integrates entity-based retrieval as a 4th signal in RRF fusion alongside semantic, lexical, and recency signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
