### PR TITLE
Enable strict concurrency and fix all CI build issues

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -180,7 +180,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 - **`@MainActor` on all ObservableObject classes** — all view models and managers that touch UI must be `@MainActor`.
 - **Nested ObservableObject**: When a view reads properties from a nested ObservableObject (e.g. `threadManager.activeViewModel.messages`), the parent must subscribe to the child's `objectWillChange` and forward it. See `ThreadManager.subscribeToActiveViewModel()`.
 - **Dependency injection**: Pass dependencies (DaemonClient, AmbientAgent) through init parameters, not singletons. Session dependencies use protocols for testability.
-- **Previews**: Add `#Preview("ComponentName")` blocks to every new view. Wrap in `ZStack { VColor.background.ignoresSafeArea() ... }` to match the dark theme. Use `#if DEBUG` guards for preview-only code. Keep preview frames reasonable (400-600pt wide).
+- **Previews**: Add `#Preview("ComponentName")` blocks to every new view. Wrap in `ZStack { VColor.background.ignoresSafeArea() ... }` to match the dark theme. Use `#if DEBUG` guards for preview-only code. Keep preview frames reasonable (400-600pt wide). **Never use `@Previewable`** — it's not supported on CI's Xcode 16.2. If a preview needs `@State`, use a `PreviewProvider` with a wrapper view instead (see `ThreadTabBar.swift` for the pattern).
 - **Gallery**: When adding or modifying a design system primitive/component, update the corresponding Gallery section file (`Gallery/Sections/`) so the visual catalog stays current.
 - **Accessibility**: Add `.accessibilityLabel()` to icon-only buttons, `.accessibilityHidden(true)` to decorative elements, and `.accessibilityValue()` to stateful controls. See existing components for patterns.
 

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -34,6 +34,9 @@ let package = Package(
                 .copy("Resources/Recipes"),
                 .process("Resources/Onboarding")
             ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),
                 .linkedFramework("CoreGraphics"),

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
@@ -69,26 +69,38 @@ extension VSidePanel where PinnedContent == EmptyView {
     .frame(width: 300, height: 300)
 }
 
-#Preview("VSidePanel with Pinned Content") {
-    @Previewable @State var tab = 1
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VSidePanel(title: "Control", onClose: {}, pinnedContent: {
-            VSegmentedControl(
-                items: ["Profile", "Settings", "Channels", "Overview"],
-                selection: $tab
-            )
-            Divider().background(VColor.surfaceBorder)
-        }) {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Tab content here")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                Text("The tab bar above stays pinned while this scrolls.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+#if DEBUG
+struct VSidePanel_PinnedContent_Preview: PreviewProvider {
+    static var previews: some View {
+        VSidePanelPinnedPreviewWrapper()
+            .frame(width: 400, height: 350)
+            .previewDisplayName("VSidePanel with Pinned Content")
+    }
+}
+
+private struct VSidePanelPinnedPreviewWrapper: View {
+    @State private var tab = 1
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VSidePanel(title: "Control", onClose: {}, pinnedContent: {
+                VSegmentedControl(
+                    items: ["Profile", "Settings", "Channels", "Overview"],
+                    selection: $tab
+                )
+                Divider().background(VColor.surfaceBorder)
+            }) {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Tab content here")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                    Text("The tab bar above stays pinned while this scrolls.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
             }
         }
     }
-    .frame(width: 400, height: 350)
 }
+#endif

--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -33,12 +33,22 @@ struct VSegmentedControl: View {
 }
 
 #if DEBUG
