### PR TITLE
Fix resource leaks in macOS app and daemon

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -492,6 +492,7 @@ function handleModelSet(
     // get recreated with the new provider once they finish processing.
     for (const [id, session] of ctx.sessions) {
       if (!session.isProcessing()) {
+        session.dispose();
         ctx.sessions.delete(id);
       } else {
         session.markStale();

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -116,10 +116,10 @@ export class DaemonServer {
       }
     });
 
-    // 2. Now abort sessions and destroy sockets. This lets server.close()
+    // 2. Now dispose sessions and destroy sockets. This lets server.close()
     //    finish promptly since all connections will be ended.
     for (const session of this.sessions.values()) {
-      session.abort();
+      session.dispose();
     }
     this.sessions.clear();
 
@@ -209,6 +209,7 @@ export class DaemonServer {
   private evictSessionsForReload(): void {
     for (const [id, session] of this.sessions) {
       if (!session.isProcessing()) {
+        session.dispose();
         this.sessions.delete(id);
       } else {
         session.markStale();
@@ -444,6 +445,11 @@ export class DaemonServer {
     }
 
     if (!session || (session.isStale() && !session.isProcessing())) {
+      // Dispose the outgoing stale session before replacing it.
+      if (session) {
+        session.dispose();
+      }
+
       // Check if another caller is already creating this session.
       // Without this guard, two concurrent getOrCreateSession calls for the
       // same conversationId would both pass the null/stale check, both create

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -252,8 +252,11 @@ export class Session {
       }
       this.messageQueue = [];
     }
+  }
 
-    // Dispose event bus listeners to prevent accumulation on session recreation
+  /** Abort and permanently tear down this session. Call when removing from the sessions map. */
+  dispose(): void {
+    this.abort();
     this.eventBus.dispose();
   }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -23,7 +23,7 @@ import { estimateCost, resolvePricing } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
-import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier } from '../tools/timer/pomodoro.js';
+import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier, pruneSessionTimers } from '../tools/timer/pomodoro.js';
 import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
 import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
@@ -244,6 +244,7 @@ export class Session {
       this.pendingSurfaceActions.clear();
       this.surfaceState.clear();
       unregisterTimerCompletionNotifier(this.conversationId);
+      pruneSessionTimers(this.conversationId);
 
       // Clear queued messages and notify each caller
       for (const queued of this.messageQueue) {
@@ -251,6 +252,9 @@ export class Session {
       }
       this.messageQueue = [];
     }
+
+    // Dispose event bus listeners to prevent accumulation on session recreation
+    this.eventBus.dispose();
   }
 
   /**
@@ -671,6 +675,9 @@ export class Session {
       this.abortController = null;
       this.processing = false;
       this.currentRequestId = undefined;
+
+      // Clean up completed/cancelled timers to prevent unbounded map growth
+      pruneSessionTimers(this.conversationId);
 
       // Drain the next queued message, if any
       this.drainQueue(yieldedForHandoff ? 'checkpoint_handoff' : 'loop_complete');

--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -18,6 +18,21 @@ export function unregisterTimerCompletionNotifier(sessionId: string): void {
   completionNotifiers.delete(sessionId);
 }
 
+/** Remove completed/cancelled timers for a session to prevent unbounded map growth. */
+export function pruneSessionTimers(sessionId: string): void {
+  const session = timers.get(sessionId);
+  if (!session) return;
+  for (const [id, timer] of session) {
+    if (timer.status === 'completed' || timer.status === 'cancelled') {
+      if (timer.timeoutHandle) clearTimeout(timer.timeoutHandle);
+      session.delete(id);
+    }
+  }
+  if (session.size === 0) {
+    timers.delete(sessionId);
+  }
+}
+
 export interface PomodoroTimer {
   id: string;
   label: string;

--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -140,6 +140,8 @@ public final class AmbientAgent: ObservableObject {
         knowledgeCron = nil
         syncClient = nil
         knowledgeStore.onEntryAdded = nil
+        knowledgeCancellable?.cancel()
+        knowledgeCancellable = nil
         state = .disabled
         log.info("Ambient agent stopped")
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -784,6 +784,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        if let observer = windowObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = settingsWindowObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
         voiceInput?.stop()
         ambientAgent.stop()
         surfaceManager.dismissAll()

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/ObservationSessionView.swift
@@ -14,6 +14,7 @@ struct ObservationSessionView: View {
     @State private var timer: Timer?
     @State private var narrationMessages: [InterviewMessage] = []
     @State private var narrationIndex: Int = 0
+    @State private var stopped = false
 
     /// Stub narration messages that simulate the assistant describing what it sees.
     private static let stubNarrations: [String] = [
@@ -167,7 +168,8 @@ struct ObservationSessionView: View {
         startPulse()
 
         // Add initial narration after a short delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [self] in
+            guard !stopped else { return }
             addNextNarration()
         }
 
@@ -184,7 +186,8 @@ struct ObservationSessionView: View {
         // Schedule narration messages at intervals
         let narrationInterval = max(Double(totalSeconds) / Double(Self.stubNarrations.count), 15.0)
         for i in 1..<Self.stubNarrations.count {
-            DispatchQueue.main.asyncAfter(deadline: .now() + narrationInterval * Double(i) + 2.0) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + narrationInterval * Double(i) + 2.0) { [self] in
+                guard !stopped else { return }
                 addNextNarration()
             }
         }
@@ -206,6 +209,7 @@ struct ObservationSessionView: View {
     }
 
     private func stopObservation() {
+        stopped = true
         timer?.invalidate()
         timer = nil
     }


### PR DESCRIPTION
The purpose of this PR is to fix resource leaks across the macOS app and daemon that cause unbounded memory/listener growth over time.

## Changes Made

### macOS App
- **AppDelegate**: Remove `windowObserver` and `settingsWindowObserver` from NotificationCenter in `applicationWillTerminate` (previously only `escapeMonitor` was cleaned up)
- **AmbientAgent**: Cancel `knowledgeCancellable` Combine subscription in `stop()` so it stops firing after the agent is disabled
- **ObservationSessionView**: Guard `DispatchQueue.main.asyncAfter` callbacks with a `stopped` flag so they no-op after the view disappears

### Daemon
- **session.ts**: Dispose `eventBus` in `abort()` to prevent listener accumulation on session recreation; prune completed timers in `runAgentLoop` finally block
- **pomodoro.ts**: Add `pruneSessionTimers()` to clean up completed/cancelled timer entries and remove empty session maps

## Testing
- macOS app builds clean
- Daemon type-checks clean

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
