### PR TITLE
Propagate SDK failure results as isError in claude_code tool

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -139,6 +139,7 @@ export const claudeCodeTool: Tool = {
       const conversation = query({ prompt, options: queryOptions });
       let resultText = '';
       let sessionId = '';
+      let hasError = false;
 
       for await (const message of conversation) {
         switch (message.type) {
@@ -163,6 +164,7 @@ export const claudeCodeTool: Tool = {
               }
             } else {
               // Error result
+              hasError = true;
               const errors = message.errors ?? [];
               if (errors.length > 0) {
                 resultText += `\n\nErrors: ${errors.join(', ')}`;
@@ -181,7 +183,7 @@ export const claudeCodeTool: Tool = {
 
       return {
         content: output + sessionInfo,
-        isError: false,
+        isError: hasError,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- When Claude Code SDK returns a non-success result, the tool now correctly reports `isError: true` instead of always returning `isError: false`
- Adds a `hasError` boolean flag that is set when `message.subtype !== 'success'` in the result handler
- Ensures callers can detect failed delegations and handle them appropriately

Addresses review feedback on #1643.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that successful SDK results still return `isError: false`
- [ ] Confirm that failed SDK results now return `isError: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
