### PR TITLE
Add proxy/auth config flags (no behavior change)

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -22,3 +22,14 @@ ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
 
 # Optional: Port for the gateway HTTP server (default: 7830)
 # GATEWAY_PORT=7830
+
+# Optional: Enable runtime proxy mode (default: false)
+# When enabled, non-Telegram requests are forwarded to the assistant runtime.
+# GATEWAY_RUNTIME_PROXY_ENABLED=false
+
+# Optional: Require bearer auth for proxied requests (default: true)
+# Only relevant when proxy mode is enabled.
+# GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=true
+
+# Required when proxy is enabled with auth required: Bearer token for proxy auth
+# RUNTIME_PROXY_BEARER_TOKEN=

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -32,6 +32,9 @@ bun run dev
 | `GATEWAY_DEFAULT_ASSISTANT_ID` | No | — | Default assistant ID for unmapped users |
 | `GATEWAY_UNMAPPED_POLICY` | No | `reject` | Policy for unmapped users: `reject` or `default` |
 | `GATEWAY_PORT` | No | `7830` | Port for the gateway HTTP server |
+| `GATEWAY_RUNTIME_PROXY_ENABLED` | No | `false` | Enable runtime proxy for non-Telegram requests |
+| `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
+| `RUNTIME_PROXY_BEARER_TOKEN` | Conditional | — | Bearer token for proxy auth (required when proxy + auth enabled) |
 
 ## Routing
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { loadConfig } from "../config.js";
+
+const BASE_ENV = {
+  TELEGRAM_BOT_TOKEN: "tok",
+  TELEGRAM_WEBHOOK_SECRET: "wh-sec",
+  ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
+};
+
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void) {
+  const saved: Record<string, string | undefined> = {};
+  const allKeys = [
+    ...Object.keys(BASE_ENV),
+    ...Object.keys(overrides),
+    "GATEWAY_RUNTIME_PROXY_ENABLED",
+    "GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH",
+    "RUNTIME_PROXY_BEARER_TOKEN",
+    "GATEWAY_ASSISTANT_ROUTING_JSON",
+    "GATEWAY_DEFAULT_ASSISTANT_ID",
+    "GATEWAY_UNMAPPED_POLICY",
+    "GATEWAY_PORT",
+  ];
+
+  for (const key of allKeys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  Object.assign(process.env, BASE_ENV, overrides);
+
+  try {
+    fn();
+  } finally {
+    for (const key of allKeys) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  }
+}
+
+describe("config: runtime proxy flags", () => {
+  test("proxy disabled by default", () => {
+    withEnv({}, () => {
+      const config = loadConfig();
+      expect(config.runtimeProxyEnabled).toBe(false);
+      expect(config.runtimeProxyRequireAuth).toBe(true);
+      expect(config.runtimeProxyBearerToken).toBeUndefined();
+    });
+  });
+
+  test("proxy enabled with auth and valid token", () => {
+    withEnv(
+      {
+        GATEWAY_RUNTIME_PROXY_ENABLED: "true",
+        RUNTIME_PROXY_BEARER_TOKEN: "secret-key",
+      },
+      () => {
+        const config = loadConfig();
+        expect(config.runtimeProxyEnabled).toBe(true);
+        expect(config.runtimeProxyRequireAuth).toBe(true);
+        expect(config.runtimeProxyBearerToken).toBe("secret-key");
+      },
+    );
+  });
+
+  test("proxy enabled with auth disabled (no token needed)", () => {
+    withEnv(
+      {
+        GATEWAY_RUNTIME_PROXY_ENABLED: "true",
+        GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
+      },
+      () => {
+        const config = loadConfig();
+        expect(config.runtimeProxyEnabled).toBe(true);
+        expect(config.runtimeProxyRequireAuth).toBe(false);
+        expect(config.runtimeProxyBearerToken).toBeUndefined();
+      },
+    );
+  });
+
+  test("proxy enabled with auth required but no token throws", () => {
+    withEnv(
+      {
+        GATEWAY_RUNTIME_PROXY_ENABLED: "true",
+        GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
+      },
+      () => {
+        expect(() => loadConfig()).toThrow(
+          "RUNTIME_PROXY_BEARER_TOKEN is required when proxy is enabled with auth required",
+        );
+      },
+    );
+  });
+
+  test("proxy disabled ignores missing token even with auth required", () => {
+    withEnv(
+      {
+        GATEWAY_RUNTIME_PROXY_ENABLED: "false",
+        GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
+      },
+      () => {
+        const config = loadConfig();
+        expect(config.runtimeProxyEnabled).toBe(false);
+      },
+    );
+  });
+
+  test("proxy enabled defaults auth to required", () => {
+    withEnv(
+      {
+        GATEWAY_RUNTIME_PROXY_ENABLED: "true",
+        RUNTIME_PROXY_BEARER_TOKEN: "my-token",
+      },
+      () => {
+        const config = loadConfig();
+        expect(config.runtimeProxyRequireAuth).toBe(true);
+      },
+    );
+  });
+});

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -12,6 +12,9 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     unmappedPolicy: "reject",
     port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -11,6 +11,9 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   defaultAssistantId: undefined,
   unmappedPolicy: "reject",
   port: 7830,
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeProxyBearerToken: undefined,
   ...overrides,
 });
 

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -17,6 +17,9 @@ export type GatewayConfig = {
   defaultAssistantId: string | undefined;
   unmappedPolicy: "reject" | "default";
   port: number;
+  runtimeProxyEnabled: boolean;
+  runtimeProxyRequireAuth: boolean;
+  runtimeProxyBearerToken: string | undefined;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -93,6 +96,21 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_PORT must be a valid port number");
   }
 
+  const runtimeProxyEnabled =
+    process.env.GATEWAY_RUNTIME_PROXY_ENABLED === "true";
+
+  const runtimeProxyRequireAuth =
+    process.env.GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH !== "false";
+
+  const runtimeProxyBearerToken =
+    process.env.RUNTIME_PROXY_BEARER_TOKEN || undefined;
+
+  if (runtimeProxyEnabled && runtimeProxyRequireAuth && !runtimeProxyBearerToken) {
+    throw new Error(
+      "RUNTIME_PROXY_BEARER_TOKEN is required when proxy is enabled with auth required",
+    );
+  }
+
   log.info(
     {
       telegramApiBaseUrl,
@@ -101,6 +119,8 @@ export function loadConfig(): GatewayConfig {
       unmappedPolicy,
       hasDefaultAssistant: !!defaultAssistantId,
       port,
+      runtimeProxyEnabled,
+      runtimeProxyRequireAuth,
     },
     "Configuration loaded",
   );
@@ -114,5 +134,8 @@ export function loadConfig(): GatewayConfig {
     defaultAssistantId,
     unmappedPolicy,
     port,
+    runtimeProxyEnabled,
+    runtimeProxyRequireAuth,
+    runtimeProxyBearerToken,
   };
 }


### PR DESCRIPTION
## Summary
- Extends `GatewayConfig` with `runtimeProxyEnabled`, `runtimeProxyRequireAuth`, and `runtimeProxyBearerToken` fields
- Adds startup validation: fails fast when proxy + auth enabled but no bearer token set
- Updates `.env.example` and gateway README config table with new variables

## Test plan
- [x] New `config.test.ts` covers all flag combinations (6 tests)
- [x] `bunx tsc --noEmit` passes
- [x] All 31 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
