### PR TITLE
Fix notarization: sign Sparkle nested binaries and detect Invalid status

### DIFF
--- a/.github/workflows/build-and-release-macos.yml
+++ b/.github/workflows/build-and-release-macos.yml
@@ -211,8 +211,9 @@ jobs:
           # Extract the submission ID for log fetching
           SUBMISSION_ID=$(echo "$NOTARIZE_OUTPUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
 
-          if [ "$NOTARIZE_FAILED" = "true" ]; then
-            echo "::error::Notarization failed"
+          # Check for failure: either the command failed or Apple rejected the submission
+          if [ "$NOTARIZE_FAILED" = "true" ] || echo "$NOTARIZE_OUTPUT" | grep -q "status: Invalid"; then
+            echo "::error::Notarization failed (status: Invalid or command error)"
             if [ -n "$SUBMISSION_ID" ]; then
               echo "Fetching notarization log for submission $SUBMISSION_ID..."
               xcrun notarytool log "$SUBMISSION_ID" \
@@ -224,11 +225,9 @@ jobs:
             exit 1
           fi
 
-          echo "Notarization succeeded"
+          echo "Notarization succeeded (status: Accepted)"
 
       - name: Staple notarization ticket
-        id: staple
-        continue-on-error: true
         run: |
           # Apple's CDN can take several minutes to propagate the ticket after notarization
           MAX_ATTEMPTS=15
@@ -327,7 +326,7 @@ jobs:
           echo "Appcast generated for $REPO"
 
       - name: Create GitHub Release on public repos
-        if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           UPSTREAM_BODY: ${{ github.event.release.body }}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -282,14 +282,29 @@ echo "Signing with: $SIGN_IDENTITY"
 # Sign components explicitly (Apple's recommended approach instead of --deep)
 # This ensures nested binaries with specific entitlements aren't overwritten
 
-# Sign Sparkle.framework first
+# Sign Sparkle.framework — must sign nested binaries inside-out before the outer framework
 if [ -d "$FRAMEWORKS_DIR/Sparkle.framework" ]; then
     FW_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
     if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
         FW_SIGN_FLAGS+=(--timestamp --options runtime)
     fi
+
+    SPARKLE_VERSIONS="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B"
+
+    # Sign XPC services first (deepest nesting)
+    for XPC in "$SPARKLE_VERSIONS"/XPCServices/*.xpc; do
+        [ -d "$XPC" ] && codesign "${FW_SIGN_FLAGS[@]}" "$XPC"
+    done
+
+    # Sign Updater.app
+    [ -d "$SPARKLE_VERSIONS/Updater.app" ] && codesign "${FW_SIGN_FLAGS[@]}" "$SPARKLE_VERSIONS/Updater.app"
+
+    # Sign Autoupdate binary
+    [ -f "$SPARKLE_VERSIONS/Autoupdate" ] && codesign "${FW_SIGN_FLAGS[@]}" "$SPARKLE_VERSIONS/Autoupdate"
+
+    # Sign the outer framework last
     codesign "${FW_SIGN_FLAGS[@]}" "$FRAMEWORKS_DIR/Sparkle.framework"
-    echo "Sparkle.framework signed"
+    echo "Sparkle.framework signed (including nested binaries)"
 fi
 
 # Sign daemon binary with its own entitlements (JIT, network)


### PR DESCRIPTION
## Summary
- Sign Sparkle's nested binaries (Updater.app, XPC services, Autoupdate) inside-out before the outer framework — Apple was rejecting notarization because these lacked Developer ID signatures
- Detect `status: Invalid` in notarytool output (it returns exit code 0 even on rejection) and dump the rejection log
- Remove `continue-on-error: true` from staple step and `if: always()` from release step so broken builds aren't silently published

## Test plan
- [x] Triggered workflow from branch — notarization now returns `status: Accepted` and stapling succeeds on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
