### PR TITLE
Fix contradiction checker loop, stale embeddings, and semantic overfetch

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
+import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItems } from './schema.js';
 
 const log = getLogger('memory-contradiction-checker');
@@ -61,6 +62,8 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     try {
       const result = await classifyRelationship(apiKey, existing, newItem);
       await handleRelationship(result, existing, newItem);
+      // Stop after the new item's disposition has been decided (invalidated or superseded)
+      if (result.relationship !== 'complement') break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err: message, newItemId, existingId: existing.id }, 'Contradiction classification failed for pair');
@@ -267,6 +270,8 @@ async function handleRelationship(
         })
         .where(eq(memoryItems.id, existingItem.id))
         .run();
+      // Re-embed the existing item so its vector matches the updated statement
+      enqueueMemoryJob('embed_item', { itemId: existingItem.id });
       // Invalidate the new item since its content has been merged into the existing one
       db.update(memoryItems)
         .set({ invalidAt: now })

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -368,9 +368,11 @@ async function semanticSearch(
     return sqliteFallbackSemanticSearch(queryVector, limit, excludedMessageIds);
   }
 
+  // Overfetch to account for items filtered out post-query (invalidated, excluded, etc.)
+  const fetchLimit = limit * 2;
   const results = await qdrant.searchWithFilter(
     queryVector,
-    limit,
+    fetchLimit,
     ['item', 'summary', 'segment'],
     excludedMessageIds,
   );
@@ -438,6 +440,7 @@ async function semanticSearch(
         finalScore: 0,
       });
     }
+    if (candidates.length >= limit) break;
   }
   return candidates;
 }


### PR DESCRIPTION
## Summary
- **Break contradiction check loop after non-complement result**: After the first `update` or `contradiction` classification, the new item's disposition is decided (invalidated or superseded). Continuing the loop would compare an already-invalidated item against further candidates, leading to corrupted state (duplicate active items or contradictory `invalidAt`/`validFrom` on the same row).
- **Re-embed existing item after update merge**: When `update` is classified, the existing item's `statement` is replaced but no `embed_item` job was queued. The new row with the fresh embedding gets immediately invalidated, leaving semantic search using a stale vector. Now queues an `embed_item` job for the existing item.
- **Overfetch from Qdrant to compensate for post-filter drops**: The `invalidAt` filter in `semanticSearch` drops invalidated items after Qdrant returns only `limit` results, causing under-delivery. Now requests `limit * 2` from Qdrant and caps post-filter results to `limit`.

Addresses review feedback on #1399.

## Test plan
- [ ] Verify contradiction checker stops after first non-complement result
- [ ] Verify `embed_item` job is queued for existing item after update merge
- [ ] Verify semantic search returns up to `limit` valid results even when some Qdrant hits are invalidated
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
