### PR TITLE
Fix DM Mono 'f' glyph rendering with Stylistic Set 5

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Tokens/TypographyTokens.swift
@@ -7,15 +7,16 @@ import SwiftUI
 /// **DM Mono** — monospaced font for body/UI text.
 enum VFont {
 
-    /// DM Mono with ligatures disabled so "fi", "fl", "ff" render as separate glyphs.
+    /// DM Mono's default "f" has an exaggerated italic-style hook.
+    /// Stylistic Set 5 (ss05) provides a conventional "f" glyph.
     private static func dmMono(_ name: String, size: CGFloat) -> Font {
         guard let nsFont = NSFont(name: name, size: size) else {
             return Font.custom(name, size: size)
         }
         let descriptor = nsFont.fontDescriptor.addingAttributes([
             .featureSettings: [[
-                NSFontDescriptor.FeatureKey.typeIdentifier: kLigaturesType,
-                NSFontDescriptor.FeatureKey.selectorIdentifier: kCommonLigaturesOffSelector,
+                NSFontDescriptor.FeatureKey.typeIdentifier: kStylisticAlternativesType,
+                NSFontDescriptor.FeatureKey.selectorIdentifier: kStylisticAltFiveOnSelector,
             ]]
         ])
         return Font(NSFont(descriptor: descriptor, size: size) ?? nsFont)


### PR DESCRIPTION
## Summary
- DM Mono has no `liga`/`calt` features — the previous fix (#1702) tried to disable nonexistent ligatures
- The weird "f" is DM Mono's default glyph design with an exaggerated italic-style hook
- Activates Stylistic Set 5 (`ss05`) which provides a conventional "f" glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
