### PR TITLE
Fix updateRule null handling to prevent trust rule corruption

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -171,11 +171,11 @@ export function updateRule(
   const index = rules.findIndex((r) => r.id === id);
   if (index === -1) throw new Error(`Trust rule not found: ${id}`);
   const rule = { ...rules[index] };
-  if (updates.tool !== undefined) rule.tool = updates.tool;
-  if (updates.pattern !== undefined) rule.pattern = updates.pattern;
-  if (updates.scope !== undefined) rule.scope = updates.scope;
-  if (updates.decision !== undefined) rule.decision = updates.decision;
-  if (updates.priority !== undefined) rule.priority = updates.priority;
+  if (updates.tool != null) rule.tool = updates.tool;
+  if (updates.pattern != null) rule.pattern = updates.pattern;
+  if (updates.scope != null) rule.scope = updates.scope;
+  if (updates.decision != null) rule.decision = updates.decision;
+  if (updates.priority != null) rule.priority = updates.priority;
   rules[index] = rule;
   rules.sort(ruleOrder);
   cachedRules = rules;


### PR DESCRIPTION
## Summary
- Changes `!== undefined` checks to `!= null` in `updateRule()` in `trust-store.ts`
- Prevents JSON `null` values from Swift clients (which encode nil optionals as `null`) from overwriting valid trust rule fields
- Addresses review feedback from PR #1577

## Test plan
- [ ] Verify that calling `updateRule` with only some fields set does not corrupt other fields
- [ ] Verify that passing `null` for a field is treated the same as not passing it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
