### PR TITLE
Clear thinking indicator on confirmation request

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -605,6 +605,7 @@ final class ChatViewModel: ObservableObject {
                       lastToolUseReceivedAt != nil,
                       shouldAcceptConfirmation?() ?? false else { return }
             }
+            isThinking = false
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,


### PR DESCRIPTION
## Summary
- Sets `isThinking = false` in the `confirmationRequest` handler so the thinking indicator stops when the app is waiting for user confirmation on approval-gated tools
- Without this fix, risky tools (shell/file edits) that require confirmation showed an indefinite thinking state

Addresses feedback from PR #1432.

## Test plan
- [ ] Trigger a tool that requires confirmation (e.g., a shell command)
- [ ] Verify the thinking indicator stops and the confirmation prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
