### PR TITLE
M3: Split ForEach into sectioned layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -94,8 +94,21 @@ struct GeneratedPanel: View {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                     }
 
-                    ForEach(displayItems) { item in
-                        appRow(item)
+                    let localItems = displayItems.filter { !$0.isShared }
+                    let sharedItems = displayItems.filter { $0.isShared }
+
+                    if !localItems.isEmpty {
+                        sectionHeader("My Apps", count: localItems.count)
+                        ForEach(localItems) { item in
+                            appRow(item)
+                        }
+                    }
+
+                    if !sharedItems.isEmpty {
+                        sectionHeader("Shared with Me", count: sharedItems.count)
+                        ForEach(sharedItems) { item in
+                            appRow(item)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Splits the single flat list into "My Apps" and "Shared with Me" sections, each with a section header and count badge.

Closes #1827
Part of #1824
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
