### PR TITLE
Move strict concurrency to local lint, remove from Package.swift

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -26,6 +26,9 @@ Single build script: `./build.sh` wraps SwiftPM → `.app` bundle → codesign. 
 # Run a single test
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SessionTests/testHappyPath_completesInThreeSteps
 
+# Lint (strict concurrency — catches CI-only errors locally)
+./build.sh lint
+
 # Watch logs from a running instance
 log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level debug
 ```

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -34,9 +34,6 @@ let package = Package(
                 .copy("Resources/Recipes"),
                 .process("Resources/Onboarding")
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),
                 .linkedFramework("CoreGraphics"),

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   ./build.sh release      Build release .app
 #   ./build.sh test         Run tests (no .app needed)
 #   ./build.sh clean        Remove build artifacts
+#   ./build.sh lint         Build with strict concurrency (catches CI-only errors locally)
 #
 # Environment variables (for CI):
 #   DISPLAY_VERSION   Override CFBundleShortVersionString (default: 0.1.0)
@@ -52,6 +53,12 @@ case "$CMD" in
         swift test
         exit 0
         ;;
+    lint)
+        echo "Linting (strict concurrency)..."
+        swift build -Xswiftc -strict-concurrency=complete
+        echo "Lint passed."
+        exit 0
+        ;;
     clean)
         echo "Cleaning..."
         rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/.build"
@@ -61,7 +68,7 @@ case "$CMD" in
     build|run|release)
         ;;
     *)
-        echo "Usage: $0 [build|run|release|test|clean]"
+        echo "Usage: $0 [build|run|release|test|clean|lint]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Removes `StrictConcurrency` from Package.swift (was causing CI to surface additional warnings-as-errors)
- Adds `./build.sh lint` command for local strict concurrency checking
- Documents lint command in CLAUDE.md

## Test plan
- [x] `./build.sh` passes locally
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
