### PR TITLE
Add password field type for JIT auth prompts

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -176,7 +176,7 @@ export interface CardSurfaceData {
 
 export interface FormField {
   id: string;
-  type: 'text' | 'textarea' | 'select' | 'toggle' | 'number';
+  type: 'text' | 'textarea' | 'select' | 'toggle' | 'number' | 'password';
   label: string;
   placeholder?: string;
   required?: boolean;

--- a/assistant/src/tools/browser/__tests__/jit-auth.test.ts
+++ b/assistant/src/tools/browser/__tests__/jit-auth.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect } from 'bun:test';
+import { buildAuthForm, buildTimeoutMessage } from '../jit-auth.js';
+import type { AuthChallenge } from '../auth-detector.js';
+
+describe('buildAuthForm', () => {
+  test('login challenge produces form with email (text) and password (password) fields', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'Google',
+      url: 'https://accounts.google.com/signin',
+      fields: [
+        { type: 'email', selector: '#identifierId', label: 'Google email' },
+        { type: 'password', selector: 'input[type="password"]', label: 'Google password' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+
+    expect(form.fields).toHaveLength(2);
+
+    expect(form.fields[0].id).toBe('email');
+    expect(form.fields[0].type).toBe('text');
+    expect(form.fields[0].label).toBe('Google email');
+    expect(form.fields[0].placeholder).toBe('you@example.com');
+    expect(form.fields[0].required).toBe(true);
+
+    expect(form.fields[1].id).toBe('password');
+    expect(form.fields[1].type).toBe('password');
+    expect(form.fields[1].label).toBe('Google password');
+    expect(form.fields[1].placeholder).toBe('Enter your password');
+    expect(form.fields[1].required).toBe(true);
+  });
+
+  test('2FA challenge produces form with code (text) field', () => {
+    const challenge: AuthChallenge = {
+      type: '2fa',
+      service: 'GitHub',
+      url: 'https://github.com/sessions/two-factor',
+      fields: [
+        { type: 'code', selector: '#otp', label: 'verification code' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+
+    expect(form.fields).toHaveLength(1);
+    expect(form.fields[0].id).toBe('code');
+    expect(form.fields[0].type).toBe('text');
+    expect(form.fields[0].label).toBe('verification code');
+    expect(form.fields[0].placeholder).toBe('Enter the code');
+    expect(form.fields[0].required).toBe(true);
+  });
+
+  test('OAuth consent challenge produces form with approval (toggle) field', () => {
+    const challenge: AuthChallenge = {
+      type: 'oauth_consent',
+      service: 'Google',
+      url: 'https://accounts.google.com/o/oauth2/consent',
+      fields: [
+        { type: 'approval', selector: '#approve', label: 'Allow' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+
+    expect(form.fields).toHaveLength(1);
+    expect(form.fields[0].id).toBe('field_0');
+    expect(form.fields[0].type).toBe('toggle');
+    expect(form.fields[0].label).toBe('Allow');
+    expect(form.fields[0].placeholder).toBeUndefined();
+    expect(form.fields[0].required).toBe(true);
+  });
+
+  test('service name appears in description', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'GitHub',
+      url: 'https://github.com/login',
+      fields: [
+        { type: 'email', selector: '#login_field', label: 'email' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+    expect(form.description).toContain('GitHub');
+  });
+
+  test('default service name ("this website") when service is undefined', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: undefined,
+      url: 'https://example.com/login',
+      fields: [
+        { type: 'email', selector: '#email', label: 'email' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+    expect(form.description).toContain('this website');
+  });
+
+  test('submit label is "Continue" for login', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'Google',
+      url: 'https://accounts.google.com/signin',
+      fields: [
+        { type: 'email', selector: '#identifierId', label: 'email' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+    expect(form.submitLabel).toBe('Continue');
+  });
+
+  test('submit label is "Approve" for oauth_consent', () => {
+    const challenge: AuthChallenge = {
+      type: 'oauth_consent',
+      service: 'Google',
+      url: 'https://accounts.google.com/o/oauth2/consent',
+      fields: [
+        { type: 'approval', selector: '#approve', label: 'Allow' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+    expect(form.submitLabel).toBe('Approve');
+  });
+
+  test('submit label is "Continue" for 2fa', () => {
+    const challenge: AuthChallenge = {
+      type: '2fa',
+      service: 'GitHub',
+      url: 'https://github.com/sessions/two-factor',
+      fields: [
+        { type: 'code', selector: '#otp', label: 'verification code' },
+      ],
+    };
+
+    const form = buildAuthForm(challenge);
+    expect(form.submitLabel).toBe('Continue');
+  });
+});
+
+describe('buildTimeoutMessage', () => {
+  test('returns 2FA-specific message for 2fa challenges', () => {
+    const challenge: AuthChallenge = {
+      type: '2fa',
+      service: 'GitHub',
+      url: 'https://github.com/sessions/two-factor',
+      fields: [
+        { type: 'code', selector: '#otp', label: 'verification code' },
+      ],
+    };
+
+    const message = buildTimeoutMessage(challenge);
+    expect(message).toContain('verification code');
+    expect(message).toContain('GitHub');
+  });
+
+  test('returns sign-in message for login challenges', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: 'Google',
+      url: 'https://accounts.google.com/signin',
+      fields: [
+        { type: 'email', selector: '#identifierId', label: 'email' },
+      ],
+    };
+
+    const message = buildTimeoutMessage(challenge);
+    expect(message).toContain('sign in');
+    expect(message).toContain('Google');
+  });
+
+  test('uses "the website" when service is undefined', () => {
+    const challenge: AuthChallenge = {
+      type: 'login',
+      service: undefined,
+      url: 'https://example.com/login',
+      fields: [
+        { type: 'email', selector: '#email', label: 'email' },
+      ],
+    };
+
+    const message = buildTimeoutMessage(challenge);
+    expect(message).toContain('the website');
+  });
+});

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -156,6 +156,12 @@ async function executeBrowserNavigate(
       if (authChallenge) {
         lines.push('');
         lines.push(formatAuthChallenge(authChallenge));
+        lines.push('');
+        lines.push('To handle this auth challenge, use ui_show with surface_type "form" and the following fields:');
+        const { buildAuthForm } = await import('./jit-auth.js');
+        const formData = buildAuthForm(authChallenge);
+        lines.push(JSON.stringify(formData, null, 2));
+        lines.push('After the user submits, use browser_type to enter the values into the corresponding page elements.');
       }
     } catch {
       // Auth detection is best-effort; don't fail navigation

--- a/assistant/src/tools/browser/jit-auth.ts
+++ b/assistant/src/tools/browser/jit-auth.ts
@@ -1,0 +1,51 @@
+import type { AuthChallenge, AuthField } from './auth-detector.js';
+import type { FormField, FormSurfaceData } from '../../daemon/ipc-protocol.js';
+
+/**
+ * Build a FormSurfaceData suitable for ui_show that prompts the user
+ * for the credentials required by the given auth challenge.
+ */
+export function buildAuthForm(challenge: AuthChallenge): FormSurfaceData {
+  const serviceName = challenge.service ?? 'this website';
+  const description = challenge.type === 'login'
+    ? `Sign in to ${serviceName}. Your password will be masked.`
+    : challenge.type === '2fa'
+      ? `${serviceName} needs a verification code to continue.`
+      : `${serviceName} is asking for permission.`;
+
+  const fields: FormField[] = challenge.fields.map((field, i) => ({
+    id: field.type === 'password' ? 'password' : field.type === 'email' ? 'email' : field.type === 'code' ? 'code' : `field_${i}`,
+    type: mapAuthFieldType(field.type),
+    label: field.label,
+    placeholder: field.type === 'email' ? 'you@example.com'
+      : field.type === 'password' ? 'Enter your password'
+      : field.type === 'code' ? 'Enter the code'
+      : undefined,
+    required: true,
+  }));
+
+  return {
+    description,
+    fields,
+    submitLabel: challenge.type === 'oauth_consent' ? 'Approve' : 'Continue',
+  };
+}
+
+function mapAuthFieldType(authType: AuthField['type']): FormField['type'] {
+  switch (authType) {
+    case 'password': return 'password';
+    case 'email': return 'text';
+    case 'code': return 'text';
+    case 'approval': return 'toggle';
+  }
+}
+
+/**
+ * Build a timeout message for when the user hasn't responded to the auth prompt.
+ */
+export function buildTimeoutMessage(challenge: AuthChallenge): string {
+  const serviceName = challenge.service ?? 'the website';
+  return challenge.type === '2fa'
+    ? `No rush — just let me know when you've got the verification code from ${serviceName}.`
+    : `Take your time — I'll continue once you sign in to ${serviceName}.`;
+}

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -33,7 +33,7 @@ export const uiShowTool: Tool = {
     '- table: Data table with columns, selectable rows, and action buttons. ' +
     'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
     '- form: Input form with typed fields. ' +
-    'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }\n' +
+    'data shape: { description?: string, fields: Array<{ id: string, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label: string, placeholder?: string, required?: boolean, defaultValue?: string|number|boolean, options?: Array<{ label: string, value: string }> }>, submitLabel?: string }\n' +
     '- list: Selectable list of items. ' +
     'data shape: { items: Array<{ id: string, title: string, subtitle?: string, icon?: string, selected?: boolean }>, selectionMode: "single"|"multiple"|"none" }\n' +
     '- confirmation: Yes/no confirmation dialog. ' +


### PR DESCRIPTION
Part of #1371. Adds 'password' field type to FormField in the IPC protocol and ui_show tool, enabling masked password input for JIT browser auth. Includes jit-auth.ts helpers for building auth prompt forms.

## Changes
- Modified: `assistant/src/daemon/ipc-protocol.ts` — add 'password' to FormField.type
- Modified: `assistant/src/tools/ui-surface/definitions.ts` — document password field in ui_show
- New: `assistant/src/tools/browser/jit-auth.ts` — form builder helpers for auth challenges
- Modified: `assistant/src/tools/browser/headless-browser.ts` — add form data hint after auth detection
- New: `assistant/src/tools/browser/__tests__/jit-auth.test.ts` — unit tests

Closes #1373
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
