### PR TITLE
Fix browser screenshot param naming and token estimation

### DIFF
--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -34,10 +34,17 @@ export function estimateContentBlockTokens(block: ContentBlock, options?: TokenE
       return TOOL_BLOCK_OVERHEAD_TOKENS
         + estimateTextTokens(block.name)
         + estimateTextTokens(stableJson(block.input));
-    case 'tool_result':
-      return TOOL_BLOCK_OVERHEAD_TOKENS
+    case 'tool_result': {
+      let tokens = TOOL_BLOCK_OVERHEAD_TOKENS
         + estimateTextTokens(block.tool_use_id)
         + estimateTextTokens(block.content);
+      if (block.contentBlocks) {
+        for (const cb of block.contentBlocks) {
+          tokens += estimateContentBlockTokens(cb, options);
+        }
+      }
+      return tokens;
+    }
     case 'image':
       return IMAGE_BLOCK_TOKENS;
     case 'file':

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -357,7 +357,7 @@ async function executeBrowserScreenshot(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const fullPage = !!input.fullPage;
+  const fullPage = input.full_page === true;
 
   try {
     const page = await browserManager.getOrCreateSessionPage(context.sessionId);
@@ -398,7 +398,7 @@ class BrowserScreenshotTool implements Tool {
       input_schema: {
         type: 'object',
         properties: {
-          fullPage: {
+          full_page: {
             type: 'boolean',
             description: 'Capture the full scrollable page instead of just the viewport.',
           },


### PR DESCRIPTION
## Summary
- Rename `fullPage` to `full_page` in the `browser_screenshot` tool schema to match the snake_case convention used by all other browser tool parameters
- Use strict `=== true` comparison instead of `!!` coercion to prevent truthy non-boolean values (e.g. `"false"`) from being treated as `true`
- Account for `contentBlocks` (especially images) in `tool_result` token estimation so conversations with screenshots don't silently exceed context limits

Addresses feedback from #1844.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
