### PR TITLE
Add Apple Weather-style template card system and inline weather widget

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -102,6 +102,8 @@ IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, table
 - Use display: "panel" for interactive forms, confirmations, and workflows that need dedicated focus.
 - Use surface_type "table" for tabular data with optional row selection and action buttons (e.g. email declutter, file lists, search results).
 - Use surface_type "card" for structured info like weather, summaries, status reports.
+- Cards support a "template" field for rich native rendering. After calling get_weather, ALWAYS use template "weather_forecast" with templateData containing: { location, currentTemp, feelsLike, unit ("F" or "C"), condition, humidity, windSpeed, windDirection, forecast: [{ day, icon (SF Symbol name), low, high, precip (number or null), condition }] }.
+  SF Symbol icons for weather: "sun.max.fill" (clear/sunny), "cloud.fill" (overcast), "cloud.sun.fill" (partly cloudy), "cloud.rain.fill" (rain/drizzle), "snowflake" (snow), "cloud.bolt.fill" (thunderstorm), "cloud.fog.fill" (fog). Use "Today" for the first day label.
 
 This is your primary way of presenting information to the user.
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -172,6 +172,10 @@ export interface CardSurfaceData {
   subtitle?: string;
   body: string;
   metadata?: Array<{ label: string; value: string }>;
+  /** Optional template name for specialized rendering (e.g. "weather_forecast"). */
+  template?: string;
+  /** Arbitrary data consumed by the template renderer. Shape depends on template. */
+  templateData?: Record<string, unknown>;
 }
 
 export interface FormField {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -29,7 +29,11 @@ export const uiShowTool: Tool = {
     'Show a UI surface to the user. Use display: "inline" (default) to embed in chat, or "panel" for a floating window.\n\n' +
     'Supported surface types:\n' +
     '- card: Informational card with title, subtitle, body text, and optional metadata key-value pairs. ' +
-    'data shape: { title: string, subtitle?: string, body: string, metadata?: Array<{ label: string, value: string }> }\n' +
+    'Cards support an optional template field for specialized native rendering. ' +
+    'data shape: { title: string, subtitle?: string, body: string, metadata?: Array<{ label: string, value: string }>, template?: string, templateData?: object }\n' +
+    '  Template "weather_forecast": renders an Apple Weather-style forecast widget. ' +
+    'templateData shape: { location: string, currentTemp: number, feelsLike: number, unit: "F"|"C", condition: string, humidity: number, windSpeed: number, windDirection: string, ' +
+    'forecast: Array<{ day: string, icon: string (SF Symbol name), low: number, high: number, precip: number|null, condition: string }> }\n' +
     '- table: Data table with columns, selectable rows, and action buttons. ' +
     'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +
     '- form: Input form with typed fields. ' +

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -78,6 +78,24 @@ interface ForecastResponse {
   daily_units: Record<string, string>;
 }
 
+/**
+ * Maps WMO weather codes to SF Symbol icon names for native rendering.
+ */
+export function weatherCodeToSFSymbol(code: number): string {
+  if (code === 0) return 'sun.max.fill';
+  if (code === 1) return 'sun.max.fill';
+  if (code === 2) return 'cloud.sun.fill';
+  if (code === 3) return 'cloud.fill';
+  if (code === 45 || code === 48) return 'cloud.fog.fill';
+  if (code >= 51 && code <= 57) return 'cloud.rain.fill';
+  if (code >= 61 && code <= 67) return 'cloud.rain.fill';
+  if (code >= 71 && code <= 77) return 'snowflake';
+  if (code >= 80 && code <= 82) return 'cloud.rain.fill';
+  if (code >= 85 && code <= 86) return 'snowflake';
+  if (code >= 95) return 'cloud.bolt.fill';
+  return 'cloud.fill';
+}
+
 function windDirectionToCompass(degrees: number): string {
   const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW'];
   const index = Math.round(degrees / 22.5) % 16;
@@ -136,7 +154,7 @@ export async function executeGetWeather(
   // Step 2: Fetch the weather forecast
   let forecast: ForecastResponse;
   try {
-    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=5`;
+    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=10`;
     log.debug({ url: weatherUrl }, 'Fetching weather forecast');
 
     const weatherResponse = await fetchFn(weatherUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
@@ -182,14 +200,55 @@ export async function executeGetWeather(
   ];
 
   const daily = forecast.daily;
+  const forecastItems: Array<{
+    day: string;
+    icon: string;
+    low: number;
+    high: number;
+    precip: number | null;
+    condition: string;
+  }> = [];
+
+  const today = new Date();
+  const todayStr = today.toISOString().split('T')[0];
+
   for (let i = 0; i < daily.time.length; i++) {
     const date = daily.time[i];
     const high = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_max[i]) : Math.round(daily.temperature_2m_max[i]);
     const low = useFahrenheit ? celsiusToFahrenheit(daily.temperature_2m_min[i]) : Math.round(daily.temperature_2m_min[i]);
     const precip = daily.precipitation_probability_max[i];
     const desc = weatherCodeToDescription(daily.weather_code[i]);
+    const icon = weatherCodeToSFSymbol(daily.weather_code[i]);
+
+    // Format day label: "Today" for today, otherwise abbreviated weekday
+    let dayLabel: string;
+    if (date === todayStr) {
+      dayLabel = 'Today';
+    } else {
+      const d = new Date(date + 'T12:00:00');
+      dayLabel = d.toLocaleDateString('en-US', { weekday: 'short' });
+    }
+
     lines.push(`${date}: High ${high}\u00B0${tempUnit}, Low ${low}\u00B0${tempUnit}, Precip ${precip}%, ${desc}`);
+
+    forecastItems.push({ day: dayLabel, icon, low, high, precip: precip > 0 ? precip : null, condition: desc });
   }
+
+  // Include structured data for ui_show weather_forecast template
+  const structured = {
+    location: locationDisplay,
+    currentTemp,
+    feelsLike: currentFeelsLike,
+    unit: tempUnit,
+    condition: currentDescription,
+    humidity: current.relative_humidity_2m,
+    windSpeed: currentWind,
+    windDirection: windDir,
+    forecast: forecastItems,
+  };
+
+  lines.push('', '--- Structured Data (for ui_show template "weather_forecast") ---');
+  lines.push(JSON.stringify(structured));
 
   return { content: lines.join('\n'), isError: false };
 }

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -1,10 +1,21 @@
 import SwiftUI
 
 /// Inline card widget for displaying structured information in chat.
+/// Supports template-based rendering for specialized layouts (e.g. weather forecasts).
 struct InlineCardWidget: View {
     let data: CardSurfaceData
 
     var body: some View {
+        if data.template == "weather_forecast",
+           let templateData = data.templateData,
+           let weatherData = WeatherForecastData.parse(from: templateData) {
+            InlineWeatherWidget(data: weatherData)
+        } else {
+            standardCardLayout
+        }
+    }
+
+    private var standardCardLayout: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             // Title + subtitle
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
@@ -20,10 +31,12 @@ struct InlineCardWidget: View {
             }
 
             // Body text
-            Text(markdownBody)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
+            if !data.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(markdownBody)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .textSelection(.enabled)
+            }
 
             // Metadata grid
             if let metadata = data.metadata, !metadata.isEmpty {
@@ -78,7 +91,9 @@ struct InlineCardWidget: View {
                 (label: "Low", value: "45°F"),
                 (label: "Humidity", value: "65%"),
                 (label: "Wind", value: "12 mph NW"),
-            ]
+            ],
+            template: nil,
+            templateData: nil
         ))
         .padding()
     }

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+
+// MARK: - Data Model
+
+struct WeatherForecastItem: Identifiable {
+    let id: String
+    let day: String
+    let icon: String
+    let lowC: Double
+    let highC: Double
+    let precip: Int?
+    let condition: String
+
+    /// Whether the original data was in Fahrenheit.
+    let sourceIsFahrenheit: Bool
+
+    func low(useFahrenheit: Bool) -> Int {
+        if sourceIsFahrenheit == useFahrenheit { return Int(lowC) }
+        return useFahrenheit ? Int(lowC * 9 / 5 + 32) : Int((lowC - 32) * 5 / 9)
+    }
+
+    func high(useFahrenheit: Bool) -> Int {
+        if sourceIsFahrenheit == useFahrenheit { return Int(highC) }
+        return useFahrenheit ? Int(highC * 9 / 5 + 32) : Int((highC - 32) * 5 / 9)
+    }
+}
+
+struct WeatherForecastData {
+    let location: String
+    let currentTemp: Double
+    let feelsLike: Double
+    let condition: String
+    let humidity: Int
+    let windSpeed: Int
+    let windDirection: String
+    let sourceIsFahrenheit: Bool
+    let forecast: [WeatherForecastItem]
+
+    func currentTemp(useFahrenheit: Bool) -> Int {
+        if sourceIsFahrenheit == useFahrenheit { return Int(currentTemp) }
+        return useFahrenheit ? Int(currentTemp * 9 / 5 + 32) : Int((currentTemp - 32) * 5 / 9)
+    }
+
+    static func parse(from dict: [String: Any?]) -> WeatherForecastData? {
+        guard let location = dict["location"] as? String else { return nil }
+
+        let currentTemp = (dict["currentTemp"] as? Double) ?? Double(dict["currentTemp"] as? Int ?? 0)
+        let feelsLike = (dict["feelsLike"] as? Double) ?? Double(dict["feelsLike"] as? Int ?? 0)
+        let condition = dict["condition"] as? String ?? ""
+        let humidity = dict["humidity"] as? Int ?? 0
+        let windSpeed = dict["windSpeed"] as? Int ?? 0
+        let windDirection = dict["windDirection"] as? String ?? ""
+        let unit = dict["unit"] as? String ?? "F"
+        let isFahrenheit = unit == "F"
+
+        var items: [WeatherForecastItem] = []
+        if let forecastArray = dict["forecast"] as? [[String: Any?]] {
+            for (index, entry) in forecastArray.enumerated() {
+                let day = entry["day"] as? String ?? ""
+                let icon = entry["icon"] as? String ?? "cloud.fill"
+                let low = (entry["low"] as? Double) ?? Double(entry["low"] as? Int ?? 0)
+                let high = (entry["high"] as? Double) ?? Double(entry["high"] as? Int ?? 0)
+                let precip: Int? = entry["precip"] as? Int
+                let itemCondition = entry["condition"] as? String ?? ""
+                items.append(WeatherForecastItem(
+                    id: "\(index)-\(day)",
+                    day: day, icon: icon,
+                    lowC: low, highC: high,
+                    precip: precip,
+                    condition: itemCondition,
+                    sourceIsFahrenheit: isFahrenheit
+                ))
+            }
+        }
+
+        return WeatherForecastData(
+            location: location,
+            currentTemp: currentTemp,
+            feelsLike: feelsLike,
+            condition: condition,
+            humidity: humidity,
+            windSpeed: windSpeed,
+            windDirection: windDirection,
+            sourceIsFahrenheit: isFahrenheit,
+            forecast: items
+        )
+    }
+}
+
+// MARK: - Widget View
+
+struct InlineWeatherWidget: View {
+    let data: WeatherForecastData
+
+    @State private var useFahrenheit: Bool
+
+    init(data: WeatherForecastData) {
+        self.data = data
+        self._useFahrenheit = State(initialValue: data.sourceIsFahrenheit)
+    }
+
+    private var unit: String { useFahrenheit ? "F" : "C" }
+
+    /// Global min/max across all forecast days, used to normalize the temperature bars.
+    private var globalRange: (min: Int, max: Int) {
+        let lows = data.forecast.map { $0.low(useFahrenheit: useFahrenheit) }
+        let highs = data.forecast.map { $0.high(useFahrenheit: useFahrenheit) }
+        let allMin = (lows.min() ?? 0)
+        let allMax = (highs.max() ?? 100)
+        return (allMin, allMax)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(Slate._700.opacity(0.3))
+
+            ForEach(Array(data.forecast.enumerated()), id: \.element.id) { index, item in
+                forecastRow(item, isFirst: index == 0)
+                if index < data.forecast.count - 1 {
+                    Divider().background(Slate._700.opacity(0.3))
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Image(systemName: "calendar")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+            Text("\(data.forecast.count)-DAY FORECAST")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+            Spacer()
+            Picker("", selection: $useFahrenheit) {
+                Text("°F").tag(true)
+                Text("°C").tag(false)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 80)
+        }
+        .padding(.vertical, VSpacing.sm)
+    }
+
+    // MARK: - Forecast Row
+
+    private func forecastRow(_ item: WeatherForecastItem, isFirst: Bool) -> some View {
+        let low = item.low(useFahrenheit: useFahrenheit)
+        let high = item.high(useFahrenheit: useFahrenheit)
+
+        return HStack(spacing: VSpacing.sm) {
+            // Day name
+            Text(item.day)
+                .font(item.day == "Today" ? VFont.bodyBold : VFont.bodyMedium)
+                .foregroundColor(VColor.textPrimary)
+                .frame(width: 46, alignment: .leading)
+
+            // Weather icon + optional precip
+            VStack(spacing: VSpacing.xxs) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 16))
+                    .foregroundColor(iconColor(for: item.icon))
+                    .frame(width: 24, height: 20)
+
+                if let precip = item.precip {
+                    Text("\(precip)%")
+                        .font(VFont.small)
+                        .foregroundColor(Amber._500)
+                }
+            }
+            .frame(width: 36)
+
+            // Low temp
+            Text("\(low)°")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+                .frame(width: 32, alignment: .trailing)
+
+            // Temperature bar
+            temperatureBar(low: low, high: high, currentTemp: isFirst ? data.currentTemp(useFahrenheit: useFahrenheit) : nil)
+
+            // High temp
+            Text("\(high)°")
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .frame(width: 32, alignment: .trailing)
+        }
+        .padding(.vertical, VSpacing.sm)
+    }
+
+    // MARK: - Temperature Bar
+
+    private func temperatureBar(low: Int, high: Int, currentTemp: Int?) -> some View {
+        let range = globalRange
+        let span = max(range.max - range.min, 1)
+
+        // Calculate the start and end positions of the filled portion (0...1)
+        let startFraction = CGFloat(low - range.min) / CGFloat(span)
+        let endFraction = CGFloat(high - range.min) / CGFloat(span)
+
+        return GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let barStart = totalWidth * startFraction
+            let barWidth = totalWidth * (endFraction - startFraction)
+
+            ZStack(alignment: .leading) {
+                // Background track
+                Capsule()
+                    .fill(Slate._700.opacity(0.3))
+                    .frame(height: 4)
+
+                // Filled portion with gradient
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [Indigo._400, Emerald._400],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: max(barWidth, 4), height: 4)
+                    .offset(x: barStart)
+
+                // Current temperature dot (today only)
+                if let temp = currentTemp {
+                    let dotFraction = CGFloat(temp - range.min) / CGFloat(span)
+                    let dotX = totalWidth * dotFraction
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 6, height: 6)
+                        .shadow(color: .black.opacity(0.3), radius: 1, y: 1)
+                        .offset(x: dotX - 3)
+                }
+            }
+        }
+        .frame(height: 6)
+    }
+
+    // MARK: - Helpers
+
+    private func iconColor(for sfSymbol: String) -> Color {
+        switch sfSymbol {
+        case "sun.max.fill": return Amber._400
+        case "cloud.sun.fill": return Amber._300
+        case "cloud.fill": return Slate._400
+        case "cloud.rain.fill": return Indigo._400
+        case "snowflake": return Indigo._300
+        case "cloud.bolt.fill": return Amber._500
+        case "cloud.fog.fill": return Slate._500
+        default: return VColor.textSecondary
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("InlineWeatherWidget") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        InlineWeatherWidget(data: WeatherForecastData(
+            location: "New York, NY",
+            currentTemp: 28,
+            feelsLike: 19,
+            condition: "Overcast",
+            humidity: 65,
+            windSpeed: 12,
+            windDirection: "NW",
+            sourceIsFahrenheit: true,
+            forecast: [
+                WeatherForecastItem(id: "0", day: "Today", icon: "cloud.fill", lowC: 24, highC: 36, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "1", day: "Fri", icon: "sun.max.fill", lowC: 20, highC: 36, precip: nil, condition: "Sunny", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "2", day: "Sat", icon: "snowflake", lowC: 23, highC: 41, precip: 35, condition: "Snow", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "3", day: "Sun", icon: "cloud.fill", lowC: 26, highC: 37, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "4", day: "Mon", icon: "cloud.sun.fill", lowC: 28, highC: 40, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "5", day: "Tue", icon: "cloud.sun.fill", lowC: 34, highC: 49, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "6", day: "Wed", icon: "cloud.fill", lowC: 33, highC: 44, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "7", day: "Thu", icon: "snowflake", lowC: 35, highC: 44, precip: 55, condition: "Snow", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "8", day: "Fri", icon: "snowflake", lowC: 33, highC: 40, precip: 65, condition: "Snow", sourceIsFahrenheit: true),
+                WeatherForecastItem(id: "9", day: "Sat", icon: "cloud.fill", lowC: 31, highC: 43, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+            ]
+        ))
+        .padding()
+        .frame(width: 450)
+    }
+    .frame(width: 500, height: 600)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Surfaces/CardSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/CardSurfaceView.swift
@@ -53,7 +53,9 @@ struct CardSurfaceView: View {
         metadata: [
             (label: "Duration", value: "12s"),
             (label: "Steps", value: "3"),
-        ]
+        ],
+        template: nil,
+        templateData: nil
     ))
     .padding()
 }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -161,7 +161,9 @@ private struct ConditionalPanelBackground: ViewModifier {
                     title: "Screenshot Captured",
                     subtitle: "Step 2 of 5",
                     body: "Captured the current screen state for analysis.",
-                    metadata: nil
+                    metadata: nil,
+                    template: nil,
+                    templateData: nil
                 )),
                 actions: [
                     SurfaceActionButton(id: "dismiss", label: "Dismiss", style: .secondary),

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceTypes.swift
@@ -31,6 +31,10 @@ struct CardSurfaceData: Sendable {
     let subtitle: String?
     let body: String
     let metadata: [(label: String, value: String)]?
+    /// Optional template name for specialized rendering (e.g. "weather_forecast").
+    let template: String?
+    /// Arbitrary data consumed by the template renderer. Shape depends on template.
+    let templateData: [String: Any?]?
 }
 
 struct FormFieldOption: Sendable {
@@ -292,7 +296,12 @@ extension Surface {
             }
         }
 
-        return CardSurfaceData(title: title, subtitle: subtitle, body: body, metadata: metadata)
+        let template: String? = update.keys.contains("template")
+            ? (update["template"] as? String) : existing.template
+        let templateData: [String: Any?]? = update.keys.contains("templateData")
+            ? (update["templateData"] as? [String: Any?]) : existing.templateData
+
+        return CardSurfaceData(title: title, subtitle: subtitle, body: body, metadata: metadata, template: template, templateData: templateData)
     }
 
     private static func mergeFormData(existing: FormSurfaceData, update: [String: Any?]) -> FormSurfaceData {
@@ -401,12 +410,14 @@ extension Surface {
     // MARK: - Full Parse Helpers
 
     private static func parseCardData(_ dict: [String: Any?]) -> CardSurfaceData? {
-        guard let title = dict["title"] as? String,
-              let body = dict["body"] as? String else {
+        guard let title = dict["title"] as? String else {
             return nil
         }
 
+        let body = (dict["body"] as? String) ?? ""
         let subtitle = dict["subtitle"] as? String
+        let template = dict["template"] as? String
+        let templateData = dict["templateData"] as? [String: Any?]
 
         var metadata: [(label: String, value: String)]?
         if let metaArray = dict["metadata"] as? [[String: Any?]] {
@@ -421,7 +432,9 @@ extension Surface {
             title: title,
             subtitle: subtitle,
             body: body,
-            metadata: metadata
+            metadata: metadata,
+            template: template,
+            templateData: templateData
         )
     }
 


### PR DESCRIPTION
## Summary
- Introduces a generic **template card system** — `CardSurfaceData` now supports optional `template` and `templateData` fields that route to specialized SwiftUI renderers, with graceful fallback to the standard card layout for unknown templates
- Adds the first template, `"weather_forecast"`, which renders an **Apple Weather-style 10-day forecast widget** with SF Symbol weather icons, temperature range gradient bars, precipitation percentages, current-temp dot, and an F/C toggle
- Extends the `get_weather` tool to fetch 10-day forecasts with structured JSON output (SF Symbol icon names, day labels, forecast items) for direct piping into `ui_show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
