### PR TITLE
Fix test platform mocks to include getRootDir

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -7,7 +7,8 @@ import { join } from 'node:path';
 const checkerTestDir = mkdtempSync(join(tmpdir(), 'checker-test-'));
 
 mock.module('../util/platform.js', () => ({
-  getDataDir: () => checkerTestDir,
+  getRootDir: () => checkerTestDir,
+  getDataDir: () => join(checkerTestDir, 'data'),
   isMacOS: () => process.platform === 'darwin',
   isLinux: () => process.platform === 'linux',
   isWindows: () => process.platform === 'win32',
@@ -46,7 +47,7 @@ describe('Permission Checker', () => {
   beforeEach(() => {
     // Reset trust-store state between tests
     clearCache();
-    try { rmSync(join(checkerTestDir, 'trust.json')); } catch { /* may not exist */ }
+    try { rmSync(join(checkerTestDir, 'protected', 'trust.json')); } catch { /* may not exist */ }
     try { rmSync(join(checkerTestDir, 'skills'), { recursive: true, force: true }); } catch { /* may not exist */ }
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -31,7 +31,8 @@ mock.module('../util/logger.js', () => ({
 }));
 
 mock.module('../util/platform.js', () => ({
-  getDataDir: () => TEST_DIR,
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => join(TEST_DIR, 'data'),
   getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => ensureTestDir(),
   isMacOS: () => false,

--- a/assistant/src/__tests__/key-migration.test.ts
+++ b/assistant/src/__tests__/key-migration.test.ts
@@ -18,7 +18,8 @@ mock.module('../util/logger.js', () => ({
 }));
 
 mock.module('../util/platform.js', () => ({
-  getDataDir: () => TEST_DIR,
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => join(TEST_DIR, 'data'),
   getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
   ensureDataDir: () => {
     if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- Add `getRootDir` to platform.js mocks in `checker.test.ts`, `config-schema.test.ts`, and `key-migration.test.ts`
- Without this, `trust-store.ts` and `config/loader.ts` used the real `~/.vellum` directory instead of test temp dirs, causing trust rules to leak between tests and config to read from the real config file
- Also fix `beforeEach` cleanup in checker.test.ts to remove `protected/trust.json` (matching the new trust file path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
