### PR TITLE
Limit proxy timeout to connection phase only

### DIFF
--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -62,6 +62,14 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
 
+    // Use a manual AbortController so the timeout only covers the connection
+    // phase (waiting for response headers). Once headers arrive, the timeout is
+    // cleared so streaming responses (SSE, chunked) can run indefinitely.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    }, config.runtimeTimeoutMs);
+
     let response: Response;
     try {
       response = await fetch(upstream, {
@@ -70,9 +78,11 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
         body: req.body,
         // @ts-expect-error Bun supports duplex on Request
         duplex: "half",
-        signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+        signal: controller.signal,
       });
+      clearTimeout(timeoutId);
     } catch (err) {
+      clearTimeout(timeoutId);
       const duration = Math.round(performance.now() - start);
       if (err instanceof DOMException && err.name === "TimeoutError") {
         log.error(


### PR DESCRIPTION
## Summary
- Replaces `AbortSignal.timeout()` with a manual `AbortController` + `setTimeout` that is cleared once `fetch()` resolves (headers received)
- Prevents the timeout from aborting healthy streaming responses (SSE, chunked) that legitimately run longer than `runtimeTimeoutMs`

## Context
Addresses review feedback on #1551: `AbortSignal.timeout()` applied the deadline to the entire response lifecycle including body streaming, so SSE/chunked responses would be aborted mid-stream after the timeout elapsed.

## Test plan
- [ ] Verify type-check passes
- [ ] Confirm proxy still returns 504 on connection timeout
- [ ] Confirm streaming responses are not aborted after headers arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
