### PR TITLE
Fix auth-cache to ensureLoaded before markAuthenticated and invalidate

### DIFF
--- a/assistant/src/tools/browser/__tests__/auth-cache.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-cache.test.ts
@@ -137,6 +137,70 @@ describe('AuthSessionCache', () => {
     expect(cache.isAuthenticated('stale.com')).toBe(false);
   });
 
+  test('markAuthenticated on fresh cache preserves existing sessions on disk', () => {
+    // Write pre-existing sessions to disk
+    const sessions: AuthSession[] = [
+      {
+        domain: 'existing.com',
+        authenticatedAt: Date.now(),
+        expiresAt: Date.now() + 86_400_000,
+        method: 'stored',
+      },
+    ];
+    writeSessionsFile(tmpDir, sessions);
+
+    // Create a fresh cache — load() has NOT been called
+    const cache = new AuthSessionCache(tmpDir);
+
+    // markAuthenticated should ensureLoaded first, so existing sessions
+    // are not clobbered when save() writes to disk
+    cache.markAuthenticated('newdomain.com', 'jit');
+
+    // Verify existing session is still present
+    expect(cache.isAuthenticated('existing.com')).toBe(true);
+    expect(cache.isAuthenticated('newdomain.com')).toBe(true);
+
+    // Double-check by loading a second cache instance from the same disk file
+    const cache2 = new AuthSessionCache(tmpDir);
+    expect(cache2.isAuthenticated('existing.com')).toBe(true);
+    expect(cache2.isAuthenticated('newdomain.com')).toBe(true);
+  });
+
+  test('invalidate on fresh cache preserves unrelated sessions on disk', () => {
+    // Write pre-existing sessions to disk
+    const sessions: AuthSession[] = [
+      {
+        domain: 'keep-me.com',
+        authenticatedAt: Date.now(),
+        expiresAt: Date.now() + 86_400_000,
+        method: 'stored',
+      },
+      {
+        domain: 'remove-me.com',
+        authenticatedAt: Date.now(),
+        expiresAt: Date.now() + 86_400_000,
+        method: 'jit',
+      },
+    ];
+    writeSessionsFile(tmpDir, sessions);
+
+    // Create a fresh cache — load() has NOT been called
+    const cache = new AuthSessionCache(tmpDir);
+
+    // invalidate should ensureLoaded first, so unrelated sessions
+    // are not clobbered when save() writes to disk
+    cache.invalidate('remove-me.com');
+
+    // Verify the targeted session is gone but the other is preserved
+    expect(cache.isAuthenticated('remove-me.com')).toBe(false);
+    expect(cache.isAuthenticated('keep-me.com')).toBe(true);
+
+    // Double-check by loading a second cache instance from the same disk file
+    const cache2 = new AuthSessionCache(tmpDir);
+    expect(cache2.isAuthenticated('remove-me.com')).toBe(false);
+    expect(cache2.isAuthenticated('keep-me.com')).toBe(true);
+  });
+
   test('domain normalization: www prefix and case insensitivity', () => {
     const sessions: AuthSession[] = [
       {

--- a/assistant/src/tools/browser/auth-cache.ts
+++ b/assistant/src/tools/browser/auth-cache.ts
@@ -121,6 +121,7 @@ export class AuthSessionCache {
   }
 
   markAuthenticated(domain: string, method: 'jit' | 'stored'): void {
+    this.ensureLoaded();
     const key = normalizeDomain(domain);
     const now = Date.now();
     const session: AuthSession = {
@@ -134,6 +135,7 @@ export class AuthSessionCache {
   }
 
   invalidate(domain: string): void {
+    this.ensureLoaded();
     const key = normalizeDomain(domain);
     this.sessions.delete(key);
     void this.save();


### PR DESCRIPTION
## Summary
- Added `this.ensureLoaded()` as the first line of `markAuthenticated()` and `invalidate()` in `auth-cache.ts`
- Without this fix, calling either method before `load()` would write only the new/empty session to disk, clobbering all previously persisted sessions
- Added two test cases verifying that existing sessions on disk are preserved when `markAuthenticated()` or `invalidate()` are called on a fresh cache

Addresses review feedback from PR #1387.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/tools/browser/__tests__/auth-cache.test.ts` — all 10 tests pass (including 2 new ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
