### PR TITLE
Add Configuration section to system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -9,6 +9,7 @@ const TEST_DIR = join(tmpdir(), `vellum-sysprompt-test-${crypto.randomUUID()}`);
 import { mock } from 'bun:test';
 
 mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
   getDataDir: () => TEST_DIR,
   ensureDataDir: () => {},
   getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
@@ -33,10 +34,15 @@ mock.module('../util/logger.js', () => ({
 // Import after mock
 const { buildSystemPrompt, ensurePromptFiles } = await import('../config/system-prompt.js');
 
-/** Strip the bundled skills catalog suffix so base-prompt tests stay focused. */
+/** Strip the Configuration and Skills Catalog suffixes so base-prompt tests stay focused. */
 function basePrompt(result: string): string {
-  const idx = result.indexOf('\n\n## Skills Catalog');
-  return idx === -1 ? result : result.slice(0, idx);
+  let s = result;
+  for (const heading of ['## Configuration', '## Skills Catalog']) {
+    if (s.startsWith(heading)) { s = ''; break; }
+    const idx = s.indexOf(`\n\n${heading}`);
+    if (idx !== -1) s = s.slice(0, idx);
+  }
+  return s;
 }
 
 describe('buildSystemPrompt', () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -56,13 +56,22 @@ export function buildSystemPrompt(): string {
   const parts: string[] = [];
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
-  let basePrompt = parts.join('\n\n');
+  if (user) parts.push(user);
+  parts.push(buildConfigSection(baseDir));
 
-  if (user) {
-    basePrompt = basePrompt ? `${basePrompt}\n\n${user}` : user;
-  }
+  return appendSkillsCatalog(parts.join('\n\n'));
+}
 
-  return appendSkillsCatalog(basePrompt);
+function buildConfigSection(configDir: string): string {
+  return [
+    '## Configuration',
+    `Your configuration directory is \`${configDir}/\`. Key files you may read or edit:`,
+    '',
+    '- `IDENTITY.md` — Your name, role, and tone. Edit to change your persona.',
+    '- `SOUL.md` — Core principles and behavioral boundaries.',
+    '- `USER.md` — Profile of the user. Update as you learn about them over time.',
+    '- `skills/` — Directory of installed skills (loaded automatically at startup).',
+  ].join('\n');
 }
 
 function readPromptFile(path: string): string | null {


### PR DESCRIPTION
## Summary
- Appends a `## Configuration` section to the system prompt that tells the assistant about its config directory and key editable files (`IDENTITY.md`, `SOUL.md`, `USER.md`, `skills/`)
- Updates test helper to strip both `## Configuration` and `## Skills Catalog` sections so base-prompt tests stay focused
- Adds missing `getRootDir` mock to test setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
