### PR TITLE
Survive Qdrant startup failure instead of crashing the daemon

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -185,20 +185,24 @@ export async function runDaemon(): Promise<void> {
   initializeProviders(config);
   await initializeTools();
 
-  // Initialize Qdrant vector store
+  // Initialize Qdrant vector store — non-fatal so the daemon stays up without it
   const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
   const qdrantManager = new QdrantManager({
     url: qdrantUrl,
   });
-  await qdrantManager.start();
-  initQdrantClient({
-    url: qdrantUrl,
-    collection: config.memory.qdrant.collection,
-    vectorSize: config.memory.qdrant.vectorSize,
-    onDisk: config.memory.qdrant.onDisk,
-    quantization: config.memory.qdrant.quantization,
-  });
-  log.info('Qdrant vector store initialized');
+  try {
+    await qdrantManager.start();
+    initQdrantClient({
+      url: qdrantUrl,
+      collection: config.memory.qdrant.collection,
+      vectorSize: config.memory.qdrant.vectorSize,
+      onDisk: config.memory.qdrant.onDisk,
+      quantization: config.memory.qdrant.quantization,
+    });
+    log.info('Qdrant vector store initialized');
+  } catch (err) {
+    log.warn({ err }, 'Qdrant failed to start — memory features will be unavailable');
+  }
 
   const server = new DaemonServer();
   await server.start();


### PR DESCRIPTION
## Summary
- Wrapped Qdrant manager startup + client init in a try/catch so the daemon continues running when Qdrant is unavailable
- Memory features degrade gracefully — retriever returns empty results, jobs-worker defers embedding jobs
- Fixes daemon crash on hot-reload when Qdrant process isn't running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
