### PR TITLE
Fix recording state stuck on thread switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -42,6 +42,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     #endif
     private var windowObserver: Any?
     private var settingsWindowObserver: Any?
+    private weak var recordingViewModel: ChatViewModel?
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
@@ -414,8 +415,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // If there's an active conversation in ready state, route recording state there
             let hasActiveConvo = self?.currentTextSession?.state == .ready
 
-            // Sync recording state to the active ChatViewModel
-            self?.mainWindow?.activeViewModel?.isRecording = isRecording
+            // Sync recording state: clear on the view model that started recording
+            // to avoid stale isRecording when the user switches threads mid-recording.
+            if isRecording {
+                self?.recordingViewModel = self?.mainWindow?.activeViewModel
+            }
+            if let vm = self?.recordingViewModel {
+                vm.isRecording = isRecording
+            }
+            if !isRecording {
+                self?.recordingViewModel = nil
+            }
 
             if isRecording {
                 self?.statusItem.button?.image = NSImage(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -815,6 +815,9 @@ private struct MicrophoneButton: View {
         .onChange(of: isRecording) {
             isPulsing = isRecording
         }
+        .onAppear {
+            isPulsing = isRecording
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `isRecording` state got stuck on the wrong ChatViewModel when users switched threads during voice recording
- Added `recordingViewModel` weak reference to track which view model started recording, clearing it on that specific instance
- Added `.onAppear` to MicrophoneButton so pulse animation starts correctly when view appears with `isRecording` already true

## Changes
- `clients/macos/vellum-assistant/App/AppDelegate.swift`: Track recording view model; clear on correct instance
- `clients/macos/vellum-assistant/Features/Chat/ChatView.swift`: Add `.onAppear` to sync `isPulsing`

Addresses review feedback on #1425.

## Test plan
- [x] Manual verification of thread switching during recording
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
