### PR TITLE
Fix Ed25519 signature verification (PR #1734 feedback)

### DIFF
--- a/assistant/src/bundler/signature-verifier.ts
+++ b/assistant/src/bundler/signature-verifier.ts
@@ -139,13 +139,19 @@ export async function verifyBundleSignature(
 
   if (publicKeyBase64) {
     try {
-      const publicKeyBuffer = Buffer.from(publicKeyBase64, 'base64');
+      const rawKey = Buffer.from(publicKeyBase64, 'base64');
       const signatureBuffer = Buffer.from(signatureData.signature, 'base64');
+
+      // Ed25519 SPKI DER header (12 bytes) for wrapping raw 32-byte public key.
+      // The Swift client sends the key as rawRepresentation (32 bytes), but
+      // Node.js crypto.verify expects DER-encoded SPKI format (44 bytes).
+      const ed25519SpkiPrefix = Buffer.from('302a300506032b6570032100', 'hex');
+      const derKey = Buffer.concat([ed25519SpkiPrefix, rawKey]);
 
       const isValid = verify(
         null, // Ed25519 doesn't use a separate hash algorithm
         Buffer.from(canonicalPayload),
-        { key: publicKeyBuffer, format: 'der', type: 'spki' },
+        { key: derKey, format: 'der', type: 'spki' },
         signatureBuffer,
       );
 
@@ -158,7 +164,12 @@ export async function verifyBundleSignature(
         };
       }
     } catch {
-      // If verification throws (e.g. wrong key format), fall through to 'signed'
+      return {
+        trustTier: 'tampered',
+        signerKeyId: keyId,
+        signerDisplayName: signatureData.signer.display_name,
+        message: 'Ed25519 signature verification failed (crypto error)',
+      };
     }
   }
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -336,10 +336,14 @@ const handlers: DispatchMap = {
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
   sign_bundle_payload_response: (_msg, _socket, _ctx) => {
-    // Handled by pending promise resolution in signing flow — no-op in dispatch
+    // TODO(signing): Route to pending promise resolution once the daemon-driven
+    // IPC signing orchestration is wired up. Currently a no-op placeholder to
+    // satisfy the exhaustive dispatch map; signing is invoked via SigningCallback.
   },
   get_signing_identity_response: (_msg, _socket, _ctx) => {
-    // Handled by pending promise resolution in signing flow — no-op in dispatch
+    // TODO(signing): Route to pending promise resolution once the daemon-driven
+    // IPC signing orchestration is wired up. Currently a no-op placeholder to
+    // satisfy the exhaustive dispatch map; signing is invoked via SigningCallback.
   },
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
   ui_surface_action: (msg, _socket, ctx) => {


### PR DESCRIPTION
## Summary
- Fixes raw-to-SPKI Ed25519 public key format mismatch: Swift sends 32-byte raw keys via `rawRepresentation`, but Node.js `crypto.verify` expects DER-encoded SPKI (44 bytes). Now wraps the raw key with the standard ASN.1 header (`302a300506032b6570032100`).
- Changes the catch block in signature verification to return `tampered` instead of silently falling through to `signed`, ensuring fail-closed behavior when crypto errors occur.
- Clarifies IPC signing response handler comments with TODO markers for future daemon-driven orchestration.

Addresses review feedback from #1734.

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] Verify that a bundle signed by the Swift client can be verified by the Node.js verifier
- [ ] Verify that a tampered bundle returns `tampered` trust tier
- [ ] Verify that an invalid/corrupt key triggers `tampered` (crypto error) rather than `signed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
