### PR TITLE
Remove auto-copy of template files to ~/.vellum on startup

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, existsSync, statSync, unlinkSync, copyFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { mkdirSync, existsSync, statSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 export function isMacOS(): boolean {
@@ -97,17 +97,6 @@ export function ensureDataDir(): void {
   for (const dir of dirs) {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
-    }
-  }
-
-  const templatesDir = join(dirname(import.meta.dirname ?? __dirname), 'config', 'templates');
-  for (const file of ['IDENTITY.md', 'SOUL.md', 'USER.md']) {
-    const dest = join(base, file);
-    if (!existsSync(dest)) {
-      const src = join(templatesDir, file);
-      if (existsSync(src)) {
-        copyFileSync(src, dest);
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes the `ensureDataDir()` code that auto-copied IDENTITY.md, SOUL.md, and USER.md templates into `~/.vellum/` on every daemon startup
- This was causing `buildSystemPrompt` to replace the full `DEFAULT_SYSTEM_PROMPT` (138 lines of operational instructions) with just the short template content for all new users
- Template files remain in the source tree as examples but are no longer auto-deployed

Fixes feedback on #1412 from both Codex (P1) and Devin (P0) reviews.

## Test plan
- [ ] Verify new installations use `DEFAULT_SYSTEM_PROMPT` when no IDENTITY.md/SOUL.md files exist in `~/.vellum/`
- [ ] Verify existing users with custom IDENTITY.md/SOUL.md files are unaffected
- [ ] Type-check passes: `bunx tsc --noEmit`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
