### PR TITLE
Fix history loading race condition in ThreadManager

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -529,6 +529,7 @@ exports[`IPC message snapshots ServerMessage types history_response serializes t
       "timestamp": 1700000001,
     },
   ],
+  "sessionId": "sess-history-001",
   "type": "history_response",
 }
 `;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -336,6 +336,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   history_response: {
     type: 'history_response',
+    sessionId: 'sess-history-001',
     messages: [
       { role: 'user', text: 'Hello', timestamp: 1700000000 },
       { role: 'assistant', text: 'Hi there!', timestamp: 1700000001 },

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -673,7 +673,7 @@ function handleHistoryRequest(
     timestamp: m.timestamp,
     ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
   }));
-  ctx.send(socket, { type: 'history_response', messages: historyMessages });
+  ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });
 }
 
 export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistoryMessage[] {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -533,6 +533,7 @@ export interface HistoryResponseToolCall {
 
 export interface HistoryResponse {
   type: 'history_response';
+  sessionId: string;
   messages: Array<{
     role: string;
     text: string;

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -968,7 +968,15 @@ final class ChatViewModel: ObservableObject {
     }
 
     /// Populate messages from history data returned by the daemon.
+    /// Only replaces messages if the user hasn't sent any new messages yet,
+    /// preventing a late history_response from overwriting live conversation.
     func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
+        let hasUserSentMessages = messages.contains { $0.role == .user }
+        if hasUserSentMessages {
+            isHistoryLoaded = true
+            return
+        }
+
         var chatMessages: [ChatMessage] = []
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -19,8 +19,9 @@ final class ThreadManager: ObservableObject {
     private var viewModelCancellable: AnyCancellable?
     private var connectionCancellable: AnyCancellable?
 
-    /// Tracks which thread is currently awaiting a history_response from the daemon.
-    private var pendingHistoryThreadId: UUID?
+    /// Maps session IDs to thread IDs for in-flight history_request messages,
+    /// so rapid tab switches don't cause history from one thread to land in another.
+    private var pendingHistoryBySessionId: [String: UUID] = [:]
 
     /// Called when an inline confirmation response should dismiss the floating panel.
     var confirmationDismissHandler: ((String) -> Void)?
@@ -175,23 +176,22 @@ final class ThreadManager: ObservableObject {
     private func loadHistoryForActiveThreadIfNeeded() {
         guard let activeThreadId else { return }
         guard let thread = threads.first(where: { $0.id == activeThreadId }) else { return }
-        guard thread.sessionId != nil else { return }
+        guard let sessionId = thread.sessionId else { return }
         guard let viewModel = chatViewModels[activeThreadId] else { return }
         guard !viewModel.isHistoryLoaded else { return }
 
-        pendingHistoryThreadId = activeThreadId
+        pendingHistoryBySessionId[sessionId] = activeThreadId
 
         do {
-            try daemonClient.sendHistoryRequest(sessionId: thread.sessionId!)
+            try daemonClient.sendHistoryRequest(sessionId: sessionId)
         } catch {
             log.error("Failed to send history_request: \(error.localizedDescription)")
-            pendingHistoryThreadId = nil
+            pendingHistoryBySessionId.removeValue(forKey: sessionId)
         }
     }
 
     private func handleHistoryResponse(_ response: HistoryResponseMessage) {
-        guard let threadId = pendingHistoryThreadId else { return }
-        pendingHistoryThreadId = nil
+        guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
 
         guard let viewModel = chatViewModels[threadId] else { return }
         viewModel.populateFromHistory(response.messages)

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -691,6 +691,7 @@ struct SessionListResponseMessage: Decodable, Sendable {
 /// Response containing message history for a session.
 /// Wire type: `"history_response"`
 struct HistoryResponseMessage: Decodable, Sendable {
+    let sessionId: String
     struct HistoryToolCallItem: Decodable, Sendable {
         let name: String
         let input: [String: AnyCodable]


### PR DESCRIPTION
## Summary

Addresses review feedback on #1814:

- **Race condition fix**: Replaced single `pendingHistoryThreadId` with a `pendingHistoryBySessionId` dictionary, and added `sessionId` to the daemon's `history_response` payload. This ensures rapid tab switching doesn't route history from one thread into another — each in-flight request is correlated by session ID.

- **Overwrite guard**: `populateFromHistory` now skips replacing messages if the thread already contains user-sent messages, preventing a late `history_response` from clobbering live conversation.

## Changed files
- `assistant/src/daemon/ipc-protocol.ts` — added `sessionId` to `HistoryResponse`
- `assistant/src/daemon/handlers.ts` — echo `sessionId` back in response
- `clients/macos/.../IPCMessages.swift` — added `sessionId` to `HistoryResponseMessage`
- `clients/macos/.../ThreadManager.swift` — dictionary-based pending tracking
- `clients/macos/.../ChatViewModel.swift` — guard against overwriting live messages
- `assistant/src/__tests__/ipc-snapshot.test.ts` + snapshot — updated test fixture

## Test plan
- [x] IPC snapshot tests pass with updated fixture
- [x] TypeScript type-check passes
- [ ] Manual: restore threads, rapidly switch tabs, verify history lands in correct thread
- [ ] Manual: send a message on a restored thread, verify late history_response doesn't overwrite it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
