### PR TITLE
Add Swift IPC types and DaemonClient method for skill inspect

### DIFF
--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -71,6 +71,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `skills_operation_response` message.
     var onSkillsOperationResponse: ((SkillsOperationResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `skills_inspect_response` message.
+    var onSkillsInspectResponse: ((SkillsInspectResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -405,6 +408,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SkillsSearchMessage(query: query))
     }
 
+    /// Inspect a ClaWHub skill for detailed metadata.
+    func inspectSkill(slug: String) throws {
+        try send(SkillsInspectMessage(slug: slug))
+    }
+
     /// Configure a skill's environment, API key, or config.
     func configureSkill(name: String, env: [String: String]? = nil, apiKey: String? = nil, config: [String: AnyCodable]? = nil) throws {
         try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
@@ -546,6 +554,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSkillsUpdatesAvailable?(msg)
         case .skillsOperationResponse(let msg):
             onSkillsOperationResponse?(msg)
+        case .skillsInspectResponse(let msg):
+            onSkillsInspectResponse?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -271,6 +271,12 @@ struct SkillsSearchMessage: Encodable, Sendable {
     let query: String
 }
 
+/// Inspect a ClaWHub skill for detailed info. Wire type: "skills_inspect"
+struct SkillsInspectMessage: Encodable, Sendable {
+    let type: String = "skills_inspect"
+    let slug: String
+}
+
 // MARK: - Server → Client Messages (Decodable)
 
 /// Action to execute from the inference server.
@@ -541,6 +547,61 @@ struct SkillsOperationResponseMessage: Decodable, Sendable {
     let data: ClawhubSearchData?
 }
 
+/// Skill info from a ClaWHub inspect response.
+struct ClawhubInspectSkill: Decodable, Sendable {
+    let slug: String
+    let displayName: String
+    let summary: String
+}
+
+/// Owner info from a ClaWHub inspect response.
+struct ClawhubInspectOwner: Decodable, Sendable {
+    let handle: String
+    let displayName: String
+    let image: String?
+}
+
+/// Stats from a ClaWHub inspect response.
+struct ClawhubInspectStats: Decodable, Sendable {
+    let stars: Int
+    let installs: Int
+    let downloads: Int
+    let versions: Int
+}
+
+/// Version info from a ClaWHub inspect response.
+struct ClawhubInspectVersion: Decodable, Sendable {
+    let version: String
+    let changelog: String?
+}
+
+/// File entry from a ClaWHub inspect response.
+struct ClawhubInspectFile: Decodable, Sendable {
+    let path: String
+    let size: Int
+    let contentType: String?
+}
+
+/// Full inspect data for a ClaWHub skill.
+struct ClawhubInspectData: Decodable, Sendable {
+    let skill: ClawhubInspectSkill
+    let owner: ClawhubInspectOwner?
+    let stats: ClawhubInspectStats?
+    let createdAt: Int?
+    let updatedAt: Int?
+    let latestVersion: ClawhubInspectVersion?
+    let files: [ClawhubInspectFile]?
+    let skillMdContent: String?
+}
+
+/// Response from inspecting a ClaWHub skill.
+/// Wire type: "skills_inspect_response"
+struct SkillsInspectResponseMessage: Decodable, Sendable {
+    let slug: String
+    let data: ClawhubInspectData?
+    let error: String?
+}
+
 /// A single trust rule item returned from the daemon.
 struct TrustRuleItem: Decodable, Sendable, Identifiable {
     let id: String
@@ -710,6 +771,7 @@ enum ServerMessage: Decodable, Sendable {
     case skillStateChanged(SkillStateChangedMessage)
     case skillsUpdatesAvailable(SkillsUpdatesAvailableMessage)
     case skillsOperationResponse(SkillsOperationResponseMessage)
+    case skillsInspectResponse(SkillsInspectResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
     case toolUseStart(ToolUseStartMessage)
     case toolOutputChunk(ToolOutputChunkMessage)
@@ -800,6 +862,9 @@ enum ServerMessage: Decodable, Sendable {
         case "skills_operation_response":
             let message = try SkillsOperationResponseMessage(from: decoder)
             self = .skillsOperationResponse(message)
+        case "skills_inspect_response":
+            let message = try SkillsInspectResponseMessage(from: decoder)
+            self = .skillsInspectResponse(message)
         case "suggestion_response":
             let message = try SuggestionResponseMessage(from: decoder)
             self = .suggestionResponse(message)


### PR DESCRIPTION
Adds SkillsInspectMessage, ClawhubInspectData structs, ServerMessage case, and DaemonClient.inspectSkill() for the skill detail view feature. Part of #1705, closes #1707.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
