### PR TITLE
Fix SkillsSettingsView: stable view model and daemon ack

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -18,6 +18,7 @@ public struct SettingsView: View {
     }()
     @State private var showingPrivacy = false
     @State private var showingSkills = false
+    @State private var skillsViewModel: SkillsSettingsViewModel?
     @State private var showingTrustRules = false
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
@@ -202,10 +203,17 @@ public struct SettingsView: View {
                             showingSkills = true
                         }
                     }
-                    .sheet(isPresented: $showingSkills) {
-                        SkillsSettingsView(
-                            viewModel: SkillsSettingsViewModel(daemonClient: daemonClient)
-                        )
+                    .sheet(isPresented: $showingSkills, onDismiss: {
+                        skillsViewModel = nil
+                    }) {
+                        if let vm = skillsViewModel {
+                            SkillsSettingsView(viewModel: vm)
+                        }
+                    }
+                    .onChange(of: showingSkills) { _, isShowing in
+                        if isShowing && skillsViewModel == nil {
+                            skillsViewModel = SkillsSettingsViewModel(daemonClient: daemonClient)
+                        }
                     }
                 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -39,57 +39,80 @@ final class SkillsSettingsViewModel: ObservableObject {
     }
 
     func enableSkill(name: String) {
-        do {
-            try daemonClient.enableSkill(name)
-            if let index = skills.firstIndex(where: { $0.name == name }) {
-                // Optimistically update — will be corrected on next loadSkills
-                var updated = skills[index]
-                updated = SkillInfo(
-                    name: updated.name,
-                    description: updated.description,
-                    emoji: updated.emoji,
-                    homepage: updated.homepage,
-                    source: updated.source,
-                    state: "enabled",
-                    degraded: updated.degraded,
-                    missingRequirements: updated.missingRequirements,
-                    installedVersion: updated.installedVersion,
-                    latestVersion: updated.latestVersion,
-                    updateAvailable: updated.updateAvailable,
-                    userInvocable: updated.userInvocable,
-                    clawhub: updated.clawhub
-                )
-                skills[index] = updated
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.enableSkill(name)
+            } catch {
+                return
             }
-        } catch {
-            // Silently ignore — daemon may be disconnected
+
+            for await message in stream {
+                if case .skillsOperationResponse(let response) = message,
+                   response.operation == "enable" {
+                    if response.success {
+                        if let index = skills.firstIndex(where: { $0.name == name }) {
+                            let updated = skills[index]
+                            skills[index] = SkillInfo(
+                                name: updated.name,
+                                description: updated.description,
+                                emoji: updated.emoji,
+                                homepage: updated.homepage,
+                                source: updated.source,
+                                state: "enabled",
+                                degraded: updated.degraded,
+                                missingRequirements: updated.missingRequirements,
+                                installedVersion: updated.installedVersion,
+                                latestVersion: updated.latestVersion,
+                                updateAvailable: updated.updateAvailable,
+                                userInvocable: updated.userInvocable,
+                                clawhub: updated.clawhub
+                            )
+                        }
+                    }
+                    return
+                }
+            }
         }
     }
 
     func disableSkill(name: String) {
-        do {
-            try daemonClient.disableSkill(name)
-            if let index = skills.firstIndex(where: { $0.name == name }) {
-                var updated = skills[index]
-                updated = SkillInfo(
-                    name: updated.name,
-                    description: updated.description,
-                    emoji: updated.emoji,
-                    homepage: updated.homepage,
-                    source: updated.source,
-                    state: "disabled",
-                    degraded: updated.degraded,
-                    missingRequirements: updated.missingRequirements,
-                    installedVersion: updated.installedVersion,
-                    latestVersion: updated.latestVersion,
-                    updateAvailable: updated.updateAvailable,
-                    userInvocable: updated.userInvocable,
-                    clawhub: updated.clawhub
-                )
-                skills[index] = updated
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.disableSkill(name)
+            } catch {
+                return
             }
-        } catch {
-            // Silently ignore
+
+            for await message in stream {
+                if case .skillsOperationResponse(let response) = message,
+                   response.operation == "disable" {
+                    if response.success {
+                        if let index = skills.firstIndex(where: { $0.name == name }) {
+                            let updated = skills[index]
+                            skills[index] = SkillInfo(
+                                name: updated.name,
+                                description: updated.description,
+                                emoji: updated.emoji,
+                                homepage: updated.homepage,
+                                source: updated.source,
+                                state: "disabled",
+                                degraded: updated.degraded,
+                                missingRequirements: updated.missingRequirements,
+                                installedVersion: updated.installedVersion,
+                                latestVersion: updated.latestVersion,
+                                updateAvailable: updated.updateAvailable,
+                                userInvocable: updated.userInvocable,
+                                clawhub: updated.clawhub
+                            )
+                        }
+                    }
+                    return
+                }
+            }
         }
     }
 }
@@ -97,7 +120,7 @@ final class SkillsSettingsViewModel: ObservableObject {
 // MARK: - Skills Settings View
 
 struct SkillsSettingsView: View {
-    @ObservedObject var viewModel: SkillsSettingsViewModel
+    @StateObject var viewModel: SkillsSettingsViewModel
     @Environment(\.dismiss) var dismiss
     @State private var searchText = ""
 


### PR DESCRIPTION
## Summary
- Use `@StateObject` for `SkillsSettingsViewModel` lifecycle ownership in `SkillsSettingsView` (was `@ObservedObject`)
- Store `SkillsSettingsViewModel` as stable `@State` in `SettingsView` so the sheet doesn't recreate it on re-evaluation
- Wait for `skills_operation_response` daemon ack before mutating local skill state, preventing UI from showing stale enable/disable status

Addresses review feedback on #1629.

## Test plan
- [ ] Open Settings > Skills > Manage Skills, verify skills load and persist across sheet interactions
- [ ] Toggle a skill enable/disable, verify the toggle reflects the daemon's actual response
- [ ] Disconnect daemon, toggle a skill, verify UI does not falsely update state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
