### PR TITLE
Fix CI build: @MainActor and @Previewable errors

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -374,7 +374,7 @@ struct GeneratedPanel: View {
 
     // MARK: - Delete Shared App
 
-    private func deleteSharedApp(_ item: DisplayAppItem) {
+    @MainActor private func deleteSharedApp(_ item: DisplayAppItem) {
         guard let uuid = item.sharedUUID else { return }
 
         daemonClient.onSharedAppDeleteResponse = { response in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTabBar.swift
@@ -78,22 +78,31 @@ struct ThreadTabBar: View {
     }
 }
 
-#Preview("ThreadTabBar") {
-    @Previewable @State var panel: SidePanelType? = .settings
-    let threads = [
-        ThreadModel(title: "New Thread"),
-    ]
-
-    return ZStack {
-        VColor.background.ignoresSafeArea()
-        ThreadTabBar(
-            threads: threads,
-            activeThreadId: threads.first?.id,
-            onSelect: { _ in },
-            onClose: { _ in },
-            onCreate: {},
-            activePanel: $panel
-        )
+#if DEBUG
+struct ThreadTabBar_Preview: PreviewProvider {
+    static var previews: some View {
+        ThreadTabBarPreviewWrapper()
+            .frame(width: 600, height: 60)
+            .previewDisplayName("ThreadTabBar")
     }
-    .frame(width: 600, height: 60)
 }
+
+private struct ThreadTabBarPreviewWrapper: View {
+    @State private var panel: SidePanelType? = .settings
+    private let threads = [ThreadModel(title: "New Thread")]
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            ThreadTabBar(
+                threads: threads,
+                activeThreadId: threads.first?.id,
+                onSelect: { _ in },
+                onClose: { _ in },
+                onCreate: {},
+                activePanel: $panel
+            )
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `@MainActor` to `deleteSharedApp` in GeneratedPanel (calls `@MainActor`-isolated DaemonClient methods)
- Replace `@Previewable` with `PreviewProvider` pattern in ThreadTabBar (CI's Xcode 16.2 doesn't support `@Previewable` inside `#Preview`)
- Fixes v0.1.9 release build failure

## Test plan
- [x] `./build.sh release` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
