### PR TITLE
M2: Add sectionHeader and metaItem helpers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -217,6 +217,43 @@ struct GeneratedPanel: View {
             .foregroundColor(color)
     }
 
+    // MARK: - Section Header
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Text(title)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+
+            if let count {
+                Text("\(count)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(Slate._800)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+        }
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.sm)
+    }
+
+    private func metaItem(icon: String, value: String, color: Color = VColor.textMuted) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: icon)
+                .font(.system(size: 9))
+            Text(value)
+        }
+        .font(VFont.small)
+        .foregroundColor(color)
+    }
+
     // MARK: - Buttons
 
     @ViewBuilder


### PR DESCRIPTION
Adds reusable sectionHeader and metaItem helper views to GeneratedPanel, matching the patterns from AgentPanel.

Closes #1826
Part of #1824
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
