### PR TITLE
Fix FSWatcher and debounce timer leaks in HookManager

### DIFF
--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -78,6 +78,8 @@ export class HookManager {
     const hooksDir = getHooksDir();
     if (!existsSync(hooksDir)) return;
 
+    this.stopWatching();
+
     try {
       this.watcher = watch(hooksDir, { recursive: true }, (_eventType, filename) => {
         if (this.debounceTimer) clearTimeout(this.debounceTimer);
@@ -121,5 +123,6 @@ export function getHookManager(): HookManager {
 
 /** Reset the singleton (for testing) */
 export function resetHookManager(): void {
+  instance?.stopWatching();
   instance = null;
 }


### PR DESCRIPTION
## Summary
- `resetHookManager()` now calls `stopWatching()` before nulling the instance, preventing leaked FSWatcher and debounce timer.
- `watch()` now calls `stopWatching()` at the start to close any previous watcher before creating a new one.

Addresses review feedback on #1546.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
