### PR TITLE
Escape XML attribute values in message content and OpenAI client

### DIFF
--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -1,4 +1,5 @@
 import type { ContentBlock } from '../providers/types.js';
+import { escapeXmlAttr } from '../util/xml.js';
 
 export function extractTextFromStoredMessageContent(raw: string): string {
   try {
@@ -25,13 +26,13 @@ export function extractTextFromStoredMessageContent(raw: string): string {
           lines.push('<redacted_thinking />');
           break;
         case 'image':
-          lines.push(`<image type="${block.source.media_type}" />`);
+          lines.push(`<image type="${escapeXmlAttr(block.source.media_type)}" />`);
           break;
         case 'file':
           if (block.extracted_text) {
             lines.push(`File (${block.source.filename}): ${block.extracted_text}`);
           } else {
-            lines.push(`<file name="${block.source.filename}" type="${block.source.media_type}" />`);
+            lines.push(`<file name="${escapeXmlAttr(block.source.filename)}" type="${escapeXmlAttr(block.source.media_type)}" />`);
           }
           break;
         default:

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -8,6 +8,7 @@ import type {
   ContentBlock,
 } from '../types.js';
 import { ProviderError } from '../../util/errors.js';
+import { escapeXmlAttr } from '../../util/xml.js';
 
 export interface OpenAICompatibleProviderOptions {
   baseURL?: string;
@@ -267,7 +268,7 @@ export class OpenAIProvider implements Provider {
   }
 
   private fileBlockToText(block: Extract<ContentBlock, { type: 'file' }>): string {
-    const header = `<attached_file name="${block.source.filename}" type="${block.source.media_type}" />`;
+    const header = `<attached_file name="${escapeXmlAttr(block.source.filename)}" type="${escapeXmlAttr(block.source.media_type)}" />`;
     if (block.extracted_text && block.extracted_text.trim().length > 0) {
       return `${header}\n${block.extracted_text}`;
     }

--- a/assistant/src/util/xml.ts
+++ b/assistant/src/util/xml.ts
@@ -1,0 +1,4 @@
+/** Escape a string for safe inclusion in an XML/HTML attribute (double-quoted). */
+export function escapeXmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}


### PR DESCRIPTION
## Summary
- Added `escapeXmlAttr()` helper in `assistant/src/util/xml.ts` that escapes `&`, `"`, `<`, `>` for safe XML attribute interpolation
- Applied escaping to all user-controlled values (`filename`, `media_type`) interpolated into XML-style tag attributes in:
  - `assistant/src/memory/message-content.ts` (image and file blocks)
  - `assistant/src/providers/openai/client.ts` (attached file header)

Addresses review feedback from Codex and Devin on PR #1684.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
