### PR TITLE
Fix chat input lag when image is attached

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum ChatRole: String {
@@ -107,6 +108,13 @@ struct ChatAttachment: Identifiable {
     let data: String
     /// Pre-rendered thumbnail for image attachments (resized to 120px max dimension).
     let thumbnailData: Data?
+    /// Pre-computed length of `data` to avoid O(n) String.count during rendering.
+    /// Swift's String.count iterates the entire string to count grapheme clusters,
+    /// which is expensive for multi-MB base64 strings on every SwiftUI render pass.
+    let dataLength: Int
+    /// Pre-decoded thumbnail NSImage, cached to avoid decoding PNG data on every
+    /// SwiftUI render pass (each keystroke triggers a re-evaluation of the composer).
+    let thumbnailImage: NSImage?
 }
 
 struct SkillInvocationData: Equatable {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -323,13 +323,12 @@ struct ChatView: View {
     }
 
     private func attachmentChip(_ attachment: ChatAttachment) -> some View {
-        let fileSize = formattedFileSize(base64Length: attachment.data.count)
+        let fileSize = formattedFileSize(base64Length: attachment.dataLength)
         let isImage = attachment.mimeType.hasPrefix("image/")
 
         return VStack(spacing: VSpacing.xxs) {
             ZStack(alignment: .topTrailing) {
-                if isImage, let thumbnailData = attachment.thumbnailData,
-                   let nsImage = NSImage(data: thumbnailData) {
+                if isImage, let nsImage = attachment.thumbnailImage {
                     Image(nsImage: nsImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
@@ -644,7 +643,7 @@ private struct ChatBubble: View {
                 .foregroundColor(isUser ? .white : VColor.textPrimary)
                 .lineLimit(1)
 
-            Text(formattedFileSize(base64Length: attachment.data.count))
+            Text(formattedFileSize(base64Length: attachment.dataLength))
                 .font(VFont.small)
                 .foregroundColor(isUser ? .white.opacity(0.6) : VColor.textMuted)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -120,7 +120,9 @@ final class ChatViewModel: ObservableObject {
             filename: filename,
             mimeType: mimeType,
             data: base64,
-            thumbnailData: thumbnail
+            thumbnailData: thumbnail,
+            dataLength: base64.count,
+            thumbnailImage: thumbnail.flatMap { NSImage(data: $0) }
         )
         pendingAttachments.append(attachment)
     }
@@ -166,7 +168,9 @@ final class ChatViewModel: ObservableObject {
             filename: "Pasted Image.png",
             mimeType: "image/png",
             data: base64,
-            thumbnailData: thumbnail
+            thumbnailData: thumbnail,
+            dataLength: base64.count,
+            thumbnailImage: thumbnail.flatMap { NSImage(data: $0) }
         )
         pendingAttachments.append(attachment)
     }


### PR DESCRIPTION
## Summary
- Pre-compute `dataLength` and `thumbnailImage` on `ChatAttachment` at creation time instead of re-deriving them on every SwiftUI render pass
- Previously each keystroke triggered O(n) `String.count` on multi-MB base64 strings and re-decoded thumbnail PNG data into `NSImage` on the main thread
- Eliminates the typing lag reported when images are attached in the chat bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
