### PR TITLE
Fix: apply 50-char limit after extracting first line in suggestion

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -348,11 +348,12 @@ export class RuntimeHttpServer {
     const textBlock = response.content.find((b) => b.type === 'text');
     const raw = textBlock && 'text' in textBlock ? textBlock.text.trim() : '';
 
-    if (!raw || raw.length > 50) return null;
+    if (!raw) return null;
 
-    // Take first line only
+    // Take first line only, then enforce the length cap
     const firstLine = raw.split('\n')[0].trim();
-    return firstLine || null;
+    if (!firstLine || firstLine.length > 50) return null;
+    return firstLine;
   }
 
   private async handleSendMessage(assistantId: string, req: Request): Promise<Response> {


### PR DESCRIPTION
## Summary
- Moves the 50-char length check in `generateLlmSuggestion` to run **after** extracting the first line from the raw LLM response, rather than on the full raw output
- Previously, multi-line responses like `"Sure—want a quick example?\n(added explanation)"` were rejected even though the usable first line was under 50 chars
- This prevents tab-complete suggestions from disappearing for otherwise valid responses

Addresses review feedback on #1460.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify tab-complete suggestions appear for multi-line LLM responses where the first line is under 50 chars
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
