### PR TITLE
Treat selection_changed as non-terminal surface action

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -196,6 +196,11 @@ export class ComputerUseSession {
       log.warn({ surfaceId, actionId }, 'No pending surface action found');
       return;
     }
+    // selection_changed is a non-terminal state update — don't consume the
+    // pending entry. The selection state will be in the action button payload.
+    if (actionId === 'selection_changed') {
+      return;
+    }
     this.pendingSurfaceActions.delete(surfaceId);
     pending.resolve({
       content: JSON.stringify({ actionId, data: data ?? {} }),

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -763,6 +763,13 @@ export class Session {
       log.warn({ surfaceId, actionId }, 'No pending surface action found');
       return;
     }
+    // selection_changed is a non-terminal state update — don't consume the
+    // pending entry or send a message. The selection state will be included
+    // in the data payload when the user clicks a real action button.
+    if (actionId === 'selection_changed') {
+      log.debug({ surfaceId, data }, 'Selection changed (non-terminal, not forwarding)');
+      return;
+    }
     const content = JSON.stringify({
       surfaceAction: true,
       surfaceId,


### PR DESCRIPTION
## Summary
- `selection_changed` events from table/list row toggles were consuming the `pendingSurfaceActions` entry
- This caused subsequent action button clicks to be dropped with "No pending surface action found"
- Now treats `selection_changed` as non-terminal — the pending entry stays alive for real action buttons
- Selection state is included in the action button's data payload (from PR #1442)

## Changes
- `assistant/src/daemon/session.ts`: Skip `selection_changed` in `handleSurfaceAction`
- `assistant/src/daemon/computer-use-session.ts`: Same change

Addresses review feedback on #1442.

## Test plan
- [x] Type-check passes
- [x] Row selection no longer blocks action buttons from working
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
