### PR TITLE
Remove onboarding variant picker and fix card centering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/OnboardingStageImage.swift
@@ -74,7 +74,6 @@ struct OnboardingStageImage: View {
             Rectangle()
                 .fill(.white)
                 .opacity(flashOpacity)
-                .ignoresSafeArea()
         }
         .onAppear {
             displayedStage = stageNumber

--- a/clients/macos/vellum-assistant/Features/Onboarding/MeadowBackground.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/MeadowBackground.swift
@@ -14,7 +14,6 @@ struct MeadowBackground: View {
                     .aspectRatio(contentMode: .fill)
             }
         }
-        .ignoresSafeArea()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -8,105 +8,108 @@ struct OnboardingFlowView: View {
     var onOpenSettings: () -> Void
 
     var body: some View {
-        ZStack {
-            VColor.background
-                .ignoresSafeArea()
+        GeometryReader { geometry in
+            ZStack {
+                VColor.background
+                    .ignoresSafeArea()
 
-            // Dimmed mock chrome — gives the "chat UI behind" effect
-            VStack(spacing: 0) {
-                mockToolbar
-                Spacer()
-                mockInputBar
-            }
-            .opacity(0.25)
-            .allowsHitTesting(false)
-
-            if state.currentStep <= 6 {
-                // Vertical card layout (steps 0-6)
+                // Dimmed mock chrome — gives the "chat UI behind" effect
                 VStack(spacing: 0) {
-                    // TOP: Meadow background + stage image
-                    ZStack {
-                        MeadowBackground()
-
-                        OnboardingStageImage(currentStep: state.currentStep)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .padding(VSpacing.xxl)
-                    }
-                    .frame(height: 350)
-                    .clipped()
-
-                    // BOTTOM: Dark content panel
-                    VStack(spacing: VSpacing.lg) {
-                        Group {
-                            switch state.currentStep {
-                            case 0:
-                                WakeUpStepView(state: state)
-                            case 1:
-                                NamingStepView(state: state)
-                            case 2:
-                                FnKeyStepView(state: state)
-                            case 3:
-                                SpeechPermissionStepView(state: state)
-                            case 4:
-                                AccessibilityPermissionStepView(state: state)
-                            case 5:
-                                ScreenPermissionStepView(state: state)
-                            case 6:
-                                AliveStepView(
-                                    state: state,
-                                    onComplete: onComplete,
-                                    onOpenSettings: onOpenSettings
-                                )
-                            default:
-                                EmptyView()
-                            }
-                        }
-                        .transition(
-                            .asymmetric(
-                                insertion: .opacity.combined(with: .offset(y: 12)),
-                                removal: .opacity.combined(with: .offset(y: -8))
-                            )
-                        )
-                        .id(state.currentStep)
-
-                        OnboardingProgressDots(currentStep: state.currentStep)
-                            .padding(.top, VSpacing.xs)
-                    }
-                    .padding(.horizontal, VSpacing.xxl)
-                    .padding(.top, VSpacing.xl)
-                    .padding(.bottom, VSpacing.xxl)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        Rectangle()
-                            .fill(.ultraThinMaterial)
-                            .overlay(
-                                Rectangle()
-                                    .fill(Meadow.panelBackground)
-                            )
-                    )
+                    mockToolbar
+                    Spacer()
+                    mockInputBar
                 }
-                .frame(maxWidth: 640)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .stroke(Meadow.panelBorder, lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.4), radius: 24, y: 12)
-                .padding(.vertical, VSpacing.xxxl)
-            } else {
-                // Step 7: Interview — manages its own layout
-                InterviewStepView(
-                    state: state,
-                    daemonClient: daemonClient,
-                    onComplete: onComplete
-                )
-                .transition(
-                    .opacity.combined(with: .scale(scale: 0.97))
-                )
-                .id(state.currentStep)
+                .opacity(0.25)
+                .allowsHitTesting(false)
+
+                if state.currentStep <= 6 {
+                    // Vertical card layout (steps 0-6)
+                    VStack(spacing: 0) {
+                        // TOP: Meadow background + stage image
+                        ZStack {
+                            MeadowBackground()
+
+                            OnboardingStageImage(currentStep: state.currentStep)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .padding(VSpacing.xxl)
+                        }
+                        .frame(height: 350)
+                        .clipped()
+
+                        // BOTTOM: Dark content panel
+                        VStack(spacing: VSpacing.lg) {
+                            Group {
+                                switch state.currentStep {
+                                case 0:
+                                    WakeUpStepView(state: state)
+                                case 1:
+                                    NamingStepView(state: state)
+                                case 2:
+                                    FnKeyStepView(state: state)
+                                case 3:
+                                    SpeechPermissionStepView(state: state)
+                                case 4:
+                                    AccessibilityPermissionStepView(state: state)
+                                case 5:
+                                    ScreenPermissionStepView(state: state)
+                                case 6:
+                                    AliveStepView(
+                                        state: state,
+                                        onComplete: onComplete,
+                                        onOpenSettings: onOpenSettings
+                                    )
+                                default:
+                                    EmptyView()
+                                }
+                            }
+                            .transition(
+                                .asymmetric(
+                                    insertion: .opacity.combined(with: .offset(y: 12)),
+                                    removal: .opacity.combined(with: .offset(y: -8))
+                                )
+                            )
+                            .id(state.currentStep)
+
+                            OnboardingProgressDots(currentStep: state.currentStep)
+                                .padding(.top, VSpacing.xs)
+                        }
+                        .padding(.horizontal, VSpacing.xxl)
+                        .padding(.top, VSpacing.xl)
+                        .padding(.bottom, VSpacing.xxl)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            Rectangle()
+                                .fill(.ultraThinMaterial)
+                                .overlay(
+                                    Rectangle()
+                                        .fill(Meadow.panelBackground)
+                                )
+                        )
+                    }
+                    .frame(maxWidth: 640)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.xl)
+                            .stroke(Meadow.panelBorder, lineWidth: 1)
+                    )
+                    .shadow(color: .black.opacity(0.4), radius: 24, y: 12)
+                    .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+                } else {
+                    // Step 7: Interview — manages its own layout
+                    InterviewStepView(
+                        state: state,
+                        daemonClient: daemonClient,
+                        onComplete: onComplete
+                    )
+                    .transition(
+                        .opacity.combined(with: .scale(scale: 0.97))
+                    )
+                    .id(state.currentStep)
+                }
             }
