### PR TITLE
Fix entitySearch for short-word entity names

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -603,22 +603,39 @@ function entitySearch(query: string): Candidate[] {
     .toLowerCase()
     .split(/[^a-z0-9_.-]+/g)
     .filter((t) => t.length >= 3);
-  if (tokens.length === 0) return [];
+  const fullQuery = trimmed.toLowerCase();
 
   // Use exact matching on entity names and json_each() for individual alias values.
   // Also match the full trimmed query to support multi-word entity names (e.g. "Visual Studio Code").
-  const namePlaceholders = tokens.map(() => '?').join(',');
-  const fullQuery = trimmed.toLowerCase();
-  const entityQuery = `
-    SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
-    FROM memory_entities me
-    WHERE LOWER(me.name) IN (${namePlaceholders}) OR LOWER(me.name) = ?
-    UNION
-    SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
-    FROM memory_entities me, json_each(me.aliases) je
-    WHERE me.aliases IS NOT NULL AND (LOWER(je.value) IN (${namePlaceholders}) OR LOWER(je.value) = ?)
-    LIMIT 20
-  `;
+  // When tokens is empty (all words < 3 chars), only match on fullQuery.
+  let entityQuery: string;
+  let queryParams: string[];
+  if (tokens.length > 0) {
+    const namePlaceholders = tokens.map(() => '?').join(',');
+    entityQuery = `
+      SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+      FROM memory_entities me
+      WHERE LOWER(me.name) IN (${namePlaceholders}) OR LOWER(me.name) = ?
+      UNION
+      SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+      FROM memory_entities me, json_each(me.aliases) je
+      WHERE me.aliases IS NOT NULL AND (LOWER(je.value) IN (${namePlaceholders}) OR LOWER(je.value) = ?)
+      LIMIT 20
+    `;
+    queryParams = [...tokens, fullQuery, ...tokens, fullQuery];
+  } else {
+    entityQuery = `
+      SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+      FROM memory_entities me
+      WHERE LOWER(me.name) = ?
+      UNION
+      SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
+      FROM memory_entities me, json_each(me.aliases) je
+      WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
+      LIMIT 20
+    `;
+    queryParams = [fullQuery, fullQuery];
+  }
 
   let matchedEntities: Array<{
     id: string;
@@ -628,7 +645,7 @@ function entitySearch(query: string): Candidate[] {
     mention_count: number;
   }> = [];
   try {
-    matchedEntities = raw.query(entityQuery).all(...tokens, fullQuery, ...tokens, fullQuery) as Array<{
+    matchedEntities = raw.query(entityQuery).all(...queryParams) as Array<{
       id: string;
       name: string;
       type: string;


### PR DESCRIPTION
## Summary
- Fixes entitySearch returning empty results when all query words are < 3 characters (e.g. "Ed Li", "Bo Xi")
- Restructures SQL query building to conditionally omit `IN (...)` clauses when tokens is empty, using only `LOWER(me.name) = ?` / `LOWER(je.value) = ?` fullQuery matching
- Follows up on review feedback from PR #1415

## What changed
Previously, the early return `if (tokens.length === 0) return []` at line 606 prevented the `fullQuery` matching logic from being reached when all individual words in the query were shorter than 3 characters. Now the function conditionally builds the SQL query:
- If `tokens.length > 0`: includes `IN (placeholders)` clauses alongside fullQuery matching (original behavior)
- If `tokens.length === 0`: only uses `LOWER(me.name) = ?` and `LOWER(je.value) = ?` conditions with fullQuery

## Test plan
- [ ] Verify entity named "Ed Li" is matched when querying "Ed Li"
- [ ] Verify existing multi-word entity matching still works (e.g. "Visual Studio Code")
- [ ] Verify single-word entities with >= 3 chars still work as before
- [ ] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
