### PR TITLE
Remove fixedSize from segmented tab labels to prevent overflow

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -14,7 +14,6 @@ struct VSegmentedControl: View {
                             .foregroundColor(selection == index ? VColor.textPrimary : VColor.textMuted)
                             .padding(.horizontal, VSpacing.xl)
                             .padding(.vertical, VSpacing.xs)
-                            .fixedSize(horizontal: true, vertical: false)
 
                         Rectangle()
                             .fill(selection == index ? VColor.accent : .clear)


### PR DESCRIPTION
## Summary
- Removes `.fixedSize(horizontal: true, vertical: false)` from `VSegmentedControl` tab labels that was preventing labels from shrinking in constrained widths
- Addresses review feedback from PR #1703: trailing tabs could overflow and clip in the Agent panel, which caps panel width to half the window (400pt at minimum window width)

## Test plan
- [ ] Open the Agent panel and verify all four segmented tabs are visible and accessible at minimum window width
- [ ] Resize the window to various widths and confirm tabs shrink gracefully without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
