### PR TITLE
Delete blocked user message from DB without cascading to run

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -400,13 +400,12 @@ export class Session {
       });
 
       if (preMessageResult.blocked) {
-        // Roll back the user message from in-memory history only.
-        // We intentionally do NOT call deleteLastExchange here because
-        // message_runs.message_id has ON DELETE CASCADE — deleting the
-        // message would cascade-delete the run record, causing
-        // runsStore.failRun/completeRun to be no-ops and clients
-        // polling GET /runs/{id} to get 404.
+        // Roll back the user message from both in-memory history and the DB.
+        // We use deleteMessageById (not deleteLastExchange) because it NULLs
+        // nullable FK references (message_runs, channel_inbound_events) before
+        // deleting the message row, so the run record survives.
         this.messages.pop();
+        conversationStore.deleteMessageById(userMessageId);
         onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
         return;
       }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, count, sql } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages } from './schema.js';
+import { conversations, messages, messageRuns, channelInboundEvents } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -242,4 +242,32 @@ export function deleteLastExchange(conversationId: string): number {
   });
 
   return deleted;
+}
+
+/**
+ * Delete a single message by ID without cascading to message_runs or
+ * channel_inbound_events. Nullable FK columns in those tables are set to
+ * NULL before the message row is removed, so associated run and event
+ * records survive.
+ *
+ * Other tables with NOT NULL FK references (memory_segments,
+ * memory_item_sources, message_attachments) cascade-delete normally,
+ * which is fine — for a freshly blocked message they will be empty.
+ */
+export function deleteMessageById(messageId: string): void {
+  const db = getDb();
+  db.transaction((tx) => {
+    // Detach nullable FK references so the cascade doesn't destroy them.
+    tx.update(messageRuns)
+      .set({ messageId: null })
+      .where(eq(messageRuns.messageId, messageId))
+      .run();
+    tx.update(channelInboundEvents)
+      .set({ messageId: null })
+      .where(eq(channelInboundEvents.messageId, messageId))
+      .run();
+
+    // Now safe to delete — only NOT NULL cascades remain.
+    tx.delete(messages).where(eq(messages.id, messageId)).run();
+  });
 }


### PR DESCRIPTION
## Summary
- Fixes the issue from PR #1599 where a pre-message hook block left the user message persisted in the `messages` table
- The dangling message leaked into history APIs (`handleHistoryRequest`) and could be folded into future prompts via `repairHistory` on session reload
- Adds `deleteMessageById` to `conversation-store.ts` that NULLs nullable FK references in `message_runs` and `channel_inbound_events` before deleting the message row, so run records survive
- Calls `deleteMessageById` in the pre-message hook blocked path in `session.ts`

## Why not just delete the message directly?
`message_runs.message_id` has `ON DELETE CASCADE` — a plain DELETE would cascade-destroy the run record. The new function detaches the FK first (sets to NULL) then deletes.

## Files changed
- `assistant/src/memory/conversation-store.ts` — new `deleteMessageById` function
- `assistant/src/daemon/session.ts` — call `deleteMessageById` when pre-message hook blocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
