### PR TITLE
Enlarge side panel close button hitbox

### DIFF
--- a/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/macos/vellum-assistant/DesignSystem/Components/Layout/VSidePanel.swift
@@ -19,6 +19,8 @@ struct VSidePanel<PinnedContent: View, Content: View>: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundColor(VColor.textMuted)
+                            .frame(width: 32, height: 32)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Close \(title)")


### PR DESCRIPTION
## Summary
- Added a 32x32pt frame and `contentShape(Rectangle())` to the VSidePanel close button, making the click target much larger than the 12pt icon alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
