### PR TITLE
Subscribe to $isTrustRulesSheetOpen publisher instead of objectWillChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -255,8 +255,10 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
-        .onReceive(daemonClient?.objectWillChange.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            isTrustRulesSheetOpen = daemonClient?.isTrustRulesSheetOpen ?? false
+        .onReceive(
+            daemonClient.map { $0.$isTrustRulesSheetOpen.eraseToAnyPublisher() } ?? Empty().eraseToAnyPublisher()
+        ) { newValue in
+            isTrustRulesSheetOpen = newValue
         }
         .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
             daemonClient?.isTrustRulesSheetOpen = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -255,8 +255,10 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .onReceive(daemonClient?.objectWillChange.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            isTrustRulesSheetOpen = daemonClient?.isTrustRulesSheetOpen ?? false
+        .onReceive(
+            daemonClient.map { $0.$isTrustRulesSheetOpen.eraseToAnyPublisher() } ?? Empty().eraseToAnyPublisher()
+        ) { newValue in
+            isTrustRulesSheetOpen = newValue
         }
         .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
             daemonClient?.isTrustRulesSheetOpen = false


### PR DESCRIPTION
## Summary

Fixes a bug introduced in PR #1813 where `.onReceive(daemonClient?.objectWillChange...)` reads `daemonClient?.isTrustRulesSheetOpen` during `willSet`, getting the **old** value instead of the new one. This causes the local `@State isTrustRulesSheetOpen` to never transition correctly, breaking the trust rules sheet.

**Fix:** Replace the `objectWillChange`-based `onReceive` with a subscription to the `@Published` property's projected publisher (`$isTrustRulesSheetOpen`), which emits the **new** value after the change. This matches the existing pattern at `MainWindowView.swift:83` which uses `daemonClient.$isConnected`.

## Changes

- `SettingsPanel.swift` — subscribe to `$isTrustRulesSheetOpen` publisher instead of `objectWillChange`
- `SettingsView.swift` — same fix

## Test plan

- [ ] Open Settings panel, click "Manage..." to open trust rules sheet — sheet should appear
- [ ] Close the sheet — button should re-enable
- [ ] Verify the same behavior works from the standalone Settings window
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
