### PR TITLE
Handle file content blocks in memory ingestion

### DIFF
--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -27,6 +27,13 @@ export function extractTextFromStoredMessageContent(raw: string): string {
         case 'image':
           lines.push(`[image ${block.source.media_type}]`);
           break;
+        case 'file':
+          if (block.extracted_text) {
+            lines.push(`File (${block.source.filename}): ${block.extracted_text}`);
+          } else {
+            lines.push(`[file ${block.source.filename} ${block.source.media_type}]`);
+          }
+          break;
         default:
           lines.push('[unknown content block]');
       }


### PR DESCRIPTION
## Summary
File attachments (`type: "file"`) with `extracted_text` were falling through to the default `[unknown content block]` case in `extractTextFromStoredMessageContent()`.

Added a `case 'file'` handler that:
- Includes `extracted_text` content with the filename when present
- Falls back to a descriptive `[file filename media_type]` placeholder when `extracted_text` is not available

## Files changed
- `assistant/src/memory/message-content.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
