### PR TITLE
Improve buildMemoryQuery summary truncation with head+tail

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1214,7 +1214,14 @@ function buildMemoryQuery(content: string, messages: Message[]): string {
   const summaryText = messages
     .map((message) => getSummaryFromContextMessage(message))
     .find((summary): summary is string => summary !== null) ?? '';
-  const compactSummary = summaryText.slice(0, 1200);
+  const maxLen = 1200;
+  let compactSummary: string;
+  if (summaryText.length <= maxLen) {
+    compactSummary = summaryText;
+  } else {
+    const half = Math.floor((maxLen - 5) / 2); // 5 chars for "[...]"
+    compactSummary = summaryText.slice(0, half) + '[...]' + summaryText.slice(-half);
+  }
   return compactSummary.length > 0
     ? `${content}\n\nContext summary:\n${compactSummary}`
     : content;


### PR DESCRIPTION
## Summary
- Changed `buildMemoryQuery()` in `session.ts` to use a head+tail truncation strategy instead of first-1200-chars-only.
- Long conversation summaries now preserve both the beginning (~597 chars) and end (~597 chars), joined by `[...]`.
- This ensures recent context (often most relevant for memory recall) is not lost when summaries exceed 1200 characters.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Summaries <= 1200 chars: no change in behavior
- Summaries > 1200 chars: both early and recent context preserved
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
