### PR TITLE
Preserve user-edited IDENTITY.md when updating name

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -643,6 +643,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Writes (or updates) `~/.vellum/IDENTITY.md` with the user-chosen assistant name.
+    ///
+    /// If the file already exists, only the `- **Name:** …` line is replaced so that
+    /// user customizations (extra persona instructions, changed role/tone, etc.) are preserved.
+    /// If the file does not exist, a fresh template is created.
     private func writeIdentityFile(name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
@@ -650,22 +654,39 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let vellumDir = NSHomeDirectory() + "/.vellum"
         let identityPath = vellumDir + "/IDENTITY.md"
 
-        let content = """
-        # IDENTITY
-
-        _Customize this file to give your assistant a distinct identity._
-
-        - **Name:** \(trimmed)
-        - **Role:** Personal AI assistant
-        - **Tone:** Direct, concise, and helpful
-        """
-
         do {
             try FileManager.default.createDirectory(
                 atPath: vellumDir,
                 withIntermediateDirectories: true,
                 attributes: nil
             )
+
+            let content: String
+            if FileManager.default.fileExists(atPath: identityPath),
+               let existing = try? String(contentsOfFile: identityPath, encoding: .utf8) {
+                // Replace only the Name line, preserving everything else
+                let namePattern = #"^- \*\*Name:\*\*.*$"#
+                if let regex = try? NSRegularExpression(pattern: namePattern, options: .anchorsMatchLines) {
+                    let range = NSRange(existing.startIndex..., in: existing)
+                    let replacement = "- **Name:** \(trimmed)"
+                    let updated = regex.stringByReplacingMatches(in: existing, range: range, withTemplate: NSRegularExpression.escapedTemplate(for: replacement))
+                    // Only use the updated content if a substitution actually happened
+                    content = updated != existing ? updated : existing
+                } else {
+                    content = existing
+                }
+            } else {
+                content = """
+                # IDENTITY
+
+                _Customize this file to give your assistant a distinct identity._
+
+                - **Name:** \(trimmed)
+                - **Role:** Personal AI assistant
+                - **Tone:** Direct, concise, and helpful
+                """
+            }
+
             try content.write(toFile: identityPath, atomically: true, encoding: .utf8)
             log.info("Wrote IDENTITY.md with name: \(trimmed)")
         } catch {


### PR DESCRIPTION
## Summary
- `writeIdentityFile(name:)` now checks if `~/.vellum/IDENTITY.md` already exists before writing
- When the file exists, only the `- **Name:** …` line is replaced via regex, preserving all user customizations (extra persona instructions, changed role/tone, etc.)
- When the file does not exist, the full default template is created as before

Addresses review feedback on #1527 — replaying onboarding no longer silently overwrites user-edited IDENTITY.md content.

## Test plan
- [ ] Fresh install (no IDENTITY.md): verify template is created with chosen name
- [ ] Existing IDENTITY.md with custom content: replay onboarding, verify only Name line changes while rest is preserved
- [ ] Existing IDENTITY.md with no Name line: verify file is left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
