### PR TITLE
Fix Trust Rules sheet unresponsive dismiss on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -202,7 +202,7 @@ struct SettingsPanel: View {
                 .vCard(background: Slate._900)
 
                 // TRUST RULES section
-                if let daemonClient {
+                if daemonClient != nil {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("TRUST RULES")
                             .font(VFont.sectionTitle)
@@ -226,9 +226,6 @@ struct SettingsPanel: View {
                     }
                     .padding(VSpacing.lg)
                     .vCard(background: Slate._900)
-                    .sheet(isPresented: $showTrustRulesSheet) {
-                        TrustRulesView(daemonClient: daemonClient)
-                    }
                 }
 
                 // PRIVACY & SECURITY section
@@ -256,6 +253,11 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
+        }
+        .sheet(isPresented: $showTrustRulesSheet) {
+            if let daemonClient {
+                TrustRulesView(daemonClient: daemonClient)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -204,13 +204,6 @@ public struct SettingsView: View {
                             showingSkills = true
                         }
                     }
-                    .sheet(isPresented: $showingSkills, onDismiss: {
-                        skillsViewModel = nil
-                    }) {
-                        if let vm = skillsViewModel {
-                            SkillsSettingsView(viewModel: vm)
-                        }
-                    }
                 }
 
                 Section("Trust Rules") {
@@ -226,9 +219,6 @@ public struct SettingsView: View {
                             showingTrustRules = true
                         }
                         .disabled(showingTrustRules)
-                    }
-                    .sheet(isPresented: $showingTrustRules) {
-                        TrustRulesView(daemonClient: daemonClient)
                     }
                 }
             }
@@ -259,6 +249,18 @@ public struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
+        }
+        .sheet(isPresented: $showingSkills, onDismiss: {
+            skillsViewModel = nil
+        }) {
+            if let vm = skillsViewModel {
+                SkillsSettingsView(viewModel: vm)
+            }
+        }
+        .sheet(isPresented: $showingTrustRules) {
+            if let daemonClient {
+                TrustRulesView(daemonClient: daemonClient)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Move `.sheet` modifiers from inside `ScrollView`/`Form` content to the top-level view body in both `SettingsPanel` and `SettingsView`
- On macOS, `.sheet(isPresented:)` inside scrollable containers loses its binding connection, causing `@Environment(\.dismiss)` to silently fail — the Done button becomes unresponsive and the sheet can't be closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
