### PR TITLE
Fix VTab hit area to cover full tab surface

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Primitives/Navigation/VTab.swift
@@ -35,19 +35,16 @@ struct VTab: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Button(action: onSelect) {
-                HStack(spacing: VSpacing.xs) {
-                    if let icon = icon {
-                        Image(systemName: icon)
-                            .font(.system(size: 12))
-                    }
-                    Text(label)
-                        .font(VFont.caption)
-                        .lineLimit(1)
+            HStack(spacing: VSpacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12))
                 }
-                .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
+                Text(label)
+                    .font(VFont.caption)
+                    .lineLimit(1)
             }
-            .buttonStyle(.plain)
+            .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
 
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
@@ -61,6 +58,8 @@ struct VTab: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .onTapGesture { onSelect() }
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(


### PR DESCRIPTION
## Summary
- Fixes a regression from PR #1380 where clicking on the padding areas of a VTab (or the space between the title and close button) did not trigger tab selection
- The `onSelect` action was previously wrapped only around the inner icon/title `Button`, while the visible pill surface (with padding and background) was the outer `HStack`
- Moves selection handling from an inner `Button` to `.contentShape(RoundedRectangle) + .onTapGesture` on the outer container so the entire visible tab surface is tappable

## Test plan
- [ ] Click on the padding area of a tab (left/right edges of the pill) and verify it selects the tab
- [ ] Click on the icon or title text and verify it still selects the tab
- [ ] Click on the close button (xmark) and verify it closes the tab (not selects it)
- [ ] Verify hover state still works across the full tab surface
- [ ] Verify all three tab styles (pill, flat, rectangular) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
