### PR TITLE
Add trust rules access to the Control panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -129,7 +129,7 @@ struct MainWindowView: View {
             case .agent:
                 AgentPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .control:
-                ControlPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent)
+                ControlPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent, daemonClient: daemonClient)
             case .directory:
                 DirectoryPanel(onClose: { activePanel = nil })
             case .debug:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -4,12 +4,14 @@ import SwiftUI
 struct ControlPanel: View {
     var onClose: () -> Void
     var ambientAgent: AmbientAgent
+    var daemonClient: DaemonClient?
 
     @State private var selectedTabIndex: Int = 1
     @State private var apiKeyText: String = ""
     @State private var hasKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
+    @State private var showingTrustRules = false
 
     private enum ControlTab: String, CaseIterable {
         case profile, settings, channels, overview
@@ -193,6 +195,35 @@ struct ControlPanel: View {
             }
             .padding(VSpacing.lg)
             .vCard(background: Slate._900)
+
+            // TRUST RULES section
+            if let daemonClient {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("TRUST RULES")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.textPrimary)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Manage Trust Rules")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                            Text("Control which tool actions are automatically allowed or denied")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                        Spacer()
+                        VButton(label: "Manage...", style: .ghost) {
+                            showingTrustRules = true
+                        }
+                    }
+                }
+                .padding(VSpacing.lg)
+                .vCard(background: Slate._900)
+                .sheet(isPresented: $showingTrustRules) {
+                    TrustRulesView(daemonClient: daemonClient)
+                }
+            }
 
             // PRIVACY & SECURITY section
             VStack(alignment: .leading, spacing: VSpacing.md) {


### PR DESCRIPTION
## Summary
- Adds a "Trust Rules" section to the Control panel (Settings tab) with a "Manage..." button that opens the existing TrustRulesView sheet
- Passes `daemonClient` through from MainWindowView to ControlPanel so the trust rules IPC is available
- Previously, trust rules were only accessible from the separate Settings window (Cmd+,), which was hard to discover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
