### PR TITLE
Validate fallback embedding dimensions before Qdrant upsert

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -141,6 +141,14 @@ export async function embedWithBackend(
       if (vectors.length !== texts.length) {
         throw new Error(`Embedding backend returned ${vectors.length} vectors for ${texts.length} texts`);
       }
+      const expectedDim = config.memory.qdrant.vectorSize;
+      for (const vec of vectors) {
+        if (vec.length !== expectedDim) {
+          throw new Error(
+            `Embedding backend "${backend.provider}" (model ${backend.model}) returned vectors of dimension ${vec.length}, but Qdrant collection expects ${expectedDim}`,
+          );
+        }
+      }
       return { provider: backend.provider, model: backend.model, vectors };
     } catch (err) {
       lastErr = err;


### PR DESCRIPTION
## Summary
- Validates that vectors returned by fallback embedding backends match the configured `memory.qdrant.vectorSize` before returning them
- A dimension mismatch (e.g. local model produces 384-dim vectors, but OpenAI fallback produces 1536-dim) would cause Qdrant upsert failures and repeated job retries — the exact failure mode the fallback logic was designed to recover from
- The dimension check throws inside the existing fallback loop, so the next backend is tried automatically; only if no backend produces correctly-sized vectors does the error propagate

Addresses P1 feedback from PR #1394.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that a fallback backend with mismatched dimensions is skipped in favor of the next backend
- [ ] Verify that if no backend produces correct dimensions, the error propagates

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
