### PR TITLE
Show text bubble when message has text and inline surfaces

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -495,8 +495,8 @@ private struct ChatBubble: View {
     /// exist (the thinking indicator already signals progress).
     private var shouldShowBubble: Bool {
         if isUser { return true }
-        if !message.inlineSurfaces.isEmpty { return false }
         if hasText || !message.attachments.isEmpty { return true }
+        if !message.inlineSurfaces.isEmpty { return false }
         // During streaming, hide tool-call-only bubbles so the thinking
         // indicator stays visible instead of showing raw tool progress.
         if message.isStreaming { return false }


### PR DESCRIPTION
## Summary
- `shouldShowBubble` hid the text bubble whenever inline surfaces were present, even when the message contained meaningful text or attachments (e.g., "Here's the weather for your area:")
- Swapped the check order so `hasText || !message.attachments.isEmpty` is evaluated before `!message.inlineSurfaces.isEmpty`

## Changes
- `clients/macos/vellum-assistant/Features/Chat/ChatView.swift`: Reorder `shouldShowBubble` checks

Addresses review feedback on #1426.

## Test plan
- [x] Messages with both text and inline surfaces show the text bubble above the widget
- [x] Messages with only inline surfaces (no text) still hide the empty bubble
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
