### PR TITLE
Fix and restyle GeneratedPanel app list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -124,60 +124,69 @@ struct GeneratedPanel: View {
         let isHovered = hoveredAppId == item.id
         let isBundlingThis = sharingAppId == item.id && isBundling
 
-        return HStack(spacing: VSpacing.md) {
-            // Icon
-            Text(item.icon ?? "\u{1F4F1}")
-                .font(.system(size: 20))
-                .frame(width: 28, height: 28)
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Row 1: Icon + name/description + action buttons
+            HStack(spacing: VSpacing.md) {
+                Text(item.icon ?? "\u{1F4F1}")
+                    .font(.system(size: 20))
+                    .frame(width: 24, height: 24)
 
-            // Name + badges + description
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: VSpacing.xs) {
-                    Text(item.name)
-                        .font(VFont.bodyBold)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-
-                    if item.isShared {
-                        sharedBadge
-                    }
-
-                    if let tier = item.trustTier {
-                        trustBadge(tier: tier)
-                    }
-                }
-
-                if let description = item.description, !description.isEmpty {
-                    Text(description)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .lineLimit(2)
-                }
-
-                Text(item.dateLabel)
-                    .font(VFont.small)
-                    .foregroundColor(VColor.textMuted)
-            }
-
-            Spacer()
-
-            // Action buttons — visible on hover
-            let showingShareSheet = showShareSheet && sharingAppId == item.id
-            if isHovered || isBundlingThis || showingShareSheet {
-                HStack(spacing: VSpacing.xs) {
-                    if isBundlingThis {
-                        ProgressView()
-                            .controlSize(.mini)
-                            .frame(width: 24, height: 24)
-                    } else {
-                        shareButton(for: item)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(item.name)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.textPrimary)
 
                         if item.isShared {
-                            deleteButton(for: item)
+                            sharedBadge
+                        }
+
+                        if let tier = item.trustTier {
+                            trustBadge(tier: tier)
+                        }
+                    }
+
+                    if let description = item.description, !description.isEmpty {
+                        Text(description)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer()
+
+                // Action buttons — visible on hover
+                let showingShareSheet = showShareSheet && sharingAppId == item.id
+                if isHovered || isBundlingThis || showingShareSheet {
+                    HStack(spacing: VSpacing.xs) {
+                        if isBundlingThis {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .frame(width: 24, height: 24)
+                        } else {
+                            shareButton(for: item)
+
+                            if item.isShared {
+                                deleteButton(for: item)
+                            }
                         }
                     }
                 }
             }
+
+            // Row 2: Metadata
+            HStack(spacing: VSpacing.lg) {
+                metaItem(icon: "clock", value: item.dateLabel)
+                metaItem(icon: item.isShared ? "arrow.down.circle" : "hammer", value: item.isShared ? "Received" : "Local")
+
+                if let signer = item.signerDisplayName, !signer.isEmpty {
+                    metaItem(icon: "person.fill", value: signer)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, 24 + VSpacing.md)
         }
         .padding(VSpacing.lg)
         .background(isHovered ? Slate._800 : Slate._900)
@@ -196,17 +205,9 @@ struct GeneratedPanel: View {
     // MARK: - Badges
 
     private var sharedBadge: some View {
-        HStack(spacing: 2) {
-            Image(systemName: "person.2.fill")
-                .font(.system(size: 8))
-            Text("Shared")
-                .font(VFont.small)
-        }
-        .foregroundColor(Violet._400)
-        .padding(.horizontal, 5)
-        .padding(.vertical, 1)
-        .background(Violet._900.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        Text("SHARED")
+            .font(VFont.small)
+            .foregroundColor(Violet._400)
     }
 
     private func trustBadge(tier: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -217,6 +217,43 @@ struct GeneratedPanel: View {
             .foregroundColor(color)
     }
 
+    // MARK: - Section Header
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Text(title)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textMuted)
+
+            if let count {
+                Text("\(count)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(Slate._800)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+
+            Rectangle()
+                .fill(VColor.surfaceBorder)
+                .frame(height: 1)
+        }
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.sm)
+    }
+
+    private func metaItem(icon: String, value: String, color: Color = VColor.textMuted) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: icon)
+                .font(.system(size: 9))
+            Text(value)
+        }
+        .font(VFont.small)
+        .foregroundColor(color)
+    }
+
     // MARK: - Buttons
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -94,8 +94,21 @@ struct GeneratedPanel: View {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                     }
 
