### PR TITLE
Fix path resolution bug and unknown version overwrite in permissions

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -513,13 +513,13 @@ describe('Permission Checker', () => {
     test('relative path to protected file is still denied', async () => {
       // Simulate a relative path that resolves to the protected directory.
       // The default deny pattern uses an absolute path, so the checker
-      // must resolve relative paths before matching.
-      const cwd = process.cwd();
+      // must resolve relative paths against workingDir before matching.
+      const workingDir = '/tmp';
       const protectedPath = join(checkerTestDir, 'protected', 'trust.json');
-      // Build a relative path from cwd to the protected file
+      // Build a relative path from workingDir to the protected file
       const { relative } = await import('node:path');
-      const relPath = relative(cwd, protectedPath);
-      const result = await check('file_read', { path: relPath }, '/tmp');
+      const relPath = relative(workingDir, protectedPath);
+      const result = await check('file_read', { path: relPath }, workingDir);
       expect(result.decision).toBe('deny');
     });
   });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -617,13 +617,18 @@ describe('Trust Store', () => {
       expect(defaults).toHaveLength(NUM_DEFAULTS);
     });
 
-    test('default deny rules are backfilled after unknown file version', () => {
+    test('default deny rules are backfilled in-memory after unknown file version without overwriting disk', () => {
       mkdirSync(dirname(trustPath), { recursive: true });
-      writeFileSync(trustPath, JSON.stringify({ version: 9999, rules: [] }));
+      const originalContent = JSON.stringify({ version: 9999, rules: [{ id: 'future-rule', tool: 'bash', pattern: 'future *', scope: 'everywhere', decision: 'allow', priority: 50, createdAt: 1000 }] });
+      writeFileSync(trustPath, originalContent);
       clearCache();
       const rules = getAllRules();
+      // Defaults should be present in-memory
       const defaults = rules.filter((r) => r.id.startsWith('default:'));
       expect(defaults).toHaveLength(NUM_DEFAULTS);
+      // The on-disk file must NOT be overwritten — it preserves the unknown format
+      const diskContent = readFileSync(trustPath, 'utf-8');
+      expect(diskContent).toBe(originalContent);
     });
 
     test('clearAllRules preserves default deny rules', () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -123,7 +123,7 @@ function escapeMinimatchLiteral(value: string): string {
   return value.replace(/([\\*?[\]{}()!+@|])/g, '\\$1');
 }
 
-function buildCommandCandidates(toolName: string, input: Record<string, unknown>): string[] {
+function buildCommandCandidates(toolName: string, input: Record<string, unknown>, workingDir: string): string[] {
   if (toolName === 'bash') {
     return [getStringField(input, 'command')];
   }
@@ -165,7 +165,7 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
   }
 
   const fileTarget = getStringField(input, 'path', 'file_path');
-  const resolved = fileTarget ? resolve(fileTarget) : fileTarget;
+  const resolved = fileTarget ? resolve(workingDir, fileTarget) : fileTarget;
   const candidates = [`${toolName}:${resolved}`];
   // Also include the raw path if it differs, so user-created rules with
   // raw paths still match.
@@ -268,7 +268,7 @@ export async function check(
   const risk = await classifyRisk(toolName, input);
 
   // Build command string candidates for rule matching
-  const commandCandidates = buildCommandCandidates(toolName, input);
+  const commandCandidates = buildCommandCandidates(toolName, input, workingDir);
 
   // Find the highest-priority matching rule across all candidates
   const matchedRule = findHighestPriorityRule(toolName, commandCandidates, workingDir);

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -78,8 +78,14 @@ function loadFromDisk(): TrustRule[] {
       } else if (data.version === TRUST_FILE_VERSION) {
         rules = data.rules ?? [];
       } else {
-        log.warn({ version: data.version }, 'Unknown trust file version, ignoring');
-        // Fall through to backfill defaults even for unknown versions
+        log.warn({ version: data.version }, 'Unknown trust file version, applying defaults in-memory only');
+        // Apply default deny rules in-memory so the assistant is still
+        // protected, but do NOT persist — we must not overwrite a newer
+        // trust file format we don't understand.
+        const memRules: TrustRule[] = [];
+        backfillDefaults(memRules);
+        memRules.sort(ruleOrder);
+        return memRules;
       }
     } catch (err) {
       log.error({ err }, 'Failed to load trust file');


### PR DESCRIPTION
## Summary
- **Fix security bug**: `buildCommandCandidates` now resolves relative file paths against `workingDir` instead of `process.cwd()`, matching how file tools actually resolve paths in `path-guard.ts`. Previously, when `workingDir != process.cwd()`, an attacker-controlled relative path could bypass deny rules protecting sensitive files.
- **Fix unknown version overwrite**: When `trust.json` has an unknown/newer version, `loadFromDisk` now returns early with in-memory defaults only, instead of falling through and overwriting the file with v2 defaults. This prevents silently erasing user trust rules during a downgrade scenario.

Addresses review feedback on #1498.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 95 checker tests pass
- [x] All 63 trust-store tests pass
- [x] Updated relative path test to use `workingDir` instead of `process.cwd()`
- [x] Updated unknown version test to verify on-disk file is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
