### PR TITLE
Strip underscore-prefixed comment lines from prompt .md files

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -32,7 +32,7 @@ mock.module('../util/logger.js', () => ({
 }));
 
 // Import after mock
-const { buildSystemPrompt, ensurePromptFiles } = await import('../config/system-prompt.js');
+const { buildSystemPrompt, ensurePromptFiles, stripCommentLines } = await import('../config/system-prompt.js');
 
 /** Strip the Configuration and Skills sections so base-prompt tests stay focused. */
 function basePrompt(result: string): string {
@@ -168,6 +168,52 @@ describe('buildSystemPrompt', () => {
     writeFileSync(join(TEST_DIR, 'USER.md'), '  \n  ');
     const result = buildSystemPrompt();
     expect(basePrompt(result)).toBe('');
+  });
+
+  test('strips comment lines starting with _ from prompt files', () => {
+    writeFileSync(
+      join(TEST_DIR, 'IDENTITY.md'),
+      '# Identity\n_ This is a comment\nI am Vellum.\n_ Another comment',
+    );
+    const result = buildSystemPrompt();
+    expect(basePrompt(result)).toBe('# Identity\nI am Vellum.');
+  });
+
+  test('collapses whitespace around stripped comment lines', () => {
+    writeFileSync(
+      join(TEST_DIR, 'SOUL.md'),
+      'First paragraph\n\n_ Comment between paragraphs\n\nSecond paragraph',
+    );
+    const result = buildSystemPrompt();
+    expect(basePrompt(result)).toBe('First paragraph\n\nSecond paragraph');
+  });
+
+  test('file with only comment lines is treated as empty', () => {
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), '_ All comments\n_ Nothing else');
+    const result = buildSystemPrompt();
+    expect(basePrompt(result)).toBe('');
+  });
+});
+
+describe('stripCommentLines', () => {
+  test('removes lines starting with _', () => {
+    expect(stripCommentLines('hello\n_ comment\nworld')).toBe('hello\nworld');
+  });
+
+  test('removes lines with leading whitespace before _', () => {
+    expect(stripCommentLines('hello\n  _ indented comment\nworld')).toBe('hello\nworld');
+  });
+
+  test('preserves underscores mid-line', () => {
+    expect(stripCommentLines('hello_world\nsome_var = 1')).toBe('hello_world\nsome_var = 1');
+  });
+
+  test('collapses triple+ newlines to double', () => {
+    expect(stripCommentLines('a\n\n_ removed\n\nb')).toBe('a\n\nb');
+  });
+
+  test('returns empty string for all-comment content', () => {
+    expect(stripCommentLines('_ one\n_ two')).toBe('');
   });
 });
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -4,6 +4,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { getConfig } from './loader.js';
 import { getRootDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
+import { stripCommentLines } from './system-prompt.js';
 
 const log = getLogger('skills');
 
@@ -229,7 +230,7 @@ function parseFrontmatter(content: string, skillFilePath: string): ParsedFrontma
   return {
     name,
     description,
-    body: content.slice(match[0].length).trim(),
+    body: stripCommentLines(content.slice(match[0].length)),
     homepage,
     userInvocable,
     disableModelInvocation,

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -74,11 +74,24 @@ function buildConfigSection(configDir: string): string {
   ].join('\n');
 }
 
+/**
+ * Strip lines starting with `_` (comment convention for prompt .md files)
+ * and collapse any resulting consecutive blank lines.
+ */
+export function stripCommentLines(content: string): string {
+  return content
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('_'))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 function readPromptFile(path: string): string | null {
   if (!existsSync(path)) return null;
 
   try {
-    const content = readFileSync(path, 'utf-8').trim();
+    const content = stripCommentLines(readFileSync(path, 'utf-8'));
     if (content.length === 0) return null;
     log.debug({ path }, 'Loaded prompt file');
     return content;


### PR DESCRIPTION
## Summary
- Lines starting with `_` in prompt .md files (SOUL.md, IDENTITY.md, USER.md, SKILL.md bodies) are now treated as author comments and stripped during system prompt compilation
- Surrounding whitespace is collapsed to prevent blank gaps where comments were removed
- Added `stripCommentLines` utility with unit tests and integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
