### PR TITLE
Fix regex stripping legitimate segment text in retriever

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -427,7 +427,7 @@ async function semanticSearch(
         key: `segment:${payload.target_id}`,
         type: 'segment',
         id: payload.target_id,
-        text: payload.text.replace(/^\[[^\]]+\]\s*/, ''),
+        text: payload.text,
         kind: 'segment',
         confidence: 0.55,
         importance: 0.5,


### PR DESCRIPTION
## Summary

- Remove the `.replace(/^\[[^\]]+\]\s*/, '')` call from segment candidate creation in `semanticSearch()` (line ~430 of `retriever.ts`)
- Segments are stored in Qdrant **without** a `[kind]` prefix (see `jobs-worker.ts:178`), unlike summaries which DO have a `[scope]` prefix (see `jobs-worker.ts:216`)
- The regex was a no-op for most segments, but incorrectly stripped content from segments starting with bracket-enclosed text like `[URGENT] Please fix the bug` or `[TODO] ship to prod`
- The `.replace()` for summary candidates (line ~415) is left intact since summaries genuinely have the prefix

Addresses review feedback from Devin and Codex on #1400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
