### PR TITLE
Fix scrub DB path and delete WAL/SHM files

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -21,7 +21,7 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
 
 3. Remove the daemon database (conversations, messages, etc.):
    ```bash
-   rm -f ~/.vellum/data/assistant.db
+   rm -f ~/.vellum/data/db/assistant.db ~/.vellum/data/db/assistant.db-shm ~/.vellum/data/db/assistant.db-wal
    ```
 
 4. Remove caches:


### PR DESCRIPTION
## Summary
- Fix DB path from `~/.vellum/data/assistant.db` to `~/.vellum/data/db/assistant.db`
- Also delete SQLite WAL and SHM journal files during scrub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
