### PR TITLE
Preserve escalation handler dimensions on user message

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -420,7 +420,12 @@ async function handleUserMessage(
   try {
     ctx.socketToSession.set(socket, msg.sessionId);
     const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
-    wireEscalationHandler(session, socket, ctx);
+    // Only wire the escalation handler if one isn't already set — handleTaskSubmit
+    // sets a handler with the client's actual screen dimensions, and overwriting it
+    // here would replace those dimensions with the daemon's defaults.
+    if (!session.hasEscalationHandler()) {
+      wireEscalationHandler(session, socket, ctx);
+    }
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -280,6 +280,10 @@ export class Session {
     this.onEscalateToComputerUse = handler;
   }
 
+  hasEscalationHandler(): boolean {
+    return this.onEscalateToComputerUse !== undefined;
+  }
+
   isProcessing(): boolean {
     return this.processing;
   }


### PR DESCRIPTION
## Summary

`handleUserMessage` unconditionally called `wireEscalationHandler` with default screen dimensions (1920x1080), overwriting the escalation handler that `handleTaskSubmit` had previously configured with the client's actual screen dimensions.

This caused computer-use escalation after the first follow-up message in a `task_submit` session to use the wrong screen dimensions.

## Changes

- Added `Session.hasEscalationHandler()` to check whether an escalation handler is already set
- Guarded the `wireEscalationHandler` call in `handleUserMessage` so it only sets a handler when one doesn't already exist, preserving the client's actual screen dimensions from `handleTaskSubmit`

## Test plan

- Type-check passes (`bunx tsc --noEmit`)
- Verify that `task_submit` sessions preserve client screen dimensions across follow-up user messages
- Verify that regular `user_message` sessions (without prior `task_submit`) still get an escalation handler wired

Fixes feedback from PR #1837.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
