### PR TITLE
Add production Dockerfile + dockerignore for gateway

### DIFF
--- a/gateway/.dockerignore
+++ b/gateway/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,45 @@
+# Build stage
+FROM debian:bookworm AS builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+COPY . .
+
+# Runtime stage
+FROM debian:bookworm-slim AS runner
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash && \
+    mv /root/.bun/bin/bun /usr/local/bin/bun && \
+    rm -rf /root/.bun
+
+RUN groupadd --system --gid 1001 gateway && \
+    useradd --system --uid 1001 --gid gateway --create-home gateway
+
+COPY --from=builder --chown=gateway:gateway /app /app
+
+USER gateway
+
+EXPOSE 7830
+
+ENV GATEWAY_PORT=7830
+
+CMD ["bun", "run", "src/index.ts"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -96,6 +96,22 @@ curl -i -X POST http://localhost:7830/webhooks/telegram
 - The `host` header is not forwarded to upstream.
 - Upstream connection failures return `502 Bad Gateway`.
 
+## Docker
+
+```bash
+# Build
+docker build -t vellum-gateway:local gateway
+
+# Run (pass required env vars)
+docker run --rm -p 7830:7830 \
+  -e TELEGRAM_BOT_TOKEN=... \
+  -e TELEGRAM_WEBHOOK_SECRET=... \
+  -e ASSISTANT_RUNTIME_BASE_URL=http://host.docker.internal:7821 \
+  vellum-gateway:local
+```
+
+The image runs as non-root user `gateway` (uid 1001) and exposes port `7830`.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary
- Add multi-stage `gateway/Dockerfile` (debian-slim runtime, non-root user, port 7830)
- Add `gateway/.dockerignore` to exclude node_modules, .env, logs
- Document Docker build/run commands in README

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (53 tests)
- [ ] `docker build -t vellum-gateway:local gateway` succeeds
- [ ] Container starts and listens on 7830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
