### PR TITLE
Filter direct item candidates by excluded message IDs and add graceful degradation

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -128,7 +128,20 @@ async function collectAndMergeCandidates(
   }
 
   // Direct item search supplements FTS with LIKE-based matching
-  const directItems = directItemSearch(query, Math.max(10, config.memory.retrieval.lexicalTopK), scopeIds);
+  let directItems = directItemSearch(query, Math.max(10, config.memory.retrieval.lexicalTopK), scopeIds);
+
+  // Filter direct items by excluded message IDs — items whose only evidence
+  // comes from excluded messages should not leak back into recall.
+  if (excludeMessageIds.length > 0 && directItems.length > 0) {
+    const db = getDb();
+    directItems = directItems.filter((candidate) => {
+      const sources = db.select().from(memoryItemSources)
+        .where(eq(memoryItemSources.memoryItemId, candidate.id)).all();
+      if (sources.length === 0) return true;
+      const nonExcluded = sources.filter((s) => !excludeMessageIds.includes(s.messageId));
+      return nonExcluded.length > 0;
+    });
+  }
 
   const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness);
 
@@ -1399,12 +1412,19 @@ export async function searchMemoryItems(
     }
   }
 
-  const { merged } = await collectAndMergeCandidates(trimmed, config, {
-    queryVector,
-    provider,
-    model,
-    scopeId,
-  });
+  let merged: Candidate[];
+  try {
+    const result = await collectAndMergeCandidates(trimmed, config, {
+      queryVector,
+      provider,
+      model,
+      scopeId,
+    });
+    merged = result.merged;
+  } catch (err) {
+    log.warn({ err }, 'Memory search retrieval failed, returning empty results');
+    return [];
+  }
 
   return merged.slice(0, limit).map((c) => ({
     id: c.id,


### PR DESCRIPTION
## Summary
- **P1 fix**: `directItemSearch()` results are now filtered by `excludeMessageIds` — items whose only evidence comes from excluded messages no longer leak back into recall
- **P2 fix**: `searchMemoryItems()` now wraps `collectAndMergeCandidates()` in try/catch, returning empty results instead of a hard failure when Qdrant is unavailable

Addresses review feedback from #1776.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm direct item search respects message exclusion by checking that items sourced only from excluded messages are filtered
- [ ] Confirm `memory_search` returns empty results (not an error) when Qdrant is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
