### PR TITLE
Simplify Agent panel into single-page Skills panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -75,7 +75,6 @@ struct AgentPanel: View {
     let daemonClient: DaemonClient
 
     @StateObject private var skillsManager: SkillsManager
-    @State private var selectedTab = 0
     @State private var expandedSkillId: String?
     @State private var hoveredSkillButtonId: String?
     @State private var selectedSkillSlug: String?
@@ -89,41 +88,45 @@ struct AgentPanel: View {
     }
 
     var body: some View {
-        VSidePanel(title: "Agent", onClose: onClose, pinnedContent: {
-            VSegmentedControl(
-                items: ["Skills", "Available Skills", "Nodes", "Personality"],
-                selection: $selectedTab
-            )
-            .padding(.top, VSpacing.sm)
+        VSidePanel(title: "Skills", onClose: onClose) {
+            // Installed skills section
+            sectionHeader("Installed", count: userSkills.count)
 
-            Divider().background(VColor.surfaceBorder)
-        }) {
-            switch selectedTab {
-            case 0:
-                skillsContent
-            case 1:
-                availableSkillsContent
-            case 2:
-                VEmptyState(
-                    title: "No nodes",
-                    subtitle: "Agent nodes will appear here",
-                    icon: "point.3.connected.trianglepath.dotted"
-                )
-                .frame(height: 250)
-            case 3:
-                VEmptyState(
-                    title: "Personality",
-                    subtitle: "Configure agent personality here",
-                    icon: "person.text.rectangle"
-                )
-                .frame(height: 250)
-            default:
-                EmptyView()
-            }
+            skillsContent
+
+            // Available skills section
+            sectionHeader("Available")
+
+            availableSkillsContent
         }
         .onAppear {
             skillsManager.fetchSkills()
         }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Text(title)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+
+            if let count {
+                Text("\(count)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(Slate._800)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+        }
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.sm)
     }
 
     // MARK: - Available Skills Tab
@@ -800,14 +803,13 @@ struct AgentPanel: View {
                     .controlSize(.small)
                 Spacer()
             }
-            .frame(height: 250)
+            .frame(height: 60)
         } else if userSkills.isEmpty {
-            VEmptyState(
-                title: "No skills",
-                subtitle: "Agent skills will appear here",
-                icon: "bolt.fill"
-            )
-            .frame(height: 250)
+            Text("No skills installed")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, VSpacing.sm)
         } else {
             VStack(spacing: VSpacing.md) {
                 ForEach(userSkills) { skill in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -44,7 +44,7 @@ struct ThreadTabBar: View {
                     VIconButton(label: "Generated", icon: "wand.and.stars", isActive: activePanel == .generated) {
                         togglePanel(.generated)
                     }
-                    VIconButton(label: "Agent", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
+                    VIconButton(label: "Skills", icon: "exclamationmark.triangle", isActive: activePanel == .agent) {
                         togglePanel(.agent)
                     }
                     VIconButton(label: "Settings", icon: "gearshape", isActive: activePanel == .settings) {


### PR DESCRIPTION
The purpose of this PR is to simplify the Agent panel from a 4-tab layout into a single scrollable Skills page.

## Changes Made
- Remove segmented control with Skills, Available Skills, Nodes, and Personality tabs
- Combine installed and available skills into a single scrollable page with section headers
- Rename "Agent" → "Skills" in the tab bar button and panel header
- Remove empty Nodes and Personality placeholder tabs
- Replace tall empty state with compact "No skills installed" message

## Testing
- `./build.sh` compiles successfully
- Visual verification: panel shows "SKILLS" header, installed section at top, available section below, detail drill-down still works

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
