### PR TITLE
Guard skills/entries config nodes against malformed data

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -714,13 +714,15 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
   ctx.send(socket, { type: 'skills_list_response', skills });
 }
 
-/** Get or create the skill entry object for a given skill name, creating intermediate objects as needed. */
+/** Get or create the skill entry object for a given skill name, creating intermediate objects as needed.
+ *  Guards against malformed config (e.g. skills or entries being a string, array, or null)
+ *  by resetting non-object intermediates to {}, restoring self-healing behavior. */
 function ensureSkillEntry(raw: Record<string, unknown>, name: string): Record<string, unknown> {
-  if (!raw.skills) raw.skills = {};
+  if (!isRecord(raw.skills)) raw.skills = {};
   const skills = raw.skills as Record<string, unknown>;
-  if (!skills.entries) skills.entries = {};
+  if (!isRecord(skills.entries)) skills.entries = {};
   const entries = skills.entries as Record<string, unknown>;
-  if (!entries[name]) entries[name] = {};
+  if (!isRecord(entries[name])) entries[name] = {};
   return entries[name] as Record<string, unknown>;
 }
 function handleSkillsEnable(


### PR DESCRIPTION
## Summary
- Add type guards in `ensureSkillEntry` to reset malformed `skills`/`entries` nodes (strings, arrays, null, etc.) to `{}` before mutating
- Restores self-healing behavior for invalid config states that the previous `setNestedValue` path provided

Addresses review feedback on #1651.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Manually verify: set `"skills": "broken"` in config, then enable a skill — should auto-heal instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
