### PR TITLE
Add hooks infrastructure: types, discovery, and config

### DIFF
--- a/assistant/src/__tests__/hooks-config.test.ts
+++ b/assistant/src/__tests__/hooks-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-config-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { loadHooksConfig, saveHooksConfig, isHookEnabled, setHookEnabled, ensureHookInConfig } from '../hooks/config.js';
+
+describe('Hooks Config', () => {
+  beforeEach(() => {
+    const hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('loadHooksConfig returns defaults when no config file exists', () => {
+    const config = loadHooksConfig();
+    expect(config.version).toBe(1);
+    expect(config.hooks).toEqual({});
+  });
+
+  test('loadHooksConfig reads existing config', () => {
+    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      version: 1,
+      hooks: { 'my-hook': { enabled: true } },
+    }));
+
+    const config = loadHooksConfig();
+    expect(config.hooks['my-hook'].enabled).toBe(true);
+  });
+
+  test('loadHooksConfig returns defaults for invalid JSON', () => {
+    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    writeFileSync(configPath, 'NOT VALID JSON {{{');
+
+    const config = loadHooksConfig();
+    expect(config.version).toBe(1);
+    expect(config.hooks).toEqual({});
+  });
+
+  test('loadHooksConfig returns defaults for invalid structure', () => {
+    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    writeFileSync(configPath, JSON.stringify({ foo: 'bar' }));
+
+    const config = loadHooksConfig();
+    expect(config.version).toBe(1);
+    expect(config.hooks).toEqual({});
+  });
+
+  test('saveHooksConfig writes config to disk', () => {
+    const config = { version: 1, hooks: { 'test-hook': { enabled: true } } };
+    saveHooksConfig(config);
+
+    const configPath = join(testDir, '.vellum', 'hooks', 'config.json');
+    expect(existsSync(configPath)).toBe(true);
+    const read = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(read.hooks['test-hook'].enabled).toBe(true);
+  });
+
+  test('isHookEnabled returns false for unknown hook', () => {
+    expect(isHookEnabled('nonexistent')).toBe(false);
+  });
+
+  test('setHookEnabled enables a hook', () => {
+    setHookEnabled('my-hook', true);
+    expect(isHookEnabled('my-hook')).toBe(true);
+  });
+
+  test('setHookEnabled disables a hook', () => {
+    setHookEnabled('my-hook', true);
+    setHookEnabled('my-hook', false);
+    expect(isHookEnabled('my-hook')).toBe(false);
+  });
+
+  test('ensureHookInConfig adds hook if missing', () => {
+    ensureHookInConfig('new-hook', { enabled: false });
+    const config = loadHooksConfig();
+    expect(config.hooks['new-hook']).toEqual({ enabled: false });
+  });
+
+  test('ensureHookInConfig does not overwrite existing hook', () => {
+    setHookEnabled('existing', true);
+    ensureHookInConfig('existing', { enabled: false });
+    expect(isHookEnabled('existing')).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/hooks-discovery.test.ts
+++ b/assistant/src/__tests__/hooks-discovery.test.ts
@@ -1,0 +1,199 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { discoverHooks } from '../hooks/discovery.js';
+import { saveHooksConfig } from '../hooks/config.js';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-discovery-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+function createHook(hooksDir: string, name: string, manifest: Record<string, unknown>, scriptContent = '#!/bin/bash\nexit 0'): void {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+  writeFileSync(join(hookDir, 'hook.json'), JSON.stringify(manifest));
+  const scriptName = (manifest.script as string) ?? 'run.sh';
+  const scriptPath = join(hookDir, scriptName);
+  writeFileSync(scriptPath, scriptContent);
+  chmodSync(scriptPath, 0o755);
+}
+
+describe('Hooks Discovery', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('returns empty array when no hooks exist', () => {
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('discovers a valid hook', () => {
+    createHook(hooksDir, 'my-hook', {
+      name: 'my-hook',
+      description: 'Test hook',
+      version: '1.0.0',
+      events: ['pre-tool-execute'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].name).toBe('my-hook');
+    expect(hooks[0].manifest.events).toEqual(['pre-tool-execute']);
+    expect(hooks[0].enabled).toBe(false);
+  });
+
+  test('discovers multiple hooks sorted alphabetically', () => {
+    createHook(hooksDir, 'zebra-hook', {
+      name: 'zebra-hook',
+      description: 'Z hook',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+    });
+    createHook(hooksDir, 'alpha-hook', {
+      name: 'alpha-hook',
+      description: 'A hook',
+      version: '1.0.0',
+      events: ['post-message'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toHaveLength(2);
+    expect(hooks[0].name).toBe('alpha-hook');
+    expect(hooks[1].name).toBe('zebra-hook');
+  });
+
+  test('skips directory without hook.json', () => {
+    mkdirSync(join(hooksDir, 'no-manifest'), { recursive: true });
+    writeFileSync(join(hooksDir, 'no-manifest', 'run.sh'), '#!/bin/bash\nexit 0');
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('skips hook with invalid JSON in manifest', () => {
+    const hookDir = join(hooksDir, 'bad-json');
+    mkdirSync(hookDir, { recursive: true });
+    writeFileSync(join(hookDir, 'hook.json'), 'NOT JSON {{{');
+    writeFileSync(join(hookDir, 'run.sh'), '#!/bin/bash\nexit 0');
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('skips hook with missing required fields', () => {
+    createHook(hooksDir, 'missing-fields', {
+      name: 'missing-fields',
+      // missing events and script
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('skips hook with invalid event names', () => {
+    createHook(hooksDir, 'bad-events', {
+      name: 'bad-events',
+      description: 'Bad',
+      version: '1.0.0',
+      events: ['not-a-real-event'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('skips hook with missing script file', () => {
+    const hookDir = join(hooksDir, 'no-script');
+    mkdirSync(hookDir, { recursive: true });
+    writeFileSync(join(hookDir, 'hook.json'), JSON.stringify({
+      name: 'no-script',
+      description: 'Missing script',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'nonexistent.sh',
+    }));
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toEqual([]);
+  });
+
+  test('respects enabled state from config', () => {
+    createHook(hooksDir, 'enabled-hook', {
+      name: 'enabled-hook',
+      description: 'Enabled',
+      version: '1.0.0',
+      events: ['pre-tool-execute'],
+      script: 'run.sh',
+    });
+
+    saveHooksConfig({
+      version: 1,
+      hooks: { 'enabled-hook': { enabled: true } },
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].enabled).toBe(true);
+  });
+
+  test('defaults to disabled when not in config', () => {
+    createHook(hooksDir, 'unconfigured', {
+      name: 'unconfigured',
+      description: 'Not in config',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks[0].enabled).toBe(false);
+  });
+
+  test('returns empty for nonexistent hooks directory', () => {
+    const hooks = discoverHooks('/nonexistent/path');
+    expect(hooks).toEqual([]);
+  });
+
+  test('skips non-directory entries', () => {
+    writeFileSync(join(hooksDir, 'some-file.txt'), 'not a directory');
+
+    createHook(hooksDir, 'valid-hook', {
+      name: 'valid-hook',
+      description: 'Valid',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].name).toBe('valid-hook');
+  });
+
+  test('hook with multiple events is discovered', () => {
+    createHook(hooksDir, 'multi-event', {
+      name: 'multi-event',
+      description: 'Multi',
+      version: '1.0.0',
+      events: ['pre-tool-execute', 'post-tool-execute', 'on-error'],
+      script: 'run.sh',
+    });
+
+    const hooks = discoverHooks(hooksDir);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].manifest.events).toHaveLength(3);
+  });
+});

--- a/assistant/src/hooks/config.ts
+++ b/assistant/src/hooks/config.ts
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { getHooksDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+import type { HookConfig, HookConfigEntry } from './types.js';
+
+const log = getLogger('hooks-config');
+
+const HOOKS_CONFIG_VERSION = 1;
+
+function getConfigPath(): string {
+  return join(getHooksDir(), 'config.json');
+}
+
+export function loadHooksConfig(): HookConfig {
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) {
+    return { version: HOOKS_CONFIG_VERSION, hooks: {} };
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as HookConfig;
+    if (typeof parsed.version !== 'number' || typeof parsed.hooks !== 'object') {
+      log.warn({ configPath }, 'Invalid hooks config, using defaults');
+      return { version: HOOKS_CONFIG_VERSION, hooks: {} };
+    }
+    return parsed;
+  } catch (err) {
+    log.warn({ err, configPath }, 'Failed to read hooks config, using defaults');
+    return { version: HOOKS_CONFIG_VERSION, hooks: {} };
+  }
+}
+
+export function saveHooksConfig(config: HookConfig): void {
+  const configPath = getConfigPath();
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+export function isHookEnabled(hookName: string): boolean {
+  const config = loadHooksConfig();
+  return config.hooks[hookName]?.enabled ?? false;
+}
+
+export function setHookEnabled(hookName: string, enabled: boolean): void {
+  const config = loadHooksConfig();
+  config.hooks[hookName] = { ...config.hooks[hookName], enabled };
+  saveHooksConfig(config);
+}
+
+export function ensureHookInConfig(hookName: string, entry: HookConfigEntry): void {
+  const config = loadHooksConfig();
+  if (hookName in config.hooks) return;
+  config.hooks[hookName] = entry;
+  saveHooksConfig(config);
+}

--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, existsSync, type Dirent } from 'node:fs';
+import { join } from 'node:path';
+import { getHooksDir } from '../util/platform.js';
+import { loadHooksConfig } from './config.js';
+import { getLogger } from '../util/logger.js';
+import type { HookManifest, DiscoveredHook } from './types.js';
+
+const log = getLogger('hooks-discovery');
+
+const VALID_EVENTS = new Set<string>([
+  'daemon-start', 'daemon-stop',
+  'session-start', 'session-end',
+  'pre-llm-call', 'post-llm-call',
+  'pre-tool-execute', 'post-tool-execute',
+  'permission-request', 'permission-resolve',
+  'pre-message', 'post-message',
+  'on-error',
+]);
+
+function isValidManifest(manifest: unknown): manifest is HookManifest {
+  if (typeof manifest !== 'object' || manifest === null) return false;
+  const m = manifest as Record<string, unknown>;
+  if (typeof m.name !== 'string' || !m.name) return false;
+  if (typeof m.script !== 'string' || !m.script) return false;
+  if (!Array.isArray(m.events) || m.events.length === 0) return false;
+  for (const e of m.events) {
+    if (typeof e !== 'string' || !VALID_EVENTS.has(e)) return false;
+  }
+  return true;
+}
+
+export function discoverHooks(hooksDir?: string): DiscoveredHook[] {
+  const dir = hooksDir ?? getHooksDir();
+  if (!existsSync(dir)) return [];
+
+  const config = loadHooksConfig();
+  const hooks: DiscoveredHook[] = [];
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];
+  } catch (err) {
+    log.warn({ err, dir }, 'Failed to read hooks directory');
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const hookDir = join(dir, entry.name);
+    const manifestPath = join(hookDir, 'hook.json');
+    if (!existsSync(manifestPath)) continue;
+
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    } catch (err) {
+      log.warn({ err, hookDir }, 'Failed to parse hook manifest');
+      continue;
+    }
+
+    if (!isValidManifest(manifest)) {
+      log.warn({ hookDir }, 'Invalid hook manifest, skipping');
+      continue;
+    }
+
+    const scriptPath = join(hookDir, manifest.script);
+    if (!existsSync(scriptPath)) {
+      log.warn({ hookDir, script: manifest.script }, 'Hook script not found, skipping');
+      continue;
+    }
+
+    hooks.push({
+      name: entry.name,
+      dir: hookDir,
+      manifest,
+      scriptPath,
+      enabled: config.hooks[entry.name]?.enabled ?? false,
+    });
+  }
+
+  return hooks.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -1,0 +1,53 @@
+export type HookEventName =
+  // Daemon lifecycle
+  | 'daemon-start'
+  | 'daemon-stop'
+  // Session lifecycle
+  | 'session-start'
+  | 'session-end'
+  // LLM call lifecycle
+  | 'pre-llm-call'
+  | 'post-llm-call'
+  // Tool execution lifecycle
+  | 'pre-tool-execute'
+  | 'post-tool-execute'
+  // Permission lifecycle
+  | 'permission-request'
+  | 'permission-resolve'
+  // Message lifecycle
+  | 'pre-message'
+  | 'post-message'
+  // Error
+  | 'on-error';
+
+export interface HookManifest {
+  name: string;
+  description: string;
+  version: string;
+  events: HookEventName[];
+  script: string;
+}
+
+export interface HookConfigEntry {
+  enabled: boolean;
+}
+
+export interface HookConfig {
+  version: number;
+  hooks: Record<string, HookConfigEntry>;
+}
+
+export interface DiscoveredHook {
+  name: string;
+  /** Absolute path to hook directory */
+  dir: string;
+  manifest: HookManifest;
+  /** Absolute path to the script */
+  scriptPath: string;
+  enabled: boolean;
+}
+
+export interface HookEventData {
+  event: HookEventName;
+  [key: string]: unknown;
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -98,12 +98,17 @@ export function getHistoryPath(): string {
   return join(getDataDir(), 'history');
 }
 
+export function getHooksDir(): string {
+  return join(getRootDir(), 'hooks');
+}
+
 export function ensureDataDir(): void {
   const root = getRootDir();
   const data = getDataDir();
   const dirs = [
     root,
     join(root, 'skills'),
+    join(root, 'hooks'),
     join(root, 'protected'),
     data,
     join(data, 'db'),


### PR DESCRIPTION
## Summary
- Introduces `HookEventName` type with 13 hook events across daemon, session, LLM, tool, permission, message, and error lifecycles
- Adds hook discovery that scans `~/.vellum/hooks/` for directories with valid `hook.json` manifests
- Adds hooks config system (`~/.vellum/hooks/config.json`) for enabled/disabled state management
- Adds `getHooksDir()` helper and creates hooks directory on startup via `ensureDataDir()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
