### PR TITLE
M6: Share button & NSSharingServicePicker

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -239,6 +239,13 @@ exports[`IPC message snapshots ClientMessage types skills_search serializes to e
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types skills_inspect serializes to expected JSON 1`] = `
+{
+  "slug": "clawhub/my-skill",
+  "type": "skills_inspect",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types suggestion_request serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -279,6 +286,19 @@ exports[`IPC message snapshots ClientMessage types update_trust_rule serializes 
   "scope": "/projects/my-app",
   "tool": "bash",
   "type": "update_trust_rule",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types bundle_app serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "bundle_app",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types apps_list serializes to expected JSON 1`] = `
+{
+  "type": "apps_list",
 }
 `;
 
@@ -693,6 +713,47 @@ Do the thing."
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types skills_inspect_response serializes to expected JSON 1`] = `
+{
+  "data": {
+    "createdAt": 1700000000,
+    "files": [
+      {
+        "path": "SKILL.md",
+        "size": 1024,
+      },
+    ],
+    "latestVersion": {
+      "changelog": "Bug fixes",
+      "version": "1.2.0",
+    },
+    "owner": {
+      "displayName": "ClaWHub",
+      "handle": "clawhub",
+    },
+    "skill": {
+      "displayName": "My Skill",
+      "slug": "clawhub/my-skill",
+      "summary": "A test skill",
+    },
+    "skillMdContent": 
+"# My Skill
+
+Does things."
+,
+    "stats": {
+      "downloads": 5000,
+      "installs": 1000,
+      "stars": 42,
+      "versions": 3,
+    },
+    "updatedAt": 1700001000,
+  },
+  "slug": "clawhub/my-skill",
+  "type": "skills_inspect_response",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types suggestion_response serializes to expected JSON 1`] = `
 {
   "requestId": "req-suggest-001",
@@ -743,5 +804,35 @@ exports[`IPC message snapshots ServerMessage types trust_rules_list_response ser
     },
   ],
   "type": "trust_rules_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types bundle_app_response serializes to expected JSON 1`] = `
+{
+  "bundlePath": "/tmp/My_App-abc12345.vellumapp",
+  "manifest": {
+    "capabilities": [],
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "created_by": "vellum-assistant/0.1.6",
+    "description": "A test app",
+    "entry": "index.html",
+    "format_version": 1,
+    "name": "My App",
+  },
+  "type": "bundle_app_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types apps_list_response serializes to expected JSON 1`] = `
+{
+  "apps": [
+    {
+      "createdAt": 1700000000,
+      "description": "A test app",
+      "id": "app-001",
+      "name": "My App",
+    },
+  ],
+  "type": "apps_list_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -196,6 +196,9 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'bundle_app',
     appId: 'app-001',
   },
+  apps_list: {
+    type: 'apps_list',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -512,6 +515,17 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       entry: 'index.html',
       capabilities: [],
     },
+  },
+  apps_list_response: {
+    type: 'apps_list_response',
+    apps: [
+      {
+        id: 'app-001',
+        name: 'My App',
+        description: 'A test app',
+        createdAt: 1700000000,
+      },
+    ],
   },
 };
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -49,7 +49,7 @@ import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../confi
 import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
-import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord } from '../memory/app-store.js';
+import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps } from '../memory/app-store.js';
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { packageApp } from '../bundler/app-bundler.js';
@@ -326,6 +326,7 @@ const handlers: DispatchMap = {
   remove_trust_rule: handleRemoveTrustRule,
   update_trust_rule: handleUpdateTrustRule,
   bundle_app: handleBundleApp,
+  apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
@@ -1387,6 +1388,27 @@ async function generateSuggestion(apiKey: string, assistantText: string): Promis
 
   const firstLine = raw.split('\n')[0].trim();
   return firstLine || null;
+}
+
+// ─── Apps list handler ──────────────────────────────────────────────────────
+
+function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
+  try {
+    const apps = listApps();
+    ctx.send(socket, {
+      type: 'apps_list_response',
+      apps: apps.map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description,
+        createdAt: a.createdAt,
+      })),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to list apps');
+    ctx.send(socket, { type: 'error', message: `Failed to list apps: ${message}` });
+  }
 }
 
 // ─── Bundle app handler ─────────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -230,6 +230,10 @@ export interface UpdateTrustRule {
   priority?: number;
 }
 
