### PR TITLE
Emit selection actions from inline table/list widgets

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineListWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineListWidget.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Inline list widget for selectable items in chat.
 struct InlineListWidget: View {
     let data: ListSurfaceData
+    let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
 
@@ -65,6 +66,7 @@ struct InlineListWidget: View {
                     selectedIds.insert(item.id)
                 }
             }
+            onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
         }
     }
 }
@@ -73,14 +75,17 @@ struct InlineListWidget: View {
 #Preview("InlineListWidget") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        InlineListWidget(data: ListSurfaceData(
-            items: [
-                ListItemData(id: "1", title: "Option A", subtitle: "First choice", icon: nil, selected: false),
-                ListItemData(id: "2", title: "Option B", subtitle: "Second choice", icon: nil, selected: true),
-                ListItemData(id: "3", title: "Option C", subtitle: nil, icon: nil, selected: false),
-            ],
-            selectionMode: .single
-        ))
+        InlineListWidget(
+            data: ListSurfaceData(
+                items: [
+                    ListItemData(id: "1", title: "Option A", subtitle: "First choice", icon: nil, selected: false),
+                    ListItemData(id: "2", title: "Option B", subtitle: "Second choice", icon: nil, selected: true),
+                    ListItemData(id: "3", title: "Option C", subtitle: nil, icon: nil, selected: false),
+                ],
+                selectionMode: .single
+            ),
+            onAction: { _, _ in }
+        )
         .padding()
     }
     .frame(width: 400, height: 250)

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -5,6 +5,8 @@ struct InlineSurfaceRouter: View {
     let surface: InlineSurfaceData
     let onAction: (String, String, [String: AnyCodable]?) -> Void
 
+    @State private var selectionPayload: [String: AnyCodable]?
+
     /// Whether the surface content handles its own header/chrome.
     private var isTemplateCard: Bool {
         if case .card(let data) = surface.data, data.template != nil {
@@ -47,10 +49,18 @@ struct InlineSurfaceRouter: View {
             InlineCardWidget(data: data)
         case .table(let data):
             InlineTableWidget(data: data) { actionId, payload in
+                if actionId == "selection_changed" {
+                    selectionPayload = payload
+                }
                 onAction(surface.id, actionId, payload)
             }
         case .list(let data):
-            InlineListWidget(data: data)
+            InlineListWidget(data: data) { actionId, payload in
+                if actionId == "selection_changed" {
+                    selectionPayload = payload
+                }
+                onAction(surface.id, actionId, payload)
+            }
         default:
             InlineFallbackChip(surfaceType: surface.surfaceType)
         }
@@ -61,7 +71,7 @@ struct InlineSurfaceRouter: View {
             Spacer()
             ForEach(surface.actions) { action in
                 Button {
-                    onAction(surface.id, action.id, nil)
+                    onAction(surface.id, action.id, selectionPayload)
                 } label: {
                     Text(action.label)
                         .font(VFont.bodyMedium)

--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -101,6 +101,7 @@ struct InlineTableWidget: View {
                 selectedIds.insert(id)
             }
         }
+        onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
     }
 }
 


### PR DESCRIPTION
## Summary
- **InlineTableWidget**: `toggleSelection` now calls `onAction("selection_changed", ...)` after updating `selectedIds`, so the daemon receives selection state changes
- **InlineListWidget**: Added `onAction` callback parameter and fires it on selection changes, matching InlineTableWidget's pattern
- **InlineSurfaceRouter**: Tracks the latest selection payload from child widgets via `@State` and passes it to action buttons instead of always sending `nil`

Addresses feedback on #1349.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
