### PR TITLE
Make migration-resilience test deterministic with spyOn

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+import * as fs from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 
@@ -486,9 +487,11 @@ describe('Trust Store', () => {
         }],
       }));
 
-      // Make the directory read-only so saveToDisk will fail
-      const protectedDir = dirname(trustPath);
-      chmodSync(protectedDir, 0o555);
+      // Spy on writeFileSync to throw when saveToDisk is called during migration.
+      // This is deterministic regardless of user privileges (unlike chmod 0o555).
+      const spy = spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        throw new Error('Simulated write failure');
+      });
 
       try {
         clearCache();
@@ -498,9 +501,10 @@ describe('Trust Store', () => {
         const migratedRule = rules.find((r) => r.id === 'v1-readonly');
         expect(migratedRule).toBeDefined();
         expect(migratedRule!.priority).toBe(100);
+        // Verify that saveToDisk was attempted (writeFileSync was called)
+        expect(spy).toHaveBeenCalled();
       } finally {
-        // Restore directory permissions for cleanup
-        chmodSync(protectedDir, 0o755);
+        spy.mockRestore();
       }
     });
   });


### PR DESCRIPTION
## Summary
- Replaces `chmodSync(dir, 0o555)` with `spyOn(fs, 'writeFileSync')` in the migration-resilience test
- The chmod approach does not reliably prevent writes in privileged environments (e.g. tests running as root in CI containers), so the catch path in `loadFromDisk` was effectively untested in some setups
- The spyOn approach deterministically simulates a write failure and also verifies that `saveToDisk` was actually attempted

Addresses review feedback on #1496.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test --filter "trust-store"` — all 63 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
