### PR TITLE
Add thread tab spacing and dividers

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
@@ -26,41 +26,41 @@ struct VTab: View {
     }
 
     var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: VSpacing.xs) {
-                if let icon = icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 12))
+        HStack(spacing: 6) {
+            Button(action: onSelect) {
+                HStack(spacing: VSpacing.xs) {
+                    if let icon = icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 12))
+                    }
+                    Text(label)
+                        .font(VFont.caption)
+                        .lineLimit(1)
                 }
-                Text(label)
-                    .font(VFont.caption)
-                    .lineLimit(1)
+                .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
             }
-            .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.pill)
-                    .stroke(Slate._300, lineWidth: 1)
-                    .opacity(style == .pill && isSelected ? 1 : 0)
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in isHovered = hovering }
-        .overlay(alignment: .trailing) {
+            .buttonStyle(.plain)
+
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(VColor.textMuted)
-                        .padding(.trailing, VSpacing.xs)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close \(label)")
             }
         }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(background)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.pill)
+                .stroke(Slate._300, lineWidth: 1)
+                .opacity(style == .pill && isSelected ? 1 : 0)
+        )
+        .onHover { hovering in isHovered = hovering }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -10,7 +10,13 @@ struct ThreadTabBar: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                ForEach(threads) { thread in
+                ForEach(Array(threads.enumerated()), id: \.element.id) { index, thread in
+                    if index > 0 {
+                        Rectangle()
+                            .fill(Slate._600)
+                            .frame(width: 1, height: 14)
+                    }
+
                     VTab(
                         label: thread.title,
                         icon: "flame",


### PR DESCRIPTION
## Summary
- Move VTab close button from overlay into HStack with 6px spacing for precise gap between title and X button
- Add vertical dividers (1px Slate._600, 14px tall) between each thread tab in ThreadTabBar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
