### PR TITLE
Add configurable recall injection format (markdown/structured_v1)

### DIFF
--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -40,6 +40,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       lexicalTopK: 80,
       semanticTopK: 40,
       maxInjectTokens: 10000,
+      injectionFormat: 'markdown' as const,
       reranking: {
         enabled: true,
         model: 'claude-haiku-4-5-20251001',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -191,6 +191,9 @@ export const MemoryRetrievalConfigSchema = z.object({
     .int('memory.retrieval.maxInjectTokens must be an integer')
     .positive('memory.retrieval.maxInjectTokens must be a positive integer')
     .default(10000),
+  injectionFormat: z
+    .enum(['markdown', 'structured_v1'], { error: 'memory.retrieval.injectionFormat must be "markdown" or "structured_v1"' })
+    .default('markdown'),
   reranking: MemoryRerankingConfigSchema.default({
     enabled: true,
     model: 'claude-haiku-4-5-20251001',
@@ -278,6 +281,7 @@ export const MemoryConfigSchema = z.object({
     lexicalTopK: 80,
     semanticTopK: 40,
     maxInjectTokens: 10000,
+    injectionFormat: 'markdown',
     reranking: {
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
@@ -397,6 +401,7 @@ export const AssistantConfigSchema = z.object({
       lexicalTopK: 80,
       semanticTopK: 40,
       maxInjectTokens: 10000,
+      injectionFormat: 'markdown',
       reranking: {
         enabled: true,
         model: 'claude-haiku-4-5-20251001',

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -253,7 +253,7 @@ export async function buildMemoryRecall(
   const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens);
   markItemUsage(selected);
 
-  const injectedText = buildInjectedText(selected);
+  const injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
   const topCandidates: MemoryRecallCandiateDebug[] = selected.slice(0, 10).map((c) => ({
     key: c.key,
     type: c.type,
@@ -938,8 +938,12 @@ const SECTION_ORDER = [
  * Layout per section uses "Lost in the Middle" (Liu et al., Stanford 2023)
  * ordering — see applyAttentionOrdering().
  */
-function buildInjectedText(candidates: Candidate[]): string {
+function buildInjectedText(candidates: Candidate[], format: string = 'markdown'): string {
   if (candidates.length === 0) return '';
+
+  if (format === 'structured_v1') {
+    return buildStructuredInjectedText(candidates);
+  }
 
   // Group candidates by section
   const groups = new Map<string, Candidate[]>();
@@ -967,6 +971,34 @@ function buildInjectedText(candidates: Candidate[]): string {
   }
   parts.push(MEMORY_RECALL_CLOSE_TAG);
   return parts.join('\n');
+}
+
+/**
+ * Structured injection format (structured_v1): each memory item is
+ * rendered as a structured XML entry with explicit fields for kind,
+ * text, time, and confidence. This is less prone to prompt injection
+ * than the markdown format since the model can parse fields explicitly.
+ */
+function buildStructuredInjectedText(candidates: Candidate[]): string {
+  const parts: string[] = [MEMORY_RECALL_OPEN_TAG, MEMORY_RECALL_DISCLAIMER];
+  parts.push('<entries>');
+  const ordered = applyAttentionOrdering(candidates);
+  for (const candidate of ordered) {
+    const absolute = formatAbsoluteTime(candidate.createdAt);
+    const relative = formatRelativeTime(candidate.createdAt);
+    parts.push(
+      `<entry kind="${escapeXmlAttr(candidate.kind)}" type="${candidate.type}" confidence="${candidate.confidence.toFixed(2)}" time="${absolute} (${relative})">` +
+      escapeXmlTags(truncate(candidate.text, 320)) +
+      '</entry>',
+    );
+  }
+  parts.push('</entries>');
+  parts.push(MEMORY_RECALL_CLOSE_TAG);
+  return parts.join('\n');
+}
+
+function escapeXmlAttr(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 function applyAttentionOrdering(candidates: Candidate[]): Candidate[] {


### PR DESCRIPTION
## Summary
- Add `memory.retrieval.injectionFormat` config: `"markdown"` (default, no change) or `"structured_v1"`
- `structured_v1` renders each memory as a structured XML `<entry>` element with explicit `kind`, `type`, `confidence`, and `time` attributes
- Structured format reduces prompt injection surface by making fields machine-parseable

This is PR 6 of the memory improvements plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
