### PR TITLE
Revamp Agent panel with tabbed layout and pixel-art skill cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,11 +1,82 @@
 import SwiftUI
 
+// MARK: - Pixel Border Shape
+
+private struct PixelBorderShape: Shape {
+    let pixelSize: CGFloat
+    let cornerSteps: Int
+
+    init(pixelSize: CGFloat = 3, cornerSteps: Int = 3) {
+        self.pixelSize = pixelSize
+        self.cornerSteps = cornerSteps
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let s = pixelSize
+        let n = cornerSteps
+        let W = rect.width
+        let H = rect.height
+
+        var path = Path()
+
+        // Start at top edge after top-left corner
+        path.move(to: CGPoint(x: CGFloat(n) * s, y: 0))
+
+        // Top edge
+        path.addLine(to: CGPoint(x: W - CGFloat(n) * s, y: 0))
+
+        // Top-right corner (step right-down)
+        for i in 0..<n {
+            let fi = CGFloat(i)
+            path.addLine(to: CGPoint(x: W - CGFloat(n - 1 - i) * s, y: fi * s))
+            path.addLine(to: CGPoint(x: W - CGFloat(n - 1 - i) * s, y: (fi + 1) * s))
+        }
+
+        // Right edge
+        path.addLine(to: CGPoint(x: W, y: H - CGFloat(n) * s))
+
+        // Bottom-right corner (step down-left)
+        for i in 0..<n {
+            let fi = CGFloat(i)
+            path.addLine(to: CGPoint(x: W - fi * s, y: H - CGFloat(n - 1 - i) * s))
+            path.addLine(to: CGPoint(x: W - (fi + 1) * s, y: H - CGFloat(n - 1 - i) * s))
+        }
+
+        // Bottom edge
+        path.addLine(to: CGPoint(x: CGFloat(n) * s, y: H))
+
+        // Bottom-left corner (step left-up)
+        for i in 0..<n {
+            let fi = CGFloat(i)
+            path.addLine(to: CGPoint(x: CGFloat(n - 1 - i) * s, y: H - fi * s))
+            path.addLine(to: CGPoint(x: CGFloat(n - 1 - i) * s, y: H - (fi + 1) * s))
+        }
+
+        // Left edge
+        path.addLine(to: CGPoint(x: 0, y: CGFloat(n) * s))
+
+        // Top-left corner (step up-right)
+        for i in 0..<n {
+            let fi = CGFloat(i)
+            path.addLine(to: CGPoint(x: fi * s, y: CGFloat(n - 1 - i) * s))
+            path.addLine(to: CGPoint(x: (fi + 1) * s, y: CGFloat(n - 1 - i) * s))
+        }
+
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Agent Panel
+
 struct AgentPanel: View {
     var onClose: () -> Void
     let daemonClient: DaemonClient
 
     @StateObject private var skillsManager: SkillsManager
+    @State private var selectedTab = 0
     @State private var expandedSkillId: String?
+    @State private var hoveredSkillButtonId: String?
 
     init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
         self.onClose = onClose
@@ -14,22 +85,74 @@ struct AgentPanel: View {
     }
 
     var body: some View {
-        VSidePanel(title: "Agent", onClose: onClose) {
-            VStack(alignment: .leading, spacing: VSpacing.xl) {
-                sectionHeader("Skills")
-                skillsContent
+        VStack(alignment: .leading, spacing: 0) {
+            // Header (matches VSidePanel style)
+            HStack {
+                Text("AGENT")
+                    .font(VFont.display)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close Agent")
+            }
+            .padding(VSpacing.xl)
 
-                Divider()
+            // Tabbed navigation — pinned above scroll
+            VSegmentedControl(
+                items: ["Skills", "Available Skills", "Nodes", "Personality"],
+                selection: $selectedTab
+            )
+            .padding(.horizontal, VSpacing.sm)
 
-                sectionHeader("Nodes")
-                VEmptyState(title: "No nodes", subtitle: "Agent nodes will appear here", icon: "point.3.connected.trianglepath.dotted")
-                    .frame(height: 150)
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Scrollable tab content
+            ScrollView {
+                Group {
+                    switch selectedTab {
+                    case 0:
+                        skillsContent
+                    case 1:
+                        VEmptyState(
+                            title: "No available skills",
+                            subtitle: "Browse and add new skills",
+                            icon: "plus.square.on.square"
+                        )
+                        .frame(height: 250)
+                    case 2:
+                        VEmptyState(
+                            title: "No nodes",
+                            subtitle: "Agent nodes will appear here",
+                            icon: "point.3.connected.trianglepath.dotted"
+                        )
+                        .frame(height: 250)
+                    case 3:
+                        VEmptyState(
+                            title: "Personality",
+                            subtitle: "Configure agent personality here",
+                            icon: "person.text.rectangle"
+                        )
+                        .frame(height: 250)
+                    default:
+                        EmptyView()
+                    }
+                }
+                .padding(VSpacing.xl)
             }
         }
+        .background(VColor.backgroundSubtle)
         .onAppear {
             skillsManager.fetchSkills()
         }
     }
+
+    // MARK: - Skills Tab
 
     @ViewBuilder
     private var skillsContent: some View {
@@ -40,70 +163,98 @@ struct AgentPanel: View {
                     .controlSize(.small)
                 Spacer()
             }
-            .frame(height: 150)
+            .frame(height: 250)
         } else if skillsManager.skills.isEmpty {
-            VEmptyState(title: "No skills", subtitle: "Agent skills will appear here", icon: "bolt.fill")
-                .frame(height: 150)
+            VEmptyState(
+                title: "No skills",
+                subtitle: "Agent skills will appear here",
+                icon: "bolt.fill"
+            )
+            .frame(height: 250)
         } else {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(spacing: VSpacing.md) {
                 ForEach(skillsManager.skills) { skill in
-                    skillRow(skill)
+                    skillCard(skill)
                 }
             }
         }
     }
 
-    private func skillRow(_ skill: SkillSummaryItem) -> some View {
+    private func skillCard(_ skill: SkillSummaryItem) -> some View {
         let isExpanded = expandedSkillId == skill.id
+        let isHovered = hoveredSkillButtonId == skill.id
+        let borderColor = isHovered ? Amber._600.opacity(0.8) : Amber._700.opacity(0.6)
 
         return VStack(alignment: .leading, spacing: 0) {
-            Button(action: {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    if isExpanded {
-                        expandedSkillId = nil
-                    } else {
-                        expandedSkillId = skill.id
-                        skillsManager.fetchSkillBody(skillId: skill.id)
+            HStack(spacing: VSpacing.md) {
+                // Pixel-bordered button to use the skill
+                Button(action: {
+                    // TODO: implement skill usage
+                }) {
+                    HStack(spacing: VSpacing.md) {
+                        skillIcon(skill.icon)
+
+                        Text(skill.name)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.md)
+                    .background(isHovered ? Slate._700 : Slate._900)
+                    .clipShape(PixelBorderShape())
+                    .overlay(
+                        PixelBorderShape()
+                            .stroke(borderColor, lineWidth: 2.5)
+                    )
+                    .contentShape(PixelBorderShape())
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    withAnimation(VAnimation.fast) {
+                        hoveredSkillButtonId = hovering ? skill.id : nil
                     }
                 }
-            }) {
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 12)
-                        .padding(.top, 3)
 
-                    skillIcon(skill.icon)
-                        .padding(.top, 1)
+                Spacer()
 
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(skill.name)
+                // View button — expands skill details
+                VButton(label: "View", style: .ghost) {
+                    withAnimation(VAnimation.standard) {
+                        if isExpanded {
+                            expandedSkillId = nil
+                        } else {
+                            expandedSkillId = skill.id
+                            skillsManager.fetchSkillBody(skillId: skill.id)
+                        }
+                    }
+                }
+            }
+
+            // Expanded body
+            if isExpanded {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        // Summary (description)
+                        Text(skill.description)
                             .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textPrimary)
-                        Text(skill.description)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                            .lineLimit(isExpanded ? nil : 2)
+
+                        // Full body content
+                        skillBody(for: skill.id)
                     }
-
-                    Spacer()
+                    .padding(VSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(.vertical, VSpacing.sm)
-                .padding(.horizontal, VSpacing.md)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if isExpanded {
-                skillBody(for: skill.id)
-                    .padding(.leading, 12 + VSpacing.sm)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.bottom, VSpacing.sm)
+                .frame(maxHeight: 300)
+                .background(Slate._900)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.surfaceBorder, lineWidth: 1)
+                )
+                .padding(.top, VSpacing.md)
             }
         }
-        .background(isExpanded ? VColor.surface.opacity(0.5) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 
     @ViewBuilder
@@ -128,19 +279,14 @@ struct AgentPanel: View {
             Image(nsImage: nsImage)
                 .resizable()
                 .interpolation(.none)
-                .frame(width: 16, height: 16)
+                .frame(width: 24, height: 24)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
         } else {
             Image(systemName: "bolt.fill")
-                .font(.system(size: 12))
+                .font(.system(size: 13))
                 .foregroundColor(VColor.textMuted)
-                .frame(width: 16, height: 16)
+                .frame(width: 24, height: 24)
         }
-    }
-
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(VFont.captionMedium)
-            .foregroundColor(VColor.textSecondary)
     }
 }
 


### PR DESCRIPTION
## Summary
- Redesigned Agent side panel from flat sections to a **4-tab layout** (Skills, Available Skills, Nodes, Personality) using `VSegmentedControl`
- Skill rows now use a custom **`PixelBorderShape`** with stepped corners for a retro game aesthetic, with amber-toned solid borders
- Each skill is a pixel-bordered **"use" button** (icon + mono name) with hover state, plus a separate ghost **"View" button** that expands a scrollable detail container (max 300pt) showing description and full body

## Test plan
- [ ] `./build.sh` compiles without errors
- [ ] Open Agent panel — verify 4 tabs render with underline indicator
- [ ] Skills tab: skills load, pixel-bordered cards display with icons and mono names
- [ ] Hover over skill button: background lightens, border brightens
- [ ] Click "View": scrollable detail container appears with description + body, bounded to 300pt max height
- [ ] Switch between tabs: empty state placeholders render for Available Skills, Nodes, Personality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
