### PR TITLE
Add Start the Day bundled skill and wire Available Skills to ClaWHub

### DIFF
--- a/assistant/src/config/bundled-skills/start-the-day/SKILL.md
+++ b/assistant/src/config/bundled-skills/start-the-day/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: "Start the Day"
+description: "Get a personalized daily briefing with weather, news, and actionable insights"
+user-invocable: true
+metadata: {"vellum": {"emoji": "🌅"}}
+---
+
+You are a personal daily briefing assistant. When the user invokes this skill, generate a concise, actionable briefing tailored to the current moment.
+
+## Briefing Structure
+
+Build the briefing in sections. Use what you know about the user and their context to decide which sections are relevant. Don't include sections you have nothing useful to say about.
+
+### 1. Weather & Conditions
+
+Check the user's location (from system context or ask once) and provide:
+- Current conditions and temperature
+- High/low for the day
+- Notable weather (rain, extreme temps, wind) — only if it affects plans
+
+### 2. Top Headlines
+
+Summarize 3-5 notable news items. Prioritize:
+- Stories relevant to the user's interests or industry
+- Major world events
+- Tech/product launches if relevant
+- Keep each to one sentence
+
+### 3. Calendar & Meetings
+
+If you have access to calendar context:
+- List today's meetings with times
+- Flag any prep needed (documents to review, talking points)
+- Note gaps that could be used for focused work
+
+### 4. Email & Messages
+
+If you have access to communication context:
+- Summarize unread messages that need responses
+- Draft quick replies for straightforward ones — present them for review
+- Flag anything urgent or time-sensitive
+
+### 5. Tasks & Priorities
+
+If you have context on the user's work:
+- Surface top 3 priorities for the day
+- Note any deadlines approaching
+- Suggest one thing to tackle first
+
+### 6. Something Interesting
+
+End with one of:
+- An interesting fact or quote
+- A relevant article worth reading later
+- A tip related to something the user is working on
+
+## Tone
+
+- Concise and scannable — use bullet points, not paragraphs
+- Conversational but efficient — like a sharp executive assistant
+- Don't pad with filler — if you only have 2 useful sections, give 2 sections
+- Time-aware: morning briefings differ from afternoon check-ins
+
+## Adaptation Over Time
+
+As you learn more about the user:
+- Weight news toward their interests and industry
+- Remember their schedule patterns (e.g. "you usually have standup at 10")
+- Track recurring tasks and deadlines
+- Get more specific and less generic with each use

