### PR TITLE
Persist scopeId when segment upsert hits conflicts

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -63,6 +63,7 @@ export function indexMessageNow(
       set: {
         text: segment.text,
         tokenEstimate: segment.tokenEstimate,
+        scopeId: input.scopeId ?? 'default',
         updatedAt: now,
       },
     }).run();


### PR DESCRIPTION
## Summary
- Adds `scopeId` to the `onConflictDoUpdate.set` object in `indexMessageNow` so that reindexed/backfilled segments pick up the correct scope instead of retaining a stale `'default'` value.

Addresses review feedback on #1785.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Verified that the `onConflictDoUpdate` set now includes `scopeId: input.scopeId ?? 'default'`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
