### PR TITLE
Register claude_code in tool registry

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -156,5 +156,44 @@ export async function initializeTools(): Promise<void> {
     },
   });
 
+  // Claude Code tool — delegates coding tasks to Claude Code via the Agent SDK.
+  // Registered lazily since the SDK spawns a subprocess and is only needed on demand.
+  registerLazyTool({
+    name: 'claude_code',
+    description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
+    category: 'coding',
+    defaultRiskLevel: RiskLevel.Medium,
+    definition: {
+      name: 'claude_code',
+      description: 'Delegate a coding task to Claude Code, an AI-powered coding agent that can read, write, and edit files, run shell commands, and perform complex multi-step software engineering tasks autonomously.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'The coding task or question for Claude Code to work on',
+          },
+          working_dir: {
+            type: 'string',
+            description: 'Working directory for Claude Code (defaults to session working directory)',
+          },
+          resume: {
+            type: 'string',
+            description: 'Claude Code session ID to resume a previous session',
+          },
+          model: {
+            type: 'string',
+            description: 'Model to use (defaults to claude-sonnet-4-5-20250929)',
+          },
+        },
+        required: ['prompt'],
+      },
+    },
+    loader: async () => {
+      const mod = await import('./claude-code/claude-code.js');
+      return mod.claudeCodeTool;
+    },
+  });
+
   log.info({ count: tools.size }, 'Tools initialized');
 }


### PR DESCRIPTION
Part of #1630. Registers the `claude_code` tool as a lazy tool in the tool registry, so it's available to Velly's LLM but only loads the Agent SDK on first use.

## Changes

- Added a `registerLazyTool` call for `claude_code` in `initializeTools()` in `assistant/src/tools/registry.ts`
- The tool is categorized as `coding` with `RiskLevel.Medium`
- Input schema accepts `prompt` (required), `working_dir`, `resume`, and `model` parameters
- The loader dynamically imports `./claude-code/claude-code.js` to defer subprocess spawning

## Test plan

- [x] `bunx tsc --noEmit` passes with no errors
- The lazy registration ensures the Agent SDK module is only loaded when the tool is first invoked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
