### PR TITLE
Guard against non-array files in clawhubInspect

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -255,7 +255,7 @@ export async function clawhubInspect(slug: string): Promise<{ data?: ClawhubInsp
           version: parsed.latestVersion.version ?? '',
           changelog: parsed.latestVersion.changelog ?? undefined,
         } : null,
-        files: parsed.files ? parsed.files.map((f: Record<string, unknown>) => ({
+        files: Array.isArray(parsed.files) ? parsed.files.map((f: Record<string, unknown>) => ({
           path: (f.path as string) ?? '',
           size: (f.size as number) ?? 0,
           contentType: (f.contentType as string) ?? undefined,


### PR DESCRIPTION
Uses Array.isArray() guard on parsed.files to prevent TypeError when CLI returns non-array value. Addresses review feedback from #1715.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
