### PR TITLE
Honor blocking outcome for pre-message hooks

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -394,10 +394,15 @@ export class Session {
     let yieldedForHandoff = false;
 
     try {
-      await getHookManager().trigger('pre-message', {
+      const preMessageResult = await getHookManager().trigger('pre-message', {
         sessionId: this.conversationId,
         messagePreview: content.slice(0, 200),
       });
+
+      if (preMessageResult.blocked) {
+        onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
+        return;
+      }
 
       const isFirstMessage = this.messages.length === 1;
 


### PR DESCRIPTION
## Summary
- The `pre-message` hook in `session.ts` awaited `trigger('pre-message', ...)` but ignored the `.blocked` result
- A hook marked `blocking: true` could return non-zero for `pre-message` but the message would still be processed
- Now checks the result and returns an error event if blocked, matching the pattern used by `pre-llm-call` in `loop.ts` and `pre-tool-execute` in `executor.ts`

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Create a blocking `pre-message` hook that exits non-zero and confirm the message is rejected with an error event
- [ ] Confirm non-blocking hooks still allow messages through normally

Addresses feedback from #1541.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
