### PR TITLE
Fix skillIcon to render emoji as Text instead of SVG

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -272,15 +272,10 @@ struct AgentPanel: View {
     }
 
     @ViewBuilder
-    private func skillIcon(_ svgString: String?) -> some View {
-        if let svgString,
-           let data = svgString.data(using: .utf8),
-           let nsImage = NSImage(data: data) {
-            Image(nsImage: nsImage)
-                .resizable()
-                .interpolation(.none)
-                .frame(width: 24, height: 24)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+    private func skillIcon(_ emoji: String?) -> some View {
+        if let emoji, !emoji.isEmpty {
+            Text(emoji)
+                .font(.system(size: 20))
         } else {
             Image(systemName: "bolt.fill")
                 .font(.system(size: 13))


### PR DESCRIPTION
## Summary
- Fixed `skillIcon` in `AgentPanel.swift` to render the `emoji` string as a SwiftUI `Text` view with `.font(.system(size: 20))` instead of attempting to parse it as SVG image data via `NSImage(data:)`.
- The previous implementation would always fall through to the `bolt.fill` fallback because emoji strings are not valid image data.

Addresses feedback from #1627.

## Test plan
- [x] `./build.sh` compiles successfully
- [ ] Verify skills with emoji icons display the emoji character in the skill card button
- [ ] Verify skills without emoji fall back to the `bolt.fill` system image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
