### PR TITLE
Fix file_edit command preview key and default fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -40,7 +40,7 @@ struct ToolConfirmationData: Equatable {
         case "file_write":
             return "write \((input["path"]?.value as? String) ?? "")"
         case "file_edit":
-            return "edit \((input["file_path"]?.value as? String) ?? "")"
+            return "edit \((input["path"]?.value as? String) ?? "")"
         case "web_fetch":
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":
@@ -50,7 +50,7 @@ struct ToolConfirmationData: Equatable {
             if let firstString = input.values.compactMap({ $0.value as? String }).first {
                 return firstString
             }
-            return toolName
+            return ""
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -163,7 +163,7 @@ struct ToolConfirmationView: View {
         case "file_write":
             return "write \((input["path"]?.value as? String) ?? "")"
         case "file_edit":
-            return "edit \((input["file_path"]?.value as? String) ?? "")"
+            return "edit \((input["path"]?.value as? String) ?? "")"
         case "web_fetch":
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #1554:

- **Fix wrong key for file_edit**: Both `ChatMessage.swift` and `ToolConfirmationManager.swift` used `input["file_path"]` for the file_edit case, but the tool schema uses `path`. Changed to `input["path"]` so file_edit confirmations correctly show the target file.
- **Fix inconsistent default fallback**: `ChatMessage.commandPreview` returned `toolName` as the default when no string input was found, while `ToolConfirmationManager.commandPreview` returned `""`. Changed ChatMessage to also return `""` so both surfaces behave consistently.

## Files changed
- `clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift`
- `clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift`

## Test plan
- [ ] Verify file_edit confirmation shows the file path in both inline chat and floating panel
- [ ] Verify unknown tools show empty preview instead of raw tool name in inline chat
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
