### PR TITLE
Show full command in permission prompt on desktop app

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -23,15 +23,41 @@ enum ToolConfirmationState: Equatable {
 struct ToolConfirmationData: Equatable {
     let requestId: String
     let toolName: String
+    let input: [String: AnyCodable]
     let riskLevel: String
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
     let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
     var state: ToolConfirmationState = .pending
 
-    init(requestId: String, toolName: String, riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], state: ToolConfirmationState = .pending) {
+    /// Human-readable preview of the tool input (e.g. the bash command or file path).
+    var commandPreview: String {
+        switch toolName {
+        case "bash":
+            return (input["command"]?.value as? String) ?? ""
+        case "file_read":
+            return "read \((input["path"]?.value as? String) ?? "")"
+        case "file_write":
+            return "write \((input["path"]?.value as? String) ?? "")"
+        case "file_edit":
+            return "edit \((input["file_path"]?.value as? String) ?? "")"
+        case "web_fetch":
+            return "fetch \((input["url"]?.value as? String) ?? "")"
+        case "browser_navigate":
+            return "navigate \((input["url"]?.value as? String) ?? "")"
+        default:
+            // Fallback: show first string value or tool name
+            if let firstString = input.values.compactMap({ $0.value as? String }).first {
+                return firstString
+            }
+            return toolName
+        }
+    }
+
+    init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
+        self.input = input
         self.riskLevel = riskLevel
         self.diff = diff
         self.allowlistOptions = allowlistOptions

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -616,6 +616,7 @@ final class ChatViewModel: ObservableObject {
             let confirmation = ToolConfirmationData(
                 requestId: msg.requestId,
                 toolName: msg.toolName,
+                input: msg.input,
                 riskLevel: msg.riskLevel,
                 diff: msg.diff,
                 allowlistOptions: msg.allowlistOptions,

--- a/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolConfirmationBubble.swift
@@ -52,6 +52,17 @@ struct ToolConfirmationBubble: View {
                 Spacer()
             }
 
+            // Command preview
+            if !confirmation.commandPreview.isEmpty {
+                Text(confirmation.commandPreview)
+                    .font(VFont.monoSmall)
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.sm)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.backgroundSubtle)
+                    .cornerRadius(VRadius.md)
+            }
+
             // Diff preview (if present)
             if let diff = confirmation.diff {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -259,6 +270,7 @@ struct ToolConfirmationBubble: View {
             confirmation: ToolConfirmationData(
                 requestId: "test-1",
                 toolName: "bash",
+                input: ["command": AnyCodable("git push origin main")],
                 riskLevel: "medium",
                 diff: nil,
                 allowlistOptions: [
@@ -278,6 +290,7 @@ struct ToolConfirmationBubble: View {
             confirmation: ToolConfirmationData(
                 requestId: "test-2",
                 toolName: "file_write",
+                input: ["path": AnyCodable("/Users/test/project/src/main.swift")],
                 riskLevel: "high",
                 diff: ConfirmationRequestMessage.ConfirmationDiffInfo(
                     filePath: "/Users/test/project/src/main.swift",
@@ -294,6 +307,7 @@ struct ToolConfirmationBubble: View {
             confirmation: ToolConfirmationData(
                 requestId: "test-3",
                 toolName: "bash",
+                input: ["command": AnyCodable("npm install")],
                 riskLevel: "medium",
                 diff: nil,
                 allowlistOptions: [

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -31,6 +31,7 @@ final class ToolConfirmationManager {
         let hasRuleOptions = !message.allowlistOptions.isEmpty && !message.scopeOptions.isEmpty
         let view = ToolConfirmationView(
             toolName: message.toolName,
+            input: message.input,
             riskLevel: message.riskLevel,
             diff: message.diff,
             allowlistOptions: message.allowlistOptions,
@@ -116,6 +117,7 @@ final class ToolConfirmationManager {
 
 struct ToolConfirmationView: View {
     let toolName: String
+    let input: [String: AnyCodable]
     let riskLevel: String
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
@@ -152,6 +154,28 @@ struct ToolConfirmationView: View {
         }
     }
 
+    private var commandPreview: String {
+        switch toolName {
+        case "bash":
+            return (input["command"]?.value as? String) ?? ""
+        case "file_read":
+            return "read \((input["path"]?.value as? String) ?? "")"
+        case "file_write":
+            return "write \((input["path"]?.value as? String) ?? "")"
+        case "file_edit":
+            return "edit \((input["file_path"]?.value as? String) ?? "")"
+        case "web_fetch":
+            return "fetch \((input["url"]?.value as? String) ?? "")"
+        case "browser_navigate":
+            return "navigate \((input["url"]?.value as? String) ?? "")"
+        default:
+            if let firstString = input.values.compactMap({ $0.value as? String }).first {
+                return firstString
+            }
+            return ""
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Header
@@ -170,6 +194,17 @@ struct ToolConfirmationView: View {
                 }
 
                 Spacer()
+            }
+
+            // Command preview
+            if !commandPreview.isEmpty {
+                Text(commandPreview)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(VColor.textPrimary)
+                    .padding(VSpacing.sm)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(VColor.surface)
+                    .cornerRadius(VRadius.md)
             }
 
             // Diff preview


### PR DESCRIPTION
## Summary
- The macOS desktop app received tool `input` from the daemon but never displayed it — users only saw the tool name (e.g. "Run Command") with no way to know what was actually being run
- Added `input` field to `ToolConfirmationData` and a `commandPreview` computed property that formats the input for display (bash commands, file paths, URLs, etc.)
- Both the inline chat bubble (`ToolConfirmationBubble`) and the floating panel (`ToolConfirmationView`) now show the full command preview so users can make informed allow/deny decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
