### PR TITLE
Restructure AgentPanel to use VSidePanel and restore fixedSize

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -14,6 +14,7 @@ struct VSegmentedControl: View {
                             .foregroundColor(selection == index ? VColor.textPrimary : VColor.textMuted)
                             .padding(.horizontal, VSpacing.xl)
                             .padding(.vertical, VSpacing.xs)
+                            .fixedSize(horizontal: true, vertical: false)
 
                         Rectangle()
                             .fill(selection == index ? VColor.accent : .clear)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -85,62 +85,38 @@ struct AgentPanel: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header (matches VSidePanel style)
-            HStack {
-                Text("AGENT")
-                    .font(VFont.panelTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Spacer()
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close Agent")
-            }
-            .padding(VSpacing.xl)
-
-            // Tabbed navigation — pinned above scroll
+        VSidePanel(title: "Agent", onClose: onClose, pinnedContent: {
             VSegmentedControl(
                 items: ["Skills", "Available Skills", "Nodes", "Personality"],
                 selection: $selectedTab
             )
+            .padding(.top, VSpacing.sm)
 
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            // Scrollable tab content
-            ScrollView {
-                Group {
-                    switch selectedTab {
-                    case 0:
-                        skillsContent
-                    case 1:
-                        availableSkillsContent
-                    case 2:
-                        VEmptyState(
-                            title: "No nodes",
-                            subtitle: "Agent nodes will appear here",
-                            icon: "point.3.connected.trianglepath.dotted"
-                        )
-                        .frame(height: 250)
-                    case 3:
-                        VEmptyState(
-                            title: "Personality",
-                            subtitle: "Configure agent personality here",
-                            icon: "person.text.rectangle"
-                        )
-                        .frame(height: 250)
-                    default:
-                        EmptyView()
-                    }
-                }
-                .padding(VSpacing.xl)
+            Divider().background(VColor.surfaceBorder)
+        }) {
+            switch selectedTab {
+            case 0:
+                skillsContent
+            case 1:
+                availableSkillsContent
+            case 2:
+                VEmptyState(
+                    title: "No nodes",
+                    subtitle: "Agent nodes will appear here",
+                    icon: "point.3.connected.trianglepath.dotted"
+                )
+                .frame(height: 250)
+            case 3:
+                VEmptyState(
+                    title: "Personality",
+                    subtitle: "Configure agent personality here",
+                    icon: "person.text.rectangle"
+                )
+                .frame(height: 250)
+            default:
+                EmptyView()
             }
         }
-        .background(VColor.backgroundSubtle)
         .onAppear {
             skillsManager.fetchSkills()
         }


### PR DESCRIPTION
## Summary
- Restructure AgentPanel body to use `VSidePanel(title:onClose:pinnedContent:content:)` pattern, matching ControlPanel's layout approach
- Restore `.fixedSize(horizontal: true, vertical: false)` on VSegmentedControl tab labels to prevent text truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
