### PR TITLE
Fix trust rule test and CLI error handling for default rules

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -631,10 +631,11 @@ describe('Trust Store', () => {
     test('removed default rule is re-backfilled on next load', () => {
       // First load backfills defaults
       getAllRules();
-      // Remove one default rule
-      const defaultRule = getAllRules().find((r) => r.id === 'default:deny-file_read-protected');
-      expect(defaultRule).toBeDefined();
-      removeRule(defaultRule!.id);
+      // Remove one default rule by editing trust.json directly on disk
+      // (removeRule() throws for default rules, so we simulate external editing)
+      const raw = JSON.parse(readFileSync(trustPath, 'utf-8'));
+      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:deny-file_read-protected');
+      writeFileSync(trustPath, JSON.stringify(raw, null, 2));
       // After reload, the rule is re-backfilled (defaults are always present)
       clearCache();
       const rules = getAllRules();

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -459,7 +459,12 @@ trust
       console.error(`No rule found matching "${id}"`);
       process.exit(1);
     }
-    removeRule(match.id);
+    try {
+      removeRule(match.id);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
     console.log(`Removed rule ${match.id.slice(0, 8)} (${match.tool}: ${match.pattern})`);
   });
 


### PR DESCRIPTION
## Summary
- Rewrites test at `trust-store.test.ts:631` to manipulate `trust.json` on disk directly instead of calling `removeRule()`, which now throws for default rules
- Adds try/catch in CLI `trust remove` command (`index.ts`) so prefix-matching a default rule prints a friendly error instead of crashing

Addresses review feedback from PR #1590.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
