### PR TITLE
Add regenerate message button with full memory cleanup

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -78,6 +78,13 @@ exports[`IPC message snapshots ClientMessage types undo serializes to expected J
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types regenerate serializes to expected JSON 1`] = `
+{
+  "sessionId": "sess-001",
+  "type": "regenerate",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types usage_request serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -62,6 +62,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'undo',
     sessionId: 'sess-001',
   },
+  regenerate: {
+    type: 'regenerate',
+    sessionId: 'sess-001',
+  },
   usage_request: {
     type: 'usage_request',
     sessionId: 'sess-001',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -19,6 +19,7 @@ import type {
   ModelSetRequest,
   HistoryRequest,
   UndoRequest,
+  RegenerateRequest,
   UsageRequest,
   SandboxSetRequest,
   UserMessage,
@@ -337,6 +338,7 @@ const handlers: DispatchMap = {
   model_set: handleModelSet,
   history_request: handleHistoryRequest,
   undo: handleUndo,
+  regenerate: handleRegenerate,
   usage_request: handleUsageRequest,
   sandbox_set: handleSandboxSet,
   cu_session_create: handleCuSessionCreate,
@@ -725,6 +727,27 @@ function handleUndo(
   }
   const removedCount = session.undo();
   ctx.send(socket, { type: 'undo_complete', removedCount });
+}
+
+async function handleRegenerate(
+  msg: RegenerateRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const session = ctx.sessions.get(msg.sessionId);
+  if (!session) {
+    ctx.send(socket, { type: 'error', message: 'No active session' });
+    return;
+  }
+
+  const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+  try {
+    await session.regenerate(sendEvent);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');
+    ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
+  }
 }
 
 function handleUsageRequest(

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -82,6 +82,11 @@ export interface UndoRequest {
   sessionId: string;
 }
 
+export interface RegenerateRequest {
+  type: 'regenerate';
+  sessionId: string;
+}
+
 export interface UsageRequest {
   type: 'usage_request';
   sessionId: string;
@@ -389,6 +394,7 @@ export type ClientMessage =
   | ModelSetRequest
   | HistoryRequest
   | UndoRequest
+  | RegenerateRequest
   | UsageRequest
   | SandboxSetRequest
   | CuSessionCreate

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -3,6 +3,8 @@ import { v4 as uuid } from 'uuid';
 import type { Message, ContentBlock, ImageContent } from '../providers/types.js';
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
+import { getQdrantClient } from '../memory/qdrant-client.js';
+import type { DeletedMemoryIds } from '../memory/conversation-store.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { CheckpointDecision } from '../agent/loop.js';
@@ -958,6 +960,118 @@ export class Session {
     }
 
     return removed;
+  }
+
+  /**
+   * Regenerate the last assistant response: remove the assistant's reply
+   * (and any intermediate tool_result messages) from memory, DB, and
+   * Qdrant, then re-run the agent loop with the same user message.
+   */
+  async regenerate(onEvent: (msg: ServerMessage) => void): Promise<void> {
+    if (this.processing) {
+      onEvent({ type: 'error', message: 'Cannot regenerate while processing' });
+      return;
+    }
+
+    // Find the last undoable user message — everything after it is the
+    // assistant's exchange that we want to regenerate.
+    const lastUserIdx = findLastUndoableUserMessageIndex(this.messages);
+    if (lastUserIdx === -1) {
+      onEvent({ type: 'error', message: 'No messages to regenerate' });
+      return;
+    }
+
+    // There must be at least one message after the user message (the assistant reply).
+    if (lastUserIdx >= this.messages.length - 1) {
+      onEvent({ type: 'error', message: 'No assistant response to regenerate' });
+      return;
+    }
+
+    // Remove the assistant's exchange from in-memory history (keep the user message).
+    this.messages = this.messages.slice(0, lastUserIdx + 1);
+
+    // Find DB message IDs to delete: get all messages from the DB, then
+    // identify the ones that come after the last user message.
+    const dbMessages = conversationStore.getMessages(this.conversationId);
+
+    // Walk backwards to find the last real (non-tool_result) user message in the DB.
+    let dbUserMsgIdx = -1;
+    for (let i = dbMessages.length - 1; i >= 0; i--) {
+      if (dbMessages[i].role !== 'user') continue;
+      try {
+        const parsed = JSON.parse(dbMessages[i].content);
+        if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((b: Record<string, unknown>) => b.type === 'tool_result')) {
+          continue; // Skip tool_result-only user messages
+        }
+      } catch { /* plain text = real user message */ }
+      dbUserMsgIdx = i;
+      break;
+    }
+
+    if (dbUserMsgIdx === -1) {
+      onEvent({ type: 'error', message: 'No user message found in DB' });
+      return;
+    }
+
+    // Everything after the user message needs to be deleted.
+    const messagesToDelete = dbMessages.slice(dbUserMsgIdx + 1);
+
+    // Delete each message via deleteMessageById and collect IDs for Qdrant cleanup.
+    const allSegmentIds: string[] = [];
+    const allOrphanedItemIds: string[] = [];
+    for (const msg of messagesToDelete) {
+      const deleted = conversationStore.deleteMessageById(msg.id);
+      allSegmentIds.push(...deleted.segmentIds);
+      allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    }
+
+    // Clean up Qdrant vectors (fire-and-forget).
+    this.cleanupQdrantVectors(allSegmentIds, allOrphanedItemIds).catch((err) => {
+      log.warn({ err, conversationId: this.conversationId }, 'Qdrant cleanup after regenerate failed (non-fatal)');
+    });
+
+    // Re-extract the user message content for the agent loop.
+    const userMessage = this.messages[lastUserIdx];
+    const textBlocks = userMessage.content.filter(
+      (b) => b.type === 'text',
+    );
+    const content = textBlocks
+      .map((b) => (b as { type: 'text'; text: string }).text)
+      .join('');
+
+    // Notify client that the old response has been removed.
+    onEvent({ type: 'undo_complete', removedCount: messagesToDelete.length });
+
+    // Re-run the agent loop with the same user message.
+    await this.processMessage(content, [], onEvent);
+  }
+
+  /**
+   * Delete Qdrant vector entries for the given segment and item IDs.
+   */
+  private async cleanupQdrantVectors(segmentIds: string[], orphanedItemIds: string[]): Promise<void> {
+    let qdrant: ReturnType<typeof getQdrantClient>;
+    try {
+      qdrant = getQdrantClient();
+    } catch {
+      return; // Qdrant not initialized — nothing to clean up.
+    }
+
+    const deletions: Promise<void>[] = [];
+    for (const segId of segmentIds) {
+      deletions.push(qdrant.deleteByTarget('segment', segId));
+    }
+    for (const itemId of orphanedItemIds) {
+      deletions.push(qdrant.deleteByTarget('item', itemId));
+    }
+
+    if (deletions.length > 0) {
+      await Promise.all(deletions);
+      log.info(
+        { conversationId: this.conversationId, segments: segmentIds.length, items: orphanedItemIds.length },
+        'Cleaned up Qdrant vectors after regenerate',
+      );
+    }
   }
 
   private async surfaceProxyResolver(

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities } from './schema.js';
+import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -244,6 +244,16 @@ export function deleteLastExchange(conversationId: string): number {
 }
 
 /**
+ * IDs collected during message deletion for Qdrant vector cleanup.
+ * Callers must delete these from the Qdrant collection after the
+ * SQLite transaction commits.
+ */
+export interface DeletedMemoryIds {
+  segmentIds: string[];
+  orphanedItemIds: string[];
+}
+
+/**
  * Delete a single message by ID without cascading to message_runs or
  * channel_inbound_events. Nullable FK columns in those tables are set to
  * NULL before the message row is removed, so associated run and event
@@ -255,10 +265,23 @@ export function deleteLastExchange(conversationId: string): number {
  * Without cleanup, those items would leak into summaries and recall.
  * We delete any memory_items that become orphaned (no remaining sources)
  * after this message is removed.
+ *
+ * Returns segment and orphaned item IDs so the caller can clean up the
+ * corresponding Qdrant vector entries.
  */
-export function deleteMessageById(messageId: string): void {
+export function deleteMessageById(messageId: string): DeletedMemoryIds {
   const db = getDb();
+  const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+
   db.transaction((tx) => {
+    // Collect memory segment IDs linked to this message before cascade.
+    const linkedSegments = tx
+      .select({ id: memorySegments.id })
+      .from(memorySegments)
+      .where(eq(memorySegments.messageId, messageId))
+      .all();
+    result.segmentIds = linkedSegments.map((r) => r.id);
+
     // Collect memory item IDs linked to this message before cascade.
     const linkedItems = tx
       .select({ memoryItemId: memoryItemSources.memoryItemId })
@@ -281,6 +304,16 @@ export function deleteMessageById(messageId: string): void {
     // memory_segments, and message_attachments.
     tx.delete(messages).where(eq(messages.id, messageId)).run();
 
+    // Clean up segment embeddings from SQLite (Qdrant cleanup is the caller's job).
+    if (result.segmentIds.length > 0) {
+      tx.delete(memoryEmbeddings)
+        .where(and(
+          eq(memoryEmbeddings.targetType, 'segment'),
+          inArray(memoryEmbeddings.targetId, result.segmentIds),
+        ))
+        .run();
+    }
+
     // Clean up orphaned memory items whose only source was this message.
     if (candidateItemIds.length > 0) {
       // Find which items still have at least one remaining source.
@@ -291,6 +324,7 @@ export function deleteMessageById(messageId: string): void {
         .all();
       const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
       const orphanedIds = candidateItemIds.filter((id) => !survivingIds.has(id));
+      result.orphanedItemIds = orphanedIds;
 
       if (orphanedIds.length > 0) {
         // Delete memory_item_entities (no FK cascade on this table).
@@ -311,4 +345,6 @@ export function deleteMessageById(messageId: string): void {
       }
     }
   });
+
+  return result;
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -27,6 +27,7 @@ struct ChatView: View {
     let onConfirmationDeny: (String) -> Void
     let onAddTrustRule: (String, String, String, String) -> Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
+    let onRegenerate: () -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -106,6 +107,25 @@ struct ChatView: View {
                             ChatBubble(message: message, onSurfaceAction: onSurfaceAction)
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        }
+
+                        // Regenerate button on the last assistant message
+                        if message.role == .assistant
+                            && !message.isStreaming
+                            && index == messages.count - 1
+                            && !isSending {
+                            HStack {
+                                Button(action: onRegenerate) {
+                                    Image(systemName: "arrow.trianglehead.counterclockwise")
+                                        .font(.system(size: 13, weight: .medium))
+                                        .foregroundColor(VColor.textMuted)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Regenerate response")
+                                .help("Regenerate response")
+                                Spacer()
+                            }
+                            .padding(.top, -VSpacing.sm)
                         }
                     }
 
@@ -885,7 +905,8 @@ private struct ChatViewPreviewWrapper: View {
                 onConfirmationAllow: { _ in },
                 onConfirmationDeny: { _ in },
                 onAddTrustRule: { _, _, _, _ in true },
-                onSurfaceAction: { _, _, _ in }
+                onSurfaceAction: { _, _, _ in },
+                onRegenerate: {}
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -499,6 +499,15 @@ final class ChatViewModel: ObservableObject {
                 fetchSuggestion()
             }
 
+        case .undoComplete:
+            // Remove all messages after the last user message (the assistant
+            // exchange that was regenerated). The daemon will immediately start
+            // streaming a new response.
+            if let lastUserIndex = messages.lastIndex(where: { $0.role == .user }) {
+                messages.removeSubrange((lastUserIndex + 1)...)
+            }
+            currentAssistantMessageId = nil
+
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
             cancelTimeoutTask?.cancel()
@@ -873,6 +882,35 @@ final class ChatViewModel: ObservableObject {
                     self.messages[i].status = .sent
                 }
             }
+        }
+    }
+
+    /// Regenerate the last assistant response. Removes the old reply from
+    /// all memory systems (including Qdrant) and re-runs the agent loop.
+    func regenerateLastMessage() {
+        guard let sessionId, !isSending else { return }
+        guard daemonClient.isConnected else {
+            errorText = "Cannot connect to daemon. Please ensure it's running."
+            return
+        }
+
+        isSending = true
+        isThinking = true
+        suggestion = nil
+        pendingSuggestionRequestId = nil
+
+        // Make sure we're listening for the response
+        if messageLoopTask == nil {
+            startMessageLoop()
+        }
+
+        do {
+            try daemonClient.sendRegenerate(sessionId: sessionId)
+        } catch {
+            log.error("Failed to send regenerate: \(error.localizedDescription)")
+            isSending = false
+            isThinking = false
+            errorText = "Failed to regenerate message."
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,7 +64,8 @@ struct MainWindowView: View {
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                             onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
                             onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
-                            onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) }
+                            onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
+                            onRegenerate: { viewModel.regenerateLastMessage() }
                         )
                     }
                 }, panel: {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -488,6 +488,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(SkillsConfigureMessage(name: name, env: env, apiKey: apiKey, config: config))
     }
 
+    // MARK: - Regenerate
+
+    /// Regenerate the last assistant response for a session.
+    func sendRegenerate(sessionId: String) throws {
+        try send(RegenerateMessage(sessionId: sessionId))
+    }
+
     // MARK: - Sessions
 
     /// Request the list of past sessions from the daemon.

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -338,6 +338,17 @@ public struct SessionListRequestMessage: Encodable, Sendable {
     public init() {}
 }
 
+/// Sent to regenerate the last assistant response.
+/// Wire type: `"regenerate"`
+public struct RegenerateMessage: Encodable, Sendable {
+    public let type: String = "regenerate"
+    public let sessionId: String
+
+    public init(sessionId: String) {
+        self.sessionId = sessionId
+    }
+}
+
 /// Sent to request message history for a specific session.
 /// Wire type: `"history_request"`
 public struct HistoryRequestMessage: Encodable, Sendable {
@@ -640,6 +651,11 @@ public struct UiSurfaceUpdateMessage: Decodable, Sendable {
 public struct UiSurfaceDismissMessage: Decodable, Sendable {
     public let sessionId: String
     public let surfaceId: String
+}
+
+/// Confirms undo/regenerate removed messages.
+public struct UndoCompleteMessage: Decodable, Sendable {
+    public let removedCount: Int
 }
 
 /// Confirms generation was cancelled.
@@ -1263,6 +1279,7 @@ public enum ServerMessage: Decodable, Sendable {
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
     case uiSurfaceDismiss(UiSurfaceDismissMessage)
+    case undoComplete(UndoCompleteMessage)
     case generationCancelled(GenerationCancelledMessage)
     case generationHandoff(GenerationHandoffMessage)
     case confirmationRequest(ConfirmationRequestMessage)
@@ -1346,6 +1363,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "ui_surface_dismiss":
             let message = try UiSurfaceDismissMessage(from: decoder)
             self = .uiSurfaceDismiss(message)
+        case "undo_complete":
+            let message = try UndoCompleteMessage(from: decoder)
+            self = .undoComplete(message)
         case "generation_cancelled":
             let message = try GenerationCancelledMessage(from: decoder)
             self = .generationCancelled(message)


### PR DESCRIPTION
## Summary
- Adds a regenerate (redo) button below the last assistant message in the chat UI
- Clicking it deletes the old response from SQLite, memory segments, memory items, and Qdrant vectors
- Re-runs the agent loop with the same user message to produce a fresh response
- Full-stack implementation: IPC protocol, daemon handler, session logic, macOS client UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
