### PR TITLE
Guard default deny trust rules against modification and deletion

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -162,6 +162,9 @@ export function updateRule(
   id: string,
   updates: { tool?: string; pattern?: string; scope?: string; decision?: 'allow' | 'deny'; priority?: number },
 ): TrustRule {
+  const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
+  if (defaultIds.has(id)) throw new Error(`Cannot modify default trust rule: ${id}`);
+
   // Re-read from disk to avoid lost updates from concurrent modifications.
   cachedRules = null;
   const rules = [...getRules()];
@@ -182,6 +185,9 @@ export function updateRule(
 }
 
 export function removeRule(id: string): boolean {
+  const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
+  if (defaultIds.has(id)) throw new Error(`Cannot remove default trust rule: ${id}`);
+
   // Re-read from disk to avoid lost updates from concurrent modifications.
   cachedRules = null;
   const rules = [...getRules()];


### PR DESCRIPTION
Prevents `updateRule` and `removeRule` from operating on built-in default rules (those whose IDs come from `getDefaultRuleTemplates`), protecting safety-critical deny rules from being weakened or removed via IPC.

Previously, `updateRule` could change a default deny rule's `decision` field to `allow` while preserving its ID, so `backfillDefaults` would see the ID as present and skip re-adding it — the corruption persisted across restarts. Similarly, `removeRule` could delete a built-in deny rule.

Addresses review feedback from PR #1575.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
