### PR TITLE
feat: add hardcoded starter skill to Available Skills tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -119,12 +119,7 @@ struct AgentPanel: View {
                     case 0:
                         skillsContent
                     case 1:
-                        VEmptyState(
-                            title: "No available skills",
-                            subtitle: "Browse and add new skills",
-                            icon: "plus.square.on.square"
-                        )
-                        .frame(height: 250)
+                        availableSkillsContent
                     case 2:
                         VEmptyState(
                             title: "No nodes",
@@ -149,6 +144,129 @@ struct AgentPanel: View {
         .background(VColor.backgroundSubtle)
         .onAppear {
             skillsManager.fetchSkills()
+        }
+    }
+
+    // MARK: - Available Skills Tab
+
+    /// Hardcoded starter skill shown to new users as an onboarding tutorial.
+    private struct StarterSkill {
+        let slug: String
+        let name: String
+        let description: String
+        let emoji: String
+
+        static let summarizePage = StarterSkill(
+            slug: "summarize-page",
+            name: "Summarize Page",
+            description: "Read the current browser page and produce a concise summary",
+            emoji: "📄"
+        )
+    }
+
+    /// Whether the starter skill is already installed (exists in the skills list).
+    private var isStarterSkillInstalled: Bool {
+        skillsManager.skills.contains { $0.name == StarterSkill.summarizePage.name }
+    }
+
+    @ViewBuilder
+    private var availableSkillsContent: some View {
+        if isStarterSkillInstalled {
+            // Starter skill already installed — point to ClawhHub
+            VStack(spacing: VSpacing.lg) {
+                VEmptyState(
+                    title: "You're all set!",
+                    subtitle: "Browse more community skills on ClawhHub",
+                    icon: "sparkles"
+                )
+                .frame(height: 200)
+            }
+        } else {
+            VStack(spacing: VSpacing.lg) {
+                starterSkillCard(StarterSkill.summarizePage)
+            }
+        }
+    }
+
+    @State private var isInstallingStarter = false
+    @State private var hoveredStarterInstall = false
+
+    private func starterSkillCard(_ starter: StarterSkill) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.md) {
+                // Emoji icon
+                Text(starter.emoji)
+                    .font(.system(size: 20))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(starter.name)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textPrimary)
+
+                    Text(starter.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                // Install button
+                Button(action: {
+                    guard !isInstallingStarter else { return }
+                    isInstallingStarter = true
+                    skillsManager.installSkill(slug: starter.slug)
+                    // Reset after a delay in case the response is slow
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                        isInstallingStarter = false
+                    }
+                }) {
+                    HStack(spacing: VSpacing.sm) {
+                        if isInstallingStarter {
+                            ProgressView()
+                                .controlSize(.mini)
+                        } else {
+                            Image(systemName: "arrow.down.circle.fill")
+                                .font(.system(size: 12))
+                        }
+                        Text(isInstallingStarter ? "Installing…" : "Install")
+                            .font(VFont.mono)
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.sm)
+                    .foregroundColor(hoveredStarterInstall ? Slate._900 : Emerald._400)
+                    .background(hoveredStarterInstall ? Emerald._400 : Slate._800)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(isInstallingStarter)
+                .onHover { hovering in
+                    withAnimation(VAnimation.fast) {
+                        hoveredStarterInstall = hovering
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .background(Slate._900)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+            )
+
+            // Onboarding hint
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "lightbulb.fill")
+                    .font(.system(size: 10))
+                    .foregroundColor(Amber._500)
+                Text("Install this skill to get started. More skills coming soon via ClawhHub.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -64,4 +64,27 @@ final class SkillsManager: ObservableObject {
             }
         }
     }
+
+    func installSkill(slug: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.installSkill(slug: slug)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .skillsOperationResponse(let response) = message,
+                   response.operation == "install" {
+                    if response.success {
+                        // Refresh the skills list after successful install
+                        fetchSkills()
+                    }
+                    return
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a hardcoded "Summarize Page" starter skill card to the **Available Skills** tab in the Agent panel, serving as an onboarding tutorial for new users.

## Changes

### `AgentPanel.swift`
- Replaced the empty state in the "Available Skills" tab with a starter skill card
- Card shows skill name, description, emoji (📄), and a green **Install** button
- Install button shows loading state while installing
- Once installed, the card disappears and shows a "You're all set!" message pointing to ClawhHub
- Onboarding hint at the bottom: "Install this skill to get started. More skills coming soon via ClawhHub."
- Green (Emerald) accent distinguishes available skills from installed (Amber) skills

### `SkillsManager.swift`
- Added `installSkill(slug:)` method
- Sends `SkillsInstallMessage` to the daemon via IPC
- Listens for `skillsOperationResponse` with operation "install"
- On success, auto-refreshes the skills list

## Flow
1. New user opens Agent → Available Skills → sees the Summarize Page card
2. Taps **Install** → calls `installSkill(slug: "summarize-page")` via ClawhHub
3. On success, skills list refreshes → starter skill appears in the "Skills" tab
4. Available Skills tab detects it's installed → shows "browse ClawhHub" message

## Next steps
- Connect to ClawhHub to populate full available skills catalog after starter skill is installed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
