### PR TITLE
Handle inline surface update and dismiss events in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -685,6 +685,36 @@ final class ChatViewModel: ObservableObject {
                 messages.append(newMsg)
             }
 
+        case .uiSurfaceUpdate(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            // Find the inline surface across all messages and update its data
+            for msgIndex in messages.indices {
+                if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {
+                    let existing = messages[msgIndex].inlineSurfaces[surfaceIndex]
+                    let tempSurface = Surface(id: existing.id, sessionId: msg.sessionId, type: existing.surfaceType, title: existing.title, data: existing.data, actions: existing.actions)
+                    if let updated = tempSurface.updated(with: msg) {
+                        messages[msgIndex].inlineSurfaces[surfaceIndex] = InlineSurfaceData(
+                            id: updated.id,
+                            surfaceType: updated.type,
+                            title: updated.title,
+                            data: updated.data,
+                            actions: updated.actions
+                        )
+                    }
+                    return
+                }
+            }
+
+        case .uiSurfaceDismiss(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            // Find and remove the inline surface across all messages
+            for msgIndex in messages.indices {
+                if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {
+                    messages[msgIndex].inlineSurfaces.remove(at: surfaceIndex)
+                    return
+                }
+            }
+
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Add `.uiSurfaceUpdate` handler to update inline surface data when the daemon sends changes
- Add `.uiSurfaceDismiss` handler to remove inline surfaces when dismissed by the daemon
- Previously these events fell through to `default: break` and were silently ignored

Addresses review feedback from #1348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
