### PR TITLE
Add workflow_dispatch to Slack release notification

### DIFF
--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -3,6 +3,7 @@ name: Slack Release Notification
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so the Slack release notification can be tested manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
