### PR TITLE
Fix skills submenu cache: serialize refreshes and observe state changes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -106,6 +106,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private weak var recordingViewModel: ChatViewModel?
     private var statusIconCancellable: AnyCancellable?
     private var cachedSkills: [SkillInfo] = []
+    private var refreshSkillsTask: Task<Void, Never>?
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
@@ -160,6 +161,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         daemonClient.onOpenBundleResponse = { [weak self] response in
             guard let self else { return }
             self.handleOpenBundleResponse(response)
+        }
+
+        // Refresh skills cache whenever skill state changes through any path
+        daemonClient.onSkillStateChanged = { [weak self] _ in
+            self?.refreshSkillsCache()
         }
 
         // Handle escalation: text_qa -> computer_use via request_computer_control
@@ -542,12 +548,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func refreshSkillsCache() {
-        Task {
+        // Cancel any in-flight refresh so we don't consume a stale response.
+        // The new task will send its own request and wait for the next response,
+        // ensuring the cache always reflects the latest daemon state.
+        refreshSkillsTask?.cancel()
+        refreshSkillsTask = Task {
             let stream = daemonClient.subscribe()
             do {
                 try daemonClient.send(SkillsListRequestMessage())
             } catch { return }
             for await message in stream {
+                guard !Task.isCancelled else { return }
                 if case .skillsListResponse(let response) = message {
                     self.cachedSkills = response.skills
                     return


### PR DESCRIPTION
## Summary
- Serialize overlapping `refreshSkillsCache()` calls by cancelling any in-flight refresh task before starting a new one, preventing stale responses from being consumed by concurrent refreshes
- Subscribe to `daemonClient.onSkillStateChanged` to trigger a cache refresh whenever skill state changes through any path (not just on connect and after `toggleSkill`), keeping the menu bar submenu in sync
- Add `Task.isCancelled` guard inside the stream loop so cancelled tasks exit promptly

Addresses review feedback on #1628.

## Test plan
- [ ] Toggle a skill from the menu bar submenu and verify the menu updates on next open
- [ ] Change skill state from Settings or another client and verify the menu bar submenu reflects the change
- [ ] Rapidly toggle skills to verify no stale state appears (serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
