### PR TITLE
Consult trust store before prompting for Claude Code sub-tool approvals

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -11,7 +11,7 @@ import { createUserMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getApp } from '../memory/app-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
-import { addRule } from '../permissions/trust-store.js';
+import { addRule, findHighestPriorityRule } from '../permissions/trust-store.js';
 import { ToolExecutor } from '../tools/executor.js';
 import type { ToolLifecycleEventHandler, ToolExecutionResult } from '../tools/types.js';
 import { getAllToolDefinitions } from '../tools/registry.js';
@@ -147,6 +147,17 @@ export class Session {
         onToolLifecycleEvent: handleToolLifecycleEvent,
         proxyToolResolver: this.surfaceProxyResolver.bind(this),
         requestConfirmation: async (req) => {
+          // Check trust store before prompting
+          const existingRule = findHighestPriorityRule(
+            'cc:' + req.toolName,
+            [req.toolName, `cc:${req.toolName}`, 'cc:*'],
+            this.workingDir,
+          );
+          if (existingRule) {
+            return {
+              decision: existingRule.decision === 'allow' ? 'allow' as const : 'deny' as const,
+            };
+          }
           const allowlistOptions = [
             { label: `cc:${req.toolName}`, description: `Claude Code ${req.toolName}`, pattern: `cc:${req.toolName}` },
             { label: 'cc:*', description: 'All Claude Code sub-tools', pattern: 'cc:*' },


### PR DESCRIPTION
## Summary
- Addresses review feedback on #1649 where trust rules were persisted but never consulted
- Adds a `findHighestPriorityRule` lookup in the `requestConfirmation` callback before calling `this.prompter.prompt()`
- When a matching allow/deny rule exists, returns the decision immediately without prompting the user

## Test plan
- [ ] Choose "Always Allow" for a Claude Code sub-tool, then trigger the same sub-tool again — should not be re-prompted
- [ ] Choose "Always Deny" for a Claude Code sub-tool, then trigger it again — should be denied without prompting
- [ ] One-time "Allow" and "Deny" decisions still work as before (no rule persisted, user prompted next time)
- [ ] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
