### PR TITLE
Rename cron tools to schedule (#1403)

### DIFF
--- a/assistant/src/cron/cron-scheduler.ts
+++ b/assistant/src/cron/cron-scheduler.ts
@@ -30,7 +30,7 @@ export function startCronScheduler(processMessage: CronMessageProcessor): CronSc
     try {
       await runCronOnce(processMessage);
     } catch (err) {
-      log.error({ err }, 'Cron scheduler tick failed');
+      log.error({ err }, 'Schedule tick failed');
     } finally {
       tickRunning = false;
     }
@@ -58,21 +58,21 @@ async function runCronOnce(processMessage: CronMessageProcessor): Promise<number
 
   let processed = 0;
   for (const job of jobs) {
-    const conversation = createConversation(`Cron: ${job.name}`);
+    const conversation = createConversation(`Schedule: ${job.name}`);
     const runId = createCronRun(job.id, conversation.id);
 
     try {
-      log.info({ jobId: job.id, name: job.name, conversationId: conversation.id }, 'Executing cron job');
+      log.info({ jobId: job.id, name: job.name, conversationId: conversation.id }, 'Executing schedule');
       await processMessage(conversation.id, job.message);
       completeCronRun(runId, { status: 'ok' });
       processed += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.warn({ err, jobId: job.id, name: job.name }, 'Cron job execution failed');
+      log.warn({ err, jobId: job.id, name: job.name }, 'Schedule execution failed');
       completeCronRun(runId, { status: 'error', error: message });
     }
   }
 
-  log.info({ processed, total: jobs.length }, 'Cron tick complete');
+  log.info({ processed, total: jobs.length }, 'Schedule tick complete');
   return processed;
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -201,7 +201,7 @@ export async function runDaemon(): Promise<void> {
   await server.start();
   const memoryWorker = startMemoryJobsWorker();
   const cronScheduler = startCronScheduler(async (conversationId, message) => {
-    await server.processMessage('cron', conversationId, message);
+    await server.processMessage('schedule', conversationId, message);
   });
 
   // Start optional runtime HTTP server when RUNTIME_HTTP_PORT is set

--- a/assistant/src/tools/cron/create.ts
+++ b/assistant/src/tools/cron/create.ts
@@ -5,9 +5,9 @@ import { registerTool } from '../registry.js';
 import { createCronJob, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronCreateTool implements Tool {
-  name = 'cron_create';
-  description = 'Create a scheduled cron job that sends a message at a recurring interval';
-  category = 'cron';
+  name = 'schedule_create';
+  description = 'Create a scheduled task that sends a message at a recurring interval';
+  category = 'schedule';
   defaultRiskLevel = RiskLevel.Medium;
 
   getDefinition(): ToolDefinition {
@@ -19,7 +19,7 @@ class CronCreateTool implements Tool {
         properties: {
           name: {
             type: 'string',
-            description: 'A human-readable name for the cron job',
+            description: 'A human-readable name for the scheduled task',
           },
           cron_expression: {
             type: 'string',
@@ -31,7 +31,7 @@ class CronCreateTool implements Tool {
           },
           message: {
             type: 'string',
-            description: 'The message to send to the assistant when the cron job triggers',
+            description: 'The message to send to the assistant when the schedule triggers',
           },
           enabled: {
             type: 'boolean',
@@ -68,7 +68,7 @@ class CronCreateTool implements Tool {
       const nextRunDate = formatLocalDate(job.nextRunAt);
       return {
         content: [
-          `Cron job created successfully.`,
+          `Schedule created successfully.`,
           `  ID: ${job.id}`,
           `  Name: ${job.name}`,
           `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
@@ -79,7 +79,7 @@ class CronCreateTool implements Tool {
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error creating cron job: ${msg}`, isError: true };
+      return { content: `Error creating schedule: ${msg}`, isError: true };
     }
   }
 }

--- a/assistant/src/tools/cron/delete.ts
+++ b/assistant/src/tools/cron/delete.ts
@@ -5,9 +5,9 @@ import { registerTool } from '../registry.js';
 import { deleteCronJob, getCronJob } from '../../cron/cron-store.js';
 
 class CronDeleteTool implements Tool {
-  name = 'cron_delete';
-  description = 'Delete a cron job and all its run history';
-  category = 'cron';
+  name = 'schedule_delete';
+  description = 'Delete a scheduled task and all its run history';
+  category = 'schedule';
   defaultRiskLevel = RiskLevel.High;
 
   getDefinition(): ToolDefinition {
@@ -19,7 +19,7 @@ class CronDeleteTool implements Tool {
         properties: {
           job_id: {
             type: 'string',
-            description: 'The ID of the cron job to delete',
+            description: 'The ID of the schedule to delete',
           },
         },
         required: ['job_id'],
@@ -36,16 +36,16 @@ class CronDeleteTool implements Tool {
     // Fetch the job first for the confirmation message
     const job = getCronJob(jobId);
     if (!job) {
-      return { content: `Error: Cron job not found: ${jobId}`, isError: true };
+      return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
     const deleted = deleteCronJob(jobId);
     if (!deleted) {
-      return { content: `Error: Failed to delete cron job: ${jobId}`, isError: true };
+      return { content: `Error: Failed to delete schedule: ${jobId}`, isError: true };
     }
 
     return {
-      content: `Cron job deleted: "${job.name}" (${jobId})`,
+      content: `Schedule deleted: "${job.name}" (${jobId})`,
       isError: false,
     };
   }

--- a/assistant/src/tools/cron/list.ts
+++ b/assistant/src/tools/cron/list.ts
@@ -5,9 +5,9 @@ import { registerTool } from '../registry.js';
 import { listCronJobs, getCronJob, getCronRuns, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronListTool implements Tool {
-  name = 'cron_list';
-  description = 'List cron jobs, or show details and recent runs for a specific job';
-  category = 'cron';
+  name = 'schedule_list';
+  description = 'List scheduled tasks, or show details and recent runs for a specific task';
+  category = 'schedule';
   defaultRiskLevel = RiskLevel.Low;
 
   getDefinition(): ToolDefinition {
@@ -39,12 +39,12 @@ class CronListTool implements Tool {
     if (jobId) {
       const job = getCronJob(jobId);
       if (!job) {
-        return { content: `Error: Cron job not found: ${jobId}`, isError: true };
+        return { content: `Error: Schedule not found: ${jobId}`, isError: true };
       }
 
       const runs = getCronRuns(jobId, 5);
       const lines = [
-        `Cron Job: ${job.name}`,
+        `Schedule: ${job.name}`,
         `  ID: ${job.id}`,
         `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
@@ -72,10 +72,10 @@ class CronListTool implements Tool {
     // List mode
     const jobs = listCronJobs({ enabledOnly });
     if (jobs.length === 0) {
-      return { content: 'No cron jobs found.', isError: false };
+      return { content: 'No schedules found.', isError: false };
     }
 
-    const lines = [`Cron Jobs (${jobs.length}):`];
+    const lines = [`Schedules (${jobs.length}):`];
     for (const job of jobs) {
       const status = job.enabled ? 'enabled' : 'disabled';
       const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';

--- a/assistant/src/tools/cron/update.ts
+++ b/assistant/src/tools/cron/update.ts
@@ -5,9 +5,9 @@ import { registerTool } from '../registry.js';
 import { updateCronJob, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
 
 class CronUpdateTool implements Tool {
-  name = 'cron_update';
-  description = 'Update an existing cron job (schedule, message, name, or enabled state)';
-  category = 'cron';
+  name = 'schedule_update';
+  description = 'Update an existing scheduled task (schedule, message, name, or enabled state)';
+  category = 'schedule';
   defaultRiskLevel = RiskLevel.Medium;
 
   getDefinition(): ToolDefinition {
@@ -19,7 +19,7 @@ class CronUpdateTool implements Tool {
         properties: {
           job_id: {
             type: 'string',
-            description: 'The ID of the cron job to update',
+            description: 'The ID of the schedule to update',
           },
           name: {
             type: 'string',
@@ -74,12 +74,12 @@ class CronUpdateTool implements Tool {
       });
 
       if (!job) {
-        return { content: `Error: Cron job not found: ${jobId}`, isError: true };
+        return { content: `Error: Schedule not found: ${jobId}`, isError: true };
       }
 
       return {
         content: [
-          `Cron job updated successfully.`,
+          `Schedule updated successfully.`,
           `  ID: ${job.id}`,
           `  Name: ${job.name}`,
           `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
@@ -90,7 +90,7 @@ class CronUpdateTool implements Tool {
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error updating cron job: ${msg}`, isError: true };
+      return { content: `Error updating schedule: ${msg}`, isError: true };
     }
   }
 }


### PR DESCRIPTION
## Summary
- Renames all four cron tool names: `cron_create` → `schedule_create`, `cron_list` → `schedule_list`, `cron_update` → `schedule_update`, `cron_delete` → `schedule_delete`
- Changes tool category from `'cron'` to `'schedule'` in all four tool classes
- Updates all user-facing strings: tool descriptions, parameter descriptions, success messages, and error messages to use "schedule"/"scheduled task" terminology instead of "cron job"
- Updates log messages in `cron-scheduler.ts` and the conversation title prefix from `Cron:` to `Schedule:`
- Changes the `processMessage` call in `lifecycle.ts` from `'cron'` to `'schedule'`

No file/directory/function/interface renames — only tool names, descriptions, categories, and user-facing strings.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify schedule_create/list/update/delete tools register correctly
- [ ] Verify scheduled task execution creates conversations with "Schedule: <name>" title
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
