### PR TITLE
Fix VButton primary colors (Violet) and disabled hover state

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Buttons/VButton.swift
@@ -17,7 +17,7 @@ struct VButton: View {
                 .font(VFont.bodyMedium)
         }
         .buttonStyle(VButtonStyle(style: style, isHovered: isHovered, isFullWidth: isFullWidth))
-        .onHover { isHovered = $0 }
+        .onHover { isHovered = isDisabled ? false : $0 }
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.5 : 1.0)
         .accessibilityHint(isDisabled ? "Button is currently disabled" : "")
@@ -51,7 +51,7 @@ private struct VButtonStyle: ButtonStyle {
     private var shadowColor: Color {
         switch style {
         case .primary:
-            return isHovered ? Indigo._600 : Indigo._800
+            return isHovered ? Violet._600 : Violet._800
         case .danger:
             return isHovered ? Rose._700 : Rose._800
         case .ghost:
@@ -62,9 +62,9 @@ private struct VButtonStyle: ButtonStyle {
     private func backgroundColor(isPressed: Bool) -> Color {
         switch style {
         case .primary:
-            if isPressed { return Indigo._400 }
-            if isHovered { return Indigo._500 }
-            return Indigo._600
+            if isPressed { return Violet._400 }
+            if isHovered { return Violet._500 }
+            return Violet._600
         case .danger:
             if isPressed { return Rose._400 }
             if isHovered { return Rose._500 }


### PR DESCRIPTION
## Summary
- Replace Indigo color references with Violet in VButton primary style to match `VColor.accent` (Violet._600) design token
- Suppress hover visual feedback on disabled buttons by guarding `.onHover` callback
- Addresses review feedback from #1583

## Test plan
- [ ] Verify primary buttons render with Violet colors (not Indigo)
- [ ] Verify disabled buttons do not show hover color/shadow changes
- [ ] Verify danger and ghost button styles are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
