### PR TITLE
Add .qdrant-initialized to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist
 # misc
 .DS_Store
 *.pem
+.qdrant-initialized
 .claude/*
 !.claude/commands/
 !.claude/README.md


### PR DESCRIPTION
## Summary
- Gitignore `.qdrant-initialized` marker file created by the Qdrant binary at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
