### PR TITLE
Fix lint errors: ref update during render, unused vars

### DIFF
--- a/web/src/hooks/useVoiceInput.ts
+++ b/web/src/hooks/useVoiceInput.ts
@@ -41,7 +41,9 @@ export function useVoiceInput({ onTranscript }: UseVoiceInputOptions) {
   const isListeningRef = useRef(false);
   const onTranscriptRef = useRef(onTranscript);
 
-  onTranscriptRef.current = onTranscript;
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  });
 
   useEffect(() => {
     setIsSupported(getSpeechRecognition() !== null);

--- a/web/src/lib/gcp.ts
+++ b/web/src/lib/gcp.ts
@@ -12,9 +12,6 @@ const GCP_ZONE = process.env.GCP_ZONE || "us-central1-a";
 const GCP_MACHINE_TYPE = process.env.GCP_MACHINE_TYPE || "e2-medium";
 const GCP_SERVICE_ACCOUNT = process.env.GCP_SERVICE_ACCOUNT || "nextjs-web@vellum-ai-prod.iam.gserviceaccount.com";
 
-// Templates are uploaded to GCS by GitHub Actions on merge to main
-const GCS_TEMPLATES_PREFIX = `${GCS_PREFIX_BASE}/templates`;
-
 function getGcpCredentials(): { projectId: string } {
   return { projectId: GCP_PROJECT_ID };
 }

--- a/web/src/lib/runtime/resolver.ts
+++ b/web/src/lib/runtime/resolver.ts
@@ -28,6 +28,7 @@ export interface ResolvedRuntime {
  *   - `LOCAL_RUNTIME_URL`  — override the default local runtime URL
  *   - `CLOUD_RUNTIME_URL`  — base URL for the hosted cloud runtime
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function resolveRuntime(_assistantId: string): ResolvedRuntime {
   const mode = getAssistantConnectionMode();
 


### PR DESCRIPTION
## Summary
- Move `onTranscriptRef.current` update into a `useEffect` to fix React `react-hooks/refs` error
- Remove unused `GCS_TEMPLATES_PREFIX` constant from `gcp.ts`
- Suppress `no-unused-vars` for intentionally unused `_assistantId` parameter in `resolver.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
