### PR TITLE
Fix GitHub SERVICE_PATTERN to require auth path match

### DIFF
--- a/assistant/src/tools/browser/__tests__/auth-detector.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-detector.test.ts
@@ -48,6 +48,16 @@ describe('identifyService', () => {
     expect(identifyService('https://github.com/login')).toBe('GitHub');
   });
 
+  it('identifies GitHub from github.com/session', () => {
+    expect(identifyService('https://github.com/session')).toBe('GitHub');
+  });
+
+  it('does not identify GitHub from regular github.com pages', () => {
+    expect(identifyService('https://github.com/vellum-ai/vellum-assistant')).toBeUndefined();
+    expect(identifyService('https://github.com/pulls')).toBeUndefined();
+    expect(identifyService('https://github.com/')).toBeUndefined();
+  });
+
   it('identifies Microsoft from login.microsoftonline.com', () => {
     expect(identifyService('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')).toBe('Microsoft');
   });
@@ -105,6 +115,13 @@ describe('isAuthUrl', () => {
 
   it('matches /sso path', () => {
     expect(isAuthUrl('https://example.com/sso/login')).toBe(true);
+  });
+
+  it('does not treat regular github.com URLs as auth URLs', () => {
+    expect(isAuthUrl('https://github.com/vellum-ai/vellum-assistant')).toBe(false);
+    expect(isAuthUrl('https://github.com/pulls')).toBe(false);
+    expect(isAuthUrl('https://github.com/')).toBe(false);
+    expect(isAuthUrl('https://github.com/notifications')).toBe(false);
   });
 
   it('does not match unrelated URLs', () => {
@@ -255,6 +272,13 @@ describe('detectAuthChallenge — OAuth consent', () => {
 describe('detectAuthChallenge — non-auth pages', () => {
   it('returns null for a regular page', async () => {
     const page = mockPage('https://example.com/dashboard', null);
+
+    const result = await detectAuthChallenge(page);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a regular github.com page with no auth elements', async () => {
+    const page = mockPage('https://github.com/vellum-ai/vellum-assistant', null);
 
     const result = await detectAuthChallenge(page);
     expect(result).toBeNull();

--- a/assistant/src/tools/browser/auth-detector.ts
+++ b/assistant/src/tools/browser/auth-detector.ts
@@ -20,17 +20,21 @@ export interface AuthChallenge {
 interface ServicePattern {
   pattern: RegExp;
   service: string;
+  /** When set, the URL pathname must also match this pattern for the service to be recognised. */
+  pathPattern?: RegExp;
 }
 
 const SERVICE_PATTERNS: ServicePattern[] = [
+  // Auth-subdomain services — hostname match is sufficient
   { pattern: /accounts\.google\.com/, service: 'Google' },
-  { pattern: /github\.com/, service: 'GitHub' },
   { pattern: /login\.microsoftonline\.com/, service: 'Microsoft' },
   { pattern: /appleid\.apple\.com/, service: 'Apple' },
   { pattern: /login\.salesforce\.com/, service: 'Salesforce' },
   { pattern: /id\.atlassian\.com/, service: 'Atlassian' },
   { pattern: /auth0\.com/, service: 'Auth0' },
   { pattern: /okta\.com/, service: 'Okta' },
+  // General-domain services — need both hostname AND path match
+  { pattern: /github\.com/, service: 'GitHub', pathPattern: /^\/(login|session)/ },
 ];
 
 const GENERIC_AUTH_PATTERNS: RegExp[] = [
@@ -47,14 +51,17 @@ const GENERIC_AUTH_PATTERNS: RegExp[] = [
  * service is matched.
  */
 export function identifyService(url: string): string | undefined {
-  let hostname: string;
+  let parsed: URL;
   try {
-    hostname = new URL(url).hostname;
+    parsed = new URL(url);
   } catch {
     return undefined;
   }
-  for (const { pattern, service } of SERVICE_PATTERNS) {
-    if (pattern.test(hostname)) return service;
+  for (const { pattern, service, pathPattern } of SERVICE_PATTERNS) {
+    if (pattern.test(parsed.hostname)) {
+      if (pathPattern && !pathPattern.test(parsed.pathname)) continue;
+      return service;
+    }
   }
   return undefined;
 }
@@ -69,8 +76,14 @@ export function isAuthUrl(url: string): boolean {
   } catch {
     return false;
   }
-  // Known service URLs are always auth-related
-  if (SERVICE_PATTERNS.some(({ pattern }) => pattern.test(parsedUrl.hostname))) return true;
+  // Known service URLs are always auth-related (respecting pathPattern when present)
+  if (
+    SERVICE_PATTERNS.some(
+      ({ pattern, pathPattern }) =>
+        pattern.test(parsedUrl.hostname) && (!pathPattern || pathPattern.test(parsedUrl.pathname)),
+    )
+  )
+    return true;
   // Generic path patterns — match against pathname only to avoid false positives
   // from query parameters or fragments that happen to contain auth-related words.
   return GENERIC_AUTH_PATTERNS.some((p) => p.test(parsedUrl.pathname));


### PR DESCRIPTION
## Summary
- GitHub uses its main domain for all pages unlike other auth services that use dedicated subdomains. The previous hostname-only match caused every `github.com` URL to be treated as an auth URL.
- Added optional `pathPattern` field to `ServicePattern` so GitHub requires both hostname and path (`/login`, `/session`) match.
- Added tests to verify regular `github.com` URLs (repos, PRs, etc.) are NOT detected as auth URLs.

Addresses review feedback from PR #1386.

## Test plan
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [x] All 38 auth-detector tests pass
- [x] `github.com/login` and `github.com/session` are correctly identified as GitHub auth URLs
- [x] `github.com/vellum-ai/vellum-assistant`, `github.com/pulls`, `github.com/` are NOT treated as auth URLs
- [x] Auth-subdomain services (Google, Microsoft, etc.) continue to work with hostname-only matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
