### PR TITLE
Make deferral migration atomic and race-safe

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -444,6 +444,7 @@ function migrateJobDeferrals(database: ReturnType<typeof drizzle<typeof schema>>
   if (checkpoint) return;
 
   raw.exec(/*sql*/ `
+    BEGIN;
     UPDATE memory_jobs
     SET deferrals = attempts,
         attempts = 0,
@@ -452,12 +453,10 @@ function migrateJobDeferrals(database: ReturnType<typeof drizzle<typeof schema>>
     WHERE status = 'pending'
       AND attempts > 0
       AND deferrals = 0
-      AND type IN ('embed_segment', 'embed_item', 'embed_summary')
-  `);
-
-  raw.exec(/*sql*/ `
-    INSERT INTO memory_checkpoints (key, value, updated_at)
-    VALUES ('migration_job_deferrals', '1', ${Date.now()})
+      AND type IN ('embed_segment', 'embed_item', 'embed_summary');
+    INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at)
+    VALUES ('migration_job_deferrals', '1', ${Date.now()});
+    COMMIT;
   `);
 }
 


### PR DESCRIPTION
## Summary
- Wraps the `migrateJobDeferrals` UPDATE and checkpoint INSERT in a single SQLite transaction (`BEGIN`/`COMMIT`) so a crash between the two statements cannot leave the checkpoint unrecorded — preventing the migration from re-running and incorrectly resetting post-migration failed jobs
- Changes the checkpoint `INSERT` to `INSERT OR IGNORE` so concurrent `initializeDb()` calls (daemon startup + CLI) that both pass the checkpoint check don't fail with `UNIQUE constraint failed`

Addresses review feedback from Devin (P0) and Codex (P2) on #1624.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify migration runs once on fresh DB, checkpoint is recorded
- [ ] Verify subsequent startups skip the migration (checkpoint exists)
- [ ] Verify concurrent daemon+CLI startup doesn't crash on checkpoint insert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
