### PR TITLE
Guard voice recognition onend restart against stale instances

### DIFF
--- a/web/src/hooks/useVoiceInput.ts
+++ b/web/src/hooks/useVoiceInput.ts
@@ -87,7 +87,7 @@ export function useVoiceInput({ onTranscript }: UseVoiceInputOptions) {
 
     recognition.onend = () => {
       // Browser sometimes stops recognition early — restart if still listening
-      if (isListeningRef.current) {
+      if (isListeningRef.current && recognitionRef.current === recognition) {
         try {
           recognition.start();
         } catch {


### PR DESCRIPTION
## Summary
- Add `recognitionRef.current === recognition` check in onend handler to prevent stale recognition instances from restarting alongside new ones
- Without this guard, aborting and recreating a recognition instance could result in the old instance's onend handler restarting it, creating duplicate active sessions

Addresses review feedback from #1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
