### PR TITLE
Fix hook runner: stdin error, timeout race, event override

### DIFF
--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -43,7 +43,7 @@ export class HookManager {
     if (!hooks || hooks.length === 0) return { blocked: false };
 
     const isPreEvent = event.startsWith('pre-');
-    const eventData: HookEventData = { event, ...data };
+    const eventData: HookEventData = { ...data, event };
 
     for (const hook of hooks) {
       try {

--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -52,9 +52,17 @@ export async function runHookScript(
 
     const timer = setTimeout(() => {
       if (settled) return;
-      settled = true;
       child.kill('SIGTERM');
-      resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
+      // Give the process a short grace period to exit after SIGTERM, then SIGKILL
+      const killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, 2000);
+      child.once('close', () => {
+        clearTimeout(killTimer);
+        if (settled) return;
+        settled = true;
+        resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
+      });
     }, timeoutMs);
 
     child.on('close', (code) => {
@@ -71,6 +79,8 @@ export async function runHookScript(
       resolve({ exitCode: null, stdout, stderr: stderr + '\n' + err.message });
     });
 
+    // Suppress unhandled EPIPE errors if the child exits before we finish writing
+    child.stdin.on('error', () => {});
     // Write event data to stdin and close
     child.stdin.write(JSON.stringify(eventData));
     child.stdin.end();


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1530:

- **stdin error handling**: Add `child.stdin.on('error', () => {})` before writing to prevent unhandled EPIPE crashes when the child process exits before stdin write completes
- **Timeout race condition**: Instead of resolving immediately after SIGTERM, wait for the process to actually exit via the `close` event. If it doesn't exit within 2s, follow up with SIGKILL.
- **Event field override**: Swap spread order in `trigger()` from `{ event, ...data }` to `{ ...data, event }` so caller-provided `data.event` cannot overwrite the actual triggered event

## Modified files
- `assistant/src/hooks/runner.ts` — stdin error handler + timeout fix
- `assistant/src/hooks/manager.ts` — event field ordering fix

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify hook timeout sends SIGTERM then waits for close
- [ ] Verify EPIPE on stdin doesn't crash the process
- [ ] Verify event field is always the triggered event name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
