### PR TITLE
Show thinking indicator instead of tool call chips during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -486,13 +486,16 @@ private struct ChatBubble: View {
     }
 
     /// Whether the bubble chrome should be rendered.
-    /// Hides the bubble when it would only contain tool-call chips and an
-    /// inline surface widget is present, since the widget already provides
-    /// visual feedback for the tool invocation.
+    /// Hides the bubble when an inline surface widget is present (the widget
+    /// replaces the text), and during streaming when only tool-call chips
+    /// exist (the thinking indicator already signals progress).
     private var shouldShowBubble: Bool {
         if isUser { return true }
         if !message.inlineSurfaces.isEmpty { return false }
         if hasText || !message.attachments.isEmpty { return true }
+        // During streaming, hide tool-call-only bubbles so the thinking
+        // indicator stays visible instead of showing raw tool progress.
+        if message.isStreaming { return false }
         return !message.toolCalls.isEmpty
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -629,7 +629,6 @@ final class ChatViewModel: ObservableObject {
             guard belongsToSession(msg.sessionId) else { return }
             guard !isCancelling else { return }
             lastToolUseReceivedAt = Date()
-            isThinking = false
             // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
             if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" || msg.toolName == "request_file" {
                 break
@@ -669,6 +668,7 @@ final class ChatViewModel: ObservableObject {
             guard belongsToSession(msg.sessionId) else { return }
             guard msg.display == nil || msg.display == "inline" else { break }
             guard let surface = Surface.from(msg) else { break }
+            isThinking = false
             let inlineSurface = InlineSurfaceData(
                 id: surface.id,
                 surfaceType: surface.type,


### PR DESCRIPTION
## Summary
- Keep `isThinking` true during tool execution so users see thinking dots instead of raw tool call chips
- Hide tool-call-only bubbles during streaming in `shouldShowBubble`
- Clear `isThinking` when an inline surface widget arrives so the widget appears cleanly without residual thinking dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
