### PR TITLE
Fix button and tab hit areas to cover full surface

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VButton.swift
@@ -23,6 +23,7 @@ struct VButton: View {
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(borderColor, lineWidth: style == .ghost ? 1 : 0)
                 )
+                .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
         .buttonStyle(VButtonPressStyle())
         .disabled(isDisabled)

--- a/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VIconButton.swift
@@ -22,6 +22,7 @@ struct VIconButton: View {
             .padding(.vertical, VSpacing.sm)
             .background(isActive ? VColor.surfaceBorder : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.pill))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.pill)
                     .stroke(isActive ? VColor.textSecondary : VColor.surfaceBorder.opacity(0.5), lineWidth: 1)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
@@ -15,19 +15,16 @@ struct ThreadTab: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Button(action: onSelect) {
-                HStack(spacing: VSpacing.xs) {
-                    if let icon = icon {
-                        Image(systemName: icon)
-                            .font(.system(size: 12))
-                    }
-                    Text(label)
-                        .font(VFont.tabLabel)
-                        .lineLimit(1)
+            HStack(spacing: VSpacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12))
                 }
-                .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
+                Text(label)
+                    .font(VFont.tabLabel)
+                    .lineLimit(1)
             }
-            .buttonStyle(.plain)
+            .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
 
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
@@ -41,6 +38,8 @@ struct ThreadTab: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
+        .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onTapGesture { onSelect() }
         .background(isHovered && !isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onHover { hovering in isHovered = hovering }


### PR DESCRIPTION
## Summary
- Add `.contentShape()` to VButton and VIconButton so the full padded/background area is clickable
- Refactor ThreadTab to use `onTapGesture` + `.contentShape()` (matching VTab's pattern) for full-surface click targets
- No visual changes — only hit testing is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
