### PR TITLE
Clear thinking indicator on confirmation request

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -605,6 +605,7 @@ final class ChatViewModel: ObservableObject {
                       lastToolUseReceivedAt != nil,
                       shouldAcceptConfirmation?() ?? false else { return }
             }
+            isThinking = false
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,


### PR DESCRIPTION
## Summary
- The thinking indicator stayed on while waiting for user confirmation on risky tool calls (shell/file edits)
- Added `isThinking = false` to the `confirmationRequest` handler so the UI correctly shows the confirmation dialog

## Changes
- `clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift`: Set `isThinking = false` when a confirmation request arrives

Addresses review feedback on #1432.

## Test plan
- [x] Manual verification that thinking indicator clears when confirmation dialog appears
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
