### PR TITLE
Wait for timed-out hook to exit before resolving

### DIFF
--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -86,8 +86,8 @@ export async function runHookScript(
       }, 2000);
       child.once('close', () => {
         clearTimeout(killTimer);
+        resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
       });
-      resolve({ exitCode: null, stdout, stderr: stderr + '\nHook timed out' });
     }, timeoutMs);
 
     child.on('close', (code) => {


### PR DESCRIPTION
Moves `resolve()` into the child `close` handler within the timeout callback, ensuring the promise only resolves after the child process has actually exited. This prevents overlapping hook execution when a hook times out.

Addresses review feedback from PR #1586.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
