### PR TITLE
M1: Add SkillInvocationData model and ChatViewModel support

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -109,6 +109,12 @@ struct ChatAttachment: Identifiable {
     let thumbnailData: Data?
 }
 
+struct SkillInvocationData: Equatable {
+    let name: String
+    let emoji: String?
+    let description: String
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
@@ -118,11 +124,12 @@ struct ChatMessage: Identifiable {
     var status: ChatMessageStatus
     /// Non-nil when this message is an inline tool confirmation request.
     var confirmation: ToolConfirmationData?
+    var skillInvocation: SkillInvocationData?
     var attachments: [ChatAttachment]
     var toolCalls: [ToolCallData]
     var inlineSurfaces: [InlineSurfaceData]
 
-    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
+    init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
         self.id = id
         self.role = role
         self.text = text
@@ -130,6 +137,7 @@ struct ChatMessage: Identifiable {
         self.isStreaming = isStreaming
         self.status = status
         self.confirmation = confirmation
+        self.skillInvocation = skillInvocation
         self.attachments = attachments
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -16,6 +16,7 @@ final class ChatViewModel: ObservableObject {
     @Published var suggestion: String?
     @Published var pendingAttachments: [ChatAttachment] = []
     @Published var isRecording: Bool = false
+    @Published var pendingSkillInvocation: SkillInvocationData?
 
     /// Maximum file size per attachment (20 MB).
     private static let maxFileSize = 20 * 1024 * 1024
@@ -203,7 +204,8 @@ final class ChatViewModel: ObservableObject {
         // Append user message immediately for responsive UX
         let willBeQueued = isSending && sessionId != nil
         let status: ChatMessageStatus = willBeQueued ? .queued(position: 0) : .sent
-        let userMessage = ChatMessage(role: .user, text: text, status: status, attachments: attachments)
+        let userMessage = ChatMessage(role: .user, text: text, status: status, skillInvocation: pendingSkillInvocation, attachments: attachments)
+        pendingSkillInvocation = nil
         messages.append(userMessage)
         // Only track in pendingMessageIds when the message will actually be
         // queued by the daemon (i.e. sent while another message is processing).


### PR DESCRIPTION
Part of #1735. Adds SkillInvocationData struct to ChatMessage and pendingSkillInvocation to ChatViewModel for skill invocation from the Skills tab. Closes #1736.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
