### PR TITLE
Use byte length for webhook payload size fallback check

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -44,8 +44,8 @@ export function createTelegramWebhookHandler(
       return Response.json({ error: "Failed to read body" }, { status: 400 });
     }
 
-    if (rawBody.length > config.maxWebhookPayloadBytes) {
-      log.warn({ bodyLength: rawBody.length }, "Webhook payload too large");
+    if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
+      log.warn({ bodyLength: Buffer.byteLength(rawBody) }, "Webhook payload too large");
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 


### PR DESCRIPTION
## Summary
- Fixes the fallback payload size check in `telegram-webhook.ts` to use `Buffer.byteLength(rawBody)` instead of `rawBody.length`
- `rawBody.length` measures UTF-16 code units, which underestimates the actual byte size for multi-byte UTF-8 characters, potentially allowing oversized payloads to bypass the guard
- Addresses review feedback on #1532

## Test plan
- [ ] Verify type check passes (`bunx tsc --noEmit`)
- [ ] Confirm that payloads with multi-byte characters exceeding the byte limit are correctly rejected with 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
