### PR TITLE
Gate ack stripping to separate_context_message injection strategy

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -730,7 +730,7 @@ export class Session {
       // (beyond the repaired prefix) are carried forward.
       const newMessages = updatedHistory.slice(preRunHistoryLength);
       const restoredHistory = [...preRepairMessages, ...newMessages];
-      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText);
+      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, runtimeConfig.memory.retrieval.injectionStrategy);
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent');
 

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -348,6 +348,7 @@ const MEMORY_CONTEXT_ACK = '[Memory context loaded.]';
 export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'; content: Array<{ type: string; text?: string }> }>(
   messages: T[],
   memoryRecallText?: string,
+  injectionStrategy?: 'prepend_user_block' | 'separate_context_message',
 ): T[] {
   const recallText = memoryRecallText ?? '';
   if (recallText.trim().length === 0) return messages;
@@ -401,8 +402,11 @@ export function stripMemoryRecallMessages<T extends { role: 'user' | 'assistant'
   // Check if the message after targetIndex is the assistant ack from a
   // merged separate-context injection (deepRepairHistory can merge the
   // standalone recall user message into an adjacent user message, leaving
-  // the ack orphaned).
+  // the ack orphaned). Only check when the injection strategy is
+  // separate_context_message — prepend_user_block never injects a
+  // synthetic ack, so stripping here would delete a real assistant reply.
   const ackIndex =
+    injectionStrategy !== 'prepend_user_block' &&
     targetIndex + 1 < messages.length &&
     messages[targetIndex + 1].role === 'assistant' &&
     messages[targetIndex + 1].content.length === 1 &&


### PR DESCRIPTION
## Summary

- `stripMemoryRecallMessages` now accepts an `injectionStrategy` parameter
- The fallback path's ack-stripping logic is skipped when using `prepend_user_block`, since that strategy never injects a synthetic assistant ack turn
- Prevents accidental deletion of a real assistant response that happens to equal `[Memory context loaded.]`

Addresses feedback from #1798.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- Existing tests cover both `separate_context_message` and `prepend_user_block` stripping paths
- The `separate_context_message` ack stripping behavior is unchanged
- In `prepend_user_block` mode, a legitimate assistant reply matching the ack text is no longer stripped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
