### PR TITLE
Preserve bare IDs in memory_search and accept typed IDs in memory_update

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -37,7 +37,7 @@ export async function handleMemorySearch(
     for (const result of results) {
       const timeAgo = formatRelativeTime(result.createdAt);
       lines.push(`- **[${result.kind}]** ${result.text}`);
-      lines.push(`  _Source: ${result.type}:${result.id} | ${timeAgo} | confidence: ${result.confidence.toFixed(2)} | importance: ${result.importance.toFixed(2)}_`);
+      lines.push(`  _ID: ${result.id} | source: ${result.type} | ${timeAgo} | confidence: ${result.confidence.toFixed(2)} | importance: ${result.importance.toFixed(2)}_`);
     }
 
     return { content: lines.join('\n'), isError: false };
@@ -146,10 +146,13 @@ export async function handleMemoryUpdate(
   args: Record<string, unknown>,
   _config: AssistantConfig,
 ): Promise<ToolExecutionResult> {
-  const memoryId = args.memory_id;
-  if (typeof memoryId !== 'string' || memoryId.trim().length === 0) {
+  const rawMemoryId = args.memory_id;
+  if (typeof rawMemoryId !== 'string' || rawMemoryId.trim().length === 0) {
     return { content: 'Error: memory_id is required and must be a non-empty string', isError: true };
   }
+
+  // Accept both bare IDs and typed IDs (e.g. "item:abc-123" -> "abc-123")
+  const memoryId = stripTypedIdPrefix(rawMemoryId.trim());
 
   const statement = args.statement;
   if (typeof statement !== 'string' || statement.trim().length === 0) {
@@ -161,7 +164,7 @@ export async function handleMemoryUpdate(
     const existing = db
       .select()
       .from(memoryItems)
-      .where(eq(memoryItems.id, memoryId.trim()))
+      .where(eq(memoryItems.id, memoryId))
       .get();
 
     if (!existing) {
@@ -216,4 +219,13 @@ function inferSubjectFromStatement(statement: string): string {
   // Take first few words as a subject label
   const words = statement.split(/\s+/).slice(0, 6).join(' ');
   return words.slice(0, 80);
+}
+
+/**
+ * Strip a typed ID prefix (e.g. "item:abc-123" -> "abc-123") so that IDs
+ * copied from memory_search output work in memory_update.
+ */
+function stripTypedIdPrefix(id: string): string {
+  const match = id.match(/^(?:item|segment|summary):(.+)$/);
+  return match ? match[1] : id;
 }


### PR DESCRIPTION
## Summary
- Fix memory_search output to show bare ID separately (`ID: <id> | source: <type>`) instead of only the typed format (`type:id`)
- Make memory_update accept both bare IDs (`abc-123`) and typed IDs (`item:abc-123`) by stripping known prefixes
- Addresses codex review feedback on #1777: the documented memory_search -> memory_update flow now works reliably

## Test plan
- [ ] Verify memory_search output shows `ID: <bare-id> | source: <type>` format
- [ ] Verify memory_update works with bare IDs (existing behavior)
- [ ] Verify memory_update works with typed IDs like `item:abc-123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