+            .frame(width: geometry.size.width, height: geometry.size.height)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
     }
 
     // MARK: - Mock Chrome

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -17,45 +17,26 @@ final class OnboardingWindow {
         if CommandLine.arguments.contains("--skip-permission-checks") {
             state.skipPermissionChecks = true
         }
-        if let idx = CommandLine.arguments.firstIndex(of: "--onboarding-variant"),
-           idx + 1 < CommandLine.arguments.count,
-           CommandLine.arguments[idx + 1] == "first_meeting" {
-            state.onboardingVariant = .firstMeeting
-            UserDefaults.standard.set(OnboardingVariant.firstMeeting.rawValue, forKey: "onboarding.variant")
-        }
         #endif
 
-        let onComplete: () -> Void = { [weak self] in
-            guard let self else { return }
-            self.onComplete?(self.state)
-        }
-        let onOpenSettings: () -> Void = { [weak self] in
-            guard let self else { return }
-            self.onComplete?(self.state)
-            // Settings will be opened by AppDelegate after onComplete
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        let flowView = OnboardingFlowView(
+            state: state,
+            daemonClient: daemonClient,
+            onComplete: { [weak self] in
+                guard let self else { return }
+                self.onComplete?(self.state)
+            },
+            onOpenSettings: { [weak self] in
+                guard let self else { return }
+                self.onComplete?(self.state)
+                // Settings will be opened by AppDelegate after onComplete
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                }
             }
-        }
+        )
 
-        let contentView: AnyView
-        if state.onboardingVariant == .firstMeeting {
-            contentView = AnyView(FirstMeetingFlowView(
-                state: state,
-                daemonClient: daemonClient,
-                onComplete: onComplete,
-                onOpenSettings: onOpenSettings
-            ))
-        } else {
-            contentView = AnyView(OnboardingFlowView(
-                state: state,
-                daemonClient: daemonClient,
-                onComplete: onComplete,
-                onOpenSettings: onOpenSettings
-            ))
-        }
-
-        let hostingController = NSHostingController(rootView: contentView)
+        let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),

--- a/clients/macos/vellum-assistant/Features/Onboarding/TypewriterText.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/TypewriterText.swift
@@ -11,15 +11,25 @@ struct TypewriterText: View {
     @State private var charIndex = 0
 
     var body: some View {
-        Text(displayedText)
-            .font(font)
-            .foregroundColor(VColor.textPrimary)
-            .onAppear {
-                startTyping()
-            }
-            .onDisappear {
-                timer?.invalidate()
-            }
+        ZStack {
+            // Invisible full text reserves the final height
+            Text(fullText)
+                .font(font)
+                .foregroundColor(.clear)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityHidden(true)
+
+            Text(displayedText)
+                .font(font)
+                .foregroundColor(VColor.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .onAppear {
+            startTyping()
+        }
+        .onDisappear {
+            timer?.invalidate()
+        }
     }
 
     private func startTyping() {


### PR DESCRIPTION
The purpose of this PR is to remove the First Meeting onboarding variant and fix the onboarding card being pinned to the bottom of the window instead of vertically centered.

## Changes Made
- Remove the variant picker (Default / First Meeting segmented control) from `NamingStepView` and simplify `confirmName()` to always advance
- Simplify `OnboardingWindow` to pass `OnboardingFlowView` directly to `NSHostingController` (matching pre-variant state), removing the `OnboardingRootView` wrapper
- Collapse the replay-onboarding submenu in `AppDelegate` back to a single menu item
- Fix card centering by using `GeometryReader` + `.position()` for explicit center placement and `.ignoresSafeArea()` on the reader to use the full window
- Remove nested `.ignoresSafeArea()` from `MeadowBackground` and `OnboardingStageImage` flash overlay that disrupted parent layout
- Add invisible full-text placeholder in `TypewriterText` to reserve final height upfront, preventing card resizing during text streaming

## Testing
- Manual testing: scrub + launch verified card is centered on step 0, stays centered through all steps, and transitions don't push the card down

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
