### PR TITLE
Validate proxy boolean env flags strictly

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -96,11 +96,21 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_PORT must be a valid port number");
   }
 
-  const runtimeProxyEnabled =
-    process.env.GATEWAY_RUNTIME_PROXY_ENABLED === "true";
+  const proxyEnabledRaw = process.env.GATEWAY_RUNTIME_PROXY_ENABLED;
+  if (proxyEnabledRaw !== undefined && proxyEnabledRaw !== "true" && proxyEnabledRaw !== "false") {
+    throw new Error(
+      `GATEWAY_RUNTIME_PROXY_ENABLED must be "true" or "false", got "${proxyEnabledRaw}"`,
+    );
+  }
+  const runtimeProxyEnabled = proxyEnabledRaw === "true";
 
-  const runtimeProxyRequireAuth =
-    process.env.GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH !== "false";
+  const proxyRequireAuthRaw = process.env.GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH;
+  if (proxyRequireAuthRaw !== undefined && proxyRequireAuthRaw !== "true" && proxyRequireAuthRaw !== "false") {
+    throw new Error(
+      `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH must be "true" or "false", got "${proxyRequireAuthRaw}"`,
+    );
+  }
+  const runtimeProxyRequireAuth = proxyRequireAuthRaw !== "false";
 
   const runtimeProxyBearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || undefined;


### PR DESCRIPTION
## Summary
- Reject `GATEWAY_RUNTIME_PROXY_ENABLED` and `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` values that are not exactly `"true"` or `"false"` at startup
- Prevents silent coercion of typos or differently-cased values (e.g. `TRUE`, `False`) that could leave proxy mode unexpectedly off or unexpectedly require auth

Addresses review feedback on #1475.

## Test plan
- [ ] Verify startup fails with clear error for invalid boolean values
- [ ] Verify "true" and "false" still work correctly
- [ ] Verify unset env vars still use defaults
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
