### PR TITLE
Pass configured format to trimToTokenBudget

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -281,7 +281,7 @@ export async function buildMemoryRecall(
   }
 
   const mergedCount = merged.length;
-  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens);
+  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens, config.memory.retrieval.injectionFormat);
   markItemUsage(selected);
 
   const injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
@@ -1056,11 +1056,11 @@ async function rerankWithLLM(
   return reranked.map((r) => r.candidate);
 }
 
-function trimToTokenBudget(candidates: Candidate[], maxTokens: number): Candidate[] {
+function trimToTokenBudget(candidates: Candidate[], maxTokens: number, format: string = 'markdown'): Candidate[] {
   if (maxTokens <= 0) return [];
   const selected: Candidate[] = [];
   for (const candidate of candidates) {
-    const tentativeText = buildInjectedText([...selected, candidate]);
+    const tentativeText = buildInjectedText([...selected, candidate], format);
     const cost = estimateTextTokens(tentativeText);
     if (cost > maxTokens) continue;
     selected.push(candidate);


### PR DESCRIPTION
## Summary
- `trimToTokenBudget` was calling `buildInjectedText` without the `format` parameter, defaulting to `'markdown'` even when `injectionFormat` is `'structured_v1'`
- This caused the token budget check to estimate costs in markdown while actual injection uses structured format, leading to over/under-selection near the token limit
- Now passes the configured `injectionFormat` through to `trimToTokenBudget` → `buildInjectedText` so the budget estimation matches the actual output format

Addresses feedback on #1779.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify token budget selection accuracy with `structured_v1` format near the limit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
