### PR TITLE
Add skill id to catalog XML for unambiguous skill_load

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -112,9 +112,10 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('Custom identity');
     expect(result).toContain('## Available Skills');
     expect(result).toContain('<available_skills>');
+    expect(result).toContain('id="release-checklist"');
     expect(result).toContain('name="Release Checklist"');
     expect(result).toContain('description="Deployment checks."');
-    expect(result).toContain('call the `skill_load` tool');
+    expect(result).toContain('call the `skill_load` tool with its `id`');
   });
 
   test('keeps SOUL.md and IDENTITY.md additive with skills', () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -113,16 +113,17 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
 
   const lines = ['<available_skills>'];
   for (const skill of visible) {
+    const idAttr = escapeXml(skill.id);
     const nameAttr = escapeXml(skill.name);
     const descAttr = escapeXml(skill.description);
     const locAttr = escapeXml(skill.directoryPath);
-    lines.push(`<skill name="${nameAttr}" description="${descAttr}" location="${locAttr}" />`);
+    lines.push(`<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}" />`);
   }
   lines.push('</available_skills>');
 
   return [
     '## Available Skills',
-    'The following skills are available. Before executing one, call the `skill_load` tool with its name to load the full instructions.',
+    'The following skills are available. Before executing one, call the `skill_load` tool with its `id` to load the full instructions.',
     '',
     lines.join('\n'),
   ].join('\n');


### PR DESCRIPTION
## Summary
- Adds the unique `id` attribute to each `<skill>` element in the system prompt's XML skill catalog, so the model has an unambiguous selector for `skill_load`.
- Updates the instruction text from "call `skill_load` with its name" to "call `skill_load` with its `id`", matching how `resolveSkillSelector` resolves skills.
- Updates test assertions to verify the `id` attribute is present and the instruction text references `id`.

Addresses feedback from #1623: the previous catalog format only exposed `name` (which can be ambiguous), causing `resolveSkillSelector` to return an error when multiple skills share a name.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/system-prompt.test.ts` — all 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
