### PR TITLE
Fix floating panel early dismissal and optional chaining

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -209,10 +209,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.toolConfirmationManager.showConfirmation(msg)
         }
         toolConfirmationManager.onResponse = { [weak self] requestId, decision in
+            guard let self else { return false }
             // Send the response to daemon; return false on failure so
             // the floating panel stays visible for retry.
             do {
-                try self?.daemonClient.sendConfirmationResponse(
+                try self.daemonClient.sendConfirmationResponse(
                     requestId: requestId,
                     decision: decision
                 )
@@ -222,7 +223,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             // Sync the inline message state across ALL ChatViewModels so the
             // originating thread is updated even if the user switched threads.
-            self?.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
+            self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
                 requestId: requestId,
                 decision: decision
             )

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -28,6 +28,7 @@ final class ToolConfirmationManager {
         // Dismiss existing panel for same request, if any
         dismissConfirmation(requestId: message.requestId)
 
+        let hasRuleOptions = !message.allowlistOptions.isEmpty && !message.scopeOptions.isEmpty
         let view = ToolConfirmationView(
             toolName: message.toolName,
             riskLevel: message.riskLevel,
@@ -35,10 +36,10 @@ final class ToolConfirmationManager {
             allowlistOptions: message.allowlistOptions,
             scopeOptions: message.scopeOptions,
             onAllow: { [weak self] in
-                self?.respond(requestId: message.requestId, decision: "allow") ?? false
+                self?.respond(requestId: message.requestId, decision: "allow", hasRuleOptions: hasRuleOptions) ?? false
             },
             onDeny: { [weak self] in
-                self?.respond(requestId: message.requestId, decision: "deny") ?? false
+                self?.respond(requestId: message.requestId, decision: "deny", hasRuleOptions: hasRuleOptions) ?? false
             },
             onDismiss: { [weak self] in
                 self?.dismissConfirmation(requestId: message.requestId)
@@ -102,9 +103,9 @@ final class ToolConfirmationManager {
         panels.removeAll()
     }
 
-    private func respond(requestId: String, decision: String) -> Bool {
+    private func respond(requestId: String, decision: String, hasRuleOptions: Bool) -> Bool {
         let success = onResponse?(requestId, decision) ?? true
-        if success {
+        if success && !hasRuleOptions {
             dismissConfirmation(requestId: requestId)
         }
         return success


### PR DESCRIPTION
## Summary
- **ToolConfirmationManager.respond()** now only dismisses the floating panel when `hasRuleOptions` is false. Previously it unconditionally dismissed on success, preventing the view from transitioning to `.decided` phase to show the trust rule picker.
- **AppDelegate's onResponse closure** uses `guard let self` instead of optional chaining on `self?`, so it correctly returns `false` when `self` is nil rather than silently succeeding without sending the IPC message.

Addresses feedback on #1499.

## Test plan
- [ ] Verify Allow/Deny on a tool with allowlist+scope options keeps the panel open for rule picker
- [ ] Verify Allow/Deny on a tool without rule options still dismisses immediately
- [ ] Build succeeds (`./build.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
