### PR TITLE
Fix VSegmentedControl layout to match design mock

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -12,20 +12,23 @@ struct VSegmentedControl: View {
                         Text(items[index])
                             .font(VFont.captionMedium)
                             .foregroundColor(selection == index ? VColor.textPrimary : VColor.textMuted)
-                            .padding(.vertical, VSpacing.md)
+                            .padding(.horizontal, VSpacing.xl)
+                            .padding(.vertical, VSpacing.xs)
 
                         Rectangle()
                             .fill(selection == index ? VColor.accent : .clear)
                             .frame(height: 2)
                     }
-                    .frame(maxWidth: .infinity)
+                    .fixedSize(horizontal: true, vertical: false)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(items[index])
                 .accessibilityAddTraits(selection == index ? .isSelected : [])
             }
+            Spacer()
         }
+        .padding(.horizontal, VSpacing.sm)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -27,7 +27,6 @@ struct ControlPanel: View {
                 items: ControlTab.allCases.map { $0.rawValue.capitalized },
                 selection: $selectedTabIndex
             )
-            .padding(.horizontal, VSpacing.sm)
             .padding(.top, VSpacing.sm)
 
             Divider().background(VColor.surfaceBorder)


### PR DESCRIPTION
## Summary
- Make VSegmentedControl tabs content-sized and left-aligned with trailing space, matching the design mock
- Use `fixedSize` to prevent the underline Rectangle from expanding tabs to fill width
- Reduce vertical padding for a more compact tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
