### PR TITLE
Fix credential prompt abort handling and add safety explainer

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -282,9 +282,14 @@ describe('AgentLoop', () => {
     // The loop should exit quickly (~50ms for abort), not wait 10s for the tool
     expect(elapsed).toBeLessThan(2000);
 
-    // Only the user message + assistant tool_use message should be in history
-    // (no tool results since abort interrupted before tool completed)
-    expect(history).toHaveLength(2);
+    // User message + assistant tool_use + synthesized cancellation tool_result
+    expect(history).toHaveLength(3);
+    const lastMsg = history[2];
+    expect(lastMsg.role).toBe('user');
+    expect(lastMsg.content).toHaveLength(1);
+    expect(lastMsg.content[0].type).toBe('tool_result');
+    expect((lastMsg.content[0] as { type: 'tool_result'; tool_use_id: string; content: string; is_error: boolean }).content).toBe('Cancelled by user');
+    expect((lastMsg.content[0] as { type: 'tool_result'; tool_use_id: string; content: string; is_error: boolean }).is_error).toBe(true);
   });
 
   // 7. Events — verify text_delta and other events are emitted

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -75,6 +75,7 @@ export class AgentLoop {
       if (signal?.aborted) break;
 
       const turnStart = Date.now();
+      let toolUseBlocks: Extract<ContentBlock, { type: 'tool_use' }>[] = [];
 
       try {
         const providerConfig: Record<string, unknown> = { max_tokens: this.config.maxTokens };
@@ -181,7 +182,7 @@ export class AgentLoop {
         onEvent({ type: 'message_complete', message: assistantMessage });
 
         // Check for tool use
-        const toolUseBlocks = response.content.filter(
+        toolUseBlocks = response.content.filter(
           (block): block is Extract<ContentBlock, { type: 'tool_use' }> =>
             block.type === 'tool_use',
         );
@@ -334,8 +335,21 @@ export class AgentLoop {
           }
         }
       } catch (error) {
-        // Abort errors are expected when user cancels — don't emit as errors
-        if (signal?.aborted) break;
+        // Abort errors are expected when user cancels — synthesize
+        // cancellation tool_results so the history stays valid for the
+        // Anthropic API (every tool_use must have a matching tool_result).
+        if (signal?.aborted) {
+          if (toolUseBlocks.length > 0) {
+            const cancelledBlocks: ContentBlock[] = toolUseBlocks.map((toolUse) => ({
+              type: 'tool_result' as const,
+              tool_use_id: toolUse.id,
+              content: 'Cancelled by user',
+              is_error: true,
+            }));
+            history.push({ role: 'user', content: cancelledBlocks });
+          }
+          break;
+        }
         const err = error instanceof Error ? error : new Error(String(error));
         rlog.error({ err, turn: toolUseTurns, messageCount: history.length }, 'Agent loop error during turn processing');
         Sentry.captureException(err);

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -42,8 +42,6 @@ import type {
   RemoveTrustRule,
   UpdateTrustRule,
   BundleAppRequest,
-  OpenBundleRequest,
-  SharedAppsListRequest,
   SharedAppDeleteRequest,
 } from './ipc-protocol.js';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
@@ -1530,7 +1528,6 @@ function handleSharedAppDelete(
 
     ctx.send(socket, { type: 'shared_app_delete_response', success: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, 'Failed to delete shared app');
     ctx.send(socket, { type: 'shared_app_delete_response', success: false });
   }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -39,7 +39,7 @@ final class SecretPromptManager {
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = .preferredContentSize
 
-        let panelHeight: CGFloat = message.description != nil ? 220 : 180
+        let panelHeight: CGFloat = message.description != nil ? 270 : 230
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
             styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -142,6 +142,18 @@ struct SecretPromptView: View {
                 .textFieldStyle(.roundedBorder)
                 .font(VFont.mono)
 
+            // Safety explainer
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                safetyBullet(
+                    icon: "key.fill",
+                    text: "Stored in your Mac's Keychain, not sent to any server"
+                )
+                safetyBullet(
+                    icon: "eye.slash.fill",
+                    text: "The AI never sees this value — only your Mac can read it"
+                )
+            }
+
             if saved {
                 HStack(spacing: VSpacing.xs) {
                     Image(systemName: "checkmark.circle.fill")
@@ -170,5 +182,17 @@ struct SecretPromptView: View {
         .padding(VSpacing.xl)
         .frame(width: 400)
         .vPanelBackground()
+    }
+
+    private func safetyBullet(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundColor(VColor.success)
+                .frame(width: 14, alignment: .center)
+            Text(text)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
     }
 }


### PR DESCRIPTION
The purpose of this PR is to fix a tool_use ordering error when aborting during credential prompts and improve the credential prompt UI with safety messaging for non-technical users.

## Changes Made
- **Fix dangling tool_use blocks on abort** (`loop.ts`): When the user cancels a session while tools are executing (e.g. waiting for a secret prompt), the agent loop now synthesizes `tool_result` blocks before breaking. Previously it broke without them, causing Anthropic API 400 errors on the next request.
- **Add safety explainer to credential prompt** (`SecretPromptManager.swift`): Two clear bullet points below the input field explain that credentials are stored locally in macOS Keychain and never seen by the AI.

## Testing
- TypeScript compiles clean
- macOS app builds successfully

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
