### PR TITLE
Add Skip button to hotkey onboarding step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -48,6 +48,12 @@ struct FnKeyStepView: View {
                     state.advance()
                 }
                 .transition(.opacity)
+            } else {
+                OnboardingButton(title: "Skip", style: .ghost) {
+                    state.chosenKey = .none
+                    state.advance()
+                }
+                .transition(.opacity)
             }
         }
         .animation(.easeOut(duration: 0.3), value: wrongKeyHint)


### PR DESCRIPTION
## Summary
- Adds a ghost-style "Skip" button to the FnKeyStepView onboarding step, allowing users to skip hotkey setup
- Sets `chosenKey = .none` and advances to the next step when skipped
- Skip button is replaced by Continue once the user selects fn or ctrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
