### PR TITLE
M12: Enforce budget warnings and blocking in daemon/runtime

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -286,6 +286,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     provider: 'openai',
     model: 'text-embedding-3-small',
   },
+  budget_warning: {
+    type: 'budget_warning',
+    violations: [
+      { period: 'day', amountUsd: 10, currentSpend: 10.5, action: 'warn' },
+    ],
+  },
   cu_action: {
     type: 'cu_action',
     sessionId: 'cu-sess-001',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -31,6 +31,8 @@ import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon, readCachedSkill
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
+import { evaluateBudgets } from '../usage/budget-policy.js';
+import type { BudgetWarning } from './ipc-protocol.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -318,6 +320,88 @@ export function handleMessage(
   handler(msg, socket, ctx);
 }
 
+// ─── Budget enforcement helpers ──────────────────────────────────────────────
+
+/**
+ * Check budget limits before processing a request. Returns a structured error
+ * message if a hard (block) limit is exceeded, or `null` if the request may
+ * proceed. Warning-level violations are emitted as IPC events but do not
+ * block the request.
+ *
+ * If the budget evaluation itself throws (e.g. DB error), the error is logged
+ * and the request is allowed to proceed (non-fatal).
+ */
+function checkBudgetPreRequest(
+  sendEvent: (event: ServerMessage) => void,
+): string | null {
+  try {
+    const config = getConfig();
+    const evaluation = evaluateBudgets(config.costControls);
+
+    if (evaluation.hasBlocks) {
+      const blockingViolation = evaluation.violations.find(
+        (v) => v.exceeded && v.action === 'block',
+      );
+      return `Budget limit exceeded: you have spent $${blockingViolation!.currentSpend.toFixed(2)} ` +
+        `of your $${blockingViolation!.amountUsd.toFixed(2)} ${blockingViolation!.period} budget. ` +
+        `Please adjust your budget settings or wait for the next period.`;
+    }
+
+    if (evaluation.hasWarnings) {
+      const warningViolations = evaluation.violations.filter(
+        (v) => v.exceeded && v.action === 'warn',
+      );
+      const warning: BudgetWarning = {
+        type: 'budget_warning',
+        violations: warningViolations.map((v) => ({
+          period: v.period,
+          amountUsd: v.amountUsd,
+          currentSpend: v.currentSpend,
+          action: v.action,
+        })),
+      };
+      sendEvent(warning);
+    }
+
+    return null;
+  } catch (err) {
+    log.warn({ err }, 'Budget check failed (non-fatal), allowing request to proceed');
+    return null;
+  }
+}
+
+/**
+ * Evaluate budgets after usage has been recorded. Emits a warning event if
+ * a warning threshold has been crossed. Non-fatal: errors are logged and
+ * swallowed.
+ */
+function checkBudgetPostUsage(
+  sendEvent: (event: ServerMessage) => void,
+): void {
+  try {
+    const config = getConfig();
+    const evaluation = evaluateBudgets(config.costControls);
+
+    if (evaluation.hasWarnings) {
+      const warningViolations = evaluation.violations.filter(
+        (v) => v.exceeded && v.action === 'warn',
+      );
+      const warning: BudgetWarning = {
+        type: 'budget_warning',
+        violations: warningViolations.map((v) => ({
+          period: v.period,
+          amountUsd: v.amountUsd,
+          currentSpend: v.currentSpend,
+          action: v.action,
+        })),
+      };
+      sendEvent(warning);
+    }
+  } catch (err) {
+    log.warn({ err }, 'Post-usage budget check failed (non-fatal)');
+  }
+}
+
 // ─── Individual handlers ─────────────────────────────────────────────────────
 
 async function handleUserMessage(
@@ -328,10 +412,18 @@ async function handleUserMessage(
   const requestId = uuid();
   const rlog = log.child({ sessionId: msg.sessionId, requestId });
   try {
+    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+
+    // Pre-request budget check: block if a hard limit is exceeded
+    const budgetError = checkBudgetPreRequest(sendEvent);
+    if (budgetError) {
+      rlog.warn('Message blocked by budget policy');
+      ctx.send(socket, { type: 'error', message: budgetError });
+      return;
+    }
+
     ctx.socketToSession.set(socket, msg.sessionId);
     const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
-
-    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
     if (result.rejected) {
@@ -354,7 +446,10 @@ async function handleUserMessage(
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
-    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
+    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).then(() => {
+      // Post-usage budget check: emit warnings if thresholds are crossed
+      checkBudgetPostUsage(sendEvent);
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
       ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
@@ -737,6 +832,16 @@ async function handleTaskSubmit(
   const rlog = log.child({ requestId });
 
   try {
+    const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+
+    // Pre-request budget check: block if a hard limit is exceeded
+    const budgetError = checkBudgetPreRequest(sendEvent);
+    if (budgetError) {
+      rlog.warn('Task blocked by budget policy');
+      ctx.send(socket, { type: 'error', message: budgetError });
+      return;
+    }
+
     const interactionType = await classifyInteraction(msg.task, msg.source);
     rlog.info({ interactionType, task: msg.task }, 'Task classified');
 
@@ -777,7 +882,10 @@ async function handleTaskSubmit(
       // Start streaming immediately — client doesn't need to send user_message
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
-      }, requestId).catch((err) => {
+      }, requestId).then(() => {
+        // Post-usage budget check: emit warnings if thresholds are crossed
+        checkBudgetPostUsage(sendEvent);
+      }).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -412,6 +412,16 @@ export interface MemoryRecalled {
   latencyMs: number;
 }
 
+export interface BudgetWarning {
+  type: 'budget_warning';
+  violations: Array<{
+    period: string;
+    amountUsd: number;
+    currentSpend: number;
+    action: string;
+  }>;
+}
+
 export interface MemoryStatus {
   type: 'memory_status';
   enabled: boolean;
@@ -593,6 +603,7 @@ export type ServerMessage =
   | SecretDetected
   | MemoryRecalled
   | MemoryStatus
+  | BudgetWarning
   | CuAction
   | CuComplete
   | CuError

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -22,6 +22,7 @@ import {
 } from './ipc-protocol.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import { evaluateBudgets } from '../usage/budget-policy.js';
 
 const log = getLogger('server');
 
@@ -499,6 +500,26 @@ export class DaemonServer {
     content: string,
     attachmentIds?: string[],
   ): Promise<{ messageId: string }> {
+    // Pre-request budget check
+    try {
+      const config = getConfig();
+      const evaluation = evaluateBudgets(config.costControls);
+      if (evaluation.hasBlocks) {
+        const v = evaluation.violations.find((v) => v.exceeded && v.action === 'block');
+        throw new Error(
+          `Budget limit exceeded: you have spent $${v!.currentSpend.toFixed(2)} ` +
+          `of your $${v!.amountUsd.toFixed(2)} ${v!.period} budget. ` +
+          `Please adjust your budget settings or wait for the next period.`,
+        );
+      }
+    } catch (err) {
+      // Re-throw budget-blocked errors; swallow unexpected evaluation failures
+      if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+        throw err;
+      }
+      log.warn({ err }, 'Budget check failed (non-fatal), allowing request to proceed');
+    }
+
     const session = await this.getOrCreateSession(conversationId);
 
     // Reject concurrent requests upfront. The HTTP path should never use
@@ -541,6 +562,25 @@ export class DaemonServer {
     content: string,
     attachmentIds?: string[],
   ): Promise<{ messageId: string }> {
+    // Pre-request budget check
+    try {
+      const config = getConfig();
+      const evaluation = evaluateBudgets(config.costControls);
+      if (evaluation.hasBlocks) {
+        const v = evaluation.violations.find((v) => v.exceeded && v.action === 'block');
+        throw new Error(
+          `Budget limit exceeded: you have spent $${v!.currentSpend.toFixed(2)} ` +
+          `of your $${v!.amountUsd.toFixed(2)} ${v!.period} budget. ` +
+          `Please adjust your budget settings or wait for the next period.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+        throw err;
+      }
+      log.warn({ err }, 'Budget check failed (non-fatal), allowing request to proceed');
+    }
+
     const session = await this.getOrCreateSession(conversationId);
 
     if (session.isProcessing()) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -19,6 +19,7 @@ import { getConfig } from '../config/loader.js';
 import { getUsageSummary } from '../usage/summary.js';
 import type { RunOrchestrator } from './run-orchestrator.js';
 import { recordDirectLlmUsage } from '../usage/recorders.js';
+import { evaluateBudgets } from '../usage/budget-policy.js';
 
 const log = getLogger('runtime-http');
 
@@ -428,6 +429,12 @@ export class RuntimeHttpServer {
           { status: 409 },
         );
       }
+      if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+        return Response.json(
+          { error: err.message },
+          { status: 429 },
+        );
+      }
       throw err;
     }
   }
@@ -494,6 +501,12 @@ export class RuntimeHttpServer {
         return Response.json(
           { error: 'Session is busy processing another message. Please retry.' },
           { status: 409 },
+        );
+      }
+      if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+        return Response.json(
+          { error: err.message },
+          { status: 429 },
         );
       }
       throw err;
@@ -705,6 +718,12 @@ export class RuntimeHttpServer {
         await this.processMessage(assistantId, result.conversationId, content ?? '', hasAttachments ? attachmentIds : undefined);
         processingSucceeded = true;
       } catch (err) {
+        if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+          return Response.json(
+            { error: err.message },
+            { status: 429 },
+          );
+        }
         log.error({ err, conversationId: result.conversationId }, 'Failed to process channel inbound message');
       }
     }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -16,6 +16,8 @@ import type { Session } from '../daemon/session.js';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { UserDecision } from '../permissions/types.js';
 import { getLogger } from '../util/logger.js';
+import { getConfig } from '../config/loader.js';
+import { evaluateBudgets } from '../usage/budget-policy.js';
 
 const log = getLogger('run-orchestrator');
 
@@ -67,6 +69,25 @@ export class RunOrchestrator {
     content: string,
     attachmentIds?: string[],
   ): Promise<Run> {
+    // Pre-request budget check
+    try {
+      const config = getConfig();
+      const evaluation = evaluateBudgets(config.costControls);
+      if (evaluation.hasBlocks) {
+        const v = evaluation.violations.find((v) => v.exceeded && v.action === 'block');
+        throw new Error(
+          `Budget limit exceeded: you have spent $${v!.currentSpend.toFixed(2)} ` +
+          `of your $${v!.amountUsd.toFixed(2)} ${v!.period} budget. ` +
+          `Please adjust your budget settings or wait for the next period.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Budget limit exceeded')) {
+        throw err;
+      }
+      log.warn({ err }, 'Budget check failed (non-fatal), allowing run to proceed');
+    }
+
     const session = await this.deps.getOrCreateSession(conversationId);
 
     if (session.isProcessing()) {


### PR DESCRIPTION
## Summary
- Add pre-run budget evaluation to daemon handlers (`handleSendMessage`, `handleCreateRun`, `handleChannelInbound`)
- Add budget check to HTTP server run endpoint
- Add `budget_warning` IPC message type for daemon-to-client communication
- Integrate `evaluateBudgets()` from M11 into the runtime flow

Closes #1247

## Test plan
- [x] TypeScript types pass
- [ ] Verify budget warnings are emitted when spend exceeds warn threshold
- [ ] Verify runs are blocked when spend exceeds block threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
