### PR TITLE
Clear stale selectedSkillSlug when search results change

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -190,6 +190,13 @@ struct AgentPanel: View {
                 }
             }
         }
+        .onChange(of: skillsManager.searchResults) {
+            if let slug = selectedSkillSlug,
+               !skillsManager.searchResults.contains(where: { $0.slug == slug }) {
+                selectedSkillSlug = nil
+                skillsManager.clearInspection()
+            }
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -555,7 +555,7 @@ struct SkillsUpdatesAvailableMessage: Decodable, Sendable {
 }
 
 /// A ClaWHub skill returned from a search or explore query.
-struct ClawhubSkillItem: Decodable, Sendable, Identifiable {
+struct ClawhubSkillItem: Decodable, Sendable, Identifiable, Equatable {
     var id: String { slug }
     let name: String
     let slug: String


### PR DESCRIPTION
## Summary
- Add `.onChange(of: searchResults)` to detect when the currently selected skill slug is no longer present in search results
- Clear `selectedSkillSlug` and call `clearInspection()` to reset stale state and prevent inconsistent UI
- Add `Equatable` conformance to `ClawhubSkillItem` so SwiftUI can observe array changes

Addresses review feedback on #1731.

## Test plan
- [ ] Open Available Skills tab, click into a skill detail view
- [ ] Trigger a search results refresh (e.g. by re-searching) — verify the detail view resets to the list if the selected skill is no longer in results
- [ ] Verify normal detail view navigation (back button) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
