### PR TITLE
Fix stop button not working when tools are stuck

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -256,6 +256,37 @@ describe('AgentLoop', () => {
     expect(hasToolUse).toBe(true);
   });
 
+  // 6b. Abort signal during long-running tool execution — loop exits immediately
+  test('stops immediately when abort fires during a stuck tool execution', async () => {
+    const controller = new AbortController();
+
+    const { provider } = createMockProvider([
+      toolUseResponse('t1', 'read_file', { path: '/stuck.txt' }),
+      textResponse('Should not reach'),
+    ]);
+
+    // Simulate a stuck tool that never resolves — abort fires while it's running
+    const toolExecutor = async () => {
+      // Abort from a timer while this tool is "stuck"
+      setTimeout(() => controller.abort(), 50);
+      // Simulate being stuck for a long time
+      await new Promise(resolve => setTimeout(resolve, 10_000));
+      return { content: 'should never return', isError: false };
+    };
+
+    const loop = new AgentLoop(provider, 'system', {}, dummyTools, toolExecutor);
+    const start = Date.now();
+    const history = await loop.run([userMessage], () => {}, controller.signal);
+    const elapsed = Date.now() - start;
+
+    // The loop should exit quickly (~50ms for abort), not wait 10s for the tool
+    expect(elapsed).toBeLessThan(2000);
+
+    // Only the user message + assistant tool_use message should be in history
+    // (no tool results since abort interrupted before tool completed)
+    expect(history).toHaveLength(2);
+  });
+
   // 7. Events — verify text_delta and other events are emitted
   test('emits text_delta events during streaming', async () => {
     const { provider } = createMockProvider([textResponse('Hello world')]);

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -200,8 +200,10 @@ export class AgentLoop {
           break;
         }
 
-        // Execute all tools concurrently for reduced latency
-        const toolResults = await Promise.all(
+        // Execute all tools concurrently for reduced latency.
+        // Race against the abort signal so cancellation isn't blocked by
+        // stuck tools (e.g. a hung browser navigation).
+        const toolExecutionPromise = Promise.all(
           toolUseBlocks.map(async (toolUse) => {
             const toolStart = Date.now();
 
@@ -223,6 +225,16 @@ export class AgentLoop {
             return { toolUse, result };
           }),
         );
+
+        let toolResults: Awaited<typeof toolExecutionPromise>;
+        if (signal && !signal.aborted) {
+          const abortPromise = new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => reject(new DOMException('The operation was aborted', 'AbortError')), { once: true });
+          });
+          toolResults = await Promise.race([toolExecutionPromise, abortPromise]);
+        } else {
+          toolResults = await toolExecutionPromise;
+        }
 
         // Emit tool_result events in deterministic tool_use order after all complete
         for (const { toolUse, result } of toolResults) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -43,6 +43,9 @@ final class ChatViewModel: ObservableObject {
     private var pendingMessageIds: [UUID] = []
     /// Tracks the current in-flight suggestion request so stale responses are ignored.
     private var pendingSuggestionRequestId: String?
+    /// Safety timer that force-resets the UI if the daemon never acknowledges
+    /// a cancel request (e.g. a stuck tool blocks the generation_cancelled event).
+    private var cancelTimeoutTask: Task<Void, Never>?
 
     /// Timestamp of the most recent `toolUseStart` event received by this view model.
     /// Used by ThreadManager to route `confirmationRequest` messages to the correct
@@ -460,6 +463,8 @@ final class ChatViewModel: ObservableObject {
 
         case .messageComplete(let complete):
             guard belongsToSession(complete.sessionId) else { return }
+            cancelTimeoutTask?.cancel()
+            cancelTimeoutTask = nil
             isCancelling = false
             isThinking = false
             // Only clear isSending if no messages are still queued
@@ -485,6 +490,8 @@ final class ChatViewModel: ObservableObject {
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
+            cancelTimeoutTask?.cancel()
+            cancelTimeoutTask = nil
             isCancelling = false
             isThinking = false
             if pendingQueuedCount == 0 {
@@ -826,6 +833,23 @@ final class ChatViewModel: ObservableObject {
             for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
                 messages[index].toolCalls[j].isComplete = true
             }
+        }
+
+        // Safety timeout: if the daemon never acknowledges the cancel (e.g. a
+        // tool is stuck and blocks the response), force-reset the UI so the
+        // user can start a new interaction.
+        cancelTimeoutTask?.cancel()
+        cancelTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000) // 5 seconds
+            guard let self, !Task.isCancelled else { return }
+            guard self.isCancelling else { return }
+            log.warning("Cancel acknowledgment timed out after 5s — force-resetting UI state")
+            self.isCancelling = false
+            self.isSending = false
+            self.currentAssistantMessageId = nil
+            self.pendingQueuedCount = 0
+            self.pendingMessageIds = []
+            self.requestIdToMessageId = [:]
         }
     }
 


### PR DESCRIPTION
## Summary
- Race tool execution against the abort signal in the agent loop so the stop button immediately unblocks when a tool (e.g. browser navigate) hangs indefinitely
- Add a 5-second safety timeout on the macOS client that force-resets UI state if the daemon never acknowledges the cancel
- Add test verifying the loop exits in <2s when a tool is stuck for 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
