### PR TITLE
Honor runtime timeout in runtime-proxy fetches

### DIFF
--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -160,6 +160,36 @@ describe("runtime proxy handler", () => {
     expect(res.headers.get("content-type")).toBe("text/plain");
   });
 
+  test("returns 504 on upstream timeout", async () => {
+    const timeoutError = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    globalThis.fetch = mock(async () => {
+      throw timeoutError;
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 100 }));
+    const req = new Request("http://localhost:7830/v1/health");
+    const res = await handler(req);
+
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body.error).toBe("Gateway Timeout");
+  });
+
+  test("passes AbortSignal.timeout to upstream fetch", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: any, init?: any) => {
+      capturedSignal = init?.signal;
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    const handler = createRuntimeProxyHandler(makeConfig({ runtimeTimeoutMs: 5000 }));
+    const req = new Request("http://localhost:7830/v1/health");
+    await handler(req);
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+  });
+
   test("does not forward host header to upstream", async () => {
     let capturedHeaders: Headers | undefined;
     globalThis.fetch = mock(async (_input: any, init?: any) => {

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -70,9 +70,17 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
         body: req.body,
         // @ts-expect-error Bun supports duplex on Request
         duplex: "half",
+        signal: AbortSignal.timeout(config.runtimeTimeoutMs),
       });
     } catch (err) {
       const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error(
+          { method: req.method, path: url.pathname, duration, timeoutMs: config.runtimeTimeoutMs },
+          "Upstream request timed out",
+        );
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
       log.error(
         { err, method: req.method, path: url.pathname, duration },
         "Upstream connection failed",


### PR DESCRIPTION
## Summary
- Adds `AbortSignal.timeout(config.runtimeTimeoutMs)` to the upstream `fetch` call in `gateway/src/http/routes/runtime-proxy.ts` so that proxy traffic respects `GATEWAY_RUNTIME_TIMEOUT_MS` instead of hanging indefinitely on stalled upstream connections
- Catches `TimeoutError` and returns a **504 Gateway Timeout** response (other fetch errors still produce 502 Bad Gateway)
- Adds two new tests: one verifying the 504 response on timeout, another confirming the AbortSignal is passed to fetch

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [x] All 9 runtime-proxy tests pass (including 2 new timeout tests)
- [x] All 5 runtime-proxy-auth tests still pass

Addresses review feedback on #1528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
