### PR TITLE
Skills IPC protocol extensions and handlers (#1609)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -176,6 +176,69 @@ exports[`IPC message snapshots ClientMessage types skill_detail serializes to ex
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types skills_enable serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_enable",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_disable serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_disable",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_configure serializes to expected JSON 1`] = `
+{
+  "apiKey": "sk-test",
+  "config": {
+    "verbose": true,
+  },
+  "env": {
+    "API_KEY": "test-key",
+  },
+  "name": "my-skill",
+  "type": "skills_configure",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_install serializes to expected JSON 1`] = `
+{
+  "slug": "clawhub/my-skill",
+  "type": "skills_install",
+  "version": "1.0.0",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_uninstall serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_uninstall",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_update serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "type": "skills_update",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_check_updates serializes to expected JSON 1`] = `
+{
+  "type": "skills_check_updates",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types skills_search serializes to expected JSON 1`] = `
+{
+  "query": "weather",
+  "type": "skills_search",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types suggestion_request serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -191,6 +254,31 @@ exports[`IPC message snapshots ClientMessage types add_trust_rule serializes to 
   "scope": "/projects/my-app",
   "toolName": "bash",
   "type": "add_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types trust_rules_list serializes to expected JSON 1`] = `
+{
+  "type": "trust_rules_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types remove_trust_rule serializes to expected JSON 1`] = `
+{
+  "id": "rule-001",
+  "type": "remove_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types update_trust_rule serializes to expected JSON 1`] = `
+{
+  "decision": "allow",
+  "id": "rule-001",
+  "pattern": "git push *",
+  "priority": 50,
+  "scope": "/projects/my-app",
+  "tool": "bash",
+  "type": "update_trust_rule",
 }
 `;
 
@@ -562,12 +650,33 @@ exports[`IPC message snapshots ServerMessage types skills_list_response serializ
 {
   "skills": [
     {
+      "degraded": false,
       "description": "A test skill",
-      "id": "my-skill",
+      "emoji": "🔧",
       "name": "My Skill",
+      "source": "bundled",
+      "state": "enabled",
+      "updateAvailable": false,
+      "userInvocable": true,
     },
   ],
   "type": "skills_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_state_changed serializes to expected JSON 1`] = `
+{
+  "name": "my-skill",
+  "state": "enabled",
+  "type": "skills_state_changed",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types skills_operation_response serializes to expected JSON 1`] = `
+{
+  "operation": "enable",
+  "success": true,
+  "type": "skills_operation_response",
 }
 `;
 
@@ -616,31 +725,6 @@ exports[`IPC message snapshots ServerMessage types timer_completed serializes to
   "sessionId": "sess-001",
   "timerId": "tmr-001",
   "type": "timer_completed",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types trust_rules_list serializes to expected JSON 1`] = `
-{
-  "type": "trust_rules_list",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types remove_trust_rule serializes to expected JSON 1`] = `
-{
-  "id": "rule-001",
-  "type": "remove_trust_rule",
-}
-`;
-
-exports[`IPC message snapshots ClientMessage types update_trust_rule serializes to expected JSON 1`] = `
-{
-  "decision": "allow",
-  "id": "rule-001",
-  "pattern": "git push *",
-  "priority": 50,
-  "scope": "/projects/my-app",
-  "tool": "bash",
-  "type": "update_trust_rule",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -125,6 +125,41 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skill_detail',
     skillId: 'my-skill',
   },
+  skills_enable: {
+    type: 'skills_enable',
+    name: 'my-skill',
+  },
+  skills_disable: {
+    type: 'skills_disable',
+    name: 'my-skill',
+  },
+  skills_configure: {
+    type: 'skills_configure',
+    name: 'my-skill',
+    env: { API_KEY: 'test-key' },
+    apiKey: 'sk-test',
+    config: { verbose: true },
+  },
+  skills_install: {
+    type: 'skills_install',
+    slug: 'clawhub/my-skill',
+    version: '1.0.0',
+  },
+  skills_uninstall: {
+    type: 'skills_uninstall',
+    name: 'my-skill',
+  },
+  skills_update: {
+    type: 'skills_update',
+    name: 'my-skill',
+  },
+  skills_check_updates: {
+    type: 'skills_check_updates',
+  },
+  skills_search: {
+    type: 'skills_search',
+    query: 'weather',
+  },
   suggestion_request: {
     type: 'suggestion_request',
     sessionId: 'sess-001',
@@ -377,8 +412,27 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   skills_list_response: {
     type: 'skills_list_response',
     skills: [
-      { id: 'my-skill', name: 'My Skill', description: 'A test skill' },
+      {
+        name: 'My Skill',
+        description: 'A test skill',
+        emoji: '🔧',
+        source: 'bundled',
+        state: 'enabled',
+        degraded: false,
+        updateAvailable: false,
+        userInvocable: true,
+      },
     ],
+  },
+  skills_state_changed: {
+    type: 'skills_state_changed',
+    name: 'my-skill',
+    state: 'enabled',
+  },
+  skills_operation_response: {
+    type: 'skills_operation_response',
+    operation: 'enable',
+    success: true,
   },
   skill_detail_response: {
     type: 'skill_detail_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import Anthropic from '@anthropic-ai/sdk';
-import { getConfig, loadRawConfig, saveRawConfig } from '../config/loader.js';
+import { getConfig, loadRawConfig, saveRawConfig, setNestedValue, invalidateConfigCache } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -27,6 +27,14 @@ import type {
   TaskSubmit,
   AppDataRequest,
   SkillDetailRequest,
+  SkillsEnableRequest,
+  SkillsDisableRequest,
+  SkillsConfigureRequest,
+  SkillsInstallRequest,
+  SkillsUninstallRequest,
+  SkillsUpdateRequest,
+  SkillsCheckUpdatesRequest,
+  SkillsSearchRequest,
   SuggestionRequest,
   AddTrustRule,
   TrustRulesList,
@@ -35,6 +43,7 @@ import type {
 } from './ipc-protocol.js';
 import { addRule, removeRule, updateRule, getAllRules } from '../permissions/trust-store.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
+import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
@@ -255,6 +264,7 @@ export interface HandlerContext {
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
   send(socket: net.Socket, msg: ServerMessage): void;
+  broadcast(msg: ServerMessage): void;
   getOrCreateSession(
     conversationId: string,
     socket?: net.Socket,
@@ -295,6 +305,14 @@ const handlers: DispatchMap = {
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
+  skills_enable: handleSkillsEnable,
+  skills_disable: handleSkillsDisable,
+  skills_configure: handleSkillsConfigure,
+  skills_install: handleSkillsInstall,
+  skills_uninstall: handleSkillsUninstall,
+  skills_update: handleSkillsUpdate,
+  skills_check_updates: handleSkillsCheckUpdates,
+  skills_search: handleSkillsSearch,
   suggestion_request: handleSuggestionRequest,
   add_trust_rule: handleAddTrustRule,
   trust_rules_list: (_msg, socket, ctx) => handleTrustRulesList(socket, ctx),
@@ -652,19 +670,239 @@ function handleUsageRequest(
 // ─── Skills handlers ─────────────────────────────────────────────────────────
 
 function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
+  const config = getConfig();
   const catalog = loadSkillCatalog();
-  // Respond immediately with cached icons (sync reads only)
-  const skills = catalog.map((s) => {
-    const icon = readCachedSkillIcon(s.directoryPath);
-    return { id: s.id, name: s.name, description: s.description, ...(icon ? { icon } : {}) };
-  });
-  ctx.send(socket, { type: 'skills_list_response', skills });
+  const resolved = resolveSkillStates(catalog, config);
 
-  // Generate missing icons in the background (fire-and-forget)
-  const missing = catalog.filter((s) => !readCachedSkillIcon(s.directoryPath));
-  if (missing.length > 0) {
-    Promise.all(missing.map((s) => ensureSkillIcon(s.directoryPath, s.name, s.description))).catch(() => {});
+  const skills = resolved.map((r) => ({
+    name: r.summary.name,
+    description: r.summary.description,
+    emoji: r.summary.emoji,
+    homepage: r.summary.homepage,
+    source: r.summary.source as 'bundled' | 'managed' | 'workspace' | 'clawhub',
+    state: (r.state === 'degraded' ? 'enabled' : r.state) as 'enabled' | 'disabled' | 'available',
+    degraded: r.degraded,
+    missingRequirements: r.missingRequirements,
+    updateAvailable: false,
+    userInvocable: r.summary.userInvocable,
+  }));
+
+  ctx.send(socket, { type: 'skills_list_response', skills });
+}
+
+function handleSkillsEnable(
+  msg: SkillsEnableRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const raw = loadRawConfig();
+    setNestedValue(raw, `skills.entries.${msg.name}.enabled`, true);
+
+    ctx.setSuppressConfigReload(true);
+    try {
+      saveRawConfig(raw);
+    } catch (err) {
+      ctx.setSuppressConfigReload(false);
+      throw err;
+    }
+    invalidateConfigCache();
+
+    const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
+    if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+
+    ctx.updateConfigFingerprint();
+
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'enable',
+      success: true,
+    });
+    ctx.broadcast({
+      type: 'skills_state_changed',
+      name: msg.name,
+      state: 'enabled',
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to enable skill');
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'enable',
+      success: false,
+      error: message,
+    });
   }
+}
+
+function handleSkillsDisable(
+  msg: SkillsDisableRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const raw = loadRawConfig();
+    setNestedValue(raw, `skills.entries.${msg.name}.enabled`, false);
+
+    ctx.setSuppressConfigReload(true);
+    try {
+      saveRawConfig(raw);
+    } catch (err) {
+      ctx.setSuppressConfigReload(false);
+      throw err;
+    }
+    invalidateConfigCache();
+
+    const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
+    if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+
+    ctx.updateConfigFingerprint();
+
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'disable',
+      success: true,
+    });
+    ctx.broadcast({
+      type: 'skills_state_changed',
+      name: msg.name,
+      state: 'disabled',
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to disable skill');
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'disable',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+function handleSkillsConfigure(
+  msg: SkillsConfigureRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const raw = loadRawConfig();
+
+    if (msg.env) {
+      setNestedValue(raw, `skills.entries.${msg.name}.env`, msg.env);
+    }
+    if (msg.apiKey !== undefined) {
+      setNestedValue(raw, `skills.entries.${msg.name}.apiKey`, msg.apiKey);
+    }
+    if (msg.config) {
+      setNestedValue(raw, `skills.entries.${msg.name}.config`, msg.config);
+    }
+
+    ctx.setSuppressConfigReload(true);
+    try {
+      saveRawConfig(raw);
+    } catch (err) {
+      ctx.setSuppressConfigReload(false);
+      throw err;
+    }
+    invalidateConfigCache();
+
+    const existingSuppressTimer = ctx.debounceTimers.get('__suppress_reset__');
+    if (existingSuppressTimer) clearTimeout(existingSuppressTimer);
+    const resetTimer = setTimeout(() => { ctx.setSuppressConfigReload(false); }, 300);
+    ctx.debounceTimers.set('__suppress_reset__', resetTimer);
+
+    ctx.updateConfigFingerprint();
+
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'configure',
+      success: true,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to configure skill');
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'configure',
+      success: false,
+      error: message,
+    });
+  }
+}
+
+function handleSkillsInstall(
+  msg: SkillsInstallRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  log.warn({ slug: msg.slug }, 'skills_install not yet implemented');
+  ctx.send(socket, {
+    type: 'skills_operation_response',
+    operation: 'install',
+    success: false,
+    error: 'Not yet implemented',
+  });
+}
+
+function handleSkillsUninstall(
+  msg: SkillsUninstallRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  log.warn({ name: msg.name }, 'skills_uninstall not yet implemented');
+  ctx.send(socket, {
+    type: 'skills_operation_response',
+    operation: 'uninstall',
+    success: false,
+    error: 'Not yet implemented',
+  });
+}
+
+function handleSkillsUpdate(
+  msg: SkillsUpdateRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  log.warn({ name: msg.name }, 'skills_update not yet implemented');
+  ctx.send(socket, {
+    type: 'skills_operation_response',
+    operation: 'update',
+    success: false,
+    error: 'Not yet implemented',
+  });
+}
+
+function handleSkillsCheckUpdates(
+  _msg: SkillsCheckUpdatesRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  log.warn('skills_check_updates not yet implemented');
+  ctx.send(socket, {
+    type: 'skills_operation_response',
+    operation: 'check_updates',
+    success: false,
+    error: 'Not yet implemented',
+  });
+}
+
+function handleSkillsSearch(
+  msg: SkillsSearchRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  log.warn({ query: msg.query }, 'skills_search not yet implemented');
+  ctx.send(socket, {
+    type: 'skills_operation_response',
+    operation: 'search',
+    success: false,
+    error: 'Not yet implemented',
+  });
 }
 
 async function handleSkillDetail(

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -149,6 +149,49 @@ export interface SkillDetailRequest {
   skillId: string;
 }
 
+export interface SkillsEnableRequest {
+  type: 'skills_enable';
+  name: string;
+}
+
+export interface SkillsDisableRequest {
+  type: 'skills_disable';
+  name: string;
+}
+
+export interface SkillsConfigureRequest {
+  type: 'skills_configure';
+  name: string;
+  env?: Record<string, string>;
+  apiKey?: string;
+  config?: Record<string, unknown>;
+}
+
+export interface SkillsInstallRequest {
+  type: 'skills_install';
+  slug: string;
+  version?: string;
+}
+
+export interface SkillsUninstallRequest {
+  type: 'skills_uninstall';
+  name: string;
+}
+
+export interface SkillsUpdateRequest {
+  type: 'skills_update';
+  name: string;
+}
+
+export interface SkillsCheckUpdatesRequest {
+  type: 'skills_check_updates';
+}
+
+export interface SkillsSearchRequest {
+  type: 'skills_search';
+  query: string;
+}
+
 export interface SuggestionRequest {
   type: 'suggestion_request';
   sessionId: string;
@@ -309,6 +352,14 @@ export type ClientMessage =
   | AppDataRequest
   | SkillsListRequest
   | SkillDetailRequest
+  | SkillsEnableRequest
+  | SkillsDisableRequest
+  | SkillsConfigureRequest
+  | SkillsInstallRequest
+  | SkillsUninstallRequest
+  | SkillsUpdateRequest
+  | SkillsCheckUpdatesRequest
+  | SkillsSearchRequest
   | SuggestionRequest
   | AddTrustRule
   | TrustRulesList
@@ -552,7 +603,34 @@ export interface AppDataResponse {
 
 export interface SkillsListResponse {
   type: 'skills_list_response';
-  skills: Array<{ id: string; name: string; description: string; icon?: string }>;
+  skills: Array<{
+    name: string;
+    description: string;
+    emoji?: string;
+    homepage?: string;
+    source: 'bundled' | 'managed' | 'workspace' | 'clawhub';
+    state: 'enabled' | 'disabled' | 'available';
+    degraded: boolean;
+    missingRequirements?: { bins?: string[]; env?: string[]; permissions?: string[] };
+    installedVersion?: string;
+    latestVersion?: string;
+    updateAvailable: boolean;
+    userInvocable: boolean;
+    clawhub?: { author: string; stars: number; installs: number; reports: number; publishedAt: string };
+  }>;
+}
+
+export interface SkillStateChanged {
+  type: 'skills_state_changed';
+  name: string;
+  state: 'enabled' | 'disabled' | 'installed' | 'uninstalled';
+}
+
+export interface SkillsOperationResponse {
+  type: 'skills_operation_response';
+  operation: string;
+  success: boolean;
+  error?: string;
 }
 
 export interface SkillDetailResponse {
@@ -705,6 +783,8 @@ export type ServerMessage =
   | AppDataResponse
   | SkillsListResponse
   | SkillDetailResponse
+  | SkillStateChanged
+  | SkillsOperationResponse
   | SuggestionResponse
   | MessageQueued
   | MessageDequeued

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -408,6 +408,12 @@ export class DaemonServer {
     }
   }
 
+  private broadcast(msg: ServerMessage): void {
+    for (const socket of this.connectedSockets) {
+      this.send(socket, msg);
+    }
+  }
+
   private async sendInitialSession(socket: net.Socket): Promise<void> {
     // Get or create a session
     let conversation = conversationStore.getLatestConversation();
@@ -527,6 +533,7 @@ export class DaemonServer {
         this.lastConfigRefreshTime = Date.now();
       },
       send: (socket, msg) => this.send(socket, msg),
+      broadcast: (msg) => this.broadcast(msg),
       getOrCreateSession: (id, socket?, rebind?, options?) =>
         this.getOrCreateSession(id, socket, rebind, options),
     };


### PR DESCRIPTION
## Summary
- Extended the IPC protocol with 8 new client-to-server skill management message types: `skills_enable`, `skills_disable`, `skills_configure`, `skills_install`, `skills_uninstall`, `skills_update`, `skills_check_updates`, `skills_search`
- Replaced the simple `SkillsListResponse` with a richer shape that uses `resolveSkillStates()` to include state, degraded status, missing requirements, source, emoji, homepage, and userInvocable fields
- Added `SkillStateChanged` push event and `SkillsOperationResponse` generic response for mutating operations
- Implemented handlers for enable/disable/configure with proper config save pattern (loadRawConfig + setNestedValue + saveRawConfig + suppress/debounce)
- Stubbed install/uninstall/update/check_updates/search handlers for M4 ClaWHub integration
- Added `broadcast()` method to HandlerContext for push events to all connected clients
- Updated IPC snapshot tests for all new message types

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests pass with updated snapshots (77/77 pass)
- [x] All new client message types are in the `ClientMessage` union
- [x] All new server message types are in the `ServerMessage` union
- [x] Enable/disable/configure handlers follow the `handleModelSet` config save pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
