### PR TITLE
Always show Skip button on hotkey onboarding step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -48,13 +48,13 @@ struct FnKeyStepView: View {
                     state.advance()
                 }
                 .transition(.opacity)
-            } else {
-                OnboardingButton(title: "Skip", style: .ghost) {
-                    state.chosenKey = .none
-                    state.advance()
-                }
-                .transition(.opacity)
             }
+
+            OnboardingButton(title: "Skip", style: .ghost) {
+                state.chosenKey = .none
+                state.advance()
+            }
+            .transition(.opacity)
         }
         .animation(.easeOut(duration: 0.3), value: wrongKeyHint)
         .animation(.easeOut(duration: 0.3), value: highlightedKey)


### PR DESCRIPTION
## Summary
- Skip button is now always visible on the hotkey onboarding step, even after selecting fn or ctrl
- Allows users to change their mind and skip hotkey setup after accidentally selecting an option

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
