### PR TITLE
Narrow deferral migration to exclude legitimately-retried jobs

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -430,7 +430,9 @@ export function initializeDb(): void {
  * attempt count into `deferrals` and resets `attempts` to 0 for affected jobs.
  *
  * Affected jobs: status='pending' (deferred jobs are returned to pending), attempts > 0,
- * deferrals = 0 (not yet migrated).
+ * deferrals = 0 (not yet migrated), last_error IS NULL (excludes jobs retried via
+ * failMemoryJob which always sets lastError), and only embed job types (embed_segment,
+ * embed_item, embed_summary) since only those can enter the deferral path.
  *
  * Idempotent: once deferrals > 0 or attempts = 0, rows are no longer matched.
  */
@@ -444,6 +446,8 @@ function migrateJobDeferrals(database: ReturnType<typeof drizzle<typeof schema>>
     WHERE status = 'pending'
       AND attempts > 0
       AND deferrals = 0
+      AND last_error IS NULL
+      AND type IN ('embed_segment', 'embed_item', 'embed_summary')
   `);
 }
 


### PR DESCRIPTION
## Summary
- Adds `AND last_error IS NULL` to the `migrateJobDeferrals` WHERE clause, since `failMemoryJob` always sets `lastError` to a non-null error string while the old `deferMemoryJob` did not
- Restricts migration to embed job types (`embed_segment`, `embed_item`, `embed_summary`) since only those can enter the deferral path via `BackendUnavailableError`
- Prevents the migration from misidentifying legitimately-retried jobs as old deferred jobs, which would reset their retry count and corrupt the deferrals counter

Addresses review feedback on #1616.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify that pending embed jobs with `attempts > 0`, `deferrals = 0`, and `last_error IS NULL` are migrated
- [ ] Verify that pending jobs with `last_error` set (from `failMemoryJob`) are not migrated
- [ ] Verify that non-embed pending jobs with `attempts > 0` are not migrated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
