### PR TITLE
Add Fireworks AI as an LLM provider

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -11,7 +11,7 @@ import type { AssistantConfig } from './types.js';
 const log = getLogger('config');
 
 // Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
-const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'brave'] as const;
+const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave'] as const;
 
 let cached: AssistantConfig | null = null;
 let loading = false;
@@ -183,6 +183,9 @@ export function loadConfig(): AssistantConfig {
     }
     if (process.env.OLLAMA_API_KEY) {
       config.apiKeys.ollama = process.env.OLLAMA_API_KEY;
+    }
+    if (process.env.FIREWORKS_API_KEY) {
+      config.apiKeys.fireworks = process.env.FIREWORKS_API_KEY;
     }
     if (process.env.BRAVE_API_KEY) {
       config.apiKeys.brave = process.env.BRAVE_API_KEY;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getDataDir } from '../util/platform.js';
 
-const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama'] as const;
+const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -367,7 +367,7 @@ keys
   .description('List all stored API key names')
   .action(() => {
     const stored: string[] = [];
-    for (const provider of ['anthropic', 'openai', 'gemini', 'ollama']) {
+    for (const provider of ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks']) {
       const value = getSecureKey(provider);
       if (value) stored.push(provider);
     }
@@ -655,6 +655,7 @@ program
       openai: 'OPENAI_API_KEY',
       gemini: 'GEMINI_API_KEY',
       ollama: 'OLLAMA_API_KEY',
+      fireworks: 'FIREWORKS_API_KEY',
     };
     const configKey = (raw.apiKeys as Record<string, string> | undefined)?.[provider];
     const envVar = providerEnvVar[provider];

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -1,0 +1,18 @@
+import { OpenAIProvider } from '../openai/client.js';
+
+export interface FireworksProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+const DEFAULT_FIREWORKS_BASE_URL = 'https://api.fireworks.ai/inference/v1';
+
+export class FireworksProvider extends OpenAIProvider {
+  constructor(apiKey: string, model: string, options: FireworksProviderOptions = {}) {
+    super(apiKey, model, {
+      baseURL: options.baseURL?.trim() || DEFAULT_FIREWORKS_BASE_URL,
+      providerName: 'fireworks',
+      providerLabel: 'Fireworks',
+    });
+  }
+}

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { AnthropicProvider } from "./anthropic/client.js";
 import { OpenAIProvider } from "./openai/client.js";
 import { GeminiProvider } from "./gemini/client.js";
 import { OllamaProvider } from "./ollama/client.js";
+import { FireworksProvider } from "./fireworks/client.js";
 import { RetryProvider } from "./retry.js";
 import { ConfigError } from "../util/errors.js";
 
@@ -11,6 +12,7 @@ const DEFAULT_MODELS: Record<string, string> = {
   openai: 'gpt-5.2',
   gemini: 'gemini-3-flash',
   ollama: 'llama3.2',
+  fireworks: 'accounts/fireworks/models/kimi-k2p5',
 };
 
 const providers = new Map<string, Provider>();
@@ -76,6 +78,12 @@ export function initializeProviders(config: ProvidersConfig): void {
     const model = resolveModel(config, 'ollama');
     registerProvider('ollama', new RetryProvider(
       new OllamaProvider(model, { apiKey: config.apiKeys.ollama }),
+    ));
+  }
+  if (config.apiKeys.fireworks) {
+    const model = resolveModel(config, 'fireworks');
+    registerProvider('fireworks', new RetryProvider(
+      new FireworksProvider(config.apiKeys.fireworks, model),
     ));
   }
 }

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -32,6 +32,9 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     'gemini-2.5-flash': { inputPer1M: 0.15, outputPer1M: 0.60 },
     'gemini-2.0-flash': { inputPer1M: 0.10, outputPer1M: 0.40 },
   },
+  fireworks: {
+    'accounts/fireworks/models/kimi-k2p5': { inputPer1M: 0.60, outputPer1M: 3.00 },
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds Fireworks AI as a new LLM provider, extending the OpenAI-compatible pattern (like Ollama) with base URL `https://api.fireworks.ai/inference/v1`
- Default model is `accounts/fireworks/models/kimi-k2p5` (Kimi K2.5) with image input support inherited from the OpenAI provider
- Full integration: API key management (FIREWORKS_API_KEY env var, secure storage, config.json), pricing ($0.60/1M input, $3.00/1M output), CLI keys list, and doctor diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
