### PR TITLE
Add friendly descriptions to allowlist pattern options

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -184,6 +184,16 @@ exports[`IPC message snapshots ClientMessage types suggestion_request serializes
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "pattern": "git *",
+  "scope": "/projects/my-app",
+  "toolName": "bash",
+  "type": "add_trust_rule",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",
@@ -240,6 +250,7 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
 {
   "allowlistOptions": [
     {
+      "description": "Allow rm commands",
       "label": "Allow rm commands",
       "pattern": "bash:rm *",
     },
@@ -605,15 +616,5 @@ exports[`IPC message snapshots ServerMessage types timer_completed serializes to
   "sessionId": "sess-001",
   "timerId": "tmr-001",
   "type": "timer_completed",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to expected JSON 1`] = `
-{
-  "decision": "allow",
-  "pattern": "git *",
-  "scope": "/projects/my-app",
-  "toolName": "bash",
-  "type": "add_trust_rule",
 }
 `;

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -530,9 +530,9 @@ describe('Permission Checker', () => {
     test('shell: generates exact, subcommand wildcard, and program wildcard', () => {
       const options = generateAllowlistOptions('bash', { command: 'npm install express' });
       expect(options).toHaveLength(3);
-      expect(options[0]).toEqual({ label: 'npm install express', pattern: 'npm install express' });
-      expect(options[1]).toEqual({ label: 'npm install *', pattern: 'npm install *' });
-      expect(options[2]).toEqual({ label: 'npm *', pattern: 'npm *' });
+      expect(options[0]).toEqual({ label: 'npm install express', description: 'This exact command', pattern: 'npm install express' });
+      expect(options[1]).toEqual({ label: 'npm install *', description: 'Any "npm install" command', pattern: 'npm install *' });
+      expect(options[2]).toEqual({ label: 'npm *', description: 'Any npm command', pattern: 'npm *' });
     });
 
     test('shell: single-word command deduplicates', () => {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -183,7 +183,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     input: { command: 'rm -rf /tmp/test' },
     riskLevel: 'high',
     allowlistOptions: [
-      { label: 'Allow rm commands', pattern: 'bash:rm *' },
+      { label: 'Allow rm commands', description: 'Allow rm commands', pattern: 'bash:rm *' },
     ],
     scopeOptions: [
       { label: 'In /tmp', scope: '/tmp' },

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -43,7 +43,7 @@ mock.module('../util/logger.js', () => ({
 mock.module('../permissions/checker.js', () => ({
   classifyRisk: async () => checkerRisk,
   check: async () => ({ decision: checkerDecision, reason: checkerReason }),
-  generateAllowlistOptions: () => [{ label: 'exact', pattern: 'exact' }],
+  generateAllowlistOptions: () => [{ label: 'exact', description: 'exact', pattern: 'exact' }],
   generateScopeOptions: () => [{ label: '/tmp', scope: '/tmp' }],
 }));
 
@@ -157,7 +157,7 @@ describe('ToolExecutor lifecycle events', () => {
     expect(promptEvent.riskLevel).toBe('medium');
     expect(promptEvent.reason).toBe('medium risk: requires approval');
     expect(promptEvent.sandboxed).toBe(true);
-    expect(promptEvent.allowlistOptions).toEqual([{ label: 'exact', pattern: 'exact' }]);
+    expect(promptEvent.allowlistOptions).toEqual([{ label: 'exact', description: 'exact', pattern: 'exact' }]);
     expect(promptEvent.scopeOptions).toEqual([{ label: '/tmp', scope: '/tmp' }]);
 
     const deniedEvent = events[2];

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -334,7 +334,7 @@ export interface ConfirmationRequest {
   toolName: string;
   input: Record<string, unknown>;
   riskLevel: string;
-  allowlistOptions: Array<{ label: string; pattern: string }>;
+  allowlistOptions: Array<{ label: string; description: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
   sandboxed?: boolean;

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -298,26 +298,46 @@ export async function check(
   return { decision: 'prompt', reason: `${risk} risk: requires approval` };
 }
 
+const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  file_read: 'file reads',
+  file_write: 'file writes',
+  file_edit: 'file edits',
+  web_fetch: 'URL fetches',
+  browser_navigate: 'browser navigations',
+};
+
+function friendlyBasename(filePath: string): string {
+  const parts = filePath.split('/');
+  return parts[parts.length - 1] || filePath;
+}
+
+function friendlyHostname(url: URL): string {
+  return url.hostname.replace(/^www\./, '');
+}
+
 export function generateAllowlistOptions(toolName: string, input: Record<string, unknown>): AllowlistOption[] {
   if (toolName === 'bash') {
     const command = ((input.command as string) ?? '').trim();
     const parts = command.split(/\s+/);
+    const program = parts[0] ?? command;
     const options: AllowlistOption[] = [];
 
     // Exact match
-    options.push({ label: command, pattern: command });
+    options.push({ label: command, description: 'This exact command', pattern: command });
 
     if (parts.length >= 2) {
       // Subcommand wildcard: "npm install *"
+      const sub = parts.slice(0, -1).join(' ');
       options.push({
-        label: `${parts.slice(0, -1).join(' ')} *`,
-        pattern: `${parts.slice(0, -1).join(' ')} *`,
+        label: `${sub} *`,
+        description: `Any "${sub}" command`,
+        pattern: `${sub} *`,
       });
     }
 
     if (parts.length >= 1) {
       // Program wildcard: "npm *"
-      options.push({ label: `${parts[0]} *`, pattern: `${parts[0]} *` });
+      options.push({ label: `${program} *`, description: `Any ${program} command`, pattern: `${program} *` });
     }
 
     // Deduplicate
@@ -331,18 +351,20 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
 
   if (toolName === 'file_write' || toolName === 'file_read' || toolName === 'file_edit') {
     const filePath = (input.path as string) ?? (input.file_path as string) ?? '';
+    const toolLabel = TOOL_DISPLAY_NAMES[toolName] ?? toolName;
     const options: AllowlistOption[] = [];
 
     // Patterns must match the "tool:path" format used by check()
     // Exact file
-    options.push({ label: filePath, pattern: `${toolName}:${filePath}` });
+    options.push({ label: filePath, description: `This file only`, pattern: `${toolName}:${filePath}` });
 
     // Directory wildcard
     const dir = dirname(filePath);
-    options.push({ label: `${dir}/*`, pattern: `${toolName}:${dir}/*` });
+    const dirName = friendlyBasename(dir);
+    options.push({ label: `${dir}/*`, description: `Any file in ${dirName}/`, pattern: `${toolName}:${dir}/*` });
 
     // Tool wildcard
-    options.push({ label: `${toolName}:*`, pattern: `${toolName}:*` });
+    options.push({ label: `${toolName}:*`, description: `All ${toolLabel}`, pattern: `${toolName}:*` });
 
     return options;
   }
@@ -354,15 +376,18 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
 
     const options: AllowlistOption[] = [];
     if (exact) {
-      options.push({ label: exact, pattern: `${toolName}:${escapeMinimatchLiteral(exact)}` });
+      options.push({ label: exact, description: 'This exact URL', pattern: `${toolName}:${escapeMinimatchLiteral(exact)}` });
     }
     if (normalized) {
+      const host = friendlyHostname(normalized);
       options.push({
         label: `${normalized.origin}/*`,
+        description: `Any page on ${host}`,
         pattern: `${toolName}:${escapeMinimatchLiteral(normalized.origin)}/*`,
       });
     }
-    options.push({ label: `${toolName}:*`, pattern: `${toolName}:*` });
+    const toolLabel = TOOL_DISPLAY_NAMES[toolName] ?? toolName;
+    options.push({ label: `${toolName}:*`, description: `All ${toolLabel}`, pattern: `${toolName}:*` });
 
     const seen = new Set<string>();
     return options.filter((o) => {
@@ -372,7 +397,7 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
     });
   }
 
-  return [{ label: '*', pattern: '*' }];
+  return [{ label: '*', description: 'Everything', pattern: '*' }];
 }
 
 export function generateScopeOptions(workingDir: string): ScopeOption[] {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -53,7 +53,7 @@ export class PermissionPrompter {
         toolName,
         input,
         riskLevel,
-        allowlistOptions: allowlistOptions.map((o) => ({ label: o.label, pattern: o.pattern })),
+        allowlistOptions: allowlistOptions.map((o) => ({ label: o.label, description: o.description, pattern: o.pattern })),
         scopeOptions: scopeOptions.map((o) => ({ label: o.label, scope: o.scope })),
         diff,
         sandboxed,

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -24,6 +24,7 @@ export interface PermissionCheckResult {
 
 export interface AllowlistOption {
   label: string;
+  description: string;
   pattern: string;
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -185,7 +185,7 @@ struct ToolConfirmationBubble: View {
                         .foregroundColor(VColor.textSecondary)
                     Picker("", selection: $selectedPattern) {
                         ForEach(confirmation.allowlistOptions, id: \.pattern) { option in
-                            Text(option.label).tag(option.pattern)
+                            Text(option.description ?? option.label).tag(option.pattern)
                         }
                     }
                     .pickerStyle(.menu)
@@ -196,8 +196,8 @@ struct ToolConfirmationBubble: View {
                     Text("Pattern:")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
-                    Text(single.label)
-                        .font(VFont.monoSmall)
+                    Text(single.description ?? single.label)
+                        .font(VFont.caption)
                         .foregroundColor(VColor.textPrimary)
                 }
             }
@@ -262,8 +262,8 @@ struct ToolConfirmationBubble: View {
                 riskLevel: "medium",
                 diff: nil,
                 allowlistOptions: [
-                    .init(label: "git push", pattern: "git push"),
-                    .init(label: "All git commands", pattern: "git *"),
+                    .init(label: "git push", description: "This exact command", pattern: "git push"),
+                    .init(label: "git *", description: "Any git command", pattern: "git *"),
                 ],
                 scopeOptions: [
                     .init(label: "This project", scope: "/Users/test/project"),
@@ -297,7 +297,7 @@ struct ToolConfirmationBubble: View {
                 riskLevel: "medium",
                 diff: nil,
                 allowlistOptions: [
-                    .init(label: "npm install", pattern: "npm install"),
+                    .init(label: "npm install", description: "This exact command", pattern: "npm install"),
                 ],
                 scopeOptions: [
                     .init(label: "Everywhere", scope: "everywhere"),

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -291,7 +291,7 @@ struct ToolConfirmationView: View {
                         .foregroundColor(VColor.textSecondary)
                     Picker("", selection: $selectedPattern) {
                         ForEach(allowlistOptions, id: \.pattern) { option in
-                            Text(option.label).tag(option.pattern)
+                            Text(option.description ?? option.label).tag(option.pattern)
                         }
                     }
                     .pickerStyle(.menu)
@@ -302,8 +302,8 @@ struct ToolConfirmationView: View {
                     Text("Pattern:")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
-                    Text(single.label)
-                        .font(.system(size: 11, design: .monospaced))
+                    Text(single.description ?? single.label)
+                        .font(VFont.caption)
                         .foregroundColor(VColor.textPrimary)
                 }
             }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -459,6 +459,7 @@ struct ConfirmationRequestMessage: Decodable, Sendable {
 
     struct ConfirmationAllowlistOption: Decodable, Sendable, Equatable {
         let label: String
+        let description: String?
         let pattern: String
     }
     struct ConfirmationScopeOption: Decodable, Sendable, Equatable {


### PR DESCRIPTION
## Summary
- Adds a `description` field to `AllowlistOption` with human-readable labels (e.g. "This exact command", "Any file in project/", "Any page on example.com")
- Updates both SwiftUI confirmation views (inline bubble + floating panel) to display descriptions instead of raw patterns
- Updates IPC protocol, prompter, and tests to carry the new field end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
