### PR TITLE
Make hook manifest description and version optional for discovery

### DIFF
--- a/assistant/src/hooks/cli.ts
+++ b/assistant/src/hooks/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { existsSync, cpSync, readFileSync, chmodSync, rmSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
-import { discoverHooks, isValidManifest } from './discovery.js';
+import { discoverHooks, isValidInstallManifest } from './discovery.js';
 import { setHookEnabled, ensureHookInConfig, removeHook } from './config.js';
 import { getHooksDir } from '../util/platform.js';
 
@@ -95,7 +95,7 @@ export function registerHooksCommand(program: Command): void {
         process.exit(1);
       }
 
-      if (!isValidManifest(manifest)) {
+      if (!isValidInstallManifest(manifest)) {
         console.error('Invalid hook.json: must have a non-empty name, script, description (string), version (string), and at least one valid event');
         process.exit(1);
       }

--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -17,19 +17,34 @@ const VALID_EVENTS = new Set<string>([
   'on-error',
 ]);
 
+/**
+ * Validates the core manifest fields required for discovery.
+ * `description` and `version` are optional here so that legacy hook manifests
+ * (created before those fields were added) continue to be discovered.
+ */
 export function isValidManifest(manifest: unknown): manifest is HookManifest {
   if (typeof manifest !== 'object' || manifest === null) return false;
   const m = manifest as Record<string, unknown>;
   if (typeof m.name !== 'string' || !m.name) return false;
-  if (typeof m.description !== 'string' || !m.description) return false;
-  if (typeof m.version !== 'string' || !m.version) return false;
   if (typeof m.script !== 'string' || !m.script) return false;
-  if (typeof m.description !== 'string') return false;
-  if (typeof m.version !== 'string') return false;
   if (!Array.isArray(m.events) || m.events.length === 0) return false;
   for (const e of m.events) {
     if (typeof e !== 'string' || !VALID_EVENTS.has(e)) return false;
   }
+  // Optional fields: allow if present but must be strings
+  if (m.description !== undefined && typeof m.description !== 'string') return false;
+  if (m.version !== undefined && typeof m.version !== 'string') return false;
+  return true;
+}
+
+/**
+ * Stricter validation for installing new hooks.
+ * Requires `description` and `version` in addition to the core fields.
+ */
+export function isValidInstallManifest(manifest: unknown): manifest is HookManifest & { description: string; version: string } {
+  if (!isValidManifest(manifest)) return false;
+  if (typeof manifest.description !== 'string' || !manifest.description) return false;
+  if (typeof manifest.version !== 'string' || !manifest.version) return false;
   return true;
 }
 

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -28,8 +28,8 @@ export interface HookSettingsSchemaEntry {
 
 export interface HookManifest {
   name: string;
-  description: string;
-  version: string;
+  description?: string;
+  version?: string;
   events: HookEventName[];
   script: string;
   /** When true, non-zero exit from this hook cancels pre-* actions. Default false. */


### PR DESCRIPTION
## Summary
- Make `description` and `version` optional in `HookManifest` interface and discovery validation
- Add `isValidInstallManifest()` that enforces `description` and `version` for new installs
- Preserves backward compatibility with legacy hook manifests that lack these fields

Addresses review feedback from PR #1570.

## Test plan
- [x] All 20 hooks tests pass
- [x] TypeScript type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
