### PR TITLE
Fix error handling in GeneratedPanel to prevent stuck UI states

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -111,7 +111,8 @@ struct GeneratedPanel: View {
             Spacer()
 
             // Action buttons — visible on hover
-            if isHovered || isBundlingThis {
+            let showingShareSheet = showShareSheet && sharingAppId == item.id
+            if isHovered || isBundlingThis || showingShareSheet {
                 HStack(spacing: VSpacing.xs) {
                     if isBundlingThis {
                         ProgressView()
@@ -264,6 +265,23 @@ struct GeneratedPanel: View {
             if self.pendingResponses <= 0 {
                 self.buildDisplayItems()
                 self.isLoading = false
+            }
+        }
+
+        // Handle daemon-side errors that arrive as generic `error` messages
+        // instead of typed responses — reset loading/bundling state so the UI
+        // never gets permanently stuck.
+        daemonClient.onError = { _ in
+            if self.isLoading {
+                self.pendingResponses -= 1
+                if self.pendingResponses <= 0 {
+                    self.buildDisplayItems()
+                    self.isLoading = false
+                }
+            }
+            if self.isBundling {
+                self.isBundling = false
+                self.sharingAppId = nil
             }
         }
 

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -89,6 +89,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `open_bundle_response` message.
     var onOpenBundleResponse: ((OpenBundleResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
+    var onError: ((ErrorMessage) -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -643,6 +646,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onBundleAppResponse?(msg)
         case .openBundleResponse(let msg):
             onOpenBundleResponse?(msg)
+        case .error(let msg):
+            onError?(msg)
         case .signBundlePayload(let msg):
             handleSignBundlePayload(msg)
         case .getSigningIdentity:


### PR DESCRIPTION
## Summary
- Wire `DaemonClient.onError` callback so generic daemon `error` messages are forwarded to consumers
- In `GeneratedPanel.fetchApps`, subscribe to `onError` to decrement `pendingResponses` and reset `isLoading` when the daemon fails to list apps
- Reset `isBundling`/`sharingAppId` on error so the share button is never permanently blocked
- Keep share anchor (`ShareSheetButton`) mounted while the share sheet is active, not just while hovered/bundling

Addresses review feedback from #1738.

## Test plan
- [x] Swift builds (`swift build`)
- [ ] Manual: Verify share button recovers after a daemon bundling error
- [ ] Manual: Verify loading spinner clears after a daemon apps-list error
- [ ] Manual: Verify share sheet still presents if pointer leaves the row during bundling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
