### PR TITLE
Fix timeout race, loadError clearing, and late response handling in GeneratedPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -34,6 +34,9 @@ struct GeneratedPanel: View {
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
 
+    // Generation counter to invalidate stale timeouts when fetchApps() is re-invoked
+    @State private var fetchGeneration = 0
+
     init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
         self.onClose = onClose
         self.daemonClient = daemonClient
@@ -339,6 +342,8 @@ struct GeneratedPanel: View {
         loadError = nil
         isLoading = true
         pendingResponses = 2
+        fetchGeneration += 1
+        let currentGeneration = fetchGeneration
 
         Task { @MainActor in
             daemonClient.onAppsListResponse = { response in
@@ -347,6 +352,9 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                } else if !self.isLoading {
+                    // Response arrived after timeout — rebuild with whatever data we have
+                    self.buildDisplayItems()
                 }
             }
 
@@ -356,6 +364,9 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                } else if !self.isLoading {
+                    // Response arrived after timeout — rebuild with whatever data we have
+                    self.buildDisplayItems()
                 }
             }
 
@@ -393,9 +404,11 @@ struct GeneratedPanel: View {
                 isLoading = false
             }
 
-            // Timeout: if still loading after 10s, show partial results or error
+            // Timeout: if still loading after 10s, show partial results or error.
+            // Guard on fetchGeneration to prevent stale timeouts from a previous
+            // fetchApps() call from terminating a newer loading cycle.
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                guard self.isLoading else { return }
+                guard self.isLoading, self.fetchGeneration == currentGeneration else { return }
                 self.buildDisplayItems()
                 self.isLoading = false
                 if self.displayItems.isEmpty {
@@ -408,7 +421,6 @@ struct GeneratedPanel: View {
     }
 
     private func buildDisplayItems() {
-        loadError = nil
         var items: [DisplayAppItem] = []
 
         // Local apps


### PR DESCRIPTION
## Summary
Addresses review feedback from PRs #1829 and #1830:

- **Stale timeout race**: Add `fetchGeneration` counter so that when the user clicks Retry, the previous `DispatchQueue.main.asyncAfter` timeout is invalidated and won't prematurely terminate the new loading cycle
- **loadError incorrectly cleared**: Remove `loadError = nil` from `buildDisplayItems()` — it was unconditionally wiping timeout warning banners whenever the display list was rebuilt (e.g., on shared app deletion). The error is already correctly cleared at the start of `fetchApps()`
- **Late responses ignored after timeout**: Add `else if !self.isLoading` branch in both response handlers so that responses arriving after the 10s timeout still trigger `buildDisplayItems()` to update the UI with whatever data is available

## Test plan
- [ ] Open Generated panel, verify apps load normally
- [ ] Simulate slow daemon: click Retry after timeout fires, verify the new fetch gets its own full 10s window
- [ ] After timeout shows partial results + warning banner, delete a shared app — verify warning banner persists
- [ ] Simulate one response arriving after timeout — verify UI updates with the late data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
