### PR TITLE
Add memory scope columns for project isolation

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -67,6 +67,7 @@ import {
   memoryItems,
   memoryItemSources,
   memoryJobs,
+  memorySegments,
   memorySummaries,
   messages,
 } from '../memory/schema.js';
@@ -1551,5 +1552,115 @@ describe('Memory V2 regressions', () => {
     const freshItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-sweep-fresh')).get();
     expect(freshItem).toBeDefined();
     expect(freshItem!.invalidAt).toBeNull();
+  });
+
+  test('scope columns: memory items default to scope_id=default', () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values({
+      id: 'item-scope-default',
+      kind: 'fact',
+      subject: 'scope test',
+      statement: 'This item should have default scope',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-scope-default',
+      firstSeenAt: now,
+      lastSeenAt: now,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-scope-default')).get();
+    expect(item).toBeDefined();
+    expect(item!.scopeId).toBe('default');
+  });
+
+  test('scope columns: memory items can be inserted with explicit scope_id', () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values({
+      id: 'item-scope-custom',
+      kind: 'fact',
+      subject: 'scope test',
+      statement: 'This item has a custom scope',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-scope-custom',
+      scopeId: 'project-abc',
+      firstSeenAt: now,
+      lastSeenAt: now,
+      accessCount: 0,
+      verificationState: 'user_confirmed',
+    }).run();
+
+    const item = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-scope-custom')).get();
+    expect(item).toBeDefined();
+    expect(item!.scopeId).toBe('project-abc');
+  });
+
+  test('scope columns: segments get scopeId from indexer input', () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(conversations).values({
+      id: 'conv-scope-test',
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-scope-test',
+      conversationId: 'conv-scope-test',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Remember my scope preference' }]),
+      createdAt: now,
+    }).run();
+
+    indexMessageNow({
+      messageId: 'msg-scope-test',
+      conversationId: 'conv-scope-test',
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'Remember my scope preference' }]),
+      createdAt: now,
+      scopeId: 'project-xyz',
+    }, DEFAULT_CONFIG.memory);
+
+    const segments = db.select().from(memorySegments).where(eq(memorySegments.messageId, 'msg-scope-test')).all();
+    expect(segments.length).toBeGreaterThan(0);
+    for (const seg of segments) {
+      expect(seg.scopeId).toBe('project-xyz');
+    }
+  });
+
+  test('scope columns: summaries default to scope_id=default', () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memorySummaries).values({
+      id: 'summary-scope-test',
+      scope: 'weekly_global',
+      scopeKey: '2025-W01',
+      summary: 'Test summary for scope',
+      tokenEstimate: 10,
+      startAt: now - 7 * 86_400_000,
+      endAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+
+    const summary = db.select().from(memorySummaries).where(eq(memorySummaries.id, 'summary-scope-test')).get();
+    expect(summary).toBeDefined();
+    expect(summary!.scopeId).toBe('default');
   });
 });

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -374,6 +374,9 @@ export function initializeDb(): void {
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN invalid_at INTEGER`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN verification_state TEXT NOT NULL DEFAULT 'assistant_inferred'`); } catch { /* already exists */ }
   try { database.run(/*sql*/ `ALTER TABLE memory_jobs ADD COLUMN deferrals INTEGER NOT NULL DEFAULT 0`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_segments ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_items ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
+  try { database.run(/*sql*/ `ALTER TABLE memory_summaries ADD COLUMN scope_id TEXT NOT NULL DEFAULT 'default'`); } catch { /* already exists */ }
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
@@ -390,6 +393,9 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time ON memory_summaries(scope, end_at DESC)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_id ON memory_items(scope_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_id ON memory_summaries(scope_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_keys_assistant_key ON conversation_keys(assistant_id, conversation_key)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_attachments_assistant_id ON attachments(assistant_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_message_attachments_message_id ON message_attachments(message_id)`);

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -18,6 +18,7 @@ export interface IndexMessageInput {
   role: string;
   content: string;
   createdAt: number;
+  scopeId?: string;
 }
 
 export interface IndexMessageResult {
@@ -54,6 +55,7 @@ export function indexMessageNow(
       segmentIndex: segment.segmentIndex,
       text: segment.text,
       tokenEstimate: segment.tokenEstimate,
+      scopeId: input.scopeId ?? 'default',
       createdAt: input.createdAt,
       updatedAt: now,
     }).onConflictDoUpdate({

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -49,6 +49,7 @@ export const memorySegments = sqliteTable('memory_segments', {
   segmentIndex: integer('segment_index').notNull(),
   text: text('text').notNull(),
   tokenEstimate: integer('token_estimate').notNull(),
+  scopeId: text('scope_id').notNull().default('default'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
@@ -64,6 +65,7 @@ export const memoryItems = sqliteTable('memory_items', {
   accessCount: integer('access_count').notNull().default(0),
   fingerprint: text('fingerprint').notNull(),
   verificationState: text('verification_state').notNull().default('assistant_inferred'),
+  scopeId: text('scope_id').notNull().default('default'),
   firstSeenAt: integer('first_seen_at').notNull(),
   lastSeenAt: integer('last_seen_at').notNull(),
   lastUsedAt: integer('last_used_at'),
@@ -89,6 +91,7 @@ export const memorySummaries = sqliteTable('memory_summaries', {
   summary: text('summary').notNull(),
   tokenEstimate: integer('token_estimate').notNull(),
   version: integer('version').notNull().default(1),
+  scopeId: text('scope_id').notNull().default('default'),
   startAt: integer('start_at').notNull(),
   endAt: integer('end_at').notNull(),
   createdAt: integer('created_at').notNull(),


### PR DESCRIPTION
## Summary
- Adds `scope_id` column (`TEXT NOT NULL DEFAULT 'default'`) to `memory_segments`, `memory_items`, and `memory_summaries` tables
- Existing rows are automatically backfilled to `'default'` via the column default value
- `IndexMessageInput` accepts an optional `scopeId` that propagates to segment inserts
- Adds indexes on `scope_id` for each table to support future scope-filtered queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
