### PR TITLE
Add freshness policy and stale suppression for memory items

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -51,7 +51,7 @@ import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
 import { claimMemoryJobs, enqueueMemoryJob } from '../memory/jobs-store.js';
-import { currentWeekWindow, runMemoryJobsOnce } from '../memory/jobs-worker.js';
+import { currentWeekWindow, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
   escapeXmlTags,
@@ -1388,5 +1388,168 @@ describe('Memory V2 regressions', () => {
     expect(unknown).toBeDefined();
     // The finalScore should be > 0 (trust weight is bounded, not zero)
     expect(unknown!.finalScore).toBeGreaterThan(0);
+  });
+
+  test('freshness decay: stale event item scores lower than fresh one', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const MS_PER_DAY = 86_400_000;
+
+    // Fresh event item (5 days old — well within the 30-day default window)
+    db.insert(memoryItems).values({
+      id: 'item-fresh-event',
+      kind: 'event',
+      subject: 'freshness decay test',
+      statement: 'User attended a workshop on machine learning',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-fresh-event',
+      firstSeenAt: now - 5 * MS_PER_DAY,
+      lastSeenAt: now - 5 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    // Stale event item (60 days old — past the 30-day event window)
+    db.insert(memoryItems).values({
+      id: 'item-stale-event',
+      kind: 'event',
+      subject: 'freshness decay test',
+      statement: 'User attended a workshop on machine learning basics',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-stale-event',
+      firstSeenAt: now - 60 * MS_PER_DAY,
+      lastSeenAt: now - 60 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: { ...DEFAULT_CONFIG.memory.embeddings, required: false },
+      },
+    };
+
+    const recall = await buildMemoryRecall('machine learning workshop', 'conv-fresh-1', config);
+
+    const fresh = recall.topCandidates.find((c) => c.key === 'item:item-fresh-event');
+    const stale = recall.topCandidates.find((c) => c.key === 'item:item-stale-event');
+    expect(fresh).toBeDefined();
+    expect(stale).toBeDefined();
+
+    // Fresh item should score higher than stale item due to freshness decay
+    expect(fresh!.finalScore).toBeGreaterThan(stale!.finalScore);
+  });
+
+  test('freshness decay: fact items with maxAgeDays=0 are never decayed', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const MS_PER_DAY = 86_400_000;
+
+    // Very old fact item (365 days) — facts have maxAgeDays=0 (no expiry)
+    db.insert(memoryItems).values({
+      id: 'item-old-fact',
+      kind: 'fact',
+      subject: 'freshness no-decay test',
+      statement: 'The speed of light is 299792458 meters per second',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-old-fact',
+      firstSeenAt: now - 365 * MS_PER_DAY,
+      lastSeenAt: now - 365 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    // Recent fact with same text similarity
+    db.insert(memoryItems).values({
+      id: 'item-new-fact',
+      kind: 'fact',
+      subject: 'freshness no-decay test',
+      statement: 'The speed of light is approximately 3e8 meters per second',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-new-fact',
+      firstSeenAt: now - 1 * MS_PER_DAY,
+      lastSeenAt: now - 1 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: { ...DEFAULT_CONFIG.memory.embeddings, required: false },
+      },
+    };
+
+    const recall = await buildMemoryRecall('speed of light', 'conv-fresh-2', config);
+
+    const oldFact = recall.topCandidates.find((c) => c.key === 'item:item-old-fact');
+    const newFact = recall.topCandidates.find((c) => c.key === 'item:item-new-fact');
+    expect(oldFact).toBeDefined();
+    expect(newFact).toBeDefined();
+
+    // Both should have similar scores — old facts are NOT decayed
+    // The scores may differ slightly due to recency scores, but the ratio should be close to 1
+    const ratio = oldFact!.finalScore / newFact!.finalScore;
+    expect(ratio).toBeGreaterThan(0.8);
+  });
+
+  test('sweepStaleItems marks deeply stale items as invalid', () => {
+    const db = getDb();
+    const now = Date.now();
+    const MS_PER_DAY = 86_400_000;
+
+    // Item 100 days old with kind=event (default maxAgeDays=30, so 2x=60 — past the deep-stale threshold)
+    db.insert(memoryItems).values({
+      id: 'item-deeply-stale',
+      kind: 'event',
+      subject: 'sweep test',
+      statement: 'Old event that should be swept',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-sweep-stale',
+      firstSeenAt: now - 100 * MS_PER_DAY,
+      lastSeenAt: now - 100 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'assistant_inferred',
+    }).run();
+
+    // Fresh event item — should NOT be swept
+    db.insert(memoryItems).values({
+      id: 'item-sweep-fresh',
+      kind: 'event',
+      subject: 'sweep test',
+      statement: 'Recent event that should not be swept',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-sweep-fresh',
+      firstSeenAt: now - 5 * MS_PER_DAY,
+      lastSeenAt: now - 5 * MS_PER_DAY,
+      accessCount: 0,
+      verificationState: 'assistant_inferred',
+    }).run();
+
+    const marked = sweepStaleItems(DEFAULT_CONFIG);
+    expect(marked).toBeGreaterThanOrEqual(1);
+
+    const staleItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-deeply-stale')).get();
+    expect(staleItem).toBeDefined();
+    expect(staleItem!.invalidAt).not.toBeNull();
+
+    const freshItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-sweep-fresh')).get();
+    expect(freshItem).toBeDefined();
+    expect(freshItem!.invalidAt).toBeNull();
   });
 });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -47,6 +47,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         model: 'claude-haiku-4-5-20251001',
         topK: 20,
       },
