### PR TITLE
Add MemGPT-style memory tools: search, save, and update

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -985,3 +985,108 @@ function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return err.name === 'AbortError' || err.name === 'APIUserAbortError';
 }
+
+// ── Simple search API for memory tools ───────────────────────────────
+
+export interface MemorySearchResult {
+  id: string;
+  type: CandidateType;
+  kind: string;
+  text: string;
+  confidence: number;
+  importance: number;
+  createdAt: number;
+  finalScore: number;
+}
+
+/**
+ * Search memory items using lexical and entity search.
+ * Returns a simplified result set suitable for the memory_search tool.
+ * Unlike buildMemoryRecall, this does not build injection text or manage
+ * embedding-based semantic search — it is a lightweight, synchronous-safe
+ * search for the agent's explicit memory tool use.
+ */
+export function searchMemoryItems(
+  query: string,
+  limit: number,
+  config: { memory: { entity: { enabled: boolean } } },
+): MemorySearchResult[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0 || limit <= 0) return [];
+
+  const lexicalCandidates = lexicalSearch(trimmed, Math.max(limit * 2, 20));
+  const entityCandidates = config.memory.entity.enabled
+    ? entitySearch(trimmed)
+    : [];
+
+  // Also search memory_items directly by subject/statement for better recall
+  const itemCandidates = directItemSearch(trimmed, Math.max(limit, 10));
+
+  const merged = mergeCandidates(lexicalCandidates, [], [], [...entityCandidates, ...itemCandidates]);
+  return merged.slice(0, limit).map((c) => ({
+    id: c.id,
+    type: c.type,
+    kind: c.kind,
+    text: c.text,
+    confidence: c.confidence,
+    importance: c.importance,
+    createdAt: c.createdAt,
+    finalScore: c.finalScore,
+  }));
+}
+
+/**
+ * Direct search over memory_items table by subject and statement text.
+ * Supplements FTS-based lexical search with LIKE-based matching on items.
+ */
+function directItemSearch(query: string, limit: number): Candidate[] {
+  const db = getDb();
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9_.-]+/g)
+    .filter((t) => t.length >= 2);
+  if (tokens.length === 0) return [];
+
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+  const likeClauses = tokens.map(
+    (t) => `(LOWER(subject) LIKE '%${escapeSqlLike(t)}%' OR LOWER(statement) LIKE '%${escapeSqlLike(t)}%')`,
+  );
+  const sqlQuery = `
+    SELECT id, kind, subject, statement, status, confidence, importance, first_seen_at, last_seen_at
+    FROM memory_items
+    WHERE status = 'active' AND (${likeClauses.join(' OR ')})
+    ORDER BY last_seen_at DESC
+    LIMIT ?
+  `;
+
+  let rows: Array<{
+    id: string;
+    kind: string;
+    subject: string;
+    statement: string;
+    confidence: number;
+    importance: number | null;
+    first_seen_at: number;
+    last_seen_at: number;
+  }> = [];
+  try {
+    rows = raw.query(sqlQuery).all(limit) as typeof rows;
+  } catch {
+    return [];
+  }
+
+  return rows.map((row) => ({
+    key: `item:${row.id}`,
+    type: 'item' as CandidateType,
+    id: row.id,
+    text: `${row.subject}: ${row.statement}`,
+    kind: row.kind,
+    confidence: row.confidence,
+    importance: row.importance ?? 0.5,
+    createdAt: row.last_seen_at,
+    lexical: 0,
+    semantic: 0,
+    recency: computeRecencyScore(row.last_seen_at),
+    finalScore: 0,
+  }));
+}

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -1,0 +1,69 @@
+import type { ToolDefinition } from '../../providers/types.js';
+
+export const memorySearchDefinition: ToolDefinition = {
+  name: 'memory_search',
+  description: 'Search your memory for previously saved facts, preferences, decisions, and other information. Use this when you need to recall something from past conversations.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Natural language search query describing what you want to recall',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results to return (default: 5)',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+export const memorySaveDefinition: ToolDefinition = {
+  name: 'memory_save',
+  description: 'Save a fact, preference, decision, or other noteworthy information to memory for future recall. Use this when the user shares something worth remembering.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      statement: {
+        type: 'string',
+        description: 'The fact or preference to remember (1-2 sentences)',
+      },
+      kind: {
+        type: 'string',
+        enum: ['preference', 'fact', 'decision', 'profile', 'relationship', 'event', 'opinion', 'instruction'],
+        description: 'Category of the memory item',
+      },
+      subject: {
+        type: 'string',
+        description: 'Short subject/topic label (2-8 words)',
+      },
+    },
+    required: ['statement', 'kind'],
+  },
+};
+
+export const memoryUpdateDefinition: ToolDefinition = {
+  name: 'memory_update',
+  description: 'Update or correct an existing memory item. Use this when previously saved information needs to be changed.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      memory_id: {
+        type: 'string',
+        description: 'ID of the memory item to update (from memory_search results)',
+      },
+      statement: {
+        type: 'string',
+        description: 'The updated statement to replace the existing one',
+      },
+    },
+    required: ['memory_id', 'statement'],
+  },
+};
+
+export const memoryToolDefinitions: ToolDefinition[] = [
+  memorySearchDefinition,
+  memorySaveDefinition,
+  memoryUpdateDefinition,
+];

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import type { AssistantConfig } from '../../config/types.js';
+import { getLogger } from '../../util/logger.js';
+import { getDb } from '../../memory/db.js';
+import { memoryItems } from '../../memory/schema.js';
+import { enqueueMemoryJob } from '../../memory/jobs-store.js';
+import { searchMemoryItems, formatRelativeTime } from '../../memory/retriever.js';
+import type { ToolExecutionResult } from '../types.js';
+
+const log = getLogger('memory-tools');
+
+// ── memory_search ────────────────────────────────────────────────────
+
+export async function handleMemorySearch(
+  args: Record<string, unknown>,
+  config: AssistantConfig,
+): Promise<ToolExecutionResult> {
+  const query = args.query;
+  if (typeof query !== 'string' || query.trim().length === 0) {
+    return { content: 'Error: query is required and must be a non-empty string', isError: true };
+  }
+
+  const limit = typeof args.limit === 'number' && args.limit > 0
+    ? Math.min(args.limit, 20)
+    : 5;
+
+  try {
+    const results = searchMemoryItems(query, limit, config);
+
+    if (results.length === 0) {
+      return { content: 'No matching memories found.', isError: false };
+    }
+
+    const lines: string[] = [`Found ${results.length} memory item(s):\n`];
+    for (const result of results) {
+      const timeAgo = formatRelativeTime(result.createdAt);
+      lines.push(`- **[${result.kind}]** ${result.text}`);
+      lines.push(`  ID: ${result.id} | ${timeAgo}`);
+    }
+
+    return { content: lines.join('\n'), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, query }, 'memory_search failed');
+    return { content: `Error: Memory search failed: ${msg}`, isError: true };
+  }
+}
+
+// ── memory_save ──────────────────────────────────────────────────────
+
+export async function handleMemorySave(
+  args: Record<string, unknown>,
+  _config: AssistantConfig,
+  conversationId: string,
+  messageId: string | undefined,
+): Promise<ToolExecutionResult> {
+  const statement = args.statement;
+  if (typeof statement !== 'string' || statement.trim().length === 0) {
+    return { content: 'Error: statement is required and must be a non-empty string', isError: true };
+  }
+
+  const kind = args.kind;
+  const validKinds = new Set([
+    'preference', 'fact', 'decision', 'profile',
+    'relationship', 'event', 'opinion', 'instruction',
+  ]);
+  if (typeof kind !== 'string' || !validKinds.has(kind)) {
+    return {
+      content: `Error: kind is required and must be one of: ${[...validKinds].join(', ')}`,
+      isError: true,
+    };
+  }
+
+  const subject = typeof args.subject === 'string' && args.subject.trim().length > 0
+    ? args.subject.trim().slice(0, 80)
+    : inferSubjectFromStatement(statement.trim());
+
+  try {
+    const db = getDb();
+    const id = uuid();
+    const now = Date.now();
+    const trimmedStatement = statement.trim().slice(0, 500);
+
+    // Build fingerprint for dedup consistency with items-extractor
+    const normalized = `${kind}|${subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
+    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+
+    // Check for existing item with same fingerprint
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.fingerprint, fingerprint))
+      .get();
+
+    if (existing) {
+      // Update existing item's lastSeenAt and ensure active
+      db.update(memoryItems)
+        .set({
+          status: 'active',
+          importance: 0.8,
+          lastSeenAt: now,
+        })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+
+      enqueueMemoryJob('embed_item', { itemId: existing.id });
+      return {
+        content: `Memory already exists (ID: ${existing.id}). Updated and refreshed.`,
+        isError: false,
+      };
+    }
+
+    db.insert(memoryItems).values({
+      id,
+      kind,
+      subject,
+      statement: trimmedStatement,
+      status: 'active',
+      confidence: 0.95,     // explicit saves have high confidence
+      importance: 0.8,       // explicit saves are high importance
+      fingerprint,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastUsedAt: null,
+    }).run();
+
+    enqueueMemoryJob('embed_item', { itemId: id });
+
+    log.debug({ id, kind, subject, conversationId, messageId }, 'Memory item saved via tool');
+    return {
+      content: `Saved to memory (ID: ${id}).\nKind: ${kind}\nSubject: ${subject}\nStatement: ${trimmedStatement}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'memory_save failed');
+    return { content: `Error: Failed to save memory: ${msg}`, isError: true };
+  }
+}
+
+// ── memory_update ────────────────────────────────────────────────────
+
+export async function handleMemoryUpdate(
+  args: Record<string, unknown>,
+  _config: AssistantConfig,
+): Promise<ToolExecutionResult> {
+  const memoryId = args.memory_id;
+  if (typeof memoryId !== 'string' || memoryId.trim().length === 0) {
+    return { content: 'Error: memory_id is required and must be a non-empty string', isError: true };
+  }
+
+  const statement = args.statement;
+  if (typeof statement !== 'string' || statement.trim().length === 0) {
+    return { content: 'Error: statement is required and must be a non-empty string', isError: true };
+  }
+
+  try {
+    const db = getDb();
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, memoryId.trim()))
+      .get();
+
+    if (!existing) {
+      return { content: `Error: Memory item with ID "${memoryId}" not found`, isError: true };
+    }
+
+    const now = Date.now();
+    const trimmedStatement = statement.trim().slice(0, 500);
+
+    // Recompute fingerprint with updated statement
+    const normalized = `${existing.kind}|${existing.subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
+    const fingerprint = createHash('sha256').update(normalized).digest('hex');
+
+    db.update(memoryItems)
+      .set({
+        statement: trimmedStatement,
+        fingerprint,
+        lastSeenAt: now,
+        importance: 0.8,
+      })
+      .where(eq(memoryItems.id, existing.id))
+      .run();
+
+    // Queue re-embedding with updated text
+    enqueueMemoryJob('embed_item', { itemId: existing.id });
+
+    log.debug({ id: existing.id, kind: existing.kind }, 'Memory item updated via tool');
+    return {
+      content: `Updated memory (ID: ${existing.id}).\nKind: ${existing.kind}\nSubject: ${existing.subject}\nNew statement: ${trimmedStatement}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, memoryId }, 'memory_update failed');
+    return { content: `Error: Failed to update memory: ${msg}`, isError: true };
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function inferSubjectFromStatement(statement: string): string {
+  // Take first few words as a subject label
+  const words = statement.split(/\s+/).slice(0, 6).join(' ');
+  return words.slice(0, 80);
+}

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -1,0 +1,67 @@
+import { RiskLevel } from '../../permissions/types.js';
+import { getConfig } from '../../config/loader.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { memorySearchDefinition, memorySaveDefinition, memoryUpdateDefinition } from './definitions.js';
+import { handleMemorySearch, handleMemorySave, handleMemoryUpdate } from './handlers.js';
+
+// ── memory_search ────────────────────────────────────────────────────
+
+class MemorySearchTool implements Tool {
+  name = 'memory_search';
+  description = memorySearchDefinition.description;
+  category = 'memory';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return memorySearchDefinition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const config = getConfig();
+    return handleMemorySearch(input, config);
+  }
+}
+
+// ── memory_save ──────────────────────────────────────────────────────
+
+class MemorySaveTool implements Tool {
+  name = 'memory_save';
+  description = memorySaveDefinition.description;
+  category = 'memory';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return memorySaveDefinition;
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const config = getConfig();
+    return handleMemorySave(input, config, context.conversationId, context.requestId);
+  }
+}
+
+// ── memory_update ────────────────────────────────────────────────────
+
+class MemoryUpdateTool implements Tool {
+  name = 'memory_update';
+  description = memoryUpdateDefinition.description;
+  category = 'memory';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return memoryUpdateDefinition;
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const config = getConfig();
+    return handleMemoryUpdate(input, config);
+  }
+}
+
+// ── Registration ─────────────────────────────────────────────────────
+
+registerTool(new MemorySearchTool());
+registerTool(new MemorySaveTool());
+registerTool(new MemoryUpdateTool());

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -106,6 +106,7 @@ export async function initializeTools(): Promise<void> {
   await import('./skills/load.js');
   await import('./browser/headless-browser.js');
   await import('./weather/get-weather.js');
+  await import('./memory/register.js');
   await import('./credentials/vault.js');
   await import('./credentials/account-registry.js');
   await import('./timer/pomodoro.js');


### PR DESCRIPTION
## Summary
- Adds `memory_search`, `memory_save`, and `memory_update` tools for proactive agent memory management
- Implements tool handlers with lexical + entity + direct item search, duplicate fingerprint checking, and automatic re-embedding
- Adds `searchMemoryItems` API in retriever for lightweight memory queries without full injection text building

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
