### PR TITLE
Fix onAddTrustRule returning true when self is nil

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -230,8 +230,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
         toolConfirmationManager.onAddTrustRule = { [weak self] toolName, pattern, scope, decision in
+            guard let self else { return false }
             do {
-                try self?.daemonClient.sendAddTrustRule(
+                try self.daemonClient.sendAddTrustRule(
                     toolName: toolName,
                     pattern: pattern,
                     scope: scope,


### PR DESCRIPTION
## Summary

Fixes the same nil-self bug pattern that PR #1502 addressed for the `onResponse` closure, but in the `onAddTrustRule` closure at `AppDelegate.swift:232-245`.

The `onAddTrustRule` closure used optional chaining (`self?.daemonClient.sendAddTrustRule(...)`) which silently short-circuits to `nil` when `self` is deallocated. Since the optional chain doesn't throw, execution falls through to `return true` — incorrectly reporting success when no IPC message was actually sent.

**Fix:** Add `guard let self else { return false }` and change `self?.daemonClient` to `self.daemonClient`.

Addresses feedback from Devin on #1502.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