+      freshness: {
+        enabled: true,
+        maxAgeDays: { fact: 0, preference: 0, behavior: 90, event: 30, opinion: 60 },
+        staleDecay: 0.5,
+        reinforcementShieldDays: 7,
+      },
     },
     segmentation: {
       targetTokens: 450,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -175,6 +175,54 @@ export const MemoryRerankingConfigSchema = z.object({
     .default(20),
 });
 
+/**
+ * Per-kind freshness windows (in days). Items older than their window
+ * (based on lastSeenAt) are down-ranked unless recently reinforced.
+ * A value of 0 disables freshness decay for that kind.
+ */
+const MemoryFreshnessConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.retrieval.freshness.enabled must be a boolean' })
+    .default(true),
+  maxAgeDays: z.object({
+    fact: z
+      .number({ error: 'memory.retrieval.freshness.maxAgeDays.fact must be a number' })
+      .nonnegative('memory.retrieval.freshness.maxAgeDays.fact must be non-negative')
+      .default(0),
+    preference: z
+      .number({ error: 'memory.retrieval.freshness.maxAgeDays.preference must be a number' })
+      .nonnegative('memory.retrieval.freshness.maxAgeDays.preference must be non-negative')
+      .default(0),
+    behavior: z
+      .number({ error: 'memory.retrieval.freshness.maxAgeDays.behavior must be a number' })
+      .nonnegative('memory.retrieval.freshness.maxAgeDays.behavior must be non-negative')
+      .default(90),
+    event: z
+      .number({ error: 'memory.retrieval.freshness.maxAgeDays.event must be a number' })
+      .nonnegative('memory.retrieval.freshness.maxAgeDays.event must be non-negative')
+      .default(30),
+    opinion: z
+      .number({ error: 'memory.retrieval.freshness.maxAgeDays.opinion must be a number' })
+      .nonnegative('memory.retrieval.freshness.maxAgeDays.opinion must be non-negative')
+      .default(60),
+  }).default({
+    fact: 0,
+    preference: 0,
+    behavior: 90,
+    event: 30,
+    opinion: 60,
+  }),
+  staleDecay: z
+    .number({ error: 'memory.retrieval.freshness.staleDecay must be a number' })
+    .min(0, 'memory.retrieval.freshness.staleDecay must be >= 0')
+    .max(1, 'memory.retrieval.freshness.staleDecay must be <= 1')
+    .default(0.5),
+  reinforcementShieldDays: z
+    .number({ error: 'memory.retrieval.freshness.reinforcementShieldDays must be a number' })
+    .nonnegative('memory.retrieval.freshness.reinforcementShieldDays must be non-negative')
+    .default(7),
+});
+
 export const MemoryRetrievalConfigSchema = z.object({
   lexicalTopK: z
     .number({ error: 'memory.retrieval.lexicalTopK must be a number' })
@@ -203,6 +251,18 @@ export const MemoryRetrievalConfigSchema = z.object({
     enabled: true,
     model: 'claude-haiku-4-5-20251001',
     topK: 20,
+  }),
+  freshness: MemoryFreshnessConfigSchema.default({
+    enabled: true,
+    maxAgeDays: {
+      fact: 0,
+      preference: 0,
+      behavior: 90,
+      event: 30,
+      opinion: 60,
+    },
+    staleDecay: 0.5,
+    reinforcementShieldDays: 7,
   }),
 });
 
