### PR TITLE
Polish VSegmentedControl layout, update previews, and add app-builder icon

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/icon.svg
+++ b/assistant/src/config/bundled-skills/app-builder/icon.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="12" height="12" fill="#e8e8e8" stroke="#333" stroke-width="1"/>
+  <rect x="3" y="3" width="10" height="2" fill="#4a90e2"/>
+  <rect x="3" y="6" width="4" height="6" fill="#50c878"/>
+  <rect x="8" y="6" width="5" height="2" fill="#f5a623"/>
+  <rect x="8" y="9" width="5" height="3" fill="#bd10e0"/>
+  <rect x="4" y="9" width="3" height="3" fill="#ff6b6b"/>
+</svg>

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
@@ -55,7 +55,7 @@ extension VSidePanel where PinnedContent == EmptyView {
     ZStack {
         VColor.background.ignoresSafeArea()
         VSidePanel(title: "Inspector", onClose: {}) {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("Panel content here")
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
@@ -66,4 +66,28 @@ extension VSidePanel where PinnedContent == EmptyView {
         }
     }
     .frame(width: 300, height: 300)
+}
+
+#Preview("VSidePanel with Pinned Content") {
+    @Previewable @State var tab = 1
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VSidePanel(title: "Control", onClose: {}, pinnedContent: {
+            VSegmentedControl(
+                items: ["Profile", "Settings", "Channels", "Overview"],
+                selection: $tab
+            )
+            Divider().background(VColor.surfaceBorder)
+        }) {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Tab content here")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                Text("The tab bar above stays pinned while this scrolls.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+    }
+    .frame(width: 400, height: 350)
 }

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -12,13 +12,13 @@ struct VSegmentedControl: View {
                         Text(items[index])
                             .font(VFont.captionMedium)
                             .foregroundColor(selection == index ? VColor.textPrimary : VColor.textMuted)
-                            .padding(.horizontal, VSpacing.xl)
-                            .padding(.vertical, VSpacing.sm)
+                            .padding(.vertical, VSpacing.md)
 
                         Rectangle()
                             .fill(selection == index ? VColor.accent : .clear)
                             .frame(height: 2)
                     }
+                    .frame(maxWidth: .infinity)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -31,12 +31,11 @@ struct VSegmentedControl: View {
 
 #if DEBUG
 #Preview("VSegmentedControl") {
-    @Previewable @State var selection = 0
+    @Previewable @State var selection = 1
     ZStack {
         VColor.background.ignoresSafeArea()
-        VSegmentedControl(items: ["All", "Active", "Archived"], selection: $selection)
-            .padding()
+        VSegmentedControl(items: ["Profile", "Settings", "Channels", "Overview"], selection: $selection)
     }
-    .frame(width: 400, height: 80)
+    .frame(width: 500, height: 60)
 }
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -57,7 +57,7 @@ struct LayoutGallerySection: View {
             VCard(padding: 0) {
                 VSidePanel(title: "Control", onClose: {}, pinnedContent: {
                     VSegmentedControl(
-                        items: ["Profile", "Settings", "Channels"],
+                        items: ["Profile", "Settings", "Channels", "Overview"],
                         selection: $pinnedTabSelection
                     )
                     .padding(.horizontal, VSpacing.sm)
@@ -104,7 +104,7 @@ struct LayoutGallerySection: View {
                     ) {
                         VStack {
                             Text("Main Content")
-                                .font(VFont.title)
+                                .font(VFont.panelTitle)
                                 .foregroundColor(VColor.textPrimary)
                             Text("This is the primary area")
                                 .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -28,6 +28,7 @@ struct ControlPanel: View {
                 selection: $selectedTabIndex
             )
             .padding(.horizontal, VSpacing.sm)
+            .padding(.top, VSpacing.sm)
 
             Divider().background(VColor.surfaceBorder)
         }) {


### PR DESCRIPTION
## Summary
- Make VSegmentedControl tabs fill equal width with centered text, increase vertical padding, and expand hit targets
- Update all previews to match current component API (4 tabs, correct fonts, VSpacing tokens, pinned content variant)
- Add app-builder skill icon.svg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
