### PR TITLE
Remove truncation from debug prompt logger hook

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -14,16 +14,16 @@ echo "" >&2
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "(jq not found — install jq for formatted output)" >&2
-  printf '%s' "$data" | dd bs=3000 count=1 >&2 2>/dev/null
+  printf '%s' "$data" >&2
   echo "" >&2
   echo "════════════════════════════════════════════════════════════════" >&2
   echo "" >&2
   exit 0
 fi
 
-# System prompt (first 2000 chars)
+# System prompt
 echo "── System Prompt ──────────────────────────────────────────────" >&2
-printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' | dd bs=2000 count=1 >&2 2>/dev/null
+printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' >&2
 echo "" >&2
 echo "" >&2
 
@@ -34,19 +34,19 @@ toolCount=$(printf '%s' "$data" | jq -r '.toolCount // 0')
 echo "Model: $model | Messages: $msgCount | Tools: $toolCount" >&2
 echo "" >&2
 
-# Last 10 messages (compact)
-echo "── Recent Messages (last 10) ──────────────────────────────────" >&2
+# All messages
+echo "── Messages ───────────────────────────────────────────────────" >&2
 printf '%s' "$data" | jq -r '
-  .messages[-10:][] |
+  .messages[] |
   "\(.role): " + (
     if (.content | type) == "string" then
-      .content[:200]
+      .content
     elif (.content | type) == "array" then
       [.content[] |
-        if .type == "text" then .text[:200]
-        elif .type == "tool_use" then "[tool_use: \(.name)]"
-        elif .type == "tool_result" then "[tool_result: \(.content // "" | tostring | .[:100])]"
-        else "[" + .type + "]"
+        if .type == "text" then .text
+        elif .type == "tool_use" then "[tool_use: \(.name)] \(.input | tostring)"
+        elif .type == "tool_result" then "[tool_result: \(.content // "" | tostring)]"
+        else "[" + .type + "] " + (. | tostring)
         end
       ] | join(" | ")
     else


### PR DESCRIPTION
## Summary
- Remove all truncation limits from the debug prompt logger hook template
- System prompt, messages, tool inputs, and tool results are now logged in full
- All messages are shown instead of only the last 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
