### PR TITLE
Add clawhubInspect backend + IPC types for skill detail view

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -160,6 +160,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'skills_search',
     query: 'weather',
   },
+  skills_inspect: {
+    type: 'skills_inspect',
+    slug: 'clawhub/my-skill',
+  },
   suggestion_request: {
     type: 'suggestion_request',
     sessionId: 'sess-001',
@@ -439,6 +443,20 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     type: 'skill_detail_response',
     skillId: 'my-skill',
     body: '# Skill content\n\nDo the thing.',
+  },
+  skills_inspect_response: {
+    type: 'skills_inspect_response',
+    slug: 'clawhub/my-skill',
+    data: {
+      skill: { slug: 'clawhub/my-skill', displayName: 'My Skill', summary: 'A test skill' },
+      owner: { handle: 'clawhub', displayName: 'ClaWHub' },
+      stats: { stars: 42, installs: 1000, downloads: 5000, versions: 3 },
+      createdAt: 1700000000,
+      updatedAt: 1700001000,
+      latestVersion: { version: '1.2.0', changelog: 'Bug fixes' },
+      files: [{ path: 'SKILL.md', size: 1024 }],
+      skillMdContent: '# My Skill\n\nDoes things.',
+    },
   },
   suggestion_response: {
     type: 'suggestion_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -35,6 +35,7 @@ import type {
   SkillsUpdateRequest,
   SkillsCheckUpdatesRequest,
   SkillsSearchRequest,
+  SkillsInspectRequest,
   SuggestionRequest,
   AddTrustRule,
   RemoveTrustRule,
@@ -49,7 +50,7 @@ import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
 import { getRootDir } from '../util/platform.js';
-import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates } from '../skills/clawhub.js';
+import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -316,6 +317,7 @@ const handlers: DispatchMap = {
   skills_update: handleSkillsUpdate,
   skills_check_updates: handleSkillsCheckUpdates,
   skills_search: handleSkillsSearch,
+  skills_inspect: handleSkillsInspect,
   suggestion_request: handleSuggestionRequest,
   add_trust_rule: handleAddTrustRule,
   trust_rules_list: (_msg, socket, ctx) => handleTrustRulesList(socket, ctx),
@@ -1047,6 +1049,30 @@ async function handleSkillsSearch(
       type: 'skills_operation_response',
       operation: 'search',
       success: false,
+      error: message,
+    });
+  }
+}
+
+async function handleSkillsInspect(
+  msg: SkillsInspectRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const result = await clawhubInspect(msg.slug);
+    ctx.send(socket, {
+      type: 'skills_inspect_response',
+      slug: msg.slug,
+      ...(result.data ? { data: result.data } : {}),
+      ...(result.error ? { error: result.error } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to inspect skill');
+    ctx.send(socket, {
+      type: 'skills_inspect_response',
+      slug: msg.slug,
       error: message,
     });
   }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -192,6 +192,11 @@ export interface SkillsSearchRequest {
   query: string;
 }
 
+export interface SkillsInspectRequest {
+  type: 'skills_inspect';
+  slug: string;
+}
+
 export interface SuggestionRequest {
   type: 'suggestion_request';
   sessionId: string;
@@ -360,6 +365,7 @@ export type ClientMessage =
   | SkillsUpdateRequest
   | SkillsCheckUpdatesRequest
   | SkillsSearchRequest
+  | SkillsInspectRequest
   | SuggestionRequest
   | AddTrustRule
   | TrustRulesList
@@ -643,6 +649,22 @@ export interface SkillDetailResponse {
   error?: string;
 }
 
+export interface SkillsInspectResponse {
+  type: 'skills_inspect_response';
+  slug: string;
+  data?: {
+    skill: { slug: string; displayName: string; summary: string };
+    owner?: { handle: string; displayName: string; image?: string } | null;
+    stats?: { stars: number; installs: number; downloads: number; versions: number } | null;
+    createdAt?: number | null;
+    updatedAt?: number | null;
+    latestVersion?: { version: string; changelog?: string } | null;
+    files?: Array<{ path: string; size: number; contentType?: string }> | null;
+    skillMdContent?: string | null;
+  };
+  error?: string;
+}
+
 export interface SuggestionResponse {
   type: 'suggestion_response';
   requestId: string;
@@ -787,6 +809,7 @@ export type ServerMessage =
   | SkillDetailResponse
   | SkillStateChanged
   | SkillsOperationResponse
+  | SkillsInspectResponse
   | SuggestionResponse
   | MessageQueued
   | MessageDequeued

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -207,6 +207,71 @@ export async function clawhubExplore(opts?: { limit?: number; sort?: string }): 
   }
 }
 
+export interface ClawhubInspectResult {
+  skill: { slug: string; displayName: string; summary: string };
+  owner: { handle: string; displayName: string; image?: string } | null;
+  stats: { stars: number; installs: number; downloads: number; versions: number } | null;
+  createdAt: number | null;
+  updatedAt: number | null;
+  latestVersion: { version: string; changelog?: string } | null;
+  files: Array<{ path: string; size: number; contentType?: string }> | null;
+  skillMdContent: string | null;
+}
+
+export async function clawhubInspect(slug: string): Promise<{ data?: ClawhubInspectResult; error?: string }> {
+  if (!validateSlug(slug)) {
+    return { error: `Invalid skill slug: ${slug}` };
+  }
+
+  try {
+    const result = await runClawhub(['inspect', slug, '--json', '--files', '--file', 'SKILL.md']);
+    if (result.exitCode !== 0) {
+      const error = result.stderr.trim() || result.stdout.trim() || 'Unknown error';
+      return { error };
+    }
+    try {
+      const parsed = JSON.parse(result.stdout);
+      // Normalize the raw inspect response to our interface
+      const data: ClawhubInspectResult = {
+        skill: {
+          slug: parsed.slug ?? slug,
+          displayName: parsed.displayName ?? parsed.name ?? slug,
+          summary: parsed.summary ?? parsed.description ?? '',
+        },
+        owner: parsed.owner ? {
+          handle: parsed.owner.handle ?? parsed.owner.username ?? '',
+          displayName: parsed.owner.displayName ?? parsed.owner.name ?? '',
+          image: parsed.owner.image ?? parsed.owner.avatar ?? undefined,
+        } : null,
+        stats: parsed.stats ? {
+          stars: parsed.stats.stars ?? 0,
+          installs: parsed.stats.installsAllTime ?? parsed.stats.installs ?? 0,
+          downloads: parsed.stats.downloadsAllTime ?? parsed.stats.downloads ?? 0,
+          versions: parsed.stats.versions ?? 0,
+        } : null,
+        createdAt: parsed.createdAt ?? null,
+        updatedAt: parsed.updatedAt ?? null,
+        latestVersion: parsed.latestVersion ? {
+          version: parsed.latestVersion.version ?? '',
+          changelog: parsed.latestVersion.changelog ?? undefined,
+        } : null,
+        files: parsed.files ? parsed.files.map((f: Record<string, unknown>) => ({
+          path: (f.path as string) ?? '',
+          size: (f.size as number) ?? 0,
+          contentType: (f.contentType as string) ?? undefined,
+        })) : null,
+        skillMdContent: parsed.skillMdContent ?? parsed.fileContents?.['SKILL.md'] ?? null,
+      };
+      return { data };
+    } catch {
+      return { error: 'Failed to parse inspect output' };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
+  }
+}
+
 export async function clawhubCheckUpdates(): Promise<ClawhubUpdateCheckItem[]> {
   // This is a placeholder -- clawhub doesn't have a dedicated check-updates command
   // For now return empty; will be implemented when the CLI supports it


### PR DESCRIPTION
## Summary
- Adds `clawhubInspect(slug)` function in `clawhub.ts` that runs `clawhub inspect` CLI and normalizes output to a typed `ClawhubInspectResult` interface
- Adds `SkillsInspectRequest` / `SkillsInspectResponse` IPC message types in `ipc-protocol.ts`
- Wires `handleSkillsInspect` handler in `handlers.ts` to dispatch map
- Updates IPC snapshot test with the new message types

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] IPC snapshot tests pass with updated fixtures
- [ ] Manual test: send `skills_inspect` message via IPC and verify response

Part of #1705, closes #1706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
