### PR TITLE
Restore conversation threads from daemon on app launch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -60,6 +60,9 @@ final class ChatViewModel: ObservableObject {
     /// Set by ThreadManager to coordinate routing when multiple ChatViewModels are active.
     var shouldAcceptConfirmation: (() -> Bool)?
 
+    /// Whether this view model has had its history loaded from the daemon.
+    var isHistoryLoaded: Bool = false
+
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
     }
@@ -962,6 +965,38 @@ final class ChatViewModel: ObservableObject {
             inputText = suggestion
         }
         self.suggestion = nil
+    }
+
+    /// Populate messages from history data returned by the daemon.
+    func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
+        var chatMessages: [ChatMessage] = []
+        for item in historyMessages {
+            let role: ChatRole = item.role == "assistant" ? .assistant : .user
+            var toolCalls: [ToolCallData] = []
+            if let historyToolCalls = item.toolCalls {
+                toolCalls = historyToolCalls.map { tc in
+                    ToolCallData(
+                        toolName: toolDisplayName(tc.name),
+                        inputSummary: summarizeToolInput(tc.input),
+                        result: tc.result,
+                        isError: tc.isError ?? false,
+                        isComplete: true
+                    )
+                }
+            }
+            // Skip empty messages (internal tool-result-only turns already filtered by daemon)
+            if item.text.isEmpty && toolCalls.isEmpty { continue }
+            let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
+            let chatMsg = ChatMessage(
+                role: role,
+                text: item.text,
+                timestamp: timestamp,
+                toolCalls: toolCalls
+            )
+            chatMessages.append(chatMsg)
+        }
+        self.messages = chatMessages
+        self.isHistoryLoaded = true
     }
 
     deinit {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -8,12 +8,19 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 final class ThreadManager: ObservableObject {
     @Published var threads: [ThreadModel] = []
     @Published var activeThreadId: UUID? {
-        didSet { subscribeToActiveViewModel() }
+        didSet {
+            subscribeToActiveViewModel()
+            loadHistoryForActiveThreadIfNeeded()
+        }
     }
 
     private var chatViewModels: [UUID: ChatViewModel] = [:]
     private let daemonClient: DaemonClient
     private var viewModelCancellable: AnyCancellable?
+    private var connectionCancellable: AnyCancellable?
+
+    /// Tracks which thread is currently awaiting a history_response from the daemon.
+    private var pendingHistoryThreadId: UUID?
 
     /// Called when an inline confirmation response should dismiss the floating panel.
     var confirmationDismissHandler: ((String) -> Void)?
@@ -27,18 +34,12 @@ final class ThreadManager: ObservableObject {
         self.daemonClient = daemonClient
         // Create one default thread so the window is never empty
         createThread()
+        observeDaemonConnection()
     }
 
     func createThread() {
         let thread = ThreadModel()
-        let viewModel = ChatViewModel(daemonClient: daemonClient)
-        viewModel.onInlineConfirmationResponse = { [weak self] requestId in
-            self?.confirmationDismissHandler?(requestId)
-        }
-        viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
-            guard let self, let viewModel else { return false }
-            return self.isLatestToolUseRecipient(viewModel)
-        }
+        let viewModel = makeViewModel()
         threads.append(thread)
         chatViewModels[thread.id] = viewModel
         activeThreadId = thread.id
@@ -100,7 +101,117 @@ final class ThreadManager: ObservableObject {
         return true
     }
 
+    // MARK: - Session Restoration
+
+    private func observeDaemonConnection() {
+        daemonClient.onSessionListResponse = { [weak self] response in
+            self?.handleSessionListResponse(response)
+        }
+        daemonClient.onHistoryResponse = { [weak self] response in
+            self?.handleHistoryResponse(response)
+        }
+
+        // Fetch session list when daemon connects
+        connectionCancellable = daemonClient.$isConnected
+            .removeDuplicates()
+            .filter { $0 }
+            .first()
+            .sink { [weak self] _ in
+                self?.fetchSessionList()
+            }
+    }
+
+    private func fetchSessionList() {
+        do {
+            try daemonClient.sendSessionList()
+        } catch {
+            log.error("Failed to send session_list: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleSessionListResponse(_ response: SessionListResponseMessage) {
+        guard !response.sessions.isEmpty else { return }
+
+        // Load up to 5 most recent sessions (daemon returns them sorted by updatedAt DESC)
+        let recentSessions = Array(response.sessions.prefix(5))
+
+        // Check if the default "New Thread" is still unused
+        let defaultThreadIsEmpty = threads.count == 1
+            && chatViewModels[threads[0].id]?.messages.isEmpty ?? true
+            && chatViewModels[threads[0].id]?.sessionId == nil
+
+        var restoredThreads: [ThreadModel] = []
+        for session in recentSessions {
+            let thread = ThreadModel(
+                title: session.title,
+                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                sessionId: session.id
+            )
+            let viewModel = makeViewModel()
+            viewModel.sessionId = session.id
+            chatViewModels[thread.id] = viewModel
+            restoredThreads.append(thread)
+        }
+
+        if defaultThreadIsEmpty {
+            // Replace the empty default thread with restored sessions
+            if let defaultThread = threads.first {
+                chatViewModels.removeValue(forKey: defaultThread.id)
+            }
+            threads = restoredThreads
+        } else {
+            // Keep the user's active thread, prepend restored sessions
+            threads = restoredThreads + threads
+        }
+
+        // Activate the most recent thread and load its history
+        if let firstThread = restoredThreads.first {
+            activeThreadId = firstThread.id
+        }
+
+        log.info("Restored \(restoredThreads.count) threads from daemon")
+    }
+
+    private func loadHistoryForActiveThreadIfNeeded() {
+        guard let activeThreadId else { return }
+        guard let thread = threads.first(where: { $0.id == activeThreadId }) else { return }
+        guard thread.sessionId != nil else { return }
+        guard let viewModel = chatViewModels[activeThreadId] else { return }
+        guard !viewModel.isHistoryLoaded else { return }
+
+        pendingHistoryThreadId = activeThreadId
+
+        do {
+            try daemonClient.sendHistoryRequest(sessionId: thread.sessionId!)
+        } catch {
+            log.error("Failed to send history_request: \(error.localizedDescription)")
+            pendingHistoryThreadId = nil
+        }
+    }
+
+    private func handleHistoryResponse(_ response: HistoryResponseMessage) {
+        guard let threadId = pendingHistoryThreadId else { return }
+        pendingHistoryThreadId = nil
+
+        guard let viewModel = chatViewModels[threadId] else { return }
+        viewModel.populateFromHistory(response.messages)
+        log.info("Loaded \(response.messages.count) history messages for thread \(threadId)")
+    }
+
     // MARK: - Private
+
+    /// Create a ChatViewModel with standard callback wiring.
+    private func makeViewModel() -> ChatViewModel {
+        let viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.onInlineConfirmationResponse = { [weak self] requestId in
+            self?.confirmationDismissHandler?(requestId)
+        }
+        viewModel.shouldAcceptConfirmation = { [weak self, weak viewModel] in
+            guard let self, let viewModel else { return false }
+            return self.isLatestToolUseRecipient(viewModel)
+        }
+        return viewModel
+    }
 
     /// Subscribe to the active ChatViewModel's objectWillChange so that
     /// SwiftUI re-evaluates views when the nested view model publishes

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -4,10 +4,13 @@ struct ThreadModel: Identifiable, Hashable {
     let id: UUID
     let title: String
     let createdAt: Date
+    /// Daemon conversation ID for restored threads. Nil for new, unsaved threads.
+    let sessionId: String?
 
-    init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date()) {
+    init(id: UUID = UUID(), title: String = "New Thread", createdAt: Date = Date(), sessionId: String? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
+        self.sessionId = sessionId
     }
 }

--- a/clients/macos/vellum-assistant/IPC/DaemonClient.swift
+++ b/clients/macos/vellum-assistant/IPC/DaemonClient.swift
@@ -97,6 +97,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends an `open_bundle_response` message.
     var onOpenBundleResponse: ((OpenBundleResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `session_list_response` message.
+    var onSessionListResponse: ((SessionListResponseMessage) -> Void)?
+
+    /// Called when the daemon sends a `history_response` message.
+    var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     var onError: ((ErrorMessage) -> Void)?
 
@@ -451,6 +457,18 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
     }
 
+    // MARK: - Sessions
+
+    /// Request the list of past sessions from the daemon.
+    func sendSessionList() throws {
+        try send(SessionListRequestMessage())
+    }
+
+    /// Request message history for a specific session.
+    func sendHistoryRequest(sessionId: String) throws {
+        try send(HistoryRequestMessage(sessionId: sessionId))
+    }
+
     // MARK: - Apps
 
     /// Request the list of all apps from the daemon.
@@ -663,6 +681,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onBundleAppResponse?(msg)
         case .openBundleResponse(let msg):
             onOpenBundleResponse?(msg)
+        case .sessionListResponse(let msg):
+            onSessionListResponse?(msg)
+        case .historyResponse(let msg):
+            onHistoryResponse?(msg)
         case .error(let msg):
             onError?(msg)
         case .signBundlePayload(let msg):

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -240,6 +240,19 @@ struct OpenBundleMessage: Encodable, Sendable {
     let filePath: String
 }
 
+/// Sent to request the list of all past sessions/conversations.
+/// Wire type: `"session_list"`
+struct SessionListRequestMessage: Encodable, Sendable {
+    let type: String = "session_list"
+}
+
+/// Sent to request message history for a specific session.
+/// Wire type: `"history_request"`
+struct HistoryRequestMessage: Encodable, Sendable {
+    let type: String = "history_request"
+    let sessionId: String
+}
+
 /// Sent to request the list of available skills.
 /// Wire type: `"skills_list"`
 struct SkillsListRequestMessage: Encodable, Sendable {
@@ -664,6 +677,35 @@ struct SkillsInspectResponseMessage: Decodable, Sendable {
     let error: String?
 }
 
+/// Response containing the list of past sessions.
+/// Wire type: `"session_list_response"`
+struct SessionListResponseMessage: Decodable, Sendable {
+    struct SessionItem: Decodable, Sendable {
+        let id: String
+        let title: String
+        let updatedAt: Int
+    }
+    let sessions: [SessionItem]
+}
+
+/// Response containing message history for a session.
+/// Wire type: `"history_response"`
+struct HistoryResponseMessage: Decodable, Sendable {
+    struct HistoryToolCallItem: Decodable, Sendable {
+        let name: String
+        let input: [String: AnyCodable]
+        let result: String?
+        let isError: Bool?
+    }
+    struct HistoryMessageItem: Decodable, Sendable {
+        let role: String
+        let text: String
+        let timestamp: Int
+        let toolCalls: [HistoryToolCallItem]?
+    }
+    let messages: [HistoryMessageItem]
+}
+
 /// A single trust rule item returned from the daemon.
 struct TrustRuleItem: Decodable, Sendable, Identifiable {
     let id: String
@@ -927,6 +969,8 @@ enum ServerMessage: Decodable, Sendable {
     case assistantThinkingDelta(AssistantThinkingDeltaMessage)
     case messageComplete(MessageCompleteMessage)
     case sessionInfo(SessionInfoMessage)
+    case sessionListResponse(SessionListResponseMessage)
+    case historyResponse(HistoryResponseMessage)
     case taskRouted(TaskRoutedMessage)
     case error(ErrorMessage)
     case ambientResult(AmbientResultMessage)
@@ -992,6 +1036,12 @@ enum ServerMessage: Decodable, Sendable {
         case "session_info":
             let message = try SessionInfoMessage(from: decoder)
             self = .sessionInfo(message)
+        case "session_list_response":
+            let message = try SessionListResponseMessage(from: decoder)
+            self = .sessionListResponse(message)
+        case "history_response":
+            let message = try HistoryResponseMessage(from: decoder)
+            self = .historyResponse(message)
         case "task_routed":
             let message = try TaskRoutedMessage(from: decoder)
             self = .taskRouted(message)


### PR DESCRIPTION
## Summary
- On daemon connect, fetch the session list and restore up to 5 recent conversations as thread tabs with lazy message history loading
- Add `session_list` and `history_request`/`history_response` IPC message types with DaemonClient wiring
- Add `sessionId` to `ThreadModel` and `populateFromHistory` to `ChatViewModel` for hydrating restored threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
