### PR TITLE
Fix missing Applications folder icon in DMG installer

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -127,10 +127,11 @@ jobs:
         run: |
           APP_PATH="dist/Vellum.app"
 
-          # Stage just the .app (create-dmg adds the Applications symlink)
+          # Stage the .app and an Applications symlink for the drop target
           DMG_STAGING="build/dmg-staging"
           mkdir -p "$DMG_STAGING"
           cp -R "$APP_PATH" "$DMG_STAGING/"
+          ln -s /Applications "$DMG_STAGING/Applications"
 
           echo "Staging directory size:"
           du -sh "$DMG_STAGING"
@@ -144,7 +145,7 @@ jobs:
             --icon-size 128 \
             --text-size 10 \
             --icon "Vellum.app" 175 190 \
-            --app-drop-link 485 190 \
+            --icon "Applications" 485 190 \
             --hide-extension "Vellum.app" \
             --no-internet-enable \
             "$DMG_PATH" \


### PR DESCRIPTION
## Summary
- The `--app-drop-link` flag in `create-dmg` relies on AppleScript to create the Applications symlink, which can fail silently on CI (exit code 2 is swallowed as non-fatal)
- Instead, manually create the `/Applications` symlink in the staging directory and use `--icon "Applications" 485 190` to position it, ensuring the drop target always appears in the DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
