### PR TITLE
Make tab-complete suggestions concise and conversational

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -893,18 +893,18 @@ async function generateSuggestion(apiKey: string, assistantText: string): Promis
 
   const response = await client.messages.create({
     model: 'claude-haiku-4-5-20251001',
-    max_tokens: 60,
+    max_tokens: 30,
     messages: [
       {
         role: 'user',
-        content: `The AI assistant just said the following to the user. Suggest a single short follow-up message (max 200 chars) the user might want to send next. Reply with ONLY the suggested message text, nothing else.\n\nAssistant's message:\n${truncated}`,
+        content: `Given this assistant message, write a very short tab-complete suggestion (max 50 chars) the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`,
       },
     ],
   });
 
   const textBlock = response.content.find((b) => b.type === 'text');
   const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
-  if (!raw || raw.length > 200) return null;
+  if (!raw || raw.length > 50) return null;
 
   const firstLine = raw.split('\n')[0].trim();
   return firstLine || null;

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -332,11 +332,11 @@ export class RuntimeHttpServer {
 
     const response = await client.messages.create({
       model: 'claude-haiku-4-5-20251001',
-      max_tokens: 60,
+      max_tokens: 30,
       messages: [
         {
           role: 'user',
-          content: `The AI assistant just said the following to the user. Suggest a single short follow-up message (max 200 chars) the user might want to send next. Reply with ONLY the suggested message text, nothing else.\n\nAssistant's message:\n${truncated}`,
+          content: `Given this assistant message, write a very short tab-complete suggestion (max 50 chars) the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`,
         },
       ],
     });
@@ -344,7 +344,7 @@ export class RuntimeHttpServer {
     const textBlock = response.content.find((b) => b.type === 'text');
     const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
-    if (!raw || raw.length > 200) return null;
+    if (!raw || raw.length > 50) return null;
 
     // Take first line only
     const firstLine = raw.split('\n')[0].trim();

--- a/web/src/lib/chat-suggestion.test.ts
+++ b/web/src/lib/chat-suggestion.test.ts
@@ -26,10 +26,10 @@ describe("sanitizeSuggestion", () => {
     expect(sanitizeSuggestion("   \n\n  ")).toBeNull();
   });
 
-  test("truncates to default maxLen (200)", () => {
+  test("truncates to default maxLen (50)", () => {
     const long = "a".repeat(300);
     const result = sanitizeSuggestion(long);
-    expect(result).toHaveLength(200);
+    expect(result).toHaveLength(50);
   });
 
   test("truncates to custom maxLen", () => {

--- a/web/src/lib/chat-suggestion.ts
+++ b/web/src/lib/chat-suggestion.ts
@@ -27,7 +27,7 @@ export interface ShouldShowSuggestionParams {
  * - Truncates to `maxLen` characters.
  * - Returns `null` for empty / whitespace-only input.
  */
-export function sanitizeSuggestion(raw: string, maxLen = 200): string | null {
+export function sanitizeSuggestion(raw: string, maxLen = 50): string | null {
   const firstLine = raw.split("\n")[0].trim();
   if (firstLine.length === 0) return null;
   return firstLine.length <= maxLen ? firstLine : firstLine.slice(0, maxLen);


### PR DESCRIPTION
## Summary
- Reduces tab-complete suggestion max length from 200 to 50 characters across both daemon IPC and HTTP server paths
- Rewrites the LLM prompt to generate casual, curiosity-driven follow-ups that encourage continued conversation instead of verbose formal requests
- Reduces max_tokens from 60 to 30 to match the shorter output target
- Updates the `sanitizeSuggestion` utility default and its tests accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
