### PR TITLE
Add rich content support to tool results

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -26,7 +26,7 @@ export type AgentEvent =
   | { type: 'message_complete'; message: Message }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
-  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }
+  | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }
   | { type: 'error'; error: Error }
   | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string };
 
@@ -43,14 +43,14 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }>) | null;
+  private toolExecutor: ((name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>) | null;
 
   constructor(
     provider: Provider,
     systemPrompt: string,
     config?: Partial<AgentLoopConfig>,
     tools?: ToolDefinition[],
-    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string }>,
+    toolExecutor?: (name: string, input: Record<string, unknown>, onOutput?: (chunk: string) => void) => Promise<{ content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }>,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -274,6 +274,7 @@ export class AgentLoop {
             isError: result.isError,
             diff: result.diff,
             status: result.status,
+            contentBlocks: result.contentBlocks,
           });
         }
 
@@ -283,6 +284,7 @@ export class AgentLoop {
           tool_use_id: toolUse.id,
           content: result.content,
           is_error: result.isError,
+          ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
         }));
 
         // If cancelled during execution, push completed results and stop

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -506,7 +506,7 @@ export class Session {
       let exchangeOutputTokens = 0;
       let model = '';
       let runMessages = this.messages;
-      const pendingToolResults = new Map<string, { content: string; isError: boolean }>();
+      const pendingToolResults = new Map<string, { content: string; isError: boolean; contentBlocks?: ContentBlock[] }>();
       const persistedToolUseIds = new Set<string>();
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
@@ -588,7 +588,7 @@ export class Session {
             break;
           case 'tool_result':
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId });
-            pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError });
+            pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
             break;
           case 'error':
             if (isProviderOrderingError(event.error.message)) {
@@ -609,6 +609,7 @@ export class Session {
                   tool_use_id: toolUseId,
                   content: result.content,
                   is_error: result.isError,
+                  ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
                 }),
               );
               conversationStore.addMessage(
@@ -714,6 +715,7 @@ export class Session {
             tool_use_id: toolUseId,
             content: result.content,
             is_error: result.isError,
+            ...(result.contentBlocks ? { contentBlocks: result.contentBlocks } : {}),
           }),
         );
         conversationStore.addMessage(

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -139,13 +139,40 @@ export class AnthropicProvider implements Provider {
           name: block.name,
           input: block.input,
         };
-      case "tool_result":
+      case "tool_result": {
+        if (block.contentBlocks && block.contentBlocks.length > 0) {
+          // Build rich content array: text + images for Anthropic's native multi-part tool results
+          const parts: Anthropic.ToolResultBlockParam['content'] = [
+            { type: "text" as const, text: block.content },
+          ];
+          for (const cb of block.contentBlocks) {
+            if (cb.type === 'image') {
+              parts.push({
+                type: "image" as const,
+                source: {
+                  type: "base64" as const,
+                  media_type: cb.source.media_type as Anthropic.Base64ImageSource["media_type"],
+                  data: cb.source.data,
+                },
+              });
+            } else if (cb.type === 'text') {
+              parts.push({ type: "text" as const, text: cb.text });
+            }
+          }
+          return {
+            type: "tool_result",
+            tool_use_id: block.tool_use_id,
+            content: parts,
+            is_error: block.is_error,
+          };
+        }
         return {
           type: "tool_result",
           tool_use_id: block.tool_use_id,
           content: block.content,
           is_error: block.is_error,
         };
+      }
       default: {
         const _exhaustive: never = block;
         throw new Error(`Unsupported content block type: ${(_exhaustive as ContentBlock).type}`);

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -211,15 +211,26 @@ export class GeminiProvider implements Provider {
             },
           });
           break;
-        case 'tool_result':
+        case 'tool_result': {
+          let outputText = block.content;
+          // Extract additional text from contentBlocks (Gemini function responses only support text)
+          if (block.contentBlocks && block.contentBlocks.length > 0) {
+            const extraText = block.contentBlocks
+              .filter((cb): cb is Extract<ContentBlock, { type: 'text' }> => cb.type === 'text')
+              .map((cb) => cb.text);
+            if (extraText.length > 0) {
+              outputText = outputText + '\n' + extraText.join('\n');
+            }
+          }
           parts.push({
             functionResponse: {
               id: block.tool_use_id,
               name: toolCallNames.get(block.tool_use_id) ?? block.tool_use_id,
-              response: { output: block.content },
+              response: { output: outputText },
             },
           });
           break;
+        }
         // thinking, redacted_thinking — not applicable for Gemini
       }
     }

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -177,10 +177,20 @@ export class OpenAIProvider implements Provider {
 
         // Emit tool results as separate tool-role messages
         for (const tr of toolResults) {
+          let textContent = tr.content;
+          // Extract additional text from contentBlocks (images can't be represented in OpenAI tool results)
+          if (tr.contentBlocks && tr.contentBlocks.length > 0) {
+            const extraText = tr.contentBlocks
+              .filter((cb): cb is Extract<ContentBlock, { type: 'text' }> => cb.type === 'text')
+              .map((cb) => cb.text);
+            if (extraText.length > 0) {
+              textContent = textContent + '\n' + extraText.join('\n');
+            }
+          }
           result.push({
             role: 'tool',
             tool_call_id: tr.tool_use_id,
-            content: tr.is_error ? `[ERROR] ${tr.content}` : tr.content,
+            content: tr.is_error ? `[ERROR] ${textContent}` : textContent,
           });
         }
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -46,6 +46,8 @@ export interface ToolResultContent {
   tool_use_id: string;
   content: string;
   is_error?: boolean;
+  /** Rich content blocks (e.g. images) to include alongside text in the tool result. */
+  contentBlocks?: ContentBlock[];
 }
 
 export type ContentBlock =

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,5 +1,5 @@
 import type { RiskLevel, AllowlistOption, ScopeOption } from '../permissions/types.js';
-import type { ToolDefinition } from '../providers/types.js';
+import type { ToolDefinition, ContentBlock } from '../providers/types.js';
 
 interface ToolLifecycleEventBase {
   toolName: string;
@@ -117,6 +117,8 @@ export interface ToolExecutionResult {
   diff?: DiffInfo;
   /** Optional status message for display (e.g. timeout, truncation). */
   status?: string;
+  /** Optional rich content blocks (e.g. images) to include alongside text in the tool result. */
+  contentBlocks?: ContentBlock[];
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary

Extends the tool result pipeline to support rich content blocks (images, extra text) alongside plain text, enabling tools like `browser_screenshot` to return images to the model.

- **`ToolExecutionResult`** and **`ToolResultContent`** gain an optional `contentBlocks` field
- **Agent loop** passes `contentBlocks` through events and into history blocks
- **Session** stores and persists `contentBlocks` in pending tool results
- **Anthropic provider** builds native multi-part tool results (text + image arrays)
- **OpenAI/Gemini providers** gracefully fall back to text-only extraction

### Files modified
- `assistant/src/tools/types.ts`
- `assistant/src/providers/types.ts`
- `assistant/src/agent/loop.ts`
- `assistant/src/daemon/session.ts`
- `assistant/src/providers/anthropic/client.ts`
- `assistant/src/providers/openai/client.ts`
- `assistant/src/providers/gemini/client.ts`

Closes #1841
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
