### PR TITLE
Fix path traversal check to allow filenames starting with ..

### DIFF
--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -85,7 +85,7 @@ export function discoverHooks(hooksDir?: string): DiscoveredHook[] {
 
     const scriptPath = resolve(hookDir, manifest.script);
     const rel = relative(hookDir, scriptPath);
-    if (rel.startsWith('..') || resolve(hookDir, rel) !== scriptPath) {
+    if (rel.startsWith('../') || rel === '..' || resolve(hookDir, rel) !== scriptPath) {
       log.warn({ hookDir, script: manifest.script }, 'Hook script path traversal detected, skipping');
       continue;
     }


### PR DESCRIPTION
## Summary
- Changes `startsWith('..')` to `startsWith('../') || rel === '..'` in `assistant/src/hooks/discovery.ts` to avoid false positives on filenames like `..secret`
- Addresses review feedback from PR #1585

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Filenames like `..secret` are no longer rejected by the path traversal check
- Actual traversals like `../../etc/passwd` are still correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
