### PR TITLE
Wire all 13 hook events into daemon, session, agent loop, and executor

### DIFF
--- a/assistant/src/__tests__/hooks-integration.test.ts
+++ b/assistant/src/__tests__/hooks-integration.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-integration-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { HookManager, resetHookManager } from '../hooks/manager.js';
+import { saveHooksConfig } from '../hooks/config.js';
+
+function createHook(
+  hooksDir: string,
+  name: string,
+  events: string[],
+  scriptContent: string,
+): void {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+  writeFileSync(
+    join(hookDir, 'hook.json'),
+    JSON.stringify({
+      name,
+      description: `Integration test hook: ${name}`,
+      version: '1.0.0',
+      events,
+      script: 'run.sh',
+    }),
+  );
+  const scriptPath = join(hookDir, 'run.sh');
+  writeFileSync(scriptPath, scriptContent);
+  chmodSync(scriptPath, 0o755);
+}
+
+describe('Hooks Integration', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    resetHookManager();
+  });
+
+  afterEach(() => {
+    resetHookManager();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('hook receives event data via stdin', async () => {
+    const outputFile = join(testDir, 'stdin-data.json');
+    createHook(
+      hooksDir,
+      'stdin-capture',
+      ['pre-tool-execute'],
+      `#!/bin/bash\ncat > "${outputFile}"`,
+    );
+    saveHooksConfig({ version: 1, hooks: { 'stdin-capture': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    await manager.trigger('pre-tool-execute', {
+      toolName: 'bash',
+      command: 'ls -la',
+      riskLevel: 'medium',
+    });
+
+    // Wait for file write to complete
+    await new Promise((r) => setTimeout(r, 200));
+    const data = JSON.parse(readFileSync(outputFile, 'utf-8'));
+    expect(data.event).toBe('pre-tool-execute');
+    expect(data.toolName).toBe('bash');
+    expect(data.command).toBe('ls -la');
+  });
+
+  test('hook receives environment variables', async () => {
+    const outputFile = join(testDir, 'env-data.txt');
+    createHook(
+      hooksDir,
+      'env-capture',
+      ['daemon-start'],
+      `#!/bin/bash\necho "$VELLUM_HOOK_EVENT|$VELLUM_HOOK_NAME|$VELLUM_ROOT_DIR" > "${outputFile}"`,
+    );
+    saveHooksConfig({ version: 1, hooks: { 'env-capture': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    await manager.trigger('daemon-start', { pid: 12345 });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const output = readFileSync(outputFile, 'utf-8').trim();
+    const parts = output.split('|');
+    expect(parts[0]).toBe('daemon-start');
+    expect(parts[1]).toBe('env-capture');
+    expect(parts[2]).toContain('.vellum');
+  });
+
+  test('multiple hooks for same event run in order', async () => {
+    const outputFile = join(testDir, 'order.txt');
+    createHook(
+      hooksDir,
+      'hook-c',
+      ['on-error'],
+      `#!/bin/bash\necho "c" >> "${outputFile}"`,
+    );
+    createHook(
+      hooksDir,
+      'hook-a',
+      ['on-error'],
+      `#!/bin/bash\necho "a" >> "${outputFile}"`,
+    );
+    createHook(
+      hooksDir,
+      'hook-b',
+      ['on-error'],
+      `#!/bin/bash\necho "b" >> "${outputFile}"`,
+    );
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        'hook-a': { enabled: true },
+        'hook-b': { enabled: true },
+        'hook-c': { enabled: true },
+      },
+    });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    await manager.trigger('on-error', { message: 'test error' });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const lines = readFileSync(outputFile, 'utf-8').trim().split('\n');
+    expect(lines).toEqual(['a', 'b', 'c']);
+  });
+
+  test('hook failure does not prevent subsequent hooks', async () => {
+    const outputFile = join(testDir, 'after-failure.txt');
+    createHook(
+      hooksDir,
+      'hook-fail',
+      ['post-message'],
+      '#!/bin/bash\nexit 1',
+    );
+    createHook(
+      hooksDir,
+      'hook-success',
+      ['post-message'],
+      `#!/bin/bash\necho "ran" > "${outputFile}"`,
+    );
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        'hook-fail': { enabled: true },
+        'hook-success': { enabled: true },
+      },
+    });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    await manager.trigger('post-message', {});
+
+    await new Promise((r) => setTimeout(r, 200));
+    const output = readFileSync(outputFile, 'utf-8').trim();
+    expect(output).toBe('ran');
+  });
+
+  test('disabled hooks are not triggered', async () => {
+    const outputFile = join(testDir, 'disabled.txt');
+    createHook(
+      hooksDir,
+      'disabled-hook',
+      ['pre-message'],
+      `#!/bin/bash\necho "should not run" > "${outputFile}"`,
+    );
+    // Not enabled in config (defaults to disabled)
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    await manager.trigger('pre-message', {});
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(() => readFileSync(outputFile, 'utf-8')).toThrow();
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import type { Provider, Message, ToolDefinition, ContentBlock } from '../providers/types.js';
 import { getLogger, isDebug, truncateForLog } from '../util/logger.js';
+import { getHookManager } from '../hooks/manager.js';
 
 const log = getLogger('agent-loop');
 
@@ -105,6 +106,12 @@ export class AgentLoop {
           }, 'Sending request to provider');
         }
 
+        await getHookManager().trigger('pre-llm-call', {
+          systemPrompt: this.systemPrompt,
+          messages: history,
+          toolCount: this.tools.length,
+        });
+
         const providerStart = Date.now();
 
         const response = await this.provider.sendMessage(
@@ -150,6 +157,14 @@ export class AgentLoop {
           cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
+        });
+
+        void getHookManager().trigger('post-llm-call', {
+          model: response.model,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          contentBlockCount: response.content.length,
+          durationMs: providerDurationMs,
         });
 
         const assistantMessage: Message = {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -25,6 +25,7 @@ import { initQdrantClient } from '../memory/qdrant-client.js';
 import { startScheduler } from '../schedule/scheduler.js';
 import { browserManager } from '../tools/browser/browser-manager.js';
 import { RuntimeHttpServer } from '../runtime/http-server.js';
+import { getHookManager } from '../hooks/manager.js';
 
 const log = getLogger('lifecycle');
 
@@ -234,6 +235,11 @@ export async function runDaemon(): Promise<void> {
   writePid(process.pid);
   log.info({ pid: process.pid }, 'Daemon started');
 
+  void getHookManager().trigger('daemon-start', {
+    pid: process.pid,
+    socketPath: getSocketPath(),
+  });
+
   // Rotate old audit log entries after startup handshake is complete.
   // This runs after the socket is listening so it won't block the 5s
   // readiness window in startDaemon().
@@ -251,6 +257,12 @@ export async function runDaemon(): Promise<void> {
     if (shuttingDown) return; // Prevent re-entrant shutdown
     shuttingDown = true;
     log.info('Shutting down daemon...');
+
+    try {
+      await getHookManager().trigger('daemon-stop', { pid: process.pid });
+    } catch {
+      // Don't let hook failures block shutdown
+    }
 
     // Force exit if graceful shutdown takes too long
     const forceTimer = setTimeout(() => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -33,6 +33,7 @@ import {
   createContextSummaryMessage,
   getSummaryFromContextMessage,
 } from '../context/window-manager.js';
+import { getHookManager } from '../hooks/manager.js';
 import {
   buildMemoryRecall,
   injectMemoryRecallIntoUserMessage,
@@ -159,6 +160,11 @@ export class Session {
       systemPrompt,
       config.contextWindow,
     );
+
+    void getHookManager().trigger('session-start', {
+      sessionId: this.conversationId,
+      workingDir: this.workingDir,
+    });
   }
 
   async loadFromDb(): Promise<void> {
@@ -256,6 +262,9 @@ export class Session {
 
   /** Abort and permanently tear down this session. Call when removing from the sessions map. */
   dispose(): void {
+    void getHookManager().trigger('session-end', {
+      sessionId: this.conversationId,
+    });
     this.abort();
     this.eventBus.dispose();
   }
@@ -385,6 +394,11 @@ export class Session {
     let yieldedForHandoff = false;
 
     try {
+      await getHookManager().trigger('pre-message', {
+        sessionId: this.conversationId,
+        messagePreview: content.slice(0, 200),
+      });
+
       const isFirstMessage = this.messages.length === 1;
 
       const compacted = await this.contextWindowManager.maybeCompact(
@@ -645,6 +659,10 @@ export class Session {
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent');
 
+      void getHookManager().trigger('post-message', {
+        sessionId: this.conversationId,
+      });
+
       if (yieldedForHandoff) {
         onEvent({
           type: 'generation_handoff',
@@ -673,6 +691,12 @@ export class Session {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Session processing error');
         onEvent({ type: 'error', message: `Failed to process message: ${message}` });
+        void getHookManager().trigger('on-error', {
+          error: err instanceof Error ? err.name : 'Error',
+          message,
+          stack: err instanceof Error ? err.stack : undefined,
+          sessionId: this.conversationId,
+        });
       }
     } finally {
       this.abortController = null;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -13,6 +13,7 @@ import { MAX_FILE_SIZE_BYTES } from './filesystem/size-guard.js';
 import { wrapCommand } from './terminal/sandbox.js';
 import { getConfig } from '../config/loader.js';
 import { scanText, redactSecrets } from '../security/secret-scanner.js';
+import { getHookManager } from '../hooks/manager.js';
 
 const log = getLogger('tool-executor');
 
@@ -122,6 +123,13 @@ export class ToolExecutor {
           sandboxed,
         });
 
+        void getHookManager().trigger('permission-request', {
+          toolName: name,
+          input: sanitizeToolInput(name, input),
+          riskLevel,
+          sessionId: context.sessionId,
+        });
+
         const response = await this.prompter.prompt(
           name,
           input,
@@ -134,6 +142,13 @@ export class ToolExecutor {
         );
 
         decision = response.decision;
+
+        void getHookManager().trigger('permission-resolve', {
+          toolName: name,
+          decision: response.decision,
+          riskLevel,
+          sessionId: context.sessionId,
+        });
 
         if (response.decision === 'deny') {
           const durationMs = Date.now() - startTime;
@@ -179,6 +194,15 @@ export class ToolExecutor {
           addRule(name, response.selectedPattern, response.selectedScope);
         }
       }
+
+      await getHookManager().trigger('pre-tool-execute', {
+        toolName: name,
+        input: sanitizeToolInput(name, input),
+        riskLevel,
+        decision,
+        workingDir: context.workingDir,
+        sessionId: context.sessionId,
+      });
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;
@@ -283,6 +307,15 @@ export class ToolExecutor {
         decision,
         durationMs,
         result: execResult,
+      });
+
+      void getHookManager().trigger('post-tool-execute', {
+        toolName: name,
+        input: sanitizeToolInput(name, input),
+        riskLevel,
+        isError: execResult.isError,
+        durationMs,
+        sessionId: context.sessionId,
       });
 
       return execResult;


### PR DESCRIPTION
## Summary
- Integrates hook triggers at all 13 lifecycle points across 4 files: daemon lifecycle (start/stop), session lifecycle (start/end), agent loop (pre/post LLM call, pre/post message, on-error), and tool executor (pre/post execute, permission request/resolve)
- `pre-llm-call` passes the full system prompt and conversation history, enabling the debug-prompt-logger hook (PR 4)
- 5 new end-to-end integration tests verifying stdin data piping, env vars, execution order, failure isolation, and disabled hook filtering

PR 3 of 9 in the hooks system rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
