### PR TITLE
Use API_KEY_PROVIDERS constant in keys list command

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -11,7 +11,7 @@ import type { AssistantConfig } from './types.js';
 const log = getLogger('config');
 
 // Providers that store API keys in secure storage (superset of VALID_PROVIDERS)
-const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave'] as const;
+export const API_KEY_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks', 'brave'] as const;
 
 let cached: AssistantConfig | null = null;
 let loading = false;

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -30,6 +30,7 @@ import {
   saveRawConfig,
   getNestedValue,
   setNestedValue,
+  API_KEY_PROVIDERS,
 } from './config/loader.js';
 import {
   getAllRules,
@@ -367,7 +368,7 @@ keys
   .description('List all stored API key names')
   .action(() => {
     const stored: string[] = [];
-    for (const provider of ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks']) {
+    for (const provider of API_KEY_PROVIDERS) {
       const value = getSecureKey(provider);
       if (value) stored.push(provider);
     }


### PR DESCRIPTION
## Summary
- Replaced the hardcoded provider array in the `keys list` CLI command with the shared `API_KEY_PROVIDERS` constant from `config/loader.ts`
- This fixes the missing `brave` provider and prevents future drift between the two lists

Addresses feedback from PR #1823.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
