### PR TITLE
Change default protected-directory trust rules from deny to ask

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -473,31 +473,31 @@ describe('Permission Checker', () => {
     });
   });
 
-  // ── default protected directory deny rules ─────────────────────
+  // ── default protected directory ask rules ─────────────────────
 
-  describe('default protected directory deny rules', () => {
-    test('file_read of protected file is denied', async () => {
+  describe('default protected directory ask rules', () => {
+    test('file_read of protected file prompts', async () => {
       const protectedPath = join(checkerTestDir, 'protected', 'trust.json');
       const result = await check('file_read', { path: protectedPath }, '/tmp');
-      expect(result.decision).toBe('deny');
-      expect(result.reason).toContain('deny rule');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
     });
 
-    test('file_write to protected file is denied', async () => {
+    test('file_write to protected file prompts', async () => {
       const protectedPath = join(checkerTestDir, 'protected', 'keys.enc');
       const result = await check('file_write', { path: protectedPath }, '/tmp');
-      expect(result.decision).toBe('deny');
-      expect(result.reason).toContain('deny rule');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
     });
 
-    test('file_edit of protected file is denied', async () => {
+    test('file_edit of protected file prompts', async () => {
       const protectedPath = join(checkerTestDir, 'protected', 'secret-allowlist.json');
       const result = await check('file_edit', { path: protectedPath }, '/tmp');
-      expect(result.decision).toBe('deny');
-      expect(result.reason).toContain('deny rule');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
     });
 
-    test('file_read of non-protected file is not denied', async () => {
+    test('file_read of non-protected file is not affected', async () => {
       const safePath = join(checkerTestDir, 'data', 'assistant.db');
       const result = await check('file_read', { path: safePath }, '/tmp');
       expect(result.decision).toBe('allow');
@@ -510,9 +510,9 @@ describe('Permission Checker', () => {
       expect(result.decision).not.toBe('deny');
     });
 
-    test('relative path to protected file is still denied', async () => {
+    test('relative path to protected file still prompts', async () => {
       // Simulate a relative path that resolves to the protected directory.
-      // The default deny pattern uses an absolute path, so the checker
+      // The default ask pattern uses an absolute path, so the checker
       // must resolve relative paths against workingDir before matching.
       const workingDir = '/tmp';
       const protectedPath = join(checkerTestDir, 'protected', 'trust.json');
@@ -520,7 +520,7 @@ describe('Permission Checker', () => {
       const { relative } = await import('node:path');
       const relPath = relative(workingDir, protectedPath);
       const result = await check('file_read', { path: relPath }, workingDir);
-      expect(result.decision).toBe('deny');
+      expect(result.decision).toBe('prompt');
     });
   });
 

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -570,12 +570,12 @@ describe('Trust Store', () => {
   // ── default rules ─────────────────────────────────────────────
 
   describe('default rules', () => {
-    test('backfills default deny rules for protected directory on first load', () => {
+    test('backfills default ask rules for protected directory on first load', () => {
       const rules = getAllRules();
       const defaults = rules.filter((r) => r.id.startsWith('default:'));
       expect(defaults).toHaveLength(NUM_DEFAULTS);
       for (const rule of defaults) {
-        expect(rule.decision).toBe('deny');
+        expect(rule.decision).toBe('ask');
         expect(rule.priority).toBe(1000);
         expect(rule.scope).toBe('everywhere');
         expect(rule.pattern).toContain(`${testDir}/protected/`);
@@ -634,44 +634,44 @@ describe('Trust Store', () => {
       // Remove one default rule by editing trust.json directly on disk
       // (removeRule() throws for default rules, so we simulate external editing)
       const raw = JSON.parse(readFileSync(trustPath, 'utf-8'));
-      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:deny-file_read-protected');
+      raw.rules = raw.rules.filter((r: { id: string }) => r.id !== 'default:ask-file_read-protected');
       writeFileSync(trustPath, JSON.stringify(raw, null, 2));
       // After reload, the rule is re-backfilled (defaults are always present)
       clearCache();
       const rules = getAllRules();
-      expect(rules.find((r) => r.id === 'default:deny-file_read-protected')).toBeDefined();
+      expect(rules.find((r) => r.id === 'default:ask-file_read-protected')).toBeDefined();
     });
 
-    test('findHighestPriorityRule matches default deny for protected file_read', () => {
+    test('findHighestPriorityRule matches default ask for protected file_read', () => {
       const protectedPath = join(testDir, 'protected', 'trust.json');
       const match = findHighestPriorityRule('file_read', [`file_read:${protectedPath}`], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.decision).toBe('deny');
+      expect(match!.decision).toBe('ask');
       expect(match!.priority).toBe(1000);
     });
 
-    test('findHighestPriorityRule matches default deny for protected file_write', () => {
+    test('findHighestPriorityRule matches default ask for protected file_write', () => {
       const protectedPath = join(testDir, 'protected', 'keys.enc');
       const match = findHighestPriorityRule('file_write', [`file_write:${protectedPath}`], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.decision).toBe('deny');
+      expect(match!.decision).toBe('ask');
     });
 
-    test('findHighestPriorityRule matches default deny for protected file_edit', () => {
+    test('findHighestPriorityRule matches default ask for protected file_edit', () => {
       const protectedPath = join(testDir, 'protected', 'secret-allowlist.json');
       const match = findHighestPriorityRule('file_edit', [`file_edit:${protectedPath}`], '/tmp');
       expect(match).not.toBeNull();
-      expect(match!.decision).toBe('deny');
+      expect(match!.decision).toBe('ask');
     });
 
-    test('default deny does not block files outside protected directory', () => {
+    test('default ask does not affect files outside protected directory', () => {
       const safePath = join(testDir, 'data', 'assistant.db');
       const match = findHighestPriorityRule('file_read', [`file_read:${safePath}`], '/tmp');
       // Should not match a default deny rule
       expect(match === null || !match.id.startsWith('default:')).toBe(true);
     });
 
-    test('default deny rules are backfilled after malformed JSON in trust file', () => {
+    test('default rules are backfilled after malformed JSON in trust file', () => {
       mkdirSync(dirname(trustPath), { recursive: true });
       writeFileSync(trustPath, 'NOT VALID JSON {{{');
       clearCache();
@@ -680,7 +680,7 @@ describe('Trust Store', () => {
       expect(defaults).toHaveLength(NUM_DEFAULTS);
     });
 
-    test('default deny rules are backfilled in-memory after unknown file version without overwriting disk', () => {
+    test('default rules are backfilled in-memory after unknown file version without overwriting disk', () => {
       mkdirSync(dirname(trustPath), { recursive: true });
       const originalContent = JSON.stringify({ version: 9999, rules: [{ id: 'future-rule', tool: 'bash', pattern: 'future *', scope: 'everywhere', decision: 'allow', priority: 50, createdAt: 1000 }] });
       writeFileSync(trustPath, originalContent);
@@ -694,7 +694,7 @@ describe('Trust Store', () => {
       expect(diskContent).toBe(originalContent);
     });
 
-    test('clearAllRules preserves default deny rules', () => {
+    test('clearAllRules preserves default rules', () => {
       addRule('bash', 'git *', '/tmp');
       clearAllRules();
       const rules = getAllRules();

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -214,7 +214,7 @@ export interface AddTrustRule {
   toolName: string;
   pattern: string;
   scope: string;
-  decision: 'allow' | 'deny';
+  decision: 'allow' | 'deny' | 'ask';
 }
 
 export interface TrustRulesList {
@@ -232,7 +232,7 @@ export interface UpdateTrustRule {
   tool?: string;
   pattern?: string;
   scope?: string;
-  decision?: 'allow' | 'deny';
+  decision?: 'allow' | 'deny' | 'ask';
   priority?: number;
 }
 
@@ -754,7 +754,7 @@ export interface TrustRulesListResponse {
     tool: string;
     pattern: string;
     scope: string;
-    decision: 'allow' | 'deny';
+    decision: 'allow' | 'deny' | 'ask';
     priority: number;
     createdAt: number;
   }>;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -164,7 +164,7 @@ export class Session {
             [req.toolName, `cc:${req.toolName}`, 'cc:*'],
             this.workingDir,
           );
-          if (existingRule) {
+          if (existingRule && existingRule.decision !== 'ask') {
             return {
               decision: existingRule.decision === 'allow' ? 'allow' as const : 'deny' as const,
             };

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -279,6 +279,11 @@ export async function check(
       return { decision: 'deny', reason: `Blocked by deny rule: ${matchedRule.pattern}`, matchedRule };
     }
 
+    if (matchedRule.decision === 'ask') {
+      // Ask rules always prompt — never auto-allow or auto-deny
+      return { decision: 'prompt', reason: `Matched ask rule: ${matchedRule.pattern}`, matchedRule };
+    }
+
     // Allow rule: auto-allow for non-High risk
     if (risk !== RiskLevel.High) {
       return { decision: 'allow', reason: `Matched trust rule: ${matchedRule.pattern}`, matchedRule };

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -6,7 +6,7 @@ export interface DefaultRuleTemplate {
   tool: string;
   pattern: string;
   scope: string;
-  decision: 'allow' | 'deny';
+  decision: 'allow' | 'deny' | 'ask';
   priority: number;
 }
 
@@ -23,11 +23,11 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   const protectedDir = join(getRootDir(), 'protected').replaceAll('\\', '/');
 
   return FILE_TOOLS.map((tool) => ({
-    id: `default:deny-${tool}-protected`,
+    id: `default:ask-${tool}-protected`,
     tool,
     pattern: `${tool}:${protectedDir}/**`,
     scope: 'everywhere',
-    decision: 'deny' as const,
+    decision: 'ask' as const,
     priority: 1000,
   }));
 }

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -28,17 +28,37 @@ function getTrustPath(): string {
  */
 function ruleOrder(a: TrustRule, b: TrustRule): number {
   if (b.priority !== a.priority) return b.priority - a.priority;
-  if (a.decision !== b.decision) return a.decision === 'deny' ? -1 : 1;
+  if (a.decision !== b.decision) {
+    // deny > ask > allow
+    const order = { deny: 0, ask: 1, allow: 2 };
+    return (order[a.decision] ?? 2) - (order[b.decision] ?? 2);
+  }
   return 0;
 }
 
 /**
- * Ensure default deny rules are always present in the rule set.
+ * Ensure default rules are always present in the rule set.
  * Mutates the provided array and returns whether any rules were added.
  */
 function backfillDefaults(rules: TrustRule[]): boolean {
-  let added = false;
+  let changed = false;
   const existingIds = new Set(rules.map((r) => r.id));
+
+  // Migrate old default:deny-*-protected rules → default:ask-*-protected
+  const oldDefaultPrefix = 'default:deny-';
+  const newDefaultPrefix = 'default:ask-';
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i];
+    if (rule.id.startsWith(oldDefaultPrefix) && rule.id.endsWith('-protected')) {
+      const newId = newDefaultPrefix + rule.id.slice(oldDefaultPrefix.length);
+      rules.splice(i, 1);
+      existingIds.delete(rule.id);
+      // Don't add newId to existingIds — let the backfill loop re-add it
+      changed = true;
+      log.info({ oldId: rule.id, newId }, 'Migrated default deny rule to ask');
+    }
+  }
+
   for (const template of getDefaultRuleTemplates()) {
     if (!existingIds.has(template.id)) {
       rules.push({
@@ -50,11 +70,11 @@ function backfillDefaults(rules: TrustRule[]): boolean {
         priority: template.priority,
         createdAt: Date.now(),
       });
-      added = true;
+      changed = true;
       log.info({ ruleId: template.id }, 'Backfilled default trust rule');
     }
   }
-  return added;
+  return changed;
 }
 
 function loadFromDisk(): TrustRule[] {
@@ -134,7 +154,7 @@ export function addRule(
   tool: string,
   pattern: string,
   scope: string,
-  decision: 'allow' | 'deny' = 'allow',
+  decision: 'allow' | 'deny' | 'ask' = 'allow',
   priority: number = 100,
 ): TrustRule {
   // Re-read from disk to avoid lost updates if another call modified rules
@@ -160,7 +180,7 @@ export function addRule(
 
 export function updateRule(
   id: string,
-  updates: { tool?: string; pattern?: string; scope?: string; decision?: 'allow' | 'deny'; priority?: number },
+  updates: { tool?: string; pattern?: string; scope?: string; decision?: 'allow' | 'deny' | 'ask'; priority?: number },
 ): TrustRule {
   const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
   if (defaultIds.has(id)) throw new Error(`Cannot modify default trust rule: ${id}`);
@@ -205,7 +225,7 @@ function matchesScope(ruleScope: string, workingDir: string): boolean {
   return workingDir.startsWith(ruleScope.replace(/\*$/, ''));
 }
 
-function findRuleByDecision(tool: string, command: string, scope: string, decision: 'allow' | 'deny'): TrustRule | null {
+function findRuleByDecision(tool: string, command: string, scope: string, decision: 'allow' | 'deny' | 'ask'): TrustRule | null {
   const rules = getRules();
   for (const rule of rules) {
     if (rule.tool !== tool) continue;
@@ -248,13 +268,13 @@ export function getAllRules(): TrustRule[] {
 }
 
 export function clearAllRules(): void {
-  // Re-backfill default deny rules so protected directory stays guarded.
+  // Re-backfill default rules so protected directory stays guarded.
   const rules: TrustRule[] = [];
   backfillDefaults(rules);
   rules.sort(ruleOrder);
   cachedRules = rules;
   saveToDisk(rules);
-  log.info('Cleared all user trust rules (default deny rules preserved)');
+  log.info('Cleared all user trust rules (default rules preserved)');
 }
 
 export function clearCache(): void {

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -9,7 +9,7 @@ export interface TrustRule {
   tool: string;
   pattern: string;
   scope: string;
-  decision: 'allow' | 'deny';
+  decision: 'allow' | 'deny' | 'ask';
   priority: number;
   createdAt: number;
 }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -117,6 +117,14 @@ private struct TrustRuleRow: View {
     let onEdit: () -> Void
     let onDelete: () -> Void
 
+    private func decisionColor(_ decision: String) -> Color {
+        switch decision {
+        case "allow": return .green
+        case "ask": return .orange
+        default: return .red
+        }
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
@@ -127,8 +135,8 @@ private struct TrustRuleRow: View {
                         .font(.caption)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(rule.decision == "allow" ? Color.green.opacity(0.15) : Color.red.opacity(0.15))
-                        .foregroundStyle(rule.decision == "allow" ? .green : .red)
+                        .background(decisionColor(rule.decision).opacity(0.15))
+                        .foregroundStyle(decisionColor(rule.decision))
                         .clipShape(Capsule())
                 }
                 Text(rule.pattern)
@@ -231,6 +239,7 @@ private struct TrustRuleFormView: View {
 
                 Picker("Decision", selection: $decision) {
                     Text("Allow").tag("allow")
+                    Text("Ask").tag("ask")
                     Text("Deny").tag("deny")
                 }
             }


### PR DESCRIPTION
## Summary
- Default trust rules for `~/.vellum/protected/**` now use `ask` instead of `deny`, so the assistant always prompts the user rather than silently blocking or being overridden by lower-priority allow rules
- Added `ask` as a new trust rule decision type throughout the permission system (types, checker, trust store, IPC protocol, macOS UI)
- Includes migration logic to automatically convert existing `default:deny-*-protected` rules to `default:ask-*-protected` on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
