### PR TITLE
Swift IPC types and DaemonClient methods for skills management (#1612)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -180,7 +180,7 @@ struct AgentPanel: View {
         }
     }
 
-    private func skillCard(_ skill: SkillSummaryItem) -> some View {
+    private func skillCard(_ skill: SkillInfo) -> some View {
         let isExpanded = expandedSkillId == skill.id
         let isHovered = hoveredSkillButtonId == skill.id
         let borderColor = isHovered ? Amber._600.opacity(0.8) : Amber._700.opacity(0.6)
@@ -192,7 +192,7 @@ struct AgentPanel: View {
                     // TODO: implement skill usage
                 }) {
                     HStack(spacing: VSpacing.md) {
-                        skillIcon(skill.icon)
+                        skillIcon(skill.emoji)
 
                         Text(skill.name)
                             .font(VFont.mono)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @MainActor
 final class SkillsManager: ObservableObject {
-    @Published var skills: [SkillSummaryItem] = []
+    @Published var skills: [SkillInfo] = []
     @Published var loadedBodies: [String: String] = [:]
     @Published var isLoading = false
 

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -62,6 +62,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `trust_rules_list_response` message.
     var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
 
+    /// Called when the daemon sends a `skills_state_changed` push event.
+    var onSkillStateChanged: ((SkillStateChangedMessage) -> Void)?
+
+    /// Called when the daemon sends a `skills_updates_available` push event.
+    var onSkillsUpdatesAvailable: ((SkillsUpdatesAvailableMessage) -> Void)?
+
+    /// Called when the daemon sends a `skills_operation_response` message.
+    var onSkillsOperationResponse: ((SkillsOperationResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -359,6 +368,48 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         ))
     }
 
+    // MARK: - Skills Management
+
+    /// Enable a skill by name.
+    func enableSkill(_ name: String) throws {
+        try send(SkillsEnableMessage(name: name))
+    }
+
+    /// Disable a skill by name.
+    func disableSkill(_ name: String) throws {
+        try send(SkillsDisableMessage(name: name))
+    }
+
+    /// Install a skill from ClaWHub.
+    func installSkill(slug: String, version: String? = nil) throws {
+        try send(SkillsInstallMessage(slug: slug, version: version))
+    }
+
+    /// Uninstall a skill by name.
+    func uninstallSkill(_ name: String) throws {
+        try send(SkillsUninstallMessage(name: name))
+    }
+
+    /// Update a skill to its latest version.
+    func updateSkill(_ name: String) throws {
+        try send(SkillsUpdateMessage(name: name))
+    }
+
+    /// Check for available skill updates.
+    func checkSkillUpdates() throws {
+        try send(SkillsCheckUpdatesMessage())
+    }
+
+    /// Search for skills on ClaWHub.
+    func searchSkills(query: String) throws {
+        try send(SkillsSearchMessage(query: query))
+    }
+
+    /// Configure a skill's environment, API key, or config.
+    func configureSkill(name: String, env: [String: String]? = nil, apiKey: String? = nil, config: [String: AnyCodable]? = nil) throws {
+        try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -489,6 +540,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTimerCompleted?(msg)
         case .trustRulesListResponse(let msg):
             onTrustRulesListResponse?(msg.rules)
+        case .skillStateChanged(let msg):
+            onSkillStateChanged?(msg)
+        case .skillsUpdatesAvailable(let msg):
+            onSkillsUpdatesAvailable?(msg)
+        case .skillsOperationResponse(let msg):
+            onSkillsOperationResponse?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -220,6 +220,57 @@ struct SkillDetailRequestMessage: Encodable, Sendable {
     let skillId: String
 }
 
+/// Enable a skill. Wire type: "skills_enable"
+struct SkillsEnableMessage: Encodable, Sendable {
+    let type: String = "skills_enable"
+    let name: String
+}
+
+/// Disable a skill. Wire type: "skills_disable"
+struct SkillsDisableMessage: Encodable, Sendable {
+    let type: String = "skills_disable"
+    let name: String
+}
+
+/// Configure a skill's env/apiKey/config. Wire type: "skills_configure"
+struct SkillsConfigureMessage: Encodable, Sendable {
+    let type: String = "skills_configure"
+    let name: String
+    let env: [String: String]?
+    let apiKey: String?
+    let config: [String: AnyCodable]?
+}
+
+/// Install a skill from ClaWHub. Wire type: "skills_install"
+struct SkillsInstallMessage: Encodable, Sendable {
+    let type: String = "skills_install"
+    let slug: String
+    let version: String?
+}
+
+/// Uninstall a skill. Wire type: "skills_uninstall"
+struct SkillsUninstallMessage: Encodable, Sendable {
+    let type: String = "skills_uninstall"
+    let name: String
+}
+
+/// Update a skill. Wire type: "skills_update"
+struct SkillsUpdateMessage: Encodable, Sendable {
+    let type: String = "skills_update"
+    let name: String
+}
+
+/// Check for skill updates. Wire type: "skills_check_updates"
+struct SkillsCheckUpdatesMessage: Encodable, Sendable {
+    let type: String = "skills_check_updates"
+}
+
+/// Search for skills on ClaWHub. Wire type: "skills_search"
+struct SkillsSearchMessage: Encodable, Sendable {
+    let type: String = "skills_search"
+    let query: String
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -380,18 +431,47 @@ struct AppDataResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
-/// A single skill summary item from the daemon's skill catalog.
-struct SkillSummaryItem: Decodable, Sendable, Identifiable {
-    let id: String
+/// ClaWHub metadata for a skill.
+struct ClawhubInfo: Codable, Sendable {
+    let author: String
+    let stars: Int
+    let installs: Int
+    let reports: Int
+    let publishedAt: String
+}
+
+/// Missing requirements preventing a skill from full operation.
+struct MissingRequirements: Codable, Sendable {
+    let bins: [String]?
+    let env: [String]?
+    let permissions: [String]?
+}
+
+/// Full skill info from the daemon's resolved skill list.
+struct SkillInfo: Codable, Sendable, Identifiable {
+    var id: String { name }
     let name: String
     let description: String
-    let icon: String?
+    let emoji: String?
+    let homepage: String?
+    let source: String  // "bundled" | "managed" | "workspace" | "clawhub"
+    let state: String   // "enabled" | "disabled" | "available"
+    let degraded: Bool
+    let missingRequirements: MissingRequirements?
+    let installedVersion: String?
+    let latestVersion: String?
+    let updateAvailable: Bool
+    let userInvocable: Bool
+    let clawhub: ClawhubInfo?
 }
+
+/// Backward-compatible alias for code referencing the old name.
+typealias SkillSummaryItem = SkillInfo
 
 /// Response containing the list of available skills.
 /// Wire type: `"skills_list_response"`
 struct SkillsListResponseMessage: Decodable, Sendable {
-    let skills: [SkillSummaryItem]
+    let skills: [SkillInfo]
 }
 
 /// Response containing the full body of a specific skill.
@@ -399,6 +479,29 @@ struct SkillsListResponseMessage: Decodable, Sendable {
 struct SkillDetailResponseMessage: Decodable, Sendable {
     let skillId: String
     let body: String
+    let error: String?
+}
+
+/// Push event: skill state changed. Wire type: "skills_state_changed"
+struct SkillStateChangedMessage: Decodable, Sendable {
+    let name: String
+    let state: String  // "enabled" | "disabled" | "installed" | "uninstalled"
+}
+
+/// Push event: updates available. Wire type: "skills_updates_available"
+struct SkillsUpdatesAvailableMessage: Decodable, Sendable {
+    struct UpdateInfo: Decodable, Sendable {
+        let name: String
+        let installedVersion: String
+        let latestVersion: String
+    }
+    let skills: [UpdateInfo]
+}
+
+/// Generic operation response. Wire type: "skills_operation_response"
+struct SkillsOperationResponseMessage: Decodable, Sendable {
+    let operation: String
+    let success: Bool
     let error: String?
 }
 
@@ -568,6 +671,9 @@ enum ServerMessage: Decodable, Sendable {
     case messageDequeued(MessageDequeuedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
+    case skillStateChanged(SkillStateChangedMessage)
+    case skillsUpdatesAvailable(SkillsUpdatesAvailableMessage)
+    case skillsOperationResponse(SkillsOperationResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
     case toolUseStart(ToolUseStartMessage)
     case toolOutputChunk(ToolOutputChunkMessage)
@@ -649,6 +755,15 @@ enum ServerMessage: Decodable, Sendable {
         case "skill_detail_response":
             let message = try SkillDetailResponseMessage(from: decoder)
             self = .skillDetailResponse(message)
+        case "skills_state_changed":
+            let message = try SkillStateChangedMessage(from: decoder)
+            self = .skillStateChanged(message)
+        case "skills_updates_available":
+            let message = try SkillsUpdatesAvailableMessage(from: decoder)
+            self = .skillsUpdatesAvailable(message)
+        case "skills_operation_response":
+            let message = try SkillsOperationResponseMessage(from: decoder)
+            self = .skillsOperationResponse(message)
         case "suggestion_response":
             let message = try SuggestionResponseMessage(from: decoder)
             self = .suggestionResponse(message)


### PR DESCRIPTION
## Summary
- Add 8 new client-to-server request structs for skills management: enable, disable, configure, install, uninstall, update, check updates, and search
- Replace `SkillSummaryItem` with richer `SkillInfo` struct including source, state, degraded status, version info, ClaWHub metadata, and missing requirements
- Add 3 push event response types: `SkillStateChangedMessage`, `SkillsUpdatesAvailableMessage`, `SkillsOperationResponseMessage`
- Wire up `ServerMessage` enum with new cases and decoder entries
- Add 8 `DaemonClient` convenience methods and 3 callback properties for push events
- Update `SkillsManager` and `AgentPanel` to use `SkillInfo` (with backward-compatible `SkillSummaryItem` typealias)

## Test plan
- [x] `swift build` succeeds with no errors
- [ ] Verify skills list still renders correctly in the Agent panel
- [ ] Verify new IPC messages serialize correctly when sent to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
