### PR TITLE
Add /healthz, /readyz, and graceful shutdown behavior

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -33,3 +33,6 @@ ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
 
 # Required when proxy is enabled with auth required: Bearer token for proxy auth
 # RUNTIME_PROXY_BEARER_TOKEN=
+
+# Optional: Graceful shutdown drain window in milliseconds (default: 5000)
+# GATEWAY_SHUTDOWN_DRAIN_MS=5000

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -37,6 +37,7 @@ bun run dev
 | `GATEWAY_RUNTIME_PROXY_ENABLED` | No | `false` | Enable runtime proxy for non-Telegram requests |
 | `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
 | `RUNTIME_PROXY_BEARER_TOKEN` | Conditional | — | Bearer token for proxy auth (required when proxy + auth enabled) |
+| `GATEWAY_SHUTDOWN_DRAIN_MS` | No | `5000` | Graceful shutdown drain window in milliseconds |
 
 ## Routing
 
@@ -99,6 +100,15 @@ curl -i -X POST http://localhost:7830/webhooks/telegram
 - Hop-by-hop headers (`connection`, `keep-alive`, `transfer-encoding`, etc.) are stripped from both request and response.
 - The `host` header is not forwarded to upstream.
 - Upstream connection failures return `502 Bad Gateway`.
+
+## Health & Readiness Probes
+
+| Endpoint | Method | Behavior |
+|----------|--------|----------|
+| `/healthz` | GET | Always returns `200` while the process is alive |
+| `/readyz` | GET | Returns `200` while accepting traffic; `503` during graceful shutdown drain |
+
+On `SIGTERM` the gateway enters drain mode: `/readyz` begins returning `503` so the load balancer stops sending new traffic. After `GATEWAY_SHUTDOWN_DRAIN_MS` (default 5 s) the process exits.
 
 ## Docker
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -19,6 +19,7 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void) 
     "GATEWAY_DEFAULT_ASSISTANT_ID",
     "GATEWAY_UNMAPPED_POLICY",
     "GATEWAY_PORT",
+    "GATEWAY_SHUTDOWN_DRAIN_MS",
   ];
 
   for (const key of allKeys) {

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, afterAll } from "bun:test";
+
+const PORT = 19831;
+
+const env: Record<string, string> = {
+  TELEGRAM_BOT_TOKEN: "test-tok",
+  TELEGRAM_WEBHOOK_SECRET: "wh-sec",
+  ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
+  GATEWAY_PORT: String(PORT),
+};
+
+const saved: Record<string, string | undefined> = {};
+for (const [k, v] of Object.entries(env)) {
+  saved[k] = process.env[k];
+  process.env[k] = v;
+}
+saved["GATEWAY_RUNTIME_PROXY_ENABLED"] = process.env.GATEWAY_RUNTIME_PROXY_ENABLED;
+delete process.env.GATEWAY_RUNTIME_PROXY_ENABLED;
+
+const { loadConfig } = await import("../config.js");
+const { createTelegramWebhookHandler } = await import(
+  "../http/routes/telegram-webhook.js"
+);
+
+const config = loadConfig();
+
+const handleTelegramWebhook = createTelegramWebhookHandler(
+  config,
+  async () => {},
+);
+
+let draining = false;
+
+const server = Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/healthz") {
+      return Response.json({ status: "ok" });
+    }
+
+    if (url.pathname === "/readyz") {
+      if (draining) {
+        return Response.json({ status: "draining" }, { status: 503 });
+      }
+      return Response.json({ status: "ok" });
+    }
+
+    if (url.pathname === "/webhooks/telegram") {
+      return handleTelegramWebhook(req);
+    }
+
+    return Response.json({ error: "Not found" }, { status: 404 });
+  },
+});
+
+afterAll(() => {
+  server.stop(true);
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("/healthz", () => {
+  test("returns 200 with ok status", async () => {
+    const res = await fetch(`http://localhost:${PORT}/healthz`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+});
+
+describe("/readyz", () => {
+  test("returns 200 when not draining", async () => {
+    const res = await fetch(`http://localhost:${PORT}/readyz`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("returns 503 when draining", async () => {
+    draining = true;
+    try {
+      const res = await fetch(`http://localhost:${PORT}/readyz`);
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.status).toBe("draining");
+    } finally {
+      draining = false;
+    }
+  });
+});

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyEnabled: false,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -14,6 +14,7 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   runtimeProxyEnabled: false,
   runtimeProxyRequireAuth: true,
   runtimeProxyBearerToken: undefined,
+  shutdownDrainMs: 5000,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -17,6 +17,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: TOKEN,
+    shutdownDrainMs: 5000,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyEnabled: true,
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
     ...overrides,
   };
 }

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -20,6 +20,7 @@ export type GatewayConfig = {
   runtimeProxyEnabled: boolean;
   runtimeProxyRequireAuth: boolean;
   runtimeProxyBearerToken: string | undefined;
+  shutdownDrainMs: number;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -115,6 +116,12 @@ export function loadConfig(): GatewayConfig {
   const runtimeProxyBearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || undefined;
 
+  const shutdownDrainMsRaw = process.env.GATEWAY_SHUTDOWN_DRAIN_MS || "5000";
+  const shutdownDrainMs = Number(shutdownDrainMsRaw);
+  if (!Number.isFinite(shutdownDrainMs) || shutdownDrainMs < 0) {
+    throw new Error("GATEWAY_SHUTDOWN_DRAIN_MS must be a non-negative number");
+  }
+
   if (runtimeProxyEnabled && runtimeProxyRequireAuth && !runtimeProxyBearerToken) {
     throw new Error(
       "RUNTIME_PROXY_BEARER_TOKEN is required when proxy is enabled with auth required",
@@ -147,5 +154,6 @@ export function loadConfig(): GatewayConfig {
     runtimeProxyEnabled,
     runtimeProxyRequireAuth,
     runtimeProxyBearerToken,
+    shutdownDrainMs,
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -6,6 +6,8 @@ import { sendTelegramReply } from "./telegram/send.js";
 
 const log = pino({ name: "gateway" });
 
+let draining = false;
+
 function main() {
   log.info("Starting Vellum Gateway...");
 
@@ -34,6 +36,17 @@ function main() {
     async fetch(req) {
       const url = new URL(req.url);
 
+      if (url.pathname === "/healthz") {
+        return Response.json({ status: "ok" });
+      }
+
+      if (url.pathname === "/readyz") {
+        if (draining) {
+          return Response.json({ status: "draining" }, { status: 503 });
+        }
+        return Response.json({ status: "ok" });
+      }
+
       if (url.pathname === "/webhooks/telegram") {
         return handleTelegramWebhook(req);
       }
@@ -47,6 +60,18 @@ function main() {
   });
 
   log.info({ port: server.port }, "Gateway HTTP server listening");
+
+  const drainMs = config.shutdownDrainMs;
+
+  process.on("SIGTERM", () => {
+    log.info("SIGTERM received, starting graceful shutdown");
+    draining = true;
+    setTimeout(() => {
+      log.info("Drain window elapsed, stopping server");
+      server.stop(true);
+      process.exit(0);
+    }, drainMs);
+  });
 }
 
 main();


### PR DESCRIPTION
## Summary
- Add `GET /healthz` (always 200 while process alive)
- Add `GET /readyz` (200 while accepting traffic, 503 during drain)
- Handle `SIGTERM` with configurable drain window (`GATEWAY_SHUTDOWN_DRAIN_MS`, default 5s)
- Add probe tests and update README/env docs

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (62 tests, 3 new probe tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
