### PR TITLE
Fix auth-detector URL pattern matching to prevent query-param false positives

### DIFF
--- a/assistant/src/tools/browser/__tests__/auth-detector.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-detector.test.ts
@@ -63,6 +63,14 @@ describe('identifyService', () => {
   it('returns undefined for unknown domains', () => {
     expect(identifyService('https://example.com/dashboard')).toBeUndefined();
   });
+
+  it('does not match service patterns in query parameters', () => {
+    expect(identifyService('https://example.com/page?redirect=https://accounts.google.com')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid URLs', () => {
+    expect(identifyService('not-a-url')).toBeUndefined();
+  });
 });
 
 // ── URL auth-pattern matching ────────────────────────────────────────
@@ -103,6 +111,21 @@ describe('isAuthUrl', () => {
     expect(isAuthUrl('https://example.com/dashboard')).toBe(false);
     expect(isAuthUrl('https://example.com/blog/authentication-tips')).toBe(false);
     expect(isAuthUrl('https://example.com/')).toBe(false);
+  });
+
+  it('does not false-positive on auth-like words in query parameters', () => {
+    expect(isAuthUrl('https://example.com/dashboard?redirect=/login')).toBe(false);
+    expect(isAuthUrl('https://example.com/home?next=/signin')).toBe(false);
+    expect(isAuthUrl('https://example.com/page?return_to=/auth/callback')).toBe(false);
+  });
+
+  it('does not false-positive on auth-like words in URL fragments', () => {
+    expect(isAuthUrl('https://example.com/dashboard#/login')).toBe(false);
+    expect(isAuthUrl('https://example.com/app#/auth/settings')).toBe(false);
+  });
+
+  it('returns false for invalid URLs', () => {
+    expect(isAuthUrl('not-a-url')).toBe(false);
   });
 });
 

--- a/assistant/src/tools/browser/auth-detector.ts
+++ b/assistant/src/tools/browser/auth-detector.ts
@@ -24,7 +24,7 @@ interface ServicePattern {
 
 const SERVICE_PATTERNS: ServicePattern[] = [
   { pattern: /accounts\.google\.com/, service: 'Google' },
-  { pattern: /github\.com\/login/, service: 'GitHub' },
+  { pattern: /github\.com/, service: 'GitHub' },
   { pattern: /login\.microsoftonline\.com/, service: 'Microsoft' },
   { pattern: /appleid\.apple\.com/, service: 'Apple' },
   { pattern: /login\.salesforce\.com/, service: 'Salesforce' },
@@ -47,8 +47,14 @@ const GENERIC_AUTH_PATTERNS: RegExp[] = [
  * service is matched.
  */
 export function identifyService(url: string): string | undefined {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
   for (const { pattern, service } of SERVICE_PATTERNS) {
-    if (pattern.test(url)) return service;
+    if (pattern.test(hostname)) return service;
   }
   return undefined;
 }
@@ -57,10 +63,17 @@ export function identifyService(url: string): string | undefined {
  * Check whether a URL matches a known auth-related path pattern.
  */
 export function isAuthUrl(url: string): boolean {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
   // Known service URLs are always auth-related
-  if (SERVICE_PATTERNS.some(({ pattern }) => pattern.test(url))) return true;
-  // Generic path patterns
-  return GENERIC_AUTH_PATTERNS.some((p) => p.test(url));
+  if (SERVICE_PATTERNS.some(({ pattern }) => pattern.test(parsedUrl.hostname))) return true;
+  // Generic path patterns — match against pathname only to avoid false positives
+  // from query parameters or fragments that happen to contain auth-related words.
+  return GENERIC_AUTH_PATTERNS.some((p) => p.test(parsedUrl.pathname));
 }
 
 // ── DOM-based detection ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Parses URLs with `new URL(url)` before pattern matching in `identifyService` and `isAuthUrl` to prevent false positives from query parameters and fragments
- `SERVICE_PATTERNS` now match against `hostname` only; `GENERIC_AUTH_PATTERNS` match against `pathname` only
- Added try-catch for invalid URL handling (returns `undefined`/`false` gracefully)
- Updated GitHub `SERVICE_PATTERN` to hostname-only since path matching is handled separately by generic patterns
- Added test cases verifying no false positives from URLs like `?redirect=/login` or `#/login`

Addresses review feedback from PR #1382.

## Test plan
- [x] TypeScript type checking passes (`bunx tsc --noEmit`)
- [x] All 34 auth-detector tests pass (including 5 new false-positive tests)
- [x] New tests verify query-param URLs (`?redirect=/login`, `?next=/signin`, `?return_to=/auth/callback`) return `false`
- [x] New tests verify fragment URLs (`#/login`, `#/auth/settings`) return `false`
- [x] New tests verify invalid URLs are handled gracefully
- [x] Existing tests for legitimate auth URL detection still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
