### PR TITLE
Align side panel top with chat area and fix MainWindowView preview

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSplitView.swift
@@ -16,7 +16,7 @@ struct VSplitView<Main: View, Panel: View>: View {
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding(VSpacing.sm)
+                    .padding([.bottom, .leading, .trailing], VSpacing.sm)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -144,4 +144,6 @@ struct MainWindowView: View {
 #Preview {
     let dc = DaemonClient()
     return MainWindowView(threadManager: ThreadManager(daemonClient: dc), daemonClient: dc, ambientAgent: AmbientAgent())
+        .frame(width: 900, height: 600)
+        .padding(.top, 36)
 }


### PR DESCRIPTION
## Summary
- Remove top padding from VSplitView panel so the VSidePanel top edge aligns flush with the chat area
- Add top padding and frame to MainWindowView preview to compensate for titlebar overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
