### PR TITLE
Only cache successful screen dimension queries

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -84,8 +84,7 @@ function getScreenDimensions(): { width: number; height: number } {
   } catch (err) {
     log.debug({ err }, 'Failed to query screen dimensions, using fallback');
   }
-  cachedScreenDims = FALLBACK_SCREEN;
-  return cachedScreenDims;
+  return FALLBACK_SCREEN;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Don't persist `FALLBACK_SCREEN` into `cachedScreenDims` when the swift command fails
- A transient failure (timeout, toolchain issue) previously locked every subsequent call into returning 1920x1080 for the daemon's lifetime
- Now only successful queries are cached; failures return the fallback for the current invocation and retry on the next call

Addresses feedback from #1838.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
