### PR TITLE
Fix unhandled promise rejections in abort-race and cancel-timeout message reset

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -228,10 +228,18 @@ export class AgentLoop {
 
         let toolResults: Awaited<typeof toolExecutionPromise>;
         if (signal && !signal.aborted) {
+          let abortHandler!: () => void;
           const abortPromise = new Promise<never>((_, reject) => {
-            signal.addEventListener('abort', () => reject(new DOMException('The operation was aborted', 'AbortError')), { once: true });
+            abortHandler = () => reject(new DOMException('The operation was aborted', 'AbortError'));
+            signal.addEventListener('abort', abortHandler, { once: true });
           });
-          toolResults = await Promise.race([toolExecutionPromise, abortPromise]);
+          try {
+            toolResults = await Promise.race([toolExecutionPromise, abortPromise]);
+          } finally {
+            signal.removeEventListener('abort', abortHandler);
+            // Suppress unhandled rejection from abandoned tool executions
+            toolExecutionPromise.catch(() => {});
+          }
         } else {
           toolResults = await toolExecutionPromise;
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -850,6 +850,14 @@ final class ChatViewModel: ObservableObject {
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
+            // Reset queued/processing messages to sent (matches other cancel-failure paths)
+            for i in self.messages.indices {
+                if case .queued = self.messages[i].status, self.messages[i].role == .user {
+                    self.messages[i].status = .sent
+                } else if self.messages[i].role == .user && self.messages[i].status == .processing {
+                    self.messages[i].status = .sent
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1459 ("Fix stop button not working when tools are stuck").

**1. Fix unhandled promise rejections in abort-race logic** (`assistant/src/agent/loop.ts`):
- Save a reference to the abort event handler so it can be removed after the `Promise.race` resolves or rejects
- Add `toolExecutionPromise.catch(() => {})` in a `finally` block to suppress unhandled rejections from abandoned tool executions
- This fixes two scenarios: (a) abort fires and abandoned tools later throw, (b) tools complete normally but the abort signal fires later on the still-pending abortPromise

**2. Fix queued message status reset in cancel-timeout fallback** (`clients/macos/.../ChatViewModel.swift`):
- The 5-second cancel acknowledgment timeout was resetting `pendingQueuedCount`, `pendingMessageIds`, and `requestIdToMessageId`, but was NOT resetting `.queued`/`.processing` message statuses to `.sent`
- This could leave user messages visually stuck in "queued" or "processing" state after a cancel timeout
- Now matches the behavior of other cancel-failure paths (daemon not connected, send failed, error during cancel)

## Test plan

- [ ] Verify TypeScript type-checks pass (`bunx tsc --noEmit`)
- [ ] Test cancel during tool execution — no unhandled promise rejection in logs
- [ ] Test cancel timeout scenario — queued messages should reset to sent state

🤖 Generated with [Claude Code](https://claude.com/claude-code)