### PR TITLE
Remove Chat label and merge panel buttons into single row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,19 +19,17 @@ struct MainWindowView: View {
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 0) {
-                // Row 1 — thread tab bar
+                // Row 1 — thread tab bar + panel buttons
                 ThreadTabBar(
                     threads: threadManager.threads,
                     activeThreadId: threadManager.activeThreadId,
                     onSelect: { threadManager.selectThread(id: $0) },
                     onClose: { threadManager.closeThread(id: $0) },
-                    onCreate: { threadManager.createThread() }
+                    onCreate: { threadManager.createThread() },
+                    activePanel: $activePanel
                 )
 
-                // Row 2 — navigation toolbar
-                NavigationToolbar(activePanel: $activePanel)
-
-                // Row 3 — chat content with optional side panel
+                // Row 2 — chat content with optional side panel
                 VSplitView(panelWidth: geometry.size.width * 0.5, showPanel: activePanel != nil, main: {
                     if let viewModel = threadManager.activeViewModel {
                         ChatView(

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -6,9 +6,6 @@ struct NavigationToolbar: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: VSpacing.sm) {
-                // Left group
-                VTab(label: "Chat", icon: "bubble.left", isSelected: true, isCloseable: false, onSelect: {})
-
                 Spacer()
 
                 // Right group — labeled buttons

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -6,6 +6,7 @@ struct ThreadTabBar: View {
     let onSelect: (UUID) -> Void
     let onClose: (UUID) -> Void
     let onCreate: () -> Void
+    @Binding var activePanel: SidePanelType?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -26,7 +27,7 @@ struct ThreadTabBar: View {
                         onClose: { onClose(thread.id) }
                     )
                 }
-                
+
                 Rectangle()
                     .fill(Slate._600)
                     .frame(width: 1, height: 14)
@@ -37,6 +38,28 @@ struct ThreadTabBar: View {
                     .accessibilityLabel("New Thread")
 
                 Spacer()
+
+                // Panel toggle buttons
+                HStack(spacing: VSpacing.sm) {
+                    VIconButton(label: "Generated", icon: "wand.and.stars", isActive: activePanel == .generated) {
+                        togglePanel(.generated)
+                    }
+                    VIconButton(label: "Agent", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
+                        togglePanel(.agent)
+                    }
+                    VIconButton(label: "Control", icon: "gearshape", isActive: activePanel == .control) {
+                        togglePanel(.control)
+                    }
+                    VIconButton(label: "Directory", icon: "doc.text", isActive: activePanel == .directory, iconOnly: true) {
+                        togglePanel(.directory)
+                    }
+                    VIconButton(label: "Debug", icon: "ant", isActive: activePanel == .debug, iconOnly: true) {
+                        togglePanel(.debug)
+                    }
+                    VIconButton(label: "Doctor", icon: "stethoscope", isActive: activePanel == .doctor, iconOnly: true) {
+                        togglePanel(.doctor)
+                    }
+                }
             }
             .padding(.leading, 78)
             .padding(.trailing, VSpacing.lg)
@@ -45,9 +68,18 @@ struct ThreadTabBar: View {
         }
         .ignoresSafeArea(edges: .top)
     }
+
+    private func togglePanel(_ panel: SidePanelType) {
+        if activePanel == panel {
+            activePanel = nil
+        } else {
+            activePanel = panel
+        }
+    }
 }
 
 #Preview("ThreadTabBar") {
+    @Previewable @State var panel: SidePanelType? = .control
     let threads = [
         ThreadModel(title: "New Thread"),
     ]
@@ -59,7 +91,8 @@ struct ThreadTabBar: View {
             activeThreadId: threads.first?.id,
             onSelect: { _ in },
             onClose: { _ in },
-            onCreate: {}
+            onCreate: {},
+            activePanel: $panel
         )
     }
     .frame(width: 600, height: 60)

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingFlowView.swift
@@ -172,18 +172,6 @@ struct FirstMeetingFlowView: View {
 
     private var mockToolbar: some View {
         HStack {
-            HStack(spacing: 6) {
-                Image(systemName: "bubble.left")
-                    .font(.system(size: 11))
-                Text("Chat")
-                    .font(VFont.bodyMedium)
-            }
-            .foregroundColor(VColor.textPrimary)
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.surface.opacity(0.5))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-
             Spacer()
 
             HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -116,18 +116,6 @@ struct OnboardingFlowView: View {
 
     private var mockToolbar: some View {
         HStack {
-            HStack(spacing: 6) {
-                Image(systemName: "bubble.left")
-                    .font(.system(size: 11))
-                Text("Chat")
-                    .font(VFont.bodyMedium)
-            }
-            .foregroundColor(VColor.textPrimary)
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.surface.opacity(0.5))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-
             Spacer()
 
             HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Removed the standalone "Chat" label/tab from the NavigationToolbar
- Merged panel toggle buttons (Generated, Agent, Control, Directory, Debug, Doctor) into the ThreadTabBar so everything fits on a single row
- Updated onboarding mock toolbars to match the new layout

## Test plan
- [ ] Verify thread tabs and panel buttons render on a single row
- [ ] Verify panel toggle buttons still open/close side panels correctly
- [ ] Verify onboarding flow mock toolbar renders without the Chat label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
