### PR TITLE
Fix tab padding areas not clickable for selection

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
@@ -34,22 +34,26 @@ struct VTab: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
-            Button(action: onSelect) {
-                HStack(spacing: VSpacing.xs) {
-                    if let icon = icon {
-                        Image(systemName: icon)
-                            .font(.system(size: 12))
-                    }
-                    Text(label)
-                        .font(VFont.caption)
-                        .lineLimit(1)
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12))
                 }
-                .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
-                .contentShape(Rectangle())
+                Text(label)
+                    .font(VFont.caption)
+                    .lineLimit(1)
+                if isCloseable {
+                    Spacer().frame(width: 16)
+                }
             }
-            .buttonStyle(.plain)
-
+            .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? Slate._900 : (isSelected ? VColor.textPrimary : VColor.textSecondary))
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .trailing) {
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
@@ -58,11 +62,9 @@ struct VTab: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close \(label)")
+                .padding(.trailing, VSpacing.sm)
             }
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
-        .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
@@ -14,22 +14,26 @@ struct ThreadTab: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 6) {
-            Button(action: onSelect) {
-                HStack(spacing: VSpacing.xs) {
-                    if let icon = icon {
-                        Image(systemName: icon)
-                            .font(.system(size: 12))
-                    }
-                    Text(label)
-                        .font(VFont.tabLabel)
-                        .lineLimit(1)
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.xs) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12))
                 }
-                .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
-                .contentShape(Rectangle())
+                Text(label)
+                    .font(VFont.tabLabel)
+                    .lineLimit(1)
+                if isCloseable {
+                    Spacer().frame(width: 16)
+                }
             }
-            .buttonStyle(.plain)
-
+            .foregroundColor(isSelected ? Color(hex: 0xFFFFFF) : VColor.textSecondary)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .trailing) {
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
@@ -38,11 +42,9 @@ struct ThreadTab: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close \(label)")
+                .padding(.trailing, VSpacing.sm)
             }
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
-        .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         .background(isHovered && !isSelected ? VColor.surfaceBorder.opacity(0.5) : .clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onHover { hovering in isHovered = hovering }


### PR DESCRIPTION
## Summary
- Moves padding inside the select `Button`'s label in both `VTab` and `ThreadTab` so the entire visual tab area (including padded regions) is part of the button's hit region
- Overlays the close button on top using `.overlay(alignment: .trailing)` so it intercepts taps independently without triggering `onSelect`
- Adds a `Spacer().frame(width: 16)` when closeable to reserve space for the overlaid close button

Addresses PR #1648 review feedback from Devin and Codex: the previous fix replaced `.onTapGesture` with a `Button` wrapping only the label content, making the tab's padding areas non-clickable for selection while the hover state still covered the full area.

## Test plan
- [ ] Click on a tab's padding area (outside the label text) and verify it triggers selection
- [ ] Click on the close button (X) and verify it closes the tab without selecting it
- [ ] Hover over the tab and verify the hover highlight covers the full tab area
- [ ] Verify non-closeable tabs (no close button) work correctly for selection

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
