### PR TITLE
Overfetch direct-item hits and propagate DB errors in memory_search

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -127,8 +127,14 @@ async function collectAndMergeCandidates(
     entity = entitySearch(query, scopeIds);
   }
 
-  // Direct item search supplements FTS with LIKE-based matching
-  let directItems = directItemSearch(query, Math.max(10, config.memory.retrieval.lexicalTopK), scopeIds);
+  // Direct item search supplements FTS with LIKE-based matching.
+  // Overfetch when exclusions are present so that filtering doesn't
+  // silently drop valid candidates just below the SQL LIMIT cutoff.
+  const directLimit = Math.max(10, config.memory.retrieval.lexicalTopK);
+  const directFetchLimit = excludeMessageIds.length > 0
+    ? Math.max(directLimit + 24, directLimit * 2)
+    : directLimit;
+  let directItems = directItemSearch(query, directFetchLimit, scopeIds);
 
   // Filter direct items by excluded message IDs — items whose only evidence
   // comes from excluded messages should not leak back into recall.
@@ -141,6 +147,7 @@ async function collectAndMergeCandidates(
       const nonExcluded = sources.filter((s) => !excludeMessageIds.includes(s.messageId));
       return nonExcluded.length > 0;
     });
+    directItems = directItems.slice(0, directLimit);
   }
 
   const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness);
@@ -1431,19 +1438,13 @@ export async function searchMemoryItems(
     }
   }
 
-  let merged: Candidate[];
-  try {
-    const result = await collectAndMergeCandidates(trimmed, config, {
-      queryVector,
-      provider,
-      model,
-      scopeId,
-    });
-    merged = result.merged;
-  } catch (err) {
-    log.warn({ err }, 'Memory search retrieval failed, returning empty results');
-    return [];
-  }
+  const result = await collectAndMergeCandidates(trimmed, config, {
+    queryVector,
+    provider,
+    model,
+    scopeId,
+  });
+  const merged = result.merged;
 
   return merged.slice(0, limit).map((c) => ({
     id: c.id,


### PR DESCRIPTION
## Summary
Addresses feedback from [#1794](https://github.com/vellum-ai/vellum-assistant/pull/1794):

- **Overfetch direct-item hits before excluding messages** — `directItemSearch()` results were filtered after applying the SQL `LIMIT`, so if excluded-message items dominated the newest matches, valid non-excluded items just below that cutoff were never considered. Now overfetches (`limit*2` or `limit+24`, whichever is larger) when exclusions are present, matching the pattern already used by `lexicalSearch` and `semanticSearch`. After filtering, results are truncated back to the original limit.

- **Propagate non-semantic retrieval failures in memory_search** — The blanket `catch` around `collectAndMergeCandidates()` in `searchMemoryItems()` masked real outages (e.g. local DB failures) as successful empty results. Removed the catch so DB errors propagate to callers. Semantic/Qdrant failures are already caught and handled gracefully within `collectAndMergeCandidates` itself.

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify `directItemSearch` overfetch logic matches `lexicalSearch` pattern (same `max(limit+24, limit*2)` formula)
- [ ] Verify DB errors from `collectAndMergeCandidates` now propagate in `searchMemoryItems`
- [ ] Verify semantic errors are still gracefully degraded (caught inside `collectAndMergeCandidates`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
