### PR TITLE
Fix ClaWHub CLI integration review issues

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -886,6 +886,16 @@ async function handleSkillsUninstall(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
+  // Validate skill name to prevent path traversal
+  if (msg.name.includes('/') || msg.name.includes('\\') || msg.name.includes('..')) {
+    ctx.send(socket, {
+      type: 'skills_operation_response',
+      operation: 'uninstall',
+      success: false,
+      error: 'Invalid skill name',
+    });
+    return;
+  }
   const skillDir = join(getRootDir(), 'skills', msg.name);
   if (!existsSync(skillDir)) {
     ctx.send(socket, {
@@ -993,6 +1003,7 @@ async function handleSkillsCheckUpdates(
       type: 'skills_operation_response',
       operation: 'check_updates',
       success: true,
+      data: updates,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1017,6 +1028,7 @@ async function handleSkillsSearch(
       type: 'skills_operation_response',
       operation: 'search',
       success: true,
+      data: result,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -631,6 +631,7 @@ export interface SkillsOperationResponse {
   operation: string;
   success: boolean;
   error?: string;
+  data?: unknown;
 }
 
 export interface SkillDetailResponse {

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -9,9 +9,9 @@ function getManagedSkillsDir(): string {
   return join(getRootDir(), 'skills');
 }
 
-// Validate slug format (alphanumeric + hyphens only)
+// Validate slug format (alphanumeric, hyphens, dots, underscores; optional namespace with single slash)
 function validateSlug(slug: string): boolean {
-  return /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug) || /^[a-z0-9]$/.test(slug);
+  return /^[a-zA-Z0-9]([a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)?)?$/.test(slug);
 }
 
 export interface ClawhubInstallResult {
@@ -92,9 +92,8 @@ export async function clawhubInstall(slug: string, opts?: { version?: string }):
     return { success: false, error: `Invalid skill slug: ${slug}` };
   }
 
-  const args = ['install', slug];
-  if (opts?.version) args.push(`@${opts.version}`);
-  args.push('--force'); // non-interactive
+  const installSlug = opts?.version ? `${slug}@${opts.version}` : slug;
+  const args = ['install', installSlug, '--force']; // non-interactive
 
   try {
     const result = await runClawhub(args);


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #1626:

- **Fix version arg token splitting**: `clawhubInstall` was pushing `@version` as a separate CLI argument (`npx clawhub install my-skill @1.0.0`) instead of appending it to the slug (`npx clawhub install my-skill@1.0.0`)
- **Fix path traversal in uninstall**: `handleSkillsUninstall` used `msg.name` directly in `path.join` + `rmSync({ recursive: true })` with no validation, allowing crafted IPC payloads (e.g. `../../..`) to delete arbitrary directories. Now rejects names containing `/`, `\`, or `..`
- **Include results in search/check_updates responses**: `handleSkillsSearch` and `handleSkillsCheckUpdates` fetched results but discarded them. Added `data` field to `SkillsOperationResponse` type and included results in responses
- **Accept namespaced slugs**: `validateSlug` regex rejected `/`, making namespaced slugs like `clawhub/my-skill` invalid. Updated regex to allow a single `/` for org/skill-name format

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/ipc-snapshot.test.ts` passes (77 tests, 75 snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
