### PR TITLE
Change default Anthropic model to claude-opus-4-6

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -59,7 +59,7 @@ exports[`IPC message snapshots ClientMessage types model_get serializes to expec
 
 exports[`IPC message snapshots ClientMessage types model_set serializes to expected JSON 1`] = `
 {
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "claude-opus-4-6",
   "type": "model_set",
 }
 `;
@@ -332,7 +332,7 @@ exports[`IPC message snapshots ServerMessage types generation_handoff serializes
 
 exports[`IPC message snapshots ServerMessage types model_info serializes to expected JSON 1`] = `
 {
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "claude-opus-4-6",
   "provider": "anthropic",
   "type": "model_info",
 }
@@ -367,7 +367,7 @@ exports[`IPC message snapshots ServerMessage types usage_update serializes to ex
 {
   "estimatedCost": 0.025,
   "inputTokens": 150,
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "claude-opus-4-6",
   "outputTokens": 50,
   "totalInputTokens": 1500,
   "totalOutputTokens": 500,
@@ -378,7 +378,7 @@ exports[`IPC message snapshots ServerMessage types usage_update serializes to ex
 exports[`IPC message snapshots ServerMessage types usage_response serializes to expected JSON 1`] = `
 {
   "estimatedCost": 0.025,
-  "model": "claude-sonnet-4-5-20250929",
+  "model": "claude-opus-4-6",
   "totalInputTokens": 1500,
   "totalOutputTokens": 500,
   "type": "usage_response",
@@ -393,7 +393,7 @@ exports[`IPC message snapshots ServerMessage types context_compacted serializes 
   "previousEstimatedInputTokens": 220000,
   "summaryCalls": 3,
   "summaryInputTokens": 4200,
-  "summaryModel": "claude-sonnet-4-5-20250929",
+  "summaryModel": "claude-opus-4-6",
   "summaryOutputTokens": 900,
   "thresholdTokens": 144000,
   "type": "context_compacted",

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -60,7 +60,7 @@ describe('AssistantConfigSchema', () => {
   test('parses empty object with full defaults', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.provider).toBe('anthropic');
-    expect(result.model).toBe('claude-sonnet-4-5-20250929');
+    expect(result.model).toBe('claude-opus-4-6');
     expect(result.maxTokens).toBe(64000);
     expect(result.apiKeys).toEqual({});
     expect(result.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
@@ -320,7 +320,7 @@ describe('loadConfig with schema validation', () => {
     writeConfig({});
     const config = loadConfig();
     expect(config.provider).toBe('anthropic');
-    expect(config.model).toBe('claude-sonnet-4-5-20250929');
+    expect(config.model).toBe('claude-opus-4-6');
     expect(config.maxTokens).toBe(64000);
     expect(config.thinking).toEqual({ enabled: false, budgetTokens: 10000 });
     expect(config.contextWindow).toEqual({

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -52,7 +52,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   model_set: {
     type: 'model_set',
-    model: 'claude-sonnet-4-5-20250929',
+    model: 'claude-opus-4-6',
   },
   history_request: {
     type: 'history_request',
@@ -225,7 +225,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   model_info: {
     type: 'model_info',
-    model: 'claude-sonnet-4-5-20250929',
+    model: 'claude-opus-4-6',
     provider: 'anthropic',
   },
   history_response: {
@@ -246,14 +246,14 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     totalInputTokens: 1500,
     totalOutputTokens: 500,
     estimatedCost: 0.025,
-    model: 'claude-sonnet-4-5-20250929',
+    model: 'claude-opus-4-6',
   },
   usage_response: {
     type: 'usage_response',
     totalInputTokens: 1500,
     totalOutputTokens: 500,
     estimatedCost: 0.025,
-    model: 'claude-sonnet-4-5-20250929',
+    model: 'claude-opus-4-6',
   },
   context_compacted: {
     type: 'context_compacted',
@@ -265,7 +265,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     summaryCalls: 3,
     summaryInputTokens: 4200,
     summaryOutputTokens: 900,
-    summaryModel: 'claude-sonnet-4-5-20250929',
+    summaryModel: 'claude-opus-4-6',
   },
   secret_detected: {
     type: 'secret_detected',

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -6,7 +6,7 @@ describe('provider registry (ollama)', () => {
     initializeProviders({
       apiKeys: {},
       provider: 'ollama',
-      model: 'claude-sonnet-4-5-20250929',
+      model: 'claude-opus-4-6',
     });
 
     const provider = getProvider('ollama');

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -3,7 +3,7 @@ import type { AssistantConfig } from './types.js';
 
 export const DEFAULT_CONFIG: AssistantConfig = {
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929', // alias: claude-sonnet-4-5
+  model: 'claude-opus-4-6', // alias: claude-opus-4
   apiKeys: {},
   maxTokens: 64000,
   thinking: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -328,7 +328,7 @@ export const AssistantConfigSchema = z.object({
     .default('anthropic'),
   model: z
     .string({ error: 'model must be a string' })
-    .default('claude-sonnet-4-5-20250929'),
+    .default('claude-opus-4-6'),
   apiKeys: z
     .record(z.string(), z.string({ error: 'Each apiKeys value must be a string' }))
     .default({}),

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -7,7 +7,7 @@ import { RetryProvider } from "./retry.js";
 import { ConfigError } from "../util/errors.js";
 
 const DEFAULT_MODELS: Record<string, string> = {
-  anthropic: 'claude-sonnet-4-5-20250929',
+  anthropic: 'claude-opus-4-6',
   openai: 'gpt-5.2',
   gemini: 'gemini-3-flash',
   ollama: 'llama3.2',


### PR DESCRIPTION
## Summary
- Change the default Anthropic model from `claude-sonnet-4-5-20250929` to `claude-opus-4-6` across config defaults, Zod schema, and provider registry
- Update all test fixtures and snapshots that reference the default model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
