### PR TITLE
Tighten fence detection in stripCommentLines to CommonMark spec

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -266,6 +266,37 @@ describe('stripCommentLines', () => {
     expect(stripCommentLines(input)).toBe(expected);
   });
 
+  test('does not treat deeply indented backticks as fence delimiters', () => {
+    const input = [
+      'Some text',
+      '    ```',
+      '_ this should be stripped',
+      'End',
+    ].join('\n');
+    expect(stripCommentLines(input)).toBe('Some text\n    ```\nEnd');
+  });
+
+  test('recognizes tilde fences as code block delimiters', () => {
+    const input = [
+      '~~~',
+      '_keep_this',
+      '~~~',
+      '_ strip this',
+    ].join('\n');
+    expect(stripCommentLines(input)).toBe('~~~\n_keep_this\n~~~');
+  });
+
+  test('allows up to 3 spaces before a fence delimiter', () => {
+    const input = [
+      'Start',
+      '   ```python',
+      '_keep = True',
+      '   ```',
+      '_ strip this',
+    ].join('\n');
+    expect(stripCommentLines(input)).toBe('Start\n   ```python\n_keep = True\n   ```');
+  });
+
   test('normalizes CRLF line endings before processing', () => {
     const input = 'First\r\n\r\n_ comment\r\n\r\nSecond';
     expect(stripCommentLines(input)).toBe('First\n\nSecond');

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -78,14 +78,14 @@ function buildConfigSection(configDir: string): string {
  * Strip lines starting with `_` (comment convention for prompt .md files)
  * and collapse any resulting consecutive blank lines.
  *
- * Lines inside fenced code blocks (``` delimiters) are never stripped,
- * so code examples with `_`-prefixed identifiers are preserved.
+ * Lines inside fenced code blocks (``` or ~~~ delimiters per CommonMark)
+ * are never stripped, so code examples with `_`-prefixed identifiers are preserved.
  */
 export function stripCommentLines(content: string): string {
   const normalized = content.replace(/\r\n/g, '\n');
   let inCodeBlock = false;
   const filtered = normalized.split('\n').filter((line) => {
-    if (/^\s*```/.test(line)) {
+    if (/^ {0,3}(`{3,}|~{3,})/.test(line)) {
       inCodeBlock = !inCodeBlock;
     }
     if (inCodeBlock) return true;


### PR DESCRIPTION
## Summary

Addresses codex review feedback on #1666 (P2: detect only real fence markers when toggling code mode).

- Tightened the fence regex from `/^\s*` ``` `/` to `/^ {0,3}(`{3,}|~{3,})/` per the CommonMark spec
- Only 0-3 spaces of indentation are allowed before a fence delimiter (4+ spaces = indented code block content)
- Now supports both backtick and tilde fence delimiters
- Added tests for: deeply indented backticks (not treated as fences), tilde fences, and 0-3 space indented fences

This prevents deeply indented lines containing backticks from incorrectly toggling `inCodeBlock` state, which could leak `_`-prefixed prompt comments into loaded skill/system content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
