### PR TITLE
Remove noisy attachment log from Telegram webhook

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -105,11 +105,6 @@ export function createTelegramWebhookHandler(
               attachmentIds.push(uploaded.id);
             }
           }
-
-          log.info(
-            { count: attachmentIds.length, assistantId: routing.assistantId },
-            "Attachments downloaded and uploaded",
-          );
         } catch (err) {
           log.error({ err }, "Failed to process attachments");
           return Response.json({ error: "Failed to process attachments" }, { status: 500 });


### PR DESCRIPTION
## Summary
- Removes an info-level log ("Attachments downloaded and uploaded") from the Telegram webhook handler
- This log fires on every message with attachments and doesn't add diagnostic value — errors are already logged separately

## Test plan
- [ ] Verify gateway builds cleanly
- [ ] Send a Telegram message with attachments and confirm no regression in attachment handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
