### PR TITLE
Require Qdrant on daemon startup with auto-install

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -190,19 +190,15 @@ export async function runDaemon(): Promise<void> {
   const qdrantManager = new QdrantManager({
     url: qdrantUrl,
   });
-  try {
-    await qdrantManager.start();
-    initQdrantClient({
-      url: qdrantUrl,
-      collection: config.memory.qdrant.collection,
-      vectorSize: config.memory.qdrant.vectorSize,
-      onDisk: config.memory.qdrant.onDisk,
-      quantization: config.memory.qdrant.quantization,
-    });
-    log.info('Qdrant vector store initialized');
-  } catch (err) {
-    log.warn({ err }, 'Failed to initialize Qdrant vector store, memory semantic search will be degraded');
-  }
+  await qdrantManager.start();
+  initQdrantClient({
+    url: qdrantUrl,
+    collection: config.memory.qdrant.collection,
+    vectorSize: config.memory.qdrant.vectorSize,
+    onDisk: config.memory.qdrant.onDisk,
+    quantization: config.memory.qdrant.quantization,
+  });
+  log.info('Qdrant vector store initialized');
 
   const server = new DaemonServer();
   await server.start();

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -21,7 +21,7 @@ import { indexMessageNow } from './indexer.js';
 import { checkContradictions } from './contradiction-checker.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
-import { getQdrantClient, isQdrantClientInitialized } from './qdrant-client.js';
+import { getQdrantClient } from './qdrant-client.js';
 import {
   memoryEmbeddings,
   memoryItems,
@@ -595,14 +595,6 @@ async function embedAndUpsert(
     log.debug(
       { targetType, targetId, reason: status.reason ?? 'backend unavailable' },
       'Skipping embedding job because no backend is configured',
-    );
-    return;
-  }
-
-  if (!isQdrantClientInitialized()) {
-    log.debug(
-      { targetType, targetId },
-      'Skipping embedding upsert because Qdrant client is not initialized',
     );
     return;
   }

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -43,10 +43,6 @@ export function getQdrantClient(): VellumQdrantClient {
   return _instance;
 }
 
-export function isQdrantClientInitialized(): boolean {
-  return _instance !== null;
-}
-
 export function initQdrantClient(config: QdrantClientConfig): VellumQdrantClient {
   _instance = new VellumQdrantClient(config);
   return _instance;

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -1,11 +1,13 @@
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { arch, platform } from 'node:os';
 import type { Subprocess } from 'bun';
 import { getLogger } from '../util/logger.js';
 import { getDataDir } from '../util/platform.js';
 
 const log = getLogger('qdrant-manager');
 
+const QDRANT_VERSION = '1.13.2';
 const READYZ_POLL_INTERVAL_MS = 200;
 const READYZ_TIMEOUT_MS = 30_000;
 const SHUTDOWN_GRACE_MS = 5_000;
@@ -61,10 +63,7 @@ export class QdrantManager {
 
     const binaryPath = this.getBinaryPath();
     if (!existsSync(binaryPath)) {
-      throw new Error(
-        `Qdrant binary not found at ${binaryPath}. ` +
-        'Install it or set QDRANT_URL to use an external Qdrant instance.',
-      );
+      await this.installBinary(binaryPath);
     }
 
     log.info({ binaryPath, storagePath: this.storagePath, port: this.port }, 'Starting Qdrant');
@@ -126,6 +125,64 @@ export class QdrantManager {
 
   getUrl(): string {
     return this.url;
+  }
+
+  private async installBinary(binaryPath: string): Promise<void> {
+    const os = platform();
+    const cpu = arch();
+
+    let target: string;
+    if (os === 'darwin' && cpu === 'arm64') {
+      target = 'aarch64-apple-darwin';
+    } else if (os === 'darwin' && cpu === 'x64') {
+      target = 'x86_64-apple-darwin';
+    } else if (os === 'linux' && cpu === 'x64') {
+      target = 'x86_64-unknown-linux-musl';
+    } else if (os === 'linux' && cpu === 'arm64') {
+      target = 'aarch64-unknown-linux-musl';
+    } else {
+      throw new Error(
+        `Unsupported platform: ${os}/${cpu}. ` +
+        'Set QDRANT_URL to use an external Qdrant instance.',
+      );
+    }
+
+    const filename = `qdrant-${target}.tar.gz`;
+    const url = `https://github.com/qdrant/qdrant/releases/download/v${QDRANT_VERSION}/${filename}`;
+    log.info({ url, binaryPath }, 'Downloading Qdrant binary');
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download Qdrant: ${response.status} ${response.statusText} from ${url}`);
+    }
+
+    const tarball = await response.arrayBuffer();
+
+    // Extract the qdrant binary from the tarball
+    const binDir = dirname(binaryPath);
+    mkdirSync(binDir, { recursive: true });
+
+    // Write tarball to temp file, extract with tar
+    const tmpTar = join(binDir, `qdrant-download-${Date.now()}.tar.gz`);
+    writeFileSync(tmpTar, Buffer.from(tarball));
+
+    try {
+      const proc = Bun.spawn({
+        cmd: ['tar', 'xzf', tmpTar, '-C', binDir, 'qdrant'],
+        stdout: 'ignore',
+        stderr: 'pipe',
+      });
+      await proc.exited;
+      if (proc.exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`Failed to extract Qdrant binary: ${stderr}`);
+      }
+    } finally {
+      try { unlinkSync(tmpTar); } catch { /* ignore */ }
+    }
+
+    chmodSync(binaryPath, 0o755);
+    log.info({ binaryPath, version: QDRANT_VERSION }, 'Qdrant binary installed');
   }
 
   private async waitForReady(): Promise<void> {


### PR DESCRIPTION
## Summary
- QdrantManager auto-downloads the Qdrant binary from GitHub releases when missing (macOS arm64/x64, Linux x64/arm64)
- Qdrant initialization is now mandatory — daemon fails to start if Qdrant can't be started
- Reverts the `isQdrantClientInitialized()` guard from #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
