### PR TITLE
Apply scope filter to segment and summary semantic candidates

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -7,7 +7,7 @@ import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
-import { memoryItems, memoryItemSources, memorySegments } from './schema.js';
+import { memoryItems, memoryItemSources, memorySegments, memorySummaries } from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_OPEN_TAG = '<memory source="long_term_memory" confidence="approximate">';
@@ -608,6 +608,10 @@ async function semanticSearch(
         finalScore: 0,
       });
     } else if (payload.target_type === 'summary') {
+      if (scopeIds) {
+        const summary = db.select().from(memorySummaries).where(eq(memorySummaries.id, payload.target_id)).get();
+        if (!summary || !scopeIds.includes(summary.scopeId)) continue;
+      }
       candidates.push({
         key: `summary:${payload.target_id}`,
         type: 'summary',
@@ -623,6 +627,10 @@ async function semanticSearch(
         finalScore: 0,
       });
     } else {
+      if (scopeIds) {
+        const segment = db.select().from(memorySegments).where(eq(memorySegments.id, payload.target_id)).get();
+        if (!segment || !scopeIds.includes(segment.scopeId)) continue;
+      }
       candidates.push({
         key: `segment:${payload.target_id}`,
         type: 'segment',


### PR DESCRIPTION
Fixes cross-scope data leakage in semantic search. When `scopeIds` is provided to `semanticSearch()`, only item-type candidates were filtered by scope. Segment and summary candidates returned from Qdrant were added unconditionally.

Now segment and summary candidates are looked up from their backing DB tables (`memorySegments` / `memorySummaries`) and their `scopeId` is checked against the allowed set before inclusion — matching the existing item-type behavior.

Addresses review feedback on #1787.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
