### PR TITLE
Rename internal cron modules to schedule (#1404)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -20,7 +20,7 @@ import { DaemonError } from '../util/errors.js';
 import { startMemoryJobsWorker } from '../memory/jobs-worker.js';
 import { QdrantManager } from '../memory/qdrant-manager.js';
 import { initQdrantClient } from '../memory/qdrant-client.js';
-import { startCronScheduler } from '../cron/cron-scheduler.js';
+import { startScheduler } from '../schedule/scheduler.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
 
@@ -200,7 +200,7 @@ export async function runDaemon(): Promise<void> {
   const server = new DaemonServer();
   await server.start();
   const memoryWorker = startMemoryJobsWorker();
-  const cronScheduler = startCronScheduler(async (conversationId, message) => {
+  const scheduler = startScheduler(async (conversationId, message) => {
     await server.processMessage('schedule', conversationId, message);
   });
 
@@ -259,7 +259,7 @@ export async function runDaemon(): Promise<void> {
     await server.stop();
     if (runtimeHttp) await runtimeHttp.stop();
     await browserManager.closeAllPages();
-    cronScheduler.stop();
+    scheduler.stop();
     memoryWorker.stop();
     await qdrantManager.stop();
     await Sentry.flush(2000);

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -4,7 +4,7 @@ import { Cron } from 'croner';
 import { getDb } from '../memory/db.js';
 import { cronJobs, cronRuns } from '../memory/schema.js';
 
-export interface CronJob {
+export interface ScheduleJob {
   id: string;
   name: string;
   enabled: boolean;
@@ -20,7 +20,7 @@ export interface CronJob {
   updatedAt: number;
 }
 
-export interface CronRun {
+export interface ScheduleRun {
   id: string;
   jobId: string;
   status: string;
@@ -53,14 +53,14 @@ export function computeNextRunAt(cronExpression: string, timezone?: string | nul
   return next.getTime();
 }
 
-export function createCronJob(params: {
+export function createSchedule(params: {
   name: string;
   cronExpression: string;
   timezone?: string | null;
   message: string;
   enabled?: boolean;
   createdBy?: string;
-}): CronJob {
+}): ScheduleJob {
   if (!isValidCronExpression(params.cronExpression)) {
     throw new Error(`Invalid cron expression: "${params.cronExpression}"`);
   }
@@ -92,7 +92,7 @@ export function createCronJob(params: {
   return row;
 }
 
-export function getCronJob(id: string): CronJob | null {
+export function getSchedule(id: string): ScheduleJob | null {
   const db = getDb();
   const row = db
     .select()
@@ -103,7 +103,7 @@ export function getCronJob(id: string): CronJob | null {
   return parseJobRow(row);
 }
 
-export function listCronJobs(options?: { enabledOnly?: boolean }): CronJob[] {
+export function listSchedules(options?: { enabledOnly?: boolean }): ScheduleJob[] {
   const db = getDb();
   const conditions = options?.enabledOnly ? eq(cronJobs.enabled, true) : undefined;
   const rows = db
@@ -115,7 +115,7 @@ export function listCronJobs(options?: { enabledOnly?: boolean }): CronJob[] {
   return rows.map(parseJobRow);
 }
 
-export function updateCronJob(
+export function updateSchedule(
   id: string,
   updates: {
     name?: string;
@@ -124,7 +124,7 @@ export function updateCronJob(
     message?: string;
     enabled?: boolean;
   },
-): CronJob | null {
+): ScheduleJob | null {
   const db = getDb();
   const existing = db.select().from(cronJobs).where(eq(cronJobs.id, id)).get();
   if (!existing) return null;
@@ -157,21 +157,21 @@ export function updateCronJob(
 
   db.update(cronJobs).set(set).where(eq(cronJobs.id, id)).run();
 
-  return getCronJob(id);
+  return getSchedule(id);
 }
 
-export function deleteCronJob(id: string): boolean {
+export function deleteSchedule(id: string): boolean {
   const db = getDb();
   const result = db.delete(cronJobs).where(eq(cronJobs.id, id)).run() as unknown as { changes?: number };
   return (result.changes ?? 0) > 0;
 }
 
 /**
- * Claim due cron jobs atomically. For each candidate where enabled=true and
+ * Claim due schedules atomically. For each candidate where enabled=true and
  * next_run_at <= now, we advance next_run_at using optimistic locking on the
  * old value to prevent double-claiming by concurrent ticks.
  */
-export function claimDueCronJobs(now: number): CronJob[] {
+export function claimDueSchedules(now: number): ScheduleJob[] {
   const db = getDb();
   const candidates = db
     .select()
@@ -180,7 +180,7 @@ export function claimDueCronJobs(now: number): CronJob[] {
     .orderBy(asc(cronJobs.nextRunAt))
     .all();
 
-  const claimed: CronJob[] = [];
+  const claimed: ScheduleJob[] = [];
   for (const row of candidates) {
     let newNextRunAt: number;
     try {
@@ -213,7 +213,7 @@ export function claimDueCronJobs(now: number): CronJob[] {
   return claimed;
 }
 
-export function createCronRun(jobId: string, conversationId: string): string {
+export function createScheduleRun(jobId: string, conversationId: string): string {
   const db = getDb();
   const id = uuid();
   const now = Date.now();
@@ -232,7 +232,7 @@ export function createCronRun(jobId: string, conversationId: string): string {
   return id;
 }
 
-export function completeCronRun(
+export function completeScheduleRun(
   runId: string,
   result: { status: 'ok' | 'error'; output?: string; error?: string },
 ): void {
@@ -274,7 +274,7 @@ export function completeCronRun(
   }
 }
 
-export function getCronRuns(jobId: string, limit?: number): CronRun[] {
+export function getScheduleRuns(jobId: string, limit?: number): ScheduleRun[] {
   const db = getDb();
   const rows = db
     .select()
@@ -420,7 +420,7 @@ export function describeCronExpression(expr: string): string {
   }
 }
 
-function parseJobRow(row: typeof cronJobs.$inferSelect): CronJob {
+function parseJobRow(row: typeof cronJobs.$inferSelect): ScheduleJob {
   return {
     id: row.id,
     name: row.name,
@@ -438,7 +438,7 @@ function parseJobRow(row: typeof cronJobs.$inferSelect): CronJob {
   };
 }
 
-function parseRunRow(row: typeof cronRuns.$inferSelect): CronRun {
+function parseRunRow(row: typeof cronRuns.$inferSelect): ScheduleRun {
   return {
     id: row.id,
     jobId: row.jobId,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,26 +1,26 @@
 import { getLogger } from '../util/logger.js';
 import { createConversation } from '../memory/conversation-store.js';
 import {
-  claimDueCronJobs,
-  createCronRun,
-  completeCronRun,
-} from './cron-store.js';
+  claimDueSchedules,
+  createScheduleRun,
+  completeScheduleRun,
+} from './schedule-store.js';
 
-const log = getLogger('cron-scheduler');
+const log = getLogger('scheduler');
 
-export type CronMessageProcessor = (
+export type ScheduleMessageProcessor = (
   conversationId: string,
   message: string,
 ) => Promise<unknown>;
 
-export interface CronScheduler {
+export interface SchedulerHandle {
   runOnce(): Promise<number>;
   stop(): void;
 }
 
 const TICK_INTERVAL_MS = 15_000;
 
-export function startCronScheduler(processMessage: CronMessageProcessor): CronScheduler {
+export function startScheduler(processMessage: ScheduleMessageProcessor): SchedulerHandle {
   let stopped = false;
   let tickRunning = false;
 
@@ -28,7 +28,7 @@ export function startCronScheduler(processMessage: CronMessageProcessor): CronSc
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runCronOnce(processMessage);
+      await runScheduleOnce(processMessage);
     } catch (err) {
       log.error({ err }, 'Schedule tick failed');
     } finally {
@@ -42,7 +42,7 @@ export function startCronScheduler(processMessage: CronMessageProcessor): CronSc
 
   return {
     async runOnce(): Promise<number> {
-      return runCronOnce(processMessage);
+      return runScheduleOnce(processMessage);
     },
     stop(): void {
       stopped = true;
@@ -51,25 +51,25 @@ export function startCronScheduler(processMessage: CronMessageProcessor): CronSc
   };
 }
 
-async function runCronOnce(processMessage: CronMessageProcessor): Promise<number> {
+async function runScheduleOnce(processMessage: ScheduleMessageProcessor): Promise<number> {
   const now = Date.now();
-  const jobs = claimDueCronJobs(now);
+  const jobs = claimDueSchedules(now);
   if (jobs.length === 0) return 0;
 
   let processed = 0;
   for (const job of jobs) {
     const conversation = createConversation(`Schedule: ${job.name}`);
-    const runId = createCronRun(job.id, conversation.id);
+    const runId = createScheduleRun(job.id, conversation.id);
 
     try {
       log.info({ jobId: job.id, name: job.name, conversationId: conversation.id }, 'Executing schedule');
       await processMessage(conversation.id, job.message);
-      completeCronRun(runId, { status: 'ok' });
+      completeScheduleRun(runId, { status: 'ok' });
       processed += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err, jobId: job.id, name: job.name }, 'Schedule execution failed');
-      completeCronRun(runId, { status: 'error', error: message });
+      completeScheduleRun(runId, { status: 'error', error: message });
     }
   }
 

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -111,10 +111,10 @@ export async function initializeTools(): Promise<void> {
   await import('./credentials/account-registry.js');
   await import('./timer/pomodoro.js');
   await import('./system/system-info.js');
-  await import('./cron/create.js');
-  await import('./cron/list.js');
-  await import('./cron/update.js');
-  await import('./cron/delete.js');
+  await import('./schedule/create.js');
+  await import('./schedule/list.js');
+  await import('./schedule/update.js');
+  await import('./schedule/delete.js');
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -2,9 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { createCronJob, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
+import { createSchedule, isValidCronExpression, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
 
-class CronCreateTool implements Tool {
+class ScheduleCreateTool implements Tool {
   name = 'schedule_create';
   description = 'Create a scheduled task that sends a message at a recurring interval';
   category = 'schedule';
@@ -64,7 +64,7 @@ class CronCreateTool implements Tool {
     }
 
     try {
-      const job = createCronJob({ name, cronExpression, timezone, message, enabled });
+      const job = createSchedule({ name, cronExpression, timezone, message, enabled });
       const nextRunDate = formatLocalDate(job.nextRunAt);
       return {
         content: [
@@ -84,4 +84,4 @@ class CronCreateTool implements Tool {
   }
 }
 
-registerTool(new CronCreateTool());
+registerTool(new ScheduleCreateTool());

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -2,9 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { deleteCronJob, getCronJob } from '../../cron/cron-store.js';
+import { deleteSchedule, getSchedule } from '../../schedule/schedule-store.js';
 
-class CronDeleteTool implements Tool {
+class ScheduleDeleteTool implements Tool {
   name = 'schedule_delete';
   description = 'Delete a scheduled task and all its run history';
   category = 'schedule';
@@ -34,12 +34,12 @@ class CronDeleteTool implements Tool {
     }
 
     // Fetch the job first for the confirmation message
-    const job = getCronJob(jobId);
+    const job = getSchedule(jobId);
     if (!job) {
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
-    const deleted = deleteCronJob(jobId);
+    const deleted = deleteSchedule(jobId);
     if (!deleted) {
       return { content: `Error: Failed to delete schedule: ${jobId}`, isError: true };
     }
@@ -51,4 +51,4 @@ class CronDeleteTool implements Tool {
   }
 }
 
-registerTool(new CronDeleteTool());
+registerTool(new ScheduleDeleteTool());

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -2,9 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { listCronJobs, getCronJob, getCronRuns, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
+import { listSchedules, getSchedule, getScheduleRuns, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
 
-class CronListTool implements Tool {
+class ScheduleListTool implements Tool {
   name = 'schedule_list';
   description = 'List scheduled tasks, or show details and recent runs for a specific task';
   category = 'schedule';
@@ -37,12 +37,12 @@ class CronListTool implements Tool {
 
     // Detail mode for a specific job
     if (jobId) {
-      const job = getCronJob(jobId);
+      const job = getSchedule(jobId);
       if (!job) {
         return { content: `Error: Schedule not found: ${jobId}`, isError: true };
       }
 
-      const runs = getCronRuns(jobId, 5);
+      const runs = getScheduleRuns(jobId, 5);
       const lines = [
         `Schedule: ${job.name}`,
         `  ID: ${job.id}`,
@@ -70,7 +70,7 @@ class CronListTool implements Tool {
     }
 
     // List mode
-    const jobs = listCronJobs({ enabledOnly });
+    const jobs = listSchedules({ enabledOnly });
     if (jobs.length === 0) {
       return { content: 'No schedules found.', isError: false };
     }
@@ -86,4 +86,4 @@ class CronListTool implements Tool {
   }
 }
 
-registerTool(new CronListTool());
+registerTool(new ScheduleListTool());

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -2,9 +2,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { updateCronJob, formatLocalDate, describeCronExpression } from '../../cron/cron-store.js';
+import { updateSchedule, formatLocalDate, describeCronExpression } from '../../schedule/schedule-store.js';
 
-class CronUpdateTool implements Tool {
+class ScheduleUpdateTool implements Tool {
   name = 'schedule_update';
   description = 'Update an existing scheduled task (schedule, message, name, or enabled state)';
   category = 'schedule';
@@ -65,7 +65,7 @@ class CronUpdateTool implements Tool {
     }
 
     try {
-      const job = updateCronJob(jobId, updates as {
+      const job = updateSchedule(jobId, updates as {
         name?: string;
         cronExpression?: string;
         timezone?: string | null;
@@ -95,4 +95,4 @@ class CronUpdateTool implements Tool {
   }
 }
 
-registerTool(new CronUpdateTool());
+registerTool(new ScheduleUpdateTool());


### PR DESCRIPTION
## Summary
- Renames directories: `src/cron/` -> `src/schedule/`, `src/tools/cron/` -> `src/tools/schedule/`
- Renames files: `cron-scheduler.ts` -> `scheduler.ts`, `cron-store.ts` -> `schedule-store.ts`
- Renames interfaces: `CronJob` -> `ScheduleJob`, `CronRun` -> `ScheduleRun`, `CronScheduler` -> `SchedulerHandle`, `CronMessageProcessor` -> `ScheduleMessageProcessor`
- Renames functions: `startCronScheduler` -> `startScheduler`, `createCronJob` -> `createSchedule`, `getCronJob` -> `getSchedule`, `listCronJobs` -> `listSchedules`, `updateCronJob` -> `updateSchedule`, `deleteCronJob` -> `deleteSchedule`, `claimDueCronJobs` -> `claimDueSchedules`, `createCronRun` -> `createScheduleRun`, `completeCronRun` -> `completeScheduleRun`, `getCronRuns` -> `getScheduleRuns`
- Renames classes: `CronCreateTool` -> `ScheduleCreateTool`, `CronListTool` -> `ScheduleListTool`, `CronUpdateTool` -> `ScheduleUpdateTool`, `CronDeleteTool` -> `ScheduleDeleteTool`
- Updates all import paths across `registry.ts` and `lifecycle.ts`
- DB table names (`cron_jobs`, `cron_runs`) and Drizzle schema exports preserved for backward compat
- Technically accurate names kept as-is: `isValidCronExpression`, `computeNextRunAt`, `formatLocalDate`, `describeCronExpression`

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify daemon starts and schedules execute correctly
- [ ] Verify schedule CRUD tools work via assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
