### PR TITLE
Add configurable forecast days and weather-only widget response

### DIFF
--- a/assistant/src/__tests__/get-weather.test.ts
+++ b/assistant/src/__tests__/get-weather.test.ts
@@ -176,12 +176,12 @@ describe('weather output formatting', () => {
     expect(result.content).toContain('Humidity: 72%');
   });
 
-  test('includes 5-day forecast', async () => {
+  test('includes 10-day forecast by default', async () => {
     const mockFetch = createMockFetch();
     const result = await executeGetWeather({ location: 'San Francisco' }, mockFetch);
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain('5-Day Forecast');
+    expect(result.content).toContain('10-Day Forecast');
     expect(result.content).toContain('2025-01-15');
     expect(result.content).toContain('2025-01-19');
     expect(result.content).toContain('Precip');

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -102,7 +102,8 @@ IMPORTANT: You have a ui_show tool that renders native UI surfaces (cards, table
 - Use display: "panel" for interactive forms, confirmations, and workflows that need dedicated focus.
 - Use surface_type "table" for tabular data with optional row selection and action buttons (e.g. email declutter, file lists, search results).
 - Use surface_type "card" for structured info like weather, summaries, status reports.
-- Cards support a "template" field for rich native rendering. After calling get_weather, ALWAYS use template "weather_forecast" with templateData containing: { location, currentTemp, feelsLike, unit ("F" or "C"), condition, humidity, windSpeed, windDirection, forecast: [{ day, icon (SF Symbol name), low, high, precip (number or null), condition }] }.
+- Cards support a "template" field for rich native rendering. After calling get_weather, ALWAYS use template "weather_forecast" with templateData containing the structured JSON from the tool output. Include ALL forecast days returned by the tool — never truncate or summarize. Copy the structured data exactly into templateData. Respond with ONLY the ui_show call and no additional text — the widget IS the response.
+  When calling get_weather, pass the "days" parameter matching what the user asked for (e.g. "10-day forecast" → days: 10, "weather this week" → days: 7). Default to 10 if unspecified.
   SF Symbol icons for weather: "sun.max.fill" (clear/sunny), "cloud.fill" (overcast), "cloud.sun.fill" (partly cloudy), "cloud.rain.fill" (rain/drizzle), "snowflake" (snow), "cloud.bolt.fill" (thunderstorm), "cloud.fog.fill" (fog). Use "Today" for the first day label.
 
 This is your primary way of presenting information to the user.

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -128,6 +128,10 @@ export async function executeGetWeather(
 
   const useFahrenheit = units === 'fahrenheit';
 
+  // Forecast days: default 10, clamp to 1-16 (Open-Meteo max)
+  const rawDays = typeof input.days === 'number' ? input.days : 10;
+  const forecastDays = Math.max(1, Math.min(16, Math.round(rawDays)));
+
   // Step 1: Geocode the location
   let geo: GeocodingResult;
   try {
@@ -154,7 +158,7 @@ export async function executeGetWeather(
   // Step 2: Fetch the weather forecast
   let forecast: ForecastResponse;
   try {
-    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=10`;
+    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=${forecastDays}`;
     log.debug({ url: weatherUrl }, 'Fetching weather forecast');
 
     const weatherResponse = await fetchFn(weatherUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
@@ -196,7 +200,7 @@ export async function executeGetWeather(
     `Wind: ${currentWind} ${speedUnit} ${windDir}`,
     `Conditions: ${currentDescription}`,
     '',
-    '--- 5-Day Forecast ---',
+    `--- ${forecastDays}-Day Forecast ---`,
   ];
 
   const daily = forecast.daily;
@@ -274,6 +278,10 @@ class GetWeatherTool implements Tool {
             type: 'string',
             enum: ['celsius', 'fahrenheit'],
             description: 'Temperature units to use (default: fahrenheit)',
+          },
+          days: {
+            type: 'number',
+            description: 'Number of forecast days to return (1-16, default: 10)',
           },
         },
         required: ['location'],


### PR DESCRIPTION
## Summary
- Adds a `days` parameter (1-16, default 10) to the `get_weather` tool so forecast length matches what the user asks for
- Fixes hardcoded "5-Day Forecast" text header to dynamically reflect actual day count
- Updates system prompt to instruct the LLM to respond with ONLY the weather widget (no extra text) and to pass through all forecast days without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
