### PR TITLE
Fix wind speed unit conversion in weather widget

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -61,8 +61,9 @@ struct WeatherForecastData {
     }
 
     func windSpeed(useFahrenheit: Bool) -> Int {
-        // Source wind speed is already in the right unit system
-        return windSpeed
+        if sourceIsFahrenheit == useFahrenheit { return windSpeed }
+        // Convert between mph (Fahrenheit) and km/h (Celsius)
+        return useFahrenheit ? Int(Double(windSpeed) / 1.60934) : Int(Double(windSpeed) * 1.60934)
     }
 
     static func parse(from dict: [String: Any?]) -> WeatherForecastData? {
@@ -242,7 +243,7 @@ struct InlineWeatherWidget: View {
             // Wind + Humidity chips
             HStack(spacing: VSpacing.md) {
                 Label {
-                    Text("\(data.windSpeed) \(speedUnit) \(data.windDirection)")
+                    Text("\(data.windSpeed(useFahrenheit: useFahrenheit)) \(speedUnit) \(data.windDirection)")
                         .font(VFont.caption)
                 } icon: {
                     Image(systemName: "wind")


### PR DESCRIPTION
## Summary
- Implement actual mph/km/h conversion in `windSpeed(useFahrenheit:)` instead of always returning raw value
- Update hero section to call the conversion method instead of accessing `data.windSpeed` directly

Addresses review feedback from #1413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
