### PR TITLE
Enforce optional bearer auth on non-Telegram proxy requests

### DIFF
--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { createRuntimeProxyHandler } from "../http/routes/runtime-proxy.js";
+import type { GatewayConfig } from "../config.js";
+
+const TOKEN = "test-secret-token";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-ver",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: true,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: TOKEN,
+    ...overrides,
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockUpstream() {
+  globalThis.fetch = mock(async () => {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as any;
+}
+
+describe("runtime proxy auth enforcement", () => {
+  test("auth required: rejects missing token with 401", async () => {
+    mockUpstream();
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health");
+    const res = await handler(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("auth required: rejects invalid token with 401", async () => {
+    mockUpstream();
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(401);
+  });
+
+  test("auth required: accepts valid token and proxies", async () => {
+    mockUpstream();
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("auth not required: proxies without token", async () => {
+    mockUpstream();
+    const handler = createRuntimeProxyHandler(
+      makeConfig({ runtimeProxyRequireAuth: false, runtimeProxyBearerToken: undefined }),
+    );
+    const req = new Request("http://localhost:7830/v1/health");
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+  });
+
+  test("OPTIONS request bypasses auth", async () => {
+    mockUpstream();
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      method: "OPTIONS",
+    });
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -1,11 +1,27 @@
 import pino from "pino";
 import type { GatewayConfig } from "../../config.js";
+import { validateBearerToken } from "../auth/bearer.js";
 
 const log = pino({ name: "gateway:runtime-proxy" });
 
 export function createRuntimeProxyHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
     const url = new URL(req.url);
+
+    if (
+      config.runtimeProxyRequireAuth &&
+      config.runtimeProxyBearerToken &&
+      req.method !== "OPTIONS"
+    ) {
+      const authResult = validateBearerToken(
+        req.headers.get("authorization"),
+        config.runtimeProxyBearerToken,
+      );
+      if (!authResult.authorized) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
+    }
+
     const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
 
     const headers = new Headers(req.headers);


### PR DESCRIPTION
## Summary
- Wires bearer auth validation into the runtime proxy handler from PR 2
- When `runtimeProxyRequireAuth=true`, returns 401 for missing/invalid bearer tokens
- `OPTIONS` requests bypass auth for CORS preflight support
- Telegram webhook path remains completely unaffected (handled before proxy)

## Test plan
- [x] Auth-required mode rejects missing token (401)
- [x] Auth-required mode rejects invalid token (401)
- [x] Auth-required mode accepts valid token and proxies (200)
- [x] Auth-not-required mode proxies without token
- [x] OPTIONS bypasses auth
- [x] All 50 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
