### PR TITLE
Add trust rule UI to tool confirmation dialogs

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -607,3 +607,13 @@ exports[`IPC message snapshots ServerMessage types timer_completed serializes to
   "type": "timer_completed",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "pattern": "git *",
+  "scope": "/projects/my-app",
+  "toolName": "bash",
+  "type": "add_trust_rule",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -130,6 +130,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     sessionId: 'sess-001',
     requestId: 'req-suggest-001',
   },
+  add_trust_rule: {
+    type: 'add_trust_rule',
+    toolName: 'bash',
+    pattern: 'git *',
+    scope: '/projects/my-app',
+    decision: 'allow',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -28,7 +28,9 @@ import type {
   AppDataRequest,
   SkillDetailRequest,
   SuggestionRequest,
+  AddTrustRule,
 } from './ipc-protocol.js';
+import { addRule } from '../permissions/trust-store.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
@@ -291,6 +293,7 @@ const handlers: DispatchMap = {
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
   suggestion_request: handleSuggestionRequest,
+  add_trust_rule: handleAddTrustRule,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -794,6 +797,21 @@ async function handleTaskSubmit(
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error handling task_submit');
     ctx.send(socket, { type: 'error', message: `Failed to route task: ${message}` });
+  }
+}
+
+// ─── Trust rule handler ─────────────────────────────────────────────────────
+
+function handleAddTrustRule(
+  msg: AddTrustRule,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
+): void {
+  try {
+    addRule(msg.toolName, msg.pattern, msg.scope, msg.decision);
+    log.info({ tool: msg.toolName, pattern: msg.pattern, scope: msg.scope, decision: msg.decision }, 'Trust rule added via client');
+  } catch (err) {
+    log.error({ err }, 'Failed to add trust rule');
   }
 }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -155,6 +155,14 @@ export interface SuggestionRequest {
   requestId: string;
 }
 
+export interface AddTrustRule {
+  type: 'add_trust_rule';
+  toolName: string;
+  pattern: string;
+  scope: string;
+  decision: 'allow' | 'deny';
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'table' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -282,7 +290,8 @@ export type ClientMessage =
   | AppDataRequest
   | SkillsListRequest
   | SkillDetailRequest
-  | SuggestionRequest;
+  | SuggestionRequest
+  | AddTrustRule;
 
 // === Server → Client messages ===
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -228,6 +228,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             return true
         }
+        toolConfirmationManager.onAddTrustRule = { [weak self] toolName, pattern, scope, decision in
+            do {
+                try self?.daemonClient.sendAddTrustRule(
+                    toolName: toolName,
+                    pattern: pattern,
+                    scope: scope,
+                    decision: decision
+                )
+            } catch {
+                log.error("Failed to send add_trust_rule: \(error.localizedDescription)")
+            }
+        }
     }
 
     private func setupWindowObserver() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -25,7 +25,19 @@ struct ToolConfirmationData: Equatable {
     let toolName: String
     let riskLevel: String
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
+    let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
     var state: ToolConfirmationState = .pending
+
+    init(requestId: String, toolName: String, riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], state: ToolConfirmationState = .pending) {
+        self.requestId = requestId
+        self.toolName = toolName
+        self.riskLevel = riskLevel
+        self.diff = diff
+        self.allowlistOptions = allowlistOptions
+        self.scopeOptions = scopeOptions
+        self.state = state
+    }
 }
 
 /// Data for a tool call displayed inline in an assistant message.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
     let onMicrophoneToggle: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
+    let onAddTrustRule: (String, String, String, String) -> Void
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -88,7 +89,8 @@ struct ChatView: View {
                             ToolConfirmationBubble(
                                 confirmation: confirmation,
                                 onAllow: { onConfirmationAllow(confirmation.requestId) },
-                                onDeny: { onConfirmationDeny(confirmation.requestId) }
+                                onDeny: { onConfirmationDeny(confirmation.requestId) },
+                                onAddTrustRule: onAddTrustRule
                             )
                             .id(message.id)
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -862,6 +864,7 @@ private struct MicrophoneButton: View {
             onMicrophoneToggle: {},
             onConfirmationAllow: { _ in },
             onConfirmationDeny: { _ in },
+            onAddTrustRule: { _, _, _, _ in },
             onSurfaceAction: { _, _, _ in }
         )
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -617,7 +617,9 @@ final class ChatViewModel: ObservableObject {
                 requestId: msg.requestId,
                 toolName: msg.toolName,
                 riskLevel: msg.riskLevel,
-                diff: msg.diff
+                diff: msg.diff,
+                allowlistOptions: msg.allowlistOptions,
+                scopeOptions: msg.scopeOptions
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,
@@ -905,6 +907,24 @@ final class ChatViewModel: ObservableObject {
             default:
                 break
             }
+        }
+    }
+
+    /// Send an add_trust_rule message to persist a trust rule (fire-and-forget).
+    func addTrustRule(toolName: String, pattern: String, scope: String, decision: String) {
+        guard daemonClient.isConnected else {
+            log.warning("Cannot send add_trust_rule: daemon not connected")
+            return
+        }
+        do {
+            try daemonClient.sendAddTrustRule(
+                toolName: toolName,
+                pattern: pattern,
+                scope: scope,
+                decision: decision
+            )
+        } catch {
+            log.error("Failed to send add_trust_rule: \(error.localizedDescription)")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -4,8 +4,18 @@ struct ToolConfirmationBubble: View {
     let confirmation: ToolConfirmationData
     let onAllow: () -> Void
     let onDeny: () -> Void
+    let onAddTrustRule: (String, String, String, String) -> Void
+
+    @State private var showRulePicker = false
+    @State private var selectedPattern: String = ""
+    @State private var selectedScope: String = ""
+    @State private var ruleSaved = false
 
     private var isHighRisk: Bool { confirmation.riskLevel.lowercased() == "high" }
+
+    private var hasRuleOptions: Bool {
+        !confirmation.allowlistOptions.isEmpty && !confirmation.scopeOptions.isEmpty
+    }
 
     private var toolDisplayName: String {
         switch confirmation.toolName {
@@ -83,22 +93,42 @@ struct ToolConfirmationBubble: View {
                     }
                 }
 
-            case .approved:
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
-                    Text("Allowed")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.success)
+            case .approved, .denied:
+                decisionLabel
+
+                if hasRuleOptions && !ruleSaved {
+                    if showRulePicker {
+                        rulePickerView
+                    } else {
+                        HStack {
+                            Spacer()
+                            VButton(
+                                label: confirmation.state == .approved ? "Add to Allowlist" : "Add to Denylist",
+                                style: .ghost
+                            ) {
+                                if selectedPattern.isEmpty, let first = confirmation.allowlistOptions.first {
+                                    selectedPattern = first.pattern
+                                }
+                                if selectedScope.isEmpty, let first = confirmation.scopeOptions.first {
+                                    selectedScope = first.scope
+                                }
+                                withAnimation(VAnimation.standard) {
+                                    showRulePicker = true
+                                }
+                            }
+                        }
+                    }
                 }
 
-            case .denied:
-                HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(VColor.error)
-                    Text("Denied")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.error)
+                if ruleSaved {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(VColor.success)
+                        Text("Rule saved")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.success)
+                    }
+                    .transition(.opacity)
                 }
 
             case .timedOut:
@@ -122,6 +152,104 @@ struct ToolConfirmationBubble: View {
         )
         .frame(maxWidth: 520)
     }
+
+    @ViewBuilder
+    private var decisionLabel: some View {
+        if confirmation.state == .approved {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(VColor.success)
+                Text("Allowed")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.success)
+            }
+        } else {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(VColor.error)
+                Text("Denied")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var rulePickerView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Pattern picker
+            if confirmation.allowlistOptions.count > 1 {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Pattern")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Picker("", selection: $selectedPattern) {
+                        ForEach(confirmation.allowlistOptions, id: \.pattern) { option in
+                            Text(option.label).tag(option.pattern)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                }
+            } else if let single = confirmation.allowlistOptions.first {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Pattern:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Text(single.label)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+
+            // Scope picker
+            if confirmation.scopeOptions.count > 1 {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Scope")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Picker("", selection: $selectedScope) {
+                        ForEach(confirmation.scopeOptions, id: \.scope) { option in
+                            Text(option.label).tag(option.scope)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                }
+            } else if let single = confirmation.scopeOptions.first {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Scope:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Text(single.label)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+
+            // Save / Cancel
+            HStack(spacing: VSpacing.md) {
+                Spacer()
+                VButton(label: "Cancel", style: .ghost) {
+                    withAnimation(VAnimation.standard) {
+                        showRulePicker = false
+                    }
+                }
+                VButton(label: "Save Rule", style: .primary) {
+                    let ruleDecision = confirmation.state == .approved ? "allow" : "deny"
+                    onAddTrustRule(confirmation.toolName, selectedPattern, selectedScope, ruleDecision)
+                    withAnimation(VAnimation.standard) {
+                        showRulePicker = false
+                        ruleSaved = true
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(VColor.backgroundSubtle)
+        .cornerRadius(VRadius.md)
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
 }
 
 #if DEBUG
@@ -132,10 +260,19 @@ struct ToolConfirmationBubble: View {
                 requestId: "test-1",
                 toolName: "bash",
                 riskLevel: "medium",
-                diff: nil
+                diff: nil,
+                allowlistOptions: [
+                    .init(label: "git push", pattern: "git push"),
+                    .init(label: "All git commands", pattern: "git *"),
+                ],
+                scopeOptions: [
+                    .init(label: "This project", scope: "/Users/test/project"),
+                    .init(label: "Everywhere", scope: "everywhere"),
+                ]
             ),
             onAllow: {},
-            onDeny: {}
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in }
         )
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
@@ -150,7 +287,8 @@ struct ToolConfirmationBubble: View {
                 )
             ),
             onAllow: {},
-            onDeny: {}
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in }
         )
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
@@ -158,10 +296,17 @@ struct ToolConfirmationBubble: View {
                 toolName: "bash",
                 riskLevel: "medium",
                 diff: nil,
+                allowlistOptions: [
+                    .init(label: "npm install", pattern: "npm install"),
+                ],
+                scopeOptions: [
+                    .init(label: "Everywhere", scope: "everywhere"),
+                ],
                 state: .approved
             ),
             onAllow: {},
-            onDeny: {}
+            onDeny: {},
+            onAddTrustRule: { _, _, _, _ in }
         )
     }
     .padding(VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,6 +64,7 @@ struct MainWindowView: View {
                             onMicrophoneToggle: onMicrophoneToggle,
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
+                            onAddTrustRule: { toolName, pattern, scope, decision in viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
                             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) }
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -18,26 +18,43 @@ final class ToolConfirmationManager {
 
     /// Called when the user responds to a floating confirmation panel.
     /// Returns `true` if the IPC send succeeded, `false` otherwise.
-    /// The panel is only dismissed on success.
     var onResponse: ((String, String) -> Bool)?
+
+    /// Called when the user saves a trust rule from the floating panel.
+    var onAddTrustRule: ((String, String, String, String) -> Void)?
 
     func showConfirmation(_ message: ConfirmationRequestMessage) {
         // Dismiss existing panel for same request, if any
         dismissConfirmation(requestId: message.requestId)
 
+        let hasRuleOptions = !message.allowlistOptions.isEmpty && !message.scopeOptions.isEmpty
+
         let view = ToolConfirmationView(
             toolName: message.toolName,
             riskLevel: message.riskLevel,
             diff: message.diff,
+            allowlistOptions: message.allowlistOptions,
+            scopeOptions: message.scopeOptions,
             onAllow: { [weak self] in
                 self?.respond(requestId: message.requestId, decision: "allow")
             },
             onDeny: { [weak self] in
                 self?.respond(requestId: message.requestId, decision: "deny")
+            },
+            onDismiss: { [weak self] in
+                self?.dismissConfirmation(requestId: message.requestId)
+            },
+            onAddTrustRule: { [weak self] toolName, pattern, scope, decision in
+                self?.onAddTrustRule?(toolName, pattern, scope, decision)
+                // Auto-dismiss after saving rule
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    self?.dismissConfirmation(requestId: message.requestId)
+                }
             }
         )
 
         let hostingController = NSHostingController(rootView: view)
+        hostingController.sizingOptions = .preferredContentSize
 
         let panelHeight: CGFloat = message.diff != nil ? 340 : 160
         let panel = NSPanel(
@@ -84,12 +101,9 @@ final class ToolConfirmationManager {
     }
 
     private func respond(requestId: String, decision: String) {
-        // Only dismiss the panel if the IPC send succeeds. If it fails,
-        // the panel stays visible so the user can retry.
-        let success = onResponse?(requestId, decision) ?? true
-        if success {
-            dismissConfirmation(requestId: requestId)
-        }
+        // Send the IPC response. If it fails, the panel stays visible
+        // (the ToolConfirmationView handles its own state transition).
+        _ = onResponse?(requestId, decision)
     }
 }
 
@@ -99,10 +113,29 @@ struct ToolConfirmationView: View {
     let toolName: String
     let riskLevel: String
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
+    let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
+    let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
     let onAllow: () -> Void
     let onDeny: () -> Void
+    let onDismiss: () -> Void
+    let onAddTrustRule: (String, String, String, String) -> Void
+
+    enum Phase: Equatable {
+        case pending
+        case decided(String)
+        case pickingRule(String)
+        case ruleSaved
+    }
+
+    @State private var phase: Phase = .pending
+    @State private var selectedPattern: String = ""
+    @State private var selectedScope: String = ""
 
     private var isHighRisk: Bool { riskLevel.lowercased() == "high" }
+
+    private var hasRuleOptions: Bool {
+        !allowlistOptions.isEmpty && !scopeOptions.isEmpty
+    }
 
     private var toolDisplayName: String {
         switch toolName {
@@ -162,21 +195,155 @@ struct ToolConfirmationView: View {
                 }
             }
 
-            // Action buttons
-            HStack(spacing: VSpacing.lg) {
-                Spacer()
-
-                VButton(label: "Deny", style: .ghost) {
-                    onDeny()
+            // Phase-dependent content
+            switch phase {
+            case .pending:
+                HStack(spacing: VSpacing.lg) {
+                    Spacer()
+                    VButton(label: "Deny", style: .ghost) {
+                        onDeny()
+                        if hasRuleOptions {
+                            withAnimation(VAnimation.standard) { phase = .decided("deny") }
+                        } else {
+                            onDismiss()
+                        }
+                    }
+                    VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
+                        onAllow()
+                        if hasRuleOptions {
+                            withAnimation(VAnimation.standard) { phase = .decided("allow") }
+                        } else {
+                            onDismiss()
+                        }
+                    }
                 }
 
-                VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
-                    onAllow()
+            case .decided(let decision):
+                decisionLabel(for: decision)
+
+                HStack(spacing: VSpacing.md) {
+                    Spacer()
+                    VButton(label: "Done", style: .ghost) {
+                        onDismiss()
+                    }
+                    VButton(
+                        label: decision == "allow" ? "Add to Allowlist" : "Add to Denylist",
+                        style: .ghost
+                    ) {
+                        if selectedPattern.isEmpty, let first = allowlistOptions.first {
+                            selectedPattern = first.pattern
+                        }
+                        if selectedScope.isEmpty, let first = scopeOptions.first {
+                            selectedScope = first.scope
+                        }
+                        withAnimation(VAnimation.standard) { phase = .pickingRule(decision) }
+                    }
+                }
+
+            case .pickingRule(let decision):
+                decisionLabel(for: decision)
+                rulePickerView(decision: decision)
+
+            case .ruleSaved:
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("Rule saved")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
                 }
             }
         }
         .padding(VSpacing.xl)
         .frame(width: 420)
         .vPanelBackground()
+    }
+
+    @ViewBuilder
+    private func decisionLabel(for decision: String) -> some View {
+        if decision == "allow" {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(VColor.success)
+                Text("Allowed")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.success)
+            }
+        } else {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(VColor.error)
+                Text("Denied")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rulePickerView(decision: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if allowlistOptions.count > 1 {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Pattern")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Picker("", selection: $selectedPattern) {
+                        ForEach(allowlistOptions, id: \.pattern) { option in
+                            Text(option.label).tag(option.pattern)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                }
+            } else if let single = allowlistOptions.first {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Pattern:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Text(single.label)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+
+            if scopeOptions.count > 1 {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Scope")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Picker("", selection: $selectedScope) {
+                        ForEach(scopeOptions, id: \.scope) { option in
+                            Text(option.label).tag(option.scope)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                }
+            } else if let single = scopeOptions.first {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Scope:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Text(single.label)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(VColor.textPrimary)
+                }
+            }
+
+            HStack(spacing: VSpacing.md) {
+                Spacer()
+                VButton(label: "Cancel", style: .ghost) {
+                    onDismiss()
+                }
+                VButton(label: "Save Rule", style: .primary) {
+                    onAddTrustRule(toolName, selectedPattern, selectedScope, decision)
+                    withAnimation(VAnimation.standard) { phase = .ruleSaved }
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .background(VColor.surface)
+        .cornerRadius(VRadius.md)
     }
 }

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -308,6 +308,23 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         ))
     }
 
+    // MARK: - Trust Rule Addition
+
+    /// Send an add_trust_rule message to persist a trust rule on the daemon.
+    func sendAddTrustRule(
+        toolName: String,
+        pattern: String,
+        scope: String,
+        decision: String
+    ) throws {
+        try send(AddTrustRuleMessage(
+            toolName: toolName,
+            pattern: pattern,
+            scope: scope,
+            decision: decision
+        ))
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -491,6 +491,16 @@ struct ConfirmationResponseMessage: Encodable, Sendable {
     let selectedScope: String?
 }
 
+/// Sent to add a trust rule (allowlist/denylist) independently of a confirmation response.
+/// Wire type: `"add_trust_rule"`
+struct AddTrustRuleMessage: Encodable, Sendable {
+    let type: String = "add_trust_rule"
+    let toolName: String
+    let pattern: String
+    let scope: String
+    let decision: String
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {


### PR DESCRIPTION
## Summary
- After clicking Allow or Deny in tool confirmation dialogs, an "Add to Allowlist/Denylist" button now appears
- Clicking it reveals pattern and scope pickers (populated from daemon-provided options) to create persistent trust rules
- Adds a new `add_trust_rule` IPC message type so rule creation is decoupled from the confirmation response — tools proceed immediately while rule saving is fire-and-forget
- Works in both the inline chat bubble and the floating panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
