### PR TITLE
Only break contradiction loop on update, not contradiction

### DIFF
--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -62,8 +62,10 @@ export async function checkContradictions(newItemId: string): Promise<void> {
     try {
       const result = await classifyRelationship(apiKey, existing, newItem);
       await handleRelationship(result, existing, newItem);
-      // Stop after the new item's disposition has been decided (invalidated or superseded)
-      if (result.relationship !== 'complement') break;
+      // Only stop when the new item itself is invalidated (update case).
+      // For contradiction, the old item is invalidated but the new item remains
+      // active and should continue to be checked against remaining candidates.
+      if (result.relationship === 'update') break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err: message, newItemId, existingId: existing.id }, 'Contradiction classification failed for pair');


### PR DESCRIPTION
## Summary
- Changed the break condition in `checkContradictions` loop from `result.relationship !== 'complement'` to `result.relationship === 'update'`
- For `contradiction`: the OLD item is invalidated, but the new item remains active and should continue being checked against remaining candidates to invalidate all stale facts
- For `update`: the NEW item is invalidated (merged into existing), so breaking is correct since the new item is no longer active

Addresses review feedback on #1421.

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] When multiple stale facts exist for the same subject, all are invalidated (not just the first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
