### PR TITLE
Add Skills submenu to menu bar (#1614)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -96,6 +96,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindowObserver: Any?
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
+    private var cachedSkills: [SkillInfo] = []
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
@@ -162,6 +163,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // Once connected, start ambient agent if it was waiting for daemon
             if daemonClient.isConnected {
                 setupAmbientAgent()
+                refreshSkillsCache()
             }
         }
     }
@@ -418,6 +420,45 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
+        // Skills submenu
+        let skillsItem = NSMenuItem(title: "Skills", action: nil, keyEquivalent: "")
+        skillsItem.image = NSImage(systemSymbolName: "puzzlepiece.extension", accessibilityDescription: nil)
+        let skillsSubmenu = NSMenu(title: "Skills")
+
+        let enabledSkills = cachedSkills.filter { $0.state == "enabled" }
+        let disabledSkills = cachedSkills.filter { $0.state != "enabled" }
+
+        for skill in enabledSkills {
+            let emoji = skill.emoji ?? "\u{1F527}"
+            let item = NSMenuItem(title: "\(emoji) \(skill.name)", action: #selector(toggleSkill(_:)), keyEquivalent: "")
+            item.target = self
+            item.state = .on
+            item.representedObject = skill.name
+            skillsSubmenu.addItem(item)
+        }
+
+        for skill in disabledSkills {
+            let emoji = skill.emoji ?? "\u{1F527}"
+            let item = NSMenuItem(title: "\(emoji) \(skill.name)", action: #selector(toggleSkill(_:)), keyEquivalent: "")
+            item.target = self
+            item.state = .off
+            item.representedObject = skill.name
+            skillsSubmenu.addItem(item)
+        }
+
+        if !cachedSkills.isEmpty {
+            skillsSubmenu.addItem(NSMenuItem.separator())
+        }
+
+        let manageItem = NSMenuItem(title: "Manage Skills...", action: #selector(showSettingsWindow(_:)), keyEquivalent: "")
+        manageItem.target = self
+        skillsSubmenu.addItem(manageItem)
+
+        skillsItem.submenu = skillsSubmenu
+        menu.addItem(skillsItem)
+
+        menu.addItem(NSMenuItem.separator())
+
         let settingsItem = NSMenuItem(title: "Settings...", action: #selector(showSettingsWindow(_:)), keyEquivalent: ",")
         settingsItem.target = self
         settingsItem.image = NSImage(systemSymbolName: "gear", accessibilityDescription: nil)
@@ -473,6 +514,31 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func toggleAmbientAgent() {
         ambientAgent.isEnabled = !ambientAgent.isEnabled
         updateMenuBarIcon()
+    }
+
+    @objc private func toggleSkill(_ sender: NSMenuItem) {
+        guard let name = sender.representedObject as? String else { return }
+        if sender.state == .on {
+            try? daemonClient.disableSkill(name)
+        } else {
+            try? daemonClient.enableSkill(name)
+        }
+        refreshSkillsCache()
+    }
+
+    private func refreshSkillsCache() {
+        Task {
+            let stream = daemonClient.subscribe()
+            do {
+                try daemonClient.send(SkillsListRequestMessage())
+            } catch { return }
+            for await message in stream {
+                if case .skillsListResponse(let response) = message {
+                    self.cachedSkills = response.skills
+                    return
+                }
+            }
+        }
     }
 
     #if DEBUG


### PR DESCRIPTION
## Summary
- Added Skills submenu to status bar context menu between "New Chat" and "Settings..."
- Enabled skills show a checkmark; clicking toggles enable/disable via DaemonClient IPC
- "Manage Skills..." item opens the Settings window
- Skills list is cached from daemon on connect and refreshed after each toggle

Part of #1606

Closes #1614
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
