### PR TITLE
Add Brave Search API key configuration to desktop app

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -5,32 +5,39 @@ extension Notification.Name {
     static let apiKeyManagerDidChange = Notification.Name("APIKeyManager.didChange")
 }
 
-/// Manages the Anthropic API key in the macOS login keychain.
+/// Manages API keys in the macOS login keychain.
 ///
 /// Uses the `security` CLI tool for writes so entries are created without
 /// per-application ACLs — this lets the daemon (which also uses the `security`
 /// CLI) read the same keychain item.
 enum APIKeyManager {
-    /// Shared with the daemon (keychain.ts uses service "vellum-assistant", account "anthropic").
+    /// Shared with the daemon (keychain.ts uses service "vellum-assistant", account = provider name).
     private static let service = "vellum-assistant"
-    private static let account = "anthropic"
 
     // Legacy keychain entry (pre-daemon era). Migrated on first access.
     private static let legacyService = "com.vellum-assistant.anthropic-api-key"
     private static let legacyAccount = "anthropic-api-key"
 
-    static func getKey() -> String? {
-        migrateIfNeeded()
-        return cliGetKey(service: service, account: account)
+    // MARK: - Anthropic (convenience wrappers for backward compatibility)
+
+    static func getKey() -> String? { getKey(for: "anthropic") }
+    static func setKey(_ key: String) { setKey(key, for: "anthropic") }
+    static func deleteKey() { deleteKey(for: "anthropic") }
+
+    // MARK: - Generic provider access
+
+    static func getKey(for provider: String) -> String? {
+        if provider == "anthropic" { migrateIfNeeded() }
+        return cliGetKey(service: service, account: provider)
     }
 
-    static func setKey(_ key: String) {
-        cliSetKey(service: service, account: account, value: key)
+    static func setKey(_ key: String, for provider: String) {
+        cliSetKey(service: service, account: provider, value: key)
         notifyKeyDidChange()
     }
 
-    static func deleteKey() {
-        cliDeleteKey(service: service, account: account)
+    static func deleteKey(for provider: String) {
+        cliDeleteKey(service: service, account: provider)
         notifyKeyDidChange()
     }
 
@@ -82,7 +89,7 @@ enum APIKeyManager {
     /// One-time migration from the legacy keychain entry to the daemon-shared entry.
     private static func migrateIfNeeded() {
         // Skip if new entry already exists
-        if cliGetKey(service: service, account: account) != nil { return }
+        if cliGetKey(service: service, account: "anthropic") != nil { return }
 
         // Read from legacy entry (uses Security.framework since the old entry was created with SecItemAdd)
         let legacyQuery: [String: Any] = [
@@ -98,7 +105,7 @@ enum APIKeyManager {
               let key = String(data: data, encoding: .utf8) else { return }
 
         // Write to new entry via CLI (no ACL restrictions)
-        cliSetKey(service: service, account: account, value: key)
+        cliSetKey(service: service, account: "anthropic", value: key)
 
         // Delete legacy entry
         let deleteQuery: [String: Any] = [

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ControlPanel.swift
@@ -9,6 +9,8 @@ struct ControlPanel: View {
     @State private var selectedTabIndex: Int = 1
     @State private var apiKeyText: String = ""
     @State private var hasKey: Bool = false
+    @State private var braveKeyText: String = ""
+    @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
     @State private var showingTrustRules = false
@@ -118,6 +120,62 @@ struct ControlPanel: View {
                         APIKeyManager.setKey(trimmed)
                         hasKey = true
                         apiKeyText = ""
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .vCard(background: Slate._900)
+
+            // BRAVE SEARCH section
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("BRAVE SEARCH")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                if hasBraveKey {
+                    HStack {
+                        Text("BSA...configured")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Spacer()
+                        VButton(label: "Clear", style: .danger) {
+                            APIKeyManager.deleteKey(for: "brave")
+                            hasBraveKey = false
+                            braveKeyText = ""
+                        }
+                    }
+                } else {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Enter Brave Search API Key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(VColor.textMuted)
+                    }
+
+                    SecureField("Your Brave Search API key", text: $braveKeyText)
+                        .textFieldStyle(.plain)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(VSpacing.md)
+                        .background(VColor.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
+                        )
+
+                    Text("Get your API key at brave.com/search/api")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    VButton(label: "Save", style: .primary) {
+                        let trimmed = braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        APIKeyManager.setKey(trimmed, for: "brave")
+                        hasBraveKey = true
+                        braveKeyText = ""
                     }
                 }
             }
@@ -284,6 +342,7 @@ struct ControlPanel: View {
 
     private func refreshAPIKeyState() {
         hasKey = APIKeyManager.getKey() != nil
+        hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 public struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
+    @State private var braveKeyText = ""
+    @State private var hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
     @State private var maxSteps: Double = {
         let val = UserDefaults.standard.double(forKey: "maxStepsPerSession")
         return val == 0 ? 50 : val
@@ -63,6 +65,39 @@ public struct SettingsView: View {
                             apiKeyText = ""
                         }
                         .disabled(apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+
+            Section("Brave Search API Key") {
+                if hasBraveKey {
+                    HStack {
+                        Text("BSA...configured")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Clear") {
+                            APIKeyManager.deleteKey(for: "brave")
+                            hasBraveKey = false
+                            braveKeyText = ""
+                        }
+                        .tint(.red)
+                    }
+                } else {
+                    SecureField("Enter Brave Search API key", text: $braveKeyText)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Text("Get your API key at brave.com/search/api")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Save") {
+                            let trimmed = braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            APIKeyManager.setKey(trimmed, for: "brave")
+                            hasBraveKey = true
+                            braveKeyText = ""
+                        }
+                        .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
             }
@@ -230,6 +265,7 @@ public struct SettingsView: View {
 
     private func refreshAPIKeyState() {
         hasKey = APIKeyManager.getKey() != nil
+        hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
     }
 }
 


### PR DESCRIPTION
## Summary
- Generalized `APIKeyManager` to support multiple providers via a `for: String` parameter, with backward-compatible convenience wrappers for the Anthropic key
- Added a "Brave Search API Key" section to both the Settings window and the Control panel, matching the existing Anthropic key UX (enter/save/clear)
- Keys are stored in the macOS Keychain under the shared `vellum-assistant` service so the daemon picks them up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
