### PR TITLE
Update thread tab bar style from flat to rectangular

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -22,7 +22,7 @@ struct ThreadTabBar: View {
                         icon: "flame",
                         isSelected: thread.id == activeThreadId,
                         isCloseable: threads.count > 1,
-                        style: .flat,
+                        style: .rectangular,
                         onSelect: { onSelect(thread.id) },
                         onClose: { onClose(thread.id) }
                     )


### PR DESCRIPTION
## Summary
- Change ThreadTabBar tab style from `.flat` to `.rectangular` for a more defined visual appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
