### PR TITLE
Add macOS IPC extensions for trust rule management

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -59,6 +59,9 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a pomodoro timer completes.
     var onTimerCompleted: ((TimerCompletedMessage) -> Void)?
 
+    /// Called when the daemon sends a `trust_rules_list_response` message.
+    var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -325,6 +328,37 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
         ))
     }
 
+    // MARK: - Trust Rule Management
+
+    /// Request the list of all trust rules from the daemon.
+    func sendListTrustRules() throws {
+        try send(TrustRulesListMessage())
+    }
+
+    /// Remove a trust rule by its ID.
+    func sendRemoveTrustRule(id: String) throws {
+        try send(RemoveTrustRuleMessage(id: id))
+    }
+
+    /// Update fields on an existing trust rule.
+    func sendUpdateTrustRule(
+        id: String,
+        tool: String? = nil,
+        pattern: String? = nil,
+        scope: String? = nil,
+        decision: String? = nil,
+        priority: Int? = nil
+    ) throws {
+        try send(UpdateTrustRuleMessage(
+            id: id,
+            tool: tool,
+            pattern: pattern,
+            scope: scope,
+            decision: decision,
+            priority: priority
+        ))
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -453,6 +487,8 @@ final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTaskRouted?(msg)
         case .timerCompleted(let msg):
             onTimerCompleted?(msg)
+        case .trustRulesListResponse(let msg):
+            onTrustRulesListResponse?(msg.rules)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -402,6 +402,23 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// A single trust rule item returned from the daemon.
+struct TrustRuleItem: Decodable, Sendable, Identifiable {
+    let id: String
+    let tool: String
+    let pattern: String
+    let scope: String
+    let decision: String
+    let priority: Int
+    let createdAt: Double
+}
+
+/// Response containing all trust rules.
+/// Wire type: `"trust_rules_list_response"`
+struct TrustRulesListResponseMessage: Decodable, Sendable {
+    let rules: [TrustRuleItem]
+}
+
 /// Timer completed notification from daemon.
 /// Wire type: `"timer_completed"`
 struct TimerCompletedMessage: Decodable, Sendable {
@@ -502,6 +519,31 @@ struct AddTrustRuleMessage: Encodable, Sendable {
     let decision: String
 }
 
+/// Request all trust rules from the daemon.
+/// Wire type: `"trust_rules_list"`
+struct TrustRulesListMessage: Encodable, Sendable {
+    let type: String = "trust_rules_list"
+}
+
+/// Remove a trust rule by its ID.
+/// Wire type: `"remove_trust_rule"`
+struct RemoveTrustRuleMessage: Encodable, Sendable {
+    let type: String = "remove_trust_rule"
+    let id: String
+}
+
+/// Update fields on an existing trust rule.
+/// Wire type: `"update_trust_rule"`
+struct UpdateTrustRuleMessage: Encodable, Sendable {
+    let type: String = "update_trust_rule"
+    let id: String
+    let tool: String?
+    let pattern: String?
+    let scope: String?
+    let decision: String?
+    let priority: Int?
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {
@@ -531,6 +573,7 @@ enum ServerMessage: Decodable, Sendable {
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
     case timerCompleted(TimerCompletedMessage)
+    case trustRulesListResponse(TrustRulesListResponseMessage)
     case pong
     case unknown(String)
 
@@ -621,6 +664,9 @@ enum ServerMessage: Decodable, Sendable {
         case "timer_completed":
             let message = try TimerCompletedMessage(from: decoder)
             self = .timerCompleted(message)
+        case "trust_rules_list_response":
+            let message = try TrustRulesListResponseMessage(from: decoder)
+            self = .trustRulesListResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
Part of #1563.

Adds Swift IPC message types, DaemonClient methods, and ServerMessage parsing for listing, removing, and updating trust rules.

### Changes

**IPCMessages.swift:**
- `TrustRulesListMessage`, `RemoveTrustRuleMessage`, `UpdateTrustRuleMessage` — client→server message structs
- `TrustRuleItem`, `TrustRulesListResponseMessage` — server→client response structs
- `trustRulesListResponse` case in `ServerMessage` enum with decoding

**DaemonClient.swift:**
- `sendListTrustRules()`, `sendRemoveTrustRule(id:)`, `sendUpdateTrustRule(id:tool:pattern:scope:decision:priority:)` convenience methods
- `onTrustRulesListResponse` callback property dispatched from `handleServerMessage`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
