### PR TITLE
Clean up partial template copy and guard debug hook against missing jq

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -12,22 +12,31 @@ echo "  PRE-LLM-CALL" >&2
 echo "════════════════════════════════════════════════════════════════" >&2
 echo "" >&2
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "(jq not found — install jq for formatted output)" >&2
+  printf '%s' "$data" | cut -c1-3000 >&2
+  echo "" >&2
+  echo "════════════════════════════════════════════════════════════════" >&2
+  echo "" >&2
+  exit 0
+fi
+
 # System prompt (first 2000 chars)
 echo "── System Prompt ──────────────────────────────────────────────" >&2
-echo "$data" | jq -r '.systemPrompt // "N/A"' | head -c 2000 >&2
+printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | cut -c1-2000 >&2
 echo "" >&2
 echo "" >&2
 
 # Message count and model
-model=$(echo "$data" | jq -r '.model // "unknown"')
-msgCount=$(echo "$data" | jq '.messages | length')
-toolCount=$(echo "$data" | jq -r '.toolCount // 0')
+model=$(printf '%s' "$data" | jq -r '.model // "unknown"')
+msgCount=$(printf '%s' "$data" | jq '.messages | length')
+toolCount=$(printf '%s' "$data" | jq -r '.toolCount // 0')
 echo "Model: $model | Messages: $msgCount | Tools: $toolCount" >&2
 echo "" >&2
 
 # Last 10 messages (compact)
 echo "── Recent Messages (last 10) ──────────────────────────────────" >&2
-echo "$data" | jq -r '
+printf '%s' "$data" | jq -r '
   .messages[-10:][] |
   "\(.role): " + (
     if (.content | type) == "string" then

--- a/assistant/src/hooks/templates.ts
+++ b/assistant/src/hooks/templates.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, cpSync, chmodSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, cpSync, chmodSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Dirent } from 'node:fs';
 import { getHooksDir } from '../util/platform.js';
@@ -44,6 +44,8 @@ export function installTemplates(): void {
 
       log.info({ hook: entry.name }, 'Installed hook template (disabled by default)');
     } catch (err) {
+      // Clean up partially-copied directory so the next restart can retry
+      try { rmSync(targetDir, { recursive: true, force: true }); } catch {}
       log.warn({ err, hook: entry.name }, 'Failed to install hook template');
     }
   }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1539:

- **Partial template copy cleanup**: If `cpSync` fails partway through in `installTemplates()`, the catch block now removes the partially-created target directory with `rmSync` so the next daemon restart can retry the installation instead of skipping it forever.
- **Guard against missing jq**: The `debug-prompt-logger` hook script now checks for `jq` availability upfront. When `jq` is not installed (common on stock macOS), it falls back to printing truncated raw JSON instead of failing with a command-not-found error.
- **Portability fixes**: Replaced `echo "$data" |` with `printf '%s' "$data" |` for safer data handling, and `head -c` with `cut -c` since `head` may not be available in all environments.

## Test plan

- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Simulate `cpSync` failure and confirm partial directory is cleaned up
- [ ] Run debug-prompt-logger hook without `jq` installed and verify graceful fallback
- [ ] Run debug-prompt-logger hook with `jq` installed and verify formatted output still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
