### PR TITLE
Add blocking hooks for pre-* events

### DIFF
--- a/assistant/src/__tests__/hooks-blocking.test.ts
+++ b/assistant/src/__tests__/hooks-blocking.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-blocking-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { HookManager, resetHookManager } from '../hooks/manager.js';
+import { saveHooksConfig } from '../hooks/config.js';
+
+function createHook(
+  hooksDir: string,
+  name: string,
+  events: string[],
+  scriptContent: string,
+  blocking = false,
+): void {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+  writeFileSync(
+    join(hookDir, 'hook.json'),
+    JSON.stringify({
+      name,
+      description: `Test hook ${name}`,
+      version: '1.0.0',
+      events,
+      script: 'run.sh',
+      ...(blocking ? { blocking: true } : {}),
+    }),
+  );
+  const scriptPath = join(hookDir, 'run.sh');
+  writeFileSync(scriptPath, scriptContent);
+  chmodSync(scriptPath, 0o755);
+}
+
+describe('Blocking Hooks', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    resetHookManager();
+  });
+
+  afterEach(() => {
+    resetHookManager();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('blocking hook on pre-* event cancels action on non-zero exit', async () => {
+    createHook(hooksDir, 'guard', ['pre-tool-execute'], '#!/bin/bash\nexit 1', true);
+    saveHooksConfig({ version: 1, hooks: { guard: { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('pre-tool-execute', { toolName: 'bash' });
+    expect(result.blocked).toBe(true);
+    expect(result.blockedBy).toBe('guard');
+  });
+
+  test('blocking hook on pre-* event allows action on zero exit', async () => {
+    createHook(hooksDir, 'pass-guard', ['pre-tool-execute'], '#!/bin/bash\nexit 0', true);
+    saveHooksConfig({ version: 1, hooks: { 'pass-guard': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('pre-tool-execute', { toolName: 'bash' });
+    expect(result.blocked).toBe(false);
+  });
+
+  test('non-blocking hook does not cancel even on non-zero exit', async () => {
+    createHook(hooksDir, 'logger', ['pre-tool-execute'], '#!/bin/bash\nexit 1', false);
+    saveHooksConfig({ version: 1, hooks: { logger: { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('pre-tool-execute', { toolName: 'bash' });
+    expect(result.blocked).toBe(false);
+  });
+
+  test('blocking hook on non-pre event does not cancel', async () => {
+    createHook(hooksDir, 'post-guard', ['post-tool-execute'], '#!/bin/bash\nexit 1', true);
+    saveHooksConfig({ version: 1, hooks: { 'post-guard': { enabled: true } } });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('post-tool-execute', { toolName: 'bash' });
+    expect(result.blocked).toBe(false);
+  });
+
+  test('blocking hook stops subsequent hooks from running', async () => {
+    const outputFile = join(testDir, 'after-block.txt');
+    createHook(hooksDir, 'blocker', ['pre-llm-call'], '#!/bin/bash\nexit 1', true);
+    createHook(hooksDir, 'logger', ['pre-llm-call'], `#!/bin/bash\necho "ran" > "${outputFile}"`, false);
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        blocker: { enabled: true },
+        logger: { enabled: true },
+      },
+    });
+
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('pre-llm-call', {});
+    expect(result.blocked).toBe(true);
+    expect(result.blockedBy).toBe('blocker');
+
+    // Logger should NOT have run because blocker runs first (alphabetical order)
+    await new Promise((r) => setTimeout(r, 100));
+    expect(() => require('node:fs').readFileSync(outputFile, 'utf-8')).toThrow();
+  });
+
+  test('trigger returns not blocked when no hooks match', async () => {
+    const manager = new HookManager();
+    manager.initialize();
+
+    const result = await manager.trigger('pre-tool-execute', {});
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -106,11 +106,16 @@ export class AgentLoop {
           }, 'Sending request to provider');
         }
 
-        await getHookManager().trigger('pre-llm-call', {
+        const preLlmResult = await getHookManager().trigger('pre-llm-call', {
           systemPrompt: this.systemPrompt,
           messages: history,
           toolCount: this.tools.length,
         });
+
+        if (preLlmResult.blocked) {
+          onEvent({ type: 'error', error: new Error(`LLM call blocked by hook "${preLlmResult.blockedBy}"`) });
+          break;
+        }
 
         const providerStart = Date.now();
 

--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -1,7 +1,7 @@
 import { discoverHooks } from './discovery.js';
 import { runHookScript } from './runner.js';
 import { getLogger, isDebug } from '../util/logger.js';
-import type { DiscoveredHook, HookEventName, HookEventData } from './types.js';
+import type { DiscoveredHook, HookEventName, HookEventData, HookTriggerResult } from './types.js';
 
 const log = getLogger('hooks-manager');
 
@@ -34,16 +34,22 @@ export class HookManager {
     }
   }
 
-  async trigger(event: HookEventName, data: Record<string, unknown>): Promise<void> {
+  async trigger(event: HookEventName, data: Record<string, unknown>): Promise<HookTriggerResult> {
     const hooks = this.eventIndex.get(event);
-    if (!hooks || hooks.length === 0) return;
+    if (!hooks || hooks.length === 0) return { blocked: false };
 
+    const isPreEvent = event.startsWith('pre-');
     const eventData: HookEventData = { event, ...data };
 
     for (const hook of hooks) {
       try {
         const result = await runHookScript(hook, eventData);
         if (result.exitCode !== null && result.exitCode !== 0) {
+          // Blocking hooks on pre-* events cancel the action
+          if (isPreEvent && hook.manifest.blocking) {
+            log.info({ hook: hook.name, event, exitCode: result.exitCode }, 'Blocking hook rejected action');
+            return { blocked: true, blockedBy: hook.name };
+          }
           log.warn({ hook: hook.name, event, exitCode: result.exitCode }, 'Hook exited with non-zero code');
         }
         if (result.stderr && isDebug()) {
@@ -53,6 +59,8 @@ export class HookManager {
         log.warn({ err, hook: hook.name, event }, 'Hook execution failed');
       }
     }
+
+    return { blocked: false };
   }
 
   getDiscoveredHooks(): DiscoveredHook[] {

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -26,6 +26,8 @@ export interface HookManifest {
   version: string;
   events: HookEventName[];
   script: string;
+  /** When true, non-zero exit from this hook cancels pre-* actions. Default false. */
+  blocking?: boolean;
 }
 
 export interface HookConfigEntry {
@@ -50,4 +52,11 @@ export interface DiscoveredHook {
 export interface HookEventData {
   event: HookEventName;
   [key: string]: unknown;
+}
+
+export interface HookTriggerResult {
+  /** True if a blocking hook rejected the action (non-zero exit). */
+  blocked: boolean;
+  /** Name of the hook that blocked, if any. */
+  blockedBy?: string;
 }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -195,7 +195,7 @@ export class ToolExecutor {
         }
       }
 
-      await getHookManager().trigger('pre-tool-execute', {
+      const hookResult = await getHookManager().trigger('pre-tool-execute', {
         toolName: name,
         input: sanitizeToolInput(name, input),
         riskLevel,
@@ -203,6 +203,26 @@ export class ToolExecutor {
         workingDir: context.workingDir,
         sessionId: context.sessionId,
       });
+
+      if (hookResult.blocked) {
+        const msg = `Tool execution blocked by hook "${hookResult.blockedBy}"`;
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent(context, {
+          type: 'error',
+          toolName: name,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: 'blocked',
+          durationMs,
+          errorMessage: msg,
+          isExpected: true,
+        });
+        return { content: msg, isError: true };
+      }
 
       // Execute the tool — proxy tools delegate to an external resolver
       let execResult: ToolExecutionResult;


### PR DESCRIPTION
## Summary
- Hooks with `"blocking": true` in their manifest can cancel `pre-*` actions by exiting non-zero
- Blocking is only respected on pre-* events (pre-tool-execute, pre-llm-call, pre-message); post/on events ignore the flag
- `trigger()` now returns `{ blocked, blockedBy? }` so callers can act on the result
- Tool executor returns an error result when pre-tool-execute is blocked; agent loop breaks when pre-llm-call is blocked
- 6 new tests for blocking behavior, non-blocking passthrough, non-pre event safety, and hook ordering

PR 5 of 9 in the hooks system rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
