### PR TITLE
Fix spacer condition mismatch with close button in VTab and ThreadTab

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Navigation/VTab.swift
@@ -43,7 +43,7 @@ struct VTab: View {
                 Text(label)
                     .font(VFont.caption)
                     .lineLimit(1)
-                if isCloseable {
+                if isCloseable, onClose != nil {
                     Spacer().frame(width: 16)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTab.swift
@@ -23,7 +23,7 @@ struct ThreadTab: View {
                 Text(label)
                     .font(VFont.tabLabel)
                     .lineLimit(1)
-                if isCloseable {
+                if isCloseable, onClose != nil {
                     Spacer().frame(width: 16)
                 }
             }


### PR DESCRIPTION
## Summary
- Aligns the spacer condition in `VTab` and `ThreadTab` with the close button overlay condition
- The spacer checked `if isCloseable` but the overlay checked `if isCloseable, let onClose = onClose`, causing dead trailing space when `isCloseable` is true (the default) but `onClose` is nil
- Both conditions now check `if isCloseable, onClose != nil`

Addresses review feedback from #1654.

## Test plan
- [x] `swift build` passes
- [ ] Verify tabs with `onClose: nil` no longer have trailing dead space
- [ ] Verify tabs with `onClose` handler still show close button with correct spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
