### PR TITLE
Add priority-based trust rule system

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -444,6 +444,33 @@ describe('Permission Checker', () => {
       const result = await check('web_fetch', { url: 'https://example.com/%70rivate/doc' }, '/tmp');
       expect(result.decision).toBe('deny');
     });
+
+    // Priority-based rule resolution
+    test('higher-priority allow rule overrides lower-priority deny rule', async () => {
+      addRule('bash', 'rm *', '/tmp', 'deny', 0);
+      addRule('bash', 'rm *', '/tmp', 'allow', 100);
+      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('allow');
+    });
+
+    test('higher-priority deny rule overrides lower-priority allow rule', async () => {
+      addRule('bash', 'rm *', '/tmp', 'allow', 0);
+      addRule('bash', 'rm *', '/tmp', 'deny', 100);
+      const result = await check('bash', { command: 'rm file.txt' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
+
+    test('high-risk command still prompts even with high-priority allow rule', async () => {
+      addRule('bash', 'sudo *', 'everywhere', 'allow', 100);
+      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+    });
+
+    test('high-risk command is denied by deny rule without prompting', async () => {
+      addRule('bash', 'sudo *', 'everywhere', 'deny', 100);
+      const result = await check('bash', { command: 'sudo rm -rf /' }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
   });
 
   // ── generateAllowlistOptions ───────────────────────────────────

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1,13 +1,14 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 
 // Create a temp directory for the trust file
 const testDir = mkdtempSync(join(tmpdir(), 'trust-store-test-'));
 
 // Mock platform module so trust-store writes to temp dir instead of ~/.vellum
 mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
   getDataDir: () => testDir,
   isMacOS: () => process.platform === 'darwin',
   isLinux: () => process.platform === 'linux',
@@ -37,13 +38,14 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { addRule, removeRule, findMatchingRule, findDenyRule, getAllRules, clearCache } from '../permissions/trust-store.js';
+import { addRule, removeRule, findMatchingRule, findDenyRule, findHighestPriorityRule, getAllRules, clearCache } from '../permissions/trust-store.js';
+
+const trustPath = join(testDir, 'protected', 'trust.json');
 
 describe('Trust Store', () => {
   beforeEach(() => {
     // Clear cached rules and remove the trust file between tests
     clearCache();
-    const trustPath = join(testDir, 'trust.json');
     try { rmSync(trustPath); } catch { /* may not exist */ }
   });
 
@@ -60,6 +62,7 @@ describe('Trust Store', () => {
       expect(rule.pattern).toBe('git *');
       expect(rule.scope).toBe('/home/user/project');
       expect(rule.decision).toBe('allow');
+      expect(rule.priority).toBe(100);
       expect(rule.createdAt).toBeGreaterThan(0);
     });
 
@@ -71,12 +74,12 @@ describe('Trust Store', () => {
 
     test('persists rule to disk', () => {
       addRule('bash', 'git push', '/home/user');
-      const trustPath = join(testDir, 'trust.json');
       const raw = readFileSync(trustPath, 'utf-8');
       const data = JSON.parse(raw);
-      expect(data.version).toBe(1);
+      expect(data.version).toBe(2);
       expect(data.rules).toHaveLength(1);
       expect(data.rules[0].pattern).toBe('git push');
+      expect(data.rules[0].priority).toBe(100);
     });
 
     test('multiple rules accumulate', () => {
@@ -84,6 +87,34 @@ describe('Trust Store', () => {
       addRule('file_write', '/tmp/*', '/tmp');
       addRule('bash', 'npm *', '/tmp');
       expect(getAllRules()).toHaveLength(3);
+    });
+
+    test('default priority is 100', () => {
+      const rule = addRule('bash', 'git *', '/tmp');
+      expect(rule.priority).toBe(100);
+    });
+
+    test('custom priority is respected', () => {
+      const rule = addRule('bash', 'git *', '/tmp', 'allow', 5);
+      expect(rule.priority).toBe(5);
+    });
+
+    test('rules are sorted by priority descending in getAllRules', () => {
+      addRule('bash', 'low *', '/tmp', 'allow', 0);
+      addRule('bash', 'high *', '/tmp', 'allow', 2);
+      addRule('bash', 'med *', '/tmp', 'allow', 1);
+      const rules = getAllRules();
+      expect(rules[0].priority).toBe(2);
+      expect(rules[1].priority).toBe(1);
+      expect(rules[2].priority).toBe(0);
+    });
+
+    test('at same priority deny rules sort before allow rules', () => {
+      addRule('bash', 'allow *', '/tmp', 'allow', 100);
+      addRule('bash', 'deny *', '/tmp', 'deny', 100);
+      const rules = getAllRules();
+      expect(rules[0].decision).toBe('deny');
+      expect(rules[1].decision).toBe('allow');
     });
   });
 
@@ -212,6 +243,63 @@ describe('Trust Store', () => {
     });
   });
 
+  // ── findHighestPriorityRule ──────────────────────────────────────
+
+  describe('findHighestPriorityRule', () => {
+    test('returns highest priority matching rule', () => {
+      addRule('bash', 'rm *', '/tmp', 'allow', 0);
+      addRule('bash', 'rm *', '/tmp', 'deny', 100);
+      const match = findHighestPriorityRule('bash', ['rm file.txt'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.decision).toBe('deny');
+      expect(match!.priority).toBe(100);
+    });
+
+    test('higher priority allow beats lower priority deny', () => {
+      addRule('bash', 'rm *', '/tmp', 'deny', 0);
+      addRule('bash', 'rm *', '/tmp', 'allow', 100);
+      const match = findHighestPriorityRule('bash', ['rm file.txt'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.decision).toBe('allow');
+    });
+
+    test('same priority: deny beats allow', () => {
+      addRule('bash', 'rm *', '/tmp', 'allow', 100);
+      addRule('bash', 'rm *', '/tmp', 'deny', 100);
+      const match = findHighestPriorityRule('bash', ['rm file.txt'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.decision).toBe('deny');
+    });
+
+    test('checks multiple command candidates', () => {
+      addRule('web_fetch', 'web_fetch:https://example.com/*', '/tmp', 'allow');
+      const match = findHighestPriorityRule(
+        'web_fetch',
+        ['web_fetch:https://example.com/page', 'web_fetch:https://example.com/*'],
+        '/tmp',
+      );
+      expect(match).not.toBeNull();
+    });
+
+    test('returns null when no rule matches', () => {
+      addRule('bash', 'git *', '/tmp', 'allow');
+      const match = findHighestPriorityRule('bash', ['npm install'], '/tmp');
+      expect(match).toBeNull();
+    });
+
+    test('respects scope matching', () => {
+      addRule('bash', 'rm *', '/home/user/project', 'deny');
+      expect(findHighestPriorityRule('bash', ['rm file.txt'], '/home/user/project/sub')).not.toBeNull();
+      expect(findHighestPriorityRule('bash', ['rm file.txt'], '/home/other')).toBeNull();
+    });
+
+    test('everywhere scope matches any directory', () => {
+      addRule('bash', 'git *', 'everywhere', 'allow');
+      const match = findHighestPriorityRule('bash', ['git status'], '/any/random/path');
+      expect(match).not.toBeNull();
+    });
+  });
+
   // ── getAllRules ─────────────────────────────────────────────────
 
   describe('getAllRules', () => {
@@ -253,11 +341,11 @@ describe('Trust Store', () => {
 
     test('trust file has correct structure', () => {
       addRule('bash', 'git *', '/tmp');
-      const trustPath = join(testDir, 'trust.json');
       const data = JSON.parse(readFileSync(trustPath, 'utf-8'));
-      expect(data).toHaveProperty('version', 1);
+      expect(data).toHaveProperty('version', 2);
       expect(data).toHaveProperty('rules');
       expect(Array.isArray(data.rules)).toBe(true);
+      expect(data.rules[0]).toHaveProperty('priority', 100);
     });
   });
 
@@ -320,6 +408,50 @@ describe('Trust Store', () => {
       const rule = addRule('bash', 'rm *', '/tmp', 'deny');
       expect(removeRule(rule.id)).toBe(true);
       expect(findDenyRule('bash', 'rm file.txt', '/tmp')).toBeNull();
+    });
+  });
+
+  // ── v1 migration ───────────────────────────────────────────────
+
+  describe('v1 migration', () => {
+    test('v1 rules get priority 100 on load', () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(trustPath, JSON.stringify({
+        version: 1,
+        rules: [{
+          id: 'test-v1-id',
+          tool: 'bash',
+          pattern: 'git *',
+          scope: '/tmp',
+          decision: 'allow',
+          createdAt: 1000,
+        }],
+      }));
+      clearCache();
+      const rules = getAllRules();
+      expect(rules).toHaveLength(1);
+      expect(rules[0].priority).toBe(100);
+      expect(rules[0].id).toBe('test-v1-id');
+    });
+
+    test('v1 file is upgraded to v2 on disk', () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(trustPath, JSON.stringify({
+        version: 1,
+        rules: [{
+          id: 'migrate-me',
+          tool: 'bash',
+          pattern: 'npm *',
+          scope: 'everywhere',
+          decision: 'allow',
+          createdAt: 2000,
+        }],
+      }));
+      clearCache();
+      getAllRules(); // triggers load + migration
+      const data = JSON.parse(readFileSync(trustPath, 'utf-8'));
+      expect(data.version).toBe(2);
+      expect(data.rules[0].priority).toBe(100);
     });
   });
 });

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -420,14 +420,18 @@ trust
     const toolW = 12;
     const patternW = 30;
     const scopeW = 20;
+    const decW = 6;
+    const priW = 4;
     console.log(
       'ID'.padEnd(idW) +
       'Tool'.padEnd(toolW) +
       'Pattern'.padEnd(patternW) +
       'Scope'.padEnd(scopeW) +
+      'Dcn'.padEnd(decW) +
+      'Pri'.padEnd(priW) +
       'Created',
     );
-    console.log('-'.repeat(idW + toolW + patternW + scopeW + 20));
+    console.log('-'.repeat(idW + toolW + patternW + scopeW + decW + priW + 20));
     for (const r of rules) {
       const id = r.id.slice(0, 8);
       const created = new Date(r.createdAt).toISOString().slice(0, 10);
@@ -436,6 +440,8 @@ trust
         r.tool.padEnd(toolW) +
         r.pattern.slice(0, patternW - 2).padEnd(patternW) +
         r.scope.slice(0, scopeW - 2).padEnd(scopeW) +
+        r.decision.slice(0, decW - 1).padEnd(decW) +
+        String(r.priority).padEnd(priW) +
         created,
       );
     }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,5 +1,5 @@
 import { RiskLevel, type PermissionCheckResult, type AllowlistOption, type ScopeOption } from './types.js';
-import { findMatchingRule, findDenyRule } from './trust-store.js';
+import { findHighestPriorityRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
 import { resolveSkillSelector } from '../config/skills.js';
 import { getTool } from '../tools/registry.js';
@@ -263,30 +263,29 @@ export async function check(
   // Build command string candidates for rule matching
   const commandCandidates = buildCommandCandidates(toolName, input);
 
-  // Deny rules take precedence at ALL risk levels
-  for (const command of commandCandidates) {
-    const denyRule = findDenyRule(toolName, command, workingDir);
-    if (denyRule) {
-      return { decision: 'deny', reason: `Blocked by deny rule: ${denyRule.pattern}`, matchedRule: denyRule };
+  // Find the highest-priority matching rule across all candidates
+  const matchedRule = findHighestPriorityRule(toolName, commandCandidates, workingDir);
+
+  if (matchedRule) {
+    if (matchedRule.decision === 'deny') {
+      // Deny rules apply at ALL risk levels
+      return { decision: 'deny', reason: `Blocked by deny rule: ${matchedRule.pattern}`, matchedRule };
     }
+
+    // Allow rule: auto-allow for non-High risk
+    if (risk !== RiskLevel.High) {
+      return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };
+    }
+    // High risk with allow rule → fall through to prompt
   }
 
-  // High risk → always prompt, allow rules ignored
+  // No matching rule (or High risk with allow rule) → risk-based fallback
   if (risk === RiskLevel.High) {
     return { decision: 'prompt', reason: `High risk: always requires approval` };
   }
 
-  // Low risk → auto-allow
   if (risk === RiskLevel.Low) {
     return { decision: 'allow', reason: 'Low risk: auto-allowed' };
-  }
-
-  // Medium risk → check allow rules
-  for (const command of commandCandidates) {
-    const matchedRule = findMatchingRule(toolName, command, workingDir);
-    if (matchedRule) {
-      return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };
-    }
   }
 
   return { decision: 'prompt', reason: `${risk} risk: requires approval` };

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -1,0 +1,10 @@
+export interface DefaultRuleTemplate {
+  id: string;
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: 'allow' | 'deny';
+}
+
+/** Default trust rules shipped with the assistant. Backfilled at priority 0. */
+export const DEFAULT_RULE_TEMPLATES: DefaultRuleTemplate[] = [];

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -4,11 +4,12 @@ import { v4 as uuid } from 'uuid';
 import { minimatch } from 'minimatch';
 import { getRootDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
+import { DEFAULT_RULE_TEMPLATES } from './defaults.js';
 import type { TrustRule } from './types.js';
 
 const log = getLogger('trust-store');
 
-const TRUST_FILE_VERSION = 1;
+const TRUST_FILE_VERSION = 2;
 
 interface TrustFile {
   version: number;
@@ -21,23 +22,71 @@ function getTrustPath(): string {
   return join(getRootDir(), 'protected', 'trust.json');
 }
 
+/**
+ * Sort comparator: highest priority first. At the same priority, deny rules
+ * come before allow rules for safety (deny wins ties).
+ */
+function ruleOrder(a: TrustRule, b: TrustRule): number {
+  if (b.priority !== a.priority) return b.priority - a.priority;
+  if (a.decision !== b.decision) return a.decision === 'deny' ? -1 : 1;
+  return 0;
+}
+
 function loadFromDisk(): TrustRule[] {
   const path = getTrustPath();
-  if (!existsSync(path)) {
-    return [];
-  }
-  try {
-    const raw = readFileSync(path, 'utf-8');
-    const data = JSON.parse(raw) as TrustFile;
-    if (data.version !== TRUST_FILE_VERSION) {
-      log.warn({ version: data.version }, 'Unknown trust file version, ignoring');
+  let rules: TrustRule[] = [];
+  let needsSave = false;
+
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, 'utf-8');
+      const data = JSON.parse(raw) as TrustFile;
+
+      if (data.version === 1) {
+        // Migration: v1 → v2. All existing rules are user-created → priority 100.
+        rules = (data.rules ?? []).map((r) => ({
+          ...r,
+          priority: 100,
+        }));
+        needsSave = true;
+        log.info({ ruleCount: rules.length }, 'Migrated v1 trust rules to v2 (priority=100)');
+      } else if (data.version === TRUST_FILE_VERSION) {
+        rules = data.rules ?? [];
+      } else {
+        log.warn({ version: data.version }, 'Unknown trust file version, ignoring');
+        return [];
+      }
+    } catch (err) {
+      log.error({ err }, 'Failed to load trust file');
       return [];
     }
-    return data.rules ?? [];
-  } catch (err) {
-    log.error({ err }, 'Failed to load trust file');
-    return [];
   }
+
+  // Backfill default rules (priority 0)
+  const existingIds = new Set(rules.map((r) => r.id));
+  for (const template of DEFAULT_RULE_TEMPLATES) {
+    if (!existingIds.has(template.id)) {
+      rules.push({
+        id: template.id,
+        tool: template.tool,
+        pattern: template.pattern,
+        scope: template.scope,
+        decision: template.decision,
+        priority: 0,
+        createdAt: Date.now(),
+      });
+      needsSave = true;
+      log.info({ ruleId: template.id }, 'Backfilled default trust rule');
+    }
+  }
+
+  rules.sort(ruleOrder);
+
+  if (needsSave) {
+    saveToDisk(rules);
+  }
+
+  return rules;
 }
 
 function saveToDisk(rules: TrustRule[]): void {
@@ -59,7 +108,13 @@ function getRules(): TrustRule[] {
   return cachedRules;
 }
 
-export function addRule(tool: string, pattern: string, scope: string, decision: 'allow' | 'deny' = 'allow'): TrustRule {
+export function addRule(
+  tool: string,
+  pattern: string,
+  scope: string,
+  decision: 'allow' | 'deny' = 'allow',
+  priority: number = 100,
+): TrustRule {
   // Re-read from disk to avoid lost updates if another call modified rules
   // between our last read and now (e.g. two rapid trust rule additions).
   cachedRules = null;
@@ -70,9 +125,11 @@ export function addRule(tool: string, pattern: string, scope: string, decision: 
     pattern,
     scope,
     decision,
+    priority,
     createdAt: Date.now(),
   };
   rules.push(rule);
+  rules.sort(ruleOrder);
   cachedRules = rules;
   saveToDisk(rules);
   log.info({ rule }, 'Added trust rule');
@@ -92,15 +149,37 @@ export function removeRule(id: string): boolean {
   return true;
 }
 
+function matchesScope(ruleScope: string, workingDir: string): boolean {
+  if (ruleScope === 'everywhere') return true;
+  return workingDir.startsWith(ruleScope.replace(/\*$/, ''));
+}
+
 function findRuleByDecision(tool: string, command: string, scope: string, decision: 'allow' | 'deny'): TrustRule | null {
   const rules = getRules();
   for (const rule of rules) {
     if (rule.tool !== tool) continue;
     if (rule.decision !== decision) continue;
     if (!minimatch(command, rule.pattern)) continue;
-    // Scope check: rule scope must be a prefix of the working dir, or 'everywhere'
-    if (rule.scope !== 'everywhere' && !scope.startsWith(rule.scope.replace(/\*$/, ''))) continue;
+    if (!matchesScope(rule.scope, scope)) continue;
     return rule;
+  }
+  return null;
+}
+
+/**
+ * Find the highest-priority rule that matches any of the command candidates.
+ * Rules are pre-sorted by priority descending, so the first match wins.
+ */
+export function findHighestPriorityRule(tool: string, commands: string[], scope: string): TrustRule | null {
+  const rules = getRules();
+  for (const rule of rules) {
+    if (rule.tool !== tool) continue;
+    if (!matchesScope(rule.scope, scope)) continue;
+    for (const command of commands) {
+      if (minimatch(command, rule.pattern)) {
+        return rule;
+      }
+    }
   }
   return null;
 }

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -10,6 +10,7 @@ export interface TrustRule {
   pattern: string;
   scope: string;
   decision: 'allow' | 'deny';
+  priority: number;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary
- Trust rules now have a `priority` field — default rules from code are backfilled at priority 0, user-created rules get priority 100
- Evaluation uses a unified priority-sorted lookup (`findHighestPriorityRule`) instead of separate deny-first/allow-second passes — highest priority matching rule wins
- Includes v1→v2 trust file migration (existing rules get priority 100), same-priority tie-breaking (deny wins), and `trust list` now shows Decision and Priority columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
