### PR TITLE
Count non-2xx responses as failures in load-test harness

### DIFF
--- a/benchmarking/gateway/bench-proxy.ts
+++ b/benchmarking/gateway/bench-proxy.ts
@@ -46,7 +46,7 @@ async function worker() {
       const elapsed = performance.now() - start;
       latencies.push(elapsed);
       total++;
-      if (res.status >= 500) errors++;
+      if (res.status < 200 || res.status >= 300) errors++;
     } catch {
       errors++;
       total++;

--- a/benchmarking/gateway/bench-webhook.ts
+++ b/benchmarking/gateway/bench-webhook.ts
@@ -62,10 +62,7 @@ async function worker() {
       const elapsed = performance.now() - start;
       latencies.push(elapsed);
       total++;
-      if (!res.ok && res.status !== 200) {
-        // 500-level errors count as failures
-        if (res.status >= 500) errors++;
-      }
+      if (res.status < 200 || res.status >= 300) errors++;
     } catch {
       errors++;
       total++;


### PR DESCRIPTION
## Summary
- Updates both proxy and webhook benchmarks to treat any non-2xx response as a failure
- Previously only 5xx responses were counted as errors, so 401s from invalid bearer tokens or bad webhook secrets would report 0% error rate

## Context
Addresses review feedback on #1536: auth/routing regressions (e.g., 401 Unauthorized) were silently counted as successes, making the automated pass/fail gate unreliable.

## Test plan
- [ ] Verify benchmarks correctly report errors for non-2xx responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
