### PR TITLE
Strip custom hop-by-hop headers listed in Connection header

### DIFF
--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -17,6 +17,18 @@ const HOP_BY_HOP_HEADERS = [
 
 function stripHopByHop(headers: Headers): Headers {
   const cleaned = new Headers(headers);
+
+  // Also strip any headers listed in the Connection header value
+  const connectionValue = cleaned.get("connection");
+  if (connectionValue) {
+    for (const name of connectionValue.split(",")) {
+      const trimmed = name.trim().toLowerCase();
+      if (trimmed) {
+        cleaned.delete(trimmed);
+      }
+    }
+  }
+
   for (const h of HOP_BY_HOP_HEADERS) {
     cleaned.delete(h);
   }


### PR DESCRIPTION
## Summary
- Parse the `Connection` header value and delete any header names it advertises before stripping the standard hop-by-hop set
- Prevents custom connection tokens (e.g. `Connection: x-internal` with `x-internal: secret`) from leaking through the proxy end-to-end

Addresses review feedback on #1479.

## Test plan
- [ ] Verify standard hop-by-hop headers are still stripped
- [ ] Verify custom headers listed in Connection value are stripped
- [ ] Verify headers not listed in Connection are preserved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
