### PR TITLE
Fix @MainActor isolation errors in TrustRulesView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -97,12 +97,12 @@ struct TrustRulesView: View {
         }
     }
 
-    private func loadRules() {
+    @MainActor private func loadRules() {
         isLoading = true
         try? daemonClient.sendListTrustRules()
     }
 
-    private func deleteRule(id: String) {
+    @MainActor private func deleteRule(id: String) {
         try? daemonClient.sendRemoveTrustRule(id: id)
         loadRules()
     }
@@ -261,7 +261,7 @@ private struct TrustRuleFormView: View {
         .frame(width: 420, height: 340)
     }
 
-    private func save() {
+    @MainActor private func save() {
         let trimmedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPattern.isEmpty else { return }
 


### PR DESCRIPTION
## Summary
- Adds `@MainActor` to `loadRules()`, `deleteRule()`, and `save()` in TrustRulesView
- These functions call `@MainActor`-isolated methods on `DaemonClient`, which fails on CI's stricter Swift concurrency checking
- This was causing the v0.1.9 release build to fail

## Test plan
- [x] `./build.sh release` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
