### PR TITLE
Fix sweepStaleItems shield test passing vacuously due to throttle

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -51,7 +51,7 @@ import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
 import { claimMemoryJobs, enqueueMemoryJob } from '../memory/jobs-store.js';
-import { currentWeekWindow, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
+import { currentWeekWindow, resetStaleSweepThrottle, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
   escapeXmlTags,
@@ -1589,7 +1589,12 @@ describe('Memory V2 regressions', () => {
       verificationState: 'assistant_inferred',
     }).run();
 
+    // Reset throttle so the sweep actually executes (the previous test set lastStaleSweepMs)
+    resetStaleSweepThrottle();
     const marked = sweepStaleItems(DEFAULT_CONFIG);
+
+    // Sweep ran but shielded item was not marked — should return 0
+    expect(marked).toBe(0);
 
     const shieldedItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-sweep-shielded')).get();
     expect(shieldedItem).toBeDefined();

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -690,6 +690,11 @@ function weekNumber(date: Date): number {
 const STALE_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 let lastStaleSweepMs = 0;
 
+/** Reset the sweep throttle so tests can call sweepStaleItems back-to-back. */
+export function resetStaleSweepThrottle(): void {
+  lastStaleSweepMs = 0;
+}
+
 /**
  * Mark deeply stale memory items as invalid. An item is considered deeply
  * stale when it has exceeded 2x its freshness window for its kind and has


### PR DESCRIPTION
## Summary
- Exported `resetStaleSweepThrottle()` from `jobs-worker.ts` so tests can reset the module-level throttle between sweep calls
- Called `resetStaleSweepThrottle()` before the shield test to ensure the sweep actually executes
- Added assertion that `sweepStaleItems` returns 0 (sweep ran but the shielded item was not invalidated)

Addresses review feedback on #1801 from both devin-ai-integration and chatgpt-codex-connector.

## Test plan
- [x] `bun test --test-name-pattern "sweepStaleItems"` — both sweep tests pass with 8 assertions
- [x] Type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
