### PR TITLE
Add ROLLBACK handling to migrateJobDeferrals

### DIFF
--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -443,21 +443,26 @@ function migrateJobDeferrals(database: ReturnType<typeof drizzle<typeof schema>>
   ).get();
   if (checkpoint) return;
 
-  raw.exec(/*sql*/ `
-    BEGIN;
-    UPDATE memory_jobs
-    SET deferrals = attempts,
-        attempts = 0,
-        last_error = NULL,
-        updated_at = ${Date.now()}
-    WHERE status = 'pending'
-      AND attempts > 0
-      AND deferrals = 0
-      AND type IN ('embed_segment', 'embed_item', 'embed_summary');
-    INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at)
-    VALUES ('migration_job_deferrals', '1', ${Date.now()});
-    COMMIT;
-  `);
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+      UPDATE memory_jobs
+      SET deferrals = attempts,
+          attempts = 0,
+          last_error = NULL,
+          updated_at = ${Date.now()}
+      WHERE status = 'pending'
+        AND attempts > 0
+        AND deferrals = 0
+        AND type IN ('embed_segment', 'embed_item', 'embed_summary');
+      INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at)
+      VALUES ('migration_job_deferrals', '1', ${Date.now()});
+      COMMIT;
+    `);
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wraps the `migrateJobDeferrals` transaction in a try/catch with ROLLBACK, matching the existing pattern in `migrateToolInvocationsFk`
- Without this, if `raw.exec()` throws after `BEGIN` succeeds but before `COMMIT`, the SQLite connection is left with an open transaction, causing the next migration function to fail with a cascading error that prevents `initializeDb()` from completing

Addresses Devin P0 feedback on #1635.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Verify migration runs correctly on fresh DB
- [ ] Verify error during migration properly rolls back and re-throws
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
