### PR TITLE
Fix dd redirect ordering in debug-prompt-logger

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -14,7 +14,7 @@ echo "" >&2
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "(jq not found — install jq for formatted output)" >&2
-  printf '%s' "$data" | dd bs=3000 count=1 2>/dev/null >&2
+  printf '%s' "$data" | dd bs=3000 count=1 >&2 2>/dev/null
   echo "" >&2
   echo "════════════════════════════════════════════════════════════════" >&2
   echo "" >&2
@@ -23,7 +23,7 @@ fi
 
 # System prompt (first 2000 chars)
 echo "── System Prompt ──────────────────────────────────────────────" >&2
-printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | dd bs=2000 count=1 2>/dev/null >&2
+printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | dd bs=2000 count=1 >&2 2>/dev/null
 echo "" >&2
 echo "" >&2
 


### PR DESCRIPTION
## Summary
- Swapped `2>/dev/null >&2` to `>&2 2>/dev/null` on two `dd` lines in `run.sh`
- The previous ordering redirected fd 2 to `/dev/null` first, then copied that silenced fd onto fd 1, causing both stdout and stderr to go to `/dev/null` (no output shown)
- The corrected ordering copies the original stderr onto fd 1 first (so `dd` output goes to the terminal), then suppresses `dd`'s own stderr stats

## Test plan
- [ ] Run with `VELLUM_DEBUG=1` and verify the system prompt / raw data is printed to stderr
- [ ] Verify `dd` transfer stats are suppressed (no "N+0 records in/out" noise)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
