### PR TITLE
Wire computer control escalation for all session types

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -88,8 +88,8 @@ function wireEscalationHandler(
   session: Session,
   _socket: net.Socket,
   ctx: HandlerContext,
-  screenWidth: number,
-  screenHeight: number,
+  screenWidth = 1920,
+  screenHeight = 1080,
 ): void {
   session.setEscalationHandler((task: string, sourceSessionId: string): boolean => {
     const currentSocket = findSocketForSession(sourceSessionId, ctx);
@@ -388,6 +388,7 @@ async function handleUserMessage(
   try {
     ctx.socketToSession.set(socket, msg.sessionId);
     const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+    wireEscalationHandler(session, socket, ctx);
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
@@ -477,10 +478,11 @@ async function handleSessionCreate(
   const conversation = conversationStore.createConversation(
     msg.title ?? 'New Conversation',
   );
-  await ctx.getOrCreateSession(conversation.id, socket, true, {
+  const session = await ctx.getOrCreateSession(conversation.id, socket, true, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
   });
+  wireEscalationHandler(session, socket, ctx);
   ctx.send(socket, {
     type: 'session_info',
     sessionId: conversation.id,
@@ -500,7 +502,8 @@ async function handleSessionSwitch(
     return;
   }
   ctx.socketToSession.set(socket, msg.sessionId);
-  await ctx.getOrCreateSession(msg.sessionId, socket, true);
+  const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+  wireEscalationHandler(session, socket, ctx);
   ctx.send(socket, {
     type: 'session_info',
     sessionId: conversation.id,


### PR DESCRIPTION
## Summary
- Previously `request_computer_control` only worked in task_submit sessions because `wireEscalationHandler` was only called there
- Now `handleUserMessage`, `handleSessionCreate`, and `handleSessionSwitch` all wire the escalation handler with default 1920x1080 screen dimensions
- Fixes "Computer control escalation is not available in this session" error in regular chat sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
