### PR TITLE
Fix QdrantManager external mode detection when binary not yet installed

### DIFF
--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -45,10 +45,8 @@ export class QdrantManager {
     this.storagePath = config.storagePath ?? join(getDataDir(), 'qdrant');
     this.pidPath = join(getDataDir(), 'qdrant', 'qdrant.pid');
 
-    // External mode if QDRANT_URL is explicitly set or no local binary exists
-    const hasEnvUrl = Boolean(process.env.QDRANT_URL?.trim());
-    const localBinaryPath = this.getBinaryPath();
-    this.isExternal = hasEnvUrl || !existsSync(localBinaryPath);
+    // External mode only if QDRANT_URL is explicitly set
+    this.isExternal = Boolean(process.env.QDRANT_URL?.trim());
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixed bug where QdrantManager defaulted to external mode when the Qdrant binary hadn't been installed yet, preventing auto-install from ever running
- Now only uses external mode when `QDRANT_URL` env var is explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
