### PR TITLE
Remove noisy attachment upload log

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -65,10 +65,6 @@ export function createTelegramWebhookHandler(
             const uploaded = await uploadAttachment(config, routing.assistantId, downloaded);
             attachmentIds.push(uploaded.id);
           }
-          log.info(
-            { count: attachmentIds.length, assistantId: routing.assistantId },
-            "Attachments downloaded and uploaded",
-          );
         } catch (err) {
           log.error({ err }, "Failed to process attachments");
           return Response.json({ error: "Failed to process attachments" }, { status: 500 });


### PR DESCRIPTION
## Summary
- Removes a verbose `log.info` statement from the Telegram webhook attachment processing path
- The error-level log for failures is retained; this just removes the success info log

## Test plan
- [ ] Verify Telegram attachment uploads still work without the log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
