### PR TITLE
Fix release build: wrap JIT previews in #if DEBUG

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
@@ -104,6 +104,7 @@ final class JITPermissionManager {
     }
 }
 
+#if DEBUG
 #Preview {
     @Previewable @State var manager = JITPermissionManager()
 
@@ -141,3 +142,4 @@ final class JITPermissionManager {
     .frame(width: 500, height: 300)
     .background(VColor.background)
 }
+#endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -178,6 +178,7 @@ struct JITPermissionView: View {
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview("Microphone") {
     @Previewable @State var manager: JITPermissionManager = {
         let m = JITPermissionManager()
@@ -222,3 +223,4 @@ struct JITPermissionView: View {
     }
     .frame(width: 640, height: 560)
 }
+#endif


### PR DESCRIPTION
## Summary
- Wraps `#Preview` blocks in `JITPermissionManager.swift` and `JITPermissionView.swift` with `#if DEBUG` guards
- Fixes the v0.1.5 release build failure caused by `@Previewable` being unavailable in release configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
