### PR TITLE
Add ThreadTab design system component

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -123,7 +123,7 @@ DesignSystem/
 │   ├── Display/         (VEmptyState, VListRow)
 │   └── Navigation/      (VTab)
 ├── Components/          (composed from primitives, feature-aware)
-│   ├── Navigation/      (VTabBar, VSegmentedControl)
+│   ├── Navigation/      (VTabBar, VSegmentedControl, ThreadTab)
 │   ├── Layout/          (VSidePanel, VSplitView, VToolbar)
 │   └── Display/         (VCard)
 ├── Modifiers/           (.vCard(), .vHover(), .vPanelBackground())

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/ThreadTab.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A thread tab component that renders a tab with thread-specific styling.
+/// When selected, shows white text with no background or border.
+/// Composes `VTab`-like structure with thread appearance baked in.
+struct ThreadTab: View {
+    let label: String
+    var icon: String? = nil    // SF Symbol
+    var isSelected: Bool = false
+    var isCloseable: Bool = true
+    var onSelect: () -> Void
+    var onClose: (() -> Void)? = nil
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button(action: onSelect) {
+                HStack(spacing: VSpacing.xs) {
+                    if let icon = icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 12))
+                    }
+                    Text(label)
+                        .font(VFont.caption)
+                        .lineLimit(1)
+                }
+                .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
+            }
+            .buttonStyle(.plain)
+
+            if isCloseable, let onClose = onClose {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close \(label)")
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(isHovered && !isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onHover { hovering in isHovered = hovering }
+    }
+}
+
+#Preview("ThreadTab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        HStack(spacing: 8) {
+            ThreadTab(label: "Thread 1", icon: "flame", isSelected: true, onSelect: {})
+            ThreadTab(label: "Thread 2", icon: "flame", isSelected: false, onSelect: {}, onClose: {})
+            ThreadTab(label: "Thread 3", icon: "flame", isCloseable: false, onSelect: {})
+        }
+        .padding()
+    }
+    .frame(width: 500, height: 80)
+}

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -157,6 +157,35 @@ struct NavigationGallerySection: View {
                     }
                 }
             }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - ThreadTab
+            GallerySectionHeader(
+                title: "ThreadTab",
+                description: "Thread-specific tab component. Selected state uses white text with no background or border."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Default").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        ThreadTab(label: "Thread 1", icon: "flame", onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        ThreadTab(label: "Thread 1", icon: "flame", isSelected: true, onSelect: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        ThreadTab(label: "Thread 2", icon: "flame", onSelect: {}, onClose: {})
+                    }
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Selected + Closeable").font(VFont.caption).foregroundColor(VColor.textMuted)
+                        ThreadTab(label: "Thread 2", icon: "flame", isSelected: true, onSelect: {}, onClose: {})
+                    }
+                }
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -17,12 +17,11 @@ struct ThreadTabBar: View {
                             .frame(width: 1, height: 14)
                     }
 
-                    VTab(
+                    ThreadTab(
                         label: thread.title,
                         icon: "flame",
                         isSelected: thread.id == activeThreadId,
                         isCloseable: threads.count > 1,
-                        style: .rectangular,
                         onSelect: { onSelect(thread.id) },
                         onClose: { onClose(thread.id) }
                     )


### PR DESCRIPTION
## Summary
- Add `ThreadTab` component to the design system (`DesignSystem/Components/Navigation/`) with thread-specific styling (white text when selected, no background/border)
- Migrate `ThreadTabBar` to use `ThreadTab` instead of `VTab` with rectangular style
- Add `ThreadTab` showcase to the navigation gallery section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
