### PR TITLE
Check all providers for API key instead of only Anthropic

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -24,6 +24,14 @@ enum APIKeyManager {
     static func setKey(_ key: String) { setKey(key, for: "anthropic") }
     static func deleteKey() { deleteKey(for: "anthropic") }
 
+    /// Returns true if any known provider has a key configured.
+    static func hasAnyKey() -> Bool {
+        for provider in ["anthropic", "openai", "gemini", "fireworks"] {
+            if getKey(for: provider) != nil { return true }
+        }
+        return false
+    }
+
     // MARK: - Generic provider access
 
     static func getKey(for provider: String) -> String? {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -428,7 +428,7 @@ struct ChatView: View {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "key.fill")
                     .font(VFont.caption)
-                Text("Anthropic API key not set. Add one in Settings to start chatting.")
+                Text("API key not set. Add one in Settings to start chatting.")
                     .font(VFont.caption)
                     .lineLimit(2)
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
     @State private var activePanel: SidePanelType?
-    @State private var hasAPIKey = APIKeyManager.getKey() != nil
+    @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
@@ -117,7 +117,7 @@ struct MainWindowView: View {
     }
 
     private func refreshAPIKeyState() {
-        hasAPIKey = APIKeyManager.getKey() != nil || daemonClient.isConnected
+        hasAPIKey = APIKeyManager.hasAnyKey() || daemonClient.isConnected
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
+++ b/clients/macos/vellum-assistant/Features/TaskInput/TaskInputView.swift
@@ -8,7 +8,7 @@ struct TaskInputView: View {
     let onSubmit: (TaskSubmission) -> Void
     @ObservedObject var daemonClient: DaemonClient
     @State private var taskText = ""
-    @State private var hasAPIKey = APIKeyManager.getKey() != nil
+    @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var attachments: [TaskAttachment] = []
     @State private var attachmentError: String?
     @State private var isDropTargeted = false
@@ -160,7 +160,7 @@ struct TaskInputView: View {
     }
 
     private func refreshAPIKeyState() {
-        hasAPIKey = APIKeyManager.getKey() != nil || daemonClient.isConnected
+        hasAPIKey = APIKeyManager.hasAnyKey() || daemonClient.isConnected
     }
 
     private func pickerTypes() -> [UTType] {


### PR DESCRIPTION
## Summary
- Add `APIKeyManager.hasAnyKey()` that checks anthropic, openai, gemini, and fireworks
- Use it in MainWindowView and TaskInputView instead of `getKey()` (Anthropic-only)
- Change banner text from "Anthropic API key not set" to "API key not set"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
