### PR TITLE
Filter invalidated memory items from search and summaries

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -267,6 +267,11 @@ async function handleRelationship(
         })
         .where(eq(memoryItems.id, existingItem.id))
         .run();
+      // Invalidate the new item since its content has been merged into the existing one
+      db.update(memoryItems)
+        .set({ invalidAt: now })
+        .where(eq(memoryItems.id, newItem.id))
+        .run();
       break;
     }
     case 'complement': {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { and, asc, desc, eq, gt, gte, lt, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, gte, isNull, lt, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
@@ -359,6 +359,7 @@ async function buildGlobalSummaryJob(scope: 'weekly_global' | 'monthly_global', 
     .from(memoryItems)
     .where(and(
       eq(memoryItems.status, 'active'),
+      isNull(memoryItems.invalidAt),
       gte(memoryItems.lastSeenAt, startMs),
       lt(memoryItems.lastSeenAt, endMs),
     ))

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -385,7 +385,7 @@ async function semanticSearch(
     if (payload.target_type === 'item') {
       // Validate the backing memory item is still active and has non-excluded evidence
       const item = db.select().from(memoryItems).where(eq(memoryItems.id, payload.target_id)).get();
-      if (!item || item.status !== 'active') continue;
+      if (!item || item.status !== 'active' || item.invalidAt !== null) continue;
       const sources = db.select().from(memoryItemSources)
         .where(eq(memoryItemSources.memoryItemId, payload.target_id)).all();
       if (sources.length === 0) continue;
@@ -473,7 +473,7 @@ function sqliteFallbackSemanticSearch(
 
     if (targetType === 'item') {
       const item = db.select().from(memoryItems).where(eq(memoryItems.id, targetId)).get();
-      if (!item || item.status !== 'active') continue;
+      if (!item || item.status !== 'active' || item.invalidAt !== null) continue;
       const sources = db.select().from(memoryItemSources)
         .where(eq(memoryItemSources.memoryItemId, targetId)).all();
       if (sources.length === 0) continue;


### PR DESCRIPTION
## Summary
- **Semantic search**: Add `invalidAt` null-check when validating Qdrant and SQLite fallback semantic search results against the `memory_items` table, so invalidated items are excluded from memory recall
- **Global summary builder**: Add `isNull(memoryItems.invalidAt)` to the `buildGlobalSummaryJob` where clause so weekly/monthly summaries exclude contradicted items  
- **Update handler**: Invalidate the new item after merging its content into the existing item in the `'update'` contradiction handler, preventing duplicate active items

Addresses review feedback on #1377.

## Test plan
- [ ] Verify invalidated items no longer appear in semantic search results
- [ ] Verify `buildGlobalSummaryJob` excludes items with `invalidAt` set
- [ ] Verify 'update' contradiction handler invalidates the new item after merge
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
