### PR TITLE
Observe optional DaemonClient via .onReceive for trust rules sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 @MainActor
@@ -8,6 +9,7 @@ struct SettingsPanel: View {
 
     @State private var apiKeyText: String = ""
     @State private var hasKey: Bool = false
+    @State private var isTrustRulesSheetOpen: Bool = false
     @State private var braveKeyText: String = ""
     @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
@@ -220,7 +222,7 @@ struct SettingsPanel: View {
                             VButton(label: "Manage...", style: .ghost) {
                                 daemonClient?.isTrustRulesSheetOpen = true
                             }
-                            .disabled(daemonClient?.isTrustRulesSheetOpen == true)
+                            .disabled(isTrustRulesSheetOpen)
                         }
                     }
                     .padding(VSpacing.lg)
@@ -253,10 +255,12 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
-        .sheet(isPresented: Binding(
-            get: { daemonClient?.isTrustRulesSheetOpen ?? false },
-            set: { daemonClient?.isTrustRulesSheetOpen = $0 }
-        )) {
+        .onReceive(daemonClient?.objectWillChange.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
+            isTrustRulesSheetOpen = daemonClient?.isTrustRulesSheetOpen ?? false
+        }
+        .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
+            daemonClient?.isTrustRulesSheetOpen = false
+        }) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -1,8 +1,10 @@
+import Combine
 import SwiftUI
 
 public struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
+    @State private var isTrustRulesSheetOpen = false
     @State private var braveKeyText = ""
     @State private var hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
     @State private var maxSteps: Double = {
@@ -217,7 +219,7 @@ public struct SettingsView: View {
                         Button("Manage Trust Rules...") {
                             daemonClient.isTrustRulesSheetOpen = true
                         }
-                        .disabled(daemonClient.isTrustRulesSheetOpen)
+                        .disabled(isTrustRulesSheetOpen)
                     }
                 }
             }
@@ -253,10 +255,12 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .sheet(isPresented: Binding(
-            get: { daemonClient?.isTrustRulesSheetOpen ?? false },
-            set: { daemonClient?.isTrustRulesSheetOpen = $0 }
-        )) {
+        .onReceive(daemonClient?.objectWillChange.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
+            isTrustRulesSheetOpen = daemonClient?.isTrustRulesSheetOpen ?? false
+        }
+        .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
+            daemonClient?.isTrustRulesSheetOpen = false
+        }) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }


### PR DESCRIPTION
## Summary

Fixes the trust rules sheet synchronization issue flagged in #1809.

`DaemonClient` is optional in `SettingsView` and `SettingsPanel`, so it can't be `@ObservedObject`. The previous approach used a manual `Binding(get:set:)` to bridge `daemonClient?.isTrustRulesSheetOpen`, but SwiftUI never re-evaluated the body when the `@Published` property changed because the view didn't observe `objectWillChange`.

This PR replaces the manual Binding with the `.onReceive(daemonClient?.objectWillChange)` pattern (already used in `MainWindowView:83` for `$isConnected`):

- Adds a local `@State private var isTrustRulesSheetOpen` in both views
- Syncs it via `.onReceive(daemonClient?.objectWillChange.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher())`
- Binds `.sheet(isPresented:)` and `.disabled()` to the local `@State`
- Adds `onDismiss` to reset the shared flag when the sheet closes

Both surfaces now properly react to changes from the other, and the `onDismiss` handler ensures the shared flag is always reset.

## Files changed

- `clients/macos/vellum-assistant/Features/Settings/SettingsView.swift`
- `clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift`

## Test plan

- [x] `swift build` succeeds
- [ ] Open trust rules from SettingsPanel — verify sheet opens
- [ ] Open trust rules from SettingsView — verify sheet opens
- [ ] While sheet is open from one surface, verify the button is disabled on the other
- [ ] Dismiss the sheet — verify button re-enables on both surfaces
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
