### PR TITLE
Fix memory extraction: timer leak, abort signal, importance, zero-values

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -119,6 +119,8 @@ async function extractItemsWithLLM(
 
   try {
     const client = new Anthropic({ apiKey });
+    const abortController = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
     const response = await Promise.race([
       client.messages.create({
         model: extractionConfig.model,
@@ -166,10 +168,13 @@ async function extractItemsWithLLM(
         }],
         tool_choice: { type: 'tool' as const, name: 'store_memory_items' },
         messages: [{ role: 'user' as const, content: text }],
+      }, { signal: abortController.signal }).finally(() => clearTimeout(timer)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          abortController.abort();
+          reject(new Error('LLM extraction timeout'));
+        }, 15000);
       }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('LLM extraction timeout')), 15000),
-      ),
     ]);
 
     const toolBlock = response.content.find((b) => b.type === 'tool_use');
@@ -190,8 +195,10 @@ async function extractItemsWithLLM(
       if (!raw.subject || !raw.statement) continue;
       const subject = String(raw.subject).slice(0, 80);
       const statement = String(raw.statement).slice(0, 500);
-      const confidence = clamp(Number(raw.confidence) || 0.5, 0, 1);
-      const importance = clamp(Number(raw.importance) || 0.5, 0, 1);
+      const rawConfidence = Number(raw.confidence);
+      const confidence = clamp(Number.isFinite(rawConfidence) ? rawConfidence : 0.5, 0, 1);
+      const rawImportance = Number(raw.importance);
+      const importance = clamp(Number.isFinite(rawImportance) ? rawImportance : 0.5, 0, 1);
       const normalized = `${raw.kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
       const fingerprint = createHash('sha256').update(normalized).digest('hex');
       items.push({
@@ -259,7 +266,7 @@ export async function extractAndUpsertMemoryItemsForMessage(messageId: string): 
         .set({
           status: 'active',
           confidence: Math.max(existing.confidence, item.confidence),
-          importance: item.importance,
+          importance: Math.max(existing.importance ?? 0, item.importance),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
         })
         .where(eq(memoryItems.id, existing.id))


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #1362:

- **Timer resource leak (P2)**: The `setTimeout` timer in the `Promise.race` timeout pattern was never cleared when the API call resolved before the deadline. Now cleared via `.finally()` on the API call promise.
- **Cancel timed-out LLM extractions (P2)**: The timeout only rejected the wrapper promise without cancelling the in-flight API request. Now uses `AbortController` signal passed to `client.messages.create()` to actually abort the request on timeout.
- **Importance monotonicity (P2)**: When updating an existing item, `importance` was unconditionally overwritten (could decrease). Now uses `Math.max(existing.importance ?? 0, item.importance)` consistent with how `confidence` is handled.
- **Preserve zero confidence/importance (P2)**: `Number(raw.confidence) || 0.5` treated valid `0` as missing. Now uses `Number.isFinite()` check to preserve intentional zero values from LLM output.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm timer is cleared when API resolves before timeout
- [ ] Confirm API request is aborted when timeout fires
- [ ] Confirm existing items' importance never decreases on re-extraction
- [ ] Confirm `confidence: 0` and `importance: 0` from LLM are preserved as 0, not coerced to 0.5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
