### PR TITLE
Watch USER.md for changes to evict stale sessions

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -164,10 +164,11 @@ export class DaemonServer {
       },
     };
 
-    // Prompt files (SOUL.md, IDENTITY.md) affect the system prompt.
+    // Prompt files (SOUL.md, IDENTITY.md, USER.md) affect the system prompt.
     // When they change, evict idle sessions so they pick up the new prompt.
     handlers['SOUL.md'] = () => this.evictSessionsForReload();
     handlers['IDENTITY.md'] = () => this.evictSessionsForReload();
+    handlers['USER.md'] = () => this.evictSessionsForReload();
 
     try {
       const watcher = watch(dataDir, (_eventType, filename) => {


### PR DESCRIPTION
## Summary
- Adds `USER.md` to the file watcher list in `startFileWatchers` so that edits to `~/.vellum/USER.md` trigger session eviction, just like `SOUL.md` and `IDENTITY.md`
- Fixes a bug introduced in #1414 where USER.md was added to the system prompt but the daemon wouldn't pick up changes without a restart

## Test plan
- [ ] Edit `~/.vellum/USER.md` while the daemon is running and verify sessions are evicted and recreated with the updated content

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
