### PR TITLE
Add trust signals and filtering to Available Skills tab

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -29,6 +29,7 @@ export interface ClawhubSearchResultItem {
   stars: number;
   installs: number;
   version: string;
+  createdAt: number;
 }
 
 export interface ClawhubSearchResult {
@@ -129,11 +130,11 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
   }
 
   try {
-    const result = await runClawhub(['search', query]);
+    const result = await runClawhub(['search', query, '--limit', '25']);
     if (result.exitCode !== 0) {
       return { skills: [] };
     }
-    // Try to parse JSON output; fall back to empty
+    // Try JSON first
     try {
       const parsed = JSON.parse(result.stdout);
       if (Array.isArray(parsed)) {
@@ -143,9 +144,27 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
         return parsed as ClawhubSearchResult;
       }
     } catch {
-      // CLI may not output JSON -- parse text output
+      // CLI outputs text: "slug vVersion  DisplayName  (score)"
     }
-    return { skills: [] };
+
+    // Parse text output lines: "slug vVersion  Display Name  (score)"
+    const skills: ClawhubSearchResultItem[] = [];
+    for (const line of result.stdout.split('\n')) {
+      const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
+      if (match) {
+        skills.push({
+          slug: match[1],
+          version: match[2],
+          name: match[3].trim(),
+          description: '',
+          author: '',
+          stars: 0,
+          installs: 0,
+          createdAt: 0,
+        });
+      }
+    }
+    return { skills };
   } catch (err) {
     log.warn({ err }, 'clawhub search failed');
     return { skills: [] };
@@ -154,7 +173,7 @@ export async function clawhubSearch(query: string): Promise<ClawhubSearchResult>
 
 export async function clawhubExplore(opts?: { limit?: number; sort?: string }): Promise<ClawhubSearchResult> {
   const limit = String(opts?.limit ?? 25);
-  const sort = opts?.sort ?? 'trending';
+  const sort = opts?.sort ?? 'installsAllTime';
 
   try {
     const result = await runClawhub(['explore', '--json', '--limit', limit, '--sort', sort]);
@@ -175,6 +194,7 @@ export async function clawhubExplore(opts?: { limit?: number; sort?: string }): 
         stars: (item.stats as Record<string, number>)?.stars ?? 0,
         installs: (item.stats as Record<string, number>)?.installsAllTime ?? 0,
         version: (item.tags as Record<string, string>)?.latest ?? '',
+        createdAt: (item.createdAt as number) ?? 0,
       }));
       return { skills };
     } catch {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -167,10 +167,30 @@ struct AgentPanel: View {
         )
     }
 
-    /// ClaWHub skills filtered to exclude already-installed ones.
+    /// ClaWHub skills filtered to exclude already-installed ones, with local search and sort.
     private var availableClawhubSkills: [ClawhubSkillItem] {
         let installedNames = Set(skillsManager.skills.map(\.name))
-        return skillsManager.searchResults.filter { !installedNames.contains($0.name) }
+        var filtered = skillsManager.searchResults
+            .filter { !installedNames.contains($0.name) }
+
+        // Local fuzzy filter by name/description
+        if !skillSearchQuery.isEmpty {
+            let query = skillSearchQuery.lowercased()
+            filtered = filtered.filter {
+                $0.name.lowercased().contains(query) ||
+                $0.description.lowercased().contains(query) ||
+                $0.slug.lowercased().contains(query)
+            }
+        }
+
+        switch skillSortOrder {
+        case .installs:
+            return filtered.sorted { $0.installs > $1.installs }
+        case .stars:
+            return filtered.sorted { $0.stars > $1.stars }
+        case .newest:
+            return filtered.sorted { $0.createdAt > $1.createdAt }
+        }
     }
 
     @ViewBuilder
