### PR TITLE
Add trust-aware ranking to memory retrieval

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1239,4 +1239,154 @@ describe('Memory V2 regressions', () => {
     expect(escaped).not.toContain('<br/>');
     expect(escaped).toContain('\uFF1Cbr/>');
   });
+
+  test('trust-aware ranking: user_confirmed item outranks assistant_inferred with equal relevance', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert two memory items with identical text, confidence, importance, and timestamps
+    // but different verification states
+    db.insert(memoryItems).values([
+      {
+        id: 'item-trust-confirmed',
+        kind: 'fact',
+        subject: 'trust ranking test',
+        statement: 'The user prefers dark mode for all applications',
+        status: 'active',
+        confidence: 0.8,
+        importance: 0.5,
+        fingerprint: 'fp-trust-confirmed',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        accessCount: 0,
+        verificationState: 'user_confirmed',
+      },
+      {
+        id: 'item-trust-inferred',
+        kind: 'fact',
+        subject: 'trust ranking test',
+        statement: 'The user prefers dark mode for all editors',
+        status: 'active',
+        confidence: 0.8,
+        importance: 0.5,
+        fingerprint: 'fp-trust-inferred',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        accessCount: 0,
+        verificationState: 'assistant_inferred',
+      },
+    ]).run();
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall('dark mode', 'conv-trust-test', config);
+
+    // Both items should be found (directItemSearch matches on "dark" and "mode")
+    const confirmed = recall.topCandidates.find((c) => c.key === 'item:item-trust-confirmed');
+    const inferred = recall.topCandidates.find((c) => c.key === 'item:item-trust-inferred');
+    expect(confirmed).toBeDefined();
+    expect(inferred).toBeDefined();
+
+    // user_confirmed (weight 1.0) should have a higher finalScore than assistant_inferred (weight 0.7)
+    expect(confirmed!.finalScore).toBeGreaterThan(inferred!.finalScore);
+  });
+
+  test('trust-aware ranking: user_reported item outranks assistant_inferred', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'item-trust-reported',
+        kind: 'fact',
+        subject: 'trust ranking reported',
+        statement: 'The user uses vim keybindings in their editor',
+        status: 'active',
+        confidence: 0.8,
+        importance: 0.5,
+        fingerprint: 'fp-trust-reported',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        accessCount: 0,
+        verificationState: 'user_reported',
+      },
+      {
+        id: 'item-trust-inferred2',
+        kind: 'fact',
+        subject: 'trust ranking inferred',
+        statement: 'The user uses vim keybindings in their terminal',
+        status: 'active',
+        confidence: 0.8,
+        importance: 0.5,
+        fingerprint: 'fp-trust-inferred2',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        accessCount: 0,
+        verificationState: 'assistant_inferred',
+      },
+    ]).run();
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall('vim keybindings', 'conv-trust-test2', config);
+
+    const reported = recall.topCandidates.find((c) => c.key === 'item:item-trust-reported');
+    const inferred = recall.topCandidates.find((c) => c.key === 'item:item-trust-inferred2');
+    expect(reported).toBeDefined();
+    expect(inferred).toBeDefined();
+
+    // user_reported (weight 0.9) should outrank assistant_inferred (weight 0.7)
+    expect(reported!.finalScore).toBeGreaterThan(inferred!.finalScore);
+  });
+
+  test('trust-aware ranking: weight values are bounded and non-zero', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert an item with an unknown verification state to test the default weight
+    const raw = (db as unknown as { $client: { query: (q: string) => { get: (...params: unknown[]) => unknown } } }).$client;
+    raw.query(`
+      INSERT INTO memory_items (id, kind, subject, statement, status, confidence, importance, fingerprint, first_seen_at, last_seen_at, access_count, verification_state)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).get(
+      'item-trust-unknown', 'fact', 'trust ranking unknown', 'The user has an unknown trust state preference',
+      'active', 0.8, 0.5, 'fp-trust-unknown', now, now, 0, 'some_future_state',
+    );
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          required: false,
+        },
+      },
+    };
+
+    const recall = await buildMemoryRecall('unknown trust state preference', 'conv-trust-test3', config);
+
+    const unknown = recall.topCandidates.find((c) => c.key === 'item:item-trust-unknown');
+    expect(unknown).toBeDefined();
+    // The finalScore should be > 0 (trust weight is bounded, not zero)
+    expect(unknown!.finalScore).toBeGreaterThan(0);
+  });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -783,11 +783,11 @@ function mergeCandidates(
   const recencyRanks = buildRankMap(recency, (c) => c.recency);
   const entityRanks = buildRankMap(entity, (c) => c.confidence);
 
-  // Look up access_count for item-type candidates (retrieval reinforcement)
+  // Look up access_count and verification_state for item-type candidates
   const itemIds = [...merged.values()]
     .filter((c) => c.type === 'item')
     .map((c) => c.id);
-  const accessCounts = lookupAccessCounts(itemIds);
+  const itemMetadata = lookupItemMetadata(itemIds);
 
   const rows = [...merged.values()];
   for (const row of rows) {
@@ -800,10 +800,16 @@ function mergeCandidates(
     const rrfScore = rrf(ranks);
 
     // Retrieval reinforcement: boost importance by accessCount
-    const accessCount = accessCounts.get(row.id) ?? 0;
+    const meta = itemMetadata.get(row.id);
+    const accessCount = meta?.accessCount ?? 0;
     const effectiveImportance = Math.min(1, row.importance + 0.03 * accessCount);
 
-    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance);
+    // Trust-aware ranking: items with higher verification state rank higher
+    const trustWeight = meta
+      ? (TRUST_WEIGHTS[meta.verificationState] ?? DEFAULT_TRUST_WEIGHT)
+      : DEFAULT_TRUST_WEIGHT;
+
+    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight;
   }
 
   rows.sort((a, b) => {
@@ -834,28 +840,51 @@ function buildRankMap(candidates: Candidate[], scoreAccessor: (c: Candidate) => 
   return rankMap;
 }
 
+interface ItemMetadata {
+  accessCount: number;
+  verificationState: string;
+}
+
 /**
- * Look up access_count from the memory_items table for a batch of item IDs.
- * Returns a map from item ID to access count.
+ * Look up access_count and verification_state from memory_items for a batch of item IDs.
  */
-function lookupAccessCounts(itemIds: string[]): Map<string, number> {
-  const counts = new Map<string, number>();
-  if (itemIds.length === 0) return counts;
+function lookupItemMetadata(itemIds: string[]): Map<string, ItemMetadata> {
+  const metadata = new Map<string, ItemMetadata>();
+  if (itemIds.length === 0) return metadata;
   try {
     const db = getDb();
     const rows = db
-      .select({ id: memoryItems.id, accessCount: memoryItems.accessCount })
+      .select({
+        id: memoryItems.id,
+        accessCount: memoryItems.accessCount,
+        verificationState: memoryItems.verificationState,
+      })
       .from(memoryItems)
       .where(inArray(memoryItems.id, itemIds))
       .all();
     for (const row of rows) {
-      counts.set(row.id, row.accessCount);
+      metadata.set(row.id, {
+        accessCount: row.accessCount,
+        verificationState: row.verificationState,
+      });
     }
   } catch (err) {
-    log.warn({ err }, 'Failed to look up access counts for retrieval reinforcement');
+    log.warn({ err }, 'Failed to look up item metadata for retrieval ranking');
   }
-  return counts;
+  return metadata;
 }
+
+/**
+ * Trust weight by verification state. Higher = more trusted.
+ * Bounded: lowest weight is 0.7, never zero — low-trust items are
+ * down-ranked but not suppressed.
+ */
+const TRUST_WEIGHTS: Record<string, number> = {
+  user_confirmed: 1.0,
+  user_reported: 0.9,
+  assistant_inferred: 0.7,
+};
+const DEFAULT_TRUST_WEIGHT = 0.85;
 
 /**
  * LLM re-ranking: send candidate memories to Haiku for relevance scoring.


### PR DESCRIPTION
## Summary
- Replaces `lookupAccessCounts` with `lookupItemMetadata` to fetch both `access_count` and `verification_state` for item-type candidates
- Applies bounded trust weights (`user_confirmed`=1.0, `user_reported`=0.9, `assistant_inferred`=0.7) as a multiplier on the final RRF score
- Unknown/future verification states fall back to a default weight of 0.85 — items are down-ranked but never suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
