### PR TITLE
Fix hooks config null check, manifest validation, and path traversal

### DIFF
--- a/assistant/src/hooks/config.ts
+++ b/assistant/src/hooks/config.ts
@@ -21,7 +21,7 @@ export function loadHooksConfig(): HookConfig {
   try {
     const raw = readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw) as HookConfig;
-    if (typeof parsed.version !== 'number' || typeof parsed.hooks !== 'object') {
+    if (typeof parsed.version !== 'number' || typeof parsed.hooks !== 'object' || parsed.hooks === null) {
       log.warn({ configPath }, 'Invalid hooks config, using defaults');
       return { version: HOOKS_CONFIG_VERSION, hooks: {} };
     }

--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, type Dirent } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { getHooksDir } from '../util/platform.js';
 import { loadHooksConfig } from './config.js';
 import { getLogger } from '../util/logger.js';
@@ -21,6 +21,8 @@ function isValidManifest(manifest: unknown): manifest is HookManifest {
   if (typeof manifest !== 'object' || manifest === null) return false;
   const m = manifest as Record<string, unknown>;
   if (typeof m.name !== 'string' || !m.name) return false;
+  if (typeof m.description !== 'string' || !m.description) return false;
+  if (typeof m.version !== 'string' || !m.version) return false;
   if (typeof m.script !== 'string' || !m.script) return false;
   if (!Array.isArray(m.events) || m.events.length === 0) return false;
   for (const e of m.events) {
@@ -64,7 +66,11 @@ export function discoverHooks(hooksDir?: string): DiscoveredHook[] {
       continue;
     }
 
-    const scriptPath = join(hookDir, manifest.script);
+    const scriptPath = resolve(hookDir, manifest.script);
+    if (!scriptPath.startsWith(hookDir + '/')) {
+      log.warn({ hookDir, script: manifest.script }, 'Hook script path traversal detected, skipping');
+      continue;
+    }
     if (!existsSync(scriptPath)) {
       log.warn({ hookDir, script: manifest.script }, 'Hook script not found, skipping');
       continue;


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1529:

- **Null hooks rejection** (config.ts:24): `typeof null === 'object'` allowed `hooks: null` to pass validation in `loadHooksConfig`, causing runtime crashes. Added explicit `parsed.hooks === null` check.
- **Manifest metadata validation** (discovery.ts): `isValidManifest` now checks that `description` and `version` fields are present and non-empty strings, matching the `HookManifest` type contract.
- **Path traversal prevention** (discovery.ts:69): `manifest.script` could reference files outside the hook directory via `../../`. Now uses `resolve()` and verifies the resolved path starts with `hookDir + '/'`.

## Test plan

- [ ] Verify `loadHooksConfig` returns defaults when `hooks` is `null`
- [ ] Verify hooks with missing `description` or `version` in manifest are skipped
- [ ] Verify hooks with `../` in script path are rejected with warning log
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
