### PR TITLE
Open System Settings when mic/speech permissions are denied

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -115,14 +115,28 @@ final class VoiceInputManager {
             return
         }
 
+        // Check microphone access first
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        if micStatus == .notDetermined {
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+            log.info("Requested microphone authorization — try again after approving")
+            return
+        }
+        if micStatus == .denied || micStatus == .restricted {
+            log.warning("Microphone access denied — opening System Settings")
+            openPrivacySettings(for: "Privacy_Microphone")
+            return
+        }
+
         let authStatus = SFSpeechRecognizer.authorizationStatus()
         if authStatus == .notDetermined {
             SFSpeechRecognizer.requestAuthorization { _ in }
-            log.info("Requested speech recognition authorization — hold Fn again after approving")
+            log.info("Requested speech recognition authorization — try again after approving")
             return
         }
-        guard authStatus == .authorized else {
-            log.error("Speech recognition not authorized (status: \(authStatus.rawValue))")
+        if authStatus == .denied || authStatus == .restricted {
+            log.warning("Speech recognition denied — opening System Settings")
+            openPrivacySettings(for: "Privacy_SpeechRecognition")
             return
         }
 
@@ -181,6 +195,12 @@ final class VoiceInputManager {
             onRecordingStateChanged?(false)
             recognitionRequest = nil
             recognitionTask = nil
+        }
+    }
+
+    private func openPrivacySettings(for pane: String) {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
+            NSWorkspace.shared.open(url)
         }
     }
 


### PR DESCRIPTION
## Summary
- Check microphone access (`AVCaptureDevice`) before speech recognition when the mic button is clicked
- If either permission is denied/restricted, open System Settings to the relevant Privacy pane (Microphone or Speech Recognition) instead of silently failing
- If permissions are undetermined, prompt the system dialog as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
