### PR TITLE
Skip embedding upsert when Qdrant is not initialized

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -21,7 +21,7 @@ import { indexMessageNow } from './indexer.js';
 import { checkContradictions } from './contradiction-checker.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
-import { getQdrantClient } from './qdrant-client.js';
+import { getQdrantClient, isQdrantClientInitialized } from './qdrant-client.js';
 import {
   memoryEmbeddings,
   memoryItems,
@@ -595,6 +595,14 @@ async function embedAndUpsert(
     log.debug(
       { targetType, targetId, reason: status.reason ?? 'backend unavailable' },
       'Skipping embedding job because no backend is configured',
+    );
+    return;
+  }
+
+  if (!isQdrantClientInitialized()) {
+    log.debug(
+      { targetType, targetId },
+      'Skipping embedding upsert because Qdrant client is not initialized',
     );
     return;
   }

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -43,6 +43,10 @@ export function getQdrantClient(): VellumQdrantClient {
   return _instance;
 }
 
+export function isQdrantClientInitialized(): boolean {
+  return _instance !== null;
+}
+
 export function initQdrantClient(config: QdrantClientConfig): VellumQdrantClient {
   _instance = new VellumQdrantClient(config);
   return _instance;


### PR DESCRIPTION
## Summary
- Adds `isQdrantClientInitialized()` check to qdrant-client.ts
- Jobs worker skips embedding upsert gracefully when Qdrant client is unavailable (e.g. no Qdrant server running locally)
- Eliminates "Qdrant client not initialized" error spam in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
