### PR TITLE
Fix writeIdentityFile to replace only the first Name line

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -689,11 +689,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 // Replace only the Name line, preserving everything else
                 let namePattern = #"^- \*\*Name:\*\*.*$"#
                 if let regex = try? NSRegularExpression(pattern: namePattern, options: .anchorsMatchLines) {
-                    let range = NSRange(existing.startIndex..., in: existing)
-                    let replacement = "- **Name:** \(trimmed)"
-                    let updated = regex.stringByReplacingMatches(in: existing, range: range, withTemplate: NSRegularExpression.escapedTemplate(for: replacement))
-                    // Only use the updated content if a substitution actually happened
-                    content = updated != existing ? updated : existing
+                    let fullRange = NSRange(existing.startIndex..., in: existing)
+                    if let match = regex.firstMatch(in: existing, range: fullRange),
+                       let matchRange = Range(match.range, in: existing) {
+                        var updated = existing
+                        updated.replaceSubrange(matchRange, with: "- **Name:** \(trimmed)")
+                        content = updated
+                    } else {
+                        content = existing
+                    }
                 } else {
                     content = existing
                 }


### PR DESCRIPTION
## Summary
- Fixes `writeIdentityFile` in `AppDelegate.swift` to only replace the **first** `- **Name:**` line in `IDENTITY.md`, instead of all occurrences
- Uses `firstMatch(in:)` + `replaceSubrange` instead of `stringByReplacingMatches`, which replaced every matching line

Addresses review feedback on #1534.

## Test plan
- [ ] Replay onboarding with an `IDENTITY.md` containing multiple `- **Name:**` lines — only the first should be updated
- [ ] Replay onboarding with a standard `IDENTITY.md` — name line is updated as before

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
