### PR TITLE
Load Buildx image into Docker daemon to avoid double build in CI

### DIFF
--- a/.github/workflows/ci-gateway-image.yml
+++ b/.github/workflows/ci-gateway-image.yml
@@ -23,19 +23,19 @@ jobs:
         with:
           context: gateway
           push: false
+          load: true
           tags: vellum-gateway:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Smoke check - container boots
         run: |
-          docker build -t vellum-gateway:smoke gateway
           docker run --rm -d --name gateway-smoke \
             -e TELEGRAM_BOT_TOKEN=test \
             -e TELEGRAM_WEBHOOK_SECRET=test \
             -e ASSISTANT_RUNTIME_BASE_URL=http://localhost:7821 \
             -p 19830:7830 \
-            vellum-gateway:smoke
+            vellum-gateway:pr-${{ github.event.pull_request.number }}
           sleep 3
           STATUS=$(curl -sf http://localhost:19830/healthz | jq -r '.status' || echo "failed")
           docker stop gateway-smoke || true


### PR DESCRIPTION
## Summary
- Adds `load: true` to the `docker/build-push-action` step so the built image is exported to the local Docker daemon
- Removes the redundant `docker build` in the smoke check step
- Reuses the already-built `vellum-gateway:pr-*` tag instead of rebuilding as `vellum-gateway:smoke`

## Context
Addresses review feedback on #1538: without `load: true`, the Buildx-built image only exists inside the builder's internal storage. The smoke check had to rebuild from scratch, doubling CI build time and testing a potentially different image.

## Test plan
- [ ] CI passes with the updated workflow
- [ ] Smoke check uses the Buildx-built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
