### PR TITLE
Show browser screenshot image in tool call result

### DIFF
--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -455,6 +455,8 @@ export interface ToolResult {
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };
   status?: string;
   sessionId?: string;
+  /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot). */
+  imageData?: string;
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { v4 as uuid } from 'uuid';
-import type { Message, ContentBlock } from '../providers/types.js';
+import type { Message, ContentBlock, ImageContent } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
@@ -590,10 +590,12 @@ export class Session {
           case 'tool_output_chunk':
             onEvent({ type: 'tool_output_chunk', chunk: event.chunk });
             break;
-          case 'tool_result':
-            onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId });
+          case 'tool_result': {
+            const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
+            onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
             break;
+          }
           case 'error':
             if (isProviderOrderingError(event.error.message)) {
               orderingErrorDetected = true;

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -75,14 +75,17 @@ struct ToolCallData: Identifiable, Equatable {
     var result: String?
     var isError: Bool
     var isComplete: Bool
+    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
+    var imageData: String?
 
-    init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false) {
+    init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, imageData: String? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
         self.result = result
         self.isError = isError
         self.isComplete = isComplete
+        self.imageData = imageData
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -683,6 +683,7 @@ final class ChatViewModel: ObservableObject {
                 messages[msgIndex].toolCalls[tcIndex].result = truncatedResult
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
+                messages[msgIndex].toolCalls[tcIndex].imageData = msg.imageData
             }
 
         case .uiSurfaceShow(let msg):

--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -8,11 +8,15 @@ struct ToolCallChip: View {
         toolCall.toolName
     }
 
+    private var hasExpandableContent: Bool {
+        toolCall.result != nil || toolCall.imageData != nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Chip header (always visible)
             Button {
-                if toolCall.isComplete {
+                if toolCall.isComplete && hasExpandableContent {
                     withAnimation(VAnimation.fast) { isExpanded.toggle() }
                 }
             } label: {
@@ -42,7 +46,7 @@ struct ToolCallChip: View {
                         ProgressView()
                             .scaleEffect(0.6)
                             .frame(width: 14, height: 14)
-                    } else if toolCall.result != nil {
+                    } else if hasExpandableContent {
                         // Chevron for expandable result
                         Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
                             .font(.system(size: 9, weight: .semibold))
@@ -55,15 +59,31 @@ struct ToolCallChip: View {
             .buttonStyle(.plain)
 
             // Expanded result
-            if isExpanded, let result = toolCall.result {
-                ScrollView {
-                    Text(result)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
+            if isExpanded, hasExpandableContent {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Image preview (for browser_screenshot etc.)
+                    if let imageData = toolCall.imageData,
+                       let data = Data(base64Encoded: imageData),
+                       let nsImage = NSImage(data: data) {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+
+                    // Text result
+                    if let result = toolCall.result {
+                        ScrollView {
+                            Text(result)
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxHeight: 200)
+                    }
                 }
-                .frame(maxHeight: 200)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.bottom, VSpacing.sm)
             }

--- a/clients/macos/vellum-assistant/IPC/IPCMessages.swift
+++ b/clients/macos/vellum-assistant/IPC/IPCMessages.swift
@@ -809,6 +809,8 @@ struct ToolResultMessage: Decodable, Sendable {
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let status: String?
     let sessionId: String?
+    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
+    let imageData: String?
 }
 
 /// Follow-up suggestion response from daemon.


### PR DESCRIPTION
## Summary
- Forward base64 image data from tool `contentBlocks` through the IPC `tool_result` message via a new `imageData` field
- Desktop app's `ToolCallChip` now renders the screenshot image inline when expanded, above the text result
- Chevron/expand logic updated to trigger on image data presence, not just text results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
