### PR TITLE
Add human-readable schedule descriptions (#1402)

### DIFF
--- a/assistant/src/cron/cron-store.ts
+++ b/assistant/src/cron/cron-store.ts
@@ -297,6 +297,129 @@ export function formatLocalDate(timestamp: number): string {
   });
 }
 
+// Convert a cron expression to a human-readable description.
+// Uses the croner library to parse the expression and inspect its pattern fields.
+//
+// Examples:
+//   "* * * * *"     -> "Every minute"
+//   "0 9 * * 1-5"   -> "Every weekday at 9:00 AM"
+//   "0 9 * * 0,6"   -> "Every weekend at 9:00 AM"
+//   "0 9 1 * *"     -> "On the 1st of every month at 9:00 AM"
+//   "30 14 * * *"   -> "Every day at 2:30 PM"
+export function describeCronExpression(expr: string): string {
+  try {
+    const cron = new Cron(expr, { maxRuns: 0 });
+    const p = (cron as unknown as { _states: { pattern: {
+      minute: number[];
+      hour: number[];
+      day: number[];
+      month: number[];
+      dayOfWeek: number[];
+      starDOM: boolean;
+      starDOW: boolean;
+    } } })._states.pattern;
+
+    const activeMinutes = p.minute.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeHours = p.hour.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeDays = p.day.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
+    const activeDOW = p.dayOfWeek.reduce<number[]>((acc, v, i) => { if (v) acc.push(i); return acc; }, []);
+    const activeMonths = p.month.reduce<number[]>((acc, v, i) => { if (v) acc.push(i + 1); return acc; }, []);
+
+    const allMinutes = activeMinutes.length === 60;
+    const allHours = activeHours.length === 24;
+    const allDays = p.starDOM;
+    const allDOW = p.starDOW;
+    const allMonths = activeMonths.length === 12;
+
+    // Format time as 12-hour clock
+    function formatTime(hour: number, minute: number): string {
+      const period = hour >= 12 ? 'PM' : 'AM';
+      const h = hour % 12 || 12;
+      const m = minute.toString().padStart(2, '0');
+      return `${h}:${m} ${period}`;
+    }
+
+    // Ordinal suffix helper
+    function ordinal(n: number): string {
+      const s = ['th', 'st', 'nd', 'rd'];
+      const v = n % 100;
+      return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+
+    // Every minute: all fields are wildcard
+    if (allMinutes && allHours && allDays && allDOW && allMonths) {
+      return 'Every minute';
+    }
+
+    // Every N minutes: multiple minutes, all hours, all days
+    if (!allMinutes && activeMinutes.length > 1 && allHours && allDays && allDOW && allMonths) {
+      // Check if it's a regular step pattern (e.g. */5)
+      if (activeMinutes.length >= 2 && activeMinutes[0] === 0) {
+        const step = activeMinutes[1] - activeMinutes[0];
+        const isRegularStep = activeMinutes.every((v, i) => v === i * step);
+        if (isRegularStep && 60 % step === 0) {
+          return `Every ${step} minutes`;
+        }
+      }
+    }
+
+    // Every hour: minute is fixed at one value, all hours, all days
+    if (activeMinutes.length === 1 && allHours && allDays && allDOW && allMonths) {
+      if (activeMinutes[0] === 0) {
+        return 'Every hour';
+      }
+      return `Every hour at minute ${activeMinutes[0]}`;
+    }
+
+    // Every N hours: minute is fixed, multiple hours with regular stepping, all days
+    if (activeMinutes.length === 1 && !allHours && activeHours.length > 1 && allDays && allDOW && allMonths) {
+      if (activeHours.length >= 2 && activeHours[0] === 0) {
+        const step = activeHours[1] - activeHours[0];
+        const isRegularStep = activeHours.every((v, i) => v === i * step);
+        if (isRegularStep && 24 % step === 0) {
+          return `Every ${step} hours`;
+        }
+      }
+    }
+
+    // Specific time patterns: single hour and single minute
+    if (activeMinutes.length === 1 && activeHours.length === 1 && allMonths) {
+      const timeStr = formatTime(activeHours[0], activeMinutes[0]);
+
+      // Check day-of-week constraints
+      if (allDays && !allDOW) {
+        // Weekdays: Mon-Fri (1-5)
+        if (activeDOW.length === 5 && activeDOW.every((d) => d >= 1 && d <= 5)) {
+          return `Every weekday at ${timeStr}`;
+        }
+        // Weekends: Sat, Sun (0, 6)
+        if (activeDOW.length === 2 && activeDOW.includes(0) && activeDOW.includes(6)) {
+          return `Every weekend at ${timeStr}`;
+        }
+        // Specific days of week
+        const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const names = activeDOW.map((d) => dayNames[d]);
+        return `Every ${names.join(', ')} at ${timeStr}`;
+      }
+
+      // Specific day of month
+      if (!allDays && allDOW && activeDays.length === 1) {
+        return `On the ${ordinal(activeDays[0])} of every month at ${timeStr}`;
+      }
+
+      // Every day at specific time
+      if (allDays && allDOW) {
+        return `Every day at ${timeStr}`;
+      }
+    }
+
+    // Fallback: return the raw expression
+    return expr;
+  } catch {
+    return expr;
+  }
+}
+
 function parseJobRow(row: typeof cronJobs.$inferSelect): CronJob {
   return {
     id: row.id,

--- a/assistant/src/tools/cron/create.ts
+++ b/assistant/src/tools/cron/create.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { createCronJob, isValidCronExpression, formatLocalDate } from '../../cron/cron-store.js';
+import { createCronJob, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronCreateTool implements Tool {
   name = 'cron_create';
@@ -71,7 +71,7 @@ class CronCreateTool implements Tool {
           `Cron job created successfully.`,
           `  ID: ${job.id}`,
           `  Name: ${job.name}`,
-          `  Schedule: ${job.cronExpression}${job.timezone ? ` (${job.timezone})` : ''}`,
+          `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
           `  Enabled: ${job.enabled}`,
           `  Next run: ${nextRunDate}`,
         ].join('\n'),

--- a/assistant/src/tools/cron/list.ts
+++ b/assistant/src/tools/cron/list.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { listCronJobs, getCronJob, getCronRuns, formatLocalDate } from '../../cron/cron-store.js';
+import { listCronJobs, getCronJob, getCronRuns, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronListTool implements Tool {
   name = 'cron_list';
@@ -46,7 +46,7 @@ class CronListTool implements Tool {
       const lines = [
         `Cron Job: ${job.name}`,
         `  ID: ${job.id}`,
-        `  Schedule: ${job.cronExpression}${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
         `  Message: ${job.message}`,
         `  Next run: ${formatLocalDate(job.nextRunAt)}`,
@@ -79,7 +79,7 @@ class CronListTool implements Tool {
     for (const job of jobs) {
       const status = job.enabled ? 'enabled' : 'disabled';
       const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
-      lines.push(`  - [${status}] ${job.name} (${job.cronExpression}) — next: ${next} — id: ${job.id}`);
+      lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next} — id: ${job.id}`);
     }
 
     return { content: lines.join('\n'), isError: false };

--- a/assistant/src/tools/cron/update.ts
+++ b/assistant/src/tools/cron/update.ts
@@ -2,7 +2,7 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { updateCronJob, formatLocalDate } from '../../cron/cron-store.js';
+import { updateCronJob, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronUpdateTool implements Tool {
   name = 'cron_update';
@@ -82,7 +82,7 @@ class CronUpdateTool implements Tool {
           `Cron job updated successfully.`,
           `  ID: ${job.id}`,
           `  Name: ${job.name}`,
-          `  Schedule: ${job.cronExpression}${job.timezone ? ` (${job.timezone})` : ''}`,
+          `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
           `  Enabled: ${job.enabled}`,
           `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a (disabled)'}`,
         ].join('\n'),


### PR DESCRIPTION
Adds a `describeCronExpression()` utility that converts cron expressions to human-readable strings (e.g. `0 9 * * 1-5` → `Every weekday at 9:00 AM`). Updates cron_list, cron_create, and cron_update tool output to show the readable description alongside the raw expression.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
