### PR TITLE
Prevent concurrent Trust Rules sheets from overwriting shared callback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,7 +12,6 @@ struct SettingsPanel: View {
     @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
-    @State private var showingTrustRules = false
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -219,13 +218,17 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                showingTrustRules = true
+                                daemonClient.isTrustRulesSheetOpen = true
                             }
+                            .disabled(daemonClient.isTrustRulesSheetOpen)
                         }
                     }
                     .padding(VSpacing.lg)
                     .vCard(background: Slate._900)
-                    .sheet(isPresented: $showingTrustRules) {
+                    .sheet(isPresented: Binding(
+                        get: { daemonClient.isTrustRulesSheetOpen },
+                        set: { daemonClient.isTrustRulesSheetOpen = $0 }
+                    )) {
                         TrustRulesView(daemonClient: daemonClient)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -19,7 +19,6 @@ public struct SettingsView: View {
     @State private var showingPrivacy = false
     @State private var showingSkills = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
-    @State private var showingTrustRules = false
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         return ActivationKey(rawValue: stored) ?? .fn
@@ -223,10 +222,14 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            showingTrustRules = true
+                            daemonClient.isTrustRulesSheetOpen = true
                         }
+                        .disabled(daemonClient.isTrustRulesSheetOpen)
                     }
-                    .sheet(isPresented: $showingTrustRules) {
+                    .sheet(isPresented: Binding(
+                        get: { daemonClient.isTrustRulesSheetOpen },
+                        set: { daemonClient.isTrustRulesSheetOpen = $0 }
+                    )) {
                         TrustRulesView(daemonClient: daemonClient)
                     }
                 }

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -26,6 +26,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published var isConnected: Bool = false
 
+    /// Shared flag so only one TrustRulesView sheet is open at a time across SettingsPanel and SettingsView.
+    @Published var isTrustRulesSheetOpen: Bool = false
+
     // MARK: - Surface Event Callbacks
 
     /// Called when the daemon sends a `ui_surface_show` message.


### PR DESCRIPTION
## Summary
- Adds a shared `@Published isTrustRulesSheetOpen` flag on `DaemonClient` to coordinate Trust Rules sheet state across `SettingsPanel` (side panel) and `SettingsView` (Cmd+, window)
- Both views now bind to this shared flag instead of independent `@State` booleans, so opening the sheet from one location disables the button in the other
- Fixes the issue where two concurrent `TrustRulesView` instances would overwrite each other's `onTrustRulesListResponse` callback, causing stale/broken data in the first sheet

Addresses review feedback on #1697.

## Test plan
- [ ] Open Trust Rules from the Settings side panel — verify sheet opens normally
- [ ] While the sheet is open, check that the "Manage Trust Rules..." button in the Cmd+, Settings window is disabled (and vice versa)
- [ ] Close the sheet and verify the button re-enables in both locations
- [ ] Verify trust rule CRUD operations still work correctly from either entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
