### PR TITLE
Fix workspace skill loading and selector forwarding

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -25,7 +25,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-const { loadSkillCatalog } = await import('../config/skills.js');
+const { loadSkillCatalog, loadSkillBySelector, resolveSkillSelector } = await import('../config/skills.js');
 
 /** Return only user-installed skills (filters out bundled skills that ship with the source tree). */
 function loadUserSkillCatalog() {
@@ -150,5 +150,70 @@ describe('skills catalog loading', () => {
 
     const catalog = loadUserSkillCatalog();
     expect(catalog).toHaveLength(0);
+  });
+});
+
+describe('workspace skills', () => {
+  const WORKSPACE_DIR = join(tmpdir(), `vellum-workspace-test-${crypto.randomUUID()}`);
+  const workspaceSkillsDir = join(WORKSPACE_DIR, '.vellum', 'skills');
+
+  function writeWorkspaceSkill(skillId: string, name: string, description: string, body: string = 'Workspace skill body'): void {
+    const skillDir = join(workspaceSkillsDir, skillId);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
+    );
+  }
+
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+    mkdirSync(workspaceSkillsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    if (existsSync(WORKSPACE_DIR)) {
+      rmSync(WORKSPACE_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('workspace skills appear in catalog when workspaceSkillsDir is provided', () => {
+    writeWorkspaceSkill('ws-skill', 'Workspace Skill', 'A workspace skill');
+
+    const catalog = loadSkillCatalog(workspaceSkillsDir);
+    const wsSkills = catalog.filter((s) => s.source === 'workspace');
+    expect(wsSkills).toHaveLength(1);
+    expect(wsSkills[0].id).toBe('ws-skill');
+  });
+
+  test('resolveSkillSelector finds workspace skills when workspaceSkillsDir is provided', () => {
+    writeWorkspaceSkill('ws-resolve', 'Workspace Resolve', 'Resolvable workspace skill');
+
+    const result = resolveSkillSelector('ws-resolve', workspaceSkillsDir);
+    expect(result.skill).toBeDefined();
+    expect(result.skill!.id).toBe('ws-resolve');
+    expect(result.skill!.source).toBe('workspace');
+  });
+
+  test('resolveSkillSelector does not find workspace skills without workspaceSkillsDir', () => {
+    writeWorkspaceSkill('ws-hidden', 'Hidden Workspace', 'Should not be found');
+
+    const result = resolveSkillSelector('ws-hidden');
+    expect(result.skill).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+
+  test('loadSkillBySelector loads workspace skill body without isOutsideSkillsRoot rejection', () => {
+    writeWorkspaceSkill('ws-load', 'Loadable Workspace', 'Can be loaded', 'Full workspace body here');
+
+    const result = loadSkillBySelector('ws-load', workspaceSkillsDir);
+    expect(result.error).toBeUndefined();
+    expect(result.skill).toBeDefined();
+    expect(result.skill!.id).toBe('ws-load');
+    expect(result.skill!.body).toBe('Full workspace body here');
+    expect(result.skill!.source).toBe('workspace');
   });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -651,9 +651,16 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
 }
 
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
-  const loaded = skill.bundled
-    ? readBundledSkillFromDirectory(skill.directoryPath)
-    : readSkillFromDirectory(skill.directoryPath, getSkillsDir(), skill.source);
+  let loaded: SkillDefinition | null;
+  if (skill.bundled) {
+    loaded = readBundledSkillFromDirectory(skill.directoryPath);
+  } else if (skill.source === 'workspace') {
+    // Workspace skills live outside ~/.vellum/skills, so use their parent
+    // directory as the root to avoid the isOutsideSkillsRoot rejection.
+    loaded = readSkillFromDirectory(skill.directoryPath, dirname(skill.directoryPath), skill.source);
+  } else {
+    loaded = readSkillFromDirectory(skill.directoryPath, getSkillsDir(), skill.source);
+  }
   if (!loaded) {
     return { error: `Failed to load SKILL.md for "${skill.id}"` };
   }
@@ -662,13 +669,13 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   return { skill: loaded };
 }
 
-export function resolveSkillSelector(selector: string): SkillSelectorResult {
+export function resolveSkillSelector(selector: string, workspaceSkillsDir?: string): SkillSelectorResult {
   const needle = selector.trim();
   if (!needle) {
     return { error: 'Skill selector is required and must be a non-empty string.' };
   }
 
-  const catalog = loadSkillCatalog();
+  const catalog = loadSkillCatalog(workspaceSkillsDir);
   if (catalog.length === 0) {
     return { error: 'No skills are available. Configure ~/.vellum/skills/SKILLS.md or add skill directories.' };
   }
@@ -702,8 +709,8 @@ export function resolveSkillSelector(selector: string): SkillSelectorResult {
   return { error: `No skill matched "${needle}". Available skills: ${knownSkills}` };
 }
 
-export function loadSkillBySelector(selector: string): SkillLookupResult {
-  const resolved = resolveSkillSelector(selector);
+export function loadSkillBySelector(selector: string, workspaceSkillsDir?: string): SkillLookupResult {
+  const resolved = resolveSkillSelector(selector, workspaceSkillsDir);
   if (!resolved.skill) {
     return { error: resolved.error ?? 'Failed to resolve skill selector.' };
   }


### PR DESCRIPTION
## Summary
- Fix `loadSkillDefinition` to use `dirname(skill.directoryPath)` as the skills root for workspace-source skills, instead of always using `getSkillsDir()` (managed dir `~/.vellum/skills`), which caused the `isOutsideSkillsRoot` check to reject them
- Update `resolveSkillSelector` and `loadSkillBySelector` to accept an optional `workspaceSkillsDir` parameter and forward it to `loadSkillCatalog`, so workspace skills appear in selector lookups
- Add 4 new tests covering workspace skill catalog loading, selector resolution, and full body loading

Addresses review feedback from #1620.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] All 12 skills tests pass (8 existing + 4 new) (`bun test src/__tests__/skills.test.ts`)
- [x] No breaking changes to existing callers -- new parameters are optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
