### PR TITLE
Defer embedding jobs when backend unavailable instead of failing

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -86,6 +86,20 @@ export function completeMemoryJob(id: string): void {
     .run();
 }
 
+/**
+ * Move a running job back to pending without incrementing its attempt count.
+ * Used when the failure is a missing configuration (not a transient error)
+ * so the job can be retried indefinitely once the config is available.
+ */
+export function deferMemoryJob(id: string, delayMs = 30_000): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(memoryJobs)
+    .set({ status: 'pending', runAfter: now + delayMs, updatedAt: now })
+    .where(eq(memoryJobs.id, id))
+    .run();
+}
+
 export function failMemoryJob(
   id: string,
   error: string,

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -11,6 +11,7 @@ import { getDb } from './db.js';
 import {
   claimMemoryJobs,
   completeMemoryJob,
+  deferMemoryJob,
   enqueueMemoryJob,
   failMemoryJob,
   type MemoryJob,
@@ -32,6 +33,15 @@ import {
 } from './schema.js';
 
 const log = getLogger('memory-jobs-worker');
+
+/** Sentinel error: the embedding backend is not configured yet. */
+class BackendUnavailableError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'BackendUnavailableError';
+  }
+}
+
 const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';
 const BACKFILL_CHECKPOINT_ID_KEY = 'memory:backfill:last_message_id';
 
@@ -117,9 +127,16 @@ export async function runMemoryJobsOnce(): Promise<number> {
       completeMemoryJob(job.id);
       processed += 1;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      failMemoryJob(job.id, message);
-      log.warn({ err, jobId: job.id, type: job.type }, 'Memory job failed');
+      if (err instanceof BackendUnavailableError) {
+        // Backend not configured yet -- put the job back without counting an attempt
+        // so it stays pending until the provider becomes available.
+        deferMemoryJob(job.id, 30_000);
+        log.debug({ jobId: job.id, type: job.type }, 'Embedding backend unavailable, deferring job');
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        failMemoryJob(job.id, message);
+        log.warn({ err, jobId: job.id, type: job.type }, 'Memory job failed');
+      }
     }
   }
   return processed;
@@ -592,8 +609,8 @@ async function embedAndUpsert(
 ): Promise<void> {
   const status = getMemoryBackendStatus(config);
   if (!status.provider) {
-    throw new Error(
-      `Embedding backend unavailable (${status.reason ?? 'no provider'}); job will be retried`,
+    throw new BackendUnavailableError(
+      `Embedding backend unavailable (${status.reason ?? 'no provider'})`,
     );
   }
 


### PR DESCRIPTION
## Summary
- When the embedding provider is not configured, embedding jobs (`embed_segment`, `embed_item`, `embed_summary`) were throwing a generic error that went through `failMemoryJob` with `maxAttempts=5`, permanently marking jobs as `failed`.
- Introduces a `BackendUnavailableError` sentinel in `jobs-worker.ts` and a `deferMemoryJob` helper in `jobs-store.ts` that resets the job back to `pending` with a 30-second delay, without incrementing the attempt counter.
- Jobs now stay pending indefinitely until the embedding provider becomes available, instead of being permanently failed after 5 retries.

Addresses review feedback from PR #1591.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that when `getMemoryBackendStatus` returns no provider, embedding jobs are deferred (reset to pending) rather than failed
- [ ] Confirm that once the provider is configured, deferred jobs are picked up and processed normally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
