### PR TITLE
Fix LLM re-ranking fallback for unscored candidates

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -873,17 +873,23 @@ async function rerankWithLLM(
     }
   }
 
-  // Re-sort candidates by LLM score (desc), falling back to original finalScore
+  // Re-sort candidates by LLM score (desc); unscored candidates keep original order after scored ones
   const reranked = candidates.map((c, i) => ({
     candidate: c,
-    llmScore: scoreMap.get(i) ?? 0,
+    llmScore: scoreMap.has(i) ? scoreMap.get(i)! : null,
     originalIndex: i,
   }));
 
   reranked.sort((a, b) => {
-    const scoreDelta = b.llmScore - a.llmScore;
-    if (scoreDelta !== 0) return scoreDelta;
-    // Tie-break by original RRF order
+    // Scored items come before unscored items
+    if (a.llmScore !== null && b.llmScore === null) return -1;
+    if (a.llmScore === null && b.llmScore !== null) return 1;
+    // Both scored: sort by score descending
+    if (a.llmScore !== null && b.llmScore !== null) {
+      const scoreDelta = b.llmScore - a.llmScore;
+      if (scoreDelta !== 0) return scoreDelta;
+    }
+    // Both unscored or tie: preserve original RRF order
     return a.originalIndex - b.originalIndex;
   });
 


### PR DESCRIPTION
## Summary
- Fixes the LLM re-ranking fallback in `retriever.ts` where unscored candidates received `llmScore: 0`, silently demoting them below all scored candidates
- Uses `null` for unscored candidates instead of `0`, and sorts scored items first (by score descending) while unscored items maintain their original RRF order

Addresses feedback from PR #1367.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that when LLM scores a subset of candidates, unscored ones appear after scored ones in original order (not buried at the bottom with score 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
