### PR TITLE
Fix fallback summary unbounded growth

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -508,14 +508,10 @@ async function summarizeWithLLM(
   }
 }
 
-function buildFallbackSummary(existingSummary: string | null, newContent: string, label: string): string {
+function buildFallbackSummary(_existingSummary: string | null, newContent: string, label: string): string {
   const lines = newContent.split('\n').filter((l) => l.trim().length > 0);
   const snippets = lines.slice(0, 20).map((l) => `- ${truncate(l.trim(), 180)}`);
-  const parts: string[] = [`${label} summary`, ''];
-  if (existingSummary) {
-    parts.push(existingSummary, '');
-  }
-  parts.push(...snippets);
+  const parts: string[] = [`${label} summary`, '', ...snippets];
   return parts.join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Remove `existingSummary` prepending in `buildFallbackSummary` to prevent unbounded growth
- The fallback is called with the same segment data re-fetched from DB each time, so it should replace the summary rather than accumulate
- Addresses P1 feedback from both Codex and Devin on PR #1364

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify fallback summaries no longer grow when LLM is unavailable by running summary jobs multiple times

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
