### PR TITLE
Guard against invalid Connection header tokens in stripHopByHop

### DIFF
--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -24,7 +24,11 @@ function stripHopByHop(headers: Headers): Headers {
     for (const name of connectionValue.split(",")) {
       const trimmed = name.trim().toLowerCase();
       if (trimmed) {
-        cleaned.delete(trimmed);
+        try {
+          cleaned.delete(trimmed);
+        } catch {
+          // Ignore invalid header names (e.g., malformed Connection tokens like "@@@")
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Wraps `cleaned.delete(trimmed)` in a try-catch inside `stripHopByHop` so that malformed Connection header tokens (e.g., `@@@`) that aren't valid header names are safely ignored instead of throwing a `TypeError` and failing the proxy request.

## Context
Addresses review feedback on #1487: `cleaned.delete()` on unvalidated Connection tokens can throw when the token isn't a valid header name, creating an availability issue.

## Test plan
- [ ] Verify type-check passes
- [ ] Confirm proxy handles `Connection: @@@` without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
