### PR TITLE
Fix fence delimiter matching in stripCommentLines per CommonMark spec

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -83,12 +83,18 @@ function buildConfigSection(configDir: string): string {
  */
 export function stripCommentLines(content: string): string {
   const normalized = content.replace(/\r\n/g, '\n');
-  let inCodeBlock = false;
+  let openFenceChar: string | null = null;
   const filtered = normalized.split('\n').filter((line) => {
-    if (/^ {0,3}(`{3,}|~{3,})/.test(line)) {
-      inCodeBlock = !inCodeBlock;
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (!openFenceChar) {
+        openFenceChar = char;
+      } else if (char === openFenceChar) {
+        openFenceChar = null;
+      }
     }
-    if (inCodeBlock) return true;
+    if (openFenceChar) return true;
     return !line.trimStart().startsWith('_');
   });
   return filtered


### PR DESCRIPTION
## Summary

The `stripCommentLines` function used a simple boolean toggle for code fence detection, which meant a backtick-opened block could be incorrectly closed by tildes (or vice versa). Per CommonMark spec, a closing fence must use the same character as the opening fence.

**Fix:** Replace the boolean `inCodeBlock` with `openFenceChar` that tracks which character (`\`` or `~`) opened the fence. Only close the block when the same character type is encountered.

Addresses review feedback on #1683 from both Codex and Devin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
