### PR TITLE
Defer memory jobs when Qdrant client is uninitialized

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -620,8 +620,14 @@ async function embedAndUpsert(
   const vector = embedded.vectors[0];
   if (!vector) return;
 
+  let qdrant;
   try {
-    const qdrant = getQdrantClient();
+    qdrant = getQdrantClient();
+  } catch {
+    throw new BackendUnavailableError('Qdrant client not initialized');
+  }
+
+  try {
     const now = Date.now();
     await qdrant.upsert(targetType, targetId, vector, {
       text,


### PR DESCRIPTION
## Summary

Addresses review feedback on #1765: when `getQdrantClient()` throws because Qdrant was never initialized, the error was a plain `Error` (not `BackendUnavailableError`), causing `runMemoryJobsOnce` to call `failMemoryJob` instead of `deferMemoryJob`. After 5 retries, embedding jobs were permanently marked as failed.

**Fix**: In `embedAndUpsert`, wrap the `getQdrantClient()` call to catch the "not initialized" error and re-throw it as `BackendUnavailableError`, so the existing deferral logic handles it correctly.

## Files changed

- `assistant/src/memory/jobs-worker.ts` — separate `getQdrantClient()` from the Qdrant upsert try/catch, re-throw initialization errors as `BackendUnavailableError`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
