### PR TITLE
Add hover state and rectangular style to thread tabs

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -85,4 +85,9 @@ struct GallerySectionHeader: View {
         }
     }
 }
+
+#Preview("Component Gallery") {
+    ComponentGalleryView()
+        .frame(width: 900, height: 700)
+}
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -112,6 +112,35 @@ struct ButtonsGallerySection: View {
                     }
                 }
             }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VCircleButton
+            GallerySectionHeader(
+                title: "VCircleButton",
+                description: "Circular button with SF Symbol icon, configurable fill color and size."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xl) {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Default (Emerald, 36pt)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "plus", label: "Add") {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Violet fill").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "phone.fill", label: "Call", fillColor: Violet._500) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Large (48pt)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "mic.fill", label: "Record", size: 48, iconSize: 20) {}
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Small (24pt, Rose)").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VCircleButton(icon: "xmark", label: "Close", fillColor: Rose._600, size: 24, iconSize: 10) {}
+                    }
+                }
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -6,8 +6,8 @@ struct ModifiersGallerySection: View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
             // MARK: - .vCard()
             GallerySectionHeader(
-                title: ".vCard(radius:)",
-                description: "View modifier that applies card styling with configurable corner radius."
+                title: ".vCard(radius:background:)",
+                description: "View modifier that applies card styling with configurable corner radius and background color."
             )
 
             VCard {
@@ -27,6 +27,35 @@ struct ModifiersGallerySection: View {
                                 .vCard(radius: radius)
 
                             Text(".\(name) (\(Int(radius))pt)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                }
+            }
+
+            // Background colors
+            Text("Background Colors")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    ForEach([
+                        ("surface", VColor.surface),
+                        ("background", VColor.background),
+                        ("accent", VColor.accent),
+                        ("success", VColor.success),
+                        ("error", VColor.error),
+                    ], id: \.0) { name, color in
+                        VStack(spacing: VSpacing.md) {
+                            Text("Sample content")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .padding(VSpacing.xl)
+                                .vCard(background: color)
+
+                            Text(name)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -81,7 +81,7 @@ struct NavigationGallerySection: View {
             }
 
             // Tab states
-            Text("Tab States")
+            Text("Tab States (Pill)")
                 .font(VFont.headline)
                 .foregroundColor(VColor.textSecondary)
 
@@ -102,6 +102,58 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("No icon").font(VFont.caption).foregroundColor(VColor.textMuted)
                         VTab(label: "Plain Tab", isCloseable: false, onSelect: {})
+                    }
+                }
+            }
+
+            // Flat-style tab states
+            Text("Tab States (Flat)")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Default").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Thread 1", style: .flat, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Thread 1", isSelected: true, style: .flat, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Thread 2", style: .flat, onSelect: {}, onClose: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected + Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Thread 2", isSelected: true, style: .flat, onSelect: {}, onClose: {})
+                    }
+                }
+            }
+
+            // Rectangular-style tab states
+            Text("Tab States (Rectangular)")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textSecondary)
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Default").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", style: .rectangular, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", isSelected: true, style: .rectangular, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", style: .rectangular, onSelect: {}, onClose: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected + Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        VTab(label: "Tab", icon: "doc", isSelected: true, style: .rectangular, onSelect: {}, onClose: {})
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
@@ -21,7 +21,7 @@ struct VTab: View {
         case .pill:
             return isSelected ? Slate._200 : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
         case .flat:
-            return .clear
+            return isHovered ? Slate._800 : .clear
         }
     }
 

--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 enum VTabStyle {
-    case pill   // Shows background fill on selected/hover
-    case flat   // No background fill, only text color changes
+    case pill        // Shows background fill on selected/hover, fully rounded
+    case flat        // No background fill, only text color changes
+    case rectangular // Same as pill but with VRadius.md corners (matches VButton)
 }
 
 struct VTab: View {
@@ -18,10 +19,17 @@ struct VTab: View {
 
     private var background: Color {
         switch style {
-        case .pill:
+        case .pill, .rectangular:
             return isSelected ? Slate._200 : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
         case .flat:
             return isHovered ? Slate._800 : .clear
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        switch style {
+        case .pill, .flat: return VRadius.pill
+        case .rectangular: return VRadius.md
         }
     }
 
@@ -37,7 +45,7 @@ struct VTab: View {
                         .font(VFont.caption)
                         .lineLimit(1)
                 }
-                .foregroundColor(isSelected && style == .pill ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
+                .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
             }
             .buttonStyle(.plain)
 
@@ -54,11 +62,11 @@ struct VTab: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .background(background)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(
-            RoundedRectangle(cornerRadius: VRadius.pill)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .stroke(Slate._300, lineWidth: 1)
-                .opacity(style == .pill && isSelected ? 1 : 0)
+                .opacity((style == .pill || style == .rectangular) && isSelected ? 1 : 0)
         )
         .onHover { hovering in isHovered = hovering }
     }
@@ -70,7 +78,7 @@ struct VTab: View {
         HStack(spacing: 8) {
             VTab(label: "Dashboard", icon: "house", isSelected: true, onSelect: {})
             VTab(label: "Settings", icon: "gear", onSelect: {})
-            VTab(label: "Not closeable", isCloseable: false, onSelect: {})
+            VTab(label: "Thread", icon: "plus", isCloseable: false, style: .rectangular, onSelect: {})
         }
         .padding()
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -27,18 +27,15 @@ struct ThreadTabBar: View {
                         onClose: { onClose(thread.id) }
                     )
                 }
+                
+                Rectangle()
+                    .fill(Slate._600)
+                    .frame(width: 1, height: 14)
+                    .padding(VSpacing.xs)
 
-                Button(action: onCreate) {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "plus")
-                        Text("Thread")
-                    }
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-                }
-                .buttonStyle(.plain)
-                .vHover()
-                .accessibilityLabel("New Thread")
+
+                VTab(label: "Thread", icon: "plus", isCloseable: false, style: .rectangular, onSelect: { onCreate() })
+                    
 
                 Spacer()
             }


### PR DESCRIPTION
## Summary
Add hover feedback to flat-style thread tabs and introduce a new rectangular VTab style that matches VButton's corner radius. Also backfills the component gallery with missing variants (VCircleButton, flat/rectangular VTab, .vCard background colors).

## Changes
- Add `Slate._800` hover background for flat-style VTab (thread tabs)
- Add `VTabStyle.rectangular` with `VRadius.md` corners matching VButton
- Use rectangular VTab for the "New Thread" button in ThreadTabBar
- Add VCircleButton section to buttons gallery (4 size/color variants)
- Add flat and rectangular VTab states to navigation gallery
- Add `.vCard()` background color variants to modifiers gallery
- Add `#Preview` to ComponentGalleryView for full gallery preview in Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)