### PR TITLE
Add runtime proxy route behind feature flag (no auth yet)

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: true,
+    runtimeProxyRequireAuth: false,
+    runtimeProxyBearerToken: undefined,
+    ...overrides,
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("runtime proxy handler", () => {
+  test("forwards request to upstream with correct path and query", async () => {
+    const captured: { url: string; method: string }[] = [];
+    globalThis.fetch = mock(async (input: any, init?: any) => {
+      captured.push({ url: String(input), method: init?.method ?? "GET" });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/assistants/test/health?foo=bar");
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(captured[0].url).toBe("http://localhost:7821/v1/assistants/test/health?foo=bar");
+    expect(captured[0].method).toBe("GET");
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  test("forwards POST body to upstream", async () => {
+    let capturedBody = "";
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      if (init?.body) {
+        const reader = init.body.getReader();
+        const chunks: Uint8Array[] = [];
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+        capturedBody = new TextDecoder().decode(
+          new Uint8Array(chunks.reduce((acc, c) => acc + c.length, 0)),
+        );
+        // Simpler: just read as text
+        capturedBody = Buffer.concat(chunks).toString();
+      }
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/chat", {
+      method: "POST",
+      body: JSON.stringify({ message: "hello" }),
+      headers: { "content-type": "application/json" },
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(capturedBody).toBe('{"message":"hello"}');
+  });
+
+  test("relays upstream status code", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("Not Found", { status: 404 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/nonexistent");
+    const res = await handler(req);
+
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 502 on upstream connection failure", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("Connection refused");
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health");
+    const res = await handler(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("Bad Gateway");
+  });
+});

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -1,0 +1,33 @@
+import pino from "pino";
+import type { GatewayConfig } from "../../config.js";
+
+const log = pino({ name: "gateway:runtime-proxy" });
+
+export function createRuntimeProxyHandler(config: GatewayConfig) {
+  return async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
+
+    const headers = new Headers(req.headers);
+    headers.delete("host");
+
+    let response: Response;
+    try {
+      response = await fetch(upstream, {
+        method: req.method,
+        headers,
+        body: req.body,
+        // @ts-expect-error Bun supports duplex on Request
+        duplex: "half",
+      });
+    } catch (err) {
+      log.error({ err, method: req.method, path: url.pathname }, "Upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,6 @@
 import pino from "pino";
 import { loadConfig } from "./config.js";
+import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
 import { sendTelegramReply } from "./telegram/send.js";
 
@@ -24,6 +25,10 @@ function main() {
     },
   );
 
+  const handleRuntimeProxy = config.runtimeProxyEnabled
+    ? createRuntimeProxyHandler(config)
+    : null;
+
   const server = Bun.serve({
     port: config.port,
     async fetch(req) {
@@ -31,6 +36,10 @@ function main() {
 
       if (url.pathname === "/webhooks/telegram") {
         return handleTelegramWebhook(req);
+      }
+
+      if (handleRuntimeProxy) {
+        return handleRuntimeProxy(req);
       }
 
       return Response.json({ error: "Not found" }, { status: 404 });


### PR DESCRIPTION
## Summary
- New `runtime-proxy.ts` route handler that forwards non-Telegram requests to assistant runtime
- Wired into `index.ts`: Telegram path handled first, then proxy if enabled, otherwise 404
- Preserves method, path, query string, headers, and body through to upstream
- Returns 502 on upstream connection failure

## Test plan
- [x] Forwards request to correct upstream URL with path and query
- [x] Forwards POST body to upstream
- [x] Relays upstream status codes
- [x] Returns 502 on connection failure
- [x] All 45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
