### PR TITLE
M2: Create SkillInvocationChip view and render in ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -570,6 +570,10 @@ private struct ChatBubble: View {
     private var bubbleContent: some View {
         let partitioned = partitionedAttachments
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
+            if let skillInvocation = message.skillInvocation {
+                SkillInvocationChip(data: skillInvocation)
+            }
+
             if hasText {
                 Text(markdownText)
                     .font(VFont.body)

--- a/clients/macos/vellum-assistant/Features/Chat/SkillInvocationChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/SkillInvocationChip.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct SkillInvocationChip: View {
+    let data: SkillInvocationData
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            if let emoji = data.emoji {
+                Text(emoji)
+                    .font(VFont.cardEmoji)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(data.name)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text(data.description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(Slate._800)
+        .clipShape(PixelBorderShape())
+        .overlay(
+            PixelBorderShape()
+                .stroke(Amber._600.opacity(0.6), lineWidth: 2)
+        )
+    }
+}
+
+#Preview("SkillInvocationChip") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        VStack(spacing: VSpacing.lg) {
+            SkillInvocationChip(data: SkillInvocationData(
+                name: "Summarize Page",
+                emoji: "📝",
+                description: "Summarize the contents of the current page"
+            ))
+            SkillInvocationChip(data: SkillInvocationData(
+                name: "Start the Day",
+                emoji: nil,
+                description: "Morning routine skill"
+            ))
+        }
+        .padding()
+    }
+    .frame(width: 400, height: 200)
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - Pixel Border Shape
 
-private struct PixelBorderShape: Shape {
+struct PixelBorderShape: Shape {
     let pixelSize: CGFloat
     let cornerSteps: Int
 


### PR DESCRIPTION
Part of #1735. Creates SkillInvocationChip styled card for displaying skill invocations in chat message bubbles, and renders it in ChatBubble when a message has skill invocation data. Makes PixelBorderShape accessible across modules.

Closes #1737.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
