### PR TITLE
Remove SQLite semantic fallback from memory retriever

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -7,7 +7,7 @@ import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
-import { memoryEmbeddings, memoryItems, memoryItemSources, memorySegments, memorySummaries, messages } from './schema.js';
+import { memoryItems, memoryItemSources, memorySegments } from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_MARKER = '[Memory Recall v2]';
@@ -360,13 +360,7 @@ async function semanticSearch(
 ): Promise<Candidate[]> {
   if (limit <= 0) return [];
 
-  let qdrant: ReturnType<typeof getQdrantClient>;
-  try {
-    qdrant = getQdrantClient();
-  } catch {
-    log.warn('Qdrant client not initialized, falling back to SQLite semantic search');
-    return sqliteFallbackSemanticSearch(queryVector, limit, excludedMessageIds);
-  }
+  const qdrant = getQdrantClient();
 
   // Overfetch to account for items filtered out post-query (invalidated, excluded, etc.)
   const fetchLimit = limit * 2;
@@ -443,115 +437,6 @@ async function semanticSearch(
     if (candidates.length >= limit) break;
   }
   return candidates;
-}
-
-function sqliteFallbackSemanticSearch(
-  queryVector: number[],
-  limit: number,
-  excludedMessageIds: string[],
-): Candidate[] {
-  const db = getDb();
-  const allEmbeddings = db.select().from(memoryEmbeddings).all();
-
-  const scored = allEmbeddings
-    .map((emb) => ({
-      targetType: emb.targetType,
-      targetId: emb.targetId,
-      similarity: cosineSimilarity(queryVector, JSON.parse(emb.vectorJson) as number[]),
-    }))
-    .sort((a, b) => b.similarity - a.similarity);
-
-  let excludedConversationIds: Set<string> | undefined;
-  if (excludedMessageIds.length > 0) {
-    const rows = db.select({ conversationId: messages.conversationId })
-      .from(messages)
-      .where(inArray(messages.id, excludedMessageIds))
-      .all();
-    excludedConversationIds = new Set(rows.map((r) => r.conversationId));
-  }
-
-  const candidates: Candidate[] = [];
-  for (const { targetType, targetId, similarity } of scored) {
-    const semantic = mapCosineToUnit(similarity);
-
-    if (targetType === 'item') {
-      const item = db.select().from(memoryItems).where(eq(memoryItems.id, targetId)).get();
-      if (!item || item.status !== 'active' || item.invalidAt !== null) continue;
-      const sources = db.select().from(memoryItemSources)
-        .where(eq(memoryItemSources.memoryItemId, targetId)).all();
-      if (sources.length === 0) continue;
-      if (excludedMessageIds.length > 0) {
-        const nonExcluded = sources.filter((s) => !excludedMessageIds.includes(s.messageId));
-        if (nonExcluded.length === 0) continue;
-      }
-      candidates.push({
-        key: `item:${targetId}`,
-        type: 'item',
-        id: targetId,
-        text: `${item.subject}: ${item.statement}`,
-        kind: item.kind,
-        confidence: item.confidence,
-        importance: item.importance ?? 0.5,
-        createdAt: item.lastSeenAt,
-        lexical: 0,
-        semantic,
-        recency: computeRecencyScore(item.lastSeenAt),
-        finalScore: 0,
-      });
-    } else if (targetType === 'summary') {
-      const summary = db.select().from(memorySummaries).where(eq(memorySummaries.id, targetId)).get();
-      if (!summary) continue;
-      if (excludedConversationIds && summary.scope === 'conversation' && excludedConversationIds.has(summary.scopeKey)) continue;
-      candidates.push({
-        key: `summary:${targetId}`,
-        type: 'summary',
-        id: targetId,
-        text: summary.summary,
-        kind: summary.scope === 'conversation' ? 'conversation_summary' : 'global_summary',
-        confidence: 0.6,
-        importance: 0.6,
-        createdAt: summary.createdAt,
-        lexical: 0,
-        semantic,
-        recency: computeRecencyScore(summary.createdAt),
-        finalScore: 0,
-      });
-    } else {
-      const segment = db.select().from(memorySegments).where(eq(memorySegments.id, targetId)).get();
-      if (!segment) continue;
-      if (excludedMessageIds.length > 0 && excludedMessageIds.includes(segment.messageId)) continue;
-
-      candidates.push({
-        key: `segment:${targetId}`,
-        type: 'segment',
-        id: targetId,
-        text: segment.text,
-        kind: 'segment',
-        confidence: 0.55,
-        importance: 0.5,
-        createdAt: segment.createdAt,
-        lexical: 0,
-        semantic,
-        recency: computeRecencyScore(segment.createdAt),
-        finalScore: 0,
-      });
-    }
-    if (candidates.length >= limit) break;
-  }
-  return candidates;
-}
-
-function cosineSimilarity(a: number[], b: number[]): number {
-  let dot = 0;
-  let magA = 0;
-  let magB = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    magA += a[i] * a[i];
-    magB += b[i] * b[i];
-  }
-  const denom = Math.sqrt(magA) * Math.sqrt(magB);
-  return denom === 0 ? 0 : dot / denom;
 }
 
 function recencySearch(conversationId: string, limit: number, excludedMessageIds: string[] = []): Candidate[] {


### PR DESCRIPTION
## Summary

Qdrant is now required and auto-installed on daemon startup (#1581, #1582), so the SQLite-based semantic search fallback in the memory retriever is dead code.

This PR removes:
- `sqliteFallbackSemanticSearch()` function (~90 lines) that loaded all embeddings from SQLite and computed cosine similarity in-process
- `cosineSimilarity()` helper function used only by the fallback
- The `try/catch` branch in `semanticSearch()` that caught Qdrant init failures and fell back to SQLite
- Unused schema imports (`memoryEmbeddings`, `memorySummaries`, `messages`) that were only referenced by the fallback

`semanticSearch()` now calls `getQdrantClient()` directly without a fallback — if Qdrant isn't available, the error propagates and is handled by the existing error handling in `buildMemoryRecall()`.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm memory recall works with Qdrant running
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
