### PR TITLE
Restrict trust weight penalty to item candidates only

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -875,10 +875,10 @@ function mergeCandidates(
     const accessCount = meta?.accessCount ?? 0;
     const effectiveImportance = Math.min(1, row.importance + 0.03 * accessCount);
 
-    // Trust-aware ranking: items with higher verification state rank higher
-    const trustWeight = meta
+    // Trust-aware ranking: only apply to item candidates (segments/summaries have no metadata)
+    const trustWeight = (row.type === 'item' && meta)
       ? (TRUST_WEIGHTS[meta.verificationState] ?? DEFAULT_TRUST_WEIGHT)
-      : DEFAULT_TRUST_WEIGHT;
+      : 1.0;
 
     // Freshness decay: down-rank stale items unless recently reinforced
     const freshnessWeight = computeFreshnessWeight(row, accessCount, freshnessConfig);


### PR DESCRIPTION
## Summary
- Fixes the systematic 0.85x penalty on non-item candidates (segments, summaries) introduced in #1783
- Non-item candidates never have metadata from `lookupItemMetadata`, so they were always falling through to `DEFAULT_TRUST_WEIGHT` (0.85)
- Now non-item candidates get a neutral `1.0` weight, restricting trust-aware ranking to item candidates only

Addresses review feedback from codex and devin on #1783.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify segment/summary candidates are no longer penalized relative to items in retrieval results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
