### PR TITLE
Hide raw cron strings and job IDs from schedule output (#1423)

### DIFF
--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -69,9 +69,8 @@ class ScheduleCreateTool implements Tool {
       return {
         content: [
           `Schedule created successfully.`,
-          `  ID: ${job.id}`,
           `  Name: ${job.name}`,
-          `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
+          `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
           `  Enabled: ${job.enabled}`,
           `  Next run: ${nextRunDate}`,
         ].join('\n'),

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -45,7 +45,7 @@ class ScheduleDeleteTool implements Tool {
     }
 
     return {
-      content: `Schedule deleted: "${job.name}" (${jobId})`,
+      content: `Schedule deleted: "${job.name}"`,
       isError: false,
     };
   }

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -45,8 +45,7 @@ class ScheduleListTool implements Tool {
       const runs = getScheduleRuns(jobId, 5);
       const lines = [
         `Schedule: ${job.name}`,
-        `  ID: ${job.id}`,
-        `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
+        `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
         `  Enabled: ${job.enabled}`,
         `  Message: ${job.message}`,
         `  Next run: ${formatLocalDate(job.nextRunAt)}`,
@@ -79,7 +78,7 @@ class ScheduleListTool implements Tool {
     for (const job of jobs) {
       const status = job.enabled ? 'enabled' : 'disabled';
       const next = job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a';
-      lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next} — id: ${job.id}`);
+      lines.push(`  - [${status}] ${job.name} (${describeCronExpression(job.cronExpression)}) — next: ${next}`);
     }
 
     return { content: lines.join('\n'), isError: false };

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -80,9 +80,8 @@ class ScheduleUpdateTool implements Tool {
       return {
         content: [
           `Schedule updated successfully.`,
-          `  ID: ${job.id}`,
           `  Name: ${job.name}`,
-          `  Schedule: ${describeCronExpression(job.cronExpression)} (${job.cronExpression})${job.timezone ? ` (${job.timezone})` : ''}`,
+          `  Schedule: ${describeCronExpression(job.cronExpression)}${job.timezone ? ` (${job.timezone})` : ''}`,
           `  Enabled: ${job.enabled}`,
           `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : 'n/a (disabled)'}`,
         ].join('\n'),


### PR DESCRIPTION
Removes raw cron expression strings and internal UUIDs from user-facing schedule tool output. Users now see only human-readable descriptions like "Every 4 minutes" without the technical `(*/4 * * *)` suffix or job ID fields.

## Changes

- **`create.ts`**: Removed `ID:` line; removed raw cron expression from `Schedule:` line
- **`list.ts`** (detail mode): Removed `ID:` line; removed raw cron expression from `Schedule:` line
- **`list.ts`** (list mode): Removed `— id: ${job.id}` suffix from each list entry
- **`update.ts`**: Removed `ID:` line; removed raw cron expression from `Schedule:` line
- **`delete.ts`**: Removed `(${jobId})` suffix from deletion confirmation message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
