### PR TITLE
Prevent concurrent Trust Rules sheets via shared DaemonClient flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,7 +12,6 @@ struct SettingsPanel: View {
     @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
     @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
-    @State private var showTrustRulesSheet: Bool = false
 
     var body: some View {
         VSidePanel(title: "Settings", onClose: onClose) {
@@ -219,9 +218,9 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                showTrustRulesSheet = true
+                                daemonClient?.isTrustRulesSheetOpen = true
                             }
-                            .disabled(showTrustRulesSheet)
+                            .disabled(daemonClient?.isTrustRulesSheetOpen == true)
                         }
                     }
                     .padding(VSpacing.lg)
@@ -254,7 +253,10 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
-        .sheet(isPresented: $showTrustRulesSheet) {
+        .sheet(isPresented: Binding(
+            get: { daemonClient?.isTrustRulesSheetOpen ?? false },
+            set: { daemonClient?.isTrustRulesSheetOpen = $0 }
+        )) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -18,7 +18,6 @@ public struct SettingsView: View {
     }()
     @State private var showingPrivacy = false
     @State private var showingSkills = false
-    @State private var showingTrustRules = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
@@ -216,9 +215,9 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            showingTrustRules = true
+                            daemonClient.isTrustRulesSheetOpen = true
                         }
-                        .disabled(showingTrustRules)
+                        .disabled(daemonClient.isTrustRulesSheetOpen)
                     }
                 }
             }
@@ -257,7 +256,10 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .sheet(isPresented: $showingTrustRules) {
+        .sheet(isPresented: Binding(
+            get: { daemonClient?.isTrustRulesSheetOpen ?? false },
+            set: { daemonClient?.isTrustRulesSheetOpen = $0 }
+        )) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -66,6 +66,9 @@ struct TrustRulesView: View {
             }
             loadRules()
         }
+        .onDisappear {
+            daemonClient.onTrustRulesListResponse = nil
+        }
         .sheet(isPresented: $showingAddSheet) {
             TrustRuleFormView(daemonClient: daemonClient) {
                 loadRules()

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -26,6 +26,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published var isConnected: Bool = false
 
+    /// Shared flag so only one TrustRulesView sheet is open at a time across SettingsPanel and SettingsView.
+    /// Both surfaces bind to this instead of local @State, preventing the second sheet from overwriting
+    /// the first sheet's `onTrustRulesListResponse` callback on DaemonClient.
+    @Published var isTrustRulesSheetOpen: Bool = false
+
     // MARK: - Surface Event Callbacks
 
     /// Called when the daemon sends a `ui_surface_show` message.


### PR DESCRIPTION
## Summary
- Restores a shared `@Published isTrustRulesSheetOpen` flag on `DaemonClient` so both `SettingsPanel` and `SettingsView` bind to it, preventing two Trust Rules sheets from opening simultaneously
- The underlying issue: `TrustRulesView.onAppear` sets `daemonClient.onTrustRulesListResponse` — a single callback slot — so the second sheet overwrites the first's response handler, causing stale or missing UI updates
- Also clears the callback on `onDisappear` to prevent stale handlers after sheet dismissal

Addresses feedback on #1800.

## Test plan
- [ ] Open Trust Rules from SettingsPanel (side panel) — verify sheet opens
- [ ] While sheet is open, check that the "Manage Trust Rules..." button in SettingsView (settings window) is disabled
- [ ] Dismiss the sheet, then open from SettingsView — verify it works
- [ ] Verify rules load and display correctly in the sheet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
