### PR TITLE
Guard trust-file migration writes from crashing reads

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 
@@ -465,6 +465,43 @@ describe('Trust Store', () => {
       expect(data.version).toBe(2);
       const migratedRule = data.rules.find((r: { id: string }) => r.id === 'migrate-me');
       expect(migratedRule.priority).toBe(100);
+    });
+  });
+
+  // ── loadFromDisk resilience ─────────────────────────────────────
+
+  describe('loadFromDisk resilience', () => {
+    test('returns in-memory rules when saveToDisk fails during migration', () => {
+      // Write a v1 trust file that triggers needsSave on load
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(trustPath, JSON.stringify({
+        version: 1,
+        rules: [{
+          id: 'v1-readonly',
+          tool: 'bash',
+          pattern: 'git *',
+          scope: '/tmp',
+          decision: 'allow' as const,
+          createdAt: 1000,
+        }],
+      }));
+
+      // Make the directory read-only so saveToDisk will fail
+      const protectedDir = dirname(trustPath);
+      chmodSync(protectedDir, 0o555);
+
+      try {
+        clearCache();
+        const rules = getAllRules();
+        // Should still return the migrated rules + defaults in-memory
+        expect(rules).toHaveLength(1 + NUM_DEFAULTS);
+        const migratedRule = rules.find((r) => r.id === 'v1-readonly');
+        expect(migratedRule).toBeDefined();
+        expect(migratedRule!.priority).toBe(100);
+      } finally {
+        // Restore directory permissions for cleanup
+        chmodSync(protectedDir, 0o755);
+      }
     });
   });
 

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -83,7 +83,11 @@ function loadFromDisk(): TrustRule[] {
   rules.sort(ruleOrder);
 
   if (needsSave) {
-    saveToDisk(rules);
+    try {
+      saveToDisk(rules);
+    } catch (err) {
+      log.warn({ err }, 'Failed to persist migrated trust rules (continuing with in-memory rules)');
+    }
   }
 
   return rules;


### PR DESCRIPTION
## Summary
- Wraps the `saveToDisk(rules)` call inside `loadFromDisk()` with a try/catch so that if the trust file directory is not writable (e.g. read-only mounts or permission-restricted environments), the function logs a warning and continues with the successfully loaded in-memory rules instead of crashing.
- Adds a test that simulates a read-only directory (chmod 0o555) during v1 migration to verify in-memory rules are still returned when persistence fails.

Addresses review feedback on #1462.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/trust-store.test.ts` — all 60 tests pass, including new resilience test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
