### PR TITLE
Add comment syntax explanation to prompt template files

### DIFF
--- a/assistant/src/config/templates/IDENTITY.md
+++ b/assistant/src/config/templates/IDENTITY.md
@@ -1,3 +1,5 @@
+_ Lines starting with _ are comments — they won't appear in the prompt sent to your assistant.
+
 # IDENTITY
 
 _Customize this file to give your assistant a distinct identity._

--- a/assistant/src/config/templates/SOUL.md
+++ b/assistant/src/config/templates/SOUL.md
@@ -1,3 +1,5 @@
+_ Lines starting with _ are comments — they won't appear in the prompt sent to your assistant.
+
 # SOUL
 
 _These are your core principles. Edit them to shape how your assistant behaves._

--- a/assistant/src/config/templates/USER.md
+++ b/assistant/src/config/templates/USER.md
@@ -1,3 +1,5 @@
+_ Lines starting with _ are comments — they won't appear in the prompt sent to your assistant.
+
 # USER
 
 _Your assistant learns about you over time. Fill in what you're comfortable sharing to help it help you better._


### PR DESCRIPTION
## Summary
- Added `_ Lines starting with _ are comments` note to the top of IDENTITY.md, SOUL.md, and USER.md templates
- These lines are themselves comments and get stripped during prompt compilation, so they're only visible when editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
