### PR TITLE
Increase default parallel worker count from 3 to 12

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -89,9 +89,9 @@ Spawns a pool of agents that work through `.private/TODO.md` in parallel using i
 **Frequency:** On demand. Can run for extended periods.
 
 ```
-/swarm       # 3 parallel workers, runs until TODO.md is empty
-/swarm 5     # 5 parallel workers
-/swarm 3 10  # 3 workers, stop after 10 tasks completed
+/swarm        # 12 parallel workers, runs until TODO.md is empty
+/swarm 5      # 5 parallel workers
+/swarm 12 10  # 12 workers, stop after 10 tasks completed
 ```
 
 ### `/check-reviews` - Process PR review feedback
@@ -115,9 +115,9 @@ Combines `/check-reviews` and `/swarm` into a single command. First triages all 
 **Frequency:** Every 30-60 minutes while PRs are pending review.
 
 ```
-/check-reviews-and-swarm       # check reviews, then swarm with 3 workers
-/check-reviews-and-swarm 5     # check reviews, then swarm with 5 workers
-/check-reviews-and-swarm 3 10  # check reviews, then swarm with 3 workers, max 10 tasks
+/check-reviews-and-swarm        # check reviews, then swarm with 12 workers
+/check-reviews-and-swarm 5      # check reviews, then swarm with 5 workers
+/check-reviews-and-swarm 12 10  # check reviews, then swarm with 12 workers, max 10 tasks
 ```
 
 ### `/mainline` - Ship current changes to main
@@ -190,7 +190,7 @@ The project board is created under the `vellum-ai` org with the naming conventio
 
 **Flags:**
 - `--auto` — skip the pause between swarm and sweep phases (default: pause and ask)
-- `--workers N` — number of parallel swarm workers (default: 3)
+- `--workers N` — number of parallel swarm workers (default: 12)
 - `--skip-plan` — skip issue creation; use issues already in the "Ready" column of the project board
 
 ## Typical workflow

--- a/.claude/commands/blitz.md
+++ b/.claude/commands/blitz.md
@@ -9,7 +9,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a feature descriptio
 Extract these flags from `$ARGUMENTS` before treating the remainder as the feature description:
 
 - `--auto` — skip the pause between rounds (default: pause and ask before sweep)
-- `--workers N` — parallel worker count for swarm phases (default: 3)
+- `--workers N` — parallel worker count for swarm phases (default: 12)
 - `--skip-plan` — skip planning; use issues already in the "Ready" column of the GH project
 
 Everything after stripping flags is the **feature description**.
@@ -180,7 +180,7 @@ gh api graphql -f query='mutation {
 
 Read and follow the instructions in `.claude/commands/swarm.md` with these modifications:
 
-- Pass the `--workers` count (or default 3) as the first argument.
+- Pass the `--workers` count (or default 12) as the first argument.
 - **After each milestone task completes and its PR merges**, update the corresponding GitHub issue. Skip this for non-milestone tasks (e.g., "Address the feedback on ..." items from Phase 5 — those are PR-based and have no associated milestone issue):
   1. Set the project board status to "Done":
 

--- a/.claude/commands/check-reviews-and-swarm.md
+++ b/.claude/commands/check-reviews-and-swarm.md
@@ -4,7 +4,7 @@ Arguments (optional): $ARGUMENTS
 
 Parse positional arguments (these are passed through to `/swarm`):
 
-- **First argument** (optional): number of parallel workers (default: 3).
+- **First argument** (optional): number of parallel workers (default: 12).
 - **Second argument** (optional): maximum number of tasks to complete before shutting down.
 
 ## Phase 1: Check reviews

--- a/.claude/commands/safe-blitz.md
+++ b/.claude/commands/safe-blitz.md
@@ -11,7 +11,7 @@ If `$ARGUMENTS` is empty, stop and tell the user to provide a feature descriptio
 Extract these flags from `$ARGUMENTS` before treating the remainder as the feature description:
 
 - `--auto` — skip the pause between rounds (default: pause and ask before sweep)
-- `--workers N` — parallel worker count for swarm phases (default: 3)
+- `--workers N` — parallel worker count for swarm phases (default: 12)
 - `--skip-plan` — skip planning; use issues already in the "Ready" column of the GH project
 - `--branch NAME` — custom feature branch name (default: auto-generated from feature description as `feature/<kebab-case-summary>`)
 

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -4,10 +4,10 @@ Arguments (optional): $ARGUMENTS
 
 Parse positional arguments:
 
-- **First argument** (optional): number of parallel workers (default: 3). Example: `/swarm 5` runs 5 workers.
-- **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 3 10` runs 3 workers and stops after completing 10 tasks.
+- **First argument** (optional): number of parallel workers (default: 12). Example: `/swarm 5` runs 5 workers.
+- **Second argument** (optional): maximum number of tasks to complete before automatically shutting down. Example: `/swarm 12 10` runs 12 workers and stops after completing 10 tasks.
 
-If no arguments are provided, default to 3 workers with no task limit (run until TODO.md is empty or the user says to stop).
+If no arguments are provided, default to 12 workers with no task limit (run until TODO.md is empty or the user says to stop).
 
 ## Repo-specific gotchas (include these in every agent prompt)
 
@@ -18,7 +18,7 @@ If no arguments are provided, default to 3 workers with no task limit (run until
 ## Phase 1: Setup
 
 1. Read .private/TODO.md. Keep an internal list of which items are currently in-flight.
-2. Parse the arguments: note the worker count (default: 3) and max-tasks limit (if provided). Track a **completed count** starting at 0.
+2. Parse the arguments: note the worker count (default: 12) and max-tasks limit (if provided). Track a **completed count** starting at 0.
 3. Create a team with `TeamCreate` (team name: `swarm`).
 
 ## Phase 2: Pick the next task


### PR DESCRIPTION
## Summary
- Changed the default parallel worker count from 3 to 12 across all swarm-related commands: `/swarm`, `/blitz`, `/safe-blitz`, `/check-reviews-and-swarm`
- Updated README examples and flag documentation to reflect the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
