### PR TITLE
Fail fast in resolveBunPath when bun runtime is missing

### DIFF
--- a/assistant/src/hooks/runner.ts
+++ b/assistant/src/hooks/runner.ts
@@ -26,8 +26,10 @@ function resolveBunPath(): string {
   const fallback = join(homedir(), '.bun', 'bin', 'bun');
   if (existsSync(fallback)) return fallback;
 
-  // Last resort: hope process.execPath can handle it (shouldn't get here).
-  return process.execPath;
+  throw new Error(
+    'Cannot find a bun runtime to execute .ts hooks. ' +
+    'Install bun (https://bun.sh) or ensure it is on your PATH.',
+  );
 }
 
 function getSpawnArgs(scriptPath: string): { command: string; args: string[] } {
@@ -52,7 +54,14 @@ export async function runHookScript(
   const timeoutMs = options?.timeoutMs ?? 5000;
 
   return new Promise<HookRunResult>((resolve) => {
-    const { command, args } = getSpawnArgs(hook.scriptPath);
+    let spawnResult: { command: string; args: string[] };
+    try {
+      spawnResult = getSpawnArgs(hook.scriptPath);
+    } catch (err) {
+      resolve({ exitCode: null, stdout: '', stderr: (err as Error).message });
+      return;
+    }
+    const { command, args } = spawnResult;
     const child = spawn(command, args, {
       cwd: hook.dir,
       env: {


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #1594: instead of falling back to `process.execPath` when bun cannot be found in compiled-binary mode, `resolveBunPath` now throws a descriptive error.
- `runHookScript` catches the error and returns it as a hook failure result (exitCode: null, stderr with the message), so the daemon does not hang or re-launch itself.

## Test plan
- [ ] Verify `.ts` hooks still execute correctly in dev mode (`bun run`)
- [ ] Verify `.ts` hooks execute correctly when running as a compiled binary with bun on PATH
- [ ] Verify that when bun is not found in compiled-binary mode, the hook fails immediately with a clear error instead of timing out
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
