### PR TITLE
Cap GATEWAY_SHUTDOWN_DRAIN_MS to setTimeout max range

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -123,10 +123,17 @@ export function loadConfig(): GatewayConfig {
   const runtimeProxyBearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || undefined;
 
+  const MAX_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1, max safe setTimeout delay
+
   const shutdownDrainMsRaw = process.env.GATEWAY_SHUTDOWN_DRAIN_MS || "5000";
   const shutdownDrainMs = Number(shutdownDrainMsRaw);
   if (!Number.isFinite(shutdownDrainMs) || shutdownDrainMs < 0) {
     throw new Error("GATEWAY_SHUTDOWN_DRAIN_MS must be a non-negative number");
+  }
+  if (shutdownDrainMs > MAX_TIMEOUT_MS) {
+    throw new Error(
+      `GATEWAY_SHUTDOWN_DRAIN_MS must not exceed ${MAX_TIMEOUT_MS} (setTimeout max safe delay)`,
+    );
   }
 
   const runtimeTimeoutMs = Number(process.env.GATEWAY_RUNTIME_TIMEOUT_MS || "30000");


### PR DESCRIPTION
## Summary
- Adds upper-bound validation for `GATEWAY_SHUTDOWN_DRAIN_MS` in `gateway/src/config.ts`
- The maximum allowed value is `2^31 - 1` (2,147,483,647 ms), which is the safe limit for `setTimeout` delays
- Values exceeding this limit now produce a clear error at startup instead of silently overflowing

## Context
Addresses review feedback on #1526: without this check, values above the JS timer limit (e.g. 3,000,000,000) would be accepted by config parsing but overflow when passed to `setTimeout` in Bun, causing the delay to be clamped to ~1 ms. This would make the process exit almost immediately on SIGTERM instead of honoring the configured drain window.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Verify that setting `GATEWAY_SHUTDOWN_DRAIN_MS=3000000000` causes a startup error
- [ ] Verify that setting `GATEWAY_SHUTDOWN_DRAIN_MS=2147483647` is accepted
- [ ] Verify that the default value (5000) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
