### PR TITLE
Add hook execution engine and manager

### DIFF
--- a/assistant/src/__tests__/hooks-manager.test.ts
+++ b/assistant/src/__tests__/hooks-manager.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-manager-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { HookManager, resetHookManager, getHookManager } from '../hooks/manager.js';
+import { saveHooksConfig } from '../hooks/config.js';
+
+function createHook(
+  hooksDir: string,
+  name: string,
+  events: string[],
+  scriptContent = '#!/bin/bash\nexit 0',
+): void {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+  writeFileSync(
+    join(hookDir, 'hook.json'),
+    JSON.stringify({
+      name,
+      description: `Test hook ${name}`,
+      version: '1.0.0',
+      events,
+      script: 'run.sh',
+    }),
+  );
+  const scriptPath = join(hookDir, 'run.sh');
+  writeFileSync(scriptPath, scriptContent);
+  chmodSync(scriptPath, 0o755);
+}
+
+describe('HookManager', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    resetHookManager();
+  });
+
+  afterEach(() => {
+    resetHookManager();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('initialize discovers hooks', () => {
+    createHook(hooksDir, 'test-hook', ['on-error']);
+    saveHooksConfig({ version: 1, hooks: { 'test-hook': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+    expect(manager.getDiscoveredHooks()).toHaveLength(1);
+    expect(manager.getDiscoveredHooks()[0].name).toBe('test-hook');
+  });
+
+  test('initialize returns empty when no hooks', () => {
+    const manager = new HookManager();
+    manager.initialize();
+    expect(manager.getDiscoveredHooks()).toHaveLength(0);
+  });
+
+  test('trigger does nothing for event with no hooks', async () => {
+    const manager = new HookManager();
+    manager.initialize();
+    // Should not throw
+    await manager.trigger('on-error', {});
+  });
+
+  test('trigger runs enabled hooks for matching event', async () => {
+    createHook(hooksDir, 'log-hook', ['pre-tool-execute'], '#!/bin/bash\necho "executed"');
+    saveHooksConfig({ version: 1, hooks: { 'log-hook': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+    // Should not throw — hook runs successfully
+    await manager.trigger('pre-tool-execute', { tool: 'Bash' });
+  });
+
+  test('trigger skips disabled hooks', async () => {
+    createHook(hooksDir, 'disabled-hook', ['on-error'], '#!/bin/bash\necho "should not run"');
+    // Not enabled in config (defaults to disabled)
+
+    const manager = new HookManager();
+    manager.initialize();
+    // Hook is discovered but disabled, so trigger should be a no-op for this event
+    await manager.trigger('on-error', {});
+  });
+
+  test('trigger only runs hooks subscribed to the event', async () => {
+    createHook(hooksDir, 'tool-hook', ['pre-tool-execute'], '#!/bin/bash\necho "tool"');
+    createHook(hooksDir, 'error-hook', ['on-error'], '#!/bin/bash\necho "error"');
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        'tool-hook': { enabled: true },
+        'error-hook': { enabled: true },
+      },
+    });
+
+    const manager = new HookManager();
+    manager.initialize();
+    // Should only run tool-hook, not error-hook
+    await manager.trigger('pre-tool-execute', {});
+  });
+
+  test('trigger runs hooks sequentially in alphabetical order', async () => {
+    // Create hooks that append to a shared file to verify execution order
+    const orderFile = join(testDir, 'order.txt');
+    createHook(hooksDir, 'zebra', ['post-message'], `#!/bin/bash\necho "zebra" >> "${orderFile}"`);
+    createHook(hooksDir, 'alpha', ['post-message'], `#!/bin/bash\necho "alpha" >> "${orderFile}"`);
+    createHook(hooksDir, 'middle', ['post-message'], `#!/bin/bash\necho "middle" >> "${orderFile}"`);
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        zebra: { enabled: true },
+        alpha: { enabled: true },
+        middle: { enabled: true },
+      },
+    });
+
+    const manager = new HookManager();
+    manager.initialize();
+    await manager.trigger('post-message', {});
+
+    // Wait a moment for file writes to flush
+    await new Promise((r) => setTimeout(r, 100));
+    const { readFileSync } = await import('node:fs');
+    const order = readFileSync(orderFile, 'utf-8').trim().split('\n');
+    expect(order).toEqual(['alpha', 'middle', 'zebra']);
+  });
+
+  test('trigger handles hook failure gracefully', async () => {
+    createHook(hooksDir, 'bad-hook', ['on-error'], '#!/bin/bash\nexit 1');
+    saveHooksConfig({ version: 1, hooks: { 'bad-hook': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+    // Should not throw despite hook exiting with non-zero
+    await manager.trigger('on-error', { message: 'test error' });
+  });
+
+  test('getDiscoveredHooks returns a copy', () => {
+    createHook(hooksDir, 'hook-a', ['on-error']);
+    saveHooksConfig({ version: 1, hooks: { 'hook-a': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const hooks1 = manager.getDiscoveredHooks();
+    const hooks2 = manager.getDiscoveredHooks();
+    expect(hooks1).toEqual(hooks2);
+    expect(hooks1).not.toBe(hooks2); // Different array references
+  });
+
+  test('getHookManager returns singleton', () => {
+    const mgr1 = getHookManager();
+    const mgr2 = getHookManager();
+    expect(mgr1).toBe(mgr2);
+  });
+
+  test('resetHookManager clears singleton', () => {
+    const mgr1 = getHookManager();
+    resetHookManager();
+    const mgr2 = getHookManager();
+    expect(mgr1).not.toBe(mgr2);
+  });
+
+  test('multi-event hook is triggered for each subscribed event', async () => {
+    const outputFile = join(testDir, 'multi-event.txt');
+    createHook(
+      hooksDir,
+      'multi',
+      ['pre-tool-execute', 'on-error'],
+      `#!/bin/bash\necho "$VELLUM_HOOK_EVENT" >> "${outputFile}"`,
+    );
+    saveHooksConfig({ version: 1, hooks: { multi: { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+    await manager.trigger('pre-tool-execute', {});
+    await manager.trigger('on-error', {});
+
+    await new Promise((r) => setTimeout(r, 100));
+    const { readFileSync } = await import('node:fs');
+    const events = readFileSync(outputFile, 'utf-8').trim().split('\n');
+    expect(events).toEqual(['pre-tool-execute', 'on-error']);
+  });
+});

--- a/assistant/src/__tests__/hooks-runner.test.ts
+++ b/assistant/src/__tests__/hooks-runner.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-runner-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { runHookScript } from '../hooks/runner.js';
+import type { DiscoveredHook, HookEventData } from '../hooks/types.js';
+
+function createTestHook(hooksDir: string, name: string, scriptContent: string): DiscoveredHook {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+  const scriptPath = join(hookDir, 'run.sh');
+  writeFileSync(scriptPath, scriptContent);
+  chmodSync(scriptPath, 0o755);
+
+  return {
+    name,
+    dir: hookDir,
+    manifest: {
+      name,
+      description: 'Test hook',
+      version: '1.0.0',
+      events: ['pre-tool-execute'],
+      script: 'run.sh',
+    },
+    scriptPath,
+    enabled: true,
+  };
+}
+
+describe('Hook Runner', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('runs a script and captures stdout', async () => {
+    const hook = createTestHook(hooksDir, 'echo-hook', '#!/bin/bash\necho "hello from hook"');
+    const eventData: HookEventData = { event: 'pre-tool-execute' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello from hook');
+    expect(result.stderr).toBe('');
+  });
+
+  test('captures stderr', async () => {
+    const hook = createTestHook(hooksDir, 'stderr-hook', '#!/bin/bash\necho "error output" >&2');
+    const eventData: HookEventData = { event: 'on-error' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.trim()).toBe('error output');
+  });
+
+  test('reports non-zero exit code', async () => {
+    const hook = createTestHook(hooksDir, 'fail-hook', '#!/bin/bash\nexit 42');
+    const eventData: HookEventData = { event: 'on-error' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(42);
+  });
+
+  test('pipes event data to stdin as JSON', async () => {
+    const hook = createTestHook(hooksDir, 'stdin-hook', '#!/bin/bash\ncat');
+    const eventData: HookEventData = { event: 'pre-tool-execute', tool: 'Bash', command: 'ls' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.event).toBe('pre-tool-execute');
+    expect(parsed.tool).toBe('Bash');
+    expect(parsed.command).toBe('ls');
+  });
+
+  test('sets environment variables', async () => {
+    const hook = createTestHook(
+      hooksDir,
+      'env-hook',
+      '#!/bin/bash\necho "$VELLUM_HOOK_EVENT|$VELLUM_HOOK_NAME"',
+    );
+    const eventData: HookEventData = { event: 'post-message' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('post-message|env-hook');
+  });
+
+  test('sets VELLUM_ROOT_DIR environment variable', async () => {
+    const hook = createTestHook(hooksDir, 'rootdir-hook', '#!/bin/bash\necho "$VELLUM_ROOT_DIR"');
+    const eventData: HookEventData = { event: 'daemon-start' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toContain('.vellum');
+  });
+
+  test('times out after specified duration', async () => {
+    const hook = createTestHook(hooksDir, 'slow-hook', '#!/bin/bash\nsleep 10');
+    const eventData: HookEventData = { event: 'pre-tool-execute' };
+
+    const result = await runHookScript(hook, eventData, { timeoutMs: 200 });
+    expect(result.exitCode).toBeNull();
+    expect(result.stderr).toContain('Hook timed out');
+  });
+
+  test('handles non-existent script gracefully', async () => {
+    const hook: DiscoveredHook = {
+      name: 'missing-script',
+      dir: join(hooksDir, 'missing-script'),
+      manifest: {
+        name: 'missing-script',
+        description: 'Missing',
+        version: '1.0.0',
+        events: ['on-error'],
+        script: 'nonexistent.sh',
+      },
+      scriptPath: join(hooksDir, 'missing-script', 'nonexistent.sh'),
+      enabled: true,
+    };
+    mkdirSync(hook.dir, { recursive: true });
+    const eventData: HookEventData = { event: 'on-error' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBeNull();
+    expect(result.stderr).toBeTruthy();
+  });
+
+  test('runs script in hook directory as cwd', async () => {
+    const hook = createTestHook(hooksDir, 'cwd-hook', '#!/bin/bash\npwd -P');
+    const eventData: HookEventData = { event: 'pre-tool-execute' };
+
+    const result = await runHookScript(hook, eventData);
+    expect(result.exitCode).toBe(0);
+    // Use realpathSync to resolve macOS /var -> /private/var symlinks
+    const { realpathSync } = await import('node:fs');
+    expect(result.stdout.trim()).toBe(realpathSync(hook.dir));
+  });
+});

--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -1,0 +1,76 @@
+import { discoverHooks } from './discovery.js';
+import { runHookScript } from './runner.js';
+import { getLogger, isDebug } from '../util/logger.js';
+import type { DiscoveredHook, HookEventName, HookEventData } from './types.js';
+
+const log = getLogger('hooks-manager');
+
+export class HookManager {
+  private hooks: DiscoveredHook[] = [];
+  private eventIndex = new Map<HookEventName, DiscoveredHook[]>();
+
+  initialize(): void {
+    this.hooks = discoverHooks();
+    this.buildEventIndex();
+    const enabled = this.hooks.filter((h) => h.enabled).length;
+    if (this.hooks.length > 0) {
+      log.info({ enabled, total: this.hooks.length }, 'Hooks discovered');
+    }
+  }
+
+  private buildEventIndex(): void {
+    this.eventIndex.clear();
+    for (const hook of this.hooks) {
+      if (!hook.enabled) continue;
+      for (const event of hook.manifest.events) {
+        const list = this.eventIndex.get(event) ?? [];
+        list.push(hook);
+        this.eventIndex.set(event, list);
+      }
+    }
+    // Sort alphabetically by name for deterministic ordering
+    for (const [, list] of this.eventIndex) {
+      list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+  }
+
+  async trigger(event: HookEventName, data: Record<string, unknown>): Promise<void> {
+    const hooks = this.eventIndex.get(event);
+    if (!hooks || hooks.length === 0) return;
+
+    const eventData: HookEventData = { event, ...data };
+
+    for (const hook of hooks) {
+      try {
+        const result = await runHookScript(hook, eventData);
+        if (result.exitCode !== null && result.exitCode !== 0) {
+          log.warn({ hook: hook.name, event, exitCode: result.exitCode }, 'Hook exited with non-zero code');
+        }
+        if (result.stderr && isDebug()) {
+          process.stderr.write(result.stderr);
+        }
+      } catch (err) {
+        log.warn({ err, hook: hook.name, event }, 'Hook execution failed');
+      }
+    }
+  }
+
+  getDiscoveredHooks(): DiscoveredHook[] {
+    return [...this.hooks];
+  }
+}
+
+let instance: HookManager | null = null;
+
+export function getHookManager(): HookManager {
+  if (!instance) {
+    instance = new HookManager();
+    instance.initialize();
+  }
+  return instance;
+}
+
+/** Reset the singleton (for testing) */
+export function resetHookManager(): void {
+  instance = null;
+}

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process';
+import { getRootDir } from '../util/platform.js';
+import type { DiscoveredHook, HookEventData } from './types.js';
+
+export interface HookRunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export async function runHookScript(
+  hook: DiscoveredHook,
+  eventData: HookEventData,
+  options?: { timeoutMs?: number },
+): Promise<HookRunResult> {
+  const timeoutMs = options?.timeoutMs ?? 5000;
+
+  return new Promise<HookRunResult>((resolve) => {
+    const child = spawn(hook.scriptPath, [], {
+      cwd: hook.dir,
+      env: {
+        ...process.env,
+        VELLUM_HOOK_EVENT: eventData.event,
+        VELLUM_HOOK_NAME: hook.name,
+        VELLUM_ROOT_DIR: getRootDir(),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGTERM');
+      resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: code, stdout, stderr });
+    });
+
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: null, stdout, stderr: stderr + '\n' + err.message });
+    });
+
+    // Write event data to stdin and close
+    child.stdin.write(JSON.stringify(eventData));
+    child.stdin.end();
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `runner.ts`: spawns hook scripts as child processes with JSON piped to stdin, env vars (`VELLUM_HOOK_EVENT`, `VELLUM_HOOK_NAME`, `VELLUM_ROOT_DIR`), and configurable timeout (default 5s)
- Adds `manager.ts`: singleton `HookManager` that discovers hooks on init, builds an event-to-hooks index for O(1) lookup, and triggers matching hooks sequentially in alphabetical order
- 21 new tests covering script execution, stdin piping, env vars, timeouts, error handling, event routing, ordering, and singleton behavior

PR 2 of 9 in the hooks system rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