-#Preview("VSegmentedControl") {
-    @Previewable @State var selection = 1
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VSegmentedControl(items: ["Profile", "Settings", "Channels", "Overview"], selection: $selection)
+struct VSegmentedControl_Preview: PreviewProvider {
+    static var previews: some View {
+        VSegmentedControlPreviewWrapper()
+            .frame(width: 500, height: 60)
+            .previewDisplayName("VSegmentedControl")
     }
-    .frame(width: 500, height: 60)
+}
+
+private struct VSegmentedControlPreviewWrapper: View {
+    @State private var selection = 1
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VSegmentedControl(items: ["Profile", "Settings", "Channels", "Overview"], selection: $selection)
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VSlider.swift
@@ -137,37 +137,46 @@ struct VSlider: View {
 // MARK: - Preview
 
 #if DEBUG
-#Preview("VSlider") {
-    @Previewable @State var value1: Double = 50
-    @Previewable @State var value2: Double = 30
-    @Previewable @State var value3: Double = 5
-
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Default: \(Int(value1))")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                VSlider(value: $value1)
-            }
-
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("With tick marks: \(Int(value2))")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                VSlider(value: $value2, range: 0...100, step: 5, showTickMarks: true)
-            }
-
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Small range (1-10): \(Int(value3))")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-                VSlider(value: $value3, range: 1...10, step: 1, showTickMarks: true)
-            }
-        }
-        .padding(VSpacing.xl)
+struct VSlider_Preview: PreviewProvider {
+    static var previews: some View {
+        VSliderPreviewWrapper()
+            .frame(width: 400, height: 300)
+            .previewDisplayName("VSlider")
     }
-    .frame(width: 400, height: 300)
+}
+
+private struct VSliderPreviewWrapper: View {
+    @State private var value1: Double = 50
+    @State private var value2: Double = 30
+    @State private var value3: Double = 5
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Default: \(Int(value1))")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    VSlider(value: $value1)
+                }
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("With tick marks: \(Int(value2))")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    VSlider(value: $value2, range: 0...100, step: 5, showTickMarks: true)
+                }
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Small range (1-10): \(Int(value3))")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    VSlider(value: $value3, range: 1...10, step: 1, showTickMarks: true)
+                }
+            }
+            .padding(VSpacing.xl)
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VTextEditor.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VTextEditor.swift
@@ -38,16 +38,26 @@ struct VTextEditor: View {
 }
 
 #if DEBUG
