### PR TITLE
M7: Shared app management & runtime hardening

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -302,6 +302,19 @@ exports[`IPC message snapshots ClientMessage types apps_list serializes to expec
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types shared_apps_list serializes to expected JSON 1`] = `
+{
+  "type": "shared_apps_list",
+}
+`;
+
+exports[`IPC message snapshots ClientMessage types shared_app_delete serializes to expected JSON 1`] = `
+{
+  "type": "shared_app_delete",
+  "uuid": "abc-123-def",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types open_bundle serializes to expected JSON 1`] = `
 {
   "filePath": "/tmp/My_App.vellumapp",
@@ -858,6 +871,32 @@ exports[`IPC message snapshots ServerMessage types apps_list_response serializes
     },
   ],
   "type": "apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types shared_apps_list_response serializes to expected JSON 1`] = `
+{
+  "apps": [
+    {
+      "bundleSizeBytes": 4096,
+      "description": "A shared app",
+      "entry": "index.html",
+      "icon": "📱",
+      "installedAt": "2026-01-15T00:00:00Z",
+      "name": "Shared App",
+      "signerDisplayName": "Test User",
+      "trustTier": "signed",
+      "uuid": "abc-123-def",
+    },
+  ],
+  "type": "shared_apps_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types shared_app_delete_response serializes to expected JSON 1`] = `
+{
+  "success": true,
+  "type": "shared_app_delete_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -199,6 +199,13 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   apps_list: {
     type: 'apps_list',
   },
+  shared_apps_list: {
+    type: 'shared_apps_list',
+  },
+  shared_app_delete: {
+    type: 'shared_app_delete',
+    uuid: 'abc-123-def',
+  },
   open_bundle: {
     type: 'open_bundle',
     filePath: '/tmp/My_App.vellumapp',
@@ -541,6 +548,26 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
         createdAt: 1700000000,
       },
     ],
