### PR TITLE
Add trust rules editor UI to macOS Settings

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -7,7 +7,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(ambientAgent: appDelegate.ambientAgent)
+            SettingsView(ambientAgent: appDelegate.ambientAgent, daemonClient: appDelegate.daemonClient)
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -80,7 +80,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     private var thinkingWindow: ThinkingIndicatorWindow?
     public let ambientAgent = AmbientAgent()
-    let daemonClient = DaemonClient()
+    public let daemonClient = DaemonClient()
     let surfaceManager = SurfaceManager()
     let toolConfirmationManager = ToolConfirmationManager()
     private let daemonLauncher = DaemonLauncher()
@@ -759,7 +759,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let hostingController = NSHostingController(rootView: SettingsView(ambientAgent: ambientAgent))
+        let hostingController = NSHostingController(rootView: SettingsView(ambientAgent: ambientAgent, daemonClient: daemonClient))
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 450, height: 700),
             styleMask: [.titled, .closable, .miniaturizable],

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -15,14 +15,17 @@ public struct SettingsView: View {
         return val == 0 ? 30 : val
     }()
     @State private var showingPrivacy = false
+    @State private var showingTrustRules = false
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         return ActivationKey(rawValue: stored) ?? .fn
     }()
     var ambientAgent: AmbientAgent
+    var daemonClient: DaemonClient?
 
