### PR TITLE
Add request size limits and attachment processing guardrails

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -48,3 +48,12 @@ ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821
 
 # Optional: Timeout for Telegram API/download calls in milliseconds (default: 15000)
 # GATEWAY_TELEGRAM_TIMEOUT_MS=15000
+
+# Optional: Max inbound webhook payload size in bytes (default: 1048576 = 1 MB)
+# GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES=1048576
+
+# Optional: Max single attachment size in bytes (default: 20971520 = 20 MB)
+# GATEWAY_MAX_ATTACHMENT_BYTES=20971520
+
+# Optional: Max concurrent attachment download/upload operations (default: 3)
+# GATEWAY_MAX_ATTACHMENT_CONCURRENCY=3

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -42,6 +42,9 @@ bun run dev
 | `GATEWAY_RUNTIME_MAX_RETRIES` | No | `2` | Max retries for runtime forward on 5xx/network errors |
 | `GATEWAY_RUNTIME_INITIAL_BACKOFF_MS` | No | `500` | Initial backoff between retries (doubles each attempt) |
 | `GATEWAY_TELEGRAM_TIMEOUT_MS` | No | `15000` | Timeout for Telegram API/download calls (ms) |
+| `GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES` | No | `1048576` | Max inbound webhook payload size (rejects with 413) |
+| `GATEWAY_MAX_ATTACHMENT_BYTES` | No | `20971520` | Max single attachment size (oversized are skipped) |
+| `GATEWAY_MAX_ATTACHMENT_CONCURRENCY` | No | `3` | Max concurrent attachment download/upload operations |
 
 ## Routing
 

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -24,6 +24,9 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void) 
     "GATEWAY_RUNTIME_MAX_RETRIES",
     "GATEWAY_RUNTIME_INITIAL_BACKOFF_MS",
     "GATEWAY_TELEGRAM_TIMEOUT_MS",
+    "GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES",
+    "GATEWAY_MAX_ATTACHMENT_BYTES",
+    "GATEWAY_MAX_ATTACHMENT_CONCURRENCY",
   ];
 
   for (const key of allKeys) {

--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "bun:test";
+import { createTelegramWebhookHandler } from "../http/routes/telegram-webhook.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: "tok",
+    telegramWebhookSecret: "wh-sec",
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeProxyBearerToken: undefined,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 256, // very small for testing
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    ...overrides,
+  };
+}
+
+describe("payload size guard", () => {
+  test("returns 413 when content-length exceeds limit", async () => {
+    const handler = createTelegramWebhookHandler(makeConfig());
+    const body = JSON.stringify({ data: "x".repeat(300) });
+    const req = new Request("http://localhost:7830/webhooks/telegram", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(body.length),
+        "x-telegram-bot-api-secret-token": "wh-sec",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(413);
+    const json = await res.json();
+    expect(json.error).toBe("Payload too large");
+  });
+
+  test("returns 413 when body exceeds limit even without content-length", async () => {
+    const handler = createTelegramWebhookHandler(makeConfig());
+    const body = JSON.stringify({ data: "x".repeat(300) });
+    const req = new Request("http://localhost:7830/webhooks/telegram", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": "wh-sec",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(413);
+  });
+
+  test("accepts payload within limit", async () => {
+    const handler = createTelegramWebhookHandler(
+      makeConfig({ maxWebhookPayloadBytes: 10000 }),
+    );
+    const body = JSON.stringify({ update_id: 1, message: { text: "hi", chat: { id: 1, type: "private" }, from: { id: 1 }, message_id: 1 } });
+    const req = new Request("http://localhost:7830/webhooks/telegram", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(body.length),
+        "x-telegram-bot-api-secret-token": "wh-sec",
+      },
+    });
+    const res = await handler(req);
+    // Will fail downstream (routing reject) but should NOT be 413
+    expect(res.status).not.toBe(413);
+  });
+});

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -20,6 +20,9 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
     telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -19,6 +19,9 @@ const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
   runtimeMaxRetries: 2,
   runtimeInitialBackoffMs: 500,
   telegramTimeoutMs: 15000,
+  maxWebhookPayloadBytes: 1048576,
+  maxAttachmentBytes: 20971520,
+  maxAttachmentConcurrency: 3,
   ...overrides,
 });
 

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -22,6 +22,9 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
     telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -20,6 +20,9 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeMaxRetries: 2,
     runtimeInitialBackoffMs: 500,
     telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
     ...overrides,
   };
 }

--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -75,6 +75,7 @@ describe("normalizeTelegramUpdate", () => {
     expect(result!.message.attachments![0]).toEqual({
       type: "photo",
       fileId: "large_id",
+      fileSize: undefined,
     });
   });
 
