### PR TITLE
Build gateway Docker image in PR CI (no push)

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -1,0 +1,46 @@
+name: PR Gateway Image Build
+
+on:
+  pull_request:
+    paths:
+      - 'gateway/**'
+      - '.github/workflows/ci-gateway-image.yml'
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: gateway
+          push: false
+          tags: vellum-gateway:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke check - container boots
+        run: |
+          docker build -t vellum-gateway:smoke gateway
+          docker run --rm -d --name gateway-smoke \
+            -e TELEGRAM_BOT_TOKEN=test \
+            -e TELEGRAM_WEBHOOK_SECRET=test \
+            -e ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821 \
+            -p 19830:7830 \
+            vellum-gateway:smoke
+          sleep 3
+          STATUS=$(curl -sf http://localhost:19830/healthz | jq -r '.status' || echo "failed")
+          docker stop gateway-smoke || true
+          if [ "$STATUS" != "ok" ]; then
+            echo "Smoke check failed: healthz returned '$STATUS'"
+            exit 1
+          fi
+          echo "Smoke check passed"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci-gateway-image.yml` to build the gateway Docker image on every PR touching `gateway/`
- Uses Docker Buildx with GHA cache for fast rebuilds
- Includes smoke check: boots the container and verifies `/healthz` returns 200

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (65 tests)
- [ ] Workflow triggers on this PR and builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
