### PR TITLE
Clear loadError when all responses arrive after timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -352,6 +352,7 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                    self.loadError = nil
                 } else if !self.isLoading {
                     // Response arrived after timeout — rebuild with whatever data we have
                     self.buildDisplayItems()
@@ -364,6 +365,7 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                    self.loadError = nil
                 } else if !self.isLoading {
                     // Response arrived after timeout — rebuild with whatever data we have
                     self.buildDisplayItems()


### PR DESCRIPTION
Addresses Codex review feedback on #1834: clears stale `loadError` warning when a late response arrives and completes the data set (`pendingResponses <= 0`), so the UI no longer shows "Some apps couldn't be loaded" after all data has actually loaded.

Part of #1824
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
