### PR TITLE
Treat table surfaces with selection modes as interactive

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -9,7 +9,7 @@
 import { v4 as uuid } from 'uuid';
 import type { Provider, Message, ContentBlock, ToolDefinition } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, CuObservation, SurfaceType, SurfaceData, ListSurfaceData, TableSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import type { ToolExecutionResult } from '../tools/types.js';
 import { AgentLoop } from '../agent/loop.js';
 import { ToolExecutor } from '../tools/executor.js';
@@ -231,10 +231,12 @@ export class ComputerUseSession {
         const data = input.data as SurfaceData;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
         // Interactive surfaces default to awaiting user action.
-        // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
+        // Lists and tables with selectionMode "none" are passive (no actions emitted) so they don't block.
         const isInteractive = surfaceType === 'list'
           ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-          : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
+          : surfaceType === 'table'
+            ? ((data as TableSurfaceData).selectionMode ?? 'none') !== 'none'
+            : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
         // Track surface state for ui_update merging

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
-import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, ListSurfaceData, TableSurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { CheckpointDecision } from '../agent/loop.js';
@@ -892,10 +892,12 @@ export class Session {
       const data = input.data as SurfaceData;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
       // Interactive surfaces default to awaiting user action.
-      // Lists with selectionMode "none" are passive (no actions emitted) so they don't block.
+      // Lists and tables with selectionMode "none" are passive (no actions emitted) so they don't block.
       const isInteractive = surfaceType === 'list'
         ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
-        : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
+        : surfaceType === 'table'
+          ? ((data as TableSurfaceData).selectionMode ?? 'none') !== 'none'
+          : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 
       // Track surface state for ui_update merging


### PR DESCRIPTION
## Summary
- Extend `isInteractive` check to handle `table` surfaces like `list` surfaces — tables with `selectionMode` 'single' or 'multiple' now await user action
- Updated both `session.ts` and `computer-use-session.ts`
- The Swift client already supports table rendering (added in subsequent PRs)

Addresses review feedback from #1347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
