### PR TITLE
Use local @State for trust rules sheet presentation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,6 +12,7 @@ struct SettingsPanel: View {
     @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
+    @State private var showTrustRulesSheet: Bool = false
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -218,17 +219,14 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                daemonClient.isTrustRulesSheetOpen = true
+                                showTrustRulesSheet = true
                             }
-                            .disabled(daemonClient.isTrustRulesSheetOpen)
+                            .disabled(showTrustRulesSheet)
                         }
                     }
                     .padding(VSpacing.lg)
                     .vCard(background: Slate._900)
-                    .sheet(isPresented: Binding(
-                        get: { daemonClient.isTrustRulesSheetOpen },
-                        set: { daemonClient.isTrustRulesSheetOpen = $0 }
-                    )) {
+                    .sheet(isPresented: $showTrustRulesSheet) {
                         TrustRulesView(daemonClient: daemonClient)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -18,6 +18,7 @@ public struct SettingsView: View {
     }()
     @State private var showingPrivacy = false
     @State private var showingSkills = false
+    @State private var showingTrustRules = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
@@ -222,14 +223,11 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            daemonClient.isTrustRulesSheetOpen = true
+                            showingTrustRules = true
                         }
-                        .disabled(daemonClient.isTrustRulesSheetOpen)
+                        .disabled(showingTrustRules)
                     }
-                    .sheet(isPresented: Binding(
-                        get: { daemonClient.isTrustRulesSheetOpen },
-                        set: { daemonClient.isTrustRulesSheetOpen = $0 }
-                    )) {
+                    .sheet(isPresented: $showingTrustRules) {
                         TrustRulesView(daemonClient: daemonClient)
                     }
                 }

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -26,9 +26,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published var isConnected: Bool = false
 
-    /// Shared flag so only one TrustRulesView sheet is open at a time across SettingsPanel and SettingsView.
-    @Published var isTrustRulesSheetOpen: Bool = false
-
     // MARK: - Surface Event Callbacks
 
     /// Called when the daemon sends a `ui_surface_show` message.


### PR DESCRIPTION
## Summary

- Replace shared `DaemonClient.isTrustRulesSheetOpen` flag with local `@State` in both `SettingsPanel` and `SettingsView`
- Remove the now-unused `isTrustRulesSheetOpen` published property from `DaemonClient`
- Each view now independently manages its own trust rules sheet lifecycle, preventing the dual-presentation bug when both settings surfaces are open simultaneously

## Problem

Both `SettingsPanel` (side panel) and `SettingsView` (Cmd+, window) drove `.sheet(isPresented:)` from the same shared `DaemonClient.isTrustRulesSheetOpen` boolean. This caused two issues:

1. Neither view used `@ObservedObject` for `daemonClient` (it's optional), so changes to the flag from one view wouldn't trigger re-render in the other
2. Even if observation worked, a shared flag would present `TrustRulesView` in **both** places simultaneously when both windows are open

## Fix

Use a local `@State private var showTrustRulesSheet` / `showingTrustRules` in each view, following the same pattern used for other sheets (e.g., `showingSkills`, `showingPrivacy` in `SettingsView`).

Addresses feedback from PR #1773.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
