### PR TITLE
Align VSlider track with surrounding text

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Inputs/VSlider.swift
@@ -64,21 +64,18 @@ struct VSlider: View {
     // MARK: - Track
 
     private func trackView(thumbOffset: CGFloat, trackWidth: CGFloat) -> some View {
-        let cornerRadius: CGFloat = VRadius.md
-
-        return ZStack(alignment: .leading) {
-            // Unfilled track
-            RoundedRectangle(cornerRadius: cornerRadius)
+        ZStack(alignment: .leading) {
+            // Unfilled track (edge-to-edge)
+            Rectangle()
                 .fill(Slate._700)
                 .frame(height: trackHeight)
-                .padding(.horizontal, thumbWidth / 2)
 
-            // Filled track
-            RoundedRectangle(cornerRadius: cornerRadius)
+            // Filled track (from left edge to thumb center)
+            Rectangle()
                 .fill(VColor.accent)
-                .frame(width: thumbOffset, height: trackHeight)
-                .padding(.leading, thumbWidth / 2)
+                .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
         }
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
     // MARK: - Thumb


### PR DESCRIPTION
## Summary
- Remove horizontal padding from VSlider track so it extends edge-to-edge, aligning with text content above
- Use `clipShape` on the ZStack for rounded corners instead of individual `RoundedRectangle` fills
- Filled track now extends from left edge to thumb center for proper visual fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
