### PR TITLE
M4: UTI registration & .vellumapp file handling

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -302,6 +302,13 @@ exports[`IPC message snapshots ClientMessage types apps_list serializes to expec
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types open_bundle serializes to expected JSON 1`] = `
+{
+  "filePath": "/tmp/My_App.vellumapp",
+  "type": "open_bundle",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types sign_bundle_payload_response serializes to expected JSON 1`] = `
 {
   "keyId": "abc123",
@@ -851,6 +858,35 @@ exports[`IPC message snapshots ServerMessage types apps_list_response serializes
     },
   ],
   "type": "apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types open_bundle_response serializes to expected JSON 1`] = `
+{
+  "bundleSizeBytes": 4096,
+  "manifest": {
+    "capabilities": [],
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "created_by": "vellum-assistant/0.1.6",
+    "description": "A test app",
+    "entry": "index.html",
+    "format_version": 1,
+    "name": "My App",
+  },
+  "scanResult": {
+    "blocked": [],
+    "passed": true,
+    "warnings": [
+      "Use of fetch() detected",
+    ],
+  },
+  "signatureResult": {
+    "signerAccount": "test@example.com",
+    "signerDisplayName": "Test Signer",
+    "signerKeyId": "key-001",
+    "trustTier": "signed",
+  },
+  "type": "open_bundle_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -199,6 +199,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   apps_list: {
     type: 'apps_list',
   },
+  open_bundle: {
+    type: 'open_bundle',
+    filePath: '/tmp/My_App.vellumapp',
+  },
   sign_bundle_payload_response: {
     type: 'sign_bundle_payload_response',
     signature: 'dGVzdC1zaWduYXR1cmU=',
@@ -537,6 +541,30 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         createdAt: 1700000000,
       },
     ],
