### PR TITLE
Validate item status and evidence in Qdrant semantic search

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -375,6 +375,7 @@ async function semanticSearch(
     excludedMessageIds,
   );
 
+  const db = getDb();
   const candidates: Candidate[] = [];
   for (const result of results) {
     const { payload, score } = result;
@@ -382,18 +383,28 @@ async function semanticSearch(
     const createdAt = payload.created_at ?? Date.now();
 
     if (payload.target_type === 'item') {
+      // Validate the backing memory item is still active and has non-excluded evidence
+      const item = db.select().from(memoryItems).where(eq(memoryItems.id, payload.target_id)).get();
+      if (!item || item.status !== 'active') continue;
+      const sources = db.select().from(memoryItemSources)
+        .where(eq(memoryItemSources.memoryItemId, payload.target_id)).all();
+      if (sources.length === 0) continue;
+      if (excludedMessageIds.length > 0) {
+        const nonExcluded = sources.filter((s) => !excludedMessageIds.includes(s.messageId));
+        if (nonExcluded.length === 0) continue;
+      }
       candidates.push({
         key: `item:${payload.target_id}`,
         type: 'item',
         id: payload.target_id,
-        text: payload.text,
-        kind: payload.kind ?? 'fact',
-        confidence: payload.confidence ?? 0.6,
-        importance: payload.importance ?? 0.5,
-        createdAt: payload.last_seen_at ?? createdAt,
+        text: `${item.subject}: ${item.statement}`,
+        kind: item.kind,
+        confidence: item.confidence,
+        importance: item.importance ?? 0.5,
+        createdAt: item.lastSeenAt,
         lexical: 0,
         semantic,
-        recency: computeRecencyScore(payload.last_seen_at ?? createdAt),
+        recency: computeRecencyScore(item.lastSeenAt),
         finalScore: 0,
       });
     } else if (payload.target_type === 'summary') {


### PR DESCRIPTION
## Summary
- Adds SQLite validation for item-type results from Qdrant semantic search
- Checks that backing memory items are still active and have non-excluded evidence (sources)
- Uses canonical item text (`subject: statement`) from SQLite instead of Qdrant payload for consistency
- Matches the validation already present in the SQLite fallback semantic search path

Addresses Codex P1 feedback on PR #1358.

## Test plan
- [ ] Verify that inactive/superseded items from Qdrant are filtered out and not injected into recall
- [ ] Verify that items whose only evidence comes from excluded messages are filtered out
- [ ] Verify that valid active items with non-excluded evidence still appear in recall results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