@@ -179,6 +199,52 @@ struct AgentPanel: View {
             // Bundled skills — always shown as featured
             ForEach(BundledSkill.all) { starter in
                 bundledSkillCard(starter)
+            }
+
+            // Search bar — filters locally, no API call
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12))
+                    .foregroundColor(VColor.textMuted)
+
+                TextField("Filter skills...", text: $skillSearchQuery)
+                    .textFieldStyle(.plain)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+
+                if !skillSearchQuery.isEmpty {
+                    Button(action: { skillSearchQuery = "" }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(VSpacing.md)
+            .background(Slate._800)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+            // Sort picker
+            HStack(spacing: VSpacing.sm) {
+                Text("Sort:")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+
+                ForEach(SkillSortOrder.allCases, id: \.self) { order in
+                    Button(action: { skillSortOrder = order }) {
+                        Text(order.rawValue)
+                            .font(VFont.caption)
+                            .foregroundColor(skillSortOrder == order ? Emerald._400 : VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xs)
+                            .background(skillSortOrder == order ? Emerald._400.opacity(0.15) : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
             }
 
             // ClaWHub skills
@@ -194,16 +260,34 @@ struct AgentPanel: View {
                 ForEach(availableClawhubSkills) { skill in
                     clawhubSkillCard(skill)
                 }
+            } else if !skillSearchQuery.isEmpty {
+                VEmptyState(
+                    title: "No results",
+                    subtitle: "No skills matched \"\(skillSearchQuery)\"",
+                    icon: "magnifyingglass"
+                )
+                .frame(height: 100)
             }
 
-            // Browse more nudge
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 10))
-                    .foregroundColor(Emerald._400)
-                Text("Browse more community skills on ClawhHub")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+            // Community disclaimer
+            VStack(spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "exclamationmark.shield.fill")
+                        .font(.system(size: 10))
+                        .foregroundColor(Amber._500)
+                    Text("Community skills are not verified by Vellum. Review before installing.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                HStack(spacing: VSpacing.sm) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 10))
+                        .foregroundColor(Emerald._400)
+                    Text("Browse more on ClawhHub")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
             }
         }
         .onAppear {
@@ -213,6 +297,14 @@ struct AgentPanel: View {
 
     @State private var installingSlug: String?
     @State private var hoveredStarterInstall: String?
+    @State private var skillSearchQuery = ""
+    @State private var skillSortOrder: SkillSortOrder = .installs
+
+    private enum SkillSortOrder: String, CaseIterable {
+        case installs = "Installs"
+        case stars = "Stars"
+        case newest = "Newest"
+    }
 
     private func bundledSkillCard(_ starter: BundledSkill) -> some View {
         HStack(spacing: VSpacing.md) {
@@ -245,74 +337,134 @@ struct AgentPanel: View {
         )
     }
 
+    /// How long ago a skill was published, as a human-readable string.
+    private func skillAge(_ createdAt: Int) -> String {
+        guard createdAt > 0 else { return "" }
+        let date = Date(timeIntervalSince1970: Double(createdAt) / 1000)
+        let days = Int(Date().timeIntervalSince(date) / 86400)
+        if days < 1 { return "today" }
+        if days == 1 { return "1 day ago" }
+        if days < 30 { return "\(days) days ago" }
+        let months = days / 30
+        if months == 1 { return "1 month ago" }
+        return "\(months) months ago"
+    }
+
     private func clawhubSkillCard(_ skill: ClawhubSkillItem) -> some View {
         let isInstalling = installingSlug == skill.slug
         let isHovered = hoveredStarterInstall == skill.slug
+        let isNew = skill.createdAt > 0 && Date().timeIntervalSince(
+            Date(timeIntervalSince1970: Double(skill.createdAt) / 1000)
+        ) < 7 * 86400
 
-        return HStack(spacing: VSpacing.md) {
-            Image(systemName: "shippingbox.fill")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.textMuted)
-                .frame(width: 24)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(skill.name)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-
-                Text(skill.description)
-                    .font(VFont.caption)
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.md) {
+                Image(systemName: "shippingbox.fill")
+                    .font(.system(size: 16))
                     .foregroundColor(VColor.textMuted)
-                    .lineLimit(2)
-            }
+                    .frame(width: 24)
 
-            Spacer()
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(skill.name)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
 
-            Button(action: {
-                guard installingSlug == nil else { return }
-                installingSlug = skill.slug
-                skillsManager.installSkill(slug: skill.slug)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                    if installingSlug == skill.slug {
-                        installingSlug = nil
+                        if isNew {
+                            Text("NEW")
+                                .font(VFont.small)
+                                .foregroundColor(Amber._500)
+                        }
+                    }
+
+                    Text(skill.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                Button(action: {
+                    guard installingSlug == nil else { return }
+                    installingSlug = skill.slug
+                    skillsManager.installSkill(slug: skill.slug)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                        if installingSlug == skill.slug {
+                            installingSlug = nil
+                        }
+                    }
+                }) {
+                    HStack(spacing: VSpacing.sm) {
+                        if isInstalling {
+                            ProgressView()
+                                .controlSize(.mini)
+                        } else {
+                            Image(systemName: "arrow.down.circle.fill")
+                                .font(.system(size: 12))
+                        }
+                        Text(isInstalling ? "Installing..." : "Install")
+                            .font(VFont.mono)
+                    }
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.vertical, VSpacing.sm)
+                    .foregroundColor(isHovered ? Slate._900 : Emerald._400)
+                    .background(isHovered ? Emerald._400 : Slate._800)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(installingSlug != nil)
+                .onHover { hovering in
+                    withAnimation(VAnimation.fast) {
+                        hoveredStarterInstall = hovering ? skill.slug : nil
                     }
                 }
-            }) {
-                HStack(spacing: VSpacing.sm) {
-                    if isInstalling {
-                        ProgressView()
-                            .controlSize(.mini)
-                    } else {
-                        Image(systemName: "arrow.down.circle.fill")
-                            .font(.system(size: 12))
+            }
+
+            // Trust signals row
+            HStack(spacing: VSpacing.lg) {
+                if !skill.author.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: 9))
+                        Text(skill.author)
                     }
-                    Text(isInstalling ? "Installing..." : "Install")
-                        .font(VFont.mono)
                 }
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.vertical, VSpacing.sm)
-                .foregroundColor(isHovered ? Slate._900 : Emerald._400)
-                .background(isHovered ? Emerald._400 : Slate._800)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(Emerald._500.opacity(0.6), lineWidth: 1.5)
-                )
-            }
-            .buttonStyle(.plain)
-            .disabled(installingSlug != nil)
-            .onHover { hovering in
-                withAnimation(VAnimation.fast) {
-                    hoveredStarterInstall = hovering ? skill.slug : nil
+
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 9))
+                    Text("\(skill.stars)")
+                }
+
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 9))
+                    Text("\(skill.installs)")
+                }
+
+                if !skillAge(skill.createdAt).isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "clock")
+                            .font(.system(size: 9))
+                        Text(skillAge(skill.createdAt))
+                    }
                 }
             }
