### PR TITLE
Strip assistant ack when recall block is in merged multi-block user message

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -385,8 +385,22 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   }
   if (targetIndex === -1) return messages;
 
+  // Check if the message after targetIndex is the assistant ack from a
+  // merged separate-context injection (deepRepairHistory can merge the
+  // standalone recall user message into an adjacent user message, leaving
+  // the ack orphaned).
+  const ackIndex =
+    targetIndex + 1 < messages.length &&
+    messages[targetIndex + 1].role === 'assistant' &&
+    messages[targetIndex + 1].content.length === 1 &&
+    messages[targetIndex + 1].content[0].type === 'text' &&
+    messages[targetIndex + 1].content[0].text === MEMORY_CONTEXT_ACK
+      ? targetIndex + 1
+      : -1;
+
   const cleaned: T[] = [];
   for (let index = 0; index < messages.length; index++) {
+    if (index === ackIndex) continue;
     const message = messages[index];
     if (index !== targetIndex) {
       cleaned.push(message);


### PR DESCRIPTION
## Summary
- Fixes the separate-context stripping fallback path in `stripMemoryRecallMessages` to also remove the synthetic assistant ack (`[Memory context loaded.]`) when the recall text is found inside a multi-block user message (caused by `deepRepairHistory` merging consecutive user messages).
- Previously, only the recall text block was removed, leaving the ack turn in history which could alter subsequent model behavior.

Addresses feedback on #1780.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing strip tests pass (5/5)
- [x] Existing separate-context and prepend-block stripping tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
