### PR TITLE
Add retrieval telemetry to memory recall pipeline

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -576,10 +576,33 @@ exports[`IPC message snapshots ServerMessage types memory_recalled serializes to
   "injectedTokens": 480,
   "latencyMs": 55,
   "lexicalHits": 12,
+  "mergedCount": 18,
   "model": "text-embedding-3-small",
   "provider": "openai",
   "recencyHits": 6,
+  "rerankApplied": false,
+  "selectedCount": 10,
   "semanticHits": 8,
+  "topCandidates": [
+    {
+      "finalScore": 0.85,
+      "key": "segment:seg-1",
+      "kind": "fact",
+      "lexical": 0.9,
+      "recency": 0.3,
+      "semantic": 0.7,
+      "type": "segment",
+    },
+    {
+      "finalScore": 0.72,
+      "key": "item:item-1",
+      "kind": "preference",
+      "lexical": 0.6,
+      "recency": 0.1,
+      "semantic": 0.8,
+      "type": "item",
+    },
+  ],
   "type": "memory_recalled",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -374,8 +374,15 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     semanticHits: 8,
     recencyHits: 6,
     entityHits: 3,
+    mergedCount: 18,
+    selectedCount: 10,
+    rerankApplied: false,
     injectedTokens: 480,
     latencyMs: 55,
+    topCandidates: [
+      { key: 'segment:seg-1', type: 'segment', kind: 'fact', finalScore: 0.85, lexical: 0.9, semantic: 0.7, recency: 0.3 },
+      { key: 'item:item-1', type: 'item', kind: 'preference', finalScore: 0.72, lexical: 0.6, semantic: 0.8, recency: 0.1 },
+    ],
   },
   memory_status: {
     type: 'memory_status',

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -375,7 +375,7 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       case 'memory_recalled':
         spinner.stop();
         process.stdout.write(
-          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | entity ${msg.entityHits} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
+          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | entity ${msg.entityHits} | merged ${msg.mergedCount} → selected ${msg.selectedCount}${msg.rerankApplied ? ' (reranked)' : ''} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
         );
         spinner.start('Thinking...');
         break;

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -566,6 +566,16 @@ export interface SecretDetected {
   action: 'redact' | 'warn' | 'block';
 }
 
+export interface MemoryRecalledCandidateDebug {
+  key: string;
+  type: string;
+  kind: string;
+  finalScore: number;
+  lexical: number;
+  semantic: number;
+  recency: number;
+}
+
 export interface MemoryRecalled {
   type: 'memory_recalled';
   provider: string;
@@ -574,8 +584,12 @@ export interface MemoryRecalled {
   semanticHits: number;
   recencyHits: number;
   entityHits: number;
+  mergedCount: number;
+  selectedCount: number;
+  rerankApplied: boolean;
   injectedTokens: number;
   latencyMs: number;
+  topCandidates: MemoryRecalledCandidateDebug[];
 }
 
 export interface MemoryStatus {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -522,8 +522,12 @@ export class Session {
             semanticHits: recall.semanticHits,
             recencyHits: recall.recencyHits,
             entityHits: recall.entityHits,
+            mergedCount: recall.mergedCount,
+            selectedCount: recall.selectedCount,
+            rerankApplied: recall.rerankApplied,
             injectedTokens: recall.injectedTokens,
             latencyMs: recall.latencyMs,
+            topCandidates: recall.topCandidates,
           });
         }
       }

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -34,6 +34,16 @@ interface Candidate {
   finalScore: number;
 }
 
+export interface MemoryRecallCandiateDebug {
+  key: string;
+  type: CandidateType;
+  kind: string;
+  finalScore: number;
+  lexical: number;
+  semantic: number;
+  recency: number;
+}
+
 export interface MemoryRecallResult {
   enabled: boolean;
   degraded: boolean;
@@ -44,9 +54,13 @@ export interface MemoryRecallResult {
   semanticHits: number;
   recencyHits: number;
   entityHits: number;
+  mergedCount: number;
+  selectedCount: number;
+  rerankApplied: boolean;
   injectedTokens: number;
   injectedText: string;
   latencyMs: number;
+  topCandidates: MemoryRecallCandiateDebug[];
 }
 
 interface MemoryRecallOptions {
@@ -162,6 +176,7 @@ export async function buildMemoryRecall(
 
   // LLM re-ranking: send top candidates to Haiku for relevance scoring
   const rerankingConfig = config.memory.retrieval.reranking;
+  let rerankApplied = false;
   if (rerankingConfig.enabled && merged.length >= 5) {
     const rerankStart = Date.now();
     const topCandidates = merged.slice(0, rerankingConfig.topK);
@@ -169,6 +184,7 @@ export async function buildMemoryRecall(
       const reranked = await rerankWithLLM(query, topCandidates, rerankingConfig);
       // Replace the top portion with re-ranked results, keep any overflow untouched
       merged = [...reranked, ...merged.slice(rerankingConfig.topK)];
+      rerankApplied = true;
       log.debug({ rerankLatencyMs: Date.now() - rerankStart, rerankedCount: reranked.length }, 'LLM re-ranking completed');
     } catch (err) {
       if (signal?.aborted || isAbortError(err)) {
@@ -185,10 +201,20 @@ export async function buildMemoryRecall(
     }
   }
 
+  const mergedCount = merged.length;
   const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens);
   markItemUsage(selected);
 
   const injectedText = buildInjectedText(selected);
+  const topCandidates: MemoryRecallCandiateDebug[] = selected.slice(0, 10).map((c) => ({
+    key: c.key,
+    type: c.type,
+    kind: c.kind,
+    finalScore: c.finalScore,
+    lexical: c.lexical,
+    semantic: c.semantic,
+    recency: c.recency,
+  }));
 
   const latencyMs = Date.now() - start;
   log.debug({
@@ -197,7 +223,9 @@ export async function buildMemoryRecall(
     semanticHits: semanticCandidates.length,
     recencyHits: recencyCandidates.length,
     entityHits: entityCandidates.length,
+    mergedCount,
     selected: selected.length,
+    rerankApplied,
     injectedTokens: estimateTextTokens(injectedText),
     latencyMs,
   }, 'Memory recall completed');
@@ -212,9 +240,13 @@ export async function buildMemoryRecall(
     semanticHits: semanticCandidates.length,
     recencyHits: recencyCandidates.length,
     entityHits: entityCandidates.length,
+    mergedCount,
+    selectedCount: selected.length,
+    rerankApplied,
     injectedTokens: estimateTextTokens(injectedText),
     injectedText,
     latencyMs,
+    topCandidates,
   };
 }
 
@@ -1036,9 +1068,13 @@ function emptyResult(
     semanticHits: 0,
     recencyHits: 0,
     entityHits: 0,
+    mergedCount: 0,
+    selectedCount: 0,
+    rerankApplied: false,
     injectedTokens: 0,
     injectedText: '',
     latencyMs: init.latencyMs,
+    topCandidates: [],
   };
 }
 


### PR DESCRIPTION
## Summary
- Extend `MemoryRecallResult` with `mergedCount`, `selectedCount`, `rerankApplied`, and `topCandidates` debug fields
- Extend `MemoryRecalled` IPC event with the same telemetry, enabling "why was this memory shown?" analysis
- Update CLI display to show merged → selected counts and rerank status

No ranking or retrieval behavior changes. This is PR 2 of the memory improvements plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
