### PR TITLE
Add auth challenge detection engine for browser sessions

### DIFF
--- a/assistant/src/tools/browser/__tests__/auth-detector.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-detector.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  detectAuthChallenge,
+  identifyService,
+  isAuthUrl,
+  formatAuthChallenge,
+  type AuthChallenge,
+} from '../auth-detector.js';
+import type { Page } from '../browser-manager.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal mock Page whose `url()` returns the given URL and
+ * `evaluate()` runs a callback that simulates a DOM structure.
+ *
+ * `evaluateResult` is the value that `page.evaluate()` will resolve with,
+ * matching the shape returned by the DOM_DETECT_EXPRESSION IIFE inside
+ * auth-detector.ts.
+ */
+function mockPage(url: string, evaluateResult: unknown = null): Page {
+  return {
+    close: async () => {},
+    isClosed: () => false,
+    goto: async () => null,
+    title: async () => '',
+    url: () => url,
+    evaluate: async (_expr: string) => evaluateResult,
+    click: async () => {},
+    fill: async () => {},
+    press: async () => {},
+    waitForSelector: async () => null,
+    waitForFunction: async () => null,
+    route: async () => {},
+    unroute: async () => {},
+    keyboard: { press: async () => {} },
+  };
+}
+
+// ── Service identification ───────────────────────────────────────────
+
+describe('identifyService', () => {
+  it('identifies Google from accounts.google.com', () => {
+    expect(identifyService('https://accounts.google.com/v3/signin/identifier')).toBe('Google');
+  });
+
+  it('identifies GitHub from github.com/login', () => {
+    expect(identifyService('https://github.com/login')).toBe('GitHub');
+  });
+
+  it('identifies Microsoft from login.microsoftonline.com', () => {
+    expect(identifyService('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')).toBe('Microsoft');
+  });
+
+  it('identifies Apple from appleid.apple.com', () => {
+    expect(identifyService('https://appleid.apple.com/auth/authorize')).toBe('Apple');
+  });
+
+  it('identifies Okta', () => {
+    expect(identifyService('https://mycompany.okta.com/login/login.htm')).toBe('Okta');
+  });
+
+  it('returns undefined for unknown domains', () => {
+    expect(identifyService('https://example.com/dashboard')).toBeUndefined();
+  });
+});
+
+// ── URL auth-pattern matching ────────────────────────────────────────
+
+describe('isAuthUrl', () => {
+  it('matches known service URLs', () => {
+    expect(isAuthUrl('https://accounts.google.com/ServiceLogin')).toBe(true);
+    expect(isAuthUrl('https://github.com/login')).toBe(true);
+    expect(isAuthUrl('https://login.microsoftonline.com/common/oauth2')).toBe(true);
+  });
+
+  it('matches generic /login path', () => {
+    expect(isAuthUrl('https://example.com/login')).toBe(true);
+    expect(isAuthUrl('https://example.com/user/login?next=/')).toBe(true);
+  });
+
+  it('matches generic /signin path', () => {
+    expect(isAuthUrl('https://example.com/signin')).toBe(true);
+  });
+
+  it('matches generic /sign-in path', () => {
+    expect(isAuthUrl('https://example.com/sign-in')).toBe(true);
+  });
+
+  it('matches /auth path', () => {
+    expect(isAuthUrl('https://example.com/auth/callback')).toBe(true);
+  });
+
+  it('matches /oauth path', () => {
+    expect(isAuthUrl('https://example.com/oauth/authorize')).toBe(true);
+  });
+
+  it('matches /sso path', () => {
+    expect(isAuthUrl('https://example.com/sso/login')).toBe(true);
+  });
+
+  it('does not match unrelated URLs', () => {
+    expect(isAuthUrl('https://example.com/dashboard')).toBe(false);
+    expect(isAuthUrl('https://example.com/blog/authentication-tips')).toBe(false);
+    expect(isAuthUrl('https://example.com/')).toBe(false);
+  });
+});
+
+// ── DOM detection: login pages ───────────────────────────────────────
+
+describe('detectAuthChallenge — login pages', () => {
+  it('detects a generic login page with password input', async () => {
+    const page = mockPage('https://example.com/login', {
+      type: 'login',
+      fields: [
+        { type: 'email', selector: 'input[type="email"]', label: 'email' },
+        { type: 'password', selector: 'input[type="password"]', label: 'password' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('login');
+    expect(result!.fields.some((f) => f.type === 'password')).toBe(true);
+  });
+
+  it('detects Google email step via #identifierId', async () => {
+    const page = mockPage('https://accounts.google.com/v3/signin/identifier', {
+      type: 'login',
+      fields: [
+        { type: 'email', selector: '#identifierId', label: 'Google email' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('login');
+    expect(result!.service).toBe('Google');
+    expect(result!.fields[0].selector).toBe('#identifierId');
+  });
+
+  it('detects Google password step', async () => {
+    const page = mockPage('https://accounts.google.com/v3/signin/challenge', {
+      type: 'login',
+      fields: [
+        { type: 'password', selector: 'input[type="password"][name="Passwd"]', label: 'Google password' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('login');
+    expect(result!.service).toBe('Google');
+  });
+
+  it('falls back to URL-only detection when DOM has no auth elements', async () => {
+    const page = mockPage('https://accounts.google.com/ServiceLogin', null);
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('login');
+    expect(result!.service).toBe('Google');
+    expect(result!.fields).toEqual([]);
+  });
+});
+
+// ── DOM detection: 2FA pages ─────────────────────────────────────────
+
+describe('detectAuthChallenge — 2FA pages', () => {
+  it('detects a 2FA page with code input', async () => {
+    const page = mockPage('https://accounts.google.com/signin/v2/challenge', {
+      type: '2fa',
+      fields: [
+        { type: 'code', selector: 'input[name="code"]', label: 'verification code' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('2fa');
+    expect(result!.fields.some((f) => f.type === 'code')).toBe(true);
+  });
+
+  it('detects 2FA via text patterns even without specific input', async () => {
+    const page = mockPage('https://example.com/verify', {
+      type: '2fa',
+      fields: [
+        { type: 'code', selector: '', label: 'verification code (text detected)' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('2fa');
+  });
+});
+
+// ── DOM detection: OAuth consent ─────────────────────────────────────
+
+describe('detectAuthChallenge — OAuth consent', () => {
+  it('detects an OAuth consent page with Allow button', async () => {
+    const page = mockPage('https://accounts.google.com/o/oauth2/v2/auth', {
+      type: 'oauth_consent',
+      fields: [
+        { type: 'approval', selector: '#submit_approve_access', label: 'Allow' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('oauth_consent');
+    expect(result!.service).toBe('Google');
+    expect(result!.fields.some((f) => f.type === 'approval')).toBe(true);
+  });
+
+  it('detects consent with Approve button', async () => {
+    const page = mockPage('https://github.com/login/oauth/authorize', {
+      type: 'oauth_consent',
+      fields: [
+        { type: 'approval', selector: 'button', label: 'Approve' },
+      ],
+    });
+
+    const result = await detectAuthChallenge(page);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('oauth_consent');
+  });
+});
+
+// ── Non-auth pages ───────────────────────────────────────────────────
+
+describe('detectAuthChallenge — non-auth pages', () => {
+  it('returns null for a regular page', async () => {
+    const page = mockPage('https://example.com/dashboard', null);
+
+    const result = await detectAuthChallenge(page);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a regular page with no auth elements', async () => {
+    const page = mockPage('https://news.ycombinator.com/', null);
+
+    const result = await detectAuthChallenge(page);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when page.evaluate throws', async () => {
+    const page = mockPage('https://example.com/login', null);
+    page.evaluate = async () => { throw new Error('page closed'); };
+
+    const result = await detectAuthChallenge(page);
+    expect(result).toBeNull();
+  });
+});
+
+// ── formatAuthChallenge ──────────────────────────────────────────────
+
+describe('formatAuthChallenge', () => {
+  it('formats a login challenge with service name', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'Google',
+      fields: [
+        { type: 'email', selector: '#identifierId', label: 'email' },
+        { type: 'password', selector: 'input[type="password"]', label: 'password' },
+      ],
+      url: 'https://accounts.google.com/signin',
+    };
+    const output = formatAuthChallenge(challenge);
+    expect(output).toContain('Auth challenge detected: Google login page');
+    expect(output).toContain('Type: login');
+    expect(output).toContain('Fields: email (email), password (password)');
+  });
+
+  it('formats a 2FA challenge', () => {
+    const challenge: AuthChallenge = {
+      type: '2fa',
+      fields: [
+        { type: 'code', selector: 'input[name="code"]', label: 'verification code' },
+      ],
+      url: 'https://example.com/verify',
+    };
+    const output = formatAuthChallenge(challenge);
+    expect(output).toContain('Auth challenge detected: 2FA verification');
+    expect(output).toContain('Type: 2fa');
+  });
+
+  it('formats an OAuth consent challenge', () => {
+    const challenge: AuthChallenge = {
+      type: 'oauth_consent',
+      service: 'GitHub',
+      fields: [
+        { type: 'approval', selector: 'button', label: 'Authorize' },
+      ],
+      url: 'https://github.com/login/oauth/authorize',
+    };
+    const output = formatAuthChallenge(challenge);
+    expect(output).toContain('Auth challenge detected: GitHub OAuth consent screen');
+    expect(output).toContain('Type: oauth_consent');
+  });
+
+  it('omits Fields line when there are no fields', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'Google',
+      fields: [],
+      url: 'https://accounts.google.com/signin',
+    };
+    const output = formatAuthChallenge(challenge);
+    expect(output).not.toContain('Fields:');
+  });
+});

--- a/assistant/src/tools/browser/auth-detector.ts
+++ b/assistant/src/tools/browser/auth-detector.ts
@@ -1,0 +1,250 @@
+import type { Page } from './browser-manager.js';
+
+export type AuthChallengeType = 'login' | '2fa' | 'oauth_consent';
+
+export interface AuthField {
+  type: 'email' | 'password' | 'code' | 'approval';
+  selector: string;
+  label: string;
+}
+
+export interface AuthChallenge {
+  type: AuthChallengeType;
+  service?: string;
+  fields: AuthField[];
+  url: string;
+}
+
+// ── URL pattern matching ─────────────────────────────────────────────
+
+interface ServicePattern {
+  pattern: RegExp;
+  service: string;
+}
+
+const SERVICE_PATTERNS: ServicePattern[] = [
+  { pattern: /accounts\.google\.com/, service: 'Google' },
+  { pattern: /github\.com\/login/, service: 'GitHub' },
+  { pattern: /login\.microsoftonline\.com/, service: 'Microsoft' },
+  { pattern: /appleid\.apple\.com/, service: 'Apple' },
+  { pattern: /login\.salesforce\.com/, service: 'Salesforce' },
+  { pattern: /id\.atlassian\.com/, service: 'Atlassian' },
+  { pattern: /auth0\.com/, service: 'Auth0' },
+  { pattern: /okta\.com/, service: 'Okta' },
+];
+
+const GENERIC_AUTH_PATTERNS: RegExp[] = [
+  /\/login\b/i,
+  /\/signin\b/i,
+  /\/sign-in\b/i,
+  /\/auth\b/i,
+  /\/oauth\b/i,
+  /\/sso\b/i,
+];
+
+/**
+ * Identify the service name from a URL. Returns undefined if no known
+ * service is matched.
+ */
+export function identifyService(url: string): string | undefined {
+  for (const { pattern, service } of SERVICE_PATTERNS) {
+    if (pattern.test(url)) return service;
+  }
+  return undefined;
+}
+
+/**
+ * Check whether a URL matches a known auth-related path pattern.
+ */
+export function isAuthUrl(url: string): boolean {
+  // Known service URLs are always auth-related
+  if (SERVICE_PATTERNS.some(({ pattern }) => pattern.test(url))) return true;
+  // Generic path patterns
+  return GENERIC_AUTH_PATTERNS.some((p) => p.test(url));
+}
+
+// ── DOM-based detection ──────────────────────────────────────────────
+
+interface DomDetectionResult {
+  type: AuthChallengeType;
+  fields: AuthField[];
+}
+
+/**
+ * JavaScript expression evaluated inside the page to detect auth-related
+ * DOM elements. Returns a serialisable result or null.
+ *
+ * The expression is a self-contained IIFE so it can be passed as a string
+ * to `page.evaluate()`.
+ */
+const DOM_DETECT_EXPRESSION = `(() => {
+  const fields = [];
+
+  // ── Google-specific selectors ──────────────────────────────────
+  const googleEmail = document.querySelector('#identifierId');
+  if (googleEmail) {
+    fields.push({ type: 'email', selector: '#identifierId', label: 'Google email' });
+  }
+  const googlePw = document.querySelector('input[type="password"][name="Passwd"]');
+  if (googlePw) {
+    fields.push({ type: 'password', selector: 'input[type="password"][name="Passwd"]', label: 'Google password' });
+  }
+
+  // ── Generic password inputs ────────────────────────────────────
+  const pwInputs = document.querySelectorAll('input[type="password"]');
+  for (const el of pwInputs) {
+    const sel = 'input[type="password"]';
+    // Avoid duplicating Google password already added
+    if (el.getAttribute('name') === 'Passwd') continue;
+    const label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || 'password';
+    fields.push({ type: 'password', selector: sel, label });
+  }
+
+  // ── Email / username inputs ────────────────────────────────────
+  const emailInputs = document.querySelectorAll(
+    'input[type="email"], input[name="email"], input[name="username"], input[autocomplete="username"]'
+  );
+  for (const el of emailInputs) {
+    if (el.id === 'identifierId') continue; // already handled
+    const sel = el.id ? '#' + el.id : 'input[type="email"]';
+    const label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || 'email';
+    fields.push({ type: 'email', selector: sel, label });
+  }
+
+  // ── 2FA / verification code inputs ─────────────────────────────
+  const bodyText = (document.body && document.body.innerText) || '';
+  const is2FAText = /verification code|two.?factor|2fa|authenticator|one.?time/i.test(bodyText);
+  const codeInputs = document.querySelectorAll(
+    'input[autocomplete="one-time-code"], input[name*="code"], input[name*="otp"], input[name*="token"], input[id*="code"], input[id*="otp"]'
+  );
+
+  if (is2FAText || codeInputs.length > 0) {
+    for (const el of codeInputs) {
+      const sel = el.id ? '#' + el.id : (el.getAttribute('name') ? 'input[name="' + el.getAttribute('name') + '"]' : 'input[autocomplete="one-time-code"]');
+      const label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || 'verification code';
+      fields.push({ type: 'code', selector: sel, label });
+    }
+    // If we detected 2FA text but no specific code input, still report
+    if (codeInputs.length === 0 && is2FAText) {
+      fields.push({ type: 'code', selector: '', label: 'verification code (text detected)' });
+    }
+  }
+
+  // ── OAuth consent buttons ──────────────────────────────────────
+  const buttons = document.querySelectorAll('button, input[type="submit"], [role="button"]');
+  const consentPatterns = /^(allow|approve|grant access|authorize|accept|consent)$/i;
+  let hasConsentButton = false;
+  for (const btn of buttons) {
+    const text = (btn.textContent || '').trim();
+    if (consentPatterns.test(text)) {
+      hasConsentButton = true;
+      const sel = btn.id ? '#' + btn.id : 'button';
+      fields.push({ type: 'approval', selector: sel, label: text });
+    }
+  }
+
+  // ── Sign in / Log in buttons (to support login detection) ──────
+  const signInPatterns = /^(sign in|log in|login|sign up|continue)$/i;
+  let hasSignInButton = false;
+  for (const btn of buttons) {
+    const text = (btn.textContent || '').trim();
+    if (signInPatterns.test(text)) {
+      hasSignInButton = true;
+      break;
+    }
+  }
+
+  // ── Classify ───────────────────────────────────────────────────
+  const hasPassword = fields.some(f => f.type === 'password');
+  const hasEmail = fields.some(f => f.type === 'email');
+  const hasCode = fields.some(f => f.type === 'code');
+  const hasApproval = fields.some(f => f.type === 'approval');
+
+  if (hasApproval) {
+    return { type: 'oauth_consent', fields };
+  }
+  if (hasCode && !hasPassword) {
+    return { type: '2fa', fields: fields.filter(f => f.type === 'code') };
+  }
+  if (hasPassword || (hasEmail && hasSignInButton)) {
+    return { type: 'login', fields: fields.filter(f => f.type === 'email' || f.type === 'password') };
+  }
+  if (is2FAText) {
+    return { type: '2fa', fields: fields.filter(f => f.type === 'code') };
+  }
+
+  return null;
+})()`;
+
+/**
+ * Detect whether the current page presents an authentication challenge
+ * (login form, 2FA prompt, or OAuth consent screen).
+ *
+ * Detection uses two complementary strategies:
+ * 1. URL pattern matching against known auth providers.
+ * 2. DOM inspection for login, 2FA, and consent UI elements.
+ *
+ * Returns an {@link AuthChallenge} if a challenge is detected, or `null`
+ * if the page does not appear to be an auth page.
+ */
+export async function detectAuthChallenge(page: Page): Promise<AuthChallenge | null> {
+  try {
+    const currentUrl = page.url();
+    const service = identifyService(currentUrl);
+    const urlIsAuth = isAuthUrl(currentUrl);
+
+    // DOM-based detection
+    const domResult = (await page.evaluate(DOM_DETECT_EXPRESSION)) as DomDetectionResult | null;
+
+    if (domResult) {
+      return {
+        type: domResult.type,
+        service,
+        fields: domResult.fields,
+        url: currentUrl,
+      };
+    }
+
+    // If the URL strongly suggests an auth page but the DOM didn't
+    // yield specific fields, still report it as a generic login challenge.
+    if (urlIsAuth) {
+      return {
+        type: 'login',
+        service,
+        fields: [],
+        url: currentUrl,
+      };
+    }
+
+    return null;
+  } catch {
+    // If page.evaluate throws (e.g. page closed, navigation), treat as no challenge
+    return null;
+  }
+}
+
+/**
+ * Format an {@link AuthChallenge} into a human-readable string suitable
+ * for appending to browser_navigate output.
+ */
+export function formatAuthChallenge(challenge: AuthChallenge): string {
+  const serviceName = challenge.service ? `${challenge.service} ` : '';
+  const typeLabel =
+    challenge.type === 'login'
+      ? 'login page'
+      : challenge.type === '2fa'
+        ? '2FA verification'
+        : 'OAuth consent screen';
+
+  const lines: string[] = [
+    `\u26a0\ufe0f Auth challenge detected: ${serviceName}${typeLabel}`,
+    `  Type: ${challenge.type}`,
+  ];
+
+  if (challenge.fields.length > 0) {
+    const fieldDescs = challenge.fields.map((f) => `${f.label} (${f.type})`).join(', ');
+    lines.push(`  Fields: ${fieldDescs}`);
+  }
+
+  return lines.join('\n');
+}

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -13,6 +13,7 @@ import {
 import { browserManager } from './browser-manager.js';
 import type { RouteHandler } from './browser-manager.js';
 import { detectCaptcha } from './captcha-detector.js';
+import { detectAuthChallenge, formatAuthChallenge } from './auth-detector.js';
 import { getCredentialValue } from '../credentials/vault.js';
 
 const log = getLogger('headless-browser');
@@ -147,6 +148,17 @@ async function executeBrowserNavigate(
 
     if (finalUrl !== parsedUrl.href) {
       lines.push(`Note: Page redirected from the requested URL.`);
+    }
+
+    // Detect auth challenges (login pages, 2FA, OAuth consent)
+    try {
+      const authChallenge = await detectAuthChallenge(page);
+      if (authChallenge) {
+        lines.push('');
+        lines.push(formatAuthChallenge(authChallenge));
+      }
+    } catch {
+      // Auth detection is best-effort; don't fail navigation
     }
 
     return { content: lines.join('\n'), isError: false };


### PR DESCRIPTION
Part of #1371. Adds heuristic detection for login pages, 2FA prompts, and OAuth consent screens during Playwright navigation. Surfaces auth challenge info in browser_navigate output.

## Changes
- New: `assistant/src/tools/browser/auth-detector.ts` — detection engine with URL pattern matching and DOM inspection
- Modified: `assistant/src/tools/browser/headless-browser.ts` — integrate detection after navigation
- New: `assistant/src/tools/browser/__tests__/auth-detector.test.ts` — 29 unit tests covering all detection paths

## Detection strategy
1. **URL patterns**: Matches known auth providers (Google, GitHub, Microsoft, Apple, Okta, etc.) and generic paths (`/login`, `/signin`, `/auth`, `/oauth`, `/sso`)
2. **DOM inspection**: Detects password inputs, email fields, verification code inputs, and consent buttons via `page.evaluate()`
3. **Service identification**: Maps URLs to human-readable service names

## Test plan
- [x] URL pattern matching for Google, GitHub, Microsoft, generic patterns
- [x] DOM detection for login pages (password inputs)
- [x] DOM detection for 2FA pages (code inputs)
- [x] DOM detection for OAuth consent pages
- [x] Service identification from URLs
- [x] Returns null for non-auth pages
- [x] Graceful handling of page.evaluate errors
- [x] Output formatting

Closes #1372
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