+            .font(VFont.small)
+            .foregroundColor(VColor.textMuted)
+            .padding(.leading, 24 + VSpacing.md)
         }
         .padding(VSpacing.lg)
         .background(Slate._900)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+                .stroke(isNew ? Amber._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
         )
     }
 

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -508,6 +508,8 @@ struct ClawhubSkillItem: Decodable, Sendable, Identifiable {
     let stars: Int
     let installs: Int
     let version: String
+    /// Epoch milliseconds when the skill was first published.
+    let createdAt: Int
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -518,10 +520,11 @@ struct ClawhubSkillItem: Decodable, Sendable, Identifiable {
         stars = try container.decodeIfPresent(Int.self, forKey: .stars) ?? 0
         installs = try container.decodeIfPresent(Int.self, forKey: .installs) ?? 0
         version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
+        createdAt = try container.decodeIfPresent(Int.self, forKey: .createdAt) ?? 0
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, slug, description, author, stars, installs, version
+        case name, slug, description, author, stars, installs, version, createdAt
     }
 }
 


### PR DESCRIPTION
## Summary
- Show trust signals on each ClaWHub skill card: author, stars, installs, and publish age
- Highlight skills published in the last 7 days with a "NEW" badge and amber border
- Add sort picker (Installs / Stars / Newest) for instant client-side re-sorting
- Add local filter bar that fuzzy-matches by name, description, or slug against the already-loaded list
- Add "Community skills are not verified by Vellum" disclaimer with shield icon
- Fix `clawhubSearch` text output parsing (removed slow per-result `inspect` enrichment)
- Default explore sort order to `installsAllTime` for popularity-first browsing

## Test plan
- [ ] Open Agent panel > Available Skills — skills load with trust signals (author, stars, installs, age)
- [ ] Skills less than 7 days old show "NEW" badge with amber border
- [ ] Sort picker toggles between Installs, Stars, Newest — list re-sorts instantly
- [ ] Filter bar narrows the list by typing (e.g. "google", "weather") — no loading spinner, instant
- [ ] Clear button (x) resets filter and shows full list
- [ ] Disclaimer "Community skills are not verified by Vellum" appears at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
