### PR TITLE
Fix stuck installingSlug and stale inspect responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -172,17 +172,19 @@ struct AgentPanel: View {
 
     @ViewBuilder
     private var availableSkillsContent: some View {
-        if let slug = selectedSkillSlug {
-            skillDetailView(slug: slug)
-                .onChange(of: skillsManager.installResult?.slug) {
-                    if let result = skillsManager.installResult {
-                        if result.slug == installingSlug {
-                            installingSlug = nil
-                        }
-                    }
+        Group {
+            if let slug = selectedSkillSlug {
+                skillDetailView(slug: slug)
+            } else {
+                availableSkillsList
+            }
+        }
+        .onChange(of: skillsManager.installResult?.slug) {
+            if let result = skillsManager.installResult {
+                if result.slug == installingSlug {
+                    installingSlug = nil
                 }
-        } else {
-            availableSkillsList
+            }
         }
     }
 
@@ -677,6 +679,11 @@ struct AgentPanel: View {
             guard installingSlug == nil, !isSuccess else { return }
             installingSlug = slug
             skillsManager.installSkill(slug: slug)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                if installingSlug == slug {
+                    installingSlug = nil
+                }
+            }
         }) {
             HStack(spacing: VSpacing.sm) {
                 if isSuccess {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -19,6 +19,7 @@ final class SkillsManager: ObservableObject {
     }
 
     private let daemonClient: DaemonClient
+    private var currentInspectSlug: String?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -141,6 +142,7 @@ final class SkillsManager: ObservableObject {
     }
 
     func inspectSkill(slug: String) {
+        currentInspectSlug = slug
         isInspecting = true
         inspectedSkill = nil
         inspectError = nil
@@ -151,6 +153,8 @@ final class SkillsManager: ObservableObject {
             do {
                 try daemonClient.inspectSkill(slug: slug)
             } catch {
+                // Only update if still the current request
+                guard currentInspectSlug == slug else { return }
                 isInspecting = false
                 inspectError = "Failed to connect"
                 return
@@ -159,6 +163,8 @@ final class SkillsManager: ObservableObject {
             for await message in stream {
                 if case .skillsInspectResponse(let response) = message,
                    response.slug == slug {
+                    // Only update if still the current request
+                    guard currentInspectSlug == slug else { return }
                     if let data = response.data {
                         inspectedSkill = data
                     } else {
@@ -168,11 +174,14 @@ final class SkillsManager: ObservableObject {
                     return
                 }
             }
-            isInspecting = false
+            if currentInspectSlug == slug {
+                isInspecting = false
+            }
         }
     }
 
     func clearInspection() {
+        currentInspectSlug = nil
         inspectedSkill = nil
         isInspecting = false
         inspectError = nil


### PR DESCRIPTION
## Summary
- Moves `.onChange` observer outside the `if/else` branch in `availableSkillsContent` so it persists when the user navigates away during install, preventing `installingSlug` from getting permanently stuck.
- Adds a 10-second timeout fallback to the detail install button (matching the list card behavior).
- Guards against stale inspect responses in `SkillsManager` by tracking `currentInspectSlug` and ignoring responses for superseded requests.

Addresses review feedback from #1717.

## Test plan
- [ ] Open a skill detail view, tap Install, then immediately tap Back — verify the installing state clears when the install completes (or after 10s timeout).
- [ ] Open skill A, go back quickly, open skill B — verify skill B's data is shown, not skill A's stale response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