-    public init(ambientAgent: AmbientAgent) {
+    public init(ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
         self.ambientAgent = ambientAgent
+        self.daemonClient = daemonClient
     }
 
     // Re-check permissions every 2 seconds while the window is open
@@ -145,6 +148,26 @@ public struct SettingsView: View {
                             let status = PermissionManager.screenRecordingStatus()
                             screenRecordingGranted = status == .granted
                         }
+                    }
+                }
+            }
+
+            if let daemonClient {
+                Section("Trust Rules") {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Manage Trust Rules")
+                            Text("Control which tool actions are automatically allowed or denied")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Manage Trust Rules...") {
+                            showingTrustRules = true
+                        }
+                    }
+                    .sheet(isPresented: $showingTrustRules) {
+                        TrustRulesView(daemonClient: daemonClient)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+
+// MARK: - Trust Rules View
+
+struct TrustRulesView: View {
+    let daemonClient: DaemonClient
+    @Environment(\.dismiss) var dismiss
+
+    @State private var rules: [TrustRuleItem] = []
+    @State private var isLoading = true
+    @State private var showingAddSheet = false
+    @State private var editingRule: TrustRuleItem? = nil
+    @State private var ruleToDelete: TrustRuleItem? = nil
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Trust Rules")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    showingAddSheet = true
+                } label: {
+                    Label("Add Rule", systemImage: "plus")
+                }
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding()
+
+            Divider()
+
+            if isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else if rules.isEmpty {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "shield.slash")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text("No trust rules configured")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            } else {
+                List {
+                    ForEach(rules) { rule in
+                        TrustRuleRow(
+                            rule: rule,
+                            isDefault: isDefaultRule(rule),
+                            onEdit: { editingRule = rule },
+                            onDelete: { ruleToDelete = rule }
+                        )
+                    }
+                }
+            }
+        }
+        .frame(width: 600, height: 500)
+        .onAppear {
+            daemonClient.onTrustRulesListResponse = { items in
+                rules = items
+                isLoading = false
+            }
+            loadRules()
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            TrustRuleFormView(daemonClient: daemonClient) {
+                loadRules()
+            }
+        }
+        .sheet(item: $editingRule) { rule in
+            TrustRuleFormView(daemonClient: daemonClient, existingRule: rule) {
+                loadRules()
+            }
+        }
+        .alert("Delete Trust Rule?", isPresented: Binding(
+            get: { ruleToDelete != nil },
+            set: { if !$0 { ruleToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { ruleToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let rule = ruleToDelete {
+                    deleteRule(id: rule.id)
+                    ruleToDelete = nil
+                }
+            }
+        } message: {
+            if let rule = ruleToDelete {
+                Text("Remove the \(rule.decision) rule for \(rule.tool) with pattern \"\(rule.pattern)\"?")
+            }
+        }
+    }
+
+    private func loadRules() {
+        isLoading = true
+        try? daemonClient.sendListTrustRules()
+    }
+
+    private func deleteRule(id: String) {
+        try? daemonClient.sendRemoveTrustRule(id: id)
+        loadRules()
+    }
+
+    private func isDefaultRule(_ rule: TrustRuleItem) -> Bool {
+        rule.priority >= 1000 || rule.id.hasPrefix("default:")
+    }
+}
+
+// MARK: - Trust Rule Row
+
+private struct TrustRuleRow: View {
+    let rule: TrustRuleItem
+    let isDefault: Bool
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(rule.tool)
+                        .fontWeight(.medium)
+                    Text(rule.decision)
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(rule.decision == "allow" ? Color.green.opacity(0.15) : Color.red.opacity(0.15))
+                        .foregroundStyle(rule.decision == "allow" ? .green : .red)
+                        .clipShape(Capsule())
+                }
+                Text(rule.pattern)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Text(rule.scope == "" || rule.scope == "*" ? "Everywhere" : rule.scope)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if !isDefault {
+                Button {
+                    onEdit()
+                } label: {
+                    Image(systemName: "pencil")
+                }
+                .buttonStyle(.borderless)
+
+                Button {
+                    onDelete()
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(.vertical, 2)
+        .opacity(isDefault ? 0.5 : 1.0)
+    }
+}
+
+// MARK: - Trust Rule Form (Add / Edit)
+
+private struct TrustRuleFormView: View {
+    let daemonClient: DaemonClient
+    let existingRule: TrustRuleItem?
+    let onSave: () -> Void
+    @Environment(\.dismiss) var dismiss
+
+    @State private var tool: String
+    @State private var pattern: String
+    @State private var scope: String
+    @State private var isEverywhere: Bool
+    @State private var decision: String
+
+    private let toolOptions = ["bash", "file_read", "file_write", "file_edit", "web_fetch", "skill_load"]
+
+    init(daemonClient: DaemonClient, existingRule: TrustRuleItem? = nil, onSave: @escaping () -> Void) {
+        self.daemonClient = daemonClient
+        self.existingRule = existingRule
+        self.onSave = onSave
+
+        if let rule = existingRule {
+            _tool = State(initialValue: rule.tool)
+            _pattern = State(initialValue: rule.pattern)
+            let everywhere = rule.scope == "" || rule.scope == "*"
+            _scope = State(initialValue: everywhere ? "" : rule.scope)
+            _isEverywhere = State(initialValue: everywhere)
+            _decision = State(initialValue: rule.decision)
+        } else {
+            _tool = State(initialValue: "bash")
+            _pattern = State(initialValue: "")
+            _scope = State(initialValue: "")
+            _isEverywhere = State(initialValue: true)
+            _decision = State(initialValue: "allow")
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(existingRule != nil ? "Edit Trust Rule" : "Add Trust Rule")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding()
+
+            Divider()
+
+            Form {
+                Picker("Tool", selection: $tool) {
+                    ForEach(toolOptions, id: \.self) { option in
+                        Text(option).tag(option)
+                    }
+                }
+
+                TextField("Pattern", text: $pattern, prompt: Text("e.g., git *"))
+
+                Toggle("Everywhere", isOn: $isEverywhere)
+                if !isEverywhere {
+                    TextField("Scope", text: $scope, prompt: Text("e.g., /Users/me/project"))
+                }
+
+                Picker("Decision", selection: $decision) {
+                    Text("Allow").tag("allow")
+                    Text("Deny").tag("deny")
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Spacer()
+                Button("Save") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(pattern.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 420, height: 340)
+    }
+
+    private func save() {
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPattern.isEmpty else { return }
+
+        let resolvedScope = isEverywhere ? "*" : scope.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let existing = existingRule {
+            try? daemonClient.sendUpdateTrustRule(
+                id: existing.id,
+                tool: tool,
+                pattern: trimmedPattern,
+                scope: resolvedScope,
+                decision: decision
+            )
+        } else {
+            try? daemonClient.sendAddTrustRule(
+                toolName: tool,
+                pattern: trimmedPattern,
+                scope: resolvedScope,
+                decision: decision
+            )
+        }
+
+        onSave()
+        dismiss()
+    }
+}

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -20,7 +20,7 @@ protocol DaemonClientProtocol {
 /// stream, enabling multiple consumers (ComputerUseSession, AmbientAgent) to each receive all
 /// messages and filter for the ones relevant to them.
 @MainActor
-final class DaemonClient: ObservableObject, DaemonClientProtocol {
+public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Published State
 


### PR DESCRIPTION
## Summary
- Created `TrustRulesView.swift` with a SwiftUI list view showing all trust rules (tool, pattern, scope, decision) with add/edit/delete support
- Default/built-in rules (priority >= 1000 or ID prefix "default:") are visually dimmed and non-editable
- Integrated into SettingsView as a "Trust Rules" section with a "Manage Trust Rules..." button that opens the editor as a sheet
- Made `DaemonClient` and its `AppDelegate` property `public` so the app target can pass it through to SettingsView

Part of #1567. Depends on #1575 and #1577.

## Test plan
- [ ] Open Settings, verify "Trust Rules" section appears between "Permissions" and "Privacy & Security"
- [ ] Click "Manage Trust Rules..." to open the sheet
- [ ] Verify list loads existing rules from daemon
- [ ] Add a new rule via "Add Rule" button and verify it appears after save
- [ ] Edit an existing user rule and verify changes persist
- [ ] Delete a user rule with confirmation
- [ ] Verify default/built-in rules are dimmed and lack edit/delete buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
