### PR TITLE
Fix empty state icon size inconsistency across side panels

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Display/VEmptyState.swift
@@ -10,6 +10,7 @@ struct VEmptyState: View {
             if let icon = icon {
                 Image(systemName: icon)
                     .font(.system(size: 48))
+                    .frame(width: 48, height: 48)
                     .foregroundColor(VColor.textMuted)
             }
             Text(title)


### PR DESCRIPTION
## Summary
- Adds a fixed 48x48 frame to VEmptyState icons so SF Symbols with different natural widths don't cause layout shift when switching between side panels (Directory, Debug, Doctor)

## Test plan
- [ ] Open Vellum, switch between Directory / Debug / Doctor panels — no layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
