### PR TITLE
Clear leaked pendingSkillInvocation after sendMessage early return

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -139,6 +139,8 @@ struct MainWindowView: View {
                         )
                         viewModel.inputText = "Use the \(skill.name) skill"
                         viewModel.sendMessage()
+                        // Clear leaked metadata if sendMessage() returned early
+                        viewModel.pendingSkillInvocation = nil
                     }
                 }, daemonClient: daemonClient)
             case .settings:


### PR DESCRIPTION
Addresses feedback on #1742. Clears `pendingSkillInvocation` after `sendMessage()` call to prevent metadata from leaking to the next user message if `sendMessage()` returned early (e.g. rapid-fire guard).

This is safe because `sendMessage()` already clears `pendingSkillInvocation` internally when it succeeds, so the double-nil is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
