### PR TITLE
Add migration to reconcile pre-upgrade deferral history

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -374,6 +374,7 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN invalid_at INTEGER`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_jobs ADD COLUMN deferrals INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
 
+  migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
 
   // Indexes for query performance on large datasets
@@ -418,6 +419,32 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_entities_entity ON memory_item_entities(entity_id)`);
 
   migrateMemoryFtsBackfill(database);
+}
+
+/**
+ * One-time migration: reconcile old deferral history into the new `deferrals` column.
+ *
+ * Before the `deferrals` column was added, `deferMemoryJob` incremented `attempts`.
+ * After the column is added with DEFAULT 0, those jobs still carry the old attempt
+ * count (which was really a deferral count) while `deferrals` is 0. This moves the
+ * attempt count into `deferrals` and resets `attempts` to 0 for affected jobs.
+ *
+ * Affected jobs: status='pending' (deferred jobs are returned to pending), attempts > 0,
+ * deferrals = 0 (not yet migrated).
+ *
+ * Idempotent: once deferrals > 0 or attempts = 0, rows are no longer matched.
+ */
+function migrateJobDeferrals(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  raw.exec(/*sql*/ `
+    UPDATE memory_jobs
+    SET deferrals = attempts,
+        attempts = 0,
+        updated_at = ${Date.now()}
+    WHERE status = 'pending'
+      AND attempts > 0
+      AND deferrals = 0
+  `);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a one-time idempotent migration in `initializeDb` that reconciles old deferral history into the new `deferrals` column
- For pending jobs with `attempts > 0` and `deferrals = 0` (indicating they were deferred under the old model where `deferMemoryJob` incremented `attempts`), moves the attempt count into `deferrals` and resets `attempts` to 0
- Ensures correct backoff/failure decisions and preserves the full retry budget for actual transient errors

Addresses review feedback on #1615: when `deferrals` column was added with `DEFAULT 0`, pre-upgrade jobs lost their prior deferral count, leaving them with inconsistent counters during/after an outage.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify migration is idempotent (running `initializeDb` multiple times does not re-modify already-migrated jobs)
- [ ] Confirm that after upgrade, a pending job with old `attempts=5` gets `deferrals=5, attempts=0`
- [ ] Confirm that completed/failed/running jobs are not affected by the migration
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
