### PR TITLE
Fix Slack notification for manual dispatch

### DIFF
--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -4,10 +4,21 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name for testing"
+        default: "v0.0.0-test"
+      body:
+        description: "Release body for testing"
+        default: "Test release notification"
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
+      RELEASE_BODY: ${{ github.event.release.body || inputs.body }}
+      RELEASE_URL: ${{ github.event.release.html_url || format('https://github.com/{0}/releases', github.repository) }}
     steps:
       - name: Post to Slack #releases channel
         uses: slackapi/slack-github-action@v2.1.0
@@ -21,14 +32,14 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "🚀 Vellum Assistant ${{ github.event.release.tag_name }} Released"
+                    "text": "🚀 Vellum Assistant ${{ env.TAG_NAME }} Released"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(github.event.release.body) }}
+                    "text": ${{ toJSON(env.RELEASE_BODY) }}
                   }
                 },
                 {
@@ -40,7 +51,7 @@ jobs:
                         "type": "plain_text",
                         "text": "View Release"
                       },
-                      "url": "${{ github.event.release.html_url }}"
+                      "url": "${{ env.RELEASE_URL }}"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` inputs with defaults (`v0.0.0-test`, `Test release notification`)
- Uses fallback expressions (`github.event.release.* || inputs.*`) so the payload is valid for both release events and manual triggers
- Fixes empty URL in button that caused Slack API rejection on manual dispatch

Addresses review feedback from #1490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