-#Preview("VTextEditor") {
-    @Previewable @State var text = ""
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(spacing: 16) {
-            VTextEditor(placeholder: "Write something...", text: $text)
-            VTextEditor(placeholder: "Short editor", text: $text, minHeight: 40, maxHeight: 80)
-        }
-        .padding()
+struct VTextEditor_Preview: PreviewProvider {
+    static var previews: some View {
+        VTextEditorPreviewWrapper()
+            .frame(width: 400, height: 350)
+            .previewDisplayName("VTextEditor")
     }
-    .frame(width: 400, height: 350)
+}
+
+private struct VTextEditorPreviewWrapper: View {
+    @State private var text = ""
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(spacing: 16) {
+                VTextEditor(placeholder: "Write something...", text: $text)
+                VTextEditor(placeholder: "Short editor", text: $text, minHeight: 40, maxHeight: 80)
+            }
+            .padding()
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VTextField.swift
@@ -45,18 +45,28 @@ struct VTextField: View {
 }
 
 #if DEBUG
-#Preview("VTextField") {
-    @Previewable @State var text = ""
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(spacing: 16) {
-            VTextField(placeholder: "Plain text field", text: $text)
-            VTextField(placeholder: "With leading icon", text: $text, leadingIcon: "magnifyingglass")
-            VTextField(placeholder: "With trailing icon", text: $text, trailingIcon: "envelope")
-            VTextField(placeholder: "Both icons", text: $text, leadingIcon: "magnifyingglass", trailingIcon: "xmark.circle")
-        }
-        .padding()
+struct VTextField_Preview: PreviewProvider {
+    static var previews: some View {
+        VTextFieldPreviewWrapper()
+            .frame(width: 350, height: 280)
+            .previewDisplayName("VTextField")
     }
-    .frame(width: 350, height: 280)
+}
+
+private struct VTextFieldPreviewWrapper: View {
+    @State private var text = ""
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(spacing: 16) {
+                VTextField(placeholder: "Plain text field", text: $text)
+                VTextField(placeholder: "With leading icon", text: $text, leadingIcon: "magnifyingglass")
+                VTextField(placeholder: "With trailing icon", text: $text, trailingIcon: "envelope")
+                VTextField(placeholder: "Both icons", text: $text, leadingIcon: "magnifyingglass", trailingIcon: "xmark.circle")
+            }
+            .padding()
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Core/Inputs/VToggle.swift
@@ -56,18 +56,28 @@ struct VToggle: View {
 }
 
 #if DEBUG
-#Preview("VToggle") {
-    @Previewable @State var isOnA = true
-    @Previewable @State var isOnB = false
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VStack(alignment: .leading, spacing: 16) {
-            VToggle(isOn: $isOnA, label: "Enabled toggle")
-            VToggle(isOn: $isOnB, label: "Disabled toggle")
-            VToggle(isOn: $isOnA)
-        }
-        .padding()
+struct VToggle_Preview: PreviewProvider {
+    static var previews: some View {
+        VTogglePreviewWrapper()
+            .frame(width: 300, height: 200)
+            .previewDisplayName("VToggle")
     }
-    .frame(width: 300, height: 200)
+}
+
+private struct VTogglePreviewWrapper: View {
+    @State private var isOnA = true
+    @State private var isOnB = false
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: 16) {
+                VToggle(isOn: $isOnA, label: "Enabled toggle")
+                VToggle(isOn: $isOnB, label: "Disabled toggle")
+                VToggle(isOn: $isOnA)
+            }
+            .padding()
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -837,10 +837,18 @@ private struct MicrophoneButton: View {
 // MARK: - Preview
 
 #if DEBUG
-#Preview("ChatView") {
-    @Previewable @State var text = ""
+struct ChatView_Preview: PreviewProvider {
+    static var previews: some View {
+        ChatViewPreviewWrapper()
+            .frame(width: 600, height: 500)
+            .previewDisplayName("ChatView")
+    }
+}
 
-    let sampleMessages: [ChatMessage] = [
+private struct ChatViewPreviewWrapper: View {
+    @State private var text = ""
+
+    private let sampleMessages: [ChatMessage] = [
         ChatMessage(role: .assistant, text: "Hello! How can I help you today?"),
         ChatMessage(role: .user, text: "Can you tell me about SwiftUI?"),
         ChatMessage(
@@ -850,35 +858,36 @@ private struct MicrophoneButton: View {
         ChatMessage(role: .user, text: "That sounds great, thanks!"),
     ]
 
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        ChatView(
-            messages: sampleMessages,
-            inputText: $text,
-            hasAPIKey: true,
-            isThinking: true,
-            isSending: false,
-            errorText: nil,
-            pendingQueuedCount: 0,
-            suggestion: "That sounds great, thanks!",
-            pendingAttachments: [],
-            isRecording: false,
-            onOpenSettings: {},
-            onSend: {},
-            onStop: {},
-            onDismissError: {},
-            onAcceptSuggestion: {},
-            onAttach: {},
-            onRemoveAttachment: { _ in },
-            onDropFiles: { _ in },
-            onPaste: {},
-            onMicrophoneToggle: {},
-            onConfirmationAllow: { _ in },
-            onConfirmationDeny: { _ in },
-            onAddTrustRule: { _, _, _, _ in true },
-            onSurfaceAction: { _, _, _ in }
-        )
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            ChatView(
+                messages: sampleMessages,
+                inputText: $text,
+                hasAPIKey: true,
+                isThinking: true,
+                isSending: false,
+                errorText: nil,
+                pendingQueuedCount: 0,
+                suggestion: "That sounds great, thanks!",
+                pendingAttachments: [],
+                isRecording: false,
+                onOpenSettings: {},
+                onSend: {},
+                onStop: {},
+                onDismissError: {},
+                onAcceptSuggestion: {},
+                onAttach: {},
+                onRemoveAttachment: { _ in },
+                onDropFiles: { _ in },
+                onPaste: {},
+                onMicrophoneToggle: {},
+                onConfirmationAllow: { _ in },
+                onConfirmationDeny: { _ in },
+                onAddTrustRule: { _, _, _, _ in true },
+                onSurfaceAction: { _, _, _ in }
+            )
+        }
     }
-    .frame(width: 600, height: 500)
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationToolbar.swift
@@ -46,9 +46,19 @@ struct NavigationToolbar: View {
 }
 
 #if DEBUG
-#Preview("NavigationToolbar") {
-    @Previewable @State var panel: SidePanelType? = .settings
-    NavigationToolbar(activePanel: $panel)
-        .frame(width: 700)
+struct NavigationToolbar_Preview: PreviewProvider {
+    static var previews: some View {
+        NavigationToolbarPreviewWrapper()
+            .frame(width: 700)
+            .previewDisplayName("NavigationToolbar")
+    }
+}
+
+private struct NavigationToolbarPreviewWrapper: View {
+    @State private var panel: SidePanelType? = .settings
+
+    var body: some View {
+        NavigationToolbar(activePanel: $panel)
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -246,7 +246,7 @@ struct GeneratedPanel: View {
     @State private var localApps: [AppItem] = []
     @State private var sharedApps: [SharedAppItem] = []
 
-    private func fetchApps() {
+    @MainActor private func fetchApps() {
         isLoading = true
         pendingResponses = 2
 
@@ -343,7 +343,7 @@ struct GeneratedPanel: View {
 
     // MARK: - Bundle & Share
 
-    private func bundleAndShare(appId: String, itemId: String) {
+    @MainActor private func bundleAndShare(appId: String, itemId: String) {
         guard !isBundling else { return }
         sharingAppId = itemId
         isBundling = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionManager.swift
@@ -105,41 +105,50 @@ final class JITPermissionManager {
 }
 
 #if DEBUG
-#Preview {
-    @Previewable @State var manager = JITPermissionManager()
-
-    VStack(spacing: VSpacing.xl) {
-        Text("JIT Permission Manager")
-            .font(VFont.headline)
-            .foregroundColor(VColor.textPrimary)
-
-        Text("Active: \(manager.isActive ? "Yes" : "No")")
-            .font(VFont.body)
-            .foregroundColor(VColor.textSecondary)
-
-        HStack(spacing: VSpacing.md) {
-            OnboardingButton(title: "Request Mic", style: .ghost) {
-                manager.isActive = true
-                _ = manager.requestIfNeeded(.microphone)
-            }
-            OnboardingButton(title: "Request A11y", style: .ghost) {
-                manager.isActive = true
-                _ = manager.requestIfNeeded(.accessibility)
-            }
-            OnboardingButton(title: "Request Screen", style: .ghost) {
-                manager.isActive = true
-                _ = manager.requestIfNeeded(.screenCapture)
-            }
-        }
-
-        if let request = manager.activePermissionRequest {
-            Text("Active request: \(request.title)")
-                .font(VFont.caption)
-                .foregroundColor(VColor.success)
-        }
+struct JITPermissionManager_Preview: PreviewProvider {
+    static var previews: some View {
+        JITPermissionManagerPreviewWrapper()
+            .frame(width: 500, height: 300)
+            .previewDisplayName("JITPermissionManager")
     }
-    .padding(VSpacing.xxl)
-    .frame(width: 500, height: 300)
-    .background(VColor.background)
+}
+
+private struct JITPermissionManagerPreviewWrapper: View {
+    @State private var manager = JITPermissionManager()
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            Text("JIT Permission Manager")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Active: \(manager.isActive ? "Yes" : "No")")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            HStack(spacing: VSpacing.md) {
+                OnboardingButton(title: "Request Mic", style: .ghost) {
+                    manager.isActive = true
+                    _ = manager.requestIfNeeded(.microphone)
+                }
+                OnboardingButton(title: "Request A11y", style: .ghost) {
+                    manager.isActive = true
+                    _ = manager.requestIfNeeded(.accessibility)
+                }
+                OnboardingButton(title: "Request Screen", style: .ghost) {
+                    manager.isActive = true
+                    _ = manager.requestIfNeeded(.screenCapture)
+                }
+            }
+
+            if let request = manager.activePermissionRequest {
+                Text("Active request: \(request.title)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.success)
+            }
+        }
+        .padding(VSpacing.xxl)
+        .background(VColor.background)
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -179,48 +179,39 @@ struct JITPermissionView: View {
 // MARK: - Preview
 
 #if DEBUG
-#Preview("Microphone") {
-    @Previewable @State var manager: JITPermissionManager = {
-        let m = JITPermissionManager()
-        m.isActive = true
-        m.activePermissionRequest = .microphone
-        return m
-    }()
+struct JITPermissionView_Preview: PreviewProvider {
+    static var previews: some View {
+        JITPermissionViewPreviewWrapper(permission: .microphone)
+            .frame(width: 640, height: 560)
+            .previewDisplayName("Microphone")
 
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        JITPermissionView(manager: manager)
+        JITPermissionViewPreviewWrapper(permission: .accessibility)
+            .frame(width: 640, height: 560)
+            .previewDisplayName("Accessibility")
+
+        JITPermissionViewPreviewWrapper(permission: .screenCapture)
+            .frame(width: 640, height: 560)
+            .previewDisplayName("Screen Capture")
     }
-    .frame(width: 640, height: 560)
 }
 
-#Preview("Accessibility") {
-    @Previewable @State var manager: JITPermissionManager = {
+private struct JITPermissionViewPreviewWrapper: View {
+    let permission: JITPermissionManager.JITPermissionType
+    @State private var manager: JITPermissionManager
+
+    init(permission: JITPermissionManager.JITPermissionType) {
+        self.permission = permission
         let m = JITPermissionManager()
         m.isActive = true
-        m.activePermissionRequest = .accessibility
-        return m
-    }()
-
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        JITPermissionView(manager: manager)
+        m.activePermissionRequest = permission
+        _manager = State(initialValue: m)
     }
-    .frame(width: 640, height: 560)
-}
 
-#Preview("Screen Capture") {
-    @Previewable @State var manager: JITPermissionManager = {
-        let m = JITPermissionManager()
-        m.isActive = true
-        m.activePermissionRequest = .screenCapture
-        return m
-    }()
-
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        JITPermissionView(manager: manager)
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            JITPermissionView(manager: manager)
+        }
     }
-    .frame(width: 640, height: 560)
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewChatView.swift
@@ -220,10 +220,18 @@ private struct TypingIndicator: View {
 // MARK: - Preview
 
 #if DEBUG
-#Preview("InterviewChatView") {
-    @Previewable @State var text = ""
+struct InterviewChatView_Preview: PreviewProvider {
+    static var previews: some View {
+        InterviewChatViewPreviewWrapper()
+            .frame(width: 600, height: 600)
+            .previewDisplayName("InterviewChatView")
+    }
+}
 
-    let sampleMessages: [InterviewMessage] = [
+private struct InterviewChatViewPreviewWrapper: View {
+    @State private var text = ""
+
+    private let sampleMessages: [InterviewMessage] = [
         InterviewMessage(role: .assistant, text: "Hi there! I just hatched and I am so excited to meet you."),
         InterviewMessage(role: .user, text: "Welcome! What can you do?"),
         InterviewMessage(
@@ -233,18 +241,19 @@ private struct TypingIndicator: View {
         InterviewMessage(role: .user, text: "That sounds great, tell me more."),
     ]
 
-    ZStack {
-        MeadowBackground()
-        OnboardingPanel {
-            InterviewChatView(
-                messages: sampleMessages,
-                inputText: text,
-                isThinking: true,
-                isStreaming: false
-            )
-            .frame(height: 400)
+    var body: some View {
+        ZStack {
+            MeadowBackground()
+            OnboardingPanel {
+                InterviewChatView(
+                    messages: sampleMessages,
+                    inputText: text,
+                    isThinking: true,
+                    isStreaming: false
+                )
+                .frame(height: 400)
+            }
         }
     }
-    .frame(width: 600, height: 600)
 }
 #endif


### PR DESCRIPTION
## Summary
- Adds `StrictConcurrency` experimental feature to `Package.swift` so local builds catch the same `@MainActor` isolation errors that CI (Xcode 16.2 / Swift 6.0.x) does
- Replaces all 16 `@Previewable` usages across 11 files with `PreviewProvider` + wrapper view pattern (not supported on CI's Xcode 16.2)
- Adds `@MainActor` to `fetchApps()` and `bundleAndShare()` in `GeneratedPanel.swift`
- Updates CLAUDE.md to document the `@Previewable` prohibition

## Test plan
- [x] Local build passes with strict concurrency enabled
- [ ] CI build passes on this PR
- [ ] Previews still render in Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
