### PR TITLE
Truncate base64 image/file data in debug prompt logger

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -44,6 +44,8 @@ printf '%s' "$data" | jq -r '
     elif (.content | type) == "array" then
       [.content[] |
         if .type == "text" then .text
+        elif .type == "image" then "[image: \(.source.media_type // "unknown")] \(.source.data[:1000])..."
+        elif .type == "file" then "[file: \(.source.filename // "unknown")] \(.source.data[:1000])..."
         elif .type == "tool_use" then "[tool_use: \(.name)] \(.input | tostring)"
         elif .type == "tool_result" then "[tool_result: \(.content // "" | tostring)]"
         else "[" + .type + "] " + (. | tostring)


### PR DESCRIPTION
## Summary
- Add explicit handling for `image` and `file` content blocks in the debug prompt logger hook
- Truncate base64 data to 1000 characters to prevent log blowup from attached images
- All other logging output remains untruncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
