### PR TITLE
Add trust rule list/remove/update IPC messages and handlers

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -618,3 +618,45 @@ exports[`IPC message snapshots ServerMessage types timer_completed serializes to
   "type": "timer_completed",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types trust_rules_list serializes to expected JSON 1`] = `
+{
+  "type": "trust_rules_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types remove_trust_rule serializes to expected JSON 1`] = `
+{
+  "id": "rule-001",
+  "type": "remove_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types update_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "id": "rule-001",
+  "pattern": "git push *",
+  "priority": 50,
+  "scope": "/projects/my-app",
+  "tool": "bash",
+  "type": "update_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types trust_rules_list_response serializes to expected JSON 1`] = `
+{
+  "rules": [
+    {
+      "createdAt": 1700000000,
+      "decision": "allow",
+      "id": "rule-001",
+      "pattern": "git *",
+      "priority": 100,
+      "scope": "/projects/my-app",
+      "tool": "bash",
+    },
+  ],
+  "type": "trust_rules_list_response",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -137,6 +137,22 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     scope: '/projects/my-app',
     decision: 'allow',
   },
+  trust_rules_list: {
+    type: 'trust_rules_list',
+  },
+  remove_trust_rule: {
+    type: 'remove_trust_rule',
+    id: 'rule-001',
+  },
+  update_trust_rule: {
+    type: 'update_trust_rule',
+    id: 'rule-001',
+    tool: 'bash',
+    pattern: 'git push *',
+    scope: '/projects/my-app',
+    decision: 'allow',
+    priority: 50,
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -392,6 +408,20 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     timerId: 'tmr-001',
     label: 'Focus time',
     durationMinutes: 25,
+  },
+  trust_rules_list_response: {
+    type: 'trust_rules_list_response',
+    rules: [
+      {
+        id: 'rule-001',
+        tool: 'bash',
+        pattern: 'git *',
+        scope: '/projects/my-app',
+        decision: 'allow',
+        priority: 100,
+        createdAt: 1700000000,
+      },
+    ],
   },
 };
 

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -39,7 +39,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-import { addRule, removeRule, findMatchingRule, findDenyRule, findHighestPriorityRule, getAllRules, clearAllRules, clearCache } from '../permissions/trust-store.js';
+import { addRule, removeRule, updateRule, findMatchingRule, findDenyRule, findHighestPriorityRule, getAllRules, clearAllRules, clearCache } from '../permissions/trust-store.js';
 import { getDefaultRuleTemplates } from '../permissions/defaults.js';
 
 const trustPath = join(testDir, 'protected', 'trust.json');
@@ -153,6 +153,64 @@ describe('Trust Store', () => {
       const remaining = getAllRules();
       expect(remaining).toHaveLength(1 + NUM_DEFAULTS);
       expect(remaining.find((r) => r.id === rule2.id)).toBeDefined();
+    });
+  });
+
+  // ── updateRule ─────────────────────────────────────────────────
+
+  describe('updateRule', () => {
+    test('updates pattern on an existing rule', () => {
+      const rule = addRule('bash', 'git *', '/tmp');
+      const updated = updateRule(rule.id, { pattern: 'git push *' });
+      expect(updated.pattern).toBe('git push *');
+      expect(updated.id).toBe(rule.id);
+      expect(updated.tool).toBe('bash');
+    });
+
+    test('updates multiple fields at once', () => {
+      const rule = addRule('bash', 'npm *', '/tmp');
+      const updated = updateRule(rule.id, { tool: 'file_write', scope: '/home', decision: 'deny', priority: 50 });
+      expect(updated.tool).toBe('file_write');
+      expect(updated.scope).toBe('/home');
+      expect(updated.decision).toBe('deny');
+      expect(updated.priority).toBe(50);
+    });
+
+    test('throws for non-existent rule ID', () => {
+      expect(() => updateRule('non-existent-id', { pattern: 'test' })).toThrow('Trust rule not found: non-existent-id');
+    });
+
+    test('persists update to disk', () => {
+      const rule = addRule('bash', 'git *', '/tmp');
+      updateRule(rule.id, { pattern: 'git status' });
+      clearCache();
+      const rules = getAllRules();
+      const found = rules.find((r) => r.id === rule.id);
+      expect(found).toBeDefined();
+      expect(found!.pattern).toBe('git status');
+    });
+
+    test('re-sorts rules after priority change', () => {
+      const rule1 = addRule('bash', 'low *', '/tmp', 'allow', 10);
+      const rule2 = addRule('bash', 'high *', '/tmp', 'allow', 200);
+      // rule2 should be first (higher priority)
+      let userRules = getAllRules().filter((r) => !r.id.startsWith('default:'));
+      expect(userRules[0].id).toBe(rule2.id);
+      // Update rule1 to have higher priority
+      updateRule(rule1.id, { priority: 300 });
+      userRules = getAllRules().filter((r) => !r.id.startsWith('default:'));
+      expect(userRules[0].id).toBe(rule1.id);
+    });
+
+    test('leaves unchanged fields intact', () => {
+      const rule = addRule('bash', 'git *', '/home/user', 'allow', 100);
+      updateRule(rule.id, { pattern: 'git push *' });
+      const updated = getAllRules().find((r) => r.id === rule.id)!;
+      expect(updated.tool).toBe('bash');
+      expect(updated.scope).toBe('/home/user');
+      expect(updated.decision).toBe('allow');
+      expect(updated.priority).toBe(100);
+      expect(updated.createdAt).toBe(rule.createdAt);
     });
   });
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -29,8 +29,11 @@ import type {
   SkillDetailRequest,
   SuggestionRequest,
   AddTrustRule,
+  TrustRulesList,
+  RemoveTrustRule,
+  UpdateTrustRule,
 } from './ipc-protocol.js';
-import { addRule } from '../permissions/trust-store.js';
+import { addRule, removeRule, updateRule, getAllRules } from '../permissions/trust-store.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
@@ -294,6 +297,9 @@ const handlers: DispatchMap = {
   skill_detail: handleSkillDetail,
   suggestion_request: handleSuggestionRequest,
   add_trust_rule: handleAddTrustRule,
+  trust_rules_list: (_msg, socket, ctx) => handleTrustRulesList(socket, ctx),
+  remove_trust_rule: handleRemoveTrustRule,
+  update_trust_rule: handleUpdateTrustRule,
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -812,6 +818,47 @@ function handleAddTrustRule(
     log.info({ tool: msg.toolName, pattern: msg.pattern, scope: msg.scope, decision: msg.decision }, 'Trust rule added via client');
   } catch (err) {
     log.error({ err }, 'Failed to add trust rule');
+  }
+}
+
+function handleTrustRulesList(socket: net.Socket, ctx: HandlerContext): void {
+  const rules = getAllRules();
+  ctx.send(socket, { type: 'trust_rules_list_response', rules });
+}
+
+function handleRemoveTrustRule(
+  msg: RemoveTrustRule,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
+): void {
+  try {
+    const removed = removeRule(msg.id);
+    if (!removed) {
+      log.warn({ id: msg.id }, 'Trust rule not found for removal');
+    } else {
+      log.info({ id: msg.id }, 'Trust rule removed via client');
+    }
+  } catch (err) {
+    log.error({ err }, 'Failed to remove trust rule');
+  }
+}
+
+function handleUpdateTrustRule(
+  msg: UpdateTrustRule,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
+): void {
+  try {
+    updateRule(msg.id, {
+      tool: msg.tool,
+      pattern: msg.pattern,
+      scope: msg.scope,
+      decision: msg.decision,
+      priority: msg.priority,
+    });
+    log.info({ id: msg.id }, 'Trust rule updated via client');
+  } catch (err) {
+    log.error({ err }, 'Failed to update trust rule');
   }
 }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -163,6 +163,25 @@ export interface AddTrustRule {
   decision: 'allow' | 'deny';
 }
 
+export interface TrustRulesList {
+  type: 'trust_rules_list';
+}
+
+export interface RemoveTrustRule {
+  type: 'remove_trust_rule';
+  id: string;
+}
+
+export interface UpdateTrustRule {
+  type: 'update_trust_rule';
+  id: string;
+  tool?: string;
+  pattern?: string;
+  scope?: string;
+  decision?: 'allow' | 'deny';
+  priority?: number;
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'table' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -291,7 +310,10 @@ export type ClientMessage =
   | SkillsListRequest
   | SkillDetailRequest
   | SuggestionRequest
-  | AddTrustRule;
+  | AddTrustRule
+  | TrustRulesList
+  | RemoveTrustRule
+  | UpdateTrustRule;
 
 // === Server → Client messages ===
 
@@ -548,6 +570,19 @@ export interface SuggestionResponse {
   source: 'llm' | 'none';
 }
 
+export interface TrustRulesListResponse {
+  type: 'trust_rules_list_response';
+  rules: Array<{
+    id: string;
+    tool: string;
+    pattern: string;
+    scope: string;
+    decision: 'allow' | 'deny';
+    priority: number;
+    createdAt: number;
+  }>;
+}
+
 export interface TimerCompleted {
   type: 'timer_completed';
   sessionId: string;
@@ -673,7 +708,8 @@ export type ServerMessage =
   | SuggestionResponse
   | MessageQueued
   | MessageDequeued
-  | TimerCompleted;
+  | TimerCompleted
+  | TrustRulesListResponse;
 
 // === Serialization ===
 

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -158,6 +158,29 @@ export function addRule(
   return rule;
 }
 
+export function updateRule(
+  id: string,
+  updates: { tool?: string; pattern?: string; scope?: string; decision?: 'allow' | 'deny'; priority?: number },
+): TrustRule {
+  // Re-read from disk to avoid lost updates from concurrent modifications.
+  cachedRules = null;
+  const rules = [...getRules()];
+  const index = rules.findIndex((r) => r.id === id);
+  if (index === -1) throw new Error(`Trust rule not found: ${id}`);
+  const rule = { ...rules[index] };
+  if (updates.tool !== undefined) rule.tool = updates.tool;
+  if (updates.pattern !== undefined) rule.pattern = updates.pattern;
+  if (updates.scope !== undefined) rule.scope = updates.scope;
+  if (updates.decision !== undefined) rule.decision = updates.decision;
+  if (updates.priority !== undefined) rule.priority = updates.priority;
+  rules[index] = rule;
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  saveToDisk(rules);
+  log.info({ rule }, 'Updated trust rule');
+  return rule;
+}
+
 export function removeRule(id: string): boolean {
   // Re-read from disk to avoid lost updates from concurrent modifications.
   cachedRules = null;


### PR DESCRIPTION
## Summary
- Adds three new IPC message types (`trust_rules_list`, `remove_trust_rule`, `update_trust_rule`) and corresponding server response (`trust_rules_list_response`)
- Implements handler functions in `handlers.ts` following existing patterns
- Adds `updateRule()` function to `trust-store.ts` for merging partial updates and persisting to disk
- Includes unit tests for `updateRule` and IPC snapshot tests for the new message types

Part of #1560.

## Test plan
- [x] `updateRule` tests covering: single field update, multi-field update, non-existent ID throws, persistence survives cache clear, re-sort after priority change, unchanged fields preserved
- [x] IPC snapshot tests for all 3 new client messages and 1 new server message
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All trust-store tests pass (69/69)
- [x] All IPC snapshot tests pass (67/67)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
