### PR TITLE
Fix skills IPC: add id field and prevent dot-corruption

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -653,6 +653,7 @@ exports[`IPC message snapshots ServerMessage types skills_list_response serializ
       "degraded": false,
       "description": "A test skill",
       "emoji": "🔧",
+      "id": "my-skill",
       "name": "My Skill",
       "source": "bundled",
       "state": "enabled",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -413,6 +413,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'skills_list_response',
     skills: [
       {
+        id: 'my-skill',
         name: 'My Skill',
         description: 'A test skill',
         emoji: '🔧',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import { v4 as uuid } from 'uuid';
 import Anthropic from '@anthropic-ai/sdk';
-import { getConfig, loadRawConfig, saveRawConfig, setNestedValue, invalidateConfigCache } from '../config/loader.js';
+import { getConfig, loadRawConfig, saveRawConfig, invalidateConfigCache } from '../config/loader.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
 import * as conversationStore from '../memory/conversation-store.js';
@@ -679,6 +679,7 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   const resolved = resolveSkillStates(catalog, config);
 
   const skills = resolved.map((r) => ({
+    id: r.summary.id,
     name: r.summary.name,
     description: r.summary.description,
     emoji: r.summary.emoji,
@@ -694,6 +695,15 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   ctx.send(socket, { type: 'skills_list_response', skills });
 }
 
+/** Get or create the skill entry object for a given skill name, creating intermediate objects as needed. */
+function ensureSkillEntry(raw: Record<string, unknown>, name: string): Record<string, unknown> {
+  if (!raw.skills) raw.skills = {};
+  const skills = raw.skills as Record<string, unknown>;
+  if (!skills.entries) skills.entries = {};
+  const entries = skills.entries as Record<string, unknown>;
+  if (!entries[name]) entries[name] = {};
+  return entries[name] as Record<string, unknown>;
+}
 function handleSkillsEnable(
   msg: SkillsEnableRequest,
   socket: net.Socket,
@@ -701,7 +711,7 @@ function handleSkillsEnable(
 ): void {
   try {
     const raw = loadRawConfig();
-    setNestedValue(raw, `skills.entries.${msg.name}.enabled`, true);
+    ensureSkillEntry(raw, msg.name).enabled = true;
 
     ctx.setSuppressConfigReload(true);
     try {
@@ -748,7 +758,7 @@ function handleSkillsDisable(
 ): void {
   try {
     const raw = loadRawConfig();
-    setNestedValue(raw, `skills.entries.${msg.name}.enabled`, false);
+    ensureSkillEntry(raw, msg.name).enabled = false;
 
     ctx.setSuppressConfigReload(true);
     try {
@@ -796,14 +806,15 @@ function handleSkillsConfigure(
   try {
     const raw = loadRawConfig();
 
+    const entry = ensureSkillEntry(raw, msg.name);
     if (msg.env) {
-      setNestedValue(raw, `skills.entries.${msg.name}.env`, msg.env);
+      entry.env = msg.env;
     }
     if (msg.apiKey !== undefined) {
-      setNestedValue(raw, `skills.entries.${msg.name}.apiKey`, msg.apiKey);
+      entry.apiKey = msg.apiKey;
     }
     if (msg.config) {
-      setNestedValue(raw, `skills.entries.${msg.name}.config`, msg.config);
+      entry.config = msg.config;
     }
 
     ctx.setSuppressConfigReload(true);

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -604,6 +604,7 @@ export interface AppDataResponse {
 export interface SkillsListResponse {
   type: 'skills_list_response';
   skills: Array<{
+    id: string;
     name: string;
     description: string;
     emoji?: string;


### PR DESCRIPTION
## Summary
- Add missing `id` field to `skills_list_response` so enable/disable/configure operations can correctly reference skills by their config key rather than display name
- Replace `setNestedValue` with direct object manipulation via `ensureSkillEntry` helper to prevent config corruption when skill names contain dots
- Update `SkillsListResponse` interface in `ipc-protocol.ts` to include `id: string`

## Test plan
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests updated and passing (`bun test ipc-snapshot.test.ts`)

Addresses review feedback on #1625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
