### PR TITLE
Add Usage panel to macOS desktop app

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IPC message snapshots ClientMessage types user_message serializes to expected JSON 1`] = `
 {
@@ -173,6 +173,19 @@ exports[`IPC message snapshots ClientMessage types skill_detail serializes to ex
 {
   "skillId": "my-skill",
   "type": "skill_detail",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types usage_summary_request serializes to expected JSON 1`] = `
+{
+  "preset": "24h",
+  "type": "usage_summary_request",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types budget_status_request serializes to expected JSON 1`] = `
+{
+  "type": "budget_status_request",
 }
 `;
 
@@ -428,6 +441,20 @@ exports[`IPC message snapshots ServerMessage types memory_status serializes to e
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types budget_warning serializes to expected JSON 1`] = `
+{
+  "type": "budget_warning",
+  "violations": [
+    {
+      "action": "warn",
+      "amountUsd": 10,
+      "currentSpend": 10.5,
+      "period": "day",
+    },
+  ],
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types cu_action serializes to expected JSON 1`] = `
 {
   "input": {
@@ -559,6 +586,66 @@ Do the thing."
 ,
   "skillId": "my-skill",
   "type": "skill_detail_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types usage_summary_response serializes to expected JSON 1`] = `
+{
+  "byModel": [
+    {
+      "eventCount": 42,
+      "key": "sonnet-4.5",
+      "totalCost": 1.25,
+    },
+  ],
+  "byProvider": [
+    {
+      "eventCount": 42,
+      "key": "anthropic",
+      "totalCost": 1.25,
+    },
+  ],
+  "dailyBuckets": [
+    {
+      "date": "2025-01-15",
+      "eventCount": 25,
+      "totalCost": 0.75,
+    },
+    {
+      "date": "2025-01-16",
+      "eventCount": 17,
+      "totalCost": 0.5,
+    },
+  ],
+  "eventCount": 42,
+  "preset": "24h",
+  "totalInputTokens": 50000,
+  "totalOutputTokens": 15000,
+  "totalPricedCostUsd": 1.25,
+  "type": "usage_summary_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types budget_status_response serializes to expected JSON 1`] = `
+{
+  "budgets": [
+    {
+      "action": "warn",
+      "amountUsd": 10,
+      "currentSpend": 1.25,
+      "exceeded": false,
+      "period": "day",
+    },
+    {
+      "action": "block",
+      "amountUsd": 100,
+      "currentSpend": 45,
+      "exceeded": false,
+      "period": "month",
+    },
+  ],
+  "enabled": true,
+  "type": "budget_status_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -125,6 +125,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skill_detail',
     skillId: 'my-skill',
   },
+  usage_summary_request: {
+    type: 'usage_summary_request',
+    preset: '24h',
+  },
+  budget_status_request: {
+    type: 'budget_status_request',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -360,6 +367,32 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'skill_detail_response',
     skillId: 'my-skill',
     body: '# Skill content\n\nDo the thing.',
+  },
+  usage_summary_response: {
+    type: 'usage_summary_response',
+    preset: '24h',
+    totalPricedCostUsd: 1.25,
+    totalInputTokens: 50000,
+    totalOutputTokens: 15000,
+    eventCount: 42,
+    byProvider: [
+      { key: 'anthropic', totalCost: 1.25, eventCount: 42 },
+    ],
+    byModel: [
+      { key: 'sonnet-4.5', totalCost: 1.25, eventCount: 42 },
+    ],
+    dailyBuckets: [
+      { date: '2025-01-15', totalCost: 0.75, eventCount: 25 },
+      { date: '2025-01-16', totalCost: 0.50, eventCount: 17 },
+    ],
+  },
+  budget_status_response: {
+    type: 'budget_status_response',
+    enabled: true,
+    budgets: [
+      { period: 'day', amountUsd: 10, currentSpend: 1.25, action: 'warn', exceeded: false },
+      { period: 'month', amountUsd: 100, currentSpend: 45.00, action: 'block', exceeded: false },
+    ],
   },
   message_queued: {
     type: 'message_queued',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -32,7 +32,8 @@ import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
 import { evaluateBudgets } from '../usage/budget-policy.js';
-import type { BudgetWarning } from './ipc-protocol.js';
+import { getUsageSummary } from '../usage/summary.js';
+import type { BudgetWarning, UsageSummaryRequest, BudgetStatusRequest } from './ipc-protocol.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -289,6 +290,8 @@ const handlers: DispatchMap = {
   app_data_request: handleAppDataRequest,
   skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
   skill_detail: handleSkillDetail,
+  usage_summary_request: handleUsageSummaryRequest,
+  budget_status_request: (_msg, socket, ctx) => handleBudgetStatusRequest(socket, ctx),
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -767,6 +770,69 @@ async function handleSkillDetail(
       body: '',
       error: result.error ?? 'Skill not found',
     });
+  }
+}
+
+// ─── Usage summary / budget status handlers ─────────────────────────────────
+
+const PRESET_DURATIONS_MS: Record<string, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+};
+
+function handleUsageSummaryRequest(
+  msg: UsageSummaryRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const now = Date.now();
+    const windowMs = PRESET_DURATIONS_MS[msg.preset] ?? PRESET_DURATIONS_MS['24h'];
+    const summary = getUsageSummary({ startAt: now - windowMs, endAt: now });
+
+    ctx.send(socket, {
+      type: 'usage_summary_response',
+      preset: msg.preset,
+      totalPricedCostUsd: summary.totalPricedCostUsd,
+      totalInputTokens: summary.totalInputTokens,
+      totalOutputTokens: summary.totalOutputTokens,
+      eventCount: summary.eventCount,
+      byProvider: summary.byProvider.map((e) => ({ key: e.key, totalCost: e.totalCost, eventCount: e.eventCount })),
+      byModel: summary.byModel.map((e) => ({ key: e.key, totalCost: e.totalCost, eventCount: e.eventCount })),
+      dailyBuckets: summary.dailyBuckets.map((b) => ({ date: b.date, totalCost: b.totalCost, eventCount: b.eventCount })),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Error handling usage_summary_request');
+    ctx.send(socket, { type: 'error', message: `Failed to get usage summary: ${message}` });
+  }
+}
+
+function handleBudgetStatusRequest(
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const config = getConfig();
+    const enabled = config.costControls.enabled;
+    const evaluation = evaluateBudgets(config.costControls);
+
+    ctx.send(socket, {
+      type: 'budget_status_response',
+      enabled,
+      budgets: evaluation.violations.map((v) => ({
+        period: v.period,
+        amountUsd: v.amountUsd,
+        currentSpend: v.currentSpend,
+        action: v.action,
+        exceeded: v.exceeded,
+      })),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Error handling budget_status_request');
+    ctx.send(socket, { type: 'error', message: `Failed to get budget status: ${message}` });
   }
 }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -149,6 +149,15 @@ export interface SkillDetailRequest {
   skillId: string;
 }
 
+export interface UsageSummaryRequest {
+  type: 'usage_summary_request';
+  preset: '24h' | '7d' | '30d';
+}
+
+export interface BudgetStatusRequest {
+  type: 'budget_status_request';
+}
+
 // === Surface types ===
 
 export type SurfaceType = 'card' | 'form' | 'list' | 'confirmation' | 'dynamic_page' | 'file_upload';
@@ -251,7 +260,9 @@ export type ClientMessage =
   | UiSurfaceAction
   | AppDataRequest
   | SkillsListRequest
-  | SkillDetailRequest;
+  | SkillDetailRequest
+  | UsageSummaryRequest
+  | BudgetStatusRequest;
 
 // === Server → Client messages ===
 
@@ -507,6 +518,30 @@ export interface SkillDetailResponse {
   error?: string;
 }
 
+export interface UsageSummaryResponse {
+  type: 'usage_summary_response';
+  preset: '24h' | '7d' | '30d';
+  totalPricedCostUsd: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  eventCount: number;
+  byProvider: Array<{ key: string; totalCost: number | null; eventCount: number }>;
+  byModel: Array<{ key: string; totalCost: number | null; eventCount: number }>;
+  dailyBuckets: Array<{ date: string; totalCost: number | null; eventCount: number }>;
+}
+
+export interface BudgetStatusResponse {
+  type: 'budget_status_response';
+  enabled: boolean;
+  budgets: Array<{
+    period: string;
+    amountUsd: number;
+    currentSpend: number;
+    action: string;
+    exceeded: boolean;
+  }>;
+}
+
 export interface MessageQueued {
   type: 'message_queued';
   sessionId: string;
@@ -615,6 +650,8 @@ export type ServerMessage =
   | AppDataResponse
   | SkillsListResponse
   | SkillDetailResponse
+  | UsageSummaryResponse
+  | BudgetStatusResponse
   | MessageQueued
   | MessageDequeued;
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -63,6 +63,8 @@ struct MainWindowView: View {
                 AgentPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .control:
                 ControlPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent)
+            case .usage:
+                UsagePanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .directory:
                 DirectoryPanel(onClose: { activePanel = nil })
             case .debug:

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -21,6 +21,9 @@ struct NavigationToolbar: View {
                 VIconButton(label: "Control", icon: "gearshape", isActive: activePanel == .control) {
                     togglePanel(.control)
                 }
+                VIconButton(label: "Usage", icon: "chart.bar", isActive: activePanel == .usage) {
+                    togglePanel(.usage)
+                }
 
                 // Right group — icon-only buttons
                 VIconButton(label: "Directory", icon: "doc.text", isActive: activePanel == .directory, iconOnly: true) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageManager.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+@MainActor
+final class UsageManager: ObservableObject {
+    @Published var summary: UsageSummaryResponseMessage?
+    @Published var budgetStatus: BudgetStatusResponseMessage?
+    @Published var budgetWarnings: [BudgetWarningMessage.BudgetWarningViolation] = []
+    @Published var isLoading = false
+    @Published var selectedPreset: String = "24h"
+
+    private let daemonClient: DaemonClient
+    private var warningSubscriptionTask: Task<Void, Never>?
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func fetchSummary() {
+        guard !isLoading else { return }
+        isLoading = true
+
+        Task {
+            // Subscribe before sending so we don't miss fast daemon responses
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.send(UsageSummaryRequestMessage(preset: selectedPreset))
+            } catch {
+                isLoading = false
+                return
+            }
+
+            for await message in stream {
+                if case .usageSummaryResponse(let response) = message {
+                    summary = response
+                    isLoading = false
+                    return
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    func fetchBudgetStatus() {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.send(BudgetStatusRequestMessage())
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .budgetStatusResponse(let response) = message {
+                    budgetStatus = response
+                    return
+                }
+            }
+        }
+    }
+
+    func subscribeToBudgetWarnings() {
+        warningSubscriptionTask?.cancel()
+        warningSubscriptionTask = Task {
+            let stream = daemonClient.subscribe()
+            for await message in stream {
+                if case .budgetWarning(let warning) = message {
+                    budgetWarnings = warning.violations
+                }
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsagePanel.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+import Charts
+
+@MainActor
+struct UsagePanel: View {
+    var onClose: () -> Void
+    let daemonClient: DaemonClient
+
+    @StateObject private var usageManager: UsageManager
+
+    init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
+        self.onClose = onClose
+        self.daemonClient = daemonClient
+        _usageManager = StateObject(
+            wrappedValue: UsageManager(daemonClient: daemonClient)
+        )
+    }
+
+    private let presets = ["24h", "7d", "30d"]
+
+    var body: some View {
+        VSidePanel(title: "Usage", onClose: onClose) {
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                // Time preset selector
+                presetSelector
+
+                // Budget warning banner
+                if !usageManager.budgetWarnings.isEmpty {
+                    budgetWarningBanner
+                }
+
+                // Summary totals
+                if let summary = usageManager.summary {
+                    summarySection(summary)
+                    dailyChartSection(summary)
+                    providerBreakdown(summary)
+                    modelBreakdown(summary)
+                }
+
+                // Budget status
+                if let budget = usageManager.budgetStatus, budget.enabled {
+                    budgetStatusSection(budget)
+                }
+
+                if usageManager.isLoading && usageManager.summary == nil {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            usageManager.fetchSummary()
+            usageManager.fetchBudgetStatus()
+            usageManager.subscribeToBudgetWarnings()
+        }
+    }
+
+    // MARK: - Preset Selector
+
+    private var presetSelector: some View {
+        HStack(spacing: 0) {
+            ForEach(presets, id: \.self) { preset in
+                Button(action: {
+                    usageManager.selectedPreset = preset
+                    usageManager.fetchSummary()
+                }) {
+                    Text(preset)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(
+                            usageManager.selectedPreset == preset
+                                ? VColor.textPrimary
+                                : VColor.textSecondary
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.xs)
+                }
+                .buttonStyle(.plain)
+                .background(
+                    usageManager.selectedPreset == preset
+                        ? VColor.surface
+                        : Color.clear
+                )
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Budget Warning Banner
+
+    private var budgetWarningBanner: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(VColor.warning)
+                Text("Budget Warning")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.warning)
+            }
+            ForEach(usageManager.budgetWarnings) { violation in
+                Text("Spent $\(violation.currentSpend, specifier: "%.2f") of $\(violation.amountUsd, specifier: "%.2f") \(violation.period) budget")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Summary Section
+
+    private func summarySection(_ summary: UsageSummaryResponseMessage) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("SUMMARY")
+                .font(VFont.display)
+                .foregroundColor(VColor.textPrimary)
+
+            // Total cost
+            Text("$\(summary.totalPricedCostUsd, specifier: "%.2f")")
+                .font(VFont.largeTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            // Token counts
+            HStack(spacing: VSpacing.xl) {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Input tokens")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text(formatTokenCount(summary.totalInputTokens))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("Output tokens")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text(formatTokenCount(summary.totalOutputTokens))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text("API calls")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text("\(summary.eventCount)")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Daily Chart
+
+    private func dailyChartSection(_ summary: UsageSummaryResponseMessage) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("DAILY SPEND")
+                .font(VFont.display)
+                .foregroundColor(VColor.textPrimary)
+
+            if summary.dailyBuckets.isEmpty {
+                Text("No data for this period")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                Chart(summary.dailyBuckets) { bucket in
+                    BarMark(
+                        x: .value("Date", bucket.date),
+                        y: .value("Cost", bucket.totalCost ?? 0)
+                    )
+                    .foregroundStyle(VColor.accent)
+                    .cornerRadius(VRadius.xs)
+                }
+                .chartXAxis {
+                    AxisMarks(values: .automatic) { _ in
+                        AxisValueLabel()
+                            .font(VFont.small)
+                            .foregroundStyle(VColor.textMuted)
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisGridLine()
+                            .foregroundStyle(VColor.surfaceBorder)
+                        AxisValueLabel {
+                            if let v = value.as(Double.self) {
+                                Text("$\(v, specifier: "%.2f")")
+                                    .font(VFont.small)
+                                    .foregroundStyle(VColor.textMuted)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 140)
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Provider Breakdown
+
+    private func providerBreakdown(_ summary: UsageSummaryResponseMessage) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("BY PROVIDER")
+                .font(VFont.display)
+                .foregroundColor(VColor.textPrimary)
+
+            if summary.byProvider.isEmpty {
+                Text("No data")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(summary.byProvider) { entry in
+                    breakdownRow(key: entry.key, cost: entry.totalCost, count: entry.eventCount)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Model Breakdown
+
+    private func modelBreakdown(_ summary: UsageSummaryResponseMessage) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("BY MODEL")
+                .font(VFont.display)
+                .foregroundColor(VColor.textPrimary)
+
+            if summary.byModel.isEmpty {
+                Text("No data")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(summary.byModel) { entry in
+                    breakdownRow(key: entry.key, cost: entry.totalCost, count: entry.eventCount)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Budget Status
+
+    private func budgetStatusSection(_ budget: BudgetStatusResponseMessage) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("BUDGETS")
+                .font(VFont.display)
+                .foregroundColor(VColor.textPrimary)
+
+            if budget.budgets.isEmpty {
+                Text("No budgets configured")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(budget.budgets) { entry in
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                            Text(entry.period.capitalized)
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.textPrimary)
+                            Text("\(entry.action)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: VSpacing.xxs) {
+                            Text("$\(entry.currentSpend, specifier: "%.2f") / $\(entry.amountUsd, specifier: "%.2f")")
+                                .font(VFont.mono)
+                                .foregroundColor(entry.exceeded ? VColor.error : VColor.textSecondary)
+                            if entry.exceeded {
+                                Text("Exceeded")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.error)
+                            }
+                        }
+                    }
+                    if entry.id != budget.budgets.last?.id {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .vCard()
+    }
+
+    // MARK: - Helpers
+
+    private func breakdownRow(key: String, cost: Double?, count: Int) -> some View {
+        HStack {
+            Text(key)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(1)
+            Spacer()
+            if let cost = cost {
+                Text("$\(cost, specifier: "%.2f")")
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textSecondary)
+            } else {
+                Text("N/A")
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textMuted)
+            }
+            Text("\(count) calls")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 60, alignment: .trailing)
+        }
+    }
+
+    private func formatTokenCount(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        }
+        return "\(count)"
+    }
+}
+
+#Preview("UsagePanel") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        UsagePanel(onClose: {}, daemonClient: DaemonClient())
+    }
+    .frame(width: 420, height: 700)
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -2,6 +2,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case generated
     case agent
     case control
+    case usage
     case directory
     case debug
     case doctor

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -220,6 +220,19 @@ struct SkillDetailRequestMessage: Encodable, Sendable {
     let skillId: String
 }
 
+/// Sent to request aggregated usage summary for a time window.
+/// Wire type: `"usage_summary_request"`
+struct UsageSummaryRequestMessage: Encodable, Sendable {
+    let type: String = "usage_summary_request"
+    let preset: String // "24h" | "7d" | "30d"
+}
+
+/// Sent to request current budget evaluation status.
+/// Wire type: `"budget_status_request"`
+struct BudgetStatusRequestMessage: Encodable, Sendable {
+    let type: String = "budget_status_request"
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -400,6 +413,66 @@ struct SkillDetailResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// A single entry in a usage breakdown (by provider or model).
+struct UsageBreakdownEntry: Decodable, Sendable, Identifiable {
+    let key: String
+    let totalCost: Double?
+    let eventCount: Int
+    var id: String { key }
+}
+
+/// A single daily bucket in usage data.
+struct UsageDailyBucket: Decodable, Sendable, Identifiable {
+    let date: String
+    let totalCost: Double?
+    let eventCount: Int
+    var id: String { date }
+}
+
+/// Response containing aggregated usage summary.
+/// Wire type: `"usage_summary_response"`
+struct UsageSummaryResponseMessage: Decodable, Sendable {
+    let preset: String
+    let totalPricedCostUsd: Double
+    let totalInputTokens: Int
+    let totalOutputTokens: Int
+    let eventCount: Int
+    let byProvider: [UsageBreakdownEntry]
+    let byModel: [UsageBreakdownEntry]
+    let dailyBuckets: [UsageDailyBucket]
+}
+
+/// A single budget violation entry.
+struct BudgetViolationEntry: Decodable, Sendable, Identifiable {
+    let period: String
+    let amountUsd: Double
+    let currentSpend: Double
+    let action: String
+    let exceeded: Bool
+    var id: String { "\(period)-\(action)" }
+}
+
+/// Response containing budget evaluation status.
+/// Wire type: `"budget_status_response"`
+struct BudgetStatusResponseMessage: Decodable, Sendable {
+    let enabled: Bool
+    let budgets: [BudgetViolationEntry]
+}
+
+/// Budget warning push notification from daemon.
+/// Wire type: `"budget_warning"`
+struct BudgetWarningMessage: Decodable, Sendable {
+    let violations: [BudgetWarningViolation]
+
+    struct BudgetWarningViolation: Decodable, Sendable, Identifiable {
+        let period: String
+        let amountUsd: Double
+        let currentSpend: Double
+        let action: String
+        var id: String { "\(period)-\(action)" }
+    }
+}
+
 /// Permission confirmation request from daemon.
 /// Wire type: `"confirmation_request"`
 struct ConfirmationRequestMessage: Decodable, Sendable {
@@ -462,6 +535,9 @@ enum ServerMessage: Decodable, Sendable {
     case messageDequeued(MessageDequeuedMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
+    case usageSummaryResponse(UsageSummaryResponseMessage)
+    case budgetStatusResponse(BudgetStatusResponseMessage)
+    case budgetWarning(BudgetWarningMessage)
     case pong
     case unknown(String)
 
@@ -537,6 +613,15 @@ enum ServerMessage: Decodable, Sendable {
         case "skill_detail_response":
             let message = try SkillDetailResponseMessage(from: decoder)
             self = .skillDetailResponse(message)
+        case "usage_summary_response":
+            let message = try UsageSummaryResponseMessage(from: decoder)
+            self = .usageSummaryResponse(message)
+        case "budget_status_response":
+            let message = try BudgetStatusResponseMessage(from: decoder)
+            self = .budgetStatusResponse(message)
+        case "budget_warning":
+            let message = try BudgetWarningMessage(from: decoder)
+            self = .budgetWarning(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Adds IPC message types (`usage_summary_request/response`, `budget_status_request/response`) with daemon handlers that query `getUsageSummary()` and `evaluateBudgets()`
- Adds Swift decodable types, `UsageManager` view model (subscribe-before-send pattern), and `UsagePanel` with time preset selector, summary totals, Charts-based daily spend chart, provider/model breakdowns, and budget status
- Wires into panel system with `chart.bar` toolbar button and snapshot tests for new IPC types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
