### PR TITLE
Require action buttons for table/list surface blocking

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -231,11 +231,14 @@ export class ComputerUseSession {
         const data = input.data as SurfaceData;
         const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
         // Interactive surfaces default to awaiting user action.
-        // Lists and tables with selectionMode "none" are passive (no actions emitted) so they don't block.
+        // Tables and lists only block when explicit action buttons are provided;
+        // selectionMode alone should not gate blocking because selection_changed
+        // fires on every click and would immediately resolve multi-select surfaces.
+        const hasActions = Array.isArray(actions) && actions.length > 0;
         const isInteractive = surfaceType === 'list'
-          ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
+          ? hasActions
           : surfaceType === 'table'
-            ? ((data as TableSurfaceData).selectionMode ?? 'none') !== 'none'
+            ? hasActions
             : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
         const awaitAction = (input.await_action as boolean) ?? isInteractive;
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -892,11 +892,14 @@ export class Session {
       const data = input.data as SurfaceData;
       const actions = input.actions as Array<{ id: string; label: string; style?: string }> | undefined;
       // Interactive surfaces default to awaiting user action.
-      // Lists and tables with selectionMode "none" are passive (no actions emitted) so they don't block.
+      // Tables and lists only block when explicit action buttons are provided;
+      // selectionMode alone should not gate blocking because selection_changed
+      // fires on every click and would immediately resolve multi-select surfaces.
+      const hasActions = Array.isArray(actions) && actions.length > 0;
       const isInteractive = surfaceType === 'list'
-        ? ((data as ListSurfaceData).selectionMode ?? 'none') !== 'none'
+        ? hasActions
         : surfaceType === 'table'
-          ? ((data as TableSurfaceData).selectionMode ?? 'none') !== 'none'
+          ? hasActions
           : INTERACTIVE_SURFACE_TYPES.includes(surfaceType);
       const awaitAction = (input.await_action as boolean) ?? isInteractive;
 


### PR DESCRIPTION
## Summary
- Tables and lists with `selectionMode` previously defaulted to `await_action=true`, which could stall sessions when no action buttons were provided
- Now only surfaces with explicit action buttons (`actions` array with at least one entry) are treated as interactive
- The model can still explicitly set `await_action: true` to override this default

## Changes
- `assistant/src/daemon/session.ts`: Changed `isInteractive` for table/list to check `hasActions` instead of `selectionMode`
- `assistant/src/daemon/computer-use-session.ts`: Same change

Addresses review feedback on #1438.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