@@ -292,6 +352,12 @@ export const MemoryConfigSchema = z.object({
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
       topK: 20,
+    },
+    freshness: {
+      enabled: true,
+      maxAgeDays: { fact: 0, preference: 0, behavior: 90, event: 30, opinion: 60 },
+      staleDecay: 0.5,
+      reinforcementShieldDays: 7,
     },
   }),
   segmentation: MemorySegmentationConfigSchema.default({
@@ -413,6 +479,12 @@ export const AssistantConfigSchema = z.object({
         enabled: true,
         model: 'claude-haiku-4-5-20251001',
         topK: 20,
+      },
+      freshness: {
+        enabled: true,
+        maxAgeDays: { fact: 0, preference: 0, behavior: 90, event: 30, opinion: 60 },
+        staleDecay: 0.5,
+        reinforcementShieldDays: 7,
       },
     },
     segmentation: {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -116,6 +116,10 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
 export async function runMemoryJobsOnce(): Promise<number> {
   const config = getConfig();
   if (!config.memory.enabled) return 0;
+
+  // Periodic stale item sweep (throttled to at most once per hour)
+  sweepStaleItems(config);
+
   const concurrency = Math.max(1, config.memory.jobs.workerConcurrency);
   const jobs = claimMemoryJobs(concurrency);
   if (jobs.length === 0) return 0;
@@ -679,4 +683,52 @@ function weekNumber(date: Date): number {
   tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
   const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
   return Math.ceil((((tmp.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+}
+
+// ── Stale item sweep ───────────────────────────────────────────────
+
+const STALE_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+let lastStaleSweepMs = 0;
+
+/**
+ * Mark deeply stale memory items as invalid. An item is considered deeply
+ * stale when it has exceeded 2x its freshness window for its kind and has
+ * not been recently accessed.
+ *
+ * This is non-destructive: items keep their data but get an `invalid_at`
+ * timestamp that excludes them from retrieval queries.
+ */
+export function sweepStaleItems(config: AssistantConfig): number {
+  const freshness = config.memory.retrieval.freshness;
+  if (!freshness.enabled) return 0;
+
+  const now = Date.now();
+  // Throttle: at most once per hour
+  if (now - lastStaleSweepMs < STALE_SWEEP_INTERVAL_MS) return 0;
+  lastStaleSweepMs = now;
+
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { run: (...params: unknown[]) => { changes: number } } } }).$client;
+
+  let totalMarked = 0;
+  for (const [kind, maxAgeDays] of Object.entries(freshness.maxAgeDays)) {
+    if (maxAgeDays <= 0) continue;
+    // Mark invalid if: past 2x window, no access in the shield period, and not already invalid
+    const cutoffMs = now - maxAgeDays * 2 * 86_400_000;
+    const shieldCutoffMs = now - freshness.reinforcementShieldDays * 86_400_000;
+    const result = raw.query(`
+      UPDATE memory_items
+      SET invalid_at = ?
+      WHERE kind = ?
+        AND status = 'active'
+        AND invalid_at IS NULL
+        AND last_seen_at < ?
+        AND (access_count = 0 OR last_seen_at < ?)
+    `).run(now, kind, cutoffMs, shieldCutoffMs);
+    if (result.changes > 0) {
+      log.info({ kind, marked: result.changes, cutoffMs }, 'Marked stale memory items as invalid');
+      totalMarked += result.changes;
+    }
+  }
+  return totalMarked;
 }

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -118,7 +118,7 @@ async function collectAndMergeCandidates(
   // Direct item search supplements FTS with LIKE-based matching
   const directItems = directItemSearch(query, Math.max(10, config.memory.retrieval.lexicalTopK));
 
-  const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems]);
+  const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness);
 
   return { lexical, recency, semantic, entity, merged };
 }
@@ -758,6 +758,7 @@ function mergeCandidates(
   semantic: Candidate[],
   recency: Candidate[],
   entity: Candidate[] = [],
+  freshnessConfig?: { enabled: boolean; maxAgeDays: Record<string, number>; staleDecay: number; reinforcementShieldDays: number },
 ): Candidate[] {
   // Build merged candidate map (dedup by key, keep best metadata)
   const merged = new Map<string, Candidate>();
@@ -809,7 +810,10 @@ function mergeCandidates(
       ? (TRUST_WEIGHTS[meta.verificationState] ?? DEFAULT_TRUST_WEIGHT)
       : DEFAULT_TRUST_WEIGHT;
 
-    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight;
+    // Freshness decay: down-rank stale items unless recently reinforced
+    const freshnessWeight = computeFreshnessWeight(row, accessCount, freshnessConfig);
+
+    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight * freshnessWeight;
   }
 
   rows.sort((a, b) => {
@@ -885,6 +889,43 @@ const TRUST_WEIGHTS: Record<string, number> = {
   assistant_inferred: 0.7,
 };
 const DEFAULT_TRUST_WEIGHT = 0.85;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Compute a freshness weight for a candidate based on its kind and age.
+ * Returns 1.0 for fresh items and `staleDecay` for items past their window.
+ * Items with recent reinforcement (accessCount > 0 and within shield window)
+ * are shielded from decay.
+ */
+function computeFreshnessWeight(
+  candidate: { type: string; kind: string; createdAt: number },
+  accessCount: number,
+  config?: { enabled: boolean; maxAgeDays: Record<string, number>; staleDecay: number; reinforcementShieldDays: number },
+): number {
+  if (!config?.enabled) return 1.0;
+
+  // Only apply freshness to item-type candidates
+  if (candidate.type !== 'item') return 1.0;
+
+  const maxAgeDays = config.maxAgeDays[candidate.kind] ?? 0;
+  // maxAgeDays of 0 means no expiry for this kind
+  if (maxAgeDays <= 0) return 1.0;
+
+  const now = Date.now();
+  const ageMs = now - candidate.createdAt;
+  const ageDays = ageMs / MS_PER_DAY;
+
+  if (ageDays <= maxAgeDays) return 1.0;
+
+  // Check reinforcement shield: recently accessed items are protected
+  if (accessCount > 0 && config.reinforcementShieldDays > 0) {
+    const shieldMs = config.reinforcementShieldDays * MS_PER_DAY;
+    if (ageMs - maxAgeDays * MS_PER_DAY < shieldMs) return 1.0;
+  }
+
+  return config.staleDecay;
+}
 
 /**
  * LLM re-ranking: send candidate memories to Haiku for relevance scoring.


### PR DESCRIPTION
## Summary
- Adds per-kind freshness windows (`memory.retrieval.freshness.maxAgeDays`) that down-rank stale items during retrieval with a configurable decay multiplier (default 0.5)
- Items recently reinforced (accessed within `reinforcementShieldDays`) are protected from decay
- Periodic sweep in the jobs worker marks deeply stale items (2x past window) as invalid for permanent exclusion
- Default windows: facts/preferences never expire, behavior=90d, events=30d, opinions=60d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
