### PR TITLE
Roll back persisted message when pre-message hook blocks

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -400,6 +400,10 @@ export class Session {
       });
 
       if (preMessageResult.blocked) {
+        // Roll back the user message that was already persisted by persistUserMessage
+        // so it doesn't linger in conversation history or the database.
+        this.messages.pop();
+        conversationStore.deleteLastExchange(this.conversationId);
         onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
         return;
       }


### PR DESCRIPTION
## Summary

When a `pre-message` hook blocks a message, the user message that was already persisted by `persistUserMessage` was not being rolled back. This left a dangling user message in both the in-memory conversation history and the database, polluting context for all future LLM calls.

**Fix:** When the hook blocks, pop the message from `this.messages` and delete it from the DB via `deleteLastExchange` before returning.

Addresses review feedback from PR #1565.

## Changes

- `assistant/src/daemon/session.ts`: Added rollback logic (pop + DB delete) in `runAgentLoop` when `pre-message` hook blocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
