### PR TITLE
Add hourly forecast to weather widget with day/night icons

### DIFF
--- a/assistant/src/__tests__/get-weather.test.ts
+++ b/assistant/src/__tests__/get-weather.test.ts
@@ -26,6 +26,19 @@ function createMockFetch(options?: {
     { name: 'San Francisco', latitude: 37.7749, longitude: -122.4194, country: 'United States', admin1: 'California' },
   ];
 
+  // Generate 48 hourly entries starting from 2025-01-15T00:00
+  const hourlyTimes: string[] = [];
+  const hourlyTemps: number[] = [];
+  const hourlyCodes: number[] = [];
+  const hourlyIsDay: number[] = [];
+  for (let i = 0; i < 48; i++) {
+    const h = i % 24;
+    hourlyTimes.push(`2025-01-${15 + Math.floor(i / 24)}T${String(h).padStart(2, '0')}:00`);
+    hourlyTemps.push(10 + Math.sin(i / 4) * 5);
+    hourlyCodes.push(i % 3 === 0 ? 0 : 2);
+    hourlyIsDay.push(h >= 7 && h < 19 ? 1 : 0);
+  }
+
   const defaultForecastData = {
     current: {
       temperature_2m: 15.0,
@@ -41,6 +54,17 @@ function createMockFetch(options?: {
       apparent_temperature: '\u00B0C',
       wind_speed_10m: 'km/h',
       wind_direction_10m: '\u00B0',
+    },
+    hourly: {
+      time: hourlyTimes,
+      temperature_2m: hourlyTemps,
+      weather_code: hourlyCodes,
+      is_day: hourlyIsDay,
+    },
+    hourly_units: {
+      temperature_2m: '\u00B0C',
+      weather_code: 'wmo code',
+      is_day: '',
     },
     daily: {
       time: ['2025-01-15', '2025-01-16', '2025-01-17', '2025-01-18', '2025-01-19'],

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -33,6 +33,7 @@ export const uiShowTool: Tool = {
     'data shape: { title: string, subtitle?: string, body: string, metadata?: Array<{ label: string, value: string }>, template?: string, templateData?: object }\n' +
     '  Template "weather_forecast": renders an Apple Weather-style forecast widget. ' +
     'templateData shape: { location: string, currentTemp: number, feelsLike: number, unit: "F"|"C", condition: string, humidity: number, windSpeed: number, windDirection: string, ' +
+    'hourly: Array<{ time: string, icon: string (SF Symbol name), temp: number }>, ' +
     'forecast: Array<{ day: string, icon: string (SF Symbol name), low: number, high: number, precip: number|null, condition: string }> }\n' +
     '- table: Data table with columns, selectable rows, and action buttons. ' +
     'data shape: { columns: Array<{ id: string, label: string }>, rows: Array<{ id: string, cells: Record<string, string>, selectable?: boolean, selected?: boolean }>, selectionMode?: "none"|"single"|"multiple", caption?: string }\n' +

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -63,6 +63,13 @@ interface CurrentWeather {
   wind_direction_10m: number;
 }
 
+interface HourlyForecast {
+  time: string[];
+  temperature_2m: number[];
+  weather_code: number[];
+  is_day: number[];
+}
+
 interface DailyForecast {
   time: string[];
   weather_code: number[];
@@ -74,17 +81,20 @@ interface DailyForecast {
 interface ForecastResponse {
   current: CurrentWeather;
   current_units: Record<string, string>;
+  hourly: HourlyForecast;
+  hourly_units: Record<string, string>;
   daily: DailyForecast;
   daily_units: Record<string, string>;
 }
 
 /**
  * Maps WMO weather codes to SF Symbol icon names for native rendering.
+ * When `isDay` is false, uses moon/night variants for clear and partly cloudy.
  */
-export function weatherCodeToSFSymbol(code: number): string {
-  if (code === 0) return 'sun.max.fill';
-  if (code === 1) return 'sun.max.fill';
-  if (code === 2) return 'cloud.sun.fill';
+export function weatherCodeToSFSymbol(code: number, isDay: boolean = true): string {
+  if (code === 0) return isDay ? 'sun.max.fill' : 'moon.fill';
+  if (code === 1) return isDay ? 'sun.max.fill' : 'moon.fill';
+  if (code === 2) return isDay ? 'cloud.sun.fill' : 'cloud.moon.fill';
   if (code === 3) return 'cloud.fill';
   if (code === 45 || code === 48) return 'cloud.fog.fill';
   if (code >= 51 && code <= 57) return 'cloud.rain.fill';
@@ -158,7 +168,7 @@ export async function executeGetWeather(
   // Step 2: Fetch the weather forecast
   let forecast: ForecastResponse;
   try {
-    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=${forecastDays}`;
+    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&hourly=temperature_2m,weather_code,is_day&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=${forecastDays}`;
     log.debug({ url: weatherUrl }, 'Fetching weather forecast');
 
     const weatherResponse = await fetchFn(weatherUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
@@ -238,6 +248,43 @@ export async function executeGetWeather(
     forecastItems.push({ day: dayLabel, icon, low, high, precip: precip > 0 ? precip : null, condition: desc });
   }
 
+  // Process hourly data: next 24 hours from the current hour
+  const hourlyItems: Array<{ time: string; icon: string; temp: number }> = [];
+  if (forecast.hourly?.time) {
+    const now = new Date();
+    const currentHourISO = now.toISOString().slice(0, 13); // "2026-02-13T00"
+    // Find the index of the current hour in the hourly data
+    let startIndex = forecast.hourly.time.findIndex((t) => t.startsWith(currentHourISO));
+    if (startIndex < 0) {
+      // Fallback: find the first hour that's >= now
+      startIndex = forecast.hourly.time.findIndex((t) => new Date(t) >= now);
+    }
+    if (startIndex < 0) startIndex = 0;
+
+    const count = Math.min(24, forecast.hourly.time.length - startIndex);
+    for (let i = 0; i < count; i++) {
+      const idx = startIndex + i;
+      const hourTemp = useFahrenheit
+        ? celsiusToFahrenheit(forecast.hourly.temperature_2m[idx])
+        : Math.round(forecast.hourly.temperature_2m[idx]);
+      const isDay = forecast.hourly.is_day[idx] === 1;
+      const icon = weatherCodeToSFSymbol(forecast.hourly.weather_code[idx], isDay);
+
+      let timeLabel: string;
+      if (i === 0) {
+        timeLabel = 'Now';
+      } else {
+        const d = new Date(forecast.hourly.time[idx]);
+        const hour = d.getHours();
+        const suffix = hour >= 12 ? 'PM' : 'AM';
+        const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+        timeLabel = `${displayHour}${suffix}`;
+      }
+
+      hourlyItems.push({ time: timeLabel, icon, temp: hourTemp });
+    }
+  }
+
   // Include structured data for ui_show weather_forecast template
   const structured = {
     location: locationDisplay,
@@ -248,6 +295,7 @@ export async function executeGetWeather(
     humidity: current.relative_humidity_2m,
     windSpeed: currentWind,
     windDirection: windDir,
+    hourly: hourlyItems,
     forecast: forecastItems,
   };
 

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -2,6 +2,19 @@ import SwiftUI
 
 // MARK: - Data Model
 
+struct WeatherHourlyItem: Identifiable {
+    let id: String
+    let time: String
+    let icon: String
+    let tempC: Double
+    let sourceIsFahrenheit: Bool
+
+    func temp(useFahrenheit: Bool) -> Int {
+        if sourceIsFahrenheit == useFahrenheit { return Int(tempC) }
+        return useFahrenheit ? Int(tempC * 9 / 5 + 32) : Int((tempC - 32) * 5 / 9)
+    }
+}
+
 struct WeatherForecastItem: Identifiable {
     let id: String
     let day: String
@@ -34,6 +47,7 @@ struct WeatherForecastData {
     let windSpeed: Int
     let windDirection: String
     let sourceIsFahrenheit: Bool
+    let hourly: [WeatherHourlyItem]
     let forecast: [WeatherForecastItem]
 
     func currentTemp(useFahrenheit: Bool) -> Int {
@@ -62,6 +76,22 @@ struct WeatherForecastData {
         let windDirection = dict["windDirection"] as? String ?? ""
         let unit = dict["unit"] as? String ?? "F"
         let isFahrenheit = unit == "F"
+
+        var hourlyItems: [WeatherHourlyItem] = []
+        if let hourlyArray = dict["hourly"] as? [[String: Any?]] {
+            for (index, entry) in hourlyArray.enumerated() {
+                let time = entry["time"] as? String ?? ""
+                let icon = entry["icon"] as? String ?? "cloud.fill"
+                let temp = (entry["temp"] as? Double) ?? Double(entry["temp"] as? Int ?? 0)
+                hourlyItems.append(WeatherHourlyItem(
+                    id: "h\(index)-\(time)",
+                    time: time,
+                    icon: icon,
+                    tempC: temp,
+                    sourceIsFahrenheit: isFahrenheit
+                ))
+            }
+        }
 
         var items: [WeatherForecastItem] = []
         if let forecastArray = dict["forecast"] as? [[String: Any?]] {
@@ -92,6 +122,7 @@ struct WeatherForecastData {
             windSpeed: windSpeed,
             windDirection: windDirection,
             sourceIsFahrenheit: isFahrenheit,
+            hourly: hourlyItems,
             forecast: items
         )
     }
@@ -130,8 +161,12 @@ struct InlineWeatherWidget: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             heroSection
+            if !data.hourly.isEmpty {
+                Divider().background(Slate._700.opacity(0.3))
+                hourlySection
+            }
             Divider().background(Slate._700.opacity(0.3))
-            forecastHeader
+            dailyForecastHeader
             Divider().background(Slate._700.opacity(0.3))
 
             ForEach(Array(data.forecast.enumerated()), id: \.element.id) { index, item in
@@ -228,9 +263,53 @@ struct InlineWeatherWidget: View {
         .padding(.vertical, VSpacing.sm)
     }
 
-    // MARK: - Forecast Header
+    // MARK: - Hourly Forecast
 
-    private var forecastHeader: some View {
+    private var hourlySection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "clock")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                Text("HOURLY FORECAST")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textMuted)
+                Spacer()
+            }
+            .padding(.vertical, VSpacing.sm)
+
+            Divider().background(Slate._700.opacity(0.3))
+
+            // Scrollable hourly row
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: VSpacing.xl) {
+                    ForEach(data.hourly) { item in
+                        VStack(spacing: VSpacing.sm) {
+                            Text(item.time)
+                                .font(item.time == "Now" ? VFont.bodyBold : VFont.caption)
+                                .foregroundColor(VColor.textPrimary)
+
+                            Image(systemName: item.icon)
+                                .font(.system(size: 18))
+                                .foregroundColor(iconColor(for: item.icon))
+                                .frame(height: 22)
+
+                            Text("\(item.temp(useFahrenheit: useFahrenheit))°")
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textPrimary)
+                        }
+                        .frame(minWidth: 44)
+                    }
+                }
+                .padding(.vertical, VSpacing.sm)
+            }
+        }
+    }
+
+    // MARK: - Daily Forecast Header
+
+    private var dailyForecastHeader: some View {
         HStack {
             Image(systemName: "calendar")
                 .font(VFont.caption)
@@ -343,6 +422,8 @@ struct InlineWeatherWidget: View {
         switch sfSymbol {
         case "sun.max.fill": return Amber._400
         case "cloud.sun.fill": return Amber._300
+        case "moon.fill": return Indigo._200
+        case "cloud.moon.fill": return Indigo._300
         case "cloud.fill": return Slate._400
         case "cloud.rain.fill": return Indigo._400
         case "snowflake": return Indigo._300
@@ -359,31 +440,47 @@ struct InlineWeatherWidget: View {
 #Preview("InlineWeatherWidget") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        InlineWeatherWidget(data: WeatherForecastData(
-            location: "New York, NY",
-            currentTemp: 28,
-            feelsLike: 19,
-            condition: "Overcast",
-            humidity: 65,
-            windSpeed: 12,
-            windDirection: "NW",
-            sourceIsFahrenheit: true,
-            forecast: [
-                WeatherForecastItem(id: "0", day: "Today", icon: "cloud.fill", lowC: 24, highC: 36, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "1", day: "Fri", icon: "sun.max.fill", lowC: 20, highC: 36, precip: nil, condition: "Sunny", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "2", day: "Sat", icon: "snowflake", lowC: 23, highC: 41, precip: 35, condition: "Snow", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "3", day: "Sun", icon: "cloud.fill", lowC: 26, highC: 37, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "4", day: "Mon", icon: "cloud.sun.fill", lowC: 28, highC: 40, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "5", day: "Tue", icon: "cloud.sun.fill", lowC: 34, highC: 49, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "6", day: "Wed", icon: "cloud.fill", lowC: 33, highC: 44, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "7", day: "Thu", icon: "snowflake", lowC: 35, highC: 44, precip: 55, condition: "Snow", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "8", day: "Fri", icon: "snowflake", lowC: 33, highC: 40, precip: 65, condition: "Snow", sourceIsFahrenheit: true),
-                WeatherForecastItem(id: "9", day: "Sat", icon: "cloud.fill", lowC: 31, highC: 43, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
-            ]
-        ))
-        .padding()
-        .frame(width: 450)
+        ScrollView {
+            InlineWeatherWidget(data: WeatherForecastData(
+                location: "New York, NY",
+                currentTemp: 28,
+                feelsLike: 19,
+                condition: "Overcast",
+                humidity: 65,
+                windSpeed: 12,
+                windDirection: "NW",
+                sourceIsFahrenheit: true,
+                hourly: [
+                    WeatherHourlyItem(id: "h0", time: "Now", icon: "cloud.fill", tempC: 28, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h1", time: "1AM", icon: "cloud.fill", tempC: 27, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h2", time: "2AM", icon: "cloud.fill", tempC: 26, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h3", time: "3AM", icon: "cloud.moon.fill", tempC: 25, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h4", time: "4AM", icon: "moon.fill", tempC: 24, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h5", time: "5AM", icon: "moon.fill", tempC: 24, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h6", time: "6AM", icon: "moon.fill", tempC: 23, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h7", time: "7AM", icon: "sun.max.fill", tempC: 24, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h8", time: "8AM", icon: "sun.max.fill", tempC: 26, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h9", time: "9AM", icon: "cloud.sun.fill", tempC: 29, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h10", time: "10AM", icon: "cloud.sun.fill", tempC: 31, sourceIsFahrenheit: true),
+                    WeatherHourlyItem(id: "h11", time: "11AM", icon: "cloud.fill", tempC: 33, sourceIsFahrenheit: true),
+                ],
+                forecast: [
+                    WeatherForecastItem(id: "0", day: "Today", icon: "cloud.fill", lowC: 24, highC: 36, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "1", day: "Fri", icon: "sun.max.fill", lowC: 20, highC: 36, precip: nil, condition: "Sunny", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "2", day: "Sat", icon: "snowflake", lowC: 23, highC: 41, precip: 35, condition: "Snow", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "3", day: "Sun", icon: "cloud.fill", lowC: 26, highC: 37, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "4", day: "Mon", icon: "cloud.sun.fill", lowC: 28, highC: 40, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "5", day: "Tue", icon: "cloud.sun.fill", lowC: 34, highC: 49, precip: nil, condition: "Partly cloudy", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "6", day: "Wed", icon: "cloud.fill", lowC: 33, highC: 44, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "7", day: "Thu", icon: "snowflake", lowC: 35, highC: 44, precip: 55, condition: "Snow", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "8", day: "Fri", icon: "snowflake", lowC: 33, highC: 40, precip: 65, condition: "Snow", sourceIsFahrenheit: true),
+                    WeatherForecastItem(id: "9", day: "Sat", icon: "cloud.fill", lowC: 31, highC: 43, precip: nil, condition: "Overcast", sourceIsFahrenheit: true),
+                ]
+            ))
+            .padding()
+            .frame(width: 450)
+        }
     }
-    .frame(width: 500, height: 700)
+    .frame(width: 500, height: 800)
 }
 #endif


### PR DESCRIPTION
## Summary
- Fetches hourly data (temperature, weather code, is_day) from Open-Meteo API and includes the next 24 hours in the structured widget data
- Adds a horizontally scrollable hourly forecast section to the SwiftUI weather widget, positioned between the hero and daily forecast — matching Apple Weather's layout
- Uses moon/cloud.moon SF Symbol variants for nighttime hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
