### PR TITLE
Remove hardcoded greeting message from new sessions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -61,9 +61,6 @@ final class ChatViewModel: ObservableObject {
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
-        // Add initial greeting
-        let name = UserDefaults.standard.string(forKey: "assistantName") ?? "Vellum"
-        messages.append(ChatMessage(role: .assistant, text: "Hello! I'm \(name). How can I help you today?"))
     }
 
     // MARK: - Attachments


### PR DESCRIPTION
## Summary
- Removed the placeholder "Hello! I'm <name>. How can I help you today?" message that was injected into every new chat session in ChatViewModel's init
- New sessions now start with an empty message list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
