### PR TITLE
Add browser auth session persistence cache

### DIFF
--- a/assistant/src/tools/browser/__tests__/auth-cache.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-cache.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { AuthSessionCache } from '../auth-cache.js';
+
+// Use a unique temp directory for each test run
+let testDir: string;
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `auth-cache-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('AuthSessionCache', () => {
+  beforeEach(() => {
+    testDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  // ── markAuthenticated ───────────────────────────────────────
+
+  describe('markAuthenticated', () => {
+    test('stores a session for a domain', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('example.com', 'jit');
+
+      const sessions = cache.getAll();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].domain).toBe('example.com');
+      expect(sessions[0].method).toBe('jit');
+      expect(sessions[0].authenticatedAt).toBeGreaterThan(0);
+      expect(sessions[0].expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    test('stores session with stored method', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('github.com', 'stored');
+
+      const sessions = cache.getAll();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].method).toBe('stored');
+    });
+
+    test('overwrites existing session for the same domain', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('example.com', 'jit');
+      cache.markAuthenticated('example.com', 'stored');
+
+      const sessions = cache.getAll();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].method).toBe('stored');
+    });
+  });
+
+  // ── isAuthenticated ─────────────────────────────────────────
+
+  describe('isAuthenticated', () => {
+    test('returns true for a valid session', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('example.com', 'jit');
+      expect(cache.isAuthenticated('example.com')).toBe(true);
+    });
+
+    test('returns false for unknown domain', () => {
+      const cache = new AuthSessionCache(testDir);
+      expect(cache.isAuthenticated('unknown.com')).toBe(false);
+    });
+
+    test('returns false for expired session', () => {
+      // Use a very short expiry (1ms)
+      const cache = new AuthSessionCache(testDir, 1);
+      cache.markAuthenticated('example.com', 'jit');
+
+      // Wait a small amount to ensure expiry
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        // busy-wait
+      }
+
+      expect(cache.isAuthenticated('example.com')).toBe(false);
+    });
+
+    test('cleans up expired session from cache on check', () => {
+      const cache = new AuthSessionCache(testDir, 1);
+      cache.markAuthenticated('example.com', 'jit');
+
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        // busy-wait
+      }
+
+      cache.isAuthenticated('example.com');
+      expect(cache.getAll()).toHaveLength(0);
+    });
+  });
+
+  // ── invalidate ──────────────────────────────────────────────
+
+  describe('invalidate', () => {
+    test('removes a session for a domain', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('example.com', 'jit');
+      expect(cache.isAuthenticated('example.com')).toBe(true);
+
+      cache.invalidate('example.com');
+      expect(cache.isAuthenticated('example.com')).toBe(false);
+      expect(cache.getAll()).toHaveLength(0);
+    });
+
+    test('is safe to call for non-existent domain', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.invalidate('nonexistent.com');
+      // Should not throw
+    });
+  });
+
+  // ── load and save round-trip ────────────────────────────────
+
+  describe('load and save', () => {
+    test('round-trips sessions through disk', async () => {
+      const cache1 = new AuthSessionCache(testDir);
+      cache1.markAuthenticated('example.com', 'jit');
+      cache1.markAuthenticated('github.com', 'stored');
+
+      // Wait briefly for fire-and-forget save to complete
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const cache2 = new AuthSessionCache(testDir);
+      await cache2.load();
+
+      expect(cache2.isAuthenticated('example.com')).toBe(true);
+      expect(cache2.isAuthenticated('github.com')).toBe(true);
+
+      const sessions = cache2.getAll();
+      expect(sessions).toHaveLength(2);
+    });
+
+    test('persists to the expected file path', async () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('example.com', 'jit');
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const filePath = join(testDir, 'browser-auth', 'sessions.json');
+      expect(existsSync(filePath)).toBe(true);
+
+      const raw = readFileSync(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      expect(data).toHaveLength(1);
+      expect(data[0].domain).toBe('example.com');
+    });
+
+    test('handles missing file gracefully on load', async () => {
+      const cache = new AuthSessionCache(testDir);
+      await cache.load();
+      expect(cache.getAll()).toHaveLength(0);
+    });
+
+    test('handles corrupted file gracefully on load', async () => {
+      const dir = join(testDir, 'browser-auth');
+      mkdirSync(dir, { recursive: true });
+      const filePath = join(dir, 'sessions.json');
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(filePath, 'not valid json!!!', 'utf-8');
+
+      const cache = new AuthSessionCache(testDir);
+      await cache.load();
+      expect(cache.getAll()).toHaveLength(0);
+    });
+  });
+
+  // ── domain normalization ────────────────────────────────────
+
+  describe('domain normalization', () => {
+    test('www.google.com matches google.com', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('www.google.com', 'jit');
+      expect(cache.isAuthenticated('google.com')).toBe(true);
+    });
+
+    test('google.com matches www.google.com lookup', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('google.com', 'jit');
+      expect(cache.isAuthenticated('www.google.com')).toBe(true);
+    });
+
+    test('domain lookup is case-insensitive', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('GitHub.COM', 'stored');
+      expect(cache.isAuthenticated('github.com')).toBe(true);
+      expect(cache.isAuthenticated('GITHUB.COM')).toBe(true);
+    });
+
+    test('normalized domain is stored', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('WWW.Example.COM', 'jit');
+
+      const sessions = cache.getAll();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].domain).toBe('example.com');
+    });
+  });
+
+  // ── expired sessions cleaned up on load ─────────────────────
+
+  describe('expired session cleanup on load', () => {
+    test('expired sessions are removed during load', async () => {
+      const cache1 = new AuthSessionCache(testDir, 1);
+      cache1.markAuthenticated('expired.com', 'jit');
+
+      // Wait for save and for the session to expire
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const cache2 = new AuthSessionCache(testDir);
+      await cache2.load();
+
+      expect(cache2.isAuthenticated('expired.com')).toBe(false);
+      expect(cache2.getAll()).toHaveLength(0);
+    });
+
+    test('only expired sessions are removed, valid ones kept', async () => {
+      // Create one session that expires quickly and one that doesn't
+      const cache1 = new AuthSessionCache(testDir, 1);
+      cache1.markAuthenticated('expired.com', 'jit');
+
+      // Wait for it to expire and save
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Now add a long-lived session to the same cache dir
+      const cache1b = new AuthSessionCache(testDir);
+      await cache1b.load();
+      cache1b.markAuthenticated('valid.com', 'stored');
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Load again in a fresh cache
+      const cache2 = new AuthSessionCache(testDir);
+      await cache2.load();
+
+      expect(cache2.isAuthenticated('expired.com')).toBe(false);
+      expect(cache2.isAuthenticated('valid.com')).toBe(true);
+      expect(cache2.getAll()).toHaveLength(1);
+    });
+  });
+
+  // ── getAll ──────────────────────────────────────────────────
+
+  describe('getAll', () => {
+    test('returns empty array when no sessions', () => {
+      const cache = new AuthSessionCache(testDir);
+      expect(cache.getAll()).toEqual([]);
+    });
+
+    test('returns all stored sessions', () => {
+      const cache = new AuthSessionCache(testDir);
+      cache.markAuthenticated('a.com', 'jit');
+      cache.markAuthenticated('b.com', 'stored');
+      cache.markAuthenticated('c.com', 'jit');
+
+      expect(cache.getAll()).toHaveLength(3);
+    });
+  });
+});

--- a/assistant/src/tools/browser/auth-cache.ts
+++ b/assistant/src/tools/browser/auth-cache.ts
@@ -1,0 +1,118 @@
+import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { getDataDir } from '../../util/platform.js';
+import { getLogger } from '../../util/logger.js';
+
+const log = getLogger('auth-cache');
+
+const DEFAULT_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export interface AuthSession {
+  domain: string;
+  authenticatedAt: number; // epoch ms
+  expiresAt?: number; // epoch ms, optional
+  method: 'jit' | 'stored';
+}
+
+/**
+ * Normalize a domain for consistent lookup:
+ * - lowercase
+ * - strip leading "www."
+ */
+function normalizeDomain(domain: string): string {
+  let d = domain.toLowerCase().trim();
+  if (d.startsWith('www.')) {
+    d = d.slice(4);
+  }
+  return d;
+}
+
+export class AuthSessionCache {
+  private sessions: Map<string, AuthSession> = new Map();
+  private filePath: string;
+  private defaultExpiryMs: number;
+  private loaded = false;
+
+  constructor(dataDir?: string, defaultExpiryMs?: number) {
+    const base = dataDir ?? getDataDir();
+    this.filePath = join(base, 'browser-auth', 'sessions.json');
+    this.defaultExpiryMs = defaultExpiryMs ?? DEFAULT_EXPIRY_MS;
+  }
+
+  async load(): Promise<void> {
+    try {
+      if (existsSync(this.filePath)) {
+        const raw = readFileSync(this.filePath, 'utf-8');
+        const entries: AuthSession[] = JSON.parse(raw);
+        this.sessions.clear();
+        const now = Date.now();
+        for (const entry of entries) {
+          const key = normalizeDomain(entry.domain);
+          // Skip expired sessions during load
+          if (entry.expiresAt != null && entry.expiresAt <= now) {
+            log.debug({ domain: key }, 'Skipping expired session during load');
+            continue;
+          }
+          this.sessions.set(key, { ...entry, domain: key });
+        }
+      }
+    } catch (err) {
+      log.warn({ err }, 'Failed to load auth session cache, starting fresh');
+      this.sessions.clear();
+    }
+    this.loaded = true;
+  }
+
+  async save(): Promise<void> {
+    try {
+      const dir = join(this.filePath, '..');
+      mkdirSync(dir, { recursive: true });
+      const entries = Array.from(this.sessions.values());
+      writeFileSync(this.filePath, JSON.stringify(entries, null, 2), 'utf-8');
+    } catch (err) {
+      log.warn({ err }, 'Failed to save auth session cache');
+    }
+  }
+
+  isAuthenticated(domain: string): boolean {
+    const key = normalizeDomain(domain);
+    const session = this.sessions.get(key);
+    if (!session) return false;
+
+    // Check expiry
+    if (session.expiresAt != null && session.expiresAt <= Date.now()) {
+      this.sessions.delete(key);
+      // Fire-and-forget save for cleanup
+      void this.save();
+      return false;
+    }
+
+    return true;
+  }
+
+  markAuthenticated(domain: string, method: 'jit' | 'stored'): void {
+    const key = normalizeDomain(domain);
+    const now = Date.now();
+    const session: AuthSession = {
+      domain: key,
+      authenticatedAt: now,
+      expiresAt: now + this.defaultExpiryMs,
+      method,
+    };
+    this.sessions.set(key, session);
+    void this.save();
+  }
+
+  invalidate(domain: string): void {
+    const key = normalizeDomain(domain);
+    this.sessions.delete(key);
+    void this.save();
+  }
+
+  getAll(): AuthSession[] {
+    return Array.from(this.sessions.values());
+  }
+}
+
+// Singleton export
+export const authSessionCache = new AuthSessionCache();

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { getDataDir } from '../../util/platform.js';
 import { getLogger } from '../../util/logger.js';
 import { checkBrowserRuntime } from './runtime-check.js';
+import { authSessionCache } from './auth-cache.js';
 
 const log = getLogger('browser-manager');
 
@@ -74,6 +75,9 @@ class BrowserManager {
     this.contextCreating = (async () => {
       const profileDir = getProfileDir();
       mkdirSync(profileDir, { recursive: true });
+
+      // Initialize auth session cache alongside browser context
+      await authSessionCache.load();
 
       // Auto-install Chromium if missing
       if (!launchPersistentContext) {
@@ -203,3 +207,7 @@ class BrowserManager {
 }
 
 export const browserManager = new BrowserManager();
+
+export function isAuthenticatedForDomain(domain: string): boolean {
+  return authSessionCache.isAuthenticated(domain);
+}


### PR DESCRIPTION
Part of #1371. Adds auth session caching so users don't re-authenticate every browser session. Persists per-domain auth state to disk with expiry support.

## Changes
- New: `assistant/src/tools/browser/auth-cache.ts` — AuthSessionCache with load/save/isAuthenticated/markAuthenticated/invalidate
- Modified: `assistant/src/tools/browser/browser-manager.ts` — integrate auth cache initialization and export `isAuthenticatedForDomain()` helper
- New: `assistant/src/tools/browser/__tests__/auth-cache.test.ts` — 21 unit tests covering all cache operations

## Details
- Sessions stored in `~/.vellum/browser-auth/sessions.json`
- Default 30-day expiry, configurable via constructor
- Domain normalization: case-insensitive, strips `www.` prefix
- Expired sessions cleaned on load and on access
- Auto-saves on `markAuthenticated()` and `invalidate()`
- Graceful handling of missing/corrupted session files

Closes #1375
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
