### PR TITLE
Address review feedback on PR #1747 (app bundling security and reliability)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -95,9 +95,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var mainWindow: MainWindow?
     private var settingsWindow: NSWindow?
     private var bundleConfirmationWindow: BundleConfirmationWindow?
-    /// Tracks the file path of the .vellumapp currently being confirmed, so we
-    /// can associate the daemon's open_bundle_response with the correct file.
-    private var pendingBundleFilePath: String?
+    /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
+    /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
+    /// pops the first entry so concurrent opens are correctly paired.
+    private var pendingBundleFilePaths: [String] = []
     #if DEBUG
     private var galleryWindow: ComponentGalleryWindow?
     #endif
@@ -1092,11 +1093,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             do {
-                pendingBundleFilePath = url.path
+                pendingBundleFilePaths.append(url.path)
                 try daemonClient.sendOpenBundle(filePath: url.path)
             } catch {
                 log.error("Failed to send open_bundle message: \(error.localizedDescription)")
-                pendingBundleFilePath = nil
+                // Remove the path we just appended since the send failed
+                if let idx = pendingBundleFilePaths.lastIndex(of: url.path) {
+                    pendingBundleFilePaths.remove(at: idx)
+                }
             }
         }
     }
@@ -1104,8 +1108,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Bundle Open Handling
 
     private func handleOpenBundleResponse(_ response: OpenBundleResponseMessage) {
-        let filePath = pendingBundleFilePath ?? ""
-        pendingBundleFilePath = nil
+        let filePath = pendingBundleFilePaths.isEmpty ? "" : pendingBundleFilePaths.removeFirst()
 
         // Check format version compatibility
         if response.manifest.formatVersion > 1 {
@@ -1165,48 +1168,72 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         signatureResult: OpenBundleResponseMessage.SignatureResult,
         bundleSizeBytes: Int
     ) {
-        do {
-            let (uuid, _) = try BundleSandbox.unpack(
-                filePath: filePath,
-                manifest: manifest,
-                signatureResult: signatureResult,
-                bundleSizeBytes: bundleSizeBytes
-            )
+        // Run the unzip on a background thread to avoid blocking the UI.
+        Task.detached {
+            do {
+                let (uuid, _) = try BundleSandbox.unpack(
+                    filePath: filePath,
+                    manifest: manifest,
+                    signatureResult: signatureResult,
+                    bundleSizeBytes: bundleSizeBytes
+                )
 
-            // Build the vellumapp:// URL for the entry point
-            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/\(manifest.entry)"
-            log.info("Loading shared app at \(entryURL)")
+                await MainActor.run {
+                    // Build the vellumapp:// URL for the entry point.
+                    // Sanitize manifest.entry to prevent JS string breakout.
+                    let sanitizedEntry = manifest.entry
+                        .replacingOccurrences(of: "\\", with: "")
+                        .replacingOccurrences(of: "'", with: "")
+                    let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/\(sanitizedEntry)"
+                    log.info("Loading shared app at \(entryURL)")
 
-            // Load the shared app as a surface via SurfaceManager
-            let surfaceId = "shared-app-\(uuid)"
-            let html = """
-            <!DOCTYPE html>
-            <html>
-            <head><meta charset="utf-8"><title>\(manifest.name)</title></head>
-            <body>
-                <script>window.location.href = '\(entryURL)';</script>
-            </body>
-            </html>
-            """
-            let surfaceMsg = UiSurfaceShowMessage(
-                sessionId: "shared-app",
-                surfaceId: surfaceId,
-                surfaceType: "dynamic_page",
-                title: manifest.name,
-                data: AnyCodable(["html": html]),
-                actions: nil,
-                display: "panel"
-            )
-            surfaceManager.showSurface(surfaceMsg)
-        } catch {
-            log.error("Failed to unpack bundle: \(error.localizedDescription)")
-            let alert = NSAlert()
-            alert.messageText = "Failed to open app"
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .critical
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
+                    // HTML-escape manifest.name to prevent XSS injection.
+                    let safeName = Self.htmlEscape(manifest.name)
+
+                    // Load the shared app as a surface via SurfaceManager
+                    let surfaceId = "shared-app-\(uuid)"
+                    let html = """
+                    <!DOCTYPE html>
+                    <html>
+                    <head><meta charset="utf-8"><title>\(safeName)</title></head>
+                    <body>
+                        <script>window.location.href = '\(entryURL)';</script>
+                    </body>
+                    </html>
+                    """
+                    let surfaceMsg = UiSurfaceShowMessage(
+                        sessionId: "shared-app",
+                        surfaceId: surfaceId,
+                        surfaceType: "dynamic_page",
+                        title: manifest.name,
+                        data: AnyCodable(["html": html]),
+                        actions: nil,
+                        display: "panel"
+                    )
+                    self.surfaceManager.showSurface(surfaceMsg)
+                }
+            } catch {
+                await MainActor.run {
+                    log.error("Failed to unpack bundle: \(error.localizedDescription)")
+                    let alert = NSAlert()
+                    alert.messageText = "Failed to open app"
+                    alert.informativeText = error.localizedDescription
+                    alert.alertStyle = .critical
+                    alert.addButton(withTitle: "OK")
+                    alert.runModal()
+                }
+            }
         }
+    }
+
+    /// HTML-escape a string to prevent injection when interpolated into HTML.
+    private static func htmlEscape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 
     public func applicationWillTerminate(_ notification: Notification) {

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -59,10 +59,14 @@ enum BundleSandbox {
         process.standardError = pipe
 
         try process.run()
+
+        // Read pipe data before waitUntilExit to avoid deadlock when
+        // the pipe buffer fills up and the subprocess blocks on write.
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {
-            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let output = String(data: outputData, encoding: .utf8) ?? ""
             log.error("unzip failed with status \(process.terminationStatus): \(output)")
             // Clean up on failure
             try? fm.removeItem(at: targetDir)

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -145,6 +145,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         contentController.add(context.coordinator, name: "vellumBridge")
 
         let configuration = WKWebViewConfiguration()
+        configuration.setURLSchemeHandler(VellumAppSchemeHandler(), forURLScheme: VellumAppSchemeHandler.scheme)
         configuration.userContentController = contentController
 
         #if DEBUG

--- a/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/VellumAppSchemeHandler.swift
@@ -39,10 +39,12 @@ final class VellumAppSchemeHandler: NSObject, WKURLSchemeHandler {
             ? appDir
             : appDir.appendingPathComponent(resourcePath)
 
-        // Security: ensure the resolved path is within the app directory
+        // Security: ensure the resolved path is within the app directory.
+        // Append "/" to appDirPath so that a sibling like "<uuid>-meta.json"
+        // doesn't match via simple string prefix comparison.
         let resolvedPath = filePath.standardizedFileURL.path
         let appDirPath = appDir.standardizedFileURL.path
-        guard resolvedPath.hasPrefix(appDirPath) else {
+        guard resolvedPath == appDirPath || resolvedPath.hasPrefix(appDirPath + "/") else {
             log.error("Path traversal attempt: \(resolvedPath) outside \(appDirPath)")
             fail(urlSchemeTask, statusCode: 403, message: "Access denied")
             return


### PR DESCRIPTION
## Summary
- **Path traversal hardening**: `VellumAppSchemeHandler` now appends "/" to the directory path before `hasPrefix` comparison, preventing sibling directory prefix collisions (e.g. `<uuid>-meta.json` matching `<uuid>`)
- **Pipe deadlock fix**: `BundleSandbox.unpack` now reads pipe data before calling `waitUntilExit()`, preventing deadlock when subprocess output fills the pipe buffer
- **Main thread unblocking**: Moved `BundleSandbox.unpack` call to `Task.detached` so the UI thread is not blocked during unzip operations
- **Scheme handler registration**: Registered `VellumAppSchemeHandler` with `WKWebViewConfiguration` so `vellumapp://` URLs actually resolve in the WKWebView
- **Concurrent bundle opens**: Replaced single `pendingBundleFilePath` property with a FIFO array so multiple `.vellumapp` files opened simultaneously are correctly paired with their daemon responses
- **XSS prevention**: HTML-escape `manifest.name` in the redirect template and sanitize `manifest.entry` to prevent script injection from malicious bundles

## Test plan
- [ ] Open a single `.vellumapp` file and verify it loads correctly
- [ ] Open multiple `.vellumapp` files simultaneously and verify each loads with the correct content
- [ ] Verify path traversal attempts (e.g. `../` in resource paths) are blocked with 403
- [ ] Verify large bundles unpack without freezing the UI
- [ ] Build succeeds with `swift build`

Addresses feedback from automated reviewers on #1747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
