### PR TITLE
Add source/citation metadata to memory_search results

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1160,6 +1160,12 @@ export interface MemorySearchResult {
   importance: number;
   createdAt: number;
   finalScore: number;
+  /** Per-source scores for provenance/debugging */
+  scores: {
+    lexical: number;
+    semantic: number;
+    recency: number;
+  };
 }
 
 /**
@@ -1207,6 +1213,11 @@ export async function searchMemoryItems(
     importance: c.importance,
     createdAt: c.createdAt,
     finalScore: c.finalScore,
+    scores: {
+      lexical: c.lexical,
+      semantic: c.semantic,
+      recency: c.recency,
+    },
   }));
 }
 

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -37,7 +37,7 @@ export async function handleMemorySearch(
     for (const result of results) {
       const timeAgo = formatRelativeTime(result.createdAt);
       lines.push(`- **[${result.kind}]** ${result.text}`);
-      lines.push(`  ID: ${result.id} | ${timeAgo}`);
+      lines.push(`  _Source: ${result.type}:${result.id} | ${timeAgo} | confidence: ${result.confidence.toFixed(2)} | importance: ${result.importance.toFixed(2)}_`);
     }
 
     return { content: lines.join('\n'), isError: false };


### PR DESCRIPTION
## Summary
- Add `scores` field (lexical, semantic, recency) to `MemorySearchResult` for per-source provenance
- Display source type, ID, confidence, and importance in memory_search tool output
- Each result now includes enough metadata to audit why it was recalled

This is PR 5 of the memory improvements plan (PR 4 was completed as part of PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
