### PR TITLE
Add browser_screenshot tool for visual page capture

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -30,6 +30,7 @@ function createMockPage(closed = false) {
     waitForFunction: async () => null,
     route: async () => {},
     unroute: async () => {},
+    screenshot: async () => Buffer.from(''),
     keyboard: { press: async () => {} },
   };
 }

--- a/assistant/src/tools/browser/__tests__/auth-detector.test.ts
+++ b/assistant/src/tools/browser/__tests__/auth-detector.test.ts
@@ -33,6 +33,7 @@ function mockPage(url: string, evaluateResult: unknown = null): Page {
     waitForFunction: async () => null,
     route: async () => {},
     unroute: async () => {},
+    screenshot: async () => Buffer.from(''),
     keyboard: { press: async () => {} },
   };
 }

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -42,6 +42,7 @@ export type Page = {
   waitForFunction(expression: string, options?: { timeout?: number }): Promise<unknown>;
   route(pattern: string, handler: RouteHandler): Promise<void>;
   unroute(pattern: string, handler?: RouteHandler): Promise<void>;
+  screenshot(options?: { type?: string; quality?: number; fullPage?: boolean }): Promise<Buffer>;
   keyboard: { press(key: string): Promise<void> };
 };
 

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -1,6 +1,6 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
-import type { ToolDefinition } from '../../providers/types.js';
+import type { ToolDefinition, ImageContent } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getLogger } from '../../util/logger.js';
 import {
@@ -350,6 +350,69 @@ class BrowserSnapshotTool implements Tool {
 }
 
 registerTool(new BrowserSnapshotTool());
+
+// ── browser_screenshot ───────────────────────────────────────────────
+
+async function executeBrowserScreenshot(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const fullPage = !!input.fullPage;
+
+  try {
+    const page = await browserManager.getOrCreateSessionPage(context.sessionId);
+    const buffer = await page.screenshot({ type: 'jpeg', quality: 80, fullPage });
+    const base64Data = buffer.toString('base64');
+
+    const imageBlock: ImageContent = {
+      type: 'image' as const,
+      source: {
+        type: 'base64' as const,
+        media_type: 'image/jpeg',
+        data: base64Data,
+      },
+    };
+
+    return {
+      content: `Screenshot captured (${buffer.length} bytes, ${fullPage ? 'full page' : 'viewport'})`,
+      isError: false,
+      contentBlocks: [imageBlock],
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, 'Screenshot failed');
+    return { content: `Error: Screenshot failed: ${msg}`, isError: true };
+  }
+}
+
+class BrowserScreenshotTool implements Tool {
+  name = 'browser_screenshot';
+  description = 'Take a visual screenshot of the current page. Returns a JPEG image.';
+  category = 'browser';
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          fullPage: {
+            type: 'boolean',
+            description: 'Capture the full scrollable page instead of just the viewport.',
+          },
+        },
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeBrowserScreenshot(input, context);
+  }
+}
+
+registerTool(new BrowserScreenshotTool());
 
 // ── browser_close ────────────────────────────────────────────────────
 
@@ -961,6 +1024,7 @@ registerTool(new BrowserDetectCaptchaTool());
 export {
   executeBrowserNavigate,
   executeBrowserSnapshot,
+  executeBrowserScreenshot,
   executeBrowserClose,
   executeBrowserClick,
   executeBrowserType,


### PR DESCRIPTION
## Summary

- Adds a `browser_screenshot` tool to the headless browser tools that captures a visual JPEG screenshot and returns it as a rich `ImageContent` block using the `contentBlocks` field (added in #1843)
- Supports an optional `fullPage` parameter to capture the full scrollable page instead of just the viewport
- Adds `screenshot()` to the `Page` type interface in `browser-manager.ts` and updates test mocks

## Files changed

- `assistant/src/tools/browser/headless-browser.ts` — New `BrowserScreenshotTool` class and `executeBrowserScreenshot` function
- `assistant/src/tools/browser/browser-manager.ts` — Added `screenshot()` to `Page` type
- `assistant/src/__tests__/browser-manager.test.ts` — Added `screenshot` to mock page
- `assistant/src/tools/browser/__tests__/auth-detector.test.ts` — Added `screenshot` to mock page

Closes #1842
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
