### PR TITLE
Show timestamp divider on calendar-day boundaries

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -67,7 +67,11 @@ struct ChatView: View {
 
     private func shouldShowTimestamp(at index: Int) -> Bool {
         if index == 0 { return true }
-        let gap = messages[index].timestamp.timeIntervalSince(messages[index - 1].timestamp)
+        let current = messages[index].timestamp
+        let previous = messages[index - 1].timestamp
+        // Always show a divider when crossing a calendar-day boundary
+        if !Calendar.current.isDate(current, inSameDayAs: previous) { return true }
+        let gap = current.timeIntervalSince(previous)
         return gap > 300
     }
 


### PR DESCRIPTION
## Summary
- Add calendar-day boundary check to `shouldShowTimestamp` so day transitions always show a divider
- Previously, messages less than 5 minutes apart crossing midnight would not show any day change indicator

Addresses review feedback from #1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
