### PR TITLE
Fix ThreadTab and VTab close/select gesture conflict

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
@@ -35,16 +35,20 @@ struct VTab: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            HStack(spacing: VSpacing.xs) {
-                if let icon = icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 12))
+            Button(action: onSelect) {
+                HStack(spacing: VSpacing.xs) {
+                    if let icon = icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 12))
+                    }
+                    Text(label)
+                        .font(VFont.caption)
+                        .lineLimit(1)
                 }
-                Text(label)
-                    .font(VFont.caption)
-                    .lineLimit(1)
+                .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
+                .contentShape(Rectangle())
             }
-            .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
+            .buttonStyle(.plain)
 
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
@@ -59,7 +63,6 @@ struct VTab: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
-        .onTapGesture { onSelect() }
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
@@ -15,16 +15,20 @@ struct ThreadTab: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            HStack(spacing: VSpacing.xs) {
-                if let icon = icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 12))
+            Button(action: onSelect) {
+                HStack(spacing: VSpacing.xs) {
+                    if let icon = icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 12))
+                    }
+                    Text(label)
+                        .font(VFont.tabLabel)
+                        .lineLimit(1)
                 }
-                Text(label)
-                    .font(VFont.tabLabel)
-                    .lineLimit(1)
+                .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
+                .contentShape(Rectangle())
             }
-            .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
+            .buttonStyle(.plain)
 
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
@@ -39,7 +43,6 @@ struct ThreadTab: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .onTapGesture { onSelect() }
         .background(isHovered && !isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onHover { hovering in isHovered = hovering }


### PR DESCRIPTION
## Summary
- Replaced `.onTapGesture` on the outer HStack with a `Button` wrapper around the label content in both `ThreadTab` and `VTab`
- On macOS, `onTapGesture` on a parent fires even when a child `Button` handles the tap, causing both `onSelect` and `onClose` to trigger when clicking the close button
- Using two sibling `Button`s (one for select, one for close) prevents the gesture conflict

## Test plan
- [ ] Click the close (x) button on a thread tab — should only close, not select
- [ ] Click the label area of a thread tab — should select the tab
- [ ] Verify hover states still work on both ThreadTab and VTab
- [ ] Verify VTab close button behavior matches ThreadTab fix

Addresses review feedback from #1533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
