### PR TITLE
Fix default deny rule bypasses: path resolution, error handling, clearAllRules

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -509,6 +509,19 @@ describe('Permission Checker', () => {
       // Medium risk with no matching rule → prompt (not deny)
       expect(result.decision).not.toBe('deny');
     });
+
+    test('relative path to protected file is still denied', async () => {
+      // Simulate a relative path that resolves to the protected directory.
+      // The default deny pattern uses an absolute path, so the checker
+      // must resolve relative paths before matching.
+      const cwd = process.cwd();
+      const protectedPath = join(checkerTestDir, 'protected', 'trust.json');
+      // Build a relative path from cwd to the protected file
+      const { relative } = await import('node:path');
+      const relPath = relative(cwd, protectedPath);
+      const result = await check('file_read', { path: relPath }, '/tmp');
+      expect(result.decision).toBe('deny');
+    });
   });
 
   // ── generateAllowlistOptions ───────────────────────────────────

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -38,7 +38,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { addRule, removeRule, findMatchingRule, findDenyRule, findHighestPriorityRule, getAllRules, clearCache } from '../permissions/trust-store.js';
+import { addRule, removeRule, findMatchingRule, findDenyRule, findHighestPriorityRule, getAllRules, clearAllRules, clearCache } from '../permissions/trust-store.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
 
 const trustPath = join(testDir, 'protected', 'trust.json');
@@ -606,6 +606,34 @@ describe('Trust Store', () => {
       const match = findHighestPriorityRule('file_read', [`file_read:${safePath}`], '/tmp');
       // Should not match a default deny rule
       expect(match === null || !match.id.startsWith('default:')).toBe(true);
+    });
+
+    test('default deny rules are backfilled after malformed JSON in trust file', () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(trustPath, 'NOT VALID JSON {{{');
+      clearCache();
+      const rules = getAllRules();
+      const defaults = rules.filter((r) => r.id.startsWith('default:'));
+      expect(defaults).toHaveLength(NUM_DEFAULTS);
+    });
+
+    test('default deny rules are backfilled after unknown file version', () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(trustPath, JSON.stringify({ version: 9999, rules: [] }));
+      clearCache();
+      const rules = getAllRules();
+      const defaults = rules.filter((r) => r.id.startsWith('default:'));
+      expect(defaults).toHaveLength(NUM_DEFAULTS);
+    });
+
+    test('clearAllRules preserves default deny rules', () => {
+      addRule('bash', 'git *', '/tmp');
+      clearAllRules();
+      const rules = getAllRules();
+      // User rules should be gone, but defaults should remain
+      expect(rules.filter((r) => !r.id.startsWith('default:'))).toHaveLength(0);
+      const defaults = rules.filter((r) => r.id.startsWith('default:'));
+      expect(defaults).toHaveLength(NUM_DEFAULTS);
     });
   });
 });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -3,7 +3,7 @@ import { findHighestPriorityRule } from './trust-store.js';
 import { parse } from '../tools/terminal/parser.js';
 import { resolveSkillSelector } from '../config/skills.js';
 import { getTool } from '../tools/registry.js';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { looksLikeHostPortShorthand, looksLikePathOnlyInput } from '../tools/network/url-safety.js';
 
@@ -165,7 +165,14 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
   }
 
   const fileTarget = getStringField(input, 'path', 'file_path');
