### PR TITLE
Fix tool confirmation panel not retrying on IPC failure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -236,8 +236,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     scope: scope,
                     decision: decision
                 )
+                return true
             } catch {
                 log.error("Failed to send add_trust_rule: \(error.localizedDescription)")
+                return false
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -24,7 +24,7 @@ struct ChatView: View {
     let onMicrophoneToggle: () -> Void
     let onConfirmationAllow: (String) -> Void
     let onConfirmationDeny: (String) -> Void
-    let onAddTrustRule: (String, String, String, String) -> Void
+    let onAddTrustRule: (String, String, String, String) -> Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -864,7 +864,7 @@ private struct MicrophoneButton: View {
             onMicrophoneToggle: {},
             onConfirmationAllow: { _ in },
             onConfirmationDeny: { _ in },
-            onAddTrustRule: { _, _, _, _ in },
+            onAddTrustRule: { _, _, _, _ in true },
             onSurfaceAction: { _, _, _ in }
         )
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -910,11 +910,12 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Send an add_trust_rule message to persist a trust rule (fire-and-forget).
-    func addTrustRule(toolName: String, pattern: String, scope: String, decision: String) {
+    /// Send an add_trust_rule message to persist a trust rule.
+    /// Returns `true` if the IPC send succeeded, `false` otherwise.
+    func addTrustRule(toolName: String, pattern: String, scope: String, decision: String) -> Bool {
         guard daemonClient.isConnected else {
             log.warning("Cannot send add_trust_rule: daemon not connected")
-            return
+            return false
         }
         do {
             try daemonClient.sendAddTrustRule(
@@ -923,8 +924,10 @@ final class ChatViewModel: ObservableObject {
                 scope: scope,
                 decision: decision
             )
+            return true
         } catch {
             log.error("Failed to send add_trust_rule: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -4,7 +4,7 @@ struct ToolConfirmationBubble: View {
     let confirmation: ToolConfirmationData
     let onAllow: () -> Void
     let onDeny: () -> Void
-    let onAddTrustRule: (String, String, String, String) -> Void
+    let onAddTrustRule: (String, String, String, String) -> Bool
 
     @State private var showRulePicker = false
     @State private var selectedPattern: String = ""
@@ -237,7 +237,7 @@ struct ToolConfirmationBubble: View {
                 }
                 VButton(label: "Save Rule", style: .primary) {
                     let ruleDecision = confirmation.state == .approved ? "allow" : "deny"
-                    onAddTrustRule(confirmation.toolName, selectedPattern, selectedScope, ruleDecision)
+                    guard onAddTrustRule(confirmation.toolName, selectedPattern, selectedScope, ruleDecision) else { return }
                     withAnimation(VAnimation.standard) {
                         showRulePicker = false
                         ruleSaved = true
@@ -272,7 +272,7 @@ struct ToolConfirmationBubble: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in }
+            onAddTrustRule: { _, _, _, _ in true }
         )
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
@@ -288,7 +288,7 @@ struct ToolConfirmationBubble: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in }
+            onAddTrustRule: { _, _, _, _ in true }
         )
         ToolConfirmationBubble(
             confirmation: ToolConfirmationData(
@@ -306,7 +306,7 @@ struct ToolConfirmationBubble: View {
             ),
             onAllow: {},
             onDeny: {},
-            onAddTrustRule: { _, _, _, _ in }
+            onAddTrustRule: { _, _, _, _ in true }
         )
     }
     .padding(VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,7 +64,7 @@ struct MainWindowView: View {
                             onMicrophoneToggle: onMicrophoneToggle,
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
-                            onAddTrustRule: { toolName, pattern, scope, decision in viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
+                            onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
                             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) }
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -21,13 +21,12 @@ final class ToolConfirmationManager {
     var onResponse: ((String, String) -> Bool)?
 
     /// Called when the user saves a trust rule from the floating panel.
-    var onAddTrustRule: ((String, String, String, String) -> Void)?
+    /// Returns `true` if the IPC send succeeded, `false` otherwise.
+    var onAddTrustRule: ((String, String, String, String) -> Bool)?
 
     func showConfirmation(_ message: ConfirmationRequestMessage) {
         // Dismiss existing panel for same request, if any
         dismissConfirmation(requestId: message.requestId)
-
-        let hasRuleOptions = !message.allowlistOptions.isEmpty && !message.scopeOptions.isEmpty
 
         let view = ToolConfirmationView(
             toolName: message.toolName,
@@ -36,20 +35,23 @@ final class ToolConfirmationManager {
             allowlistOptions: message.allowlistOptions,
             scopeOptions: message.scopeOptions,
             onAllow: { [weak self] in
-                self?.respond(requestId: message.requestId, decision: "allow")
+                self?.respond(requestId: message.requestId, decision: "allow") ?? false
             },
             onDeny: { [weak self] in
-                self?.respond(requestId: message.requestId, decision: "deny")
+                self?.respond(requestId: message.requestId, decision: "deny") ?? false
             },
             onDismiss: { [weak self] in
                 self?.dismissConfirmation(requestId: message.requestId)
             },
             onAddTrustRule: { [weak self] toolName, pattern, scope, decision in
-                self?.onAddTrustRule?(toolName, pattern, scope, decision)
-                // Auto-dismiss after saving rule
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                    self?.dismissConfirmation(requestId: message.requestId)
+                let success = self?.onAddTrustRule?(toolName, pattern, scope, decision) ?? false
+                if success {
+                    // Auto-dismiss after saving rule
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        self?.dismissConfirmation(requestId: message.requestId)
+                    }
                 }
+                return success
             }
         )
 
@@ -100,10 +102,12 @@ final class ToolConfirmationManager {
         panels.removeAll()
     }
 
-    private func respond(requestId: String, decision: String) {
-        // Send the IPC response. If it fails, the panel stays visible
-        // (the ToolConfirmationView handles its own state transition).
-        _ = onResponse?(requestId, decision)
+    private func respond(requestId: String, decision: String) -> Bool {
+        let success = onResponse?(requestId, decision) ?? true
+        if success {
+            dismissConfirmation(requestId: requestId)
+        }
+        return success
     }
 }
 
@@ -115,10 +119,10 @@ struct ToolConfirmationView: View {
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
     let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
-    let onAllow: () -> Void
-    let onDeny: () -> Void
+    let onAllow: () -> Bool
+    let onDeny: () -> Bool
     let onDismiss: () -> Void
-    let onAddTrustRule: (String, String, String, String) -> Void
+    let onAddTrustRule: (String, String, String, String) -> Bool
 
     enum Phase: Equatable {
         case pending
@@ -201,19 +205,15 @@ struct ToolConfirmationView: View {
                 HStack(spacing: VSpacing.lg) {
                     Spacer()
                     VButton(label: "Deny", style: .ghost) {
-                        onDeny()
+                        guard onDeny() else { return }
                         if hasRuleOptions {
                             withAnimation(VAnimation.standard) { phase = .decided("deny") }
-                        } else {
-                            onDismiss()
                         }
                     }
                     VButton(label: "Allow", style: isHighRisk ? .danger : .primary) {
-                        onAllow()
+                        guard onAllow() else { return }
                         if hasRuleOptions {
                             withAnimation(VAnimation.standard) { phase = .decided("allow") }
-                        } else {
-                            onDismiss()
                         }
                     }
                 }
@@ -337,7 +337,7 @@ struct ToolConfirmationView: View {
                     onDismiss()
                 }
                 VButton(label: "Save Rule", style: .primary) {
-                    onAddTrustRule(toolName, selectedPattern, selectedScope, decision)
+                    guard onAddTrustRule(toolName, selectedPattern, selectedScope, decision) else { return }
                     withAnimation(VAnimation.standard) { phase = .ruleSaved }
                 }
             }


### PR DESCRIPTION
## Summary

Addresses review feedback on #1463:

- **P0/P1**: The floating panel was unconditionally transitioning to decided/dismissed state even when the IPC confirmation send failed, preventing retry. Now `respond()` checks the `onResponse` return value and only dismisses on success. `onAllow`/`onDeny` closures changed from `() -> Void` to `() -> Bool` so the view stays at `.pending` phase for retry when IPC fails.

- **P2**: The inline bubble and floating panel marked "Rule saved" immediately after invoking `onAddTrustRule`, but that callback could fail silently. Now `onAddTrustRule` returns `Bool` across the entire chain (floating panel, inline bubble, ChatView, ChatViewModel, AppDelegate), and the UI only shows "Rule saved" / auto-dismisses after confirmed persistence.

## Files changed

- `clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift` - Core fix: `respond()` returns Bool, checks success before dismiss; view closures return Bool
- `clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift` - Inline bubble: `onAddTrustRule` returns Bool, gates "Rule saved" on success
- `clients/macos/vellum-assistant/Features/Chat/ChatView.swift` - Updated `onAddTrustRule` type signature
- `clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift` - `addTrustRule()` now returns Bool
- `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift` - Updated call site
- `clients/macos/vellum-assistant/App/AppDelegate.swift` - `onAddTrustRule` callback returns Bool

## Test plan

- [x] `swift build` succeeds with no warnings
- [ ] Verify floating panel stays visible when daemon socket is down and user clicks Allow/Deny
- [ ] Verify "Rule saved" only appears after successful IPC send
- [ ] Verify normal flow (IPC succeeds) still dismisses panel and shows "Rule saved" correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
