### PR TITLE
Fix Qdrant memory search, upsert retries, embedding fallback, and segment jobs

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -125,19 +125,63 @@ export async function embedWithBackend(
   if (!selection.backend) {
     throw new Error(selection.reason ?? 'No memory embedding backend configured');
   }
-  const vectors = await selection.backend.embed(texts, options);
-  if (vectors.length !== texts.length) {
-    throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
+
+  // In auto mode, build a fallback list of backends to try
+  const backends: EmbeddingBackend[] = [selection.backend];
+  if (config.memory.embeddings.provider === 'auto' && selection.backend.provider === 'local') {
+    for (const fallback of selectFallbackBackends(config, 'local')) {
+      backends.push(fallback);
+    }
   }
-  return {
-    provider: selection.backend.provider,
-    model: selection.backend.model,
-    vectors,
-  };
+
+  let lastErr: unknown;
+  for (const backend of backends) {
+    try {
+      const vectors = await backend.embed(texts, options);
+      if (vectors.length !== texts.length) {
+        throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
+      }
+      return { provider: backend.provider, model: backend.model, vectors };
+    } catch (err) {
+      lastErr = err;
+      if (backends.length > 1) {
+        log.warn({ err, provider: backend.provider }, 'Embedding backend failed, trying next');
+      }
+    }
+  }
+  throw lastErr;
 }
 
 export function logMemoryEmbeddingWarning(err: unknown, context: string): void {
   log.warn({ err }, `Memory embeddings failed (${context})`);
+}
+
+function selectFallbackBackends(config: AssistantConfig, exclude: EmbeddingProviderName): EmbeddingBackend[] {
+  const backends: EmbeddingBackend[] = [];
+  const order: EmbeddingProviderName[] = ['openai', 'gemini', 'ollama'];
+  for (const provider of order) {
+    if (provider === exclude) continue;
+    switch (provider) {
+      case 'openai':
+        if (config.apiKeys.openai) {
+          backends.push(new OpenAIEmbeddingBackend(config.apiKeys.openai, config.memory.embeddings.openaiModel));
+        }
+        break;
+      case 'gemini':
+        if (config.apiKeys.gemini) {
+          backends.push(new GeminiEmbeddingBackend(config.apiKeys.gemini, config.memory.embeddings.geminiModel));
+        }
+        break;
+      case 'ollama':
+        if (isOllamaConfigured(config)) {
+          backends.push(new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
+            apiKey: config.apiKeys.ollama,
+          }));
+        }
+        break;
+    }
+  }
+  return backends;
 }
 
 function isOllamaConfigured(config: AssistantConfig): boolean {

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -64,6 +64,7 @@ export function indexMessageNow(
         updatedAt: now,
       },
     }).run();
+    enqueueMemoryJob('embed_segment', { segmentId });
   }
 
   const shouldExtract =
@@ -75,7 +76,7 @@ export function indexMessageNow(
   enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
   enqueueSummaryRollupJobsIfDue();
 
-  const enqueuedJobs = shouldExtract ? 2 : 1;
+  const enqueuedJobs = segments.length + (shouldExtract ? 2 : 1);
   return {
     indexedSegments: segments.length,
     enqueuedJobs,

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -579,6 +579,11 @@ function rebuildIndexJob(): void {
   for (const summary of summaries) {
     enqueueMemoryJob('embed_summary', { summaryId: summary.id });
   }
+
+  const segments = db.select({ id: memorySegments.id }).from(memorySegments).all();
+  for (const segment of segments) {
+    enqueueMemoryJob('embed_segment', { segmentId: segment.id });
+  }
 }
 
 async function embedAndUpsert(
@@ -611,6 +616,7 @@ async function embedAndUpsert(
     });
   } catch (err) {
     log.warn({ err, targetType, targetId }, 'Failed to upsert embedding to Qdrant');
+    throw err;
   }
 }
 

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -200,9 +200,17 @@ export class VellumQdrantClient {
     ];
 
     if (excludeMessageIds && excludeMessageIds.length > 0) {
+      // Only require status=active for items; segments and summaries don't have a status field
       mustConditions.push({
-        key: 'status',
-        match: { value: 'active' },
+        should: [
+          {
+            must: [
+              { key: 'target_type', match: { value: 'item' } },
+              { key: 'status', match: { value: 'active' } },
+            ],
+          },
+          { key: 'target_type', match: { any: ['segment', 'summary'] } },
+        ],
       });
     }
 


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #1357 (Qdrant vector store and local embedding backend):

- **Fix status:active filter excluding segments/summaries** — The `searchWithFilter` method added a `must` condition requiring `status = active` for all points, but segments and summaries don't have a `status` field. Restructured the filter to use a `should` clause that only requires `status = active` for items while passing through segments and summaries unconditionally.

- **Rethrow Qdrant upsert failures** — The `catch` block in `embedAndUpsert` logged errors but didn't rethrow, causing jobs to be marked complete even when no vector was stored. Now rethrows so the job system can retry.

- **Fall back to remote backends in auto mode** — When `provider = auto`, `LocalEmbeddingBackend` was returned immediately. If local model init failed, no remote backends were tried. Now builds a fallback list and tries each backend in order (local -> openai -> gemini -> ollama).

- **Enqueue embed_segment jobs** — `enqueueMemoryJob('embed_segment', ...)` was never called anywhere. Added it in `indexer.ts` after each segment insert and in `rebuildIndexJob` to re-embed all existing segments.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify semantic search returns segments and summaries when `excludeMessageIds` is provided
- [ ] Verify failed Qdrant upserts cause job retries
- [ ] Verify embedding falls back to remote backends when local model fails
- [ ] Verify segment vectors appear in Qdrant after message indexing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
