### PR TITLE
Fix hourly forecast timezone mismatch

### DIFF
--- a/assistant/src/__tests__/get-weather.test.ts
+++ b/assistant/src/__tests__/get-weather.test.ts
@@ -41,6 +41,7 @@ function createMockFetch(options?: {
 
   const defaultForecastData = {
     current: {
+      time: '2025-01-15T08:00',
       temperature_2m: 15.0,
       relative_humidity_2m: 72,
       apparent_temperature: 13.5,

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -55,6 +55,7 @@ interface GeocodingResult {
 }
 
 interface CurrentWeather {
+  time: string;
   temperature_2m: number;
   relative_humidity_2m: number;
   apparent_temperature: number;
@@ -168,7 +169,7 @@ export async function executeGetWeather(
   // Step 2: Fetch the weather forecast
   let forecast: ForecastResponse;
   try {
-    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&hourly=temperature_2m,weather_code,is_day&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=${forecastDays}`;
+    const weatherUrl = `${FORECAST_API}?latitude=${geo.latitude}&longitude=${geo.longitude}&current=time,temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m&hourly=temperature_2m,weather_code,is_day&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days=${forecastDays}`;
     log.debug({ url: weatherUrl }, 'Fetching weather forecast');
 
     const weatherResponse = await fetchFn(weatherUrl, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
@@ -249,17 +250,14 @@ export async function executeGetWeather(
     forecastItems.push({ day: dayLabel, icon, low, high, precip: precip > 0 ? precip : null, condition: desc });
   }
 
-  // Process hourly data: next 24 hours from the current hour
+  // Process hourly data: next 24 hours from the current hour.
+  // Use the current time from the API response (which is in the location's local
+  // timezone, thanks to timezone=auto) to find the correct starting index.
   const hourlyItems: Array<{ time: string; icon: string; temp: number }> = [];
   if (forecast.hourly?.time) {
-    const now = new Date();
-    const currentHourISO = now.toISOString().slice(0, 13); // "2026-02-13T00"
-    // Find the index of the current hour in the hourly data
-    let startIndex = forecast.hourly.time.findIndex((t) => t.startsWith(currentHourISO));
-    if (startIndex < 0) {
-      // Fallback: find the first hour that's >= now
-      startIndex = forecast.hourly.time.findIndex((t) => new Date(t) >= now);
-    }
+    const currentTimeLocal = forecast.current.time; // e.g. "2026-02-12T22:00"
+    const currentHourPrefix = currentTimeLocal.slice(0, 13); // e.g. "2026-02-12T22"
+    let startIndex = forecast.hourly.time.findIndex((t) => t.startsWith(currentHourPrefix));
     if (startIndex < 0) startIndex = 0;
 
     const count = Math.min(24, forecast.hourly.time.length - startIndex);
@@ -275,8 +273,9 @@ export async function executeGetWeather(
       if (i === 0) {
         timeLabel = 'Now';
       } else {
-        const d = new Date(forecast.hourly.time[idx]);
-        const hour = d.getHours();
+        // Parse the hour directly from the time string (already in location-local
+        // timezone) instead of relying on Date parsing which is runtime-dependent.
+        const hour = parseInt(forecast.hourly.time[idx].slice(11, 13), 10);
         const suffix = hour >= 12 ? 'PM' : 'AM';
         const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
         timeLabel = `${displayHour}${suffix}`;


### PR DESCRIPTION
## Summary
- The hourly forecast start-index was computed using UTC time (`now.toISOString()`) to match against location-local timestamps from the Open-Meteo API (which uses `timezone=auto`), causing incorrect hours for non-UTC locations
- Now uses `forecast.current.time` from the API response, which is already in the location's local timezone, to anchor the hourly window correctly
- Parses hour labels directly from the time string (`parseInt(time.slice(11,13))`) instead of relying on runtime-dependent `new Date()` parsing

## Changes
- Added `time` to the `CurrentWeather` interface and API request URL
- Replaced UTC-based `now.toISOString().slice(0,13)` with `forecast.current.time.slice(0,13)` for the start-index lookup
- Removed the broken fallback that compared `new Date(t) >= now` (also timezone-incorrect)
- Updated test mock data to include the `time` field in `current`

Addresses review feedback on #1433.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 25 existing weather tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
