### PR TITLE
Create GitHub Action to push gateway image to GCP registry on merge to main

### DIFF
--- a/.github/workflows/cd-gateway-image.yml
+++ b/.github/workflows/cd-gateway-image.yml
@@ -1,0 +1,53 @@
+name: Push Gateway Image to GCP
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gateway/**'
+      - '.github/workflows/cd-gateway-image.yml'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker ${{ vars.GCP_REGISTRY_HOST }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: gateway
+          push: true
+          tags: |
+            ${{ vars.GCP_REGISTRY_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GATEWAY_IMAGE_NAME }}:${{ github.sha }}
+            ${{ vars.GCP_REGISTRY_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GATEWAY_IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Gateway Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ vars.GCP_REGISTRY_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GATEWAY_IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**SHA tag:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -144,6 +144,21 @@ bun run test        # Run test suite
 
 Both checks run in CI on every pull request touching `gateway/`.
 
+## CI/CD
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `ci-gateway.yml` | PR (`gateway/**`) | Typecheck + tests |
+| `ci-gateway-image.yml` | PR (`gateway/**`) | Build Docker image + smoke check |
+| `cd-gateway-image.yml` | Push to `main` (`gateway/**`) | Build + push image to GCR |
+
+The CD workflow requires these GitHub repository variables:
+- `GCP_WORKLOAD_IDENTITY_PROVIDER` — OIDC provider for keyless auth
+- `GCP_SERVICE_ACCOUNT` — Service account with push permissions
+- `GCP_PROJECT_ID` — GCP project ID
+- `GATEWAY_IMAGE_NAME` — Image name (e.g. `vellum-gateway`)
+- `GCP_REGISTRY_HOST` — Registry host (e.g. `gcr.io`)
+
 ## Load Testing
 
 See [`benchmarking/gateway/README.md`](../benchmarking/gateway/README.md) for load-test scripts and throughput targets.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/cd-gateway-image.yml` — builds and pushes the gateway Docker image to GCR on every main merge touching `gateway/`
- Uses GitHub OIDC for keyless GCP auth (no static credentials)
- Tags images with full commit SHA + `latest`
- Emits image digest in workflow summary
- Document CI/CD pipeline in gateway README

### Required GitHub Repository Variables
- `GCP_WORKLOAD_IDENTITY_PROVIDER` — OIDC provider
- `GCP_SERVICE_ACCOUNT` — Service account with push permissions
- `GCP_PROJECT_ID` — GCP project ID
- `GATEWAY_IMAGE_NAME` — Image name (e.g. `vellum-gateway`)
- `GCP_REGISTRY_HOST` — Registry host (e.g. `gcr.io`)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (65 tests)
- [ ] Merge a gateway change to main and confirm image appears in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
