### PR TITLE
Add trust rule UI to webapp tool confirmation flow

### DIFF
--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -21,6 +21,8 @@ export interface PendingConfirmation {
   toolUseId: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  allowlistOptions?: Array<{ label: string; pattern: string }>;
+  scopeOptions?: Array<{ label: string; scope: string }>;
 }
 
 export interface Run {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -17,6 +17,7 @@ import * as channelDeliveryStore from '../memory/channel-delivery-store.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
 import { getConfig } from '../config/loader.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
+import { addRule } from '../permissions/trust-store.js';
 
 const log = getLogger('runtime-http');
 
@@ -136,12 +137,15 @@ export class RuntimeHttpServer {
         return await this.handleCreateRun(assistantId, req);
       }
 
-      // Match runs/:runId and runs/:runId/decision
-      const runsMatch = endpoint.match(/^runs\/([^/]+)(\/decision)?$/);
+      // Match runs/:runId, runs/:runId/decision, runs/:runId/trust-rule
+      const runsMatch = endpoint.match(/^runs\/([^/]+)(\/decision|\/trust-rule)?$/);
       if (runsMatch) {
         const runId = runsMatch[1];
         if (runsMatch[2] === '/decision' && req.method === 'POST') {
           return await this.handleRunDecision(assistantId, runId, req);
+        }
+        if (runsMatch[2] === '/trust-rule' && req.method === 'POST') {
+          return await this.handleAddTrustRule(req);
         }
         if (req.method === 'GET') {
           return this.handleGetRun(assistantId, runId);
@@ -549,6 +553,39 @@ export class RuntimeHttpServer {
     }
 
     return Response.json({ accepted: true });
+  }
+
+  private async handleAddTrustRule(req: Request): Promise<Response> {
+    const body = await req.json() as {
+      toolName?: string;
+      pattern?: string;
+      scope?: string;
+      decision?: string;
+    };
+
+    const { toolName, pattern, scope, decision } = body;
+
+    if (!toolName || typeof toolName !== 'string') {
+      return Response.json({ error: 'toolName is required' }, { status: 400 });
+    }
+    if (!pattern || typeof pattern !== 'string') {
+      return Response.json({ error: 'pattern is required' }, { status: 400 });
+    }
+    if (!scope || typeof scope !== 'string') {
+      return Response.json({ error: 'scope is required' }, { status: 400 });
+    }
+    if (decision !== 'allow' && decision !== 'deny') {
+      return Response.json({ error: 'decision must be "allow" or "deny"' }, { status: 400 });
+    }
+
+    try {
+      addRule(toolName, pattern, scope, decision);
+      log.info({ tool: toolName, pattern, scope, decision }, 'Trust rule added via HTTP');
+      return Response.json({ accepted: true });
+    } catch (err) {
+      log.error({ err }, 'Failed to add trust rule');
+      return Response.json({ error: 'Failed to add trust rule' }, { status: 500 });
+    }
   }
 
   // ── Attachment endpoints ────────────────────────────────────────────

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -92,6 +92,8 @@ export class RunOrchestrator {
           toolUseId: msg.requestId,
           input: msg.input,
           riskLevel: msg.riskLevel,
+          allowlistOptions: msg.allowlistOptions,
+          scopeOptions: msg.scopeOptions,
         });
         this.pending.set(run.id, {
           prompterRequestId: msg.requestId,

--- a/web/src/app/api/assistants/[id]/runs/[runId]/trust-rule/route.ts
+++ b/web/src/app/api/assistants/[id]/runs/[runId]/trust-rule/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAssistantById } from "@/lib/db";
+import { createRuntimeClient, RuntimeClientError } from "@/lib/runtime/client";
+import { resolveRuntime } from "@/lib/runtime/resolver";
+
+interface RouteParams {
+  params: Promise<{ id: string; runId: string }>;
+}
+
+export const runtime = "nodejs";
+
+function getRuntimeClient(assistantId: string) {
+  const { baseUrl } = resolveRuntime(assistantId);
+  return createRuntimeClient(baseUrl, assistantId);
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: assistantId, runId } = await params;
+
+    const assistant = await getAssistantById(assistantId);
+    if (!assistant) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    const body = await request.json() as {
+      toolName?: unknown;
+      pattern?: unknown;
+      scope?: unknown;
+      decision?: unknown;
+    };
+
+    const { toolName, pattern, scope, decision } = body;
+
+    if (!toolName || typeof toolName !== "string") {
+      return NextResponse.json({ error: "toolName is required" }, { status: 400 });
+    }
+    if (!pattern || typeof pattern !== "string") {
+      return NextResponse.json({ error: "pattern is required" }, { status: 400 });
+    }
+    if (!scope || typeof scope !== "string") {
+      return NextResponse.json({ error: "scope is required" }, { status: 400 });
+    }
+    if (decision !== "allow" && decision !== "deny") {
+      return NextResponse.json(
+        { error: "decision must be \"allow\" or \"deny\"" },
+        { status: 400 },
+      );
+    }
+
+    const client = getRuntimeClient(assistantId);
+    const result = await client.addTrustRule(runId, {
+      toolName,
+      pattern,
+      scope,
+      decision,
+    });
+
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    console.error("Error adding trust rule:", error);
+    const status = error instanceof RuntimeClientError ? error.httpStatus : 500;
+    return NextResponse.json(
+      { error: "Failed to add trust rule" },
+      { status },
+    );
+  }
+}

