### PR TITLE
Reset sweep throttle in beforeEach to fix first sweep test

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -89,6 +89,7 @@ describe('Memory V2 regressions', () => {
     db.run('DELETE FROM conversations');
     db.run('DELETE FROM memory_jobs');
     db.run('DELETE FROM memory_checkpoints');
+    resetStaleSweepThrottle();
   });
 
   afterAll(() => {
@@ -1589,8 +1590,6 @@ describe('Memory V2 regressions', () => {
       verificationState: 'assistant_inferred',
     }).run();
 
-    // Reset throttle so the sweep actually executes (the previous test set lastStaleSweepMs)
-    resetStaleSweepThrottle();
     const marked = sweepStaleItems(DEFAULT_CONFIG);
 
     // Sweep ran but shielded item was not marked — should return 0


### PR DESCRIPTION
## Summary
- Moves `resetStaleSweepThrottle()` into the shared `beforeEach` block so both sweep tests in `memory-v2-regressions.test.ts` start with a clean throttle state
- Removes the now-redundant inline `resetStaleSweepThrottle()` call from the second sweep test
- Fixes the issue where `runMemoryJobsOnce()` from earlier tests silently caused the first sweep test to return 0

Addresses feedback on #1808.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [ ] Both sweep tests pass reliably regardless of test execution order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
