### PR TITLE
Add fingerprint collision check to memory_update handler

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -175,6 +175,19 @@ export async function handleMemoryUpdate(
     const normalized = `${existing.kind}|${existing.subject.toLowerCase()}|${trimmedStatement.toLowerCase()}`;
     const fingerprint = createHash('sha256').update(normalized).digest('hex');
 
+    // Check if another item already has this fingerprint
+    const collision = db
+      .select({ id: memoryItems.id })
+      .from(memoryItems)
+      .where(eq(memoryItems.fingerprint, fingerprint))
+      .get();
+    if (collision && collision.id !== existing.id) {
+      return {
+        content: `Error: Another memory item (ID: ${collision.id}) already contains this statement. Use memory_search to find it.`,
+        isError: true,
+      };
+    }
+
     db.update(memoryItems)
       .set({
         statement: trimmedStatement,


### PR DESCRIPTION
## Summary
- Adds a fingerprint collision check in `handleMemoryUpdate` before issuing the UPDATE query
- Without this check, updating a memory item's statement to match another item's fingerprint causes a cryptic SQLite UNIQUE constraint error
- Follows the same pattern already used in `handleMemorySave` (lines 90-113)

Addresses feedback from PR #1370.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm updating a memory item to a unique statement succeeds
- [ ] Confirm updating a memory item to a duplicate statement returns a helpful error message instead of a UNIQUE constraint error

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
