### PR TITLE
Fix file_edit key and default fallback in command preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -40,7 +40,7 @@ struct ToolConfirmationData: Equatable {
         case "file_write":
             return "write \((input["path"]?.value as? String) ?? "")"
         case "file_edit":
-            return "edit \((input["file_path"]?.value as? String) ?? "")"
+            return "edit \((input["path"]?.value as? String) ?? "")"
         case "web_fetch":
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":
@@ -50,7 +50,7 @@ struct ToolConfirmationData: Equatable {
             if let firstString = input.values.compactMap({ $0.value as? String }).first {
                 return firstString
             }
-            return toolName
+            return ""
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -163,7 +163,7 @@ struct ToolConfirmationView: View {
         case "file_write":
             return "write \((input["path"]?.value as? String) ?? "")"
         case "file_edit":
-            return "edit \((input["file_path"]?.value as? String) ?? "")"
+            return "edit \((input["path"]?.value as? String) ?? "")"
         case "web_fetch":
             return "fetch \((input["url"]?.value as? String) ?? "")"
         case "browser_navigate":


### PR DESCRIPTION
## Summary
- Fixed `file_edit` command preview to use `input["path"]` instead of `input["file_path"]` in both `ToolConfirmationData` (ChatMessage.swift) and `ToolConfirmationView` (ToolConfirmationManager.swift), matching the tool's actual schema
- Changed `ToolConfirmationData.commandPreview` default fallback from `toolName` to `""` for consistency with `ToolConfirmationView`, preventing the tool name from being misleadingly shown as a command preview

Addresses review feedback on #1554.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
