### PR TITLE
Add run ownership check to trust-rule endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,6 +145,13 @@ export class RuntimeHttpServer {
           return await this.handleRunDecision(assistantId, runId, req);
         }
         if (runsMatch[2] === '/trust-rule' && req.method === 'POST') {
+          if (!this.runOrchestrator) {
+            return Response.json({ error: 'Run orchestration not configured' }, { status: 503 });
+          }
+          const run = this.runOrchestrator.getRun(runId);
+          if (!run || run.assistantId !== assistantId) {
+            return Response.json({ error: 'Run not found' }, { status: 404 });
+          }
           return await this.handleAddTrustRule(req);
         }
         if (req.method === 'GET') {


### PR DESCRIPTION
## Summary
- Adds run ownership verification to the `POST /runs/:runId/trust-rule` endpoint in `http-server.ts`, matching the existing pattern used by `handleRunDecision`
- Without this check, any request with arbitrary assistant/run IDs could persist trust rules without authorization
- The `activeRunId` race condition in `InteractionTab.tsx` (feedback items #1 and #3) is no longer applicable since the `web/` directory was removed in PR #1470

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm requests with invalid run/assistant IDs return 404
- [ ] Confirm valid requests still succeed

Addresses feedback on #1466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
