### PR TITLE
M3: Wire AgentPanel skill button through MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -127,7 +127,20 @@ struct MainWindowView: View {
             case .generated:
                 GeneratedPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
             case .agent:
-                AgentPanel(onClose: { activePanel = nil }, daemonClient: daemonClient)
+                AgentPanel(onClose: { activePanel = nil }, onInvokeSkill: { skill in
+                    if threadManager.activeViewModel == nil {
+                        threadManager.createThread()
+                    }
+                    if let viewModel = threadManager.activeViewModel {
+                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                            name: skill.name,
+                            emoji: skill.emoji,
+                            description: skill.description
+                        )
+                        viewModel.inputText = "Use the \(skill.name) skill"
+                        viewModel.sendMessage()
+                    }
+                }, daemonClient: daemonClient)
             case .settings:
                 SettingsPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent, daemonClient: daemonClient)
             case .directory:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -71,6 +71,7 @@ private struct PixelBorderShape: Shape {
 
 struct AgentPanel: View {
     var onClose: () -> Void
+    var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
     @StateObject private var skillsManager: SkillsManager
@@ -80,8 +81,9 @@ struct AgentPanel: View {
     @State private var selectedSkillSlug: String?
     @State private var hoveredDetailInstall = false
 
-    init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient) {
         self.onClose = onClose
+        self.onInvokeSkill = onInvokeSkill
         self.daemonClient = daemonClient
         _skillsManager = StateObject(wrappedValue: SkillsManager(daemonClient: daemonClient))
     }
@@ -809,7 +811,7 @@ struct AgentPanel: View {
             HStack(spacing: VSpacing.md) {
                 // Pixel-bordered button to use the skill
                 Button(action: {
-                    // TODO: implement skill usage
+                    onInvokeSkill?(skill)
                 }) {
                     HStack(spacing: VSpacing.md) {
                         skillIcon(skill.emoji)


### PR DESCRIPTION
Part of #1735. Wires the skill button in AgentPanel to inject a user message into the active chat thread with skill invocation metadata, triggering skill execution. Closes #1739.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
