### PR TITLE
Hide text bubble when inline surface widgets are present

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -491,8 +491,8 @@ private struct ChatBubble: View {
     /// visual feedback for the tool invocation.
     private var shouldShowBubble: Bool {
         if isUser { return true }
-        if hasText || !message.attachments.isEmpty { return true }
         if !message.inlineSurfaces.isEmpty { return false }
+        if hasText || !message.attachments.isEmpty { return true }
         return !message.toolCalls.isEmpty
     }
 
@@ -505,11 +505,11 @@ private struct ChatBubble: View {
                     bubbleContent
                 }
 
-                // Inline surfaces render below the bubble as separate cards
+                // Inline surfaces render below the bubble as full-width cards
                 if !message.inlineSurfaces.isEmpty {
                     ForEach(message.inlineSurfaces) { surface in
                         InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
-                            .frame(maxWidth: 560, alignment: .leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Reorder checks in `shouldShowBubble` so that inline surface widgets (e.g. weather card) suppress the redundant raw text bubble above them
- Assistant messages with a UI widget now show only the widget, not both the text and widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
