### PR TITLE
Add voice input button to macOS chat and hide tool-call bubbles for inline surfaces

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -414,6 +414,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // If there's an active conversation in ready state, route recording state there
             let hasActiveConvo = self?.currentTextSession?.state == .ready
 
+            // Sync recording state to the active ChatViewModel
+            self?.mainWindow?.activeViewModel?.isRecording = isRecording
+
             if isRecording {
                 self?.statusItem.button?.image = NSImage(
                     systemSymbolName: "mic.fill",
@@ -518,6 +521,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent)
+        main.onMicrophoneToggle = { [weak self] in
+            self?.voiceInput?.toggleRecording()
+        }
         // Wire inline confirmation dismiss to close the corresponding floating panel
         main.threadManager.confirmationDismissHandler = { [weak self] requestId in
             self?.toolConfirmationManager.dismissConfirmation(requestId: requestId)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -11,6 +11,7 @@ struct ChatView: View {
     let pendingQueuedCount: Int
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
+    let isRecording: Bool
     let onOpenSettings: () -> Void
     let onSend: () -> Void
     let onStop: () -> Void
@@ -20,6 +21,7 @@ struct ChatView: View {
     let onRemoveAttachment: (String) -> Void
     let onDropFiles: ([URL]) -> Void
     let onPaste: () -> Void
+    let onMicrophoneToggle: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
@@ -246,6 +248,9 @@ struct ChatView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Stop generation")
                 } else {
+                    MicrophoneButton(isRecording: isRecording, action: onMicrophoneToggle)
+                        .disabled(!hasAPIKey)
+
                     Button(action: onAttach) {
                         Image(systemName: "paperclip")
                             .font(.system(size: 16, weight: .medium))
@@ -480,12 +485,25 @@ private struct ChatBubble: View {
         }
     }
 
+    /// Whether the bubble chrome should be rendered.
+    /// Hides the bubble when it would only contain tool-call chips and an
+    /// inline surface widget is present, since the widget already provides
+    /// visual feedback for the tool invocation.
+    private var shouldShowBubble: Bool {
+        if isUser { return true }
+        if hasText || !message.attachments.isEmpty { return true }
+        if !message.inlineSurfaces.isEmpty { return false }
+        return !message.toolCalls.isEmpty
+    }
+
     var body: some View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                bubbleContent
+                if shouldShowBubble {
+                    bubbleContent
+                }
 
                 // Inline surfaces render below the bubble as separate cards
                 if !message.inlineSurfaces.isEmpty {
@@ -760,6 +778,39 @@ private struct TimestampDivider: View {
     }
 }
 
+// MARK: - Microphone Button
+
+private struct MicrophoneButton: View {
+    let isRecording: Bool
+    let action: () -> Void
+    @State private var isPulsing = false
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                if isRecording {
+                    Circle()
+                        .fill(VColor.error.opacity(0.2))
+                        .frame(width: 30, height: 30)
+                        .scaleEffect(isPulsing ? 1.3 : 1.0)
+                        .opacity(isPulsing ? 0.0 : 1.0)
+                        .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: false), value: isPulsing)
+                }
+
+                Image(systemName: isRecording ? "mic.fill" : "mic")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(isRecording ? VColor.error : VColor.textSecondary)
+                    .padding(10)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isRecording ? "Stop recording" : "Start voice input")
+        .onChange(of: isRecording) {
+            isPulsing = isRecording
+        }
+    }
+}
+
 // MARK: - Preview
 
 #if DEBUG
@@ -788,6 +839,7 @@ private struct TimestampDivider: View {
             pendingQueuedCount: 0,
             suggestion: "That sounds great, thanks!",
             pendingAttachments: [],
+            isRecording: false,
             onOpenSettings: {},
             onSend: {},
             onStop: {},
@@ -797,6 +849,7 @@ private struct TimestampDivider: View {
             onRemoveAttachment: { _ in },
             onDropFiles: { _ in },
             onPaste: {},
+            onMicrophoneToggle: {},
             onConfirmationAllow: { _ in },
             onConfirmationDeny: { _ in },
             onSurfaceAction: { _, _, _ in }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -15,6 +15,7 @@ final class ChatViewModel: ObservableObject {
     @Published var pendingQueuedCount: Int = 0
     @Published var suggestion: String?
     @Published var pendingAttachments: [ChatAttachment] = []
+    @Published var isRecording: Bool = false
 
     /// Maximum file size per attachment (20 MB).
     private static let maxFileSize = 20 * 1024 * 1024

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -7,6 +7,7 @@ final class MainWindow {
     private let ambientAgent: AmbientAgent
     private var window: NSWindow?
     let threadManager: ThreadManager
+    var onMicrophoneToggle: (() -> Void)?
 
     /// Whether the main window is currently visible on screen.
     var isVisible: Bool {
@@ -29,14 +30,14 @@ final class MainWindow {
         if let existing = window {
             // Rebuild the SwiftUI view hierarchy so it picks up any
             // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent))
+            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -7,11 +7,13 @@ struct MainWindowView: View {
     @State private var hasAPIKey = APIKeyManager.getKey() != nil
     let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
+    let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
+    init(threadManager: ThreadManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.daemonClient = daemonClient
         self.ambientAgent = ambientAgent
+        self.onMicrophoneToggle = onMicrophoneToggle
     }
 
     var body: some View {
@@ -45,6 +47,7 @@ struct MainWindowView: View {
                             pendingQueuedCount: viewModel.pendingQueuedCount,
                             suggestion: viewModel.suggestion,
                             pendingAttachments: viewModel.pendingAttachments,
+                            isRecording: viewModel.isRecording,
                             onOpenSettings: {
                                 // Always provide an immediate, visible fallback.
                                 activePanel = .control
@@ -58,6 +61,7 @@ struct MainWindowView: View {
                             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                             onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
                             onPaste: { viewModel.addAttachmentFromPasteboard() },
+                            onMicrophoneToggle: onMicrophoneToggle,
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
                             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) }


### PR DESCRIPTION
## Summary
- Adds a microphone button to the chat composer in the macOS app, wired through MainWindow → MainWindowView → ChatView to the existing VoiceInputManager
- Hides redundant tool-call chip bubbles (e.g. "Get Weather") when an inline surface widget is already displayed for the same assistant message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