--- a/web/src/components/app/pages/RightPanel/InteractionTab.tsx
+++ b/web/src/components/app/pages/RightPanel/InteractionTab.tsx
@@ -3,6 +3,7 @@
 import {
   AlertTriangle,
   Bot,
+  Check,
   ChevronDown,
   ChevronRight,
   FileImage,
@@ -77,11 +78,23 @@ interface PendingAttachment {
   error?: string;
 }
 
+interface AllowlistOption {
+  label: string;
+  pattern: string;
+}
+
+interface ScopeOption {
+  label: string;
+  scope: string;
+}
+
 interface PendingRunConfirmation {
   toolName: string;
   toolUseId: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  allowlistOptions?: AllowlistOption[];
+  scopeOptions?: ScopeOption[];
 }
 
 interface InteractionTabProps {
@@ -177,6 +190,13 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingRunConfirmation | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  // Trust rule picker state (shown after Allow/Deny)
+  const [confirmationDecision, setConfirmationDecision] = useState<"allow" | "deny" | null>(null);
+  const [decidedConfirmation, setDecidedConfirmation] = useState<PendingRunConfirmation | null>(null);
+  const [showRulePicker, setShowRulePicker] = useState(false);
+  const [selectedPattern, setSelectedPattern] = useState("");
+  const [selectedScope, setSelectedScope] = useState("");
+  const [ruleSaved, setRuleSaved] = useState(false);
 
   const handleVoiceTranscript = useCallback((text: string) => {
     setInput((prev) => (prev ? `${prev} ${text}` : text));
@@ -699,7 +719,18 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
   const handleDecision = useCallback(async (decision: "allow" | "deny") => {
     if (!activeRunId) return;
 
+    const conf = pendingConfirmation;
     setPendingConfirmation(null);
+
+    // Save state for the trust rule picker
+    if (conf) {
+      setDecidedConfirmation(conf);
+      setConfirmationDecision(decision);
+      setShowRulePicker(false);
+      setRuleSaved(false);
+      setSelectedPattern(conf.allowlistOptions?.[0]?.pattern ?? "");
+      setSelectedScope(conf.scopeOptions?.[0]?.scope ?? "");
+    }
 
     try {
       const res = await fetch(`/api/assistants/${assistantId}/runs/${activeRunId}/decision`, {
@@ -713,7 +744,38 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
     } catch (error) {
       console.error("Failed to submit decision:", error);
     }
-  }, [activeRunId, assistantId]);
+  }, [activeRunId, assistantId, pendingConfirmation]);
+
+  const handleAddTrustRule = useCallback(async () => {
+    if (!activeRunId || !decidedConfirmation || !confirmationDecision || !selectedPattern || !selectedScope) return;
+
+    try {
+      const res = await fetch(`/api/assistants/${assistantId}/runs/${activeRunId}/trust-rule`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          toolName: decidedConfirmation.toolName,
+          pattern: selectedPattern,
+          scope: selectedScope,
+          decision: confirmationDecision,
+        }),
+      });
+      if (res.ok) {
+        setRuleSaved(true);
+        setShowRulePicker(false);
+        // Auto-dismiss after 2 seconds
+        setTimeout(() => {
+          setDecidedConfirmation(null);
+          setConfirmationDecision(null);
+          setRuleSaved(false);
+        }, 2000);
+      } else {
+        console.error("Failed to add trust rule");
+      }
+    } catch (error) {
+      console.error("Failed to add trust rule:", error);
+    }
+  }, [activeRunId, assistantId, decidedConfirmation, confirmationDecision, selectedPattern, selectedScope]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1012,6 +1074,105 @@ export function InteractionTab({ assistantId, assistantName, assistantCreatedAt 
                           Deny
                         </Button>
                       </div>
+                    </div>
+                  </div>
+                )}
+                {!pendingConfirmation && decidedConfirmation && confirmationDecision && (
+                  <div className="flex gap-3">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950">
+                      <ShieldAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+                    </div>
+                    <div className="max-w-[80%] rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950/50">
+                      <p className="text-sm text-amber-700 dark:text-amber-400">
+                        <span className="font-mono font-medium">{decidedConfirmation.toolName}</span>
+                        {" — "}
+                        <span className={confirmationDecision === "allow" ? "font-medium text-green-700 dark:text-green-400" : "font-medium text-red-700 dark:text-red-400"}>
+                          {confirmationDecision === "allow" ? "Allowed" : "Denied"}
+                        </span>
+                      </p>
+                      {ruleSaved ? (
+                        <div className="mt-2 flex items-center gap-1.5 text-sm text-green-700 dark:text-green-400">
+                          <Check className="h-4 w-4" />
+                          <span>Rule saved</span>
+                        </div>
+                      ) : showRulePicker ? (
+                        <div className="mt-3 space-y-2">
+                          {(decidedConfirmation.allowlistOptions?.length ?? 0) > 1 ? (
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-amber-700 dark:text-amber-400">Pattern</label>
+                              <select
+                                value={selectedPattern}
+                                onChange={(e) => setSelectedPattern(e.target.value)}
+                                className="w-full rounded-md border border-amber-300 bg-white px-2 py-1 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                              >
+                                {decidedConfirmation.allowlistOptions!.map((opt) => (
+                                  <option key={opt.pattern} value={opt.pattern}>{opt.label}</option>
+                                ))}
+                              </select>
+                            </div>
+                          ) : decidedConfirmation.allowlistOptions?.[0] ? (
+                            <div className="text-xs text-amber-700 dark:text-amber-400">
+                              <span className="font-medium">Pattern:</span>{" "}
+                              <span className="font-mono">{decidedConfirmation.allowlistOptions[0].label}</span>
+                            </div>
+                          ) : null}
+                          {(decidedConfirmation.scopeOptions?.length ?? 0) > 1 ? (
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-amber-700 dark:text-amber-400">Scope</label>
+                              <select
+                                value={selectedScope}
+                                onChange={(e) => setSelectedScope(e.target.value)}
+                                className="w-full rounded-md border border-amber-300 bg-white px-2 py-1 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                              >
+                                {decidedConfirmation.scopeOptions!.map((opt) => (
+                                  <option key={opt.scope} value={opt.scope}>{opt.label}</option>
+                                ))}
+                              </select>
+                            </div>
+                          ) : decidedConfirmation.scopeOptions?.[0] ? (
+                            <div className="text-xs text-amber-700 dark:text-amber-400">
+                              <span className="font-medium">Scope:</span>{" "}
+                              <span className="font-mono">{decidedConfirmation.scopeOptions[0].label}</span>
+                            </div>
+                          ) : null}
+                          <div className="flex gap-2 pt-1">
+                            <Button
+                              onClick={handleAddTrustRule}
+                              size="sm"
+                              className="bg-amber-600 text-white hover:bg-amber-700"
+                            >
+                              Save Rule
+                            </Button>
+                            <Button
+                              onClick={() => { setShowRulePicker(false); setDecidedConfirmation(null); setConfirmationDecision(null); }}
+                              size="sm"
+                              variant="ghost"
+                              className="text-amber-600 hover:bg-amber-100 dark:text-amber-400 dark:hover:bg-amber-900"
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (decidedConfirmation.allowlistOptions?.length ?? 0) > 0 && (decidedConfirmation.scopeOptions?.length ?? 0) > 0 ? (
+                        <div className="mt-2 flex gap-2">
+                          <Button
+                            onClick={() => setShowRulePicker(true)}
+                            size="sm"
+                            variant="ghost"
+                            className="text-amber-700 hover:bg-amber-100 dark:text-amber-400 dark:hover:bg-amber-900"
+                          >
+                            {confirmationDecision === "allow" ? "Add to Allowlist" : "Add to Denylist"}
+                          </Button>
+                          <Button
+                            onClick={() => { setDecidedConfirmation(null); setConfirmationDecision(null); }}
+                            size="sm"
+                            variant="ghost"
+                            className="text-amber-500 hover:bg-amber-100 dark:text-amber-500 dark:hover:bg-amber-900"
+                          >
+                            Dismiss
+                          </Button>
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                 )}

--- a/web/src/lib/runtime/client.ts
+++ b/web/src/lib/runtime/client.ts
@@ -25,6 +25,8 @@ import type {
   RunResponse,
   RunDecisionParams,
   RunDecisionResponse,
+  AddTrustRuleParams,
+  AddTrustRuleResponse,
 } from "./types";
 
 function sanitizeUrl(url: string): string {
@@ -161,6 +163,13 @@ export function createRuntimeClient(
 
     submitRunDecision(runId: string, params: RunDecisionParams) {
       return request<RunDecisionResponse>(`/runs/${runId}/decision`, {
+        method: "POST",
+        body: JSON.stringify(params),
+      });
+    },
+
+    addTrustRule(runId: string, params: AddTrustRuleParams) {
+      return request<AddTrustRuleResponse>(`/runs/${runId}/trust-rule`, {
         method: "POST",
         body: JSON.stringify(params),
       });

--- a/web/src/lib/runtime/types.ts
+++ b/web/src/lib/runtime/types.ts
@@ -137,6 +137,8 @@ export interface PendingConfirmation {
   toolUseId: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  allowlistOptions?: Array<{ label: string; pattern: string }>;
+  scopeOptions?: Array<{ label: string; scope: string }>;
 }
 
 export interface RunResponse {
@@ -154,6 +156,17 @@ export interface RunDecisionParams {
 }
 
 export interface RunDecisionResponse {
+  accepted: boolean;
+}
+
+export interface AddTrustRuleParams {
+  toolName: string;
+  pattern: string;
+  scope: string;
+  decision: "allow" | "deny";
+}
+
+export interface AddTrustRuleResponse {
   accepted: boolean;
 }
 
@@ -178,4 +191,5 @@ export interface RuntimeClient {
   createRun(params: CreateRunParams): Promise<RunResponse>;
   getRun(runId: string): Promise<RunResponse>;
   submitRunDecision(runId: string, params: RunDecisionParams): Promise<RunDecisionResponse>;
+  addTrustRule(runId: string, params: AddTrustRuleParams): Promise<AddTrustRuleResponse>;
 }


### PR DESCRIPTION
## Summary
- Extended `PendingConfirmation` to carry `allowlistOptions` and `scopeOptions` from the daemon's confirmation request through the HTTP run API
- Added `POST /runs/:runId/trust-rule` endpoint (backend HTTP server + webapp Next.js API route) that calls `addRule()` to persist trust rules
- Updated the webapp's tool confirmation dialog to show an "Add to Allowlist/Denylist" button after Allow/Deny, with pattern and scope pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