-  return [`${toolName}:${fileTarget}`];
+  const resolved = fileTarget ? resolve(fileTarget) : fileTarget;
+  const candidates = [`${toolName}:${resolved}`];
+  // Also include the raw path if it differs, so user-created rules with
+  // raw paths still match.
+  if (resolved !== fileTarget) {
+    candidates.push(`${toolName}:${fileTarget}`);
+  }
+  return candidates;
 }
 
 export async function classifyRisk(toolName: string, input: Record<string, unknown>): Promise<RiskLevel> {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -18,7 +18,9 @@ const FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
  * Computed at runtime so paths reflect the configured root directory.
  */
 export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
-  const protectedDir = join(getRootDir(), 'protected');
+  // Use forward slashes so minimatch patterns work on all platforms
+  // (path.join produces backslashes on Windows, which minimatch treats as escapes).
+  const protectedDir = join(getRootDir(), 'protected').replaceAll('\\', '/');
 
   return FILE_TOOLS.map((tool) => ({
     id: `default:deny-${tool}-protected`,

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -32,6 +32,31 @@ function ruleOrder(a: TrustRule, b: TrustRule): number {
   return 0;
 }
 
+/**
+ * Ensure default deny rules are always present in the rule set.
+ * Mutates the provided array and returns whether any rules were added.
+ */
+function backfillDefaults(rules: TrustRule[]): boolean {
+  let added = false;
+  const existingIds = new Set(rules.map((r) => r.id));
+  for (const template of getDefaultRuleTemplates()) {
+    if (!existingIds.has(template.id)) {
+      rules.push({
+        id: template.id,
+        tool: template.tool,
+        pattern: template.pattern,
+        scope: template.scope,
+        decision: template.decision,
+        priority: template.priority,
+        createdAt: Date.now(),
+      });
+      added = true;
+      log.info({ ruleId: template.id }, 'Backfilled default trust rule');
+    }
+  }
+  return added;
+}
+
 function loadFromDisk(): TrustRule[] {
   const path = getTrustPath();
   let rules: TrustRule[] = [];
@@ -54,30 +79,17 @@ function loadFromDisk(): TrustRule[] {
         rules = data.rules ?? [];
       } else {
         log.warn({ version: data.version }, 'Unknown trust file version, ignoring');
-        return [];
+        // Fall through to backfill defaults even for unknown versions
       }
     } catch (err) {
       log.error({ err }, 'Failed to load trust file');
-      return [];
+      // Fall through to backfill defaults even on parse errors
     }
   }
 
   // Backfill default rules at their declared priority
-  const existingIds = new Set(rules.map((r) => r.id));
-  for (const template of getDefaultRuleTemplates()) {
-    if (!existingIds.has(template.id)) {
-      rules.push({
-        id: template.id,
-        tool: template.tool,
-        pattern: template.pattern,
-        scope: template.scope,
-        decision: template.decision,
-        priority: template.priority,
-        createdAt: Date.now(),
-      });
-      needsSave = true;
-      log.info({ ruleId: template.id }, 'Backfilled default trust rule');
-    }
+  if (backfillDefaults(rules)) {
+    needsSave = true;
   }
 
   rules.sort(ruleOrder);
@@ -201,9 +213,13 @@ export function getAllRules(): TrustRule[] {
 }
 
 export function clearAllRules(): void {
-  cachedRules = [];
-  saveToDisk([]);
-  log.info('Cleared all trust rules');
+  // Re-backfill default deny rules so protected directory stays guarded.
+  const rules: TrustRule[] = [];
+  backfillDefaults(rules);
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  saveToDisk(rules);
+  log.info('Cleared all user trust rules (default deny rules preserved)');
 }
 
 export function clearCache(): void {


### PR DESCRIPTION
## Summary
- **Resolve file paths to absolute** before matching against deny rules, preventing bypass via relative paths (e.g. `.vellum/protected/trust.json` not matching absolute deny patterns)
- **Normalize backslashes to forward slashes** in default deny glob patterns so minimatch works on Windows
- **Backfill default deny rules on error paths** in `loadFromDisk` (malformed JSON, unknown version) instead of returning empty
- **Preserve default deny rules in `clearAllRules`** by re-backfilling after clearing user rules

Addresses review feedback on #1467.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 158 existing + new tests pass (0 failures)
- [x] New test: relative path to protected file is denied
- [x] New test: default rules backfilled after malformed JSON
- [x] New test: default rules backfilled after unknown file version
- [x] New test: `clearAllRules` preserves default deny rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
