### PR TITLE
Reduce spacing between mic and attachment icons in chat composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -255,7 +255,7 @@ struct ChatView: View {
                         Image(systemName: "paperclip")
                             .font(.system(size: 16, weight: .medium))
                             .foregroundColor(VColor.textSecondary)
-                            .padding(10)
+                            .padding(6)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Attach file")
@@ -800,7 +800,7 @@ private struct MicrophoneButton: View {
                 Image(systemName: isRecording ? "mic.fill" : "mic")
                     .font(.system(size: 16, weight: .medium))
                     .foregroundColor(isRecording ? VColor.error : VColor.textSecondary)
-                    .padding(10)
+                    .padding(6)
             }
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Tighten padding on mic and paperclip buttons from 10pt to 6pt so they sit closer together in the composer bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
