### PR TITLE
Fix emoji icon sizing in skill list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -898,6 +898,7 @@ struct AgentPanel: View {
         if let emoji, !emoji.isEmpty {
             Text(emoji)
                 .font(.system(size: 20))
+                .frame(width: 24, height: 24)
         } else {
             Image(systemName: "bolt.fill")
                 .font(.system(size: 13))


### PR DESCRIPTION
## Summary
- Add `.frame(width: 24, height: 24)` to emoji `Text` view in `skillIcon` for consistent sizing with the fallback `Image` branch

Addresses review feedback on #1639.

## Test plan
- [x] Build succeeds
- [ ] Verify emoji skill icons align consistently with fallback bolt.fill icons in the Skills tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
