### PR TITLE
Base reinforcement shield on lastUsedAt instead of item age/lastSeenAt

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1554,6 +1554,36 @@ describe('Memory V2 regressions', () => {
     expect(freshItem!.invalidAt).toBeNull();
   });
 
+  test('sweepStaleItems shields items with recent lastUsedAt', () => {
+    const db = getDb();
+    const now = Date.now();
+    const MS_PER_DAY = 86_400_000;
+
+    // Old event (100 days) but recently retrieved (lastUsedAt = 2 days ago)
+    // reinforcementShieldDays defaults to 14, so this should be shielded
+    db.insert(memoryItems).values({
+      id: 'item-sweep-shielded',
+      kind: 'event',
+      subject: 'sweep shield test',
+      statement: 'Old event that was recently used',
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: 'fp-sweep-shielded',
+      firstSeenAt: now - 100 * MS_PER_DAY,
+      lastSeenAt: now - 100 * MS_PER_DAY,
+      lastUsedAt: now - 2 * MS_PER_DAY,
+      accessCount: 3,
+      verificationState: 'assistant_inferred',
+    }).run();
+
+    const marked = sweepStaleItems(DEFAULT_CONFIG);
+
+    const shieldedItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-sweep-shielded')).get();
+    expect(shieldedItem).toBeDefined();
+    expect(shieldedItem!.invalidAt).toBeNull();
+  });
+
   test('scope columns: memory items default to scope_id=default', () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -723,7 +723,7 @@ export function sweepStaleItems(config: AssistantConfig): number {
         AND status = 'active'
         AND invalid_at IS NULL
         AND last_seen_at < ?
-        AND (access_count = 0 OR last_seen_at < ?)
+        AND (access_count = 0 OR COALESCE(last_used_at, 0) < ?)
     `).run(now, kind, cutoffMs, shieldCutoffMs);
     if (result.changes > 0) {
       log.info({ kind, marked: result.changes, cutoffMs }, 'Marked stale memory items as invalid');

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -854,7 +854,8 @@ function mergeCandidates(
       : DEFAULT_TRUST_WEIGHT;
 
     // Freshness decay: down-rank stale items unless recently reinforced
-    const freshnessWeight = computeFreshnessWeight(row, accessCount, freshnessConfig);
+    const lastUsedAt = meta?.lastUsedAt ?? null;
+    const freshnessWeight = computeFreshnessWeight(row, accessCount, lastUsedAt, freshnessConfig);
 
     row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight * freshnessWeight;
   }
@@ -889,6 +890,7 @@ function buildRankMap(candidates: Candidate[], scoreAccessor: (c: Candidate) => 
 
 interface ItemMetadata {
   accessCount: number;
+  lastUsedAt: number | null;
   verificationState: string;
 }
 
@@ -904,6 +906,7 @@ function lookupItemMetadata(itemIds: string[]): Map<string, ItemMetadata> {
       .select({
         id: memoryItems.id,
         accessCount: memoryItems.accessCount,
+        lastUsedAt: memoryItems.lastUsedAt,
         verificationState: memoryItems.verificationState,
       })
       .from(memoryItems)
@@ -912,6 +915,7 @@ function lookupItemMetadata(itemIds: string[]): Map<string, ItemMetadata> {
     for (const row of rows) {
       metadata.set(row.id, {
         accessCount: row.accessCount,
+        lastUsedAt: row.lastUsedAt,
         verificationState: row.verificationState,
       });
     }
@@ -938,12 +942,13 @@ const MS_PER_DAY = 86_400_000;
 /**
  * Compute a freshness weight for a candidate based on its kind and age.
  * Returns 1.0 for fresh items and `staleDecay` for items past their window.
- * Items with recent reinforcement (accessCount > 0 and within shield window)
- * are shielded from decay.
+ * Items with recent reinforcement (accessed via lastUsedAt within the shield
+ * window) are shielded from decay.
  */
 function computeFreshnessWeight(
   candidate: { type: string; kind: string; createdAt: number },
   accessCount: number,
+  lastUsedAt: number | null,
   config?: { enabled: boolean; maxAgeDays: Record<string, number>; staleDecay: number; reinforcementShieldDays: number },
 ): number {
   if (!config?.enabled) return 1.0;
@@ -961,10 +966,10 @@ function computeFreshnessWeight(
 
   if (ageDays <= maxAgeDays) return 1.0;
 
-  // Check reinforcement shield: recently accessed items are protected
-  if (accessCount > 0 && config.reinforcementShieldDays > 0) {
-    const shieldMs = config.reinforcementShieldDays * MS_PER_DAY;
-    if (ageMs - maxAgeDays * MS_PER_DAY < shieldMs) return 1.0;
+  // Check reinforcement shield: items retrieved within the shield window are protected
+  if (accessCount > 0 && lastUsedAt != null && config.reinforcementShieldDays > 0) {
+    const shieldCutoff = now - config.reinforcementShieldDays * MS_PER_DAY;
+    if (lastUsedAt >= shieldCutoff) return 1.0;
   }
 
   return config.staleDecay;


### PR DESCRIPTION
## Summary
- **Retriever freshness shield**: `computeFreshnessWeight` now checks `lastUsedAt` against the shield window cutoff instead of computing `ageMs - maxAgeDays`, which incorrectly based the shield on item creation time rather than actual retrieval time
- **Stale sweep shield**: `sweepStaleItems` SQL condition changed from `last_seen_at < ?` to `COALESCE(last_used_at, 0) < ?` for the reinforcement check, preventing actively-retrieved items from being permanently invalidated
- **Metadata enrichment**: `lookupItemMetadata` now fetches `lastUsedAt` to support the corrected shield logic
- Added regression test verifying that old items with recent `lastUsedAt` are shielded from the stale sweep

Addresses review feedback on #1784.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing `sweepStaleItems marks deeply stale items as invalid` test passes
- [x] New `sweepStaleItems shields items with recent lastUsedAt` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
