### PR TITLE
Fix stripCommentLines: preserve code blocks, handle CRLF

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -215,6 +215,66 @@ describe('stripCommentLines', () => {
   test('returns empty string for all-comment content', () => {
     expect(stripCommentLines('_ one\n_ two')).toBe('');
   });
+
+  test('preserves _-prefixed lines inside fenced code blocks', () => {
+    const input = [
+      '## Example',
+      '',
+      '```python',
+      'class Singleton:',
+      '    _instance = None',
+      '    _private_var = 42',
+      '```',
+      '',
+      '_ This comment should be removed',
+      'After the block.',
+    ].join('\n');
+    const expected = [
+      '## Example',
+      '',
+      '```python',
+      'class Singleton:',
+      '    _instance = None',
+      '    _private_var = 42',
+      '```',
+      '',
+      'After the block.',
+    ].join('\n');
+    expect(stripCommentLines(input)).toBe(expected);
+  });
+
+  test('handles multiple code blocks with _-prefixed lines', () => {
+    const input = [
+      '_ comment before',
+      '```',
+      '_keep_this',
+      '```',
+      '_ comment between',
+      '```js',
+      '_anotherVar = true',
+      '```',
+      '_ comment after',
+    ].join('\n');
+    const expected = [
+      '```',
+      '_keep_this',
+      '```',
+      '```js',
+      '_anotherVar = true',
+      '```',
+    ].join('\n');
+    expect(stripCommentLines(input)).toBe(expected);
+  });
+
+  test('normalizes CRLF line endings before processing', () => {
+    const input = 'First\r\n\r\n_ comment\r\n\r\nSecond';
+    expect(stripCommentLines(input)).toBe('First\n\nSecond');
+  });
+
+  test('collapses blank lines correctly with CRLF input', () => {
+    const input = 'a\r\n\r\n_ removed\r\n\r\nb';
+    expect(stripCommentLines(input)).toBe('a\n\nb');
+  });
 });
 
 describe('ensurePromptFiles', () => {

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -77,11 +77,21 @@ function buildConfigSection(configDir: string): string {
 /**
  * Strip lines starting with `_` (comment convention for prompt .md files)
  * and collapse any resulting consecutive blank lines.
+ *
+ * Lines inside fenced code blocks (``` delimiters) are never stripped,
+ * so code examples with `_`-prefixed identifiers are preserved.
  */
 export function stripCommentLines(content: string): string {
-  return content
-    .split('\n')
-    .filter((line) => !line.trimStart().startsWith('_'))
+  const normalized = content.replace(/\r\n/g, '\n');
+  let inCodeBlock = false;
+  const filtered = normalized.split('\n').filter((line) => {
+    if (/^\s*```/.test(line)) {
+      inCodeBlock = !inCodeBlock;
+    }
+    if (inCodeBlock) return true;
+    return !line.trimStart().startsWith('_');
+  });
+  return filtered
     .join('\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();


### PR DESCRIPTION
## Summary
- **Code block awareness (P0):** `stripCommentLines` now tracks an `inCodeBlock` boolean, toggled on lines matching `/^\s*```/`. Lines inside fenced code blocks are never stripped, preventing silent corruption of code examples in SKILL.md bodies (e.g. Python `_instance = None` or `_private_var` lines).
- **CRLF normalization (P2):** Normalizes `\r\n` to `\n` at the start of processing so the blank-line collapse regex `\n{3,}` works correctly on Windows-style line endings.
- Added 4 new test cases covering both scenarios.

Addresses review feedback from #1663.

## Test plan
- [x] All 29 tests pass in `system-prompt.test.ts`
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
