### PR TITLE
Open main window at full screen size by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -40,7 +40,7 @@ final class MainWindow {
         let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1366, height: 849),
+            contentRect: NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -54,10 +54,7 @@ final class MainWindow {
         window.contentMinSize = NSSize(width: 800, height: 600)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let w = min(1366, screenFrame.width)
-        let h = min(849, screenFrame.height)
-        window.setContentSize(NSSize(width: w, height: h))
-        window.center()
+        window.setFrame(screenFrame, display: true)
 
         // Keep regular activation policy — the main window should appear in Dock and Cmd+Tab
         NSApp.setActivationPolicy(.regular)


### PR DESCRIPTION
## Summary
- Main window now opens filling the entire visible screen area instead of being capped at 1366x849 and centered
- Uses `NSScreen.main?.visibleFrame` for both the initial contentRect and `setFrame`, so the window respects the menu bar and dock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