-                    ForEach(displayItems) { item in
-                        appRow(item)
+                    let localItems = displayItems.filter { !$0.isShared }
+                    let sharedItems = displayItems.filter { $0.isShared }
+
+                    if !localItems.isEmpty {
+                        sectionHeader("My Apps", count: localItems.count)
+                        ForEach(localItems) { item in
+                            appRow(item)
+                        }
+                    }
+
+                    if !sharedItems.isEmpty {
+                        sectionHeader("Shared with Me", count: sharedItems.count)
+                        ForEach(sharedItems) { item in
+                            appRow(item)
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -352,6 +352,7 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                    self.loadError = nil
                 } else if !self.isLoading {
                     // Response arrived after timeout — rebuild with whatever data we have
                     self.buildDisplayItems()
@@ -364,6 +365,7 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                    self.loadError = nil
                 } else if !self.isLoading {
                     // Response arrived after timeout — rebuild with whatever data we have
                     self.buildDisplayItems()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -34,6 +34,9 @@ struct GeneratedPanel: View {
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
 
+    // Generation counter to invalidate stale timeouts when fetchApps() is re-invoked
+    @State private var fetchGeneration = 0
+
     init(onClose: @escaping () -> Void, daemonClient: DaemonClient) {
         self.onClose = onClose
         self.daemonClient = daemonClient
@@ -339,6 +342,8 @@ struct GeneratedPanel: View {
         loadError = nil
         isLoading = true
         pendingResponses = 2
+        fetchGeneration += 1
+        let currentGeneration = fetchGeneration
 
         Task { @MainActor in
             daemonClient.onAppsListResponse = { response in
@@ -347,6 +352,9 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                } else if !self.isLoading {
+                    // Response arrived after timeout — rebuild with whatever data we have
+                    self.buildDisplayItems()
                 }
             }
 
@@ -356,6 +364,9 @@ struct GeneratedPanel: View {
                 if self.pendingResponses <= 0 {
                     self.buildDisplayItems()
                     self.isLoading = false
+                } else if !self.isLoading {
+                    // Response arrived after timeout — rebuild with whatever data we have
+                    self.buildDisplayItems()
                 }
             }
 
@@ -393,9 +404,11 @@ struct GeneratedPanel: View {
                 isLoading = false
             }
 
-            // Timeout: if still loading after 10s, show partial results or error
+            // Timeout: if still loading after 10s, show partial results or error.
+            // Guard on fetchGeneration to prevent stale timeouts from a previous
+            // fetchApps() call from terminating a newer loading cycle.
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                guard self.isLoading else { return }
+                guard self.isLoading, self.fetchGeneration == currentGeneration else { return }
                 self.buildDisplayItems()
                 self.isLoading = false
                 if self.displayItems.isEmpty {
@@ -408,7 +421,6 @@ struct GeneratedPanel: View {
     }
 
     private func buildDisplayItems() {
-        loadError = nil
         var items: [DisplayAppItem] = []
 
         // Local apps

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -29,6 +29,7 @@ struct GeneratedPanel: View {
     @State private var shareFileURL: URL?
     @State private var showShareSheet = false
     @State private var pendingDeleteId: String?
+    @State private var loadError: String?
 
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
@@ -48,6 +49,22 @@ struct GeneratedPanel: View {
                     Spacer()
                 }
                 .frame(height: 250)
+            } else if loadError != nil && displayItems.isEmpty {
+                VEmptyState(
+                    title: "Error loading apps",
+                    subtitle: loadError ?? "",
+                    icon: "exclamationmark.triangle"
+                )
+                Button(action: { fetchApps() }) {
+                    Text("Retry")
+                        .font(VFont.mono)
+                        .foregroundColor(Emerald._400)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(Slate._800)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                }
+                .buttonStyle(.plain)
             } else if displayItems.isEmpty {
                 VEmptyState(
                     title: "No generated items",
@@ -56,6 +73,27 @@ struct GeneratedPanel: View {
                 )
             } else {
                 VStack(spacing: VSpacing.md) {
+                    if let loadError {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 11))
+                                .foregroundColor(Amber._500)
+                            Text(loadError)
+                                .font(VFont.caption)
+                                .foregroundColor(Amber._500)
+                            Spacer()
+                            Button(action: { fetchApps() }) {
+                                Text("Retry")
+                                    .font(VFont.small)
+                                    .foregroundColor(VColor.textMuted)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(VSpacing.md)
+                        .background(Amber._500.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    }
+
                     ForEach(displayItems) { item in
                         appRow(item)
                     }
@@ -247,6 +285,7 @@ struct GeneratedPanel: View {
     @State private var sharedApps: [SharedAppItem] = []
 
     private func fetchApps() {
+        loadError = nil
         isLoading = true
         pendingResponses = 2
 
@@ -302,10 +341,23 @@ struct GeneratedPanel: View {
                 buildDisplayItems()
                 isLoading = false
             }
+
+            // Timeout: if still loading after 10s, show partial results or error
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                guard self.isLoading else { return }
+                self.buildDisplayItems()
+                self.isLoading = false
+                if self.displayItems.isEmpty {
+                    self.loadError = "Unable to load apps"
+                } else {
+                    self.loadError = "Some apps couldn't be loaded"
+                }
+            }
         }
     }
 
     private func buildDisplayItems() {
+        loadError = nil
         var items: [DisplayAppItem] = []
 
         // Local apps


### PR DESCRIPTION
## Summary
Fixes the infinite loading spinner in GeneratedPanel when daemon responses are lost, and restyles the app card layout to match AgentPanel's two-row skill card pattern.

## Changes
- Added 10-second timeout with partial results support and warning banner
- Added `sectionHeader` and `metaItem` reusable helper views matching AgentPanel patterns
- Split flat app list into "My Apps" and "Shared with Me" sections with headers and count badges
- Restyled `appRow` to two-row card layout (header + metadata row)
- Simplified `sharedBadge` to uppercase "SHARED" text
- Added `fetchGeneration` counter to prevent stale timeout races
- Fixed late-response handling to clear stale `loadError` warnings

## Milestone PRs (merged into feature branch)
- #1829: M1: Add load timeout with partial results and warning
- #1830: M2: Add sectionHeader and metaItem helpers
- #1831: M3: Split ForEach into sectioned layout
- #1832: M4: Restyle appRow to two-row card layout
- #1834: Fix timeout race, loadError clearing, and late response handling
- #1835: Clear loadError when all responses arrive after timeout

## Project issue
Closes #1824

## Test plan
- [ ] `cd clients/macos && swift build` — must compile
- [ ] Open Generated panel with daemon running — should load apps (no infinite spinner)
- [ ] Stop daemon, open panel — should show error after 10s with Retry button
- [ ] Cards should show two-row layout matching AgentPanel's skill cards
- [ ] Hover state, share button, delete button still work
- [ ] "My Apps" and "Shared with Me" sections display correctly with count badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
