### PR TITLE
Persist trust rules for Claude Code sub-tool confirmations

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -11,6 +11,7 @@ import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getApp } from '../memory/app-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
+import { addRule } from '../permissions/trust-store.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/types.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
@@ -160,6 +161,12 @@ export class Session {
             undefined, undefined,
             this.conversationId,
           );
+          if (response.decision === 'always_allow' && response.selectedPattern && response.selectedScope) {
+            addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope);
+          }
+          if (response.decision === 'always_deny' && response.selectedPattern && response.selectedScope) {
+            addRule('cc:' + req.toolName, response.selectedPattern, response.selectedScope, 'deny');
+          }
           return {
             decision: (response.decision === 'allow' || response.decision === 'always_allow') ? 'allow' as const : 'deny' as const,
           };


### PR DESCRIPTION
## Summary
- Fixes bug where `always_allow` and `always_deny` decisions from Claude Code sub-tool confirmation prompts were not persisted as trust rules
- Imports `addRule` from `trust-store.js` and calls it after `prompter.prompt()` when the user chooses "Always Allow" or "Always Deny"
- Matches the existing pattern used in `ToolExecutor.execute()` for standard tool permissions

Addresses review feedback on #1640.

## Test plan
- [ ] Verify that choosing "Always Allow" for a Claude Code sub-tool persists an allow rule and avoids re-prompting
- [ ] Verify that choosing "Always Deny" persists a deny rule and blocks future invocations without re-prompting
- [ ] Verify that one-time "Allow" and "Deny" decisions still work as before (no rule persisted)
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
