### PR TITLE
Fix cross-platform path containment check in hook discovery

### DIFF
--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, type Dirent } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative } from 'node:path';
 import { getHooksDir } from '../util/platform.js';
 import { loadHooksConfig } from './config.js';
 import { getLogger } from '../util/logger.js';
@@ -69,7 +69,8 @@ export function discoverHooks(hooksDir?: string): DiscoveredHook[] {
     }
 
     const scriptPath = resolve(hookDir, manifest.script);
-    if (!scriptPath.startsWith(hookDir + '/')) {
+    const rel = relative(hookDir, scriptPath);
+    if (rel.startsWith('..') || resolve(hookDir, rel) !== scriptPath) {
       log.warn({ hookDir, script: manifest.script }, 'Hook script path traversal detected, skipping');
       continue;
     }


### PR DESCRIPTION
## Summary

- Replace POSIX-specific `startsWith(hookDir + '/')` with `path.relative()` for the path traversal guard in `discoverHooks()`
- The previous check failed on Windows where paths use backslashes, causing all hooks to be skipped on win32
- Addresses review feedback from PR #1561

## Test plan

- [ ] Verify hooks with `../` in script path are still rejected
- [ ] Verify normal hooks are discovered correctly on both POSIX and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
