### PR TITLE
Clean up orphaned memory items when deleting blocked message

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
-import { eq, desc, asc, and, count, sql } from 'drizzle-orm';
+import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages, messageRuns, channelInboundEvents } from './schema.js';
+import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -250,13 +250,24 @@ export function deleteLastExchange(conversationId: string): number {
  * NULL before the message row is removed, so associated run and event
  * records survive.
  *
- * Other tables with NOT NULL FK references (memory_segments,
- * memory_item_sources, message_attachments) cascade-delete normally,
- * which is fine — for a freshly blocked message they will be empty.
+ * Also cleans up derived memory_items: if the memory worker has already
+ * processed an extract_items job for this message, deleting the message
+ * cascades memory_item_sources but leaves the memory_items active.
+ * Without cleanup, those items would leak into summaries and recall.
+ * We delete any memory_items that become orphaned (no remaining sources)
+ * after this message is removed.
  */
 export function deleteMessageById(messageId: string): void {
   const db = getDb();
   db.transaction((tx) => {
+    // Collect memory item IDs linked to this message before cascade.
+    const linkedItems = tx
+      .select({ memoryItemId: memoryItemSources.memoryItemId })
+      .from(memoryItemSources)
+      .where(eq(memoryItemSources.messageId, messageId))
+      .all();
+    const candidateItemIds = linkedItems.map((r) => r.memoryItemId);
+
     // Detach nullable FK references so the cascade doesn't destroy them.
     tx.update(messageRuns)
       .set({ messageId: null })
@@ -267,7 +278,38 @@ export function deleteMessageById(messageId: string): void {
       .where(eq(channelInboundEvents.messageId, messageId))
       .run();
 
-    // Now safe to delete — only NOT NULL cascades remain.
+    // Now safe to delete — NOT NULL cascades remove memory_item_sources,
+    // memory_segments, and message_attachments.
     tx.delete(messages).where(eq(messages.id, messageId)).run();
+
+    // Clean up orphaned memory items whose only source was this message.
+    if (candidateItemIds.length > 0) {
+      // Find which items still have at least one remaining source.
+      const surviving = tx
+        .select({ memoryItemId: memoryItemSources.memoryItemId })
+        .from(memoryItemSources)
+        .where(inArray(memoryItemSources.memoryItemId, candidateItemIds))
+        .all();
+      const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
+      const orphanedIds = candidateItemIds.filter((id) => !survivingIds.has(id));
+
+      if (orphanedIds.length > 0) {
+        // Delete memory_item_entities (no FK cascade on this table).
+        tx.delete(memoryItemEntities)
+          .where(inArray(memoryItemEntities.memoryItemId, orphanedIds))
+          .run();
+        // Delete embeddings referencing these items.
+        tx.delete(memoryEmbeddings)
+          .where(and(
+            eq(memoryEmbeddings.targetType, 'item'),
+            inArray(memoryEmbeddings.targetId, orphanedIds),
+          ))
+          .run();
+        // Delete the orphaned memory items themselves.
+        tx.delete(memoryItems)
+          .where(inArray(memoryItems.id, orphanedIds))
+          .run();
+      }
+    }
   });
 }


### PR DESCRIPTION
## Summary

Fixes a race condition where `deleteMessageById` (used when a pre-message hook blocks input) cascades `memory_item_sources` but leaves extracted `memory_items` active. If the memory worker has already processed `extract_items` for the blocked message, those items leak into `buildGlobalSummaryJob` summaries and future recall.

**Changes:**
- Before deleting the message, collect all `memory_item_id` values linked via `memory_item_sources`
- After the cascade deletes `memory_item_sources`, identify orphaned items (no remaining sources)
- Clean up `memory_item_entities`, `memory_embeddings`, and the `memory_items` rows for orphaned items

Addresses review feedback from #1605.

## Files modified
- `assistant/src/memory/conversation-store.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