+  },
+  shared_apps_list_response: {
+    type: 'shared_apps_list_response',
+    apps: [
+      {
+        uuid: 'abc-123-def',
+        name: 'Shared App',
+        description: 'A shared app',
+        icon: '\u{1F4F1}',
+        entry: 'index.html',
+        trustTier: 'signed',
+        signerDisplayName: 'Test User',
+        bundleSizeBytes: 4096,
+        installedAt: '2026-01-15T00:00:00Z',
+      },
+    ],
+  },
+  shared_app_delete_response: {
+    type: 'shared_app_delete_response',
+    success: true,
   },
   open_bundle_response: {
     type: 'open_bundle_response',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -42,8 +42,11 @@ import type {
   UpdateTrustRule,
   BundleAppRequest,
   OpenBundleRequest,
+  SharedAppsListRequest,
+  SharedAppDeleteRequest,
 } from './ipc-protocol.js';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { addRule, removeRule, updateRule, getAllRules } from '../permissions/trust-store.js';
 import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../config/skills.js';
@@ -330,6 +333,8 @@ const handlers: DispatchMap = {
   bundle_app: handleBundleApp,
   open_bundle: handleOpenBundle,
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
+  shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
+  shared_app_delete: handleSharedAppDelete,
   sign_bundle_payload_response: (_msg, _socket, _ctx) => {
     // Handled by pending promise resolution in signing flow — no-op in dispatch
   },
@@ -1417,6 +1422,93 @@ function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Failed to list apps');
     ctx.send(socket, { type: 'error', message: `Failed to list apps: ${message}` });
+  }
+}
+
+// ─── Shared apps handlers ────────────────────────────────────────────────────
+
+function getSharedAppsDir(): string {
+  return join(homedir(), 'Library', 'Application Support', 'vellum-assistant', 'shared-apps');
+}
+
+function handleSharedAppsList(socket: net.Socket, ctx: HandlerContext): void {
+  try {
+    const dir = getSharedAppsDir();
+    if (!existsSync(dir)) {
+      ctx.send(socket, { type: 'shared_apps_list_response', apps: [] });
+      return;
+    }
+
+    const files = readdirSync(dir).filter((f) => f.endsWith('-meta.json'));
+    const apps: Array<{
+      uuid: string;
+      name: string;
+      description?: string;
+      icon?: string;
+      entry: string;
+      trustTier: string;
+      signerDisplayName?: string;
+      bundleSizeBytes: number;
+      installedAt: string;
+    }> = [];
+
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(dir, file), 'utf-8');
+        const meta = JSON.parse(raw);
+        apps.push({
+          uuid: meta.uuid,
+          name: meta.name,
+          description: meta.description,
+          icon: meta.icon,
+          entry: meta.entry,
+          trustTier: meta.trustTier,
+          signerDisplayName: meta.signerDisplayName,
+          bundleSizeBytes: meta.bundleSizeBytes ?? 0,
+          installedAt: meta.installedAt,
+        });
+      } catch {
+        log.warn({ file }, 'Failed to read shared app metadata file');
+      }
+    }
+
+    ctx.send(socket, { type: 'shared_apps_list_response', apps });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to list shared apps');
+    ctx.send(socket, { type: 'error', message: `Failed to list shared apps: ${message}` });
+  }
+}
+
+function handleSharedAppDelete(
+  msg: SharedAppDeleteRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  try {
+    const uuid = msg.uuid;
+    // Validate UUID to prevent path traversal
+    if (uuid.includes('/') || uuid.includes('\\') || uuid.includes('..')) {
+      ctx.send(socket, { type: 'shared_app_delete_response', success: false });
+      return;
+    }
+
+    const dir = getSharedAppsDir();
+    const appDir = join(dir, uuid);
+    const metaFile = join(dir, `${uuid}-meta.json`);
+
+    if (existsSync(appDir)) {
+      rmSync(appDir, { recursive: true });
+    }
+    if (existsSync(metaFile)) {
+      rmSync(metaFile);
+    }
+
+    ctx.send(socket, { type: 'shared_app_delete_response', success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Failed to delete shared app');
+    ctx.send(socket, { type: 'shared_app_delete_response', success: false });
   }
 }
 

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -234,6 +234,15 @@ export interface AppsListRequest {
   type: 'apps_list';
 }
 
+export interface SharedAppsListRequest {
+  type: 'shared_apps_list';
+}
+
+export interface SharedAppDeleteRequest {
+  type: 'shared_app_delete';
+  uuid: string;
+}
+
 export interface BundleAppRequest {
   type: 'bundle_app';
   appId: string;
@@ -400,6 +409,8 @@ export type ClientMessage =
   | UpdateTrustRule
   | BundleAppRequest
   | AppsListRequest
+  | SharedAppsListRequest
+  | SharedAppDeleteRequest
   | OpenBundleRequest
   | SignBundlePayloadResponse
   | GetSigningIdentityResponse;
@@ -728,6 +739,26 @@ export interface AppsListResponse {
   }>;
 }
 
+export interface SharedAppsListResponse {
+  type: 'shared_apps_list_response';
+  apps: Array<{
+    uuid: string;
+    name: string;
+    description?: string;
+    icon?: string;
+    entry: string;
+    trustTier: string;
+    signerDisplayName?: string;
+    bundleSizeBytes: number;
+    installedAt: string;
+  }>;
+}
+
+export interface SharedAppDeleteResponse {
+  type: 'shared_app_delete_response';
+  success: boolean;
+}
+
 export interface BundleAppResponse {
   type: 'bundle_app_response';
   bundlePath: string;
@@ -910,6 +941,8 @@ export type ServerMessage =
   | TrustRulesListResponse
   | BundleAppResponse
   | AppsListResponse
+  | SharedAppsListResponse
+  | SharedAppDeleteResponse
   | OpenBundleResponse
   | SignBundlePayloadRequest
   | GetSigningIdentityRequest;

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -1096,6 +1096,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let filePath = pendingBundleFilePath ?? ""
         pendingBundleFilePath = nil
 
+        // Check format version compatibility
+        if response.manifest.formatVersion > 1 {
+            let alert = NSAlert()
+            alert.messageText = "Incompatible App"
+            alert.informativeText = "This app requires a newer version of vellum-assistant."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
         // If scan blocked, show error alert
         if !response.scanResult.passed {
             let reason = response.scanResult.blocked.first ?? "Unknown security issue"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -1,16 +1,37 @@
 import SwiftUI
 
+/// Unified display item for both local and shared apps.
+private struct DisplayAppItem: Identifiable {
+    let id: String
+    let name: String
+    let description: String?
+    let icon: String?
+    let dateLabel: String
+    let isShared: Bool
+    let trustTier: String?
+    let signerDisplayName: String?
+
+    /// For local apps: the app store ID used for bundling.
+    let localAppId: String?
+    /// For shared apps: the UUID used for deletion and re-sharing.
+    let sharedUUID: String?
+}
+
 struct GeneratedPanel: View {
     var onClose: () -> Void
     let daemonClient: DaemonClient
 
-    @State private var apps: [AppItem] = []
+    @State private var displayItems: [DisplayAppItem] = []
     @State private var isLoading = false
     @State private var hoveredAppId: String?
     @State private var sharingAppId: String?
     @State private var isBundling = false
     @State private var shareFileURL: URL?
     @State private var showShareSheet = false
+    @State private var pendingDeleteId: String?
+
+    // Track how many list responses we're waiting for
+    @State private var pendingResponses = 0
 
     init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
         self.onClose = onClose
@@ -27,7 +48,7 @@ struct GeneratedPanel: View {
                     Spacer()
                 }
                 .frame(height: 250)
-            } else if apps.isEmpty {
+            } else if displayItems.isEmpty {
                 VEmptyState(
                     title: "No generated items",
                     subtitle: "Items created by your assistant will appear here",
@@ -35,8 +56,8 @@ struct GeneratedPanel: View {
                 )
             } else {
                 VStack(spacing: VSpacing.md) {
-                    ForEach(apps) { app in
-                        appRow(app)
+                    ForEach(displayItems) { item in
+                        appRow(item)
                     }
                 }
             }
@@ -48,45 +69,61 @@ struct GeneratedPanel: View {
 
     // MARK: - App Row
 
-    private func appRow(_ app: AppItem) -> some View {
-        let isHovered = hoveredAppId == app.id
-        let isBundlingThis = sharingAppId == app.id && isBundling
+    private func appRow(_ item: DisplayAppItem) -> some View {
+        let isHovered = hoveredAppId == item.id
+        let isBundlingThis = sharingAppId == item.id && isBundling
 
         return HStack(spacing: VSpacing.md) {
             // Icon
-            Text(app.icon ?? "\u{1F4F1}")
+            Text(item.icon ?? "\u{1F4F1}")
                 .font(.system(size: 20))
                 .frame(width: 28, height: 28)
 
-            // Name + description
+            // Name + badges + description
             VStack(alignment: .leading, spacing: 2) {
-                Text(app.name)
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.textPrimary)
-                    .lineLimit(1)
+                HStack(spacing: VSpacing.xs) {
+                    Text(item.name)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
 
-                if let description = app.description, !description.isEmpty {
+                    if item.isShared {
+                        sharedBadge
+                    }
+
+                    if let tier = item.trustTier {
+                        trustBadge(tier: tier)
+                    }
+                }
+
+                if let description = item.description, !description.isEmpty {
                     Text(description)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
                         .lineLimit(2)
                 }
 
-                Text(formatDate(app.createdAt))
+                Text(item.dateLabel)
                     .font(VFont.small)
                     .foregroundColor(VColor.textMuted)
             }
 
             Spacer()
 
-            // Share button — visible on hover
+            // Action buttons — visible on hover
             if isHovered || isBundlingThis {
-                if isBundlingThis {
-                    ProgressView()
-                        .controlSize(.mini)
-                        .frame(width: 24, height: 24)
-                } else {
-                    shareButton(for: app)
+                HStack(spacing: VSpacing.xs) {
+                    if isBundlingThis {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 24, height: 24)
+                    } else {
+                        shareButton(for: item)
+
+                        if item.isShared {
+                            deleteButton(for: item)
+                        }
+                    }
                 }
             }
         }
@@ -95,61 +132,202 @@ struct GeneratedPanel: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(Emerald._700.opacity(0.4), lineWidth: 1)
+                .stroke(item.isShared ? Violet._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
         )
         .onHover { hovering in
             withAnimation(VAnimation.fast) {
-                hoveredAppId = hovering ? app.id : nil
+                hoveredAppId = hovering ? item.id : nil
             }
         }
     }
 
-    @ViewBuilder
-    private func shareButton(for app: AppItem) -> some View {
-        ZStack {
-            // Invisible NSViewRepresentable button for NSSharingServicePicker anchor
-            ShareSheetButton(
-                items: shareFileURL != nil && sharingAppId == app.id ? [shareFileURL!] : [],
-                isPresented: Binding(
-                    get: { showShareSheet && sharingAppId == app.id },
-                    set: { showShareSheet = $0 }
-                )
-            )
-            .frame(width: 28, height: 28)
+    // MARK: - Badges
 
-            // Visible SwiftUI button overlay
-            Button(action: {
-                bundleAndShare(appId: app.id)
-            }) {
-                Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 13))
-                    .foregroundColor(Emerald._400)
-                    .frame(width: 28, height: 28)
-            }
-            .buttonStyle(.plain)
+    private var sharedBadge: some View {
+        HStack(spacing: 2) {
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 8))
+            Text("Shared")
+                .font(VFont.small)
         }
+        .foregroundColor(Violet._400)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(Violet._900.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    private func trustBadge(tier: String) -> some View {
+        let (icon, color): (String, Color) = {
+            switch tier {
+            case "verified":
+                return ("checkmark.seal.fill", VColor.success)
+            case "signed":
+                return ("checkmark.seal", VColor.textSecondary)
+            case "unsigned":
+                return ("exclamationmark.triangle.fill", VColor.warning)
+            case "tampered":
+                return ("xmark.seal.fill", VColor.error)
+            default:
+                return ("questionmark.circle", VColor.textMuted)
+            }
+        }()
+
+        return Image(systemName: icon)
+            .font(.system(size: 10))
+            .foregroundColor(color)
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder
+    private func shareButton(for item: DisplayAppItem) -> some View {
+        if let localId = item.localAppId {
+            ZStack {
+                ShareSheetButton(
+                    items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
+                    isPresented: Binding(
+                        get: { showShareSheet && sharingAppId == item.id },
+                        set: { showShareSheet = $0 }
+                    )
+                )
+                .frame(width: 28, height: 28)
+
+                Button(action: {
+                    bundleAndShare(appId: localId, itemId: item.id)
+                }) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 13))
+                        .foregroundColor(Emerald._400)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+            }
+        } else if item.isShared, let uuid = item.sharedUUID {
+            // Shared apps can be re-shared — reconstruct from unpacked files
+            ZStack {
+                ShareSheetButton(
+                    items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
+                    isPresented: Binding(
+                        get: { showShareSheet && sharingAppId == item.id },
+                        set: { showShareSheet = $0 }
+                    )
+                )
+                .frame(width: 28, height: 28)
+
+                Button(action: {
+                    reshareApp(uuid: uuid, itemId: item.id)
+                }) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 13))
+                        .foregroundColor(Violet._400)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func deleteButton(for item: DisplayAppItem) -> some View {
+        Button(action: {
+            deleteSharedApp(item)
+        }) {
+            Image(systemName: "trash")
+                .font(.system(size: 12))
+                .foregroundColor(Rose._400)
+                .frame(width: 24, height: 24)
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Data Fetching
 
+    @State private var localApps: [AppItem] = []
+    @State private var sharedApps: [SharedAppItem] = []
+
     private func fetchApps() {
         isLoading = true
+        pendingResponses = 2
+
         daemonClient.onAppsListResponse = { response in
-            self.apps = response.apps
-            self.isLoading = false
+            self.localApps = response.apps
+            self.pendingResponses -= 1
+            if self.pendingResponses <= 0 {
+                self.buildDisplayItems()
+                self.isLoading = false
+            }
         }
+
+        daemonClient.onSharedAppsListResponse = { response in
+            self.sharedApps = response.apps
+            self.pendingResponses -= 1
+            if self.pendingResponses <= 0 {
+                self.buildDisplayItems()
+                self.isLoading = false
+            }
+        }
+
         do {
             try daemonClient.sendAppsList()
         } catch {
+            pendingResponses -= 1
+        }
+
+        do {
+            try daemonClient.sendSharedAppsList()
+        } catch {
+            pendingResponses -= 1
+        }
+
+        if pendingResponses <= 0 {
+            buildDisplayItems()
             isLoading = false
         }
     }
 
+    private func buildDisplayItems() {
+        var items: [DisplayAppItem] = []
+
+        // Local apps
+        for app in localApps {
+            items.append(DisplayAppItem(
+                id: "local-\(app.id)",
+                name: app.name,
+                description: app.description,
+                icon: app.icon,
+                dateLabel: formatDate(app.createdAt),
+                isShared: false,
+                trustTier: nil,
+                signerDisplayName: nil,
+                localAppId: app.id,
+                sharedUUID: nil
+            ))
+        }
+
+        // Shared apps
+        for app in sharedApps {
+            items.append(DisplayAppItem(
+                id: "shared-\(app.uuid)",
+                name: app.name,
+                description: app.description,
+                icon: app.icon,
+                dateLabel: formatISO(app.installedAt),
+                isShared: true,
+                trustTier: app.trustTier,
+                signerDisplayName: app.signerDisplayName,
+                localAppId: nil,
+                sharedUUID: app.uuid
+            ))
+        }
+
+        displayItems = items
+    }
+
     // MARK: - Bundle & Share
 
-    private func bundleAndShare(appId: String) {
+    private func bundleAndShare(appId: String, itemId: String) {
         guard !isBundling else { return }
-        sharingAppId = appId
+        sharingAppId = itemId
         isBundling = true
 
         daemonClient.onBundleAppResponse = { response in
@@ -167,10 +345,46 @@ struct GeneratedPanel: View {
         }
     }
 
+    private func reshareApp(uuid: String, itemId: String) {
+        // Share the existing unpacked directory as a folder
+        let appDir = BundleSandbox.sharedAppsDirectory.appendingPathComponent(uuid)
+        guard FileManager.default.fileExists(atPath: appDir.path) else { return }
+        sharingAppId = itemId
+        shareFileURL = appDir
+        showShareSheet = true
+    }
+
+    // MARK: - Delete Shared App
+
+    private func deleteSharedApp(_ item: DisplayAppItem) {
+        guard let uuid = item.sharedUUID else { return }
+
+        daemonClient.onSharedAppDeleteResponse = { response in
+            if response.success {
+                self.sharedApps.removeAll { $0.uuid == uuid }
+                self.buildDisplayItems()
+            }
+        }
+
+        do {
+            try daemonClient.sendSharedAppDelete(uuid: uuid)
+        } catch {
+            // Silently fail
+        }
+    }
+
     // MARK: - Helpers
 
     private func formatDate(_ epochMs: Int) -> String {
         let date = Date(timeIntervalSince1970: Double(epochMs) / 1000)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func formatISO(_ isoString: String) -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        guard let date = isoFormatter.date(from: isoString) else { return isoString }
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -10,23 +10,27 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     let appId: String?
     let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
     let onCoordinatorReady: ((Coordinator) -> Void)?
+    /// When true, blocks all network requests to external origins and restricts navigation.
+    let sandboxMode: Bool
 
     init(
         data: DynamicPageSurfaceData,
         onAction: @escaping (String, Any?) -> Void,
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
-        onCoordinatorReady: ((Coordinator) -> Void)? = nil
+        onCoordinatorReady: ((Coordinator) -> Void)? = nil,
+        sandboxMode: Bool = false
     ) {
         self.data = data
         self.onAction = onAction
         self.appId = appId
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
+        self.sandboxMode = sandboxMode
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, currentHTML: data.html)
+        Coordinator(onAction: onAction, onDataRequest: onDataRequest, currentHTML: data.html, sandboxMode: sandboxMode)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -154,7 +158,39 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         webView.navigationDelegate = context.coordinator
         context.coordinator.webView = webView
 
-        log.info("Creating DynamicPageSurfaceView: appId=\(self.appId ?? "nil", privacy: .public), dataBridge=\(self.appId != nil ? "injected" : "skipped", privacy: .public)")
+        log.info("Creating DynamicPageSurfaceView: appId=\(self.appId ?? "nil", privacy: .public), dataBridge=\(self.appId != nil ? "injected" : "skipped", privacy: .public), sandboxMode=\(self.sandboxMode)")
+
+        // When sandbox mode is enabled, compile a content rule list that blocks
+        // all network requests except those to the vellumapp:// scheme.
+        if sandboxMode {
+            let ruleJSON = """
+            [
+                {
+                    "trigger": { "url-filter": ".*" },
+                    "action": { "type": "block" }
+                },
+                {
+                    "trigger": { "url-filter": "^vellumapp://.*" },
+                    "action": { "type": "ignore-previous-rules" }
+                },
+                {
+                    "trigger": { "url-filter": "^about:blank$" },
+                    "action": { "type": "ignore-previous-rules" }
+                }
+            ]
+            """
+            WKContentRuleListStore.default().compileContentRuleList(
+                forIdentifier: "sandbox-block-external",
+                encodedContentRuleList: ruleJSON
+            ) { ruleList, error in
+                if let ruleList {
+                    webView.configuration.userContentController.add(ruleList)
+                    log.info("Sandbox content rule list installed")
+                } else if let error {
+                    log.error("Failed to compile sandbox content rule list: \(error.localizedDescription)")
+                }
+            }
+        }
 
         onCoordinatorReady?(context.coordinator)
         // Use a per-app origin so localStorage/sessionStorage work natively,
@@ -187,16 +223,19 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var onAction: (String, Any?) -> Void
         var onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
         var currentHTML: String
+        let sandboxMode: Bool
         weak var webView: WKWebView?
 
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
-            currentHTML: String
+            currentHTML: String,
+            sandboxMode: Bool = false
         ) {
             self.onAction = onAction
             self.onDataRequest = onDataRequest
             self.currentHTML = currentHTML
+            self.sandboxMode = sandboxMode
         }
 
         func userContentController(
@@ -299,10 +338,28 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
         ) {
-            if navigationAction.navigationType == .other {
-                decisionHandler(.allow)
-            } else {
+            if sandboxMode {
+                // In sandbox mode, only allow vellumapp:// and about:blank URLs
+                if let url = navigationAction.request.url {
+                    let scheme = url.scheme?.lowercased() ?? ""
+                    if scheme == VellumAppSchemeHandler.scheme || url.absoluteString == "about:blank" {
+                        decisionHandler(.allow)
+                        return
+                    }
+                    // Allow initial HTML load via https://*.vellum.local/
+                    if scheme == "https" && (url.host?.hasSuffix(".vellum.local") == true) && navigationAction.navigationType == .other {
+                        decisionHandler(.allow)
+                        return
+                    }
+                }
+                log.info("Sandbox mode: blocking navigation to \(navigationAction.request.url?.absoluteString ?? "nil", privacy: .public)")
                 decisionHandler(.cancel)
+            } else {
+                if navigationAction.navigationType == .other {
+                    decisionHandler(.allow)
+                } else {
+                    decisionHandler(.cancel)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -77,6 +77,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `apps_list_response` message.
     var onAppsListResponse: ((AppsListResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `shared_apps_list_response` message.
+    var onSharedAppsListResponse: ((SharedAppsListResponseMessage) -> Void)?
+
+    /// Called when the daemon sends a `shared_app_delete_response` message.
+    var onSharedAppDeleteResponse: ((SharedAppDeleteResponseMessage) -> Void)?
+
     /// Called when the daemon sends a `bundle_app_response` message.
     var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
 
@@ -444,6 +450,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(OpenBundleMessage(filePath: filePath))
     }
 
+    /// Request the list of shared/received apps.
+    func sendSharedAppsList() throws {
+        try send(SharedAppsListRequestMessage())
+    }
+
+    /// Delete a shared app by UUID.
+    func sendSharedAppDelete(uuid: String) throws {
+        try send(SharedAppDeleteRequestMessage(uuid: uuid))
+    }
+
     // MARK: - Signing Identity
 
     /// Handle a sign_bundle_payload request from the daemon.
@@ -619,6 +635,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSkillsInspectResponse?(msg)
         case .appsListResponse(let msg):
             onAppsListResponse?(msg)
+        case .sharedAppsListResponse(let msg):
+            onSharedAppsListResponse?(msg)
+        case .sharedAppDeleteResponse(let msg):
+            onSharedAppDeleteResponse?(msg)
         case .bundleAppResponse(let msg):
             onBundleAppResponse?(msg)
         case .openBundleResponse(let msg):

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -213,6 +213,19 @@ struct AppsListRequestMessage: Encodable, Sendable {
     let type: String = "apps_list"
 }
 
+/// Sent to request the list of shared/received apps.
+/// Wire type: `"shared_apps_list"`
+struct SharedAppsListRequestMessage: Encodable, Sendable {
+    let type: String = "shared_apps_list"
+}
+
+/// Sent to delete a shared app by UUID.
+/// Wire type: `"shared_app_delete"`
+struct SharedAppDeleteRequestMessage: Encodable, Sendable {
+    let type: String = "shared_app_delete"
+    let uuid: String
+}
+
 /// Sent to request bundling an app for sharing.
 /// Wire type: `"bundle_app"`
 struct BundleAppRequestMessage: Encodable, Sendable {
@@ -683,6 +696,32 @@ struct AppsListResponseMessage: Decodable, Sendable {
     let apps: [AppItem]
 }
 
+/// A single shared app item returned from the daemon.
+struct SharedAppItem: Decodable, Sendable, Identifiable {
+    var id: String { uuid }
+    let uuid: String
+    let name: String
+    let description: String?
+    let icon: String?
+    let entry: String
+    let trustTier: String
+    let signerDisplayName: String?
+    let bundleSizeBytes: Int
+    let installedAt: String
+}
+
+/// Response containing the list of shared apps.
+/// Wire type: `"shared_apps_list_response"`
+struct SharedAppsListResponseMessage: Decodable, Sendable {
+    let apps: [SharedAppItem]
+}
+
+/// Response from deleting a shared app.
+/// Wire type: `"shared_app_delete_response"`
+struct SharedAppDeleteResponseMessage: Decodable, Sendable {
+    let success: Bool
+}
+
 /// Response from bundling an app.
 /// Wire type: `"bundle_app_response"`
 struct BundleAppResponseMessage: Decodable, Sendable {
@@ -893,6 +932,8 @@ enum ServerMessage: Decodable, Sendable {
     case timerCompleted(TimerCompletedMessage)
     case trustRulesListResponse(TrustRulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
+    case sharedAppsListResponse(SharedAppsListResponseMessage)
+    case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
     case signBundlePayload(SignBundlePayloadMessage)
@@ -1005,6 +1046,12 @@ enum ServerMessage: Decodable, Sendable {
         case "apps_list_response":
             let message = try AppsListResponseMessage(from: decoder)
             self = .appsListResponse(message)
+        case "shared_apps_list_response":
+            let message = try SharedAppsListResponseMessage(from: decoder)
+            self = .sharedAppsListResponse(message)
+        case "shared_app_delete_response":
+            let message = try SharedAppDeleteResponseMessage(from: decoder)
+            self = .sharedAppDeleteResponse(message)
         case "bundle_app_response":
             let message = try BundleAppResponseMessage(from: decoder)
             self = .bundleAppResponse(message)


### PR DESCRIPTION
## Summary
- Add `shared_apps_list` / `shared_app_delete` IPC messages across TypeScript and Swift to manage shared/received apps
- Extend GeneratedPanel to show both local and shared apps with visual badges (Shared label, trust tier icons) and hover actions (share, delete)
- Add `sandboxMode` to DynamicPageSurfaceView that blocks external network requests via WKContentRuleList and restricts navigation to `vellumapp://` scheme
- Add format version check in bundle open flow to reject bundles requiring a newer client version

## Test plan
- [ ] Verify local apps still appear correctly in the Generated panel
- [ ] Receive a .vellumapp bundle and verify it appears in the Generated panel with "Shared" badge and trust tier icon
- [ ] Hover over a shared app and verify share + delete buttons appear
- [ ] Delete a shared app and verify it disappears from the list
- [ ] Open a shared app and verify network requests to external origins are blocked (sandbox mode)
- [ ] Try opening a bundle with format_version > 1 and verify the incompatibility alert appears
- [ ] Verify IPC snapshot tests pass with `bun test src/__tests__/ipc-snapshot.test.ts`

Closes #1729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
