### PR TITLE
Fix YAML syntax error in gateway CD workflow

### DIFF
--- a/.github/workflows/cd-gateway-image.yml
+++ b/.github/workflows/cd-gateway-image.yml
@@ -39,8 +39,7 @@ jobs:
           IMAGE="${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GATEWAY_IMAGE_NAME }}"
           TAGS="${IMAGE}:${{ github.sha }}"
           if [ "${{ github.ref_name }}" = "main" ]; then
-            TAGS="${TAGS}
-${IMAGE}:latest"
+            TAGS=$(printf "%s\n%s" "$TAGS" "${IMAGE}:latest")
           fi
           echo "tags<<EOF" >> "$GITHUB_OUTPUT"
           echo "$TAGS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The multi-line bash string for appending the `:latest` tag had its continuation line at column 0, which broke the YAML block scalar parser (syntax error on line 43)
- Replaced with `printf` to build the newline-separated tag list while keeping proper YAML indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
