### PR TITLE
Add gateway load-test harness and performance runbook

### DIFF
--- a/benchmarking/gateway/README.md
+++ b/benchmarking/gateway/README.md
@@ -1,0 +1,61 @@
+# Gateway Load Testing
+
+Scripts for measuring gateway throughput and latency.
+
+## Prerequisites
+
+- Bun installed
+- Gateway running locally (or accessible at `GATEWAY_URL`)
+- For proxy benchmarks: proxy mode enabled with a running backend
+
+## Webhook Benchmark
+
+Tests the Telegram webhook inbound path (secret verification, JSON parse, normalize, routing).
+
+```bash
+# Start gateway
+cd gateway && bun run dev
+
+# Run benchmark (separate terminal)
+GATEWAY_URL=http://localhost:7830 \
+WEBHOOK_SECRET=<your-secret> \
+DURATION_SECS=30 \
+CONCURRENCY=50 \
+bun run benchmarking/gateway/bench-webhook.ts
+```
+
+### Pass/fail criteria
+
+| Metric | Target |
+|--------|--------|
+| RPM | >= 3,000 per pod |
+| Error rate | < 1% |
+| p95 latency | Informational (logged, no hard gate) |
+
+## Proxy Benchmark
+
+Tests the runtime proxy path (auth + proxy forwarding).
+
+```bash
+GATEWAY_URL=http://localhost:7830 \
+PROXY_TOKEN=<your-token> \
+PROXY_PATH=/v1/health \
+DURATION_SECS=30 \
+CONCURRENCY=50 \
+bun run benchmarking/gateway/bench-proxy.ts
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_URL` | `http://localhost:7830` | Target gateway URL |
+| `WEBHOOK_SECRET` | — | Telegram webhook secret (webhook bench only) |
+| `PROXY_TOKEN` | — | Bearer token (proxy bench only) |
+| `PROXY_PATH` | `/v1/health` | Path to hit (proxy bench only) |
+| `DURATION_SECS` | `30` | Test duration |
+| `CONCURRENCY` | `50` | Concurrent connections |
+
+## Interpreting Results
+
+Output includes: total requests, errors, RPM, p50/p95/p99 latency, and error rate. The webhook benchmark has an automated pass/fail gate.

