### PR TITLE
Fix path traversal and validate manifests in hooks install

### DIFF
--- a/assistant/src/hooks/cli.ts
+++ b/assistant/src/hooks/cli.ts
@@ -1,10 +1,9 @@
 import { Command } from 'commander';
 import { existsSync, cpSync, readFileSync, chmodSync, rmSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { discoverHooks } from './discovery.js';
+import { join, resolve, sep } from 'node:path';
+import { discoverHooks, isValidManifest } from './discovery.js';
 import { setHookEnabled, ensureHookInConfig, removeHook } from './config.js';
 import { getHooksDir } from '../util/platform.js';
-import type { HookManifest } from './types.js';
 
 export function registerHooksCommand(program: Command): void {
   const hooks = program.command('hooks').description('Manage hooks');
@@ -88,21 +87,33 @@ export function registerHooksCommand(program: Command): void {
         process.exit(1);
       }
 
-      let manifest: HookManifest;
+      let manifest: unknown;
       try {
-        manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as HookManifest;
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
       } catch {
         console.error(`Failed to parse hook.json in ${srcDir}`);
         process.exit(1);
       }
 
-      if (!manifest.name || !manifest.script || !Array.isArray(manifest.events)) {
-        console.error('Invalid hook.json: missing required fields (name, script, events)');
+      if (!isValidManifest(manifest)) {
+        console.error('Invalid hook.json: must have a non-empty name, script, description (string), version (string), and at least one valid event');
         process.exit(1);
       }
 
       const hooksDir = getHooksDir();
-      const targetDir = join(hooksDir, manifest.name);
+      const resolvedHooksDir = resolve(hooksDir);
+      const targetDir = resolve(join(hooksDir, manifest.name));
+      if (!targetDir.startsWith(resolvedHooksDir + sep)) {
+        console.error(`Invalid hook name: "${manifest.name}" would escape the hooks directory`);
+        process.exit(1);
+      }
+
+      const scriptPath = resolve(join(targetDir, manifest.script));
+      if (!scriptPath.startsWith(targetDir + sep)) {
+        console.error(`Invalid hook script: "${manifest.script}" would escape the hook directory`);
+        process.exit(1);
+      }
+
       if (existsSync(targetDir)) {
         console.error(`Hook already installed: ${manifest.name}`);
         process.exit(1);
@@ -111,7 +122,6 @@ export function registerHooksCommand(program: Command): void {
       cpSync(srcDir, targetDir, { recursive: true });
 
       // Make script executable
-      const scriptPath = join(targetDir, manifest.script);
       if (existsSync(scriptPath)) {
         chmodSync(scriptPath, 0o755);
       }

--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -17,11 +17,13 @@ const VALID_EVENTS = new Set<string>([
   'on-error',
 ]);
 
-function isValidManifest(manifest: unknown): manifest is HookManifest {
+export function isValidManifest(manifest: unknown): manifest is HookManifest {
   if (typeof manifest !== 'object' || manifest === null) return false;
   const m = manifest as Record<string, unknown>;
   if (typeof m.name !== 'string' || !m.name) return false;
   if (typeof m.script !== 'string' || !m.script) return false;
+  if (typeof m.description !== 'string') return false;
+  if (typeof m.version !== 'string') return false;
   if (!Array.isArray(m.events) || m.events.length === 0) return false;
   for (const e of m.events) {
     if (typeof e !== 'string' || !VALID_EVENTS.has(e)) return false;


### PR DESCRIPTION
## Summary
- Prevent path traversal attacks via malicious `manifest.name` (e.g. `../../etc`) by validating that the resolved `targetDir` stays within `hooksDir`
- Prevent `manifest.script` from escaping the hook directory with a similar check
- Replace ad-hoc install validation with the shared `isValidManifest()` type guard so installed hooks always pass discovery validation
- Add `description` and `version` field checks to `isValidManifest()` to match the `HookManifest` interface

Addresses review feedback on #1544.

## Test plan
- [x] All 20 existing hooks tests pass
- [x] TypeScript type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
