### PR TITLE
Add configurable upstream timeouts and retry controls

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -36,3 +36,15 @@ ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
 
 # Optional: Graceful shutdown drain window in milliseconds (default: 5000)
 # GATEWAY_SHUTDOWN_DRAIN_MS=5000
+
+# Optional: Timeout for runtime HTTP calls in milliseconds (default: 30000)
+# GATEWAY_RUNTIME_TIMEOUT_MS=30000
+
+# Optional: Max retries for runtime forward on 5xx/network errors (default: 2)
+# GATEWAY_RUNTIME_MAX_RETRIES=2
+
+# Optional: Initial backoff between retries in milliseconds (default: 500)
+# GATEWAY_RUNTIME_INITIAL_BACKOFF_MS=500
+
+# Optional: Timeout for Telegram API/download calls in milliseconds (default: 15000)
+# GATEWAY_TELEGRAM_TIMEOUT_MS=15000

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -38,6 +38,10 @@ bun run dev
 | `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No | `true` | Require bearer auth for proxied requests |
 | `RUNTIME_PROXY_BEARER_TOKEN` | Conditional | — | Bearer token for proxy auth (required when proxy + auth enabled) |
 | `GATEWAY_SHUTDOWN_DRAIN_MS` | No | `5000` | Graceful shutdown drain window in milliseconds |
+| `GATEWAY_RUNTIME_TIMEOUT_MS` | No | `30000` | Timeout for runtime HTTP calls (ms) |
+| `GATEWAY_RUNTIME_MAX_RETRIES` | No | `2` | Max retries for runtime forward on 5xx/network errors |
+| `GATEWAY_RUNTIME_INITIAL_BACKOFF_MS` | No | `500` | Initial backoff between retries (doubles each attempt) |
+| `GATEWAY_TELEGRAM_TIMEOUT_MS` | No | `15000` | Timeout for Telegram API/download calls (ms) |
 
 ## Routing
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -20,6 +20,10 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void) 
     "GATEWAY_UNMAPPED_POLICY",
     "GATEWAY_PORT",
     "GATEWAY_SHUTDOWN_DRAIN_MS",
+    "GATEWAY_RUNTIME_TIMEOUT_MS",
+    "GATEWAY_RUNTIME_MAX_RETRIES",
+    "GATEWAY_RUNTIME_INITIAL_BACKOFF_MS",
+    "GATEWAY_TELEGRAM_TIMEOUT_MS",
   ];
 
   for (const key of allKeys) {

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -16,6 +16,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: undefined,
     shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramTimeoutMs: 15000,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -15,6 +15,10 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   runtimeProxyRequireAuth: true,
   runtimeProxyBearerToken: undefined,
   shutdownDrainMs: 5000,
+  runtimeTimeoutMs: 30000,
+  runtimeMaxRetries: 2,
+  runtimeInitialBackoffMs: 500,
+  telegramTimeoutMs: 15000,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -18,6 +18,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyRequireAuth: true,
     runtimeProxyBearerToken: TOKEN,
     shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramTimeoutMs: 15000,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -16,6 +16,10 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeProxyRequireAuth: false,
     runtimeProxyBearerToken: undefined,
     shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramTimeoutMs: 15000,
     ...overrides,
   };
 }

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -21,6 +21,10 @@ export type GatewayConfig = {
   runtimeProxyRequireAuth: boolean;
   runtimeProxyBearerToken: string | undefined;
   shutdownDrainMs: number;
+  runtimeTimeoutMs: number;
+  runtimeMaxRetries: number;
+  runtimeInitialBackoffMs: number;
+  telegramTimeoutMs: number;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -122,6 +126,26 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_SHUTDOWN_DRAIN_MS must be a non-negative number");
   }
 
+  const runtimeTimeoutMs = Number(process.env.GATEWAY_RUNTIME_TIMEOUT_MS || "30000");
+  if (!Number.isFinite(runtimeTimeoutMs) || runtimeTimeoutMs <= 0) {
+    throw new Error("GATEWAY_RUNTIME_TIMEOUT_MS must be a positive number");
+  }
+
+  const runtimeMaxRetries = Number(process.env.GATEWAY_RUNTIME_MAX_RETRIES || "2");
+  if (!Number.isInteger(runtimeMaxRetries) || runtimeMaxRetries < 0) {
+    throw new Error("GATEWAY_RUNTIME_MAX_RETRIES must be a non-negative integer");
+  }
+
+  const runtimeInitialBackoffMs = Number(process.env.GATEWAY_RUNTIME_INITIAL_BACKOFF_MS || "500");
+  if (!Number.isFinite(runtimeInitialBackoffMs) || runtimeInitialBackoffMs <= 0) {
+    throw new Error("GATEWAY_RUNTIME_INITIAL_BACKOFF_MS must be a positive number");
+  }
+
+  const telegramTimeoutMs = Number(process.env.GATEWAY_TELEGRAM_TIMEOUT_MS || "15000");
+  if (!Number.isFinite(telegramTimeoutMs) || telegramTimeoutMs <= 0) {
+    throw new Error("GATEWAY_TELEGRAM_TIMEOUT_MS must be a positive number");
+  }
+
   if (runtimeProxyEnabled && runtimeProxyRequireAuth && !runtimeProxyBearerToken) {
     throw new Error(
       "RUNTIME_PROXY_BEARER_TOKEN is required when proxy is enabled with auth required",
@@ -155,5 +179,9 @@ export function loadConfig(): GatewayConfig {
     runtimeProxyRequireAuth,
     runtimeProxyBearerToken,
     shutdownDrainMs,
+    runtimeTimeoutMs,
+    runtimeMaxRetries,
+    runtimeInitialBackoffMs,
+    telegramTimeoutMs,
   };
 }

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -3,9 +3,6 @@ import type { GatewayConfig } from "../config.js";
 
 const log = pino({ name: "gateway:runtime-client" });
 
-const MAX_RETRIES = 2;
-const INITIAL_BACKOFF_MS = 500;
-
 export type RuntimeInboundPayload = {
   sourceChannel: string;
   externalChatId: string;
@@ -40,9 +37,9 @@ export async function forwardToRuntime(
 
   let lastError: Error | null = null;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= config.runtimeMaxRetries; attempt++) {
     if (attempt > 0) {
-      const delay = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+      const delay = config.runtimeInitialBackoffMs * Math.pow(2, attempt - 1);
       log.debug({ attempt, delay, assistantId }, "Retrying runtime forward");
       await new Promise((r) => setTimeout(r, delay));
     }
@@ -52,6 +49,7 @@ export async function forwardToRuntime(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(config.runtimeTimeoutMs),
       });
 
       if (response.status >= 400 && response.status < 500) {
@@ -118,6 +116,7 @@ export async function uploadAttachment(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
   });
 
   if (!response.ok) {

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -16,6 +16,7 @@ export async function callTelegramApi<T>(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(config.telegramTimeoutMs),
   });
 
   const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -33,7 +33,9 @@ export async function downloadTelegramFile(
   }
 
   const downloadUrl = `${config.telegramApiBaseUrl}/file/bot${config.telegramBotToken}/${file.file_path}`;
-  const response = await fetch(downloadUrl);
+  const response = await fetch(downloadUrl, {
+    signal: AbortSignal.timeout(config.telegramTimeoutMs),
+  });
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Move hardcoded `MAX_RETRIES`/`INITIAL_BACKOFF_MS` from `runtime/client.ts` into config
- Add `AbortSignal.timeout()` to all upstream fetch calls (runtime forward, attachment upload, Telegram API, Telegram file download)
- New env vars: `GATEWAY_RUNTIME_TIMEOUT_MS`, `GATEWAY_RUNTIME_MAX_RETRIES`, `GATEWAY_RUNTIME_INITIAL_BACKOFF_MS`, `GATEWAY_TELEGRAM_TIMEOUT_MS`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (62 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
