### PR TITLE
Clear Qdrant vector DB in `sessions clear`

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -30,6 +30,7 @@ import {
   saveRawConfig,
   getNestedValue,
   setNestedValue,
+  getConfig,
   API_KEY_PROVIDERS,
 } from './config/loader.js';
 import {
@@ -46,6 +47,7 @@ import {
   clearAll as clearAllConversations,
 } from './memory/conversation-store.js';
 import { initializeDb } from './memory/db.js';
+import { initQdrantClient } from './memory/qdrant-client.js';
 import { formatMarkdown, formatJson } from './export/formatter.js';
 import {
   getMemorySystemStatus,
@@ -294,9 +296,9 @@ sessions
 
 sessions
   .command('clear')
-  .description('Clear all conversations and messages from the daemon SQLite DB (dev only)')
+  .description('Clear all conversations, messages, and vector data (dev only)')
   .action(async () => {
-    console.log('This will permanently delete all conversations and messages from the daemon SQLite database.');
+    console.log('This will permanently delete all conversations, messages, and vector data.');
 
     const readline = await import('node:readline');
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -312,6 +314,23 @@ sessions
     initializeDb();
     const result = clearAllConversations();
     console.log(`Cleared ${result.conversations} conversations, ${result.messages} messages`);
+
+    const config = getConfig();
+    const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
+    const qdrant = initQdrantClient({
+      url: qdrantUrl,
+      collection: config.memory.qdrant.collection,
+      vectorSize: config.memory.qdrant.vectorSize,
+      onDisk: config.memory.qdrant.onDisk,
+      quantization: config.memory.qdrant.quantization,
+    });
+    const deleted = await qdrant.deleteCollection();
+    if (deleted) {
+      console.log(`Deleted Qdrant collection "${config.memory.qdrant.collection}"`);
+    } else {
+      console.log('Qdrant collection not found or not reachable (skipped)');
+    }
+
     console.log('Done.');
   });
 

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -252,6 +252,19 @@ export class VellumQdrantClient {
     return result.count;
   }
 
+  async deleteCollection(): Promise<boolean> {
+    try {
+      const exists = await this.client.collectionExists(this.collection);
+      if (!exists.exists) return false;
+      await this.client.deleteCollection(this.collection);
+      this.collectionReady = false;
+      return true;
+    } catch (err) {
+      log.warn({ err, collection: this.collection }, 'Failed to delete Qdrant collection');
+      return false;
+    }
+  }
+
   private async findByTarget(targetType: string, targetId: string): Promise<string | null> {
     try {
       const results = await this.client.scroll(this.collection, {


### PR DESCRIPTION
## Summary
- Adds `deleteCollection()` method to `VellumQdrantClient`
- `vellum sessions clear` now deletes the Qdrant collection after clearing SQLite data
- Gracefully skips if Qdrant is not reachable or collection doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
