### PR TITLE
Move Privacy sheet out of Form to fix dismiss on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -232,9 +232,6 @@ public struct SettingsView: View {
                     showingPrivacy = true
                 }
                 .font(.caption)
-                .sheet(isPresented: $showingPrivacy) {
-                    PrivacyDetailView()
-                }
             }
         }
         .formStyle(.grouped)
@@ -263,6 +260,9 @@ public struct SettingsView: View {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
+        }
+        .sheet(isPresented: $showingPrivacy) {
+            PrivacyDetailView()
         }
     }
 


### PR DESCRIPTION
## Summary
- Moves the `.sheet(isPresented: $showingPrivacy)` modifier from the "Learn More" Button (inside the `Form`) to the top-level view, alongside the Skills and Trust Rules sheet modifiers
- Fixes `@Environment(\.dismiss)` silently failing on macOS when a `.sheet` is presented from inside a scrollable container (`Form`)
- Addresses review feedback on #1802 (devin-ai-integration bot, P1)

## Test plan
- [ ] Open Settings, scroll to Privacy & Security, click "Learn More"
- [ ] Verify the Privacy sheet opens correctly
- [ ] Click "Done" in the Privacy sheet and verify it dismisses properly

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
