### PR TITLE
Fix AgentPanel header font to match VSidePanel panelTitle token

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -89,7 +89,7 @@ struct AgentPanel: View {
             // Header (matches VSidePanel style)
             HStack {
                 Text("AGENT")
-                    .font(VFont.display)
+                    .font(VFont.panelTitle)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
                 Button(action: onClose) {


### PR DESCRIPTION
## Summary
- Update AgentPanel header from `VFont.display` to `VFont.panelTitle` to match VSidePanel
- Addresses review feedback from #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
