### PR TITLE
Fix false entity matches from LIKE substring matching

### DIFF
--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { eq, or, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
@@ -158,32 +158,27 @@ export function resolveEntity(entity: ExtractedEntity): string | null {
   const db = getDb();
   const nameLower = entity.name.toLowerCase();
 
-  // Search by exact name match or alias match using LIKE on JSON aliases field
-  const candidates = db
-    .select()
-    .from(memoryEntities)
-    .where(
-      or(
-        sql`LOWER(${memoryEntities.name}) = ${nameLower}`,
-        sql`LOWER(${memoryEntities.aliases}) LIKE ${'%' + nameLower + '%'}`,
-      ),
-    )
-    .all();
+  // Search by exact name match or exact alias match using json_each()
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+  const candidates = raw.query(`
+    SELECT DISTINCT me.* FROM memory_entities me
+    WHERE LOWER(me.name) = ?
+    UNION
+    SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
+    WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
+  `).all(nameLower, nameLower) as Array<typeof memoryEntities.$inferSelect>;
 
   if (candidates.length === 0) {
     // Also check if any of the extracted aliases match an existing entity name
     for (const alias of entity.aliases) {
       const aliasLower = alias.toLowerCase();
-      const aliasCandidates = db
-        .select()
-        .from(memoryEntities)
-        .where(
-          or(
-            sql`LOWER(${memoryEntities.name}) = ${aliasLower}`,
-            sql`LOWER(${memoryEntities.aliases}) LIKE ${'%' + aliasLower + '%'}`,
-          ),
-        )
-        .all();
+      const aliasCandidates = raw.query(`
+        SELECT DISTINCT me.* FROM memory_entities me
+        WHERE LOWER(me.name) = ?
+        UNION
+        SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
+        WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
+      `).all(aliasLower, aliasLower) as Array<typeof memoryEntities.$inferSelect>;
       if (aliasCandidates.length > 0) {
         // Return the first match — same type preferred
         const sameType = aliasCandidates.find((c) => c.type === entity.type);

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -584,19 +584,23 @@ function entitySearch(query: string): Candidate[] {
   const db = getDb();
   const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
 
-  // Tokenize query into words for entity matching
+  // Tokenize query into words for entity matching (min length 3 to reduce false positives)
   const tokens = trimmed
     .toLowerCase()
     .split(/[^a-z0-9_.-]+/g)
-    .filter((t) => t.length >= 2);
+    .filter((t) => t.length >= 3);
   if (tokens.length === 0) return [];
 
-  // Build LIKE conditions for each token against entity name and aliases
-  const likeClauses = tokens.map((t) => `(LOWER(name) LIKE '%${escapeSqlLike(t)}%' OR LOWER(aliases) LIKE '%${escapeSqlLike(t)}%')`);
+  // Use exact matching on entity names and json_each() for individual alias values
+  const namePlaceholders = tokens.map(() => '?').join(',');
   const entityQuery = `
-    SELECT id, name, type, aliases, mention_count
-    FROM memory_entities
-    WHERE ${likeClauses.join(' OR ')}
+    SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+    FROM memory_entities me
+    WHERE LOWER(me.name) IN (${namePlaceholders})
+    UNION
+    SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+    FROM memory_entities me, json_each(me.aliases) je
+    WHERE me.aliases IS NOT NULL AND LOWER(je.value) IN (${namePlaceholders})
     LIMIT 20
   `;
 
@@ -608,7 +612,7 @@ function entitySearch(query: string): Candidate[] {
     mention_count: number;
   }> = [];
   try {
-    matchedEntities = raw.query(entityQuery).all() as Array<{
+    matchedEntities = raw.query(entityQuery).all(...tokens, ...tokens) as Array<{
       id: string;
       name: string;
       type: string;


### PR DESCRIPTION
## Summary
- Replaces `LIKE '%name%'` on raw JSON aliases with `json_each()` for exact matching on individual alias values in `resolveEntity` (entity-extractor.ts), preventing false merges like "Go" matching "MongoDB"
- Switches `entitySearch` (retriever.ts) from LIKE substring to exact matching using `IN` clauses for names and `json_each()` for aliases
- Raises minimum token length from 2 to 3 in `entitySearch` to reduce false positives from short tokens like "go", "do", "is"

Addresses review feedback from PR #1368.

## Test plan
- [ ] Verify entity resolution with short names (e.g. "Go") no longer matches unrelated entities containing the substring (e.g. "MongoDB")
- [ ] Verify entitySearch with queries containing short words produces only exact entity matches
- [ ] Verify entity names with underscores (e.g. "my_project") resolve correctly with exact matching

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
