### PR TITLE
Fix skill state resolution: env merge, extraDirs source, degraded state

### DIFF
--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -54,7 +54,7 @@ export function resolveSkillStates(
     if (!reqCheck.eligible) {
       results.push({
         summary: skill,
-        state: 'enabled',
+        state: 'degraded',
         degraded: true,
         missingRequirements: reqCheck.missing,
         configEntry: entry,

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -32,7 +32,7 @@ export interface InstallerSpec {
   [key: string]: unknown;
 }
 
-export type SkillSource = 'bundled' | 'managed' | 'workspace';
+export type SkillSource = 'bundled' | 'managed' | 'workspace' | 'extra';
 
 // ─── Core interfaces ─────────────────────────────────────────────────────────
 
@@ -124,7 +124,7 @@ export function checkSkillRequirements(
 
   // env: check process.env or envOverrides
   if (requires.env) {
-    const env = envOverrides ?? process.env;
+    const env = envOverrides ? { ...process.env, ...envOverrides } : process.env;
     for (const key of requires.env) {
       if (!env[key]) {
         missingEnv.push(key);
@@ -545,7 +545,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
             homepage: parsed.homepage,
             userInvocable: parsed.userInvocable,
             disableModelInvocation: parsed.disableModelInvocation,
-            source: 'managed',
+            source: 'extra',
             metadata: parsed.metadata,
           });
         } catch (err) {
@@ -561,7 +561,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
     if (seenIds.has(skill.id)) {
       // Bundled wins over extraDirs
       const existingIndex = catalog.findIndex((s) => s.id === skill.id);
-      if (existingIndex !== -1 && catalog[existingIndex].source === 'managed') {
+      if (existingIndex !== -1 && catalog[existingIndex].source === 'extra') {
         log.info({ id: skill.id, directory: skill.directoryPath }, 'Bundled skill overrides extraDirs skill');
         catalog[existingIndex] = skill;
         continue;
@@ -585,7 +585,7 @@ export function loadSkillCatalog(workspaceSkillsDir?: string, extraDirs?: string
     if (seenIds.has(skill.id)) {
       // If the existing entry is bundled, the user skill overrides it
       const existingIndex = catalog.findIndex((s) => s.id === skill.id);
-      if (existingIndex !== -1 && catalog[existingIndex].bundled) {
+      if (existingIndex !== -1 && (catalog[existingIndex].bundled || catalog[existingIndex].source === 'extra')) {
         log.info({ id: skill.id, directory }, 'User skill overrides bundled skill');
         catalog[existingIndex] = skillSummaryFromDefinition(skill, 'managed');
         continue;


### PR DESCRIPTION
## Summary
- Fix `checkSkillRequirements` to merge `envOverrides` with `process.env` instead of replacing it, preventing false missing-env reports when config provides overrides for only some required vars
- Add `'extra'` to the `SkillSource` type and use it for `extraDirs` skills instead of `'managed'`, so managed user skills can properly override extraDirs entries (preserving the intended precedence: extraDirs < bundled < managed < workspace)
- Set `state: 'degraded'` instead of `state: 'enabled'` when skill requirements fail, matching the `SkillState` union type definition

Addresses review feedback on #1622.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/skills.test.ts` passes (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
