### PR TITLE
Avoid cascading run deletion when pre-message hook blocks

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -400,10 +400,13 @@ export class Session {
       });
 
       if (preMessageResult.blocked) {
-        // Roll back the user message that was already persisted by persistUserMessage
-        // so it doesn't linger in conversation history or the database.
+        // Roll back the user message from in-memory history only.
+        // We intentionally do NOT call deleteLastExchange here because
+        // message_runs.message_id has ON DELETE CASCADE — deleting the
+        // message would cascade-delete the run record, causing
+        // runsStore.failRun/completeRun to be no-ops and clients
+        // polling GET /runs/{id} to get 404.
         this.messages.pop();
-        conversationStore.deleteLastExchange(this.conversationId);
         onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
         return;
       }


### PR DESCRIPTION
## Summary

When a pre-message hook blocks a message, `deleteLastExchange` was called to clean up the persisted user message. However, `message_runs.message_id` has `ON DELETE CASCADE` — deleting the user message cascades and destroys the associated run record. This caused `runsStore.failRun`/`completeRun` to become no-ops, and clients polling `GET /runs/{id}` to get 404.

**Fix:** Remove the `deleteLastExchange` call and keep only `this.messages.pop()` for in-memory cleanup. The dangling user message in the DB is harmless compared to cascading deletion of the run record.

Addresses review feedback from PR #1588.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
