### PR TITLE
Fix double padding and tab clipping in VSegmentedControl

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -19,7 +19,6 @@ struct VSegmentedControl: View {
                             .fill(selection == index ? VColor.accent : .clear)
                             .frame(height: 2)
                     }
-                    .fixedSize(horizontal: true, vertical: false)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -60,7 +60,6 @@ struct LayoutGallerySection: View {
                         items: ["Profile", "Settings", "Channels", "Overview"],
                         selection: $pinnedTabSelection
                     )
-                    .padding(.horizontal, VSpacing.sm)
                     Divider().background(VColor.surfaceBorder)
                 }) {
                     VStack(alignment: .leading, spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -107,7 +107,6 @@ struct AgentPanel: View {
                 items: ["Skills", "Available Skills", "Nodes", "Personality"],
                 selection: $selectedTab
             )
-            .padding(.horizontal, VSpacing.sm)
 
             Divider()
                 .background(VColor.surfaceBorder)


### PR DESCRIPTION
## Summary
- Remove external `.padding(.horizontal, VSpacing.sm)` from AgentPanel and LayoutGallerySection call sites that were causing double horizontal padding (VSegmentedControl now applies this padding internally)
- Remove `.fixedSize(horizontal: true, vertical: false)` from tab items in VSegmentedControl to prevent tabs from clipping/overflowing in narrow panels

## Context
Addresses review feedback on PR #1696:
1. Two callers (AgentPanel, LayoutGallerySection) were not updated when padding was moved inside VSegmentedControl, causing double padding
2. `.fixedSize` prevented tabs from sharing available width, causing overflow in AgentPanel at narrow window sizes (e.g. 400pt panel with `["Skills", "Available Skills", "Nodes", "Personality"]`)

## Test plan
- [x] `swift build` passes
- [ ] Verify VSegmentedControl tabs display correctly in AgentPanel at narrow window widths
- [ ] Verify Gallery layout section preview renders without double padding
- [ ] Verify long tab labels truncate gracefully instead of clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
