### PR TITLE
Fix .ts hook execution in compiled daemon binary

### DIFF
--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -1,15 +1,39 @@
 import { spawn } from 'node:child_process';
-import { extname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import { homedir } from 'node:os';
 import { getRootDir } from '../util/platform.js';
 import { getHookSettings } from './config.js';
 import type { DiscoveredHook, HookEventData } from './types.js';
 
+/**
+ * Resolve a usable bun runtime path. When the daemon runs under plain bun
+ * (dev mode), `process.execPath` is the bun CLI and works directly.  When the
+ * daemon is a `bun build --compile` binary, `process.execPath` points to the
+ * compiled binary itself -- spawning it with `['run', script]` would re-launch
+ * the daemon.  In that case we locate bun via PATH or at `~/.bun/bin/bun`.
+ */
+function resolveBunPath(): string {
+  const execBasename = basename(process.execPath);
+  if (execBasename === 'bun' || execBasename === 'bun.exe') {
+    return process.execPath;
+  }
+
+  // Compiled-binary mode -- find a standalone bun runtime.
+  const found = Bun.which('bun');
+  if (found) return found;
+
+  const fallback = join(homedir(), '.bun', 'bin', 'bun');
+  if (existsSync(fallback)) return fallback;
+
+  // Last resort: hope process.execPath can handle it (shouldn't get here).
+  return process.execPath;
+}
+
 function getSpawnArgs(scriptPath: string): { command: string; args: string[] } {
   const ext = extname(scriptPath);
   if (ext === '.ts') {
-    // process.execPath is the bun runtime (or compiled bun binary) that
-    // started the daemon, so .ts hooks work without a separate bun install.
-    return { command: process.execPath, args: ['run', scriptPath] };
+    return { command: resolveBunPath(), args: ['run', scriptPath] };
   }
   return { command: scriptPath, args: [] };
 }


### PR DESCRIPTION
## Summary
- When the daemon runs as a `bun build --compile` binary, `process.execPath` points to the compiled binary, not a usable bun runtime — spawning it with `['run', scriptPath]` re-launches the daemon instead of executing the hook
- Adds `resolveBunPath()` to detect compiled-binary mode (basename != 'bun') and fall back to `Bun.which('bun')` or `~/.bun/bin/bun`

## Test plan
- [ ] Verify `.ts` hooks execute correctly in dev mode (`bun run`)
- [ ] Verify `.ts` hooks execute correctly when running as a compiled binary
- [ ] Verify fallback to `~/.bun/bin/bun` works when bun is not on PATH

Addresses review feedback from PR #1576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
