### PR TITLE
Add voice input button to web chat

### DIFF
--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -8,6 +8,8 @@ import {
   FileImage,
   FileText,
   Loader2,
+  Mic,
+  MicOff,
   Paperclip,
   Pause,
   Play,
@@ -31,6 +33,7 @@ import {
 } from "react";
 
 import { Button } from "@/components/app/core/Button";
+import { useVoiceInput } from "@/hooks/useVoiceInput";
 
 type AssistantStatus = "healthy" | "unhealthy" | "stopped" | "unreachable" | "unknown" | "checking" | "getting_set_up" | "setting_up" | "provisioning_failed";
 
@@ -174,6 +177,14 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingRunConfirmation | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+
+  const handleVoiceTranscript = useCallback((text: string) => {
+    setInput((prev) => (prev ? `${prev} ${text}` : text));
+  }, []);
+
+  const { isListening, isSupported: isVoiceSupported, toggleListening } = useVoiceInput({
+    onTranscript: handleVoiceTranscript,
+  });
 
   const fetchMessages = useCallback(async () => {
     try {
@@ -1078,6 +1089,22 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
               >
                 {hasUploadingAttachments ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
               </button>
+              {isVoiceSupported && (
+                <button
+                  type="button"
+                  onClick={toggleListening}
+                  className={`flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border transition-colors disabled:opacity-50 ${
+                    isListening
+                      ? "animate-pulse border-red-400 bg-red-500 text-white dark:border-red-600 dark:bg-red-600"
+                      : "border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  }`}
+                  disabled={isLoading}
+                  aria-label={isListening ? "Stop recording" : "Start voice input"}
+                  title={isListening ? "Stop recording" : "Voice input"}
+                >
+                  {isListening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+                </button>
+              )}
               <div className="relative flex-1">
                 <textarea
                   value={input}

--- a/web/src/hooks/useVoiceInput.ts
+++ b/web/src/hooks/useVoiceInput.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SpeechRecognitionEvent {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent {
+  error: string;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+function getSpeechRecognition(): SpeechRecognitionConstructor | null {
+  const w = window as unknown as Record<string, unknown>;
+  return (w.SpeechRecognition ?? w.webkitSpeechRecognition) as SpeechRecognitionConstructor | null;
+}
+
+interface UseVoiceInputOptions {
+  onTranscript: (text: string) => void;
+}
+
+export function useVoiceInput({ onTranscript }: UseVoiceInputOptions) {
+  const [isListening, setIsListening] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const isListeningRef = useRef(false);
+  const onTranscriptRef = useRef(onTranscript);
+
+  onTranscriptRef.current = onTranscript;
+
+  useEffect(() => {
+    setIsSupported(getSpeechRecognition() !== null);
+  }, []);
+
+  const stopListening = useCallback(() => {
+    isListeningRef.current = false;
+    setIsListening(false);
+    recognitionRef.current?.stop();
+  }, []);
+
+  const startListening = useCallback(() => {
+    const SpeechRecognition = getSpeechRecognition();
+    if (!SpeechRecognition) return;
+
+    // Stop any existing instance
+    recognitionRef.current?.abort();
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        if (event.results[i].isFinal) {
+          const text = event.results[i][0].transcript.trim();
+          if (text) {
+            onTranscriptRef.current(text);
+          }
+        }
+      }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === "aborted") return;
+      console.error("Speech recognition error:", event.error);
+      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        isListeningRef.current = false;
+        setIsListening(false);
+      }
+    };
+
+    recognition.onend = () => {
+      // Browser sometimes stops recognition early — restart if still listening
+      if (isListeningRef.current) {
+        try {
+          recognition.start();
+        } catch {
+          isListeningRef.current = false;
+          setIsListening(false);
+        }
+      }
+    };
+
+    recognitionRef.current = recognition;
+    isListeningRef.current = true;
+    setIsListening(true);
+
+    try {
+      recognition.start();
+    } catch {
+      isListeningRef.current = false;
+      setIsListening(false);
+    }
+  }, []);
+
+  const toggleListening = useCallback(() => {
+    if (isListeningRef.current) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  }, [startListening, stopListening]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      isListeningRef.current = false;
+      recognitionRef.current?.abort();
+    };
+  }, []);
+
+  return { isListening, isSupported, startListening, stopListening, toggleListening };
+}


### PR DESCRIPTION
## Summary
- Add a microphone button next to the paperclip icon in the web chat input bar
- Uses the browser-native Web Speech API (`SpeechRecognition` / `webkitSpeechRecognition`) — no new dependencies or backend changes
- Button pulses red while recording, shows `MicOff` icon to stop, and hides entirely in unsupported browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
