### PR TITLE
Fix lint errors: replace require() imports and remove unused imports

### DIFF
--- a/assistant/src/__tests__/hooks-blocking.test.ts
+++ b/assistant/src/__tests__/hooks-blocking.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -115,7 +115,7 @@ describe('Blocking Hooks', () => {
 
     // Logger should NOT have run because blocker runs first (alphabetical order)
     await new Promise((r) => setTimeout(r, 100));
-    expect(() => require('node:fs').readFileSync(outputFile, 'utf-8')).toThrow();
+    expect(() => readFileSync(outputFile, 'utf-8')).toThrow();
   });
 
   test('trigger returns not blocked when no hooks match', async () => {

--- a/assistant/src/__tests__/hooks-cli.test.ts
+++ b/assistant/src/__tests__/hooks-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, cpSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { discoverHooks } from '../hooks/discovery.js';
@@ -105,7 +105,7 @@ describe('hooks CLI operations', () => {
     writeFileSync(join(srcDir, 'run.sh'), '#!/bin/sh\necho installed\n', { mode: 0o755 });
 
     // Simulate install: copy to hooks dir
-    const { cpSync, chmodSync } = require('node:fs');
+    // cpSync and chmodSync imported at top level
     const targetDir = join(hooksDir, 'test-install');
     cpSync(srcDir, targetDir, { recursive: true });
     chmodSync(join(targetDir, 'run.sh'), 0o755);

--- a/assistant/src/__tests__/hooks-templates.test.ts
+++ b/assistant/src/__tests__/hooks-templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, statSync, readdirSync, cpSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -8,7 +8,7 @@ const testDir = join(tmpdir(), `hooks-templates-test-${Date.now()}`);
 process.env.BASE_DATA_DIR = testDir;
 
 import { installTemplates } from '../hooks/templates.js';
-import { loadHooksConfig } from '../hooks/config.js';
+import { loadHooksConfig, ensureHookInConfig, setHookEnabled } from '../hooks/config.js';
 
 /**
  * Create a fake hook-templates directory structure that mimics
@@ -51,7 +51,6 @@ describe('Hook Templates', () => {
     });
 
     // Manually simulate what installTemplates does
-    const { readdirSync, cpSync, chmodSync } = require('node:fs');
     const entries = readdirSync(templatesDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
@@ -97,7 +96,6 @@ describe('Hook Templates', () => {
     }, '#!/bin/bash\necho "template"');
 
     // Simulate install — should skip
-    const { readdirSync, cpSync } = require('node:fs');
     const entries = readdirSync(templatesDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
@@ -120,7 +118,6 @@ describe('Hook Templates', () => {
 
   test('config entry is added for installed template', () => {
     // Manually install a template and call ensureHookInConfig
-    const { ensureHookInConfig } = require('../hooks/config.js');
     ensureHookInConfig('new-template', { enabled: false });
 
     const config = loadHooksConfig();
@@ -129,7 +126,6 @@ describe('Hook Templates', () => {
 
   test('config entry preserves existing enabled state', () => {
     // Set hook as enabled first
-    const { setHookEnabled, ensureHookInConfig } = require('../hooks/config.js');
     setHookEnabled('my-hook', true);
 
     // ensureHookInConfig should not overwrite

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -37,14 +37,13 @@ import type {
   SkillsSearchRequest,
   SuggestionRequest,
   AddTrustRule,
-  TrustRulesList,
   RemoveTrustRule,
   UpdateTrustRule,
 } from './ipc-protocol.js';
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { addRule, removeRule, updateRule, getAllRules } from '../permissions/trust-store.js';
-import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkillIcon } from '../config/skills.js';
+import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';


### PR DESCRIPTION
## Summary
- Replace `require('node:fs')` calls with top-level ESM imports in hooks test files (hooks-blocking, hooks-cli, hooks-templates)
- Replace `require('../hooks/config.js')` calls with top-level ESM imports in hooks-templates test
- Remove unused `TrustRulesList` and `readCachedSkillIcon` imports from `handlers.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
