### PR TITLE
Add requestConfirmation to ToolContext and wire in Session

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -18,6 +18,7 @@ import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { allAppTools } from '../tools/apps/definitions.js';
 import { requestComputerControlTool } from '../tools/computer-use/request-computer-control.js';
 import type { UserDecision } from '../permissions/types.js';
+import { generateScopeOptions } from '../permissions/checker.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost, resolvePricing } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
@@ -144,6 +145,25 @@ export class Session {
         sandboxOverride: this.sandboxOverride,
         onToolLifecycleEvent: handleToolLifecycleEvent,
         proxyToolResolver: this.surfaceProxyResolver.bind(this),
+        requestConfirmation: async (req) => {
+          const allowlistOptions = [
+            { label: `cc:${req.toolName}`, description: `Claude Code ${req.toolName}`, pattern: `cc:${req.toolName}` },
+            { label: 'cc:*', description: 'All Claude Code sub-tools', pattern: 'cc:*' },
+          ];
+          const scopeOptions = generateScopeOptions(this.workingDir);
+          const response = await this.prompter.prompt(
+            `cc:${req.toolName}`,
+            req.input,
+            req.riskLevel,
+            allowlistOptions,
+            scopeOptions,
+            undefined, undefined,
+            this.conversationId,
+          );
+          return {
+            decision: (response.decision === 'allow' || response.decision === 'always_allow') ? 'allow' as const : 'deny' as const,
+          };
+        },
       });
     };
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -88,6 +88,12 @@ export interface ToolContext {
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
   /** Optional resolver for proxy tools — delegates execution to an external client. */
   proxyToolResolver?: ProxyToolResolver;
+  /** Request user confirmation for a sub-tool operation (used by claude_code tool). */
+  requestConfirmation?: (req: {
+    toolName: string;
+    input: Record<string, unknown>;
+    riskLevel: string;
+  }) => Promise<{ decision: 'allow' | 'deny' }>;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
Part of #1630. Adds an optional `requestConfirmation` callback to `ToolContext` that bridges Claude Code sub-tool approvals through Velly's existing permission IPC flow. Wires it in Session using the `PermissionPrompter`.

## Changes

- **`assistant/src/tools/types.ts`**: Added optional `requestConfirmation` field to `ToolContext` interface accepting a `{ toolName, input, riskLevel }` request and returning `{ decision: 'allow' | 'deny' }`.
- **`assistant/src/daemon/session.ts`**: Wired the callback in the `toolExecutor` lambda — it constructs allowlist/scope options and delegates to `this.prompter.prompt()` for IPC-based user confirmation, mapping `allow`/`always_allow` to `allow` and everything else to `deny`.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (confirmed locally)
- [ ] Existing tools unaffected (field is optional, backward-compatible)
- [ ] Claude Code tool integration will consume this in a follow-up PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
