### PR TITLE
Use process.execPath for .ts hooks instead of external bun lookup

### DIFF
--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -1,27 +1,15 @@
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { extname, join } from 'node:path';
-import { homedir } from 'node:os';
+import { extname } from 'node:path';
 import { getRootDir } from '../util/platform.js';
-import { getLogger } from '../util/logger.js';
 import { getHookSettings } from './config.js';
 import type { DiscoveredHook, HookEventData } from './types.js';
 
-const log = getLogger('hooks-runner');
-
-function resolveBunPath(): string | null {
-  const localBun = join(homedir(), '.bun', 'bin', 'bun');
-  if (existsSync(localBun)) return localBun;
-  // Fall back to PATH lookup — spawn will resolve it or fail with ENOENT
-  return 'bun';
-}
-
-function getSpawnArgs(scriptPath: string): { command: string; args: string[] } | null {
+function getSpawnArgs(scriptPath: string): { command: string; args: string[] } {
   const ext = extname(scriptPath);
   if (ext === '.ts') {
-    const bunPath = resolveBunPath();
-    if (bunPath === null) return null;
-    return { command: bunPath, args: ['run', scriptPath] };
+    // process.execPath is the bun runtime (or compiled bun binary) that
+    // started the daemon, so .ts hooks work without a separate bun install.
+    return { command: process.execPath, args: ['run', scriptPath] };
   }
   return { command: scriptPath, args: [] };
 }
@@ -40,13 +28,7 @@ export async function runHookScript(
   const timeoutMs = options?.timeoutMs ?? 5000;
 
   return new Promise<HookRunResult>((resolve) => {
-    const spawnArgs = getSpawnArgs(hook.scriptPath);
-    if (spawnArgs === null) {
-      log.warn({ hook: hook.name }, 'Skipping .ts hook: bun runtime not found');
-      resolve({ exitCode: null, stdout: '', stderr: 'bun runtime not found' });
-      return;
-    }
-    const { command, args } = spawnArgs;
+    const { command, args } = getSpawnArgs(hook.scriptPath);
     const child = spawn(command, args, {
       cwd: hook.dir,
       env: {


### PR DESCRIPTION
## Summary
- Replaces `resolveBunPath()` (which looked for bun in `~/.bun/bin/` or PATH) with `process.execPath` for spawning TypeScript hooks
- `process.execPath` always points to the running bun binary — whether that's a local `~/.bun/bin/bun` in dev or a compiled `vellum-daemon` binary in production (which embeds the bun runtime via `bun build --compile`)
- Removes dead code: the null-return path in `getSpawnArgs` and the associated logger/skip logic were unreachable since `resolveBunPath()` never returned null

Addresses review feedback from PR #1547 (chatgpt-codex-connector: "Avoid requiring external bun binary for .ts hooks").

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 6 TypeScript hook tests pass (`hooks-ts-runner.test.ts`)
- [x] All shell hook tests pass (`hooks-runner.test.ts`) — 1 pre-existing flaky timeout test on main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
