### PR TITLE
Add USER.md template and include in system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -145,4 +145,24 @@ describe('buildSystemPrompt', () => {
     expect(result).not.toContain('release-checklist');
     expect(result).not.toContain('incident-response');
   });
+
+  test('appends USER.md after base prompt', () => {
+    writeFileSync(join(TEST_DIR, 'USER.md'), '# User\n\nName: Alice');
+    const result = buildSystemPrompt('Base prompt');
+    expect(basePrompt(result)).toBe('Base prompt\n\n# User\n\nName: Alice');
+  });
+
+  test('appends USER.md after IDENTITY + SOUL', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'Identity');
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), 'Soul');
+    writeFileSync(join(TEST_DIR, 'USER.md'), 'User info');
+    const result = buildSystemPrompt();
+    expect(basePrompt(result)).toBe('Identity\n\nSoul\n\nUser info');
+  });
+
+  test('ignores empty USER.md', () => {
+    writeFileSync(join(TEST_DIR, 'USER.md'), '  \n  ');
+    const result = buildSystemPrompt('Fallback');
+    expect(basePrompt(result)).toBe('Fallback');
+  });
 });

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -15,7 +15,8 @@ const log = getLogger('system-prompt');
  *   1. Base prompt: SOUL.md and/or IDENTITY.md when present
  *   2. Base prompt fallback: config.systemPrompt
  *   3. Base prompt fallback: DEFAULT_SYSTEM_PROMPT
- *   4. Append skills catalog from ~/.vellum/skills
+ *   4. Append USER.md (user profile) if present
+ *   5. Append skills catalog from ~/.vellum/skills
  *
  * When both IDENTITY.md and SOUL.md exist, the base prompt is composed as:
  *   IDENTITY.md content + "\n\n" + SOUL.md content
@@ -24,9 +25,11 @@ export function buildSystemPrompt(configSystemPrompt?: string): string {
   const baseDir = getDataDir();
   const soulPath = join(baseDir, 'SOUL.md');
   const identityPath = join(baseDir, 'IDENTITY.md');
+  const userPath = join(baseDir, 'USER.md');
 
   const soul = readPromptFile(soulPath);
   const identity = readPromptFile(identityPath);
+  const user = readPromptFile(userPath);
 
   let basePrompt = configSystemPrompt ?? DEFAULT_SYSTEM_PROMPT;
 
@@ -35,6 +38,10 @@ export function buildSystemPrompt(configSystemPrompt?: string): string {
     if (identity) parts.push(identity);
     if (soul) parts.push(soul);
     basePrompt = parts.join('\n\n');
+  }
+
+  if (user) {
+    basePrompt = `${basePrompt}\n\n${user}`;
   }
 
   return appendSkillsCatalog(basePrompt);

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -1,0 +1,12 @@
+# USER
+
+_Your assistant learns about you over time. Fill in what you're comfortable sharing to help it help you better._
+
+- **Name:**
+- **Pronouns:**
+- **Timezone:**
+- **What to call you:**
+
+## Context
+
+_(What do you care about? What are you working on? What are your preferences? Add notes here over time.)_

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -101,7 +101,7 @@ export function ensureDataDir(): void {
   }
 
   const templatesDir = join(dirname(import.meta.dirname ?? __dirname), 'config', 'templates');
-  for (const file of ['IDENTITY.md', 'SOUL.md']) {
+  for (const file of ['IDENTITY.md', 'SOUL.md', 'USER.md']) {
     const dest = join(base, file);
     if (!existsSync(dest)) {
       const src = join(templatesDir, file);


### PR DESCRIPTION
## Summary
- Adds `USER.md` template with name, pronouns, timezone, and context fields
- Copies template to `~/.vellum/USER.md` on first startup (same as IDENTITY/SOUL)
- Appends USER.md content to system prompt after IDENTITY+SOUL, before skills catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
