### PR TITLE
Support TypeScript hooks via bun run

### DIFF
--- a/assistant/src/__tests__/hooks-ts-runner.test.ts
+++ b/assistant/src/__tests__/hooks-ts-runner.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runHookScript } from '../hooks/runner.js';
+import type { DiscoveredHook, HookEventData, HookManifest } from '../hooks/types.js';
+
+let hooksDir: string;
+
+function createHook(name: string, scriptName: string, scriptContent: string): DiscoveredHook {
+  const hookDir = join(hooksDir, name);
+  mkdirSync(hookDir, { recursive: true });
+
+  const manifest: HookManifest = {
+    name,
+    description: `Test hook: ${name}`,
+    version: '1.0.0',
+    events: ['pre-llm-call'],
+    script: scriptName,
+  };
+
+  writeFileSync(join(hookDir, 'hook.json'), JSON.stringify(manifest));
+
+  const scriptPath = join(hookDir, scriptName);
+  writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
+
+  return {
+    name,
+    dir: hookDir,
+    manifest,
+    scriptPath,
+    enabled: true,
+  };
+}
+
+describe('TypeScript hooks runner', () => {
+  beforeEach(() => {
+    hooksDir = join(tmpdir(), `hooks-ts-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(hooksDir, { recursive: true, force: true });
+  });
+
+  test('runs .ts hook via bun run', async () => {
+    const hook = createHook('ts-hook', 'run.ts', `
+import { readFileSync } from 'node:fs';
+const data = JSON.parse(readFileSync('/dev/stdin', 'utf-8'));
+console.log(JSON.stringify({ event: data.event, ok: true }));
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call', model: 'test' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.event).toBe('pre-llm-call');
+    expect(output.ok).toBe(true);
+  });
+
+  test('.ts hook receives event data on stdin', async () => {
+    const hook = createHook('stdin-hook', 'handler.ts', `
+import { readFileSync } from 'node:fs';
+const data = JSON.parse(readFileSync('/dev/stdin', 'utf-8'));
+console.log(data.customField);
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call', customField: 'hello-ts' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello-ts');
+  });
+
+  test('.ts hook receives env vars', async () => {
+    const hook = createHook('env-hook', 'check-env.ts', `
+console.log(process.env.VELLUM_HOOK_EVENT);
+console.log(process.env.VELLUM_HOOK_NAME);
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(0);
+    const lines = result.stdout.trim().split('\n');
+    expect(lines[0]).toBe('pre-llm-call');
+    expect(lines[1]).toBe('env-hook');
+  });
+
+  test('.ts hook non-zero exit returns exit code', async () => {
+    const hook = createHook('fail-hook', 'fail.ts', `
+process.exit(1);
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  test('.sh hook still runs directly (not via bun)', async () => {
+    const hook = createHook('sh-hook', 'run.sh', `#!/bin/sh
+echo "shell-hook"
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('shell-hook');
+  });
+
+  test('.ts hook can write to stderr', async () => {
+    const hook = createHook('stderr-hook', 'log.ts', `
+console.error('ts-stderr-output');
+`);
+
+    const eventData: HookEventData = { event: 'pre-llm-call' };
+    const result = await runHookScript(hook, eventData);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('ts-stderr-output');
+  });
+});

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -1,7 +1,16 @@
 import { spawn } from 'node:child_process';
+import { extname } from 'node:path';
 import { getRootDir } from '../util/platform.js';
 import { getHookSettings } from './config.js';
 import type { DiscoveredHook, HookEventData } from './types.js';
+
+function getSpawnArgs(scriptPath: string): { command: string; args: string[] } {
+  const ext = extname(scriptPath);
+  if (ext === '.ts') {
+    return { command: 'bun', args: ['run', scriptPath] };
+  }
+  return { command: scriptPath, args: [] };
+}
 
 export interface HookRunResult {
   exitCode: number | null;
@@ -17,7 +26,8 @@ export async function runHookScript(
   const timeoutMs = options?.timeoutMs ?? 5000;
 
   return new Promise<HookRunResult>((resolve) => {
-    const child = spawn(hook.scriptPath, [], {
+    const { command, args } = getSpawnArgs(hook.scriptPath);
+    const child = spawn(command, args, {
       cwd: hook.dir,
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary
- Detects `.ts` script extension in hook runner and spawns via `bun run` instead of direct execution
- Shell scripts and other executables continue to run directly as before
- Adds 6 tests for TypeScript hook execution (stdin, env vars, exit code, stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
