### PR TITLE
Keep selection_changed local to avoid clearing pending surface actions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -51,6 +51,7 @@ struct InlineSurfaceRouter: View {
             InlineTableWidget(data: data) { actionId, payload in
                 if actionId == "selection_changed" {
                     selectionPayload = payload
+                    return
                 }
                 onAction(surface.id, actionId, payload)
             }
@@ -58,6 +59,7 @@ struct InlineSurfaceRouter: View {
             InlineListWidget(data: data) { actionId, payload in
                 if actionId == "selection_changed" {
                     selectionPayload = payload
+                    return
                 }
                 onAction(surface.id, actionId, payload)
             }


### PR DESCRIPTION
## Summary
- Selection toggles in table/list widgets were being forwarded to the daemon via `onAction`, which triggered `handleSurfaceAction` and cleared `pendingSurfaceActions`. This caused real footer action button presses to be dropped with "No pending surface action found."
- Added `return` after storing `selectionPayload` for `selection_changed` events so they stay local to `InlineSurfaceRouter` and don't reach the daemon. The selection state is still included when the user presses an actual action button.

Addresses feedback on #1442.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
