### PR TITLE
Add 'extra' to IPC skill source type

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -698,7 +698,7 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
     description: r.summary.description,
     emoji: r.summary.emoji,
     homepage: r.summary.homepage,
-    source: r.summary.source as 'bundled' | 'managed' | 'workspace' | 'clawhub',
+    source: r.summary.source as 'bundled' | 'managed' | 'workspace' | 'clawhub' | 'extra',
     state: (r.state === 'degraded' ? 'enabled' : r.state) as 'enabled' | 'disabled' | 'available',
     degraded: r.degraded,
     missingRequirements: r.missingRequirements,

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -647,7 +647,7 @@ export interface SkillsListResponse {
     description: string;
     emoji?: string;
     homepage?: string;
-    source: 'bundled' | 'managed' | 'workspace' | 'clawhub';
+    source: 'bundled' | 'managed' | 'workspace' | 'clawhub' | 'extra';
     state: 'enabled' | 'disabled' | 'available';
     degraded: boolean;
     missingRequirements?: { bins?: string[]; env?: string[]; permissions?: string[] };

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -497,7 +497,7 @@ struct SkillInfo: Codable, Sendable, Identifiable {
     let description: String
     let emoji: String?
     let homepage: String?
-    let source: String  // "bundled" | "managed" | "workspace" | "clawhub"
+    let source: String  // "bundled" | "managed" | "workspace" | "clawhub" | "extra"
     let state: String   // "enabled" | "disabled" | "available"
     let degraded: Bool
     let missingRequirements: MissingRequirements?


### PR DESCRIPTION
## Summary
- Add `'extra'` to the `source` union type in `SkillsListResponse` (`ipc-protocol.ts`)
- Update the `as` cast in `handlers.ts` to include `'extra'`
- Update the Swift comment in `IPCMessages.swift` to document `'extra'` as a valid source value

Addresses review feedback on #1638.

## Test plan
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [ ] Skills from `extraDirs` are correctly represented in IPC responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
