### PR TITLE
Allow namespaced skill slugs in uninstall handler

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -916,8 +916,10 @@ async function handleSkillsUninstall(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  // Validate skill name to prevent path traversal
-  if (msg.name.includes('/') || msg.name.includes('\\') || msg.name.includes('..')) {
+  // Validate skill name to prevent path traversal while allowing namespaced slugs (org/name)
+  const validNamespacedSlug = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/;
+  const validSimpleName = /^[a-zA-Z0-9_-]+$/;
+  if (msg.name.includes('..') || msg.name.includes('\\') || !(validSimpleName.test(msg.name) || validNamespacedSlug.test(msg.name))) {
     ctx.send(socket, {
       type: 'skills_operation_response',
       operation: 'uninstall',


### PR DESCRIPTION
## Summary
- Updates skill name validation in `handleSkillsUninstall` to permit namespaced slugs (`org/name` format) while still blocking path traversal attempts
- Addresses review feedback on #1650: the previous guard rejected any name containing `/`, which broke uninstalling namespaced skills that `clawhubInstall` now accepts

## Test plan
- [ ] Verify uninstalling a namespaced skill like `org/skill-name` succeeds
- [ ] Verify path traversal attempts (`../foo`, `foo\bar`, `a/b/c`) are still rejected
- [ ] Verify simple skill names (`my-skill`) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
