### PR TITLE
Relax required fields in ClawhubInspectStats decoder

### DIFF
--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -567,6 +567,18 @@ struct ClawhubInspectStats: Decodable, Sendable {
     let installs: Int
     let downloads: Int
     let versions: Int
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        stars = try container.decodeIfPresent(Int.self, forKey: .stars) ?? 0
+        installs = try container.decodeIfPresent(Int.self, forKey: .installs) ?? 0
+        downloads = try container.decodeIfPresent(Int.self, forKey: .downloads) ?? 0
+        versions = try container.decodeIfPresent(Int.self, forKey: .versions) ?? 0
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case stars, installs, downloads, versions
+    }
 }
 
 /// Version info from a ClaWHub inspect response.


### PR DESCRIPTION
Uses decodeIfPresent with zero defaults for all stats fields so partial ClaWHub responses don't crash the entire inspect response decode. Addresses review feedback from #1716.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
