### PR TITLE
Fix hook timeout race condition in close handler

### DIFF
--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -54,6 +54,7 @@ export async function runHookScript(
 
     const timer = setTimeout(() => {
       if (settled) return;
+      settled = true;
       child.kill('SIGTERM');
       // Give the process a short grace period to exit after SIGTERM, then SIGKILL
       const killTimer = setTimeout(() => {
@@ -61,10 +62,8 @@ export async function runHookScript(
       }, 2000);
       child.once('close', () => {
         clearTimeout(killTimer);
-        if (settled) return;
-        settled = true;
-        resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
       });
+      resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
     }, timeoutMs);
 
     child.on('close', (code) => {


### PR DESCRIPTION
## Summary
- Sets `settled = true` before `child.kill('SIGTERM')` and resolves the promise immediately with the timeout result
- Prevents the original `close` handler from winning the race and resolving with the raw exit code (e.g. 143)
- Ensures the "Hook timed out" marker is always surfaced when a hook times out

Addresses review feedback from PR #1562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
