### PR TITLE
Fix force-exit timer ordering and missing post-tool-execute hooks

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -265,19 +265,20 @@ export async function runDaemon(): Promise<void> {
 
     hookManager.stopWatching();
 
-    try {
-      await hookManager.trigger('daemon-stop', { pid: process.pid });
-    } catch {
-      // Don't let hook failures block shutdown
-    }
-
-    // Force exit if graceful shutdown takes too long
+    // Force exit if graceful shutdown takes too long.
+    // Set this BEFORE triggering daemon-stop hooks so it covers hook execution time.
     const forceTimer = setTimeout(() => {
       log.warn('Graceful shutdown timed out, forcing exit');
       cleanupPidFile();
       process.exit(1);
     }, 10_000);
     forceTimer.unref();
+
+    try {
+      await hookManager.trigger('daemon-stop', { pid: process.pid });
+    } catch {
+      // Don't let hook failures block shutdown
+    }
 
     await server.stop();
     if (runtimeHttp) await runtimeHttp.stop();

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -309,6 +309,16 @@ export class ToolExecutor {
               durationMs,
               result: blockedResult,
             });
+
+            void getHookManager().trigger('post-tool-execute', {
+              toolName: name,
+              input: sanitizeToolInput(name, input),
+              riskLevel,
+              isError: true,
+              durationMs,
+              sessionId: context.sessionId,
+            });
+
             return blockedResult;
           }
         }
@@ -359,6 +369,15 @@ export class ToolExecutor {
         isExpected,
         errorName: err instanceof Error ? err.name : undefined,
         errorStack: err instanceof Error ? err.stack : undefined,
+      });
+
+      void getHookManager().trigger('post-tool-execute', {
+        toolName: name,
+        input: sanitizeToolInput(name, input),
+        riskLevel,
+        isError: true,
+        durationMs,
+        sessionId: context.sessionId,
       });
 
       if (isExpected) {


### PR DESCRIPTION
## Summary
- **lifecycle.ts**: Moved the 10-second force-exit timer to BEFORE the `daemon-stop` hook trigger so it covers hook execution time. Previously, a hanging hook would prevent the timer from ever being set.
- **executor.ts**: Added fire-and-forget `post-tool-execute` hook trigger in the catch block (when a tool throws) and the secret-detection block path, ensuring the hook fires consistently regardless of how tool execution ends.

Addresses review feedback on #1537.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
