### PR TITLE
Fix awk section counting in release notification

### DIFF
--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -30,9 +30,9 @@ jobs:
           slack_body=$(echo "$body" | sed 's/^## \(.*\)/*\1*/g')
 
           # Count items per section
-          features=$(echo "$body" | awk '/^## Features/,/^## /' | grep -c '^- ' || true)
-          fixes=$(echo "$body" | awk '/^## Fixes/,/^## /' | grep -c '^- ' || true)
-          infra=$(echo "$body" | awk '/^## Infrastructure/,/^## /' | grep -c '^- ' || true)
+          features=$(echo "$body" | awk '/^## Features/{f=1; next} /^## /{f=0} f' | grep -c '^- ' || true)
+          fixes=$(echo "$body" | awk '/^## Fixes/{f=1; next} /^## /{f=0} f' | grep -c '^- ' || true)
+          infra=$(echo "$body" | awk '/^## Infrastructure/{f=1; next} /^## /{f=0} f' | grep -c '^- ' || true)
 
           # Build summary line
           summary=""


### PR DESCRIPTION
## Summary
- Fixes awk range pattern that self-terminated because start line (`## Features`) also matched end pattern (`## `)
- Uses stateful flag approach (`{f=1; next} /^## /{f=0} f`) so bullets are actually counted
- Without this fix, summary always showed "New release" instead of "15 features, 9 fixes, 4 infra changes"

Addresses review feedback from #1493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
