### PR TITLE
Exclude arrays from isRecord checks in ensureSkillEntry

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -722,11 +722,11 @@ function handleSkillsList(socket: net.Socket, ctx: HandlerContext): void {
  *  Guards against malformed config (e.g. skills or entries being a string, array, or null)
  *  by resetting non-object intermediates to {}, restoring self-healing behavior. */
 function ensureSkillEntry(raw: Record<string, unknown>, name: string): Record<string, unknown> {
-  if (!isRecord(raw.skills)) raw.skills = {};
+  if (!isRecord(raw.skills) || Array.isArray(raw.skills)) raw.skills = {};
   const skills = raw.skills as Record<string, unknown>;
-  if (!isRecord(skills.entries)) skills.entries = {};
+  if (!isRecord(skills.entries) || Array.isArray(skills.entries)) skills.entries = {};
   const entries = skills.entries as Record<string, unknown>;
-  if (!isRecord(entries[name])) entries[name] = {};
+  if (!isRecord(entries[name]) || Array.isArray(entries[name])) entries[name] = {};
   return entries[name] as Record<string, unknown>;
 }
 function handleSkillsEnable(


### PR DESCRIPTION
## Summary
- Addresses review feedback on #1757: `isRecord` returns true for arrays (`typeof [] === 'object'`), so `ensureSkillEntry` wouldn't reset array config values back to `{}`
- Adds `|| Array.isArray(...)` guards to each `isRecord` check so array values are properly reset, preventing silent config persistence failures

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that setting `skills` or `entries` to an array in config.json results in self-healing reset to `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