+  },
+  open_bundle_response: {
+    type: 'open_bundle_response',
+    manifest: {
+      format_version: 1,
+      name: 'My App',
+      description: 'A test app',
+      created_at: '2026-01-01T00:00:00.000Z',
+      created_by: 'vellum-assistant/0.1.6',
+      entry: 'index.html',
+      capabilities: [],
+    },
+    scanResult: {
+      passed: true,
+      blocked: [],
+      warnings: ['Use of fetch() detected'],
+    },
+    signatureResult: {
+      trustTier: 'signed',
+      signerKeyId: 'key-001',
+      signerDisplayName: 'Test Signer',
+      signerAccount: 'test@example.com',
+    },
+    bundleSizeBytes: 4096,
   },
   sign_bundle_payload: {
     type: 'sign_bundle_payload',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -41,6 +41,7 @@ import type {
   RemoveTrustRule,
   UpdateTrustRule,
   BundleAppRequest,
+  OpenBundleRequest,
 } from './ipc-protocol.js';
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -53,6 +54,7 @@ import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, lis
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { packageApp } from '../bundler/app-bundler.js';
+import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -326,6 +328,7 @@ const handlers: DispatchMap = {
   remove_trust_rule: handleRemoveTrustRule,
   update_trust_rule: handleUpdateTrustRule,
   bundle_app: handleBundleApp,
+  open_bundle: handleOpenBundle,
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   sign_bundle_payload_response: (_msg, _socket, _ctx) => {
     // Handled by pending promise resolution in signing flow — no-op in dispatch

--- a/assistant/src/daemon/handlers/open-bundle-handler.ts
+++ b/assistant/src/daemon/handlers/open-bundle-handler.ts
@@ -1,0 +1,80 @@
+import * as net from 'node:net';
+import { stat } from 'node:fs/promises';
+import { scanBundle } from '../../bundler/bundle-scanner.js';
+import { verifyBundleSignature } from '../../bundler/signature-verifier.js';
+import { getLogger } from '../../util/logger.js';
+import type { OpenBundleRequest, OpenBundleResponse } from '../ipc-protocol.js';
+import type { HandlerContext } from '../handlers.js';
+
+const log = getLogger('open-bundle-handler');
+
+export async function handleOpenBundle(
+  msg: OpenBundleRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  try {
+    const fileStat = await stat(msg.filePath);
+    const bundleSizeBytes = fileStat.size;
+
+    // Run scanner and signature verifier in parallel
+    const [scanResult, signatureResult] = await Promise.all([
+      scanBundle(msg.filePath),
+      verifyBundleSignature(msg.filePath),
+    ]);
+
+    // Extract manifest from the zip for the response
+    const JSZip = (await import('jszip')).default;
+    const fileData = await Bun.file(msg.filePath).arrayBuffer();
+    const zip = await JSZip.loadAsync(fileData);
+    const manifestFile = zip.file('manifest.json');
+    let manifest: OpenBundleResponse['manifest'];
+    if (manifestFile) {
+      const manifestText = await manifestFile.async('text');
+      manifest = JSON.parse(manifestText) as OpenBundleResponse['manifest'];
+    } else {
+      manifest = {
+        format_version: 0,
+        name: 'Unknown',
+        created_at: '',
+        created_by: '',
+        entry: '',
+        capabilities: [],
+      };
+    }
+
+    const blocked = scanResult.findings
+      .filter((f) => f.level === 'block')
+      .map((f) => f.message);
+    const warnings = scanResult.findings
+      .filter((f) => f.level === 'warn')
+      .map((f) => f.message);
+
+    const response: OpenBundleResponse = {
+      type: 'open_bundle_response',
+      manifest,
+      scanResult: {
+        passed: scanResult.passed,
+        blocked,
+        warnings,
+      },
+      signatureResult: {
+        trustTier: signatureResult.trustTier,
+        signerKeyId: signatureResult.signerKeyId,
+        signerDisplayName: signatureResult.signerDisplayName,
+        signerAccount: signatureResult.signerAccount,
+      },
+      bundleSizeBytes,
+    };
+
+    ctx.send(socket, response);
+    log.info(
+      { filePath: msg.filePath, passed: scanResult.passed, trustTier: signatureResult.trustTier },
+      'Bundle opened and scanned',
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, filePath: msg.filePath }, 'Failed to open bundle');
+    ctx.send(socket, { type: 'error', message: `Failed to open bundle: ${message}` });
+  }
+}

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -239,6 +239,11 @@ export interface BundleAppRequest {
   appId: string;
 }
 
+export interface OpenBundleRequest {
+  type: 'open_bundle';
+  filePath: string;
+}
+
 export interface SignBundlePayloadResponse {
   type: 'sign_bundle_payload_response';
   signature: string;
@@ -395,6 +400,7 @@ export type ClientMessage =
   | UpdateTrustRule
   | BundleAppRequest
   | AppsListRequest
+  | OpenBundleRequest
   | SignBundlePayloadResponse
   | GetSigningIdentityResponse;
 
@@ -737,6 +743,32 @@ export interface BundleAppResponse {
   };
 }
 
+export interface OpenBundleResponse {
+  type: 'open_bundle_response';
+  manifest: {
+    format_version: number;
+    name: string;
+    description?: string;
+    icon?: string;
+    created_at: string;
+    created_by: string;
+    entry: string;
+    capabilities: string[];
+  };
+  scanResult: {
+    passed: boolean;
+    blocked: string[];
+    warnings: string[];
+  };
+  signatureResult: {
+    trustTier: 'verified' | 'signed' | 'unsigned' | 'tampered';
+    signerKeyId?: string;
+    signerDisplayName?: string;
+    signerAccount?: string;
+  };
+  bundleSizeBytes: number;
+}
+
 export interface SignBundlePayloadRequest {
   type: 'sign_bundle_payload';
   payload: string;
@@ -878,6 +910,7 @@ export type ServerMessage =
   | TrustRulesListResponse
   | BundleAppResponse
   | AppsListResponse
+  | OpenBundleResponse
   | SignBundlePayloadRequest
   | GetSigningIdentityRequest;
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -215,6 +215,44 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <true/>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.vellum.app-bundle</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+                <string>public.content</string>
+            </array>
+            <key>UTTypeDescription</key>
+            <string>Vellum App Bundle</string>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>vellumapp</string>
+                </array>
+                <key>public.mime-type</key>
+                <string>application/x-vellumapp</string>
+            </dict>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>vellumapp</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.vellum.app-bundle</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>
 PLIST

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1058,6 +1058,26 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - File Open Handler
+
+    public func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            guard url.pathExtension == "vellumapp" else { continue }
+            log.info("Opening .vellumapp file: \(url.path)")
+
+            guard daemonClient.isConnected else {
+                log.warning("Cannot open bundle: daemon not connected")
+                continue
+            }
+
+            do {
+                try daemonClient.sendOpenBundle(filePath: url.path)
+            } catch {
+                log.error("Failed to send open_bundle message: \(error.localizedDescription)")
+            }
+        }
+    }
+
     public func applicationWillTerminate(_ notification: Notification) {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -80,6 +80,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `bundle_app_response` message.
     var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
 
+    /// Called when the daemon sends an `open_bundle_response` message.
+    var onOpenBundleResponse: ((OpenBundleResponseMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -436,6 +439,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(BundleAppRequestMessage(appId: appId))
     }
 
+    /// Request opening and scanning a .vellumapp bundle.
+    func sendOpenBundle(filePath: String) throws {
+        try send(OpenBundleMessage(filePath: filePath))
+    }
+
     // MARK: - Signing Identity
 
     /// Handle a sign_bundle_payload request from the daemon.
@@ -613,6 +621,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onAppsListResponse?(msg)
         case .bundleAppResponse(let msg):
             onBundleAppResponse?(msg)
+        case .openBundleResponse(let msg):
+            onOpenBundleResponse?(msg)
         case .signBundlePayload(let msg):
             handleSignBundlePayload(msg)
         case .getSigningIdentity:

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -220,6 +220,13 @@ struct BundleAppRequestMessage: Encodable, Sendable {
     let appId: String
 }
 
+/// Sent to open and scan a .vellumapp bundle.
+/// Wire type: `"open_bundle"`
+struct OpenBundleMessage: Encodable, Sendable {
+    let type: String = "open_bundle"
+    let filePath: String
+}
+
 /// Sent to request the list of available skills.
 /// Wire type: `"skills_list"`
 struct SkillsListRequestMessage: Encodable, Sendable {
@@ -813,6 +820,44 @@ struct UpdateTrustRuleMessage: Encodable, Sendable {
     let priority: Int?
 }
 
+/// Response from opening and scanning a .vellumapp bundle.
+/// Wire type: `"open_bundle_response"`
+struct OpenBundleResponseMessage: Decodable, Sendable {
+    struct Manifest: Decodable, Sendable {
+        let formatVersion: Int
+        let name: String
+        let description: String?
+        let icon: String?
+        let createdAt: String
+        let createdBy: String
+        let entry: String
+        let capabilities: [String]
+
+        private enum CodingKeys: String, CodingKey {
+            case formatVersion = "format_version"
+            case name, description, icon
+            case createdAt = "created_at"
+            case createdBy = "created_by"
+            case entry, capabilities
+        }
+    }
+    struct ScanResult: Decodable, Sendable {
+        let passed: Bool
+        let blocked: [String]
+        let warnings: [String]
+    }
+    struct SignatureResult: Decodable, Sendable {
+        let trustTier: String
+        let signerKeyId: String?
+        let signerDisplayName: String?
+        let signerAccount: String?
+    }
+    let manifest: Manifest
+    let scanResult: ScanResult
+    let signatureResult: SignatureResult
+    let bundleSizeBytes: Int
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 enum ServerMessage: Decodable, Sendable {
@@ -849,6 +894,7 @@ enum ServerMessage: Decodable, Sendable {
     case trustRulesListResponse(TrustRulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
+    case openBundleResponse(OpenBundleResponseMessage)
     case signBundlePayload(SignBundlePayloadMessage)
     case getSigningIdentity
     case pong
@@ -962,6 +1008,9 @@ enum ServerMessage: Decodable, Sendable {
         case "bundle_app_response":
             let message = try BundleAppResponseMessage(from: decoder)
             self = .bundleAppResponse(message)
+        case "open_bundle_response":
+            let message = try OpenBundleResponseMessage(from: decoder)
+            self = .openBundleResponse(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Register the `.vellumapp` UTI (`com.vellum.app-bundle`) in the generated Info.plist via `build.sh` so macOS associates the file type with vellum-assistant
- Add `application(_:open:)` handler in `AppDelegate.swift` to handle `.vellumapp` file opens
- Add `open_bundle` / `open_bundle_response` IPC messages (TypeScript + Swift) for the full round-trip
- Add `open-bundle-handler.ts` daemon handler that runs `BundleScanner` + `SignatureVerifier` on opened bundles

Part of #1721. Closes #1726

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes
- [ ] Verify `./build.sh` succeeds and the generated Info.plist contains UTI declarations
- [ ] Verify IPC snapshot tests pass with `bun test --update-snapshots`
- [ ] Double-click a `.vellumapp` file and confirm the app opens and sends `open_bundle` to daemon
- [ ] Verify daemon returns `open_bundle_response` with scan + signature results
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
