### PR TITLE
Add SecureField rendering for password form fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift
@@ -58,6 +58,21 @@ struct FormSurfaceView: View {
                 )
             case .select:
                 selectField(for: field)
+            case .password:
+                SecureField(
+                    field.placeholder ?? "",
+                    text: textBinding(for: field.id)
+                )
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .padding(VSpacing.md)
+                .background(VColor.surface)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                )
             case .toggle:
                 Toggle(isOn: toggleBinding(for: field.id)) {
                     EmptyView()
@@ -127,7 +142,7 @@ struct FormSurfaceView: View {
         for field in data.fields {
             guard let defaultValue = field.defaultValue else { continue }
             switch field.type {
-            case .text, .textarea, .number:
+            case .text, .textarea, .number, .password:
                 textValues[field.id] = defaultValue.stringValue
             case .toggle:
                 if case .boolean(let b) = defaultValue {
@@ -145,7 +160,7 @@ struct FormSurfaceView: View {
         var values: [String: Any] = [:]
         for field in data.fields {
             switch field.type {
-            case .text, .textarea, .number:
+            case .text, .textarea, .number, .password:
                 values[field.id] = textValues[field.id] ?? ""
             case .toggle:
                 values[field.id] = toggleValues[field.id] ?? false

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -44,6 +44,7 @@ enum FormFieldType: String, Sendable {
     case select
     case toggle
     case number
+    case password
 }
 
 /// A form field default value that can be a string, number, or boolean,


### PR DESCRIPTION
Part of #1371. Adds `password` case to FormFieldType enum and renders it as SecureField in FormSurfaceView for masked password input during JIT auth flows.

## Changes
- Modified: `clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift` — add password case to FormFieldType
- Modified: `clients/macos/vellum-assistant/Features/Surfaces/FormSurfaceView.swift` — render password fields as SecureField

Closes #1374
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
