### PR TITLE
Remove unused GatewayInboundEventV1 import

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,6 +1,5 @@
 import pino from "pino";
 import type { GatewayConfig } from "../../config.js";
-import type { GatewayInboundEventV1 } from "../../types.js";
 import { verifyWebhookSecret } from "../../telegram/verify.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
 import { downloadTelegramFile } from "../../telegram/download.js";


### PR DESCRIPTION
## Summary
- Remove unused `GatewayInboundEventV1` type import from `gateway/src/http/routes/telegram-webhook.ts`

## Test plan
- [ ] Verify gateway builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
