### PR TITLE
Preserve embedding jobs when backend is unavailable

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -592,11 +592,9 @@ async function embedAndUpsert(
 ): Promise<void> {
   const status = getMemoryBackendStatus(config);
   if (!status.provider) {
-    log.debug(
-      { targetType, targetId, reason: status.reason ?? 'backend unavailable' },
-      'Skipping embedding job because no backend is configured',
+    throw new Error(
+      `Embedding backend unavailable (${status.reason ?? 'no provider'}); job will be retried`,
     );
-    return;
   }
 
   const embedded = await embedWithBackend(config, [text]);


### PR DESCRIPTION
## Summary
- Replaces silent early return in `embedAndUpsert()` with a thrown error when the embedding backend has no configured provider
- This prevents `runMemoryJobsOnce()` from calling `completeMemoryJob()` on a non-throwing path, which would permanently drop embed jobs
- Instead, `failMemoryJob()` is called, preserving the job in the queue for retry

Addresses review feedback from PR #1579.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that when no embedding provider is configured, embed jobs fail with a descriptive error and remain in the queue

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