--- a/assistant/src/config/bundled-skills/start-the-day/icon.svg
+++ b/assistant/src/config/bundled-skills/start-the-day/icon.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="16" height="16" fill="#1a1a2e"/>
+  <rect x="2" y="2" width="12" height="12" fill="#16213e"/>
+  <rect x="3" y="3" width="10" height="10" fill="#0f3460"/>
+  <rect x="4" y="4" width="8" height="2" fill="#e94560"/>
+  <rect x="4" y="7" width="8" height="1" fill="#ffd700"/>
+  <rect x="4" y="9" width="8" height="1" fill="#ffd700"/>
+  <rect x="4" y="11" width="8" height="1" fill="#ffd700"/>
+  <rect x="2" y="2" width="1" height="12" fill="#16a085"/>
+  <rect x="13" y="2" width="1" height="12" fill="#16a085"/>
+  <rect x="7" y="1" width="2" height="1" fill="#ffd700"/>
+  <rect x="6" y="0" width="4" height="1" fill="#e94560"/>
+</svg>

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -123,6 +123,11 @@ export async function clawhubUpdate(name: string): Promise<ClawhubUpdateResult> 
 }
 
 export async function clawhubSearch(query: string): Promise<ClawhubSearchResult> {
+  // Empty query: use explore (browse trending) instead of search
+  if (!query.trim()) {
+    return clawhubExplore();
+  }
+
   try {
     const result = await runClawhub(['search', query]);
     if (result.exitCode !== 0) {
@@ -143,6 +148,41 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
     return { skills: [] };
   } catch (err) {
     log.warn({ err }, 'clawhub search failed');
+    return { skills: [] };
+  }
+}
+
+export async function clawhubExplore(opts?: { limit?: number; sort?: string }): Promise<ClawhubSearchResult> {
+  const limit = String(opts?.limit ?? 25);
+  const sort = opts?.sort ?? 'trending';
+
+  try {
+    const result = await runClawhub(['explore', '--json', '--limit', limit, '--sort', sort]);
+    if (result.exitCode !== 0) {
+      return { skills: [] };
+    }
+    try {
+      const parsed = JSON.parse(result.stdout);
+      const items = parsed.items ?? parsed;
+      if (!Array.isArray(items)) return { skills: [] };
+
+      // Normalize explore response to ClawhubSearchResultItem shape
+      const skills: ClawhubSearchResultItem[] = items.map((item: Record<string, unknown>) => ({
+        name: (item.displayName as string) ?? (item.slug as string) ?? '',
+        slug: (item.slug as string) ?? '',
+        description: (item.summary as string) ?? '',
+        author: (item.author as string) ?? '',
+        stars: (item.stats as Record<string, number>)?.stars ?? 0,
+        installs: (item.stats as Record<string, number>)?.installsAllTime ?? 0,
+        version: (item.tags as Record<string, string>)?.latest ?? '',
+      }));
+      return { skills };
+    } catch {
+      // parse failure
+    }
+    return { skills: [] };
+  } catch (err) {
+    log.warn({ err }, 'clawhub explore failed');
     return { skills: [] };
   }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -149,128 +149,184 @@ struct AgentPanel: View {
 
     // MARK: - Available Skills Tab
 
-    /// Hardcoded starter skill shown to new users as an onboarding tutorial.
-    private struct StarterSkill {
+    /// Bundled starter skills shown as featured in the Available Skills tab.
+    private struct BundledSkill: Identifiable {
+        var id: String { slug }
         let slug: String
         let name: String
         let description: String
         let emoji: String
 
-        static let summarizePage = StarterSkill(
-            slug: "summarize-page",
-            name: "Summarize Page",
-            description: "Read the current browser page and produce a concise summary",
-            emoji: "📄"
+        static let all: [BundledSkill] = [startTheDay]
+
+        static let startTheDay = BundledSkill(
+            slug: "start-the-day",
+            name: "Start the Day",
+            description: "Get a personalized daily briefing with weather, news, and actionable insights",
+            emoji: "🌅"
         )
     }
 
-    /// Whether the starter skill is already installed (exists in the skills list).
-    private var isStarterSkillInstalled: Bool {
-        skillsManager.skills.contains { $0.name == StarterSkill.summarizePage.name }
+    /// ClaWHub skills filtered to exclude already-installed ones.
+    private var availableClawhubSkills: [ClawhubSkillItem] {
+        let installedNames = Set(skillsManager.skills.map(\.name))
+        return skillsManager.searchResults.filter { !installedNames.contains($0.name) }
     }
 
     @ViewBuilder
     private var availableSkillsContent: some View {
-        if isStarterSkillInstalled {
-            // Starter skill already installed — point to ClawhHub
-            VStack(spacing: VSpacing.lg) {
-                VEmptyState(
-                    title: "You're all set!",
-                    subtitle: "Browse more community skills on ClawhHub",
-                    icon: "sparkles"
-                )
-                .frame(height: 200)
+        VStack(spacing: VSpacing.lg) {
+            // Bundled skills — always shown as featured
+            ForEach(BundledSkill.all) { starter in
+                bundledSkillCard(starter)
             }
-        } else {
-            VStack(spacing: VSpacing.lg) {
-                starterSkillCard(StarterSkill.summarizePage)
-            }
-        }
-    }
 
-    @State private var isInstallingStarter = false
-    @State private var hoveredStarterInstall = false
-
-    private func starterSkillCard(_ starter: StarterSkill) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            HStack(spacing: VSpacing.md) {
-                // Emoji icon
-                Text(starter.emoji)
-                    .font(.system(size: 20))
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(starter.name)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-
-                    Text(starter.description)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-                        .lineLimit(2)
+            // ClaWHub skills
+            if skillsManager.isSearching {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
                 }
-
-                Spacer()
-
-                // Install button
-                Button(action: {
-                    guard !isInstallingStarter else { return }
-                    isInstallingStarter = true
-                    skillsManager.installSkill(slug: starter.slug)
-                    // Reset after a delay in case the response is slow
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                        isInstallingStarter = false
-                    }
-                }) {
-                    HStack(spacing: VSpacing.sm) {
-                        if isInstallingStarter {
-                            ProgressView()
-                                .controlSize(.mini)
-                        } else {
-                            Image(systemName: "arrow.down.circle.fill")
-                                .font(.system(size: 12))
-                        }
-                        Text(isInstallingStarter ? "Installing…" : "Install")
-                            .font(VFont.mono)
-                    }
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.vertical, VSpacing.sm)
-                    .foregroundColor(hoveredStarterInstall ? Slate._900 : Emerald._400)
-                    .background(hoveredStarterInstall ? Emerald._400 : Slate._800)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
-                    )
-                }
-                .buttonStyle(.plain)
-                .disabled(isInstallingStarter)
-                .onHover { hovering in
-                    withAnimation(VAnimation.fast) {
-                        hoveredStarterInstall = hovering
-                    }
+                .frame(height: 60)
+            } else if !availableClawhubSkills.isEmpty {
+                ForEach(availableClawhubSkills) { skill in
+                    clawhubSkillCard(skill)
                 }
             }
-            .padding(VSpacing.lg)
-            .background(Slate._900)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
-            )
 
-            // Onboarding hint
+            // Browse more nudge
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: "lightbulb.fill")
+                Image(systemName: "sparkles")
                     .font(.system(size: 10))
-                    .foregroundColor(Amber._500)
-                Text("Install this skill to get started. More skills coming soon via ClawhHub.")
+                    .foregroundColor(Emerald._400)
+                Text("Browse more community skills on ClawhHub")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
             }
         }
+        .onAppear {
+            skillsManager.searchSkills()
+        }
+    }
+
+    @State private var installingSlug: String?
+    @State private var hoveredStarterInstall: String?
+
+    private func bundledSkillCard(_ starter: BundledSkill) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Text(starter.emoji)
+                .font(.system(size: 20))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(starter.name)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(starter.description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Text("Included")
+                .font(VFont.caption)
+                .foregroundColor(Emerald._400)
+        }
+        .padding(VSpacing.lg)
+        .background(Slate._900)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+        )
+    }
+
+    private func clawhubSkillCard(_ skill: ClawhubSkillItem) -> some View {
+        let isInstalling = installingSlug == skill.slug
+        let isHovered = hoveredStarterInstall == skill.slug
+
+        return HStack(spacing: VSpacing.md) {
+            Image(systemName: "shippingbox.fill")
+                .font(.system(size: 16))
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(skill.name)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(skill.description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Button(action: {
+                guard installingSlug == nil else { return }
+                installingSlug = skill.slug
+                skillsManager.installSkill(slug: skill.slug)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                    if installingSlug == skill.slug {
+                        installingSlug = nil
+                    }
+                }
+            }) {
+                HStack(spacing: VSpacing.sm) {
+                    if isInstalling {
+                        ProgressView()
+                            .controlSize(.mini)
+                    } else {
+                        Image(systemName: "arrow.down.circle.fill")
+                            .font(.system(size: 12))
+                    }
+                    Text(isInstalling ? "Installing..." : "Install")
+                        .font(VFont.mono)
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+                .foregroundColor(isHovered ? Slate._900 : Emerald._400)
+                .background(isHovered ? Emerald._400 : Slate._800)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(installingSlug != nil)
+            .onHover { hovering in
+                withAnimation(VAnimation.fast) {
+                    hoveredStarterInstall = hovering ? skill.slug : nil
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(Slate._900)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+        )
     }
 
     // MARK: - Skills Tab
+
+    /// Names of bundled starter skills featured in Available Skills (hidden from Skills tab).
+    private static let featuredBundledNames: Set<String> = Set(
+        BundledSkill.all.map(\.name)
+    )
+
+    /// Skills to show in the Skills tab (excludes bundled starters featured in Available Skills).
+    private var userSkills: [SkillInfo] {
+        skillsManager.skills.filter { !Self.featuredBundledNames.contains($0.name) }
+    }
 
     @ViewBuilder
     private var skillsContent: some View {
@@ -282,7 +338,7 @@ struct AgentPanel: View {
                 Spacer()
             }
             .frame(height: 250)
-        } else if skillsManager.skills.isEmpty {
+        } else if userSkills.isEmpty {
             VEmptyState(
                 title: "No skills",
                 subtitle: "Agent skills will appear here",
@@ -291,7 +347,7 @@ struct AgentPanel: View {
             .frame(height: 250)
         } else {
             VStack(spacing: VSpacing.md) {
-                ForEach(skillsManager.skills) { skill in
+                ForEach(userSkills) { skill in
                     skillCard(skill)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -5,6 +5,8 @@ final class SkillsManager: ObservableObject {
     @Published var skills: [SkillInfo] = []
     @Published var loadedBodies: [String: String] = [:]
     @Published var isLoading = false
+    @Published var searchResults: [ClawhubSkillItem] = []
+    @Published var isSearching = false
 
     private let daemonClient: DaemonClient
 
@@ -62,6 +64,34 @@ final class SkillsManager: ObservableObject {
                     return
                 }
             }
+        }
+    }
+
+    func searchSkills(query: String = "") {
+        guard !isSearching else { return }
+        isSearching = true
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.searchSkills(query: query)
+            } catch {
+                isSearching = false
+                return
+            }
+
+            for await message in stream {
+                if case .skillsOperationResponse(let response) = message,
+                   response.operation == "search" {
+                    if response.success, let data = response.data {
+                        searchResults = data.skills
+                    }
+                    isSearching = false
+                    return
+                }
+            }
+            isSearching = false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -55,9 +55,14 @@ final class OnboardingWindow {
         window.contentMinSize = NSSize(width: 800, height: 600)
 
         if let visibleFrame = Self.visibleScreenFrame() {
-            window.setFrame(visibleFrame, display: true)
+            // Start at minimum width, full height — centered on screen
+            let startWidth = window.contentMinSize.width
+            let startHeight = visibleFrame.height
+            let x = visibleFrame.midX - startWidth / 2
+            let y = visibleFrame.origin.y
+            window.setFrame(NSRect(x: x, y: y, width: startWidth, height: startHeight), display: true)
         } else {
-            window.setContentSize(NSSize(width: 1366, height: 849))
+            window.setContentSize(window.contentMinSize)
             window.center()
         }
 

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -498,11 +498,44 @@ struct SkillsUpdatesAvailableMessage: Decodable, Sendable {
     let skills: [UpdateInfo]
 }
 
+/// A ClaWHub skill returned from a search or explore query.
+struct ClawhubSkillItem: Decodable, Sendable, Identifiable {
+    var id: String { slug }
+    let name: String
+    let slug: String
+    let description: String
+    let author: String
+    let stars: Int
+    let installs: Int
+    let version: String
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        slug = try container.decode(String.self, forKey: .slug)
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        author = try container.decodeIfPresent(String.self, forKey: .author) ?? ""
+        stars = try container.decodeIfPresent(Int.self, forKey: .stars) ?? 0
+        installs = try container.decodeIfPresent(Int.self, forKey: .installs) ?? 0
+        version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, slug, description, author, stars, installs, version
+    }
+}
+
+/// Wrapper for ClaWHub search results embedded in `skills_operation_response.data`.
+struct ClawhubSearchData: Decodable, Sendable {
+    let skills: [ClawhubSkillItem]
+}
+
 /// Generic operation response. Wire type: "skills_operation_response"
 struct SkillsOperationResponseMessage: Decodable, Sendable {
     let operation: String
     let success: Bool
     let error: String?
+    let data: ClawhubSearchData?
 }
 
 /// A single trust rule item returned from the daemon.


### PR DESCRIPTION
## Summary
- Adds a bundled "Start the Day" skill that provides a personalized daily briefing with weather, news, calendar, email, tasks, and something interesting
- Wires the Available Skills tab to dynamically fetch trending skills from ClaWHub via the existing `skills_search` IPC, replacing the old hardcoded starter skill
- Adds `clawhubExplore()` backend function that uses `clawhub explore --json --sort trending` for empty-query browsing (the CLI's `search` command requires a non-empty query)
- Adds `ClawhubSkillItem`/`ClawhubSearchData` Swift types and `data` field to `SkillsOperationResponseMessage` so search results are no longer silently dropped
- Adds `searchSkills(query:)` to `SkillsManager` with `isSearching`/`searchResults` published state
- Filters bundled starters from the Skills tab to avoid duplication with the Available Skills tab
- Opens onboarding window at minimum width (800px) centered on screen instead of filling the visible frame

## Test plan
- [ ] Open Agent panel → Available Skills tab shows "Start the Day" as bundled with "Included" badge
- [ ] ClaWHub trending skills load below the bundled card after a brief loading spinner
- [ ] Clicking "Install" on a ClaWHub skill triggers installation and the skill moves to the Skills tab
- [ ] Skills tab filters out bundled starters (no "Start the Day" duplicate)
- [ ] Fresh launch (scrub) shows onboarding window centered at 800px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
