### PR TITLE
Fix entitySearch multi-word entity name matching

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -602,16 +602,18 @@ function entitySearch(query: string): Candidate[] {
     .filter((t) => t.length >= 3);
   if (tokens.length === 0) return [];
 
-  // Use exact matching on entity names and json_each() for individual alias values
+  // Use exact matching on entity names and json_each() for individual alias values.
+  // Also match the full trimmed query to support multi-word entity names (e.g. "Visual Studio Code").
   const namePlaceholders = tokens.map(() => '?').join(',');
+  const fullQuery = trimmed.toLowerCase();
   const entityQuery = `
     SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
     FROM memory_entities me
-    WHERE LOWER(me.name) IN (${namePlaceholders})
+    WHERE LOWER(me.name) IN (${namePlaceholders}) OR LOWER(me.name) = ?
     UNION
     SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
     FROM memory_entities me, json_each(me.aliases) je
-    WHERE me.aliases IS NOT NULL AND LOWER(je.value) IN (${namePlaceholders})
+    WHERE me.aliases IS NOT NULL AND (LOWER(je.value) IN (${namePlaceholders}) OR LOWER(je.value) = ?)
     LIMIT 20
   `;
 
@@ -623,7 +625,7 @@ function entitySearch(query: string): Candidate[] {
     mention_count: number;
   }> = [];
   try {
-    matchedEntities = raw.query(entityQuery).all(...tokens, ...tokens) as Array<{
+    matchedEntities = raw.query(entityQuery).all(...tokens, fullQuery, ...tokens, fullQuery) as Array<{
       id: string;
       name: string;
       type: string;


### PR DESCRIPTION
## Summary
- Fixes `entitySearch` in `retriever.ts` so multi-word entity names (e.g. "Visual Studio Code", "John Doe") can be matched
- The previous exact-match approach tokenized queries into individual words and checked `LOWER(me.name) IN (tokens)`, which could never match multi-word names
- Adds an `OR LOWER(me.name) = ?` condition (and corresponding alias condition) that checks the full trimmed lowercased query against entity names and alias values

Addresses review feedback from PR #1397 (Devin P0 + Codex P1).

## Test plan
- [ ] Verify multi-word entity names (e.g. "Visual Studio Code") are found when the query contains the exact name
- [ ] Verify single-word entity matching still works as before
- [ ] Verify alias matching (both single-word and multi-word) works correctly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
