### PR TITLE
Allow dots in skill name validation to match install rules

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -923,8 +923,8 @@ async function handleSkillsUninstall(
   ctx: HandlerContext,
 ): Promise<void> {
   // Validate skill name to prevent path traversal while allowing namespaced slugs (org/name)
-  const validNamespacedSlug = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/;
-  const validSimpleName = /^[a-zA-Z0-9_-]+$/;
+  const validNamespacedSlug = /^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+  const validSimpleName = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
   if (msg.name.includes('..') || msg.name.includes('\\') || !(validSimpleName.test(msg.name) || validNamespacedSlug.test(msg.name))) {
     ctx.send(socket, {
       type: 'skills_operation_response',


### PR DESCRIPTION
## Summary
- Update `validNamespacedSlug` and `validSimpleName` regexes in `handleSkillsUninstall` to allow dots (`.`) in skill names
- Aligns uninstall validation with `validateSlug` pattern in `clawhub.ts`, which uses `[a-zA-Z0-9._-]`
- Fixes issue where skills like `org/skill.v2` or `my.skill` could be installed but not uninstalled

Addresses review feedback on #1755.

## Test plan
- [ ] Verify skills with dots in names (e.g. `org/skill.v2`, `my.skill`) can be uninstalled
- [ ] Verify path traversal prevention still works (names with `..`, `\` are rejected)
- [ ] Verify names must start with alphanumeric character

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
