### PR TITLE
Fail closed when proxy auth is required but token is unconfigured

### DIFF
--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -28,11 +28,10 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     const start = performance.now();
     const url = new URL(req.url);
 
-    if (
-      config.runtimeProxyRequireAuth &&
-      config.runtimeProxyBearerToken &&
-      req.method !== "OPTIONS"
-    ) {
+    if (config.runtimeProxyRequireAuth && req.method !== "OPTIONS") {
+      if (!config.runtimeProxyBearerToken) {
+        return Response.json({ error: "Server misconfigured" }, { status: 500 });
+      }
       const authResult = validateBearerToken(
         req.headers.get("authorization"),
         config.runtimeProxyBearerToken,


### PR DESCRIPTION
## Summary
- Restructure the proxy auth guard to check `runtimeProxyRequireAuth` first, then return 500 if `runtimeProxyBearerToken` is undefined instead of silently skipping the entire auth block
- Prevents the proxy from failing open when auth is required but no token is configured (defense-in-depth)
- Case-insensitive Bearer scheme handling is already addressed in #1485

Addresses review feedback on #1478.

## Test plan
- [ ] Verify proxy returns 500 when auth is required but token is undefined
- [ ] Verify proxy correctly validates bearer token when configured
- [ ] Verify OPTIONS requests bypass auth
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
