### PR TITLE
Remove secret references from gateway CD summary step

### DIFF
--- a/.github/workflows/cd-gateway-image.yml
+++ b/.github/workflows/cd-gateway-image.yml
@@ -60,6 +60,5 @@ ${IMAGE}:latest"
         run: |
           echo "## Gateway Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**SHA tag:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Removes the image name line from the gateway CD Summary step, which was referencing `secrets.GCP_REGISTRY_HOST`, `secrets.GCP_PROJECT_ID`, and `secrets.GATEWAY_IMAGE_NAME` — all masked as `***` by GitHub Actions
- Keeps SHA tag and digest in the summary since those aren't secrets
- Addresses review feedback on #1584

## Test plan
- [ ] Verify the workflow still runs successfully on push to main with gateway changes
- [ ] Confirm the step summary shows SHA tag and digest without masked values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
