### PR TITLE
Harden proxy header handling and failure behavior

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -104,4 +104,67 @@ describe("runtime proxy handler", () => {
     const body = await res.json();
     expect(body.error).toBe("Bad Gateway");
   });
+
+  test("strips hop-by-hop headers from request", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      capturedHeaders = init?.headers;
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: {
+        connection: "keep-alive",
+        "keep-alive": "timeout=5",
+        "transfer-encoding": "chunked",
+        "x-custom": "preserved",
+      },
+    });
+    await handler(req);
+
+    expect(capturedHeaders!.has("connection")).toBe(false);
+    expect(capturedHeaders!.has("keep-alive")).toBe(false);
+    expect(capturedHeaders!.has("transfer-encoding")).toBe(false);
+    expect(capturedHeaders!.get("x-custom")).toBe("preserved");
+  });
+
+  test("strips hop-by-hop headers from response", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+          "x-custom": "preserved",
+          "content-type": "text/plain",
+        },
+      });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health");
+    const res = await handler(req);
+
+    expect(res.headers.has("connection")).toBe(false);
+    expect(res.headers.has("transfer-encoding")).toBe(false);
+    expect(res.headers.get("x-custom")).toBe("preserved");
+    expect(res.headers.get("content-type")).toBe("text/plain");
+  });
+
+  test("does not forward host header to upstream", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      capturedHeaders = init?.headers;
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const req = new Request("http://localhost:7830/v1/health", {
+      headers: { host: "localhost:7830" },
+    });
+    await handler(req);
+
+    expect(capturedHeaders!.has("host")).toBe(false);
+  });
 });

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -4,8 +4,28 @@ import { validateBearerToken } from "../auth/bearer.js";
 
 const log = pino({ name: "gateway:runtime-proxy" });
 
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+function stripHopByHop(headers: Headers): Headers {
+  const cleaned = new Headers(headers);
+  for (const h of HOP_BY_HOP_HEADERS) {
+    cleaned.delete(h);
+  }
+  return cleaned;
+}
+
 export function createRuntimeProxyHandler(config: GatewayConfig) {
   return async (req: Request): Promise<Response> => {
+    const start = performance.now();
     const url = new URL(req.url);
 
     if (
@@ -24,26 +44,37 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     const upstream = `${config.assistantRuntimeBaseUrl}${url.pathname}${url.search}`;
 
-    const headers = new Headers(req.headers);
-    headers.delete("host");
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
 
     let response: Response;
     try {
       response = await fetch(upstream, {
         method: req.method,
-        headers,
+        headers: reqHeaders,
         body: req.body,
         // @ts-expect-error Bun supports duplex on Request
         duplex: "half",
       });
     } catch (err) {
-      log.error({ err, method: req.method, path: url.pathname }, "Upstream connection failed");
+      const duration = Math.round(performance.now() - start);
+      log.error(
+        { err, method: req.method, path: url.pathname, duration },
+        "Upstream connection failed",
+      );
       return Response.json({ error: "Bad Gateway" }, { status: 502 });
     }
 
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+    log.info(
+      { method: req.method, path: url.pathname, status: response.status, duration },
+      "Proxy request completed",
+    );
+
     return new Response(response.body, {
       status: response.status,
-      headers: response.headers,
+      headers: resHeaders,
     });
   };
 }


### PR DESCRIPTION
## Summary
- Strips hop-by-hop headers (connection, keep-alive, transfer-encoding, etc) from both request and response
- Avoids forwarding `host` header to upstream
- Returns 502 on upstream connection errors with duration in error log
- Adds concise request logging: method, path, status, and duration (no secrets)

## Test plan
- [x] Hop-by-hop headers stripped from request (connection, keep-alive, transfer-encoding)
- [x] Hop-by-hop headers stripped from response
- [x] Host header not forwarded to upstream
- [x] Network failure returns 502
- [x] Query string and body preserved
- [x] All 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
