### PR TITLE
Restore accessibility label on create-thread tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -34,7 +34,7 @@ struct ThreadTabBar: View {
 
 
                 VTab(label: "Thread", icon: "plus", isCloseable: false, style: .rectangular, onSelect: { onCreate() })
-                    
+                    .accessibilityLabel("New Thread")
 
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- Restores the `.accessibilityLabel("New Thread")` modifier on the create-thread `VTab` in `ThreadTabBar.swift` that was dropped during the rectangular tab style refactor in PR #1381.

## Context
The refactor in PR #1381 replaced the previous create-thread button with a `VTab` component but did not carry over the explicit accessibility label. Without it, VoiceOver reads the control as just "Thread" (from the visible label) instead of "New Thread", which is a functional regression for assistive technology users who need to distinguish the create action from existing thread tabs.

## Test plan
- [ ] Build the macOS app successfully
- [ ] Enable VoiceOver (Cmd+F5) and navigate to the thread tab bar
- [ ] Verify the create-thread tab is announced as "New Thread" by VoiceOver

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
