### PR TITLE
Use timingSafeEqual and case-insensitive Bearer in token validation

### DIFF
--- a/gateway/src/http/auth/bearer.ts
+++ b/gateway/src/http/auth/bearer.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "crypto";
+
 export type BearerAuthResult =
   | { authorized: true }
   | { authorized: false; reason: string };
@@ -10,13 +12,21 @@ export function validateBearerToken(
     return { authorized: false, reason: "Missing Authorization header" };
   }
 
-  if (!authorizationHeader.startsWith("Bearer ")) {
+  if (!authorizationHeader.slice(0, 7).toLowerCase().startsWith("bearer ")) {
     return { authorized: false, reason: "Invalid authorization scheme" };
   }
 
-  const token = authorizationHeader.slice("Bearer ".length);
+  const token = authorizationHeader.slice(7);
+  if (!token) {
+    return { authorized: false, reason: "Empty bearer token" };
+  }
 
-  if (token !== expectedToken) {
+  const a = Buffer.from(token);
+  const b = Buffer.from(expectedToken);
+  if (a.length !== b.length) {
+    return { authorized: false, reason: "Invalid bearer token" };
+  }
+  if (!timingSafeEqual(a, b)) {
     return { authorized: false, reason: "Invalid bearer token" };
   }
 


### PR DESCRIPTION
## Summary
- Replace `!==` with `crypto.timingSafeEqual` for bearer token comparison to prevent timing side-channel attacks, matching the existing pattern in `gateway/src/telegram/verify.ts`
- Accept the `Bearer` authorization scheme case-insensitively per HTTP spec (e.g. `bearer`, `BEARER`)
- Add early rejection for empty bearer tokens after scheme extraction

Addresses review feedback on #1476.

## Test plan
- [ ] Verify valid bearer tokens are accepted
- [ ] Verify case-insensitive Bearer scheme is accepted (e.g. `bearer <token>`)
- [ ] Verify timing-safe comparison prevents timing attacks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