--- a/benchmarking/gateway/bench-proxy.ts
+++ b/benchmarking/gateway/bench-proxy.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+/**
+ * Gateway proxy-path load-test script.
+ *
+ * Sends requests through the runtime proxy path at high concurrency.
+ * Requires a running backend at ASSISTANT_RUNTIME_BASE_URL (or a stub server).
+ *
+ * Usage:
+ *   GATEWAY_URL=http://localhost:7830 PROXY_TOKEN=<token> bun run benchmarking/gateway/bench-proxy.ts
+ *
+ * Options (env vars):
+ *   GATEWAY_URL       - Target gateway URL (default: http://localhost:7830)
+ *   PROXY_TOKEN       - Bearer token for proxy auth
+ *   PROXY_PATH        - Path to hit (default: /v1/health)
+ *   DURATION_SECS     - Test duration in seconds (default: 30)
+ *   CONCURRENCY       - Concurrent connections (default: 50)
+ */
+
+const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:7830";
+const PROXY_TOKEN = process.env.PROXY_TOKEN;
+const PROXY_PATH = process.env.PROXY_PATH || "/v1/health";
+const DURATION_SECS = Number(process.env.DURATION_SECS || "30");
+const CONCURRENCY = Number(process.env.CONCURRENCY || "50");
+
+if (!PROXY_TOKEN) {
+  console.error("PROXY_TOKEN is required");
+  process.exit(1);
+}
+
+const url = `${GATEWAY_URL}${PROXY_PATH}`;
+
+let total = 0;
+let errors = 0;
+const latencies: number[] = [];
+
+async function worker() {
+  while (Date.now() < endTime) {
+    const start = performance.now();
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${PROXY_TOKEN}`,
+        },
+      });
+      const elapsed = performance.now() - start;
+      latencies.push(elapsed);
+      total++;
+      if (res.status >= 500) errors++;
+    } catch {
+      errors++;
+      total++;
+    }
+  }
+}
+
+console.log(`Gateway proxy benchmark`);
+console.log(`  Target:      ${url}`);
+console.log(`  Duration:    ${DURATION_SECS}s`);
+console.log(`  Concurrency: ${CONCURRENCY}`);
+console.log(`  Starting...`);
+
+const startTime = Date.now();
+const endTime = startTime + DURATION_SECS * 1000;
+
+const workers = Array.from({ length: CONCURRENCY }, () => worker());
+await Promise.all(workers);
+
+const elapsed = (Date.now() - startTime) / 1000;
+latencies.sort((a, b) => a - b);
+
+const p50 = latencies[Math.floor(latencies.length * 0.5)] || 0;
+const p95 = latencies[Math.floor(latencies.length * 0.95)] || 0;
+const p99 = latencies[Math.floor(latencies.length * 0.99)] || 0;
+const rpm = (total / elapsed) * 60;
+
+console.log(`\nResults:`);
+console.log(`  Total requests:  ${total}`);
+console.log(`  Errors:          ${errors}`);
+console.log(`  Duration:        ${elapsed.toFixed(1)}s`);
+console.log(`  RPM:             ${rpm.toFixed(0)}`);
+console.log(`  Latency p50:     ${p50.toFixed(1)}ms`);
+console.log(`  Latency p95:     ${p95.toFixed(1)}ms`);
+console.log(`  Latency p99:     ${p99.toFixed(1)}ms`);
+console.log(`  Error rate:      ${((errors / total) * 100).toFixed(2)}%`);

--- a/benchmarking/gateway/bench-webhook.ts
+++ b/benchmarking/gateway/bench-webhook.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+/**
+ * Gateway webhook load-test script.
+ *
+ * Sends simulated Telegram webhook POSTs to the gateway at high concurrency.
+ * The gateway will reject them (no route configured), but this exercises the
+ * full inbound path: secret verification → JSON parse → normalize → routing.
+ *
+ * Usage:
+ *   GATEWAY_URL=http://localhost:7830 WEBHOOK_SECRET=<secret> bun run benchmarking/gateway/bench-webhook.ts
+ *
+ * Options (env vars):
+ *   GATEWAY_URL       - Target gateway URL (default: http://localhost:7830)
+ *   WEBHOOK_SECRET    - Telegram webhook secret for auth
+ *   DURATION_SECS     - Test duration in seconds (default: 30)
+ *   CONCURRENCY       - Concurrent connections (default: 50)
+ */
+
+const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:7830";
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
+const DURATION_SECS = Number(process.env.DURATION_SECS || "30");
+const CONCURRENCY = Number(process.env.CONCURRENCY || "50");
+
+if (!WEBHOOK_SECRET) {
+  console.error("WEBHOOK_SECRET is required");
+  process.exit(1);
+}
+
+const url = `${GATEWAY_URL}/webhooks/telegram`;
+
+function makePayload(i: number) {
+  return JSON.stringify({
+    update_id: 100000 + i,
+    message: {
+      message_id: i,
+      chat: { id: 10000 + (i % 100), type: "private" },
+      from: { id: 20000 + (i % 100), is_bot: false, first_name: "Bench" },
+      text: `Load test message ${i}`,
+    },
+  });
+}
+
+let total = 0;
+let errors = 0;
+let counter = 0;
+const latencies: number[] = [];
+
+async function worker() {
+  while (Date.now() < endTime) {
+    const i = counter++;
+    const body = makePayload(i);
+    const start = performance.now();
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": WEBHOOK_SECRET,
+        },
+        body,
+      });
+      const elapsed = performance.now() - start;
+      latencies.push(elapsed);
+      total++;
+      if (!res.ok && res.status !== 200) {
+        // 500-level errors count as failures
+        if (res.status >= 500) errors++;
+      }
+    } catch {
+      errors++;
+      total++;
+    }
+  }
+}
+
+console.log(`Gateway webhook benchmark`);
+console.log(`  Target:      ${url}`);
+console.log(`  Duration:    ${DURATION_SECS}s`);
+console.log(`  Concurrency: ${CONCURRENCY}`);
+console.log(`  Starting...`);
+
+const startTime = Date.now();
+const endTime = startTime + DURATION_SECS * 1000;
+
+const workers = Array.from({ length: CONCURRENCY }, () => worker());
+await Promise.all(workers);
+
+const elapsed = (Date.now() - startTime) / 1000;
+latencies.sort((a, b) => a - b);
+
+const p50 = latencies[Math.floor(latencies.length * 0.5)] || 0;
+const p95 = latencies[Math.floor(latencies.length * 0.95)] || 0;
+const p99 = latencies[Math.floor(latencies.length * 0.99)] || 0;
+const rpm = (total / elapsed) * 60;
+
+console.log(`\nResults:`);
+console.log(`  Total requests:  ${total}`);
+console.log(`  Errors:          ${errors}`);
+console.log(`  Duration:        ${elapsed.toFixed(1)}s`);
+console.log(`  RPM:             ${rpm.toFixed(0)}`);
+console.log(`  Latency p50:     ${p50.toFixed(1)}ms`);
+console.log(`  Latency p95:     ${p95.toFixed(1)}ms`);
+console.log(`  Latency p99:     ${p99.toFixed(1)}ms`);
+console.log(`  Error rate:      ${((errors / total) * 100).toFixed(2)}%`);
+
+// Pass/fail: target is 3000+ RPM per pod with <1% error rate
+const RPM_TARGET = 3000;
+const ERROR_RATE_MAX = 1;
+const errorRate = (errors / total) * 100;
+
+if (rpm >= RPM_TARGET && errorRate <= ERROR_RATE_MAX) {
+  console.log(`\n✓ PASS: ${rpm.toFixed(0)} RPM ≥ ${RPM_TARGET} target, ${errorRate.toFixed(2)}% errors ≤ ${ERROR_RATE_MAX}%`);
+} else {
+  console.log(`\n✗ FAIL:`);
+  if (rpm < RPM_TARGET) console.log(`  RPM ${rpm.toFixed(0)} < ${RPM_TARGET} target`);
+  if (errorRate > ERROR_RATE_MAX) console.log(`  Error rate ${errorRate.toFixed(2)}% > ${ERROR_RATE_MAX}% max`);
+  process.exit(1);
+}

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -144,6 +144,10 @@ bun run test        # Run test suite
 
 Both checks run in CI on every pull request touching `gateway/`.
 
+## Load Testing
+
+See [`benchmarking/gateway/README.md`](../benchmarking/gateway/README.md) for load-test scripts and throughput targets.
+
 ## Troubleshooting
 
 | Symptom | Check |


### PR DESCRIPTION
## Summary
- Add `benchmarking/gateway/bench-webhook.ts` for Telegram webhook path load testing
- Add `benchmarking/gateway/bench-proxy.ts` for runtime proxy path load testing
- Add `benchmarking/gateway/README.md` with usage docs and pass/fail criteria
- Link from gateway README

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (65 tests)
- [ ] Run benchmark locally against dev gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
