### PR TITLE
Use Slate._900 token for chatBackground instead of raw hex

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Tokens/ColorTokens.swift
@@ -101,7 +101,7 @@ enum VColor {
     // Backgrounds
     static let background = Slate._950
     static let backgroundSubtle = Slate._800
-    static let chatBackground = Color(hex: 0x0F172A)
+    static let chatBackground = Slate._900
     static let surface = Slate._800
     static let surfaceBorder = Slate._700
 


### PR DESCRIPTION
## Summary
- Replace `Color(hex: 0x0F172A)` with `Slate._900` in `VColor.chatBackground` to follow codebase convention of semantic tokens referencing scale tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
