### PR TITLE
Use VFont.monoSmall token in ToolConfirmationManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -199,7 +199,7 @@ struct ToolConfirmationView: View {
             // Command preview
             if !commandPreview.isEmpty {
                 Text(commandPreview)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(VFont.monoSmall)
                     .foregroundColor(VColor.textPrimary)
                     .padding(VSpacing.sm)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -224,7 +224,7 @@ struct ToolConfirmationView: View {
 
                     ScrollView {
                         Text(diff.newContent.prefix(500))
-                            .font(.system(size: 11, design: .monospaced))
+                            .font(VFont.monoSmall)
                             .foregroundColor(VColor.textSecondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -338,7 +338,7 @@ struct ToolConfirmationView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                     Text(single.label)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(VFont.monoSmall)
                         .foregroundColor(VColor.textPrimary)
                 }
             }
@@ -362,7 +362,7 @@ struct ToolConfirmationView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                     Text(single.label)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(VFont.monoSmall)
                         .foregroundColor(VColor.textPrimary)
                 }
             }


### PR DESCRIPTION
## Summary
- Replaced all 4 occurrences of `.font(.system(size: 11, design: .monospaced))` with `.font(VFont.monoSmall)` in `ToolConfirmationManager.swift`
- Aligns with the design token usage in `ToolConfirmationBubble.swift` which already uses `VFont.monoSmall`
- Addresses feedback from PR #1535

## Test plan
- [x] `swift build` succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
