### PR TITLE
Fix debug prompt logger to use head -c for total output truncation

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -14,7 +14,7 @@ echo "" >&2
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "(jq not found — install jq for formatted output)" >&2
-  printf '%s' "$data" | cut -c1-3000 >&2
+  printf '%s' "$data" | head -c 3000 >&2
   echo "" >&2
   echo "════════════════════════════════════════════════════════════════" >&2
   echo "" >&2
@@ -23,7 +23,7 @@ fi
 
 # System prompt (first 2000 chars)
 echo "── System Prompt ──────────────────────────────────────────────" >&2
-printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | cut -c1-2000 >&2
+printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | head -c 2000 >&2
 echo "" >&2
 echo "" >&2
 


### PR DESCRIPTION
## Summary
- Reverts `cut -c1-N` back to `head -c N` in the debug prompt logger hook script
- `cut -c1-N` truncates each line to N characters but passes all lines through, while `head -c N` limits total output to N bytes — the latter is the intended behavior
- Addresses review feedback from PR #1566

## Files changed
- `assistant/hook-templates/debug-prompt-logger/run.sh`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
