### PR TITLE
Normalize backslashes in hook path traversal check

### DIFF
--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -85,7 +85,10 @@ export function discoverHooks(hooksDir?: string): DiscoveredHook[] {
 
     const scriptPath = resolve(hookDir, manifest.script);
     const rel = relative(hookDir, scriptPath);
-    if (rel.startsWith('../') || rel === '..' || resolve(hookDir, rel) !== scriptPath) {
+    // Normalize backslashes so Windows-style traversal (e.g. `..\\..\\evil.js`) is
+    // also caught. This project targets macOS, but we check for defense in depth.
+    const normalizedRel = rel.replaceAll('\\', '/');
+    if (normalizedRel.startsWith('../') || normalizedRel === '..' || resolve(hookDir, rel) !== scriptPath) {
       log.warn({ hookDir, script: manifest.script }, 'Hook script path traversal detected, skipping');
       continue;
     }


### PR DESCRIPTION
## Summary
- Normalizes backslashes to forward slashes in the relative path before the traversal check in `discovery.ts`
- On Windows, `path.relative()` emits backslash segments (e.g. `..\\..\\evil.js`) which bypassed the existing `../` guard
- This project targets macOS, but the check is added for defense in depth

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Forward-slash traversals (`../../etc/passwd`) are still rejected
- Backslash traversals (`..\\..\\evil.js`) are now also rejected
- Normal hook scripts within the hook directory are unaffected

Addresses review feedback from #1596.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
