### PR TITLE
M5: Open confirmation dialog & sandbox unpacking

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -94,6 +94,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
     private var settingsWindow: NSWindow?
+    private var bundleConfirmationWindow: BundleConfirmationWindow?
+    /// Tracks the file path of the .vellumapp currently being confirmed, so we
+    /// can associate the daemon's open_bundle_response with the correct file.
+    private var pendingBundleFilePath: String?
     #if DEBUG
     private var galleryWindow: ComponentGalleryWindow?
     #endif
@@ -150,6 +154,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     log.error("Failed to post timer notification: \(error.localizedDescription)")
                 }
             }
+        }
+
+        // Handle open_bundle_response from the daemon
+        daemonClient.onOpenBundleResponse = { [weak self] response in
+            guard let self else { return }
+            self.handleOpenBundleResponse(response)
         }
 
         // Handle escalation: text_qa -> computer_use via request_computer_control
@@ -1071,10 +1081,109 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             do {
+                pendingBundleFilePath = url.path
                 try daemonClient.sendOpenBundle(filePath: url.path)
             } catch {
                 log.error("Failed to send open_bundle message: \(error.localizedDescription)")
+                pendingBundleFilePath = nil
             }
+        }
+    }
+
+    // MARK: - Bundle Open Handling
+
+    private func handleOpenBundleResponse(_ response: OpenBundleResponseMessage) {
+        let filePath = pendingBundleFilePath ?? ""
+        pendingBundleFilePath = nil
+
+        // If scan blocked, show error alert
+        if !response.scanResult.passed {
+            let reason = response.scanResult.blocked.first ?? "Unknown security issue"
+            let alert = NSAlert()
+            alert.messageText = "This app can't be opened"
+            alert.informativeText = "Security scan found: \(reason)"
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        // Show confirmation dialog
+        let viewModel = BundleConfirmationViewModel(
+            response: response,
+            filePath: filePath
+        )
+
+        let confirmWindow = BundleConfirmationWindow()
+        self.bundleConfirmationWindow = confirmWindow
+
+        viewModel.onConfirm = { [weak self] in
+            guard let self else { return }
+            confirmWindow.close()
+            self.bundleConfirmationWindow = nil
+            self.unpackAndLoadBundle(
+                filePath: filePath,
+                manifest: response.manifest,
+                signatureResult: response.signatureResult,
+                bundleSizeBytes: response.bundleSizeBytes
+            )
+        }
+
+        viewModel.onCancel = { [weak self] in
+            confirmWindow.close()
+            self?.bundleConfirmationWindow = nil
+        }
+
+        confirmWindow.show(viewModel: viewModel)
+    }
+
+    private func unpackAndLoadBundle(
+        filePath: String,
+        manifest: OpenBundleResponseMessage.Manifest,
+        signatureResult: OpenBundleResponseMessage.SignatureResult,
+        bundleSizeBytes: Int
+    ) {
+        do {
+            let (uuid, _) = try BundleSandbox.unpack(
+                filePath: filePath,
+                manifest: manifest,
+                signatureResult: signatureResult,
+                bundleSizeBytes: bundleSizeBytes
+            )
+
+            // Build the vellumapp:// URL for the entry point
+            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/\(manifest.entry)"
+            log.info("Loading shared app at \(entryURL)")
+
+            // Load the shared app as a surface via SurfaceManager
+            let surfaceId = "shared-app-\(uuid)"
+            let html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><title>\(manifest.name)</title></head>
+            <body>
+                <script>window.location.href = '\(entryURL)';</script>
+            </body>
+            </html>
+            """
+            let surfaceMsg = UiSurfaceShowMessage(
+                sessionId: "shared-app",
+                surfaceId: surfaceId,
+                surfaceType: "dynamic_page",
+                title: manifest.name,
+                data: AnyCodable(["html": html]),
+                actions: nil,
+                display: "panel"
+            )
+            surfaceManager.showSurface(surfaceMsg)
+        } catch {
+            log.error("Failed to unpack bundle: \(error.localizedDescription)")
+            let alert = NSAlert()
+            alert.messageText = "Failed to open app"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -1,0 +1,295 @@
+import SwiftUI
+
+struct BundleConfirmationView: View {
+    @ObservedObject var viewModel: BundleConfirmationViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            headerSection
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Content
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    trustTierSection
+                    scanResultSection
+                    bundleSizeSection
+                }
+                .padding(VSpacing.xl)
+            }
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Footer buttons
+            footerSection
+        }
+        .background(VColor.background)
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(spacing: VSpacing.sm) {
+            Text(viewModel.manifest.icon ?? "\u{1F4E6}")
+                .font(.system(size: 40))
+
+            Text(viewModel.manifest.name)
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+                .multilineTextAlignment(.center)
+
+            if let description = viewModel.manifest.description, !description.isEmpty {
+                Text(description)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+            }
+
+            Text("by \(viewModel.manifest.createdBy)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Trust Tier
+
+    private var trustTierSection: some View {
+        HStack(spacing: VSpacing.sm) {
+            trustTierIcon
+            trustTierText
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(trustTierBackground)
+        .cornerRadius(VRadius.md)
+    }
+
+    @ViewBuilder
+    private var trustTierIcon: some View {
+        switch viewModel.trustTier {
+        case .verified:
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundColor(VColor.success)
+        case .signed:
+            Image(systemName: "info.circle.fill")
+                .foregroundColor(VColor.textSecondary)
+        case .unsigned:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(VColor.warning)
+        case .tampered:
+            Image(systemName: "xmark.seal.fill")
+                .foregroundColor(VColor.error)
+        }
+    }
+
+    @ViewBuilder
+    private var trustTierText: some View {
+        switch viewModel.trustTier {
+        case .verified:
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Verified")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.success)
+                Text("Created by \(viewModel.signatureResult.signerDisplayName ?? "Unknown") (\(viewModel.signatureResult.signerAccount ?? ""))")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        case .signed:
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Signed")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                let keyId = viewModel.signatureResult.signerKeyId ?? "unknown"
+                let shortKey = keyId.count > 8 ? String(keyId.prefix(8)) + "..." : keyId
+                Text("Created by an unverified user (key: \(shortKey)). Content not modified.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        case .unsigned:
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Unsigned")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.warning)
+                Text("This app is unsigned.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        case .tampered:
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text("Tampered")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.error)
+                Text("This app has been modified since it was signed.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+        }
+    }
+
+    private var trustTierBackground: Color {
+        switch viewModel.trustTier {
+        case .verified:
+            return VColor.success.opacity(0.1)
+        case .signed:
+            return VColor.surface
+        case .unsigned:
+            return VColor.warning.opacity(0.1)
+        case .tampered:
+            return VColor.error.opacity(0.1)
+        }
+    }
+
+    // MARK: - Scan Result
+
+    @ViewBuilder
+    private var scanResultSection: some View {
+        if !viewModel.scanResult.blocked.isEmpty {
+            // Blocked state (should not normally reach here)
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(VColor.error)
+                Text("Security scan blocked")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.error)
+            }
+            .padding(VSpacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.error.opacity(0.1))
+            .cornerRadius(VRadius.md)
+        } else if !viewModel.scanResult.warnings.isEmpty {
+            // Warnings
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Button(action: { viewModel.warningsExpanded.toggle() }) {
+                    HStack(spacing: VSpacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(VColor.warning)
+                        Text("Security scan: \(viewModel.scanResult.warnings.count) warning\(viewModel.scanResult.warnings.count == 1 ? "" : "s")")
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.warning)
+                        Spacer()
+                        Image(systemName: viewModel.warningsExpanded ? "chevron.up" : "chevron.down")
+                            .foregroundColor(VColor.textSecondary)
+                            .font(.system(size: 10))
+                    }
+                }
+                .buttonStyle(.plain)
+
+                if viewModel.warningsExpanded {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        ForEach(viewModel.scanResult.warnings, id: \.self) { warning in
+                            HStack(alignment: .top, spacing: VSpacing.sm) {
+                                Text("\u{2022}")
+                                    .foregroundColor(VColor.warning)
+                                Text(warning)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textSecondary)
+                            }
+                        }
+                    }
+                    .padding(.leading, VSpacing.xl)
+                }
+            }
+            .padding(VSpacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.warning.opacity(0.1))
+            .cornerRadius(VRadius.md)
+        } else {
+            // Clean scan
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "checkmark.shield.fill")
+                    .foregroundColor(VColor.success)
+                Text("Security scan passed")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.success)
+            }
+            .padding(VSpacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.success.opacity(0.1))
+            .cornerRadius(VRadius.md)
+        }
+    }
+
+    // MARK: - Bundle Size
+
+    private var bundleSizeSection: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: "doc.zipper")
+                .foregroundColor(VColor.textSecondary)
+            Text("Bundle size: \(viewModel.formattedSize)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footerSection: some View {
+        HStack(spacing: VSpacing.md) {
+            // Cancel button
+            Button(action: { viewModel.cancel() }) {
+                Text("Cancel")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textSecondary)
+                    .padding(.vertical, VSpacing.buttonV)
+                    .padding(.horizontal, VSpacing.lg)
+            }
+            .buttonStyle(.plain)
+            .background(VColor.surface)
+            .cornerRadius(VRadius.md)
+
+            Spacer()
+
+            if viewModel.isTampered {
+                if viewModel.showTamperedWarning {
+                    // Show "Open Anyway" destructive button
+                    VStack(alignment: .trailing, spacing: VSpacing.xs) {
+                        Text("This app may contain malicious content.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.error)
+                        Button(action: { viewModel.confirm() }) {
+                            Text("Open Anyway")
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.error)
+                                .padding(.vertical, VSpacing.buttonV)
+                                .padding(.horizontal, VSpacing.lg)
+                        }
+                        .buttonStyle(.plain)
+                        .background(VColor.error.opacity(0.2))
+                        .cornerRadius(VRadius.md)
+                    }
+                } else {
+                    Button(action: { viewModel.showTamperedWarning = true }) {
+                        Text("Open Anyway...")
+                            .font(VFont.bodyMedium)
+                            .foregroundColor(VColor.textSecondary)
+                            .padding(.vertical, VSpacing.buttonV)
+                            .padding(.horizontal, VSpacing.lg)
+                    }
+                    .buttonStyle(.plain)
+                    .background(VColor.surface)
+                    .cornerRadius(VRadius.md)
+                }
+            } else {
+                // Normal "Open in Vellum" button
+                Button(action: { viewModel.confirm() }) {
+                    Text("Open in Vellum")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.vertical, VSpacing.buttonV)
+                        .padding(.horizontal, VSpacing.lg)
+                }
+                .buttonStyle(.plain)
+                .background(VColor.accent)
+                .cornerRadius(VRadius.md)
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class BundleConfirmationViewModel: ObservableObject {
+    let manifest: OpenBundleResponseMessage.Manifest
+    let scanResult: OpenBundleResponseMessage.ScanResult
+    let signatureResult: OpenBundleResponseMessage.SignatureResult
+    let bundleSizeBytes: Int
+    let filePath: String
+
+    var onConfirm: (() -> Void)?
+    var onCancel: (() -> Void)?
+
+    @Published var showTamperedWarning = false
+    @Published var warningsExpanded = false
+
+    init(
+        response: OpenBundleResponseMessage,
+        filePath: String,
+        onConfirm: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
+        self.manifest = response.manifest
+        self.scanResult = response.scanResult
+        self.signatureResult = response.signatureResult
+        self.bundleSizeBytes = response.bundleSizeBytes
+        self.filePath = filePath
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+
+    // MARK: - Trust Tier
+
+    enum TrustTier: String {
+        case verified, signed, unsigned, tampered
+    }
+
+    var trustTier: TrustTier {
+        TrustTier(rawValue: signatureResult.trustTier) ?? .unsigned
+    }
+
+    var isTampered: Bool {
+        trustTier == .tampered
+    }
+
+    // MARK: - Formatted Size
+
+    var formattedSize: String {
+        let bytes = Double(bundleSizeBytes)
+        if bytes < 1024 {
+            return "\(bundleSizeBytes) B"
+        } else if bytes < 1024 * 1024 {
+            return String(format: "%.1f KB", bytes / 1024)
+        } else if bytes < 1024 * 1024 * 1024 {
+            return String(format: "%.1f MB", bytes / (1024 * 1024))
+        } else {
+            return String(format: "%.1f GB", bytes / (1024 * 1024 * 1024))
+        }
+    }
+
+    // MARK: - Actions
+
+    func confirm() {
+        onConfirm?()
+    }
+
+    func cancel() {
+        onCancel?()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationWindow.swift
@@ -1,0 +1,46 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class BundleConfirmationWindow {
+    private var window: NSWindow?
+    private var viewModel: BundleConfirmationViewModel?
+
+    func show(viewModel: BundleConfirmationViewModel) {
+        // Close any existing window
+        close()
+
+        self.viewModel = viewModel
+
+        let confirmationView = BundleConfirmationView(viewModel: viewModel)
+        let hostingController = NSHostingController(rootView: confirmationView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 480),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.level = .floating
+        window.center()
+
+        NSApp.setActivationPolicy(.regular)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+        viewModel = nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -1,0 +1,113 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "BundleSandbox")
+
+/// Manages unpacking shared .vellumapp bundles into a sandboxed directory.
+enum BundleSandbox {
+
+    /// Base directory for all shared apps.
+    static var sharedAppsDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory() + "/Library/Application Support")
+        return appSupport
+            .appendingPathComponent("vellum-assistant")
+            .appendingPathComponent("shared-apps")
+    }
+
+    /// Metadata file stored alongside the unpacked bundle.
+    struct BundleMetadata: Codable {
+        let uuid: String
+        let name: String
+        let description: String?
+        let icon: String?
+        let entry: String
+        let createdAt: String
+        let createdBy: String
+        let capabilities: [String]
+        let trustTier: String
+        let signerKeyId: String?
+        let signerDisplayName: String?
+        let signerAccount: String?
+        let bundleSizeBytes: Int
+        let installedAt: String
+    }
+
+    /// Unpacks a `.vellumapp` zip file into the sandbox and writes metadata.
+    /// Returns the UUID and the directory URL where the contents were extracted.
+    static func unpack(
+        filePath: String,
+        manifest: OpenBundleResponseMessage.Manifest,
+        signatureResult: OpenBundleResponseMessage.SignatureResult,
+        bundleSizeBytes: Int
+    ) throws -> (uuid: String, directory: URL) {
+        let uuid = UUID().uuidString.lowercased()
+        let targetDir = sharedAppsDirectory.appendingPathComponent(uuid)
+
+        let fm = FileManager.default
+
+        // Create the target directory
+        try fm.createDirectory(at: targetDir, withIntermediateDirectories: true, attributes: nil)
+
+        // Extract the zip using the `unzip` command
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-o", "-q", filePath, "-d", targetDir.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            log.error("unzip failed with status \(process.terminationStatus): \(output)")
+            // Clean up on failure
+            try? fm.removeItem(at: targetDir)
+            throw BundleSandboxError.unzipFailed(output)
+        }
+
+        log.info("Unpacked bundle to \(targetDir.path)")
+
+        // Write metadata file
+        let metadata = BundleMetadata(
+            uuid: uuid,
+            name: manifest.name,
+            description: manifest.description,
+            icon: manifest.icon,
+            entry: manifest.entry,
+            createdAt: manifest.createdAt,
+            createdBy: manifest.createdBy,
+            capabilities: manifest.capabilities,
+            trustTier: signatureResult.trustTier,
+            signerKeyId: signatureResult.signerKeyId,
+            signerDisplayName: signatureResult.signerDisplayName,
+            signerAccount: signatureResult.signerAccount,
+            bundleSizeBytes: bundleSizeBytes,
+            installedAt: ISO8601DateFormatter().string(from: Date())
+        )
+
+        let metaPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-meta.json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let metaData = try encoder.encode(metadata)
+        try metaData.write(to: metaPath)
+
+        log.info("Wrote metadata to \(metaPath.path)")
+
+        return (uuid: uuid, directory: targetDir)
+    }
+
+    enum BundleSandboxError: Error, LocalizedError {
+        case unzipFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unzipFailed(let output):
+                return "Failed to extract bundle: \(output)"
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
@@ -1,0 +1,142 @@
+import Foundation
+@preconcurrency import WebKit
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "VellumAppScheme")
+
+/// Custom URL scheme handler for `vellumapp://{uuid}/path` URLs.
+/// Maps requests to files in the sandbox directory for shared apps.
+final class VellumAppSchemeHandler: NSObject, WKURLSchemeHandler {
+
+    /// The scheme this handler manages.
+    static let scheme = "vellumapp"
+
+    /// Base directory for shared app content.
+    private let baseDirectory: URL
+
+    init(baseDirectory: URL = BundleSandbox.sharedAppsDirectory) {
+        self.baseDirectory = baseDirectory
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url else {
+            fail(urlSchemeTask, statusCode: 400, message: "No URL in request")
+            return
+        }
+
+        // Parse: vellumapp://{uuid}/path/to/file
+        guard let host = url.host, !host.isEmpty else {
+            fail(urlSchemeTask, statusCode: 400, message: "No UUID host in URL")
+            return
+        }
+
+        let uuid = host
+        let resourcePath = url.path.hasPrefix("/") ? String(url.path.dropFirst()) : url.path
+
+        // Resolve the file path in the sandbox
+        let appDir = baseDirectory.appendingPathComponent(uuid)
+        let filePath = resourcePath.isEmpty
+            ? appDir
+            : appDir.appendingPathComponent(resourcePath)
+
+        // Security: ensure the resolved path is within the app directory
+        let resolvedPath = filePath.standardizedFileURL.path
+        let appDirPath = appDir.standardizedFileURL.path
+        guard resolvedPath.hasPrefix(appDirPath) else {
+            log.error("Path traversal attempt: \(resolvedPath) outside \(appDirPath)")
+            fail(urlSchemeTask, statusCode: 403, message: "Access denied")
+            return
+        }
+
+        // Read the file
+        guard FileManager.default.fileExists(atPath: resolvedPath) else {
+            fail(urlSchemeTask, statusCode: 404, message: "File not found: \(resourcePath)")
+            return
+        }
+
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: resolvedPath)) else {
+            fail(urlSchemeTask, statusCode: 500, message: "Failed to read file")
+            return
+        }
+
+        let mimeType = Self.mimeType(for: resolvedPath)
+        let response = URLResponse(
+            url: url,
+            mimeType: mimeType,
+            expectedContentLength: data.count,
+            textEncodingName: mimeType.hasPrefix("text/") ? "utf-8" : nil
+        )
+
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        // Nothing to cancel for synchronous file reads
+    }
+
+    // MARK: - Helpers
+
+    private func fail(_ task: WKURLSchemeTask, statusCode: Int, message: String) {
+        log.error("Scheme handler error (\(statusCode)): \(message)")
+        let response = HTTPURLResponse(
+            url: task.request.url ?? URL(string: "vellumapp://error")!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/plain"]
+        )!
+        task.didReceive(response)
+        task.didReceive(Data(message.utf8))
+        task.didFinish()
+    }
+
+    /// Determine MIME type from file extension.
+    static func mimeType(for path: String) -> String {
+        let ext = (path as NSString).pathExtension.lowercased()
+        switch ext {
+        case "html", "htm":
+            return "text/html"
+        case "css":
+            return "text/css"
+        case "js", "mjs":
+            return "application/javascript"
+        case "json":
+            return "application/json"
+        case "png":
+            return "image/png"
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "gif":
+            return "image/gif"
+        case "svg":
+            return "image/svg+xml"
+        case "ico":
+            return "image/x-icon"
+        case "woff":
+            return "font/woff"
+        case "woff2":
+            return "font/woff2"
+        case "ttf":
+            return "font/ttf"
+        case "otf":
+            return "font/otf"
+        case "webp":
+            return "image/webp"
+        case "mp3":
+            return "audio/mpeg"
+        case "mp4":
+            return "video/mp4"
+        case "webm":
+            return "video/webm"
+        case "xml":
+            return "application/xml"
+        case "txt":
+            return "text/plain"
+        case "wasm":
+            return "application/wasm"
+        default:
+            return "application/octet-stream"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BundleConfirmationView`, `BundleConfirmationViewModel`, and `BundleConfirmationWindow` for showing a confirmation dialog when opening shared `.vellumapp` bundles, with trust tier badge (verified/signed/unsigned/tampered), security scan summary, and bundle size display
- Add `BundleSandbox` to unpack `.vellumapp` zip files into `~/Library/Application Support/vellum-assistant/shared-apps/{uuid}/` with metadata JSON
- Add `VellumAppSchemeHandler` implementing `WKURLSchemeHandler` for `vellumapp://{uuid}/path` URLs with MIME type resolution and path traversal protection
- Wire `onOpenBundleResponse` in `AppDelegate` to show confirmation dialog (or error alert for blocked bundles), then unpack and load via `SurfaceManager` on user confirmation

Part of #1721. Closes #1727

## Test plan
- [ ] Open a `.vellumapp` file and verify the confirmation dialog appears with correct app name, icon, description, trust tier, scan result, and bundle size
- [ ] Verify "Cancel" closes the dialog without side effects
- [ ] Verify "Open in Vellum" unpacks to sandbox and loads the app
- [ ] Verify tampered bundles show the two-step "Open Anyway" flow with warning
- [ ] Verify blocked bundles show an error alert instead of the confirmation dialog
- [ ] Verify path traversal attempts in vellumapp:// URLs are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
