### PR TITLE
Add per-hook configurable settings

### DIFF
--- a/assistant/src/__tests__/hooks-settings.test.ts
+++ b/assistant/src/__tests__/hooks-settings.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Set BASE_DATA_DIR before importing modules that use getRootDir()
+const testDir = join(tmpdir(), `hooks-settings-test-${Date.now()}`);
+process.env.BASE_DATA_DIR = testDir;
+
+import { getHookSettings } from '../hooks/config.js';
+import { saveHooksConfig } from '../hooks/config.js';
+import { runHookScript } from '../hooks/runner.js';
+import type { HookManifest, DiscoveredHook } from '../hooks/types.js';
+
+describe('Hook Settings', () => {
+  let hooksDir: string;
+
+  beforeEach(() => {
+    hooksDir = join(testDir, '.vellum', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('getHookSettings returns empty object when no schema and no config', () => {
+    const manifest: HookManifest = {
+      name: 'test',
+      description: 'Test',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+    };
+
+    const settings = getHookSettings('test', manifest);
+    expect(settings).toEqual({});
+  });
+
+  test('getHookSettings returns defaults from manifest schema', () => {
+    const manifest: HookManifest = {
+      name: 'test',
+      description: 'Test',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+      settingsSchema: {
+        maxLen: { type: 'number', default: 2000, description: 'Max length' },
+        verbose: { type: 'boolean', default: false },
+      },
+    };
+
+    const settings = getHookSettings('test', manifest);
+    expect(settings.maxLen).toBe(2000);
+    expect(settings.verbose).toBe(false);
+  });
+
+  test('getHookSettings merges user overrides over defaults', () => {
+    const manifest: HookManifest = {
+      name: 'test',
+      description: 'Test',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+      settingsSchema: {
+        maxLen: { type: 'number', default: 2000 },
+        verbose: { type: 'boolean', default: false },
+      },
+    };
+
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        test: {
+          enabled: true,
+          settings: { maxLen: 5000 },
+        },
+      },
+    });
+
+    const settings = getHookSettings('test', manifest);
+    expect(settings.maxLen).toBe(5000); // Overridden
+    expect(settings.verbose).toBe(false); // Default preserved
+  });
+
+  test('getHookSettings allows user settings without schema', () => {
+    const manifest: HookManifest = {
+      name: 'test',
+      description: 'Test',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+    };
+
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        test: {
+          enabled: true,
+          settings: { customKey: 'customValue' },
+        },
+      },
+    });
+
+    const settings = getHookSettings('test', manifest);
+    expect(settings.customKey).toBe('customValue');
+  });
+
+  test('VELLUM_HOOK_SETTINGS env var is passed to script', async () => {
+    const hookDir = join(hooksDir, 'settings-hook');
+    mkdirSync(hookDir, { recursive: true });
+
+    const manifest: HookManifest = {
+      name: 'settings-hook',
+      description: 'Settings test',
+      version: '1.0.0',
+      events: ['on-error'],
+      script: 'run.sh',
+      settingsSchema: {
+        greeting: { type: 'string', default: 'hello' },
+      },
+    };
+    writeFileSync(join(hookDir, 'hook.json'), JSON.stringify(manifest));
+
+    const outputFile = join(testDir, 'settings-output.txt');
+    const scriptContent = `#!/bin/bash\necho "$VELLUM_HOOK_SETTINGS" > "${outputFile}"`;
+    writeFileSync(join(hookDir, 'run.sh'), scriptContent);
+    chmodSync(join(hookDir, 'run.sh'), 0o755);
+
+    saveHooksConfig({
+      version: 1,
+      hooks: {
+        'settings-hook': {
+          enabled: true,
+          settings: { greeting: 'world' },
+        },
+      },
+    });
+
+    const hook: DiscoveredHook = {
+      name: 'settings-hook',
+      dir: hookDir,
+      manifest,
+      scriptPath: join(hookDir, 'run.sh'),
+      enabled: true,
+    };
+
+    await runHookScript(hook, { event: 'on-error' });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const output = JSON.parse(readFileSync(outputFile, 'utf-8').trim());
+    expect(output.greeting).toBe('world'); // User override
+  });
+});

--- a/assistant/src/hooks/config.ts
+++ b/assistant/src/hooks/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { getHooksDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
-import type { HookConfig, HookConfigEntry } from './types.js';
+import type { HookConfig, HookConfigEntry, HookManifest } from './types.js';
 
 const log = getLogger('hooks-config');
 
@@ -57,4 +57,26 @@ export function ensureHookInConfig(hookName: string, entry: HookConfigEntry): vo
   if (hookName in config.hooks) return;
   config.hooks[hookName] = entry;
   saveHooksConfig(config);
+}
+
+/**
+ * Get merged settings for a hook. Manifest defaults are used as the base,
+ * then user overrides from config.json are applied on top.
+ */
+export function getHookSettings(hookName: string, manifest: HookManifest): Record<string, unknown> {
+  // Start with defaults from manifest schema
+  const defaults: Record<string, unknown> = {};
+  if (manifest.settingsSchema) {
+    for (const [key, schema] of Object.entries(manifest.settingsSchema)) {
+      if (schema.default !== undefined) {
+        defaults[key] = schema.default;
+      }
+    }
+  }
+
+  // Merge user overrides from config
+  const config = loadHooksConfig();
+  const userSettings = config.hooks[hookName]?.settings ?? {};
+
+  return { ...defaults, ...userSettings };
 }

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { getRootDir } from '../util/platform.js';
+import { getHookSettings } from './config.js';
 import type { DiscoveredHook, HookEventData } from './types.js';
 
 export interface HookRunResult {
@@ -23,6 +24,7 @@ export async function runHookScript(
         VELLUM_HOOK_EVENT: eventData.event,
         VELLUM_HOOK_NAME: hook.name,
         VELLUM_ROOT_DIR: getRootDir(),
+        VELLUM_HOOK_SETTINGS: JSON.stringify(getHookSettings(hook.name, hook.manifest)),
       },
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -20,6 +20,12 @@ export type HookEventName =
   // Error
   | 'on-error';
 
+export interface HookSettingsSchemaEntry {
+  type: string;
+  default?: unknown;
+  description?: string;
+}
+
 export interface HookManifest {
   name: string;
   description: string;
@@ -28,10 +34,14 @@ export interface HookManifest {
   script: string;
   /** When true, non-zero exit from this hook cancels pre-* actions. Default false. */
   blocking?: boolean;
+  /** Schema for per-hook settings with defaults and descriptions. */
+  settingsSchema?: Record<string, HookSettingsSchemaEntry>;
 }
 
 export interface HookConfigEntry {
   enabled: boolean;
+  /** Per-hook user settings that override manifest defaults. */
+  settings?: Record<string, unknown>;
 }
 
 export interface HookConfig {


### PR DESCRIPTION
## Summary
- Hooks can declare `settingsSchema` in their manifest with typed defaults and descriptions
- Users can override per-hook settings in `config.json` under `hooks.<name>.settings`
- Settings are merged (manifest defaults + user overrides) and passed to scripts as `VELLUM_HOOK_SETTINGS` env var (JSON)
- 5 new tests for default merging, user overrides, schema-less settings, and env var passing

PR 6 of 9 in the hooks system rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
