### PR TITLE
Show concrete pattern labels in trust-rule picker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -185,7 +185,7 @@ struct ToolConfirmationBubble: View {
                         .foregroundColor(VColor.textSecondary)
                     Picker("", selection: $selectedPattern) {
                         ForEach(confirmation.allowlistOptions, id: \.pattern) { option in
-                            Text(option.description ?? option.label).tag(option.pattern)
+                            Text(option.label).tag(option.pattern)
                         }
                     }
                     .pickerStyle(.menu)
@@ -196,8 +196,8 @@ struct ToolConfirmationBubble: View {
                     Text("Pattern:")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
-                    Text(single.description ?? single.label)
-                        .font(VFont.caption)
+                    Text(single.label)
+                        .font(VFont.monoSmall)
                         .foregroundColor(VColor.textPrimary)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -291,7 +291,7 @@ struct ToolConfirmationView: View {
                         .foregroundColor(VColor.textSecondary)
                     Picker("", selection: $selectedPattern) {
                         ForEach(allowlistOptions, id: \.pattern) { option in
-                            Text(option.description ?? option.label).tag(option.pattern)
+                            Text(option.label).tag(option.pattern)
                         }
                     }
                     .pickerStyle(.menu)
@@ -302,8 +302,8 @@ struct ToolConfirmationView: View {
                     Text("Pattern:")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
-                    Text(single.description ?? single.label)
-                        .font(VFont.caption)
+                    Text(single.label)
+                        .font(.system(size: 11, design: .monospaced))
                         .foregroundColor(VColor.textPrimary)
                 }
             }


### PR DESCRIPTION
## Summary
- Restores concrete pattern text (e.g., `git push`, `npm install *`) as the displayed label in the trust-rule picker, instead of showing only the generic description (e.g., "This exact command")
- Fixes both `ToolConfirmationBubble.swift` (chat bubble) and `ToolConfirmationManager.swift` (floating panel) to use `option.label` instead of `option.description`
- Restores monospace font for single-option pattern display to match original styling

## Context
Addresses review feedback on #1517: showing `option.description` instead of the concrete `label` hides the actual rule pattern the user is about to save, making it impossible to verify the exact pattern value at selection time.

## Test plan
- [ ] Build and verify the trust-rule picker shows concrete patterns (e.g., `git push`) in both dropdown and single-option views
- [ ] Verify the description field is still sent via IPC for potential future use but is not shown instead of the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