+export interface AppsListRequest {
+  type: 'apps_list';
+}
+
 export interface BundleAppRequest {
   type: 'bundle_app';
   appId: string;
@@ -376,7 +380,8 @@ export type ClientMessage =
   | TrustRulesList
   | RemoveTrustRule
   | UpdateTrustRule
-  | BundleAppRequest;
+  | BundleAppRequest
+  | AppsListRequest;
 
 // === Server → Client messages ===
 
@@ -691,6 +696,17 @@ export interface TrustRulesListResponse {
   }>;
 }
 
+export interface AppsListResponse {
+  type: 'apps_list_response';
+  apps: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    icon?: string;
+    createdAt: number;
+  }>;
+}
+
 export interface BundleAppResponse {
   type: 'bundle_app_response';
   bundlePath: string;
@@ -836,7 +852,8 @@ export type ServerMessage =
   | MessageDequeued
   | TimerCompleted
   | TrustRulesListResponse
-  | BundleAppResponse;
+  | BundleAppResponse
+  | AppsListResponse;
 
 // === Serialization ===
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -125,7 +125,7 @@ struct MainWindowView: View {
         if let panel = activePanel {
             switch panel {
             case .generated:
-                GeneratedPanel(onClose: { activePanel = nil })
+                GeneratedPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .agent:
                 AgentPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .control:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -2,18 +2,181 @@ import SwiftUI
 
 struct GeneratedPanel: View {
     var onClose: () -> Void
+    let daemonClient: DaemonClient
+
+    @State private var apps: [AppItem] = []
+    @State private var isLoading = false
+    @State private var hoveredAppId: String?
+    @State private var sharingAppId: String?
+    @State private var isBundling = false
+    @State private var shareFileURL: URL?
+    @State private var showShareSheet = false
+
+    init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
+        self.onClose = onClose
+        self.daemonClient = daemonClient
+    }
 
     var body: some View {
         VSidePanel(title: "Generated", onClose: onClose) {
-            VEmptyState(
-                title: "No generated items",
-                subtitle: "Items created by your assistant will appear here",
-                icon: "wand.and.stars"
-            )
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .frame(height: 250)
+            } else if apps.isEmpty {
+                VEmptyState(
+                    title: "No generated items",
+                    subtitle: "Items created by your assistant will appear here",
+                    icon: "wand.and.stars"
+                )
+            } else {
+                VStack(spacing: VSpacing.md) {
+                    ForEach(apps) { app in
+                        appRow(app)
+                    }
+                }
+            }
         }
+        .onAppear {
+            fetchApps()
+        }
+    }
+
+    // MARK: - App Row
+
+    private func appRow(_ app: AppItem) -> some View {
+        let isHovered = hoveredAppId == app.id
+        let isBundlingThis = sharingAppId == app.id && isBundling
+
+        return HStack(spacing: VSpacing.md) {
+            // Icon
+            Text(app.icon ?? "\u{1F4F1}")
+                .font(.system(size: 20))
+                .frame(width: 28, height: 28)
+
+            // Name + description
+            VStack(alignment: .leading, spacing: 2) {
+                Text(app.name)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                if let description = app.description, !description.isEmpty {
+                    Text(description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(2)
+                }
+
+                Text(formatDate(app.createdAt))
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer()
+
+            // Share button — visible on hover
+            if isHovered || isBundlingThis {
+                if isBundlingThis {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .frame(width: 24, height: 24)
+                } else {
+                    shareButton(for: app)
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(isHovered ? Slate._800 : Slate._900)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+        )
+        .onHover { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredAppId = hovering ? app.id : nil
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func shareButton(for app: AppItem) -> some View {
+        ZStack {
+            // Invisible NSViewRepresentable button for NSSharingServicePicker anchor
+            ShareSheetButton(
+                items: shareFileURL != nil && sharingAppId == app.id ? [shareFileURL!] : [],
+                isPresented: Binding(
+                    get: { showShareSheet && sharingAppId == app.id },
+                    set: { showShareSheet = $0 }
+                )
+            )
+            .frame(width: 28, height: 28)
+
+            // Visible SwiftUI button overlay
+            Button(action: {
+                bundleAndShare(appId: app.id)
+            }) {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 13))
+                    .foregroundColor(Emerald._400)
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Data Fetching
+
+    private func fetchApps() {
+        isLoading = true
+        daemonClient.onAppsListResponse = { response in
+            self.apps = response.apps
+            self.isLoading = false
+        }
+        do {
+            try daemonClient.sendAppsList()
+        } catch {
+            isLoading = false
+        }
+    }
+
+    // MARK: - Bundle & Share
+
+    private func bundleAndShare(appId: String) {
+        guard !isBundling else { return }
+        sharingAppId = appId
+        isBundling = true
+
+        daemonClient.onBundleAppResponse = { response in
+            let url = URL(fileURLWithPath: response.bundlePath)
+            self.shareFileURL = url
+            self.isBundling = false
+            self.showShareSheet = true
+        }
+
+        do {
+            try daemonClient.sendBundleApp(appId: appId)
+        } catch {
+            isBundling = false
+            sharingAppId = nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatDate(_ epochMs: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(epochMs) / 1000)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
     }
 }
 
 #Preview {
-    GeneratedPanel(onClose: {})
+    GeneratedPanel(onClose: {}, daemonClient: DaemonClient())
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -1,0 +1,50 @@
+import AppKit
+import SwiftUI
+
+/// An NSView wrapper that presents an NSSharingServicePicker anchored to itself.
+/// Usage: set `isPresented` to `true` to trigger the share sheet with `items`.
+struct ShareSheetButton: NSViewRepresentable {
+    let items: [Any]
+    @Binding var isPresented: Bool
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(frame: .zero)
+        button.bezelStyle = .inline
+        button.isBordered = false
+        button.title = ""
+        button.image = NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Share")
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.showPicker(_:))
+        // Make the button invisible — SwiftUI overlay handles appearance
+        button.alphaValue = 0.01
+        return button
+    }
+
+    func updateNSView(_ nsView: NSButton, context: Context) {
+        context.coordinator.items = items
+        if isPresented {
+            DispatchQueue.main.async {
+                context.coordinator.showPicker(nsView)
+                self.isPresented = false
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(items: items)
+    }
+
+    class Coordinator: NSObject, NSSharingServicePickerDelegate {
+        var items: [Any]
+
+        init(items: [Any]) {
+            self.items = items
+        }
+
+        @objc func showPicker(_ sender: NSView) {
+            let picker = NSSharingServicePicker(items: items)
+            picker.delegate = self
+            picker.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -74,6 +74,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `skills_inspect_response` message.
     var onSkillsInspectResponse: ((SkillsInspectResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `apps_list_response` message.
+    var onAppsListResponse: ((AppsListResponseMessage) -> Void)?
+
+    /// Called when the daemon sends a `bundle_app_response` message.
+    var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -418,6 +424,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
     }
 
+    // MARK: - Apps
+
+    /// Request the list of all apps from the daemon.
+    func sendAppsList() throws {
+        try send(AppsListRequestMessage())
+    }
+
+    /// Request bundling an app for sharing.
+    func sendBundleApp(appId: String) throws {
+        try send(BundleAppRequestMessage(appId: appId))
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon. Stops reconnect and ping timers.
@@ -556,6 +574,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSkillsOperationResponse?(msg)
         case .skillsInspectResponse(let msg):
             onSkillsInspectResponse?(msg)
+        case .appsListResponse(let msg):
+            onAppsListResponse?(msg)
+        case .bundleAppResponse(let msg):
+            onBundleAppResponse?(msg)
         default:
             break
         }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -207,6 +207,19 @@ struct AppDataRequestMessage: Encodable, Sendable {
     let data: [String: AnyCodable]?
 }
 
+/// Sent to request the list of all apps.
+/// Wire type: `"apps_list"`
+struct AppsListRequestMessage: Encodable, Sendable {
+    let type: String = "apps_list"
+}
+
+/// Sent to request bundling an app for sharing.
+/// Wire type: `"bundle_app"`
+struct BundleAppRequestMessage: Encodable, Sendable {
+    let type: String = "bundle_app"
+    let appId: String
+}
+
 /// Sent to request the list of available skills.
 /// Wire type: `"skills_list"`
 struct SkillsListRequestMessage: Encodable, Sendable {
@@ -631,6 +644,27 @@ struct TrustRulesListResponseMessage: Decodable, Sendable {
     let rules: [TrustRuleItem]
 }
 
+/// A single app item returned from the daemon.
+struct AppItem: Decodable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    let description: String?
+    let icon: String?
+    let createdAt: Int
+}
+
+/// Response containing the list of all apps.
+/// Wire type: `"apps_list_response"`
+struct AppsListResponseMessage: Decodable, Sendable {
+    let apps: [AppItem]
+}
+
+/// Response from bundling an app.
+/// Wire type: `"bundle_app_response"`
+struct BundleAppResponseMessage: Decodable, Sendable {
+    let bundlePath: String
+}
+
 /// Timer completed notification from daemon.
 /// Wire type: `"timer_completed"`
 struct TimerCompletedMessage: Decodable, Sendable {
@@ -790,6 +824,8 @@ enum ServerMessage: Decodable, Sendable {
     case toolResult(ToolResultMessage)
     case timerCompleted(TimerCompletedMessage)
     case trustRulesListResponse(TrustRulesListResponseMessage)
+    case appsListResponse(AppsListResponseMessage)
+    case bundleAppResponse(BundleAppResponseMessage)
     case pong
     case unknown(String)
 
@@ -895,6 +931,12 @@ enum ServerMessage: Decodable, Sendable {
         case "trust_rules_list_response":
             let message = try TrustRulesListResponseMessage(from: decoder)
             self = .trustRulesListResponse(message)
+        case "apps_list_response":
+            let message = try AppsListResponseMessage(from: decoder)
+            self = .appsListResponse(message)
+        case "bundle_app_response":
+            let message = try BundleAppResponseMessage(from: decoder)
+            self = .bundleAppResponse(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Wires up the Generated panel to show apps from app-store via new `apps_list` IPC message
- Adds share button with NSSharingServicePicker for sharing `.vellumapp` bundles
- Each app row displays name, description, icon emoji, creation date, and a share button on hover

## Changes
- **TypeScript IPC**: Added `AppsListRequest`/`AppsListResponse` types and `apps_list` handler calling `listApps()`
- **Swift IPC**: Added `AppsListRequestMessage`, `BundleAppRequestMessage`, `AppsListResponseMessage`, `BundleAppResponseMessage`, `AppItem` types
- **DaemonClient**: Added `onAppsListResponse`/`onBundleAppResponse` callbacks and `sendAppsList()`/`sendBundleApp()` methods
- **GeneratedPanel**: Replaced empty placeholder with full app list UI using VColor/VFont/VSpacing design tokens
- **ShareSheetHelper**: New NSViewRepresentable wrapping NSSharingServicePicker for native macOS share sheet

Part of #1721.

## Test plan
- [x] TypeScript type-checks (`bunx tsc --noEmit`)
- [x] Swift builds (`swift build`)
- [x] IPC snapshot tests updated and passing
- [ ] Manual: Open Generated panel, verify apps load
- [ ] Manual: Hover app row, verify share button appears
- [ ] Manual: Click share, verify NSSharingServicePicker presents with .vellumapp file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
