### PR TITLE
Track deferrals separately from retry attempts

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -372,6 +372,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_summaries ADD COLUMN version INTEGER NOT NULL DEFAULT 1`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN valid_from INTEGER`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN invalid_at INTEGER`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_jobs ADD COLUMN deferrals INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
 
   migrateToolInvocationsFk(database);
 

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -24,6 +24,7 @@ export interface MemoryJob<T = Record<string, unknown>> {
   payload: T;
   status: 'pending' | 'running' | 'completed' | 'failed';
   attempts: number;
+  deferrals: number;
   runAfter: number;
   lastError: string | null;
   createdAt: number;
@@ -44,6 +45,7 @@ export function enqueueMemoryJob(
     payload: JSON.stringify(payload),
     status: 'pending',
     attempts: 0,
+    deferrals: 0,
     runAfter,
     lastError: null,
     createdAt: now,
@@ -115,9 +117,10 @@ const DEFER_MAX_DELAY_MS = 5 * 60 * 1000;
 /**
  * Move a running job back to pending with exponential backoff.
  * Used when the failure is a missing configuration (not a transient error).
- * The job's attempt counter is incremented so that backoff grows and the job
- * eventually fails after {@link MAX_DEFERRALS} deferrals instead of retrying
- * indefinitely.
+ * The job's deferral counter is incremented (separate from the retry attempt
+ * counter used by {@link failMemoryJob}) so that backoff grows and the job
+ * eventually fails after {@link MAX_DEFERRALS} deferrals without consuming
+ * the retry budget for transient errors.
  *
  * Returns `'deferred'` if the job was put back, or `'failed'` if max deferrals
  * were exceeded and the job was marked as failed.
@@ -131,16 +134,16 @@ export function deferMemoryJob(id: string): 'deferred' | 'failed' {
     .get();
   if (!row) return 'failed';
 
-  const attempts = row.attempts + 1;
+  const deferrals = row.deferrals + 1;
   const now = Date.now();
 
-  if (attempts >= MAX_DEFERRALS) {
+  if (deferrals >= MAX_DEFERRALS) {
     db.update(memoryJobs)
       .set({
         status: 'failed',
-        attempts,
+        deferrals,
         updatedAt: now,
-        lastError: `Backend unavailable after ${attempts} deferrals`,
+        lastError: `Backend unavailable after ${deferrals} deferrals`,
       })
       .where(eq(memoryJobs.id, id))
       .run();
@@ -148,9 +151,9 @@ export function deferMemoryJob(id: string): 'deferred' | 'failed' {
   }
 
   // Exponential backoff: 30s, 60s, 120s, ... capped at 5 minutes
-  const delay = Math.min(DEFER_BASE_DELAY_MS * Math.pow(2, Math.min(attempts - 1, 10)), DEFER_MAX_DELAY_MS);
+  const delay = Math.min(DEFER_BASE_DELAY_MS * Math.pow(2, Math.min(deferrals - 1, 10)), DEFER_MAX_DELAY_MS);
   db.update(memoryJobs)
-    .set({ status: 'pending', attempts, runAfter: now + delay, updatedAt: now })
+    .set({ status: 'pending', deferrals, runAfter: now + delay, updatedAt: now })
     .where(eq(memoryJobs.id, id))
     .run();
   return 'deferred';
@@ -238,6 +241,7 @@ function parseRow(row: typeof memoryJobs.$inferSelect): MemoryJob {
     payload,
     status: row.status as MemoryJob['status'],
     attempts: row.attempts,
+    deferrals: row.deferrals,
     runAfter: row.runAfter,
     lastError: row.lastError,
     createdAt: row.createdAt,

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -112,6 +112,7 @@ export const memoryJobs = sqliteTable('memory_jobs', {
   payload: text('payload').notNull(),
   status: text('status').notNull(),
   attempts: integer('attempts').notNull().default(0),
+  deferrals: integer('deferrals').notNull().default(0),
   runAfter: integer('run_after').notNull(),
   lastError: text('last_error'),
   createdAt: integer('created_at').notNull(),


### PR DESCRIPTION
## Summary
- Adds a separate `deferrals` column to the `memory_jobs` schema so that deferral counting is independent of the retry `attempts` counter
- `deferMemoryJob` now increments `deferrals` instead of `attempts`, preserving the full retry budget (default 5) for actual transient errors in `failMemoryJob`
- Includes the SQLite migration (`ALTER TABLE ADD COLUMN`) following the existing pattern in `db.ts`

Fixes the regression introduced in #1604 where backend-outage deferrals would consume the retry budget, causing embed jobs to be permanently failed after a subsequent transient error.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] After a backend outage with many deferrals, verify that `attempts` remains 0 and `deferrals` is incremented
- [ ] After backend recovery, a transient embed/upsert failure still gets the full 5 retries
- [ ] After 200 deferrals, the job is marked as failed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
