### PR TITLE
Fix superseded-item test to assert against recalled text

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -313,13 +313,15 @@ describe('Memory Recall Quality', () => {
       expect(recall.injectedText).toContain('neovim');
       expect(recall.injectedText).toContain('LazyVim');
 
-      // Superseded preference should NOT appear as a memory item
-      // (it may appear as a raw segment, but the item-based recall should not include it)
+      // Superseded preference should NOT appear in recalled item lines.
+      // Assert against the actual statement text unique to the superseded item
+      // ("prefers vim for") rather than an internal candidate key, which is
+      // never emitted in the formatted recall output.
       const itemLines = recall.injectedText
         .split('\n')
         .filter((line) => line.includes('<kind>'));
       const hasSupersededItem = itemLines.some(
-        (line) => line.includes('item:item-old-pref'),
+        (line) => line.includes('prefers vim for'),
       );
       expect(hasSupersededItem).toBe(false);
     });


### PR DESCRIPTION
## Summary

- The superseded-item suppression test was checking for the internal candidate key `item:item-old-pref` in formatted recall output, but `buildInjectedText` never emits candidate keys — it formats lines as `- <kind>...</kind> text`. The assertion always passed trivially and could never detect a regression.
- Changed the assertion to check for the unique superseded statement substring `"prefers vim for"` in item-formatted lines, which will correctly fail if the superseded item leaks into recall output.

Addresses review feedback on #1772.

## Test plan

- [x] All 11 tests in `memory-recall-quality.test.ts` pass
- [x] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
