### PR TITLE
Fix weather forecast 'Today' detection for timezone mismatches

### DIFF
--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -213,8 +213,9 @@ export async function executeGetWeather(
     condition: string;
   }> = [];
 
-  const today = new Date();
-  const todayStr = today.toISOString().split('T')[0];
+  // The API returns dates in the location's local timezone (timezone=auto),
+  // so the first entry is always "today" for that location.
+  const todayStr = daily.time.length > 0 ? daily.time[0] : '';
 
   for (let i = 0; i < daily.time.length; i++) {
     const date = daily.time[i];


### PR DESCRIPTION
## Summary
- Use first API forecast date as 'Today' instead of UTC date
- The Open-Meteo API returns dates in the location's local timezone (timezone=auto), so comparing against UTC can mislabel the current day

Addresses review feedback from #1408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
