### PR TITLE
Add injection strategy flag (prepend_user_block vs separate_context_message)

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -58,6 +58,7 @@ import {
   formatAbsoluteTime,
   formatRelativeTime,
   injectMemoryRecallIntoUserMessage,
+  injectMemoryRecallAsSeparateMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import {
@@ -596,6 +597,70 @@ describe('Memory V2 regressions', () => {
       { type: 'text', text: 'Earlier user request' },
       { type: 'text', text: 'Latest user request' },
     ]);
+  });
+
+  test('separate_context_message injects memory as user+assistant pair before last user message', () => {
+    const history = [
+      { role: 'user' as const, content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant' as const, content: [{ type: 'text', text: 'Hi!' }] },
+      { role: 'user' as const, content: [{ type: 'text', text: 'Tell me about X' }] },
+    ];
+    const recallText = '<memory>Some recalled fact</memory>';
+    const result = injectMemoryRecallAsSeparateMessage(history, recallText);
+    // Should have 5 messages: original 2 + injected user + injected assistant ack + original last user
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe(history[0]);
+    expect(result[1]).toBe(history[1]);
+    // Injected context message
+    expect(result[2].role).toBe('user');
+    expect(result[2].content).toEqual([{ type: 'text', text: recallText }]);
+    // Assistant acknowledgment
+    expect(result[3].role).toBe('assistant');
+    expect(result[3].content).toEqual([{ type: 'text', text: '[Memory context loaded.]' }]);
+    // Original user message preserved unchanged
+    expect(result[4]).toBe(history[2]);
+  });
+
+  test('separate_context_message with empty text is a no-op', () => {
+    const history = [
+      { role: 'user' as const, content: [{ type: 'text', text: 'Hello' }] },
+    ];
+    const result = injectMemoryRecallAsSeparateMessage(history, '  ');
+    expect(result).toBe(history);
+  });
+
+  test('stripMemoryRecallMessages removes separate_context_message pair', () => {
+    const recallText = '<memory>Some recalled fact</memory>';
+    const messages = [
+      { role: 'user' as const, content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant' as const, content: [{ type: 'text', text: 'Hi!' }] },
+      // Injected context message pair
+      { role: 'user' as const, content: [{ type: 'text', text: recallText }] },
+      { role: 'assistant' as const, content: [{ type: 'text', text: '[Memory context loaded.]' }] },
+      // Real user message
+      { role: 'user' as const, content: [{ type: 'text', text: 'Tell me about X' }] },
+    ];
+    const cleaned = stripMemoryRecallMessages(messages, recallText);
+    expect(cleaned).toHaveLength(3);
+    expect(cleaned[0].content[0].text).toBe('Hello');
+    expect(cleaned[1].content[0].text).toBe('Hi!');
+    expect(cleaned[2].content[0].text).toBe('Tell me about X');
+  });
+
+  test('stripMemoryRecallMessages falls back to prepend_user_block when no separate pair found', () => {
+    const recallText = '<memory>Fact</memory>';
+    const messages = [
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text', text: recallText },
+          { type: 'text', text: 'User query' },
+        ],
+      },
+    ];
+    const cleaned = stripMemoryRecallMessages(messages, recallText);
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0].content).toEqual([{ type: 'text', text: 'User query' }]);
   });
 
   test('aborting memory recall embedding returns a non-degraded aborted recall result', async () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -41,6 +41,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       semanticTopK: 40,
       maxInjectTokens: 10000,
       injectionFormat: 'markdown' as const,
+      injectionStrategy: 'prepend_user_block' as const,
       reranking: {
         enabled: true,
         model: 'claude-haiku-4-5-20251001',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -194,6 +194,11 @@ export const MemoryRetrievalConfigSchema = z.object({
   injectionFormat: z
     .enum(['markdown', 'structured_v1'], { error: 'memory.retrieval.injectionFormat must be "markdown" or "structured_v1"' })
     .default('markdown'),
+  injectionStrategy: z
+    .enum(['prepend_user_block', 'separate_context_message'], {
+      error: 'memory.retrieval.injectionStrategy must be "prepend_user_block" or "separate_context_message"',
+    })
+    .default('prepend_user_block'),
   reranking: MemoryRerankingConfigSchema.default({
     enabled: true,
     model: 'claude-haiku-4-5-20251001',
@@ -282,6 +287,7 @@ export const MemoryConfigSchema = z.object({
     semanticTopK: 40,
     maxInjectTokens: 10000,
     injectionFormat: 'markdown',
+    injectionStrategy: 'prepend_user_block',
     reranking: {
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
@@ -402,6 +408,7 @@ export const AssistantConfigSchema = z.object({
       semanticTopK: 40,
       maxInjectTokens: 10000,
       injectionFormat: 'markdown',
+      injectionStrategy: 'prepend_user_block',
       reranking: {
         enabled: true,
         model: 'claude-haiku-4-5-20251001',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -39,6 +39,7 @@ import { getHookManager } from '../hooks/manager.js';
 import {
   buildMemoryRecall,
   injectMemoryRecallIntoUserMessage,
+  injectMemoryRecallAsSeparateMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
@@ -510,10 +511,15 @@ export class Session {
       if (recall.injectedText.length > 0) {
         const userTail = this.messages[this.messages.length - 1];
         if (userTail && userTail.role === 'user') {
-          runMessages = [
-            ...this.messages.slice(0, -1),
-            injectMemoryRecallIntoUserMessage(userTail, recall.injectedText),
-          ];
+          const strategy = runtimeConfig.memory.retrieval.injectionStrategy;
+          if (strategy === 'separate_context_message') {
+            runMessages = injectMemoryRecallAsSeparateMessage(this.messages, recall.injectedText);
+          } else {
+            runMessages = [
+              ...this.messages.slice(0, -1),
+              injectMemoryRecallIntoUserMessage(userTail, recall.injectedText),
+            ];
+          }
           onEvent({
             type: 'memory_recalled',
             provider: recall.provider ?? 'unknown',

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -298,6 +298,9 @@ export async function buildMemoryRecall(
   };
 }
 
+/** Marker text used in the assistant acknowledgment of a separate context message. */
+const MEMORY_CONTEXT_ACK = '[Memory context loaded.]';
+
 export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
   messages: T[],
   memoryRecallText?: string,
@@ -305,6 +308,31 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   const recallText = memoryRecallText ?? '';
   if (recallText.trim().length === 0) return messages;
 
+  // Try separate_context_message pattern first: look for the injected
+  // user+assistant pair (user message whose sole text block is the recall
+  // text, followed by an assistant ack message).
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role !== 'user') continue;
+    if (message.content.length !== 1) continue;
+    const block = message.content[0];
+    if (block.type !== 'text' || block.text !== recallText) continue;
+    // Check if the next message is the assistant ack
+    const next = messages[index + 1];
+    if (
+      next &&
+      next.role === 'assistant' &&
+      next.content.length === 1 &&
+      next.content[0].type === 'text' &&
+      next.content[0].text === MEMORY_CONTEXT_ACK
+    ) {
+      // Remove both the user context message and the assistant ack
+      return [...messages.slice(0, index), ...messages.slice(index + 2)];
+    }
+  }
+
+  // Fall back to prepend_user_block pattern: the recall text is a block
+  // inside a user message that also has real user content.
   let targetIndex = -1;
   let blockIndex = -1;
   for (let index = messages.length - 1; index >= 0; index--) {
@@ -354,6 +382,33 @@ export function injectMemoryRecallIntoUserMessage<T extends { role: 'user' | 'as
     ...message,
     content: [memoryBlock, ...message.content] as T['content'],
   } as T;
+}
+
+/**
+ * Inject memory recall as a separate user+assistant message pair before the
+ * last user message. This separates memory context from the user's actual
+ * query, making it clearer to the model that the memory is background context.
+ */
+export function injectMemoryRecallAsSeparateMessage<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
+  messages: T[],
+  memoryRecallText: string,
+): T[] {
+  if (memoryRecallText.trim().length === 0) return messages;
+  if (messages.length === 0) return messages;
+  const contextMessage = {
+    role: 'user' as const,
+    content: [{ type: 'text', text: memoryRecallText }],
+  } as unknown as T;
+  const ackMessage = {
+    role: 'assistant' as const,
+    content: [{ type: 'text', text: MEMORY_CONTEXT_ACK }],
+  } as unknown as T;
+  return [
+    ...messages.slice(0, -1),
+    contextMessage,
+    ackMessage,
+    messages[messages.length - 1],
+  ];
 }
 
 export function queryMemoryForCli(


### PR DESCRIPTION
## Summary
- Adds `memory.retrieval.injectionStrategy` config with `prepend_user_block` (default) and `separate_context_message` options
- `separate_context_message` inserts memory as a distinct user+assistant exchange before the user's message, cleanly separating recalled context from user intent
- `stripMemoryRecallMessages` updated to handle both strategies transparently
- 4 new tests covering injection, stripping, and edge cases for both strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