@@ -123,6 +124,7 @@ describe("normalizeTelegramUpdate", () => {
       fileId: "doc_file_id",
       fileName: "report.pdf",
       mimeType: "application/pdf",
+      fileSize: 12345,
     });
   });
 

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -25,6 +25,9 @@ export type GatewayConfig = {
   runtimeMaxRetries: number;
   runtimeInitialBackoffMs: number;
   telegramTimeoutMs: number;
+  maxWebhookPayloadBytes: number;
+  maxAttachmentBytes: number;
+  maxAttachmentConcurrency: number;
 };
 
 function parseRoutingJson(raw: string): RoutingEntry[] {
@@ -146,6 +149,21 @@ export function loadConfig(): GatewayConfig {
     throw new Error("GATEWAY_TELEGRAM_TIMEOUT_MS must be a positive number");
   }
 
+  const maxWebhookPayloadBytes = Number(process.env.GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES || String(1024 * 1024));
+  if (!Number.isFinite(maxWebhookPayloadBytes) || maxWebhookPayloadBytes <= 0) {
+    throw new Error("GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES must be a positive number");
+  }
+
+  const maxAttachmentBytes = Number(process.env.GATEWAY_MAX_ATTACHMENT_BYTES || String(20 * 1024 * 1024));
+  if (!Number.isFinite(maxAttachmentBytes) || maxAttachmentBytes <= 0) {
+    throw new Error("GATEWAY_MAX_ATTACHMENT_BYTES must be a positive number");
+  }
+
+  const maxAttachmentConcurrency = Number(process.env.GATEWAY_MAX_ATTACHMENT_CONCURRENCY || "3");
+  if (!Number.isInteger(maxAttachmentConcurrency) || maxAttachmentConcurrency < 1) {
+    throw new Error("GATEWAY_MAX_ATTACHMENT_CONCURRENCY must be a positive integer");
+  }
+
   if (runtimeProxyEnabled && runtimeProxyRequireAuth && !runtimeProxyBearerToken) {
     throw new Error(
       "RUNTIME_PROXY_BEARER_TOKEN is required when proxy is enabled with auth required",
@@ -183,5 +201,8 @@ export function loadConfig(): GatewayConfig {
     runtimeMaxRetries,
     runtimeInitialBackoffMs,
     telegramTimeoutMs,
+    maxWebhookPayloadBytes,
+    maxAttachmentBytes,
+    maxAttachmentConcurrency,
   };
 }

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -24,15 +24,34 @@ export function createTelegramWebhookHandler(
       return Response.json({ error: "Method not allowed" }, { status: 405 });
     }
 
+    // Payload size guard
+    const contentLength = req.headers.get("content-length");
+    if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
+      log.warn({ contentLength }, "Webhook payload too large");
+      return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+
     // Verify webhook secret
     if (!verifyWebhookSecret(req.headers, config.telegramWebhookSecret)) {
       log.warn("Telegram webhook request failed secret verification");
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    let rawBody: string;
+    try {
+      rawBody = await req.text();
+    } catch {
+      return Response.json({ error: "Failed to read body" }, { status: 400 });
+    }
+
+    if (rawBody.length > config.maxWebhookPayloadBytes) {
+      log.warn({ bodyLength: rawBody.length }, "Webhook payload too large");
+      return Response.json({ error: "Payload too large" }, { status: 413 });
+    }
+
     let payload: Record<string, unknown>;
     try {
-      payload = (await req.json()) as Record<string, unknown>;
+      payload = JSON.parse(rawBody) as Record<string, unknown>;
     } catch {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
@@ -57,14 +76,36 @@ export function createTelegramWebhookHandler(
       if (!isRejection(routing)) {
         try {
           attachmentIds = [];
-          for (const att of eventAttachments) {
-            const downloaded = await downloadTelegramFile(config, att.fileId, {
-              fileName: att.fileName,
-              mimeType: att.mimeType,
-            });
-            const uploaded = await uploadAttachment(config, routing.assistantId, downloaded);
-            attachmentIds.push(uploaded.id);
+
+          // Filter oversized attachments
+          const eligible = eventAttachments.filter((att) => {
+            if (att.fileSize !== undefined && att.fileSize > config.maxAttachmentBytes) {
+              log.warn(
+                { fileId: att.fileId, fileSize: att.fileSize, limit: config.maxAttachmentBytes },
+                "Skipping oversized attachment",
+              );
+              return false;
+            }
+            return true;
+          });
+
+          // Process with bounded concurrency
+          for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
+            const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
+            const results = await Promise.all(
+              batch.map(async (att) => {
+                const downloaded = await downloadTelegramFile(config, att.fileId, {
+                  fileName: att.fileName,
+                  mimeType: att.mimeType,
+                });
+                return uploadAttachment(config, routing.assistantId, downloaded);
+              }),
+            );
+            for (const uploaded of results) {
+              attachmentIds.push(uploaded.id);
+            }
           }
+
           log.info(
             { count: attachmentIds.length, assistantId: routing.assistantId },
             "Attachments downloaded and uploaded",

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -70,11 +70,11 @@ export function normalizeTelegramUpdate(
 
   const content = message.text || message.caption || "";
 
-  const attachments: { type: "photo" | "document"; fileId: string; fileName?: string; mimeType?: string }[] = [];
+  const attachments: { type: "photo" | "document"; fileId: string; fileName?: string; mimeType?: string; fileSize?: number }[] = [];
   if (message.photo && message.photo.length > 0) {
     // Telegram sends multiple sizes; pick the largest (last in array)
     const largest = message.photo[message.photo.length - 1];
-    attachments.push({ type: "photo", fileId: largest.file_id });
+    attachments.push({ type: "photo", fileId: largest.file_id, fileSize: largest.file_size });
   }
   if (message.document) {
     attachments.push({
@@ -82,6 +82,7 @@ export function normalizeTelegramUpdate(
       fileId: message.document.file_id,
       fileName: message.document.file_name,
       mimeType: message.document.mime_type,
+      fileSize: message.document.file_size,
     });
   }
 

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -15,6 +15,7 @@ export type GatewayInboundEventV1 = {
       fileId: string;
       fileName?: string;
       mimeType?: string;
+      fileSize?: number;
     }[];
   };
   sender: {


### PR DESCRIPTION
## Summary
- Add max webhook payload size guard (rejects with 413)
- Skip oversized attachments based on Telegram-reported file_size
- Bounded concurrent attachment download/upload (configurable concurrency cap)
- New env vars: `GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES`, `GATEWAY_MAX_ATTACHMENT_BYTES`, `GATEWAY_MAX_ATTACHMENT_CONCURRENCY`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (65 tests, 3 new guardrail tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
