### PR TITLE
M2: Skills config schema and state management

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -92,4 +92,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     retentionDays: 0,
   },
   pricingOverrides: [],
+  skills: {
+    entries: {},
+    load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+    install: { nodeManager: 'npm' },
+    allowBundled: null,
+  },
 };

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -320,6 +320,32 @@ export const ModelPricingOverrideSchema = z.object({
     .nonnegative('pricingOverrides[].outputPer1M must be a non-negative number'),
 });
 
+export const SkillEntryConfigSchema = z.object({
+  enabled: z.boolean({ error: 'skills.entries[].enabled must be a boolean' }).default(true),
+  apiKey: z.string({ error: 'skills.entries[].apiKey must be a string' }).optional(),
+  env: z.record(z.string(), z.string({ error: 'skills.entries[].env values must be strings' })).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const SkillsLoadConfigSchema = z.object({
+  extraDirs: z.array(z.string({ error: 'skills.load.extraDirs values must be strings' })).default([]),
+  watch: z.boolean({ error: 'skills.load.watch must be a boolean' }).default(true),
+  watchDebounceMs: z.number({ error: 'skills.load.watchDebounceMs must be a number' }).int().positive().default(250),
+});
+
+export const SkillsInstallConfigSchema = z.object({
+  nodeManager: z.enum(['npm', 'pnpm', 'yarn', 'bun'], {
+    error: 'skills.install.nodeManager must be one of: npm, pnpm, yarn, bun',
+  }).default('npm'),
+});
+
+export const SkillsConfigSchema = z.object({
+  entries: z.record(z.string(), SkillEntryConfigSchema).default({}),
+  load: SkillsLoadConfigSchema.default({ extraDirs: [], watch: true, watchDebounceMs: 250 }),
+  install: SkillsInstallConfigSchema.default({ nodeManager: 'npm' }),
+  allowBundled: z.array(z.string()).nullable().default(null),
+});
+
 export const AssistantConfigSchema = z.object({
   provider: z
     .enum(VALID_PROVIDERS, {
@@ -427,6 +453,12 @@ export const AssistantConfigSchema = z.object({
   pricingOverrides: z
     .array(ModelPricingOverrideSchema)
     .default([]),
+  skills: SkillsConfigSchema.default({
+    entries: {},
+    load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+    install: { nodeManager: 'npm' },
+    allowBundled: null,
+  }),
 }).superRefine((config, ctx) => {
   if (config.contextWindow.targetInputTokens >= config.contextWindow.maxInputTokens) {
     ctx.addIssue({
@@ -464,3 +496,7 @@ export type MemoryEntityConfig = z.infer<typeof MemoryEntityConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
 export type QdrantConfig = z.infer<typeof QdrantConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
+export type SkillEntryConfig = z.infer<typeof SkillEntryConfigSchema>;
+export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;
+export type SkillsInstallConfig = z.infer<typeof SkillsInstallConfigSchema>;
+export type SkillsConfig = z.infer<typeof SkillsConfigSchema>;

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,0 +1,95 @@
+import type { SkillSummary } from './skills.js';
+import type { AssistantConfig, SkillEntryConfig } from './schema.js';
+import { checkSkillRequirements } from './skills.js';
+
+export type SkillState = 'enabled' | 'disabled' | 'degraded' | 'available';
+
+export interface ResolvedSkill {
+  summary: SkillSummary;
+  state: SkillState;
+  degraded: boolean;
+  missingRequirements?: { bins?: string[]; env?: string[] };
+  configEntry?: SkillEntryConfig;
+}
+
+export function resolveSkillStates(
+  catalog: SkillSummary[],
+  config: AssistantConfig,
+): ResolvedSkill[] {
+  const results: ResolvedSkill[] = [];
+  const { entries, allowBundled } = config.skills;
+
+  for (const skill of catalog) {
+    // Filter bundled skills by allowlist
+    if (skill.source === 'bundled' && allowBundled !== null && !allowBundled.includes(skill.id)) {
+      continue;
+    }
+
+    const configKey = skill.id;
+    const entry = entries[configKey];
+
+    // Determine enabled state
+    let isEnabled: boolean;
+    if (entry && typeof entry.enabled === 'boolean') {
+      isEnabled = entry.enabled;
+    } else {
+      // Default: bundled skills are enabled, others are disabled
+      isEnabled = skill.source === 'bundled';
+    }
+
+    if (!isEnabled) {
+      results.push({
+        summary: skill,
+        state: 'disabled',
+        degraded: false,
+        configEntry: entry,
+      });
+      continue;
+    }
+
+    // Check requirements for enabled skills
+    const envOverrides = buildEnvOverrides(skill, entry);
+    const reqCheck = checkSkillRequirements(skill, envOverrides);
+
+    if (!reqCheck.eligible) {
+      results.push({
+        summary: skill,
+        state: 'enabled',
+        degraded: true,
+        missingRequirements: reqCheck.missing,
+        configEntry: entry,
+      });
+    } else {
+      results.push({
+        summary: skill,
+        state: 'enabled',
+        degraded: false,
+        configEntry: entry,
+      });
+    }
+  }
+
+  return results;
+}
+
+function buildEnvOverrides(
+  skill: SkillSummary,
+  entry?: SkillEntryConfig,
+): Record<string, string> | undefined {
+  if (!entry) return undefined;
+  const overrides: Record<string, string> = {};
+
+  // Map apiKey to primaryEnv
+  if (entry.apiKey && skill.metadata?.primaryEnv) {
+    overrides[skill.metadata.primaryEnv] = entry.apiKey;
+  }
+
+  // Add explicit env overrides
+  if (entry.env) {
+    for (const [key, value] of Object.entries(entry.env)) {
+      overrides[key] = value;
+    }
+  }
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -507,14 +507,65 @@ function skillSummaryFromDefinition(skill: SkillDefinition, source: SkillSource)
   };
 }
 
-export function loadSkillCatalog(workspaceSkillsDir?: string): SkillSummary[] {
+export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string[]): SkillSummary[] {
   const catalog: SkillSummary[] = [];
   const seenIds = new Set<string>();
 
-  // Load bundled skills first
+  // Load extra directories first (lowest precedence, before bundled)
+  if (extraDirs) {
+    for (const dir of extraDirs) {
+      if (!existsSync(dir)) continue;
+      const dirs = discoverSkillDirectories(dir);
+      for (const directory of dirs) {
+        const skillFilePath = join(directory, 'SKILL.md');
+        if (!existsSync(skillFilePath)) continue;
+
+        try {
+          const stat = statSync(skillFilePath);
+          if (!stat.isFile()) continue;
+
+          const content = readFileSync(skillFilePath, 'utf-8');
+          const parsed = parseFrontmatter(content, skillFilePath);
+          if (!parsed) continue;
+
+          const id = basename(directory);
+          if (seenIds.has(id)) {
+            log.warn({ id, directory }, 'Skipping duplicate skill id from extraDirs');
+            continue;
+          }
+
+          seenIds.add(id);
+          catalog.push({
+            id,
+            name: parsed.name,
+            description: parsed.description,
+            directoryPath: directory,
+            skillFilePath,
+            emoji: parsed.metadata?.emoji,
+            homepage: parsed.homepage,
+            userInvocable: parsed.userInvocable,
+            disableModelInvocation: parsed.disableModelInvocation,
+            source: 'managed',
+            metadata: parsed.metadata,
+          });
+        } catch (err) {
+          log.warn({ err, directory }, 'Failed to read skill from extraDirs');
+        }
+      }
+    }
+  }
+
+  // Load bundled skills (override extraDirs skills with same ID)
   const bundledSkills = loadBundledSkills();
   for (const skill of bundledSkills) {
     if (seenIds.has(skill.id)) {
+      // Bundled wins over extraDirs
+      const existingIndex = catalog.findIndex((s) => s.id === skill.id);
+      if (existingIndex !== -1 && catalog[existingIndex].source === 'managed') {
+        log.info({ id: skill.id, directory: skill.directoryPath }, 'Bundled skill overrides extraDirs skill');
+        catalog[existingIndex] = skill;
+        continue;
+      }
       log.warn({ id: skill.id, directory: skill.directoryPath }, 'Skipping duplicate bundled skill id');
       continue;
     }

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -19,4 +19,8 @@ export type {
   MemoryConfig,
   ModelPricingOverride,
   QdrantConfig,
+  SkillEntryConfig,
+  SkillsLoadConfig,
+  SkillsInstallConfig,
+  SkillsConfig,
 } from './schema.js';


### PR DESCRIPTION
Part of #1606. Adds SkillsConfigSchema to vellum.json config (entries, load, install, allowBundled) and skill state resolution that merges filesystem discovery with config entries. Closes #1608.

## Summary
- Add `SkillEntryConfigSchema`, `SkillsLoadConfigSchema`, `SkillsInstallConfigSchema`, and `SkillsConfigSchema` to the Zod config schema with per-skill entries (enabled, apiKey, env, config), load settings (extraDirs, watch, watchDebounceMs), install settings (nodeManager), and bundled skill allowlisting
- Create `skill-state.ts` with `resolveSkillStates()` that merges filesystem skill catalog with config entries to determine enabled/disabled/degraded state, mapping apiKey and env overrides to requirement checks
- Update `loadSkillCatalog()` to accept an optional `extraDirs` parameter for scanning additional skill directories at lowest precedence (before bundled)
- Update `defaults.ts` and `types.ts` to include the new skills config

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed)
- [ ] Verify existing skill loading still works without config changes (extraDirs defaults to undefined)
- [ ] Test that skills config in vellum.json is validated and defaults applied correctly
- [ ] Test resolveSkillStates with bundled skills (default enabled), managed skills (default disabled), and allowBundled filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
