### PR TITLE
Fix skill invocation guard in sendMessage and prevent metadata leak

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -192,10 +192,14 @@ final class ChatViewModel: ObservableObject {
     func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasAttachments = !pendingAttachments.isEmpty
-        guard !text.isEmpty || hasAttachments else { return }
+        let hasSkillInvocation = pendingSkillInvocation != nil
+        guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
         // Block rapid-fire only when bootstrapping (no session yet)
-        if isSending && sessionId == nil { return }
+        if isSending && sessionId == nil {
+            pendingSkillInvocation = nil
+            return
+        }
 
         // Snapshot and clear pending attachments
         let attachments = pendingAttachments


### PR DESCRIPTION
## Summary
- Adds `pendingSkillInvocation` to the `sendMessage()` eligibility check so skills can be invoked even with empty text
- Clears `pendingSkillInvocation` on rapid-fire early return to prevent metadata leaking to the next message

Addresses feedback on #1740.

## Test plan
- [ ] Invoke a skill with empty text input and verify the message sends
- [ ] Rapid-fire send while bootstrapping and verify pendingSkillInvocation does not leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
