### PR TITLE
Add DMG test script and fix blurry icon labels

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -81,6 +81,16 @@ scripts/run-dev.sh --clean
 scripts/run-dev.sh --team YOUR_TEAM_ID
 ```
 
+## Test DMG Installer
+
+To preview the DMG installer layout locally (requires `brew install create-dmg`):
+
+```bash
+./dmg/test-dmg.sh
+```
+
+This builds the app (if needed), generates the background image, creates a styled DMG, and opens it in Finder.
+
 ## Daemon
 
 The macOS app is a frontend — all inference (chat, computer-use sessions, ambient analysis) goes through the **daemon**, a Node/Bun process that manages Claude API calls, conversation state, and tool execution. The app connects to the daemon via a Unix domain socket at `~/.vellum/vellum.sock`.

--- a/clients/macos/dmg/generate-background.swift
+++ b/clients/macos/dmg/generate-background.swift
@@ -133,13 +133,9 @@ func drawCenteredText(_ text: String, centerX: CGFloat, y: CGFloat, font: CTFont
     ctx.restoreGState()
 }
 
-// --- Icon labels (white, baked into background for legibility on dark bg) ---
-let labelY = CGFloat(iconCenterY + 180)  // Below icons, matching Finder label position
-let labelFont = CTFontCreateWithName("Helvetica Neue" as CFString, 26.0, nil)
-let labelColor = CGColor(colorSpace: colorSpace, components: rgb(255, 255, 255, 0.9))!
-
-drawCenteredText("Vellum", centerX: CGFloat(leftIconX), y: labelY, font: labelFont, color: labelColor)
-drawCenteredText("Applications", centerX: CGFloat(rightIconX), y: labelY, font: labelFont, color: labelColor)
+// Note: "Vellum" and "Applications" labels are drawn natively by Finder
+// (white text on dark backgrounds). Don't bake them into the background
+// or they'll overlap and look blurry.
 
 // --- "Drag to install" text ---
 let textY = CGFloat(iconCenterY + 150)  // Below the icons

--- a/clients/macos/dmg/test-dmg.sh
+++ b/clients/macos/dmg/test-dmg.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Build a test DMG locally and open it in Finder.
+# Run from clients/macos/:  ./dmg/test-dmg.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Check for create-dmg
+if ! command -v create-dmg &>/dev/null; then
+  echo "create-dmg not found. Install with: brew install create-dmg"
+  exit 1
+fi
+
+# Build the app if it doesn't exist
+APP_PATH="dist/Vellum.app"
+if [ ! -d "$APP_PATH" ]; then
+  echo "Building app..."
+  ./build.sh release
+fi
+
+# Generate background
+mkdir -p build
+echo "Generating DMG background..."
+swift dmg/generate-background.swift build/dmg-background@2x.png
+
+# Stage files
+DMG_STAGING="build/dmg-staging"
+rm -rf "$DMG_STAGING"
+mkdir -p "$DMG_STAGING"
+cp -R "$APP_PATH" "$DMG_STAGING/"
+ln -s /Applications "$DMG_STAGING/Applications"
+
+# Remove old test DMG if present
+DMG_PATH="build/test.dmg"
+rm -f "$DMG_PATH"
+
+# Create DMG
+echo "Creating DMG..."
+create-dmg \
+  --volname "Vellum" \
+  --background "build/dmg-background@2x.png" \
+  --window-pos 200 120 \
+  --window-size 660 400 \
+  --icon-size 128 \
+  --text-size 10 \
+  --icon "Vellum.app" 175 190 \
+  --icon "Applications" 485 190 \
+  --hide-extension "Vellum.app" \
+  --no-internet-enable \
+  "$DMG_PATH" \
+  "$DMG_STAGING/" \
+|| {
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 2 ] && [ -f "$DMG_PATH" ]; then
+    echo "create-dmg exited with warning (code 2), but DMG was created successfully"
+  else
+    echo "create-dmg failed with exit code $EXIT_CODE"
+    exit $EXIT_CODE
+  fi
+}
+
+echo "DMG created at $DMG_PATH"
+open "$DMG_PATH"


### PR DESCRIPTION
## Summary
- Add `dmg/test-dmg.sh` — single command to build and preview the DMG installer locally (`brew install create-dmg` required)
- Remove "Vellum" and "Applications" labels from the background image to fix blurry text — Finder draws these natively in white on dark backgrounds, so the baked-in labels were overlapping and causing a doubled/blurry appearance

## Test plan
- [ ] Run `cd clients/macos && ./dmg/test-dmg.sh` and verify the DMG opens with crisp labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
