### PR TITLE
Add bearer-token parser/validator utility

### DIFF
--- a/gateway/src/__tests__/bearer-auth.test.ts
+++ b/gateway/src/__tests__/bearer-auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { validateBearerToken } from "../http/auth/bearer.js";
+
+const TOKEN = "test-secret-token";
+
+describe("validateBearerToken", () => {
+  test("missing header returns unauthorized", () => {
+    const result = validateBearerToken(null, TOKEN);
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.reason).toContain("Missing");
+    }
+  });
+
+  test("wrong scheme returns unauthorized", () => {
+    const result = validateBearerToken("Basic abc123", TOKEN);
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.reason).toContain("scheme");
+    }
+  });
+
+  test("wrong token returns unauthorized", () => {
+    const result = validateBearerToken("Bearer wrong-token", TOKEN);
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.reason).toContain("Invalid bearer token");
+    }
+  });
+
+  test("exact token returns authorized", () => {
+    const result = validateBearerToken(`Bearer ${TOKEN}`, TOKEN);
+    expect(result.authorized).toBe(true);
+  });
+
+  test("empty bearer value returns unauthorized", () => {
+    const result = validateBearerToken("Bearer ", TOKEN);
+    expect(result.authorized).toBe(false);
+  });
+});

--- a/gateway/src/http/auth/bearer.ts
+++ b/gateway/src/http/auth/bearer.ts
@@ -1,0 +1,24 @@
+export type BearerAuthResult =
+  | { authorized: true }
+  | { authorized: false; reason: string };
+
+export function validateBearerToken(
+  authorizationHeader: string | null,
+  expectedToken: string,
+): BearerAuthResult {
+  if (!authorizationHeader) {
+    return { authorized: false, reason: "Missing Authorization header" };
+  }
+
+  if (!authorizationHeader.startsWith("Bearer ")) {
+    return { authorized: false, reason: "Invalid authorization scheme" };
+  }
+
+  const token = authorizationHeader.slice("Bearer ".length);
+
+  if (token !== expectedToken) {
+    return { authorized: false, reason: "Invalid bearer token" };
+  }
+
+  return { authorized: true };
+}


### PR DESCRIPTION
## Summary
- New `gateway/src/http/auth/bearer.ts` with `validateBearerToken()` helper
- Parses `Authorization: Bearer <token>` header and validates against expected token
- Returns structured `{ authorized, reason }` result for clean error handling

## Test plan
- [x] 5 unit tests covering missing header, wrong scheme, wrong token, exact match, empty value
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
