### PR TITLE
Fix stale install timeout with per-attempt tracking

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -186,6 +186,7 @@ struct AgentPanel: View {
             if let result = skillsManager.installResult {
                 if result.slug == installingSlug {
                     installingSlug = nil
+                    installAttemptId = nil
                 }
             }
         }
@@ -294,6 +295,7 @@ struct AgentPanel: View {
     }
 
     @State private var installingSlug: String?
+    @State private var installAttemptId: UUID?
     @State private var hoveredStarterInstall: String?
     @State private var skillSearchQuery = ""
     @State private var skillSortOrder: SkillSortOrder = .installs
@@ -395,11 +397,14 @@ struct AgentPanel: View {
 
                 Button(action: {
                     guard installingSlug == nil else { return }
+                    let attemptId = UUID()
                     installingSlug = skill.slug
+                    installAttemptId = attemptId
                     skillsManager.installSkill(slug: skill.slug)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                        if installingSlug == skill.slug {
+                        if installingSlug == skill.slug && installAttemptId == attemptId {
                             installingSlug = nil
+                            installAttemptId = nil
                         }
                     }
                 }) {
@@ -714,11 +719,14 @@ struct AgentPanel: View {
 
         Button(action: {
             guard installingSlug == nil, !isSuccess else { return }
+            let attemptId = UUID()
             installingSlug = slug
+            installAttemptId = attemptId
             skillsManager.installSkill(slug: slug)
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                if installingSlug == slug {
+                if installingSlug == slug && installAttemptId == attemptId {
                     installingSlug = nil
+                    installAttemptId = nil
                 }
             }
         }) {


### PR DESCRIPTION
## Summary
- Track install attempts with a UUID (`installAttemptId`) so stale timeouts from a previous install don't clear `installingSlug` during an in-progress retry
- When the 10-second fallback fires, it now checks both the slug and the attempt ID match before clearing the loading state
- Applies to both the card install button and the detail view install button

Addresses review feedback on #1725.

## Test plan
- [ ] Install a skill, verify normal install flow still works (loading state clears on success or after 10s)
- [ ] Simulate a failed install followed by a quick retry -- the retry's loading state should not be cleared by the first attempt's stale timeout

Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
