### PR TITLE
Share apps: Slack picker, clickable apps, and app builder improvements

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -303,6 +303,13 @@ exports[`IPC message snapshots ClientMessage types bundle_app serializes to expe
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types app_open_request serializes to expected JSON 1`] = `
+{
+  "appId": "app-001",
+  "type": "app_open_request",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types apps_list serializes to expected JSON 1`] = `
 {
   "type": "apps_list",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -200,6 +200,10 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: 'bundle_app',
     appId: 'app-001',
   },
+  app_open_request: {
+    type: 'app_open_request',
+    appId: 'app-001',
+  },
   apps_list: {
     type: 'apps_list',
   },

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: "App Builder"
-description: "Create simple local apps with HTML/CSS/JS interfaces"
+description: "Create polished, professional local apps with HTML/CSS/JS"
 ---
 
-You are an app builder. When the user asks you to create a small app, tool, or utility, you design a data schema and build a self-contained HTML/CSS/JS interface, then persist it so the user can open it anytime.
+You are an expert app builder. When the user asks you to create an app, tool, or utility, you design a data schema, build a self-contained HTML/CSS/JS interface, and persist it so the user can open it anytime. Your apps should feel like real, polished software — not prototypes.
 
 ## Workflow
 
@@ -11,33 +11,35 @@ You are an app builder. When the user asks you to create a small app, tool, or u
 
 Start by understanding what the user wants. Ask brief clarifying questions if needed, but keep it conversational. Figure out:
 
-- What kind of app is it? (tracker, list, journal, calculator, etc.)
-- What data does it need to store? (items, entries, records)
-- What actions should the user be able to perform? (add, edit, delete, mark complete, filter)
+- What kind of app is it?
+- What data does it need to store?
+- What actions should the user be able to perform?
 
 If the user gives a clear description, skip the questions and go straight to building.
 
 ### 2. Design the Data Schema
 
-Create a JSON Schema that defines the structure of a single record in the app. Keep it simple and flat. Every record is automatically assigned an `id`, `appId`, `createdAt`, and `updatedAt` by the system -- you only need to define the user-facing data fields.
+Create a JSON Schema that defines the structure of a single record in the app. Every record is automatically assigned an `id`, `appId`, `createdAt`, and `updatedAt` by the system — you only need to define the user-facing data fields.
 
 Schema guidelines:
 - Use `type: "object"` at the top level
 - Define `properties` for each field the app needs
-- Use simple types: `string`, `number`, `boolean`
+- Supported types: `string`, `number`, `boolean`
 - Add a `required` array for mandatory fields
-- Do not nest objects deeply -- keep the schema flat
+- Keep schemas reasonably flat, but don't force unnatural structures — encode complex data as JSON strings in a `string` field when needed (e.g., a checklist stored as a JSON array string)
 
-Example schema for a todo app:
+Example schema for a project tracker:
 ```json
 {
   "type": "object",
   "properties": {
     "title": { "type": "string" },
-    "completed": { "type": "boolean" },
-    "priority": { "type": "string", "enum": ["low", "medium", "high"] }
+    "status": { "type": "string", "enum": ["backlog", "in-progress", "review", "done"] },
+    "priority": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+    "description": { "type": "string" },
+    "tags": { "type": "string" }
   },
-  "required": ["title"]
+  "required": ["title", "status"]
 }
 ```
 
@@ -46,105 +48,130 @@ Example schema for a todo app:
 Write a complete, self-contained HTML document. The HTML is rendered inside a sandboxed WebView on macOS with no external network access.
 
 #### Technical constraints
-- Must be a single HTML string -- no external files, CDNs, or imports
+- Must be a single HTML string — no external files, CDNs, or imports
 - All CSS goes in a `<style>` tag in the `<head>`
 - All JavaScript goes in a `<script>` tag before `</body>`
-- No external fonts, images, or resources (use system fonts and CSS-only visuals)
-- Design for a window that is roughly 400-600px wide but can resize larger
+- No external fonts, images, or resources (use system fonts and CSS/SVG for visuals)
+- Design for a window that is roughly 400-600px wide but should resize gracefully
 - The WebView blocks all navigation, so links and form submissions with `action` attributes will not work
 
-#### Styling guidelines
-- Use a light color scheme with good contrast
-- Use CSS variables for easy theming:
-  ```css
-  :root {
-    --bg: #ffffff;
-    --surface: #f5f5f7;
-    --text: #1d1d1f;
-    --text-secondary: #86868b;
-    --accent: #007aff;
-    --accent-hover: #0056b3;
-    --border: #d2d2d7;
-    --danger: #ff3b30;
-    --success: #34c759;
-    --radius: 8px;
-  }
-  ```
-- Use system fonts: `font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;`
-- Use flexbox or grid for layout
-- Keep the design clean, minimal, and functional -- follow macOS/Apple design sensibilities
-- Add subtle transitions for interactive elements (hover states, adding/removing items)
-- Make buttons and interactive elements have clear hover/active states
+#### Design philosophy
+
+Build apps that look and feel like professional native software. Every app you create should feel like something someone would pay for.
+
+- **Typography**: Use the system font stack. Establish clear hierarchy with size, weight, and color. Don't make everything the same size.
+- **Color**: Use restrained, intentional palettes. 1-2 accent colors max. Use color to convey meaning (status, priority, categories), not decoration.
+- **Layout**: Use CSS Grid and Flexbox. Give content room to breathe with generous whitespace. Align elements precisely.
+- **Motion**: Add subtle transitions on interactive elements (150-250ms). Animate state changes. Use `transform` and `opacity` for smooth 60fps animations.
+- **Interaction**: Every clickable element needs hover and active states. Add focus styles for keyboard navigation. Provide immediate visual feedback for all actions.
+- **Empty states**: Design thoughtful empty states that guide the user — not just "No items."
+- **Details**: Rounded corners, subtle shadows, smooth gradients. Polish the small things.
+
+Use CSS variables for theming:
+```css
+:root {
+  --bg: #ffffff;
+  --surface: #f5f5f7;
+  --text: #1d1d1f;
+  --text-secondary: #86868b;
+  --accent: #007aff;
+  --accent-hover: #0056b3;
+  --border: #d2d2d7;
+  --danger: #ff3b30;
+  --success: #34c759;
+  --warning: #ff9500;
+  --radius: 10px;
+  --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.06);
+}
+```
+
+Use system fonts: `font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;`
+
+#### Advanced techniques you should use
+
+You have the full power of modern web APIs. Use them to build genuinely impressive apps:
+
+- **Canvas 2D / WebGL** — charts, data visualization, drawing tools, games, generative art
+- **SVG** — icons, diagrams, interactive graphics, custom illustrations
+- **CSS animations & keyframes** — loading states, micro-interactions, page transitions
+- **CSS transforms** — drag-and-drop feel, card flips, 3D effects
+- **CSS gradients & filters** — rich visual design, blur effects, color overlays
+- **CSS Grid subgrid** — complex dashboard layouts
+- **Web Audio API** — sound effects, metronomes, music tools
+- **requestAnimationFrame** — smooth animations and interactive canvases
+- **Drag and drop** (HTML5 API) — reorderable lists, kanban boards
+- **Intersection Observer** — scroll-triggered animations, lazy rendering
+- **ResizeObserver** — responsive canvas/chart sizing
+- **Computed layouts** — masonry grids, virtual scrolling for large datasets
+
+Don't reach for these when a simple list will do, but don't avoid them when they'd make the app genuinely better.
 
 #### Data bridge API
 
 The app has access to `window.vellum.data`, a built-in RPC bridge that lets the HTML interface read and write records for this app. All methods return Promises.
 
 Available methods:
-- `window.vellum.data.query()` -- Returns an array of all records for this app. Each record has `{ id, appId, data, createdAt, updatedAt }`. The `data` field contains the user-defined fields matching your schema.
-- `window.vellum.data.create(data)` -- Creates a new record. Pass an object matching the schema. Returns the created record.
-- `window.vellum.data.update(recordId, data)` -- Updates an existing record by ID. Pass the full updated data object. Returns the updated record.
-- `window.vellum.data.delete(recordId)` -- Deletes a record by ID. Returns void.
+- `window.vellum.data.query()` — Returns an array of all records for this app. Each record has `{ id, appId, data, createdAt, updatedAt }`. The `data` field contains the user-defined fields matching your schema.
+- `window.vellum.data.create(data)` — Creates a new record. Pass an object matching the schema. Returns the created record.
+- `window.vellum.data.update(recordId, data)` — Updates an existing record by ID. Pass the full updated data object. Returns the updated record.
+- `window.vellum.data.delete(recordId)` — Deletes a record by ID. Returns void.
 
 Important notes about the data bridge:
 - Always call `query()` on page load to populate the initial state
 - The `data` field in each record is where your schema fields live (e.g., `record.data.title`, `record.data.completed`)
 - Record IDs are UUIDs as strings
-- All operations are asynchronous -- use `async/await` or `.then()`
-- Handle errors with try/catch -- the bridge will reject promises on failure
-- **NEVER use `localStorage`, `sessionStorage`, or `indexedDB`** -- they are not available in the sandboxed WebView. ALL persistence must go through `window.vellum.data`. Using localStorage will throw a SecurityError and crash the app.
+- All operations are asynchronous — use `async/await`
+- Handle errors with try/catch — the bridge will reject promises on failure
+
+#### Client-side state management
+
+`localStorage` and `sessionStorage` are available for ephemeral UI state:
+- Filter/sort selections, view modes, sidebar collapsed state
+- User preferences (theme, layout choices)
+- Form drafts and temporary input state
+- Tab selection, scroll positions
+
+Use `window.vellum.data` for persistent app records (the actual data). Use `localStorage` for UI preferences and transient state that enhances the experience but isn't critical if lost.
 
 #### JavaScript patterns
 
-Use this pattern for initializing the app:
+Initialize the app and manage state cleanly:
 ```javascript
 document.addEventListener('DOMContentLoaded', async () => {
   await loadRecords();
 });
 
+let allRecords = [];
+
 async function loadRecords() {
   try {
-    const records = await window.vellum.data.query();
-    renderRecords(records);
+    allRecords = await window.vellum.data.query();
+    render();
   } catch (err) {
     console.error('Failed to load records:', err);
   }
 }
-```
 
-For creating records:
-```javascript
-async function addItem(data) {
-  try {
-    await window.vellum.data.create(data);
-    await loadRecords(); // Refresh the list
-  } catch (err) {
-    console.error('Failed to create record:', err);
-  }
+function render() {
+  // Re-render the entire UI from allRecords
+  // Apply client-side filtering/sorting here
 }
 ```
 
-For updating records:
+For apps with complex state, keep a single state object and a single render function. This keeps the code maintainable and avoids UI/data desync:
 ```javascript
-async function updateItem(recordId, data) {
-  try {
-    await window.vellum.data.update(recordId, data);
-    await loadRecords();
-  } catch (err) {
-    console.error('Failed to update record:', err);
-  }
-}
-```
+const state = {
+  records: [],
+  filter: localStorage.getItem('filter') || 'all',
+  sortBy: localStorage.getItem('sortBy') || 'createdAt',
+  searchQuery: '',
+  editingId: null,
+};
 
-For deleting records:
-```javascript
-async function deleteItem(recordId) {
-  try {
-    await window.vellum.data.delete(recordId);
-    await loadRecords();
-  } catch (err) {
-    console.error('Failed to delete record:', err);
-  }
+function setState(updates) {
+  Object.assign(state, updates);
+  render();
 }
 ```
 
@@ -153,9 +180,9 @@ async function deleteItem(recordId) {
 Call `app_create` with:
 - `name`: A short, descriptive name for the app
 - `description`: A one-sentence summary of what the app does
-- `schema_json`: The JSON schema as a string (use `JSON.stringify` formatting)
+- `schema_json`: The JSON schema as a string
 - `html`: The complete HTML document as a string
-- `auto_open`: (optional, defaults to `true`) When true, the app is automatically opened in a dynamic_page surface immediately after creation -- no separate `app_open` call is needed
+- `auto_open`: (optional, defaults to `true`) When true, the app opens immediately after creation
 
 Since `auto_open` defaults to `true`, the app will be displayed to the user as soon as it is created. You do **not** need to call `app_open` separately after `app_create` unless `auto_open` was explicitly set to `false`.
 
@@ -164,260 +191,28 @@ Since `auto_open` defaults to `true`, the app will be displayed to the user as s
 If the user wants changes after seeing the app:
 - Use `app_update` with the `app_id` and the updated fields (`html`, `schema_json`, `name`, or `description`)
 - Then call `app_open` again to refresh the view with the updated HTML
-- If the schema changes affect existing records, mention this to the user -- old records will still have the old shape
+- If the schema changes affect existing records, mention this to the user — old records will still have the old shape
 
 If the user wants to start over, use `app_delete` to remove the app and create a fresh one.
 
 To check what apps already exist, use `app_list` to see all apps. To inspect an app's data, use `app_query` with the `app_id`.
 
-## Complete Example: Todo List App
+## What great apps look like
 
-Here is a full example showing the exact `schema_json` and `html` values for a todo list app.
+Here are the kinds of apps you should be building — not just functional, but delightful:
 
-**schema_json:**
-```json
-{
-  "type": "object",
-  "properties": {
-    "title": { "type": "string" },
-    "completed": { "type": "boolean" }
-  },
-  "required": ["title"]
-}
-```
+- **Kanban board** — draggable cards across columns, smooth animations, color-coded priorities, card detail modals
+- **Workout tracker** — exercise logging with charts showing progress over time (Canvas), rep/set tracking, personal records
+- **Pomodoro timer** — animated circular countdown (Canvas/SVG), session history, statistics dashboard
+- **Expense dashboard** — categorized spending with pie/bar charts (Canvas), monthly trends, budget vs actual
+- **Writing journal** — rich text formatting, word count stats, mood tracking with color-coded entries, calendar heatmap
+- **Habit tracker** — contribution-graph style heatmap, streak counters, weekly/monthly views with smooth transitions
+- **Recipe book** — ingredient scaling, step-by-step mode, beautiful card layouts with CSS gradients for category colors
+- **Music practice log** — metronome (Web Audio), session timer, progress charts, repertoire management
+- **Grade calculator** — weighted categories, GPA projection, what-if scenarios, clean data tables
+- **Flashcard app** — spaced repetition algorithm, card flip animations (CSS 3D transforms), progress tracking
 
-**html:**
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Todo List</title>
-  <style>
-    :root {
-      --bg: #ffffff;
-      --surface: #f5f5f7;
-      --text: #1d1d1f;
-      --text-secondary: #86868b;
-      --accent: #007aff;
-      --accent-hover: #0056b3;
-      --border: #d2d2d7;
-      --danger: #ff3b30;
-      --success: #34c759;
-      --radius: 8px;
-    }
-
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      padding: 24px;
-      line-height: 1.5;
-    }
-
-    h1 {
-      font-size: 24px;
-      font-weight: 700;
-      margin-bottom: 20px;
-    }
-
-    .input-row {
-      display: flex;
-      gap: 8px;
-      margin-bottom: 20px;
-    }
-
-    .input-row input {
-      flex: 1;
-      padding: 10px 14px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      font-size: 14px;
-      outline: none;
-      transition: border-color 0.2s;
-    }
-
-    .input-row input:focus {
-      border-color: var(--accent);
-    }
-
-    .input-row button {
-      padding: 10px 20px;
-      background: var(--accent);
-      color: white;
-      border: none;
-      border-radius: var(--radius);
-      font-size: 14px;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-
-    .input-row button:hover {
-      background: var(--accent-hover);
-    }
-
-    .todo-list {
-      list-style: none;
-    }
-
-    .todo-item {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 14px;
-      background: var(--surface);
-      border-radius: var(--radius);
-      margin-bottom: 8px;
-      transition: opacity 0.2s;
-    }
-
-    .todo-item input[type="checkbox"] {
-      width: 18px;
-      height: 18px;
-      accent-color: var(--accent);
-      cursor: pointer;
-    }
-
-    .todo-item .title {
-      flex: 1;
-      font-size: 14px;
-    }
-
-    .todo-item .title.completed {
-      text-decoration: line-through;
-      color: var(--text-secondary);
-    }
-
-    .todo-item .delete-btn {
-      background: none;
-      border: none;
-      color: var(--text-secondary);
-      cursor: pointer;
-      font-size: 16px;
-      padding: 4px 8px;
-      border-radius: 4px;
-      transition: color 0.2s, background 0.2s;
-    }
-
-    .todo-item .delete-btn:hover {
-      color: var(--danger);
-      background: rgba(255, 59, 48, 0.1);
-    }
-
-    .empty-state {
-      text-align: center;
-      color: var(--text-secondary);
-      padding: 40px 0;
-      font-size: 14px;
-    }
-  </style>
-</head>
-<body>
-  <h1>Todo List</h1>
-  <div class="input-row">
-    <input type="text" id="newTodo" placeholder="What needs to be done?">
-    <button onclick="addTodo()">Add</button>
-  </div>
-  <ul class="todo-list" id="todoList"></ul>
-
-  <script>
-    let allRecords = [];
-
-    document.addEventListener('DOMContentLoaded', async () => {
-      document.getElementById('newTodo').addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') addTodo();
-      });
-      await loadTodos();
-    });
-
-    async function loadTodos() {
-      try {
-        const records = await window.vellum.data.query();
-        renderTodos(records);
-      } catch (err) {
-        console.error('Failed to load todos:', err);
-      }
-    }
-
-    function renderTodos(records) {
-      allRecords = records;
-      const list = document.getElementById('todoList');
-      if (records.length === 0) {
-        list.innerHTML = '<div class="empty-state">No todos yet. Add one above!</div>';
-        return;
-      }
-      list.innerHTML = records
-        .sort((a, b) => a.createdAt - b.createdAt)
-        .map(r => `
-          <li class="todo-item">
-            <input type="checkbox" ${r.data.completed ? 'checked' : ''}
-              onchange="toggleTodo('${r.id}')">
-            <span class="title ${r.data.completed ? 'completed' : ''}">${escapeHtml(r.data.title)}</span>
-            <button class="delete-btn" onclick="deleteTodo('${r.id}')">&#x2715;</button>
-          </li>
-        `).join('');
-    }
-
-    async function addTodo() {
-      const input = document.getElementById('newTodo');
-      const title = input.value.trim();
-      if (!title) return;
-      input.value = '';
-      try {
-        await window.vellum.data.create({ title, completed: false });
-        await loadTodos();
-      } catch (err) {
-        console.error('Failed to add todo:', err);
-      }
-    }
-
-    async function toggleTodo(id) {
-      const record = allRecords.find(r => r.id === id);
-      if (!record) return;
-      try {
-        await window.vellum.data.update(id, { title: record.data.title, completed: !record.data.completed });
-        await loadTodos();
-      } catch (err) {
-        console.error('Failed to toggle todo:', err);
-      }
-    }
-
-    async function deleteTodo(id) {
-      try {
-        await window.vellum.data.delete(id);
-        await loadTodos();
-      } catch (err) {
-        console.error('Failed to delete todo:', err);
-      }
-    }
-
-    function escapeHtml(str) {
-      const div = document.createElement('div');
-      div.textContent = str;
-      return div.innerHTML;
-    }
-  </script>
-</body>
-</html>
-```
-
-## App Ideas That Work Well
-
-These types of apps are a good fit for this system:
-
-- **Todo list / task tracker** -- Simple items with a title, status, and optional priority
-- **Notes / journal** -- Text entries with a title and body, sorted by date
-- **Expense tracker** -- Amount, category, date, and description for each entry
-- **Contacts / address book** -- Name, email, phone, and notes for each person
-- **Habit tracker** -- List of habits with daily check-off
-- **Simple counter** -- A numeric value that can be incremented and decremented
-- **Bookmarks** -- URL, title, and tags for saved links
-- **Flashcards** -- Question and answer pairs for studying
-
-Keep apps simple. This system is best for single-purpose utilities with a flat data model and straightforward CRUD interactions. Avoid complex multi-table relationships, real-time collaboration, or features that require network access.
+These apps should have filtering, sorting, search, keyboard shortcuts, empty states, confirmation dialogs for destructive actions, and smooth transitions throughout.
 
 ## Error Handling
 

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -44,6 +44,7 @@ import type {
   UpdateTrustRule,
   BundleAppRequest,
   SharedAppDeleteRequest,
+  UiSurfaceShow,
 } from './ipc-protocol.js';
 import { execSync } from 'node:child_process';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
@@ -54,7 +55,7 @@ import { loadSkillCatalog, loadSkillBySelector, ensureSkillIcon } from '../confi
 import { resolveSkillStates } from '../config/skill-state.js';
 import { handleAmbientObservation } from './ambient-handler.js';
 import { classifyInteraction } from './classifier.js';
-import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps } from '../memory/app-store.js';
+import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp } from '../memory/app-store.js';
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { packageApp } from '../bundler/app-bundler.js';
@@ -365,6 +366,7 @@ const handlers: DispatchMap = {
   update_trust_rule: handleUpdateTrustRule,
   bundle_app: handleBundleApp,
   open_bundle: handleOpenBundle,
+  app_open_request: (msg, socket, ctx) => handleAppOpenRequest(msg, socket, ctx),
   apps_list: (_msg, socket, ctx) => handleAppsList(socket, ctx),
   shared_apps_list: (_msg, socket, ctx) => handleSharedAppsList(socket, ctx),
   shared_app_delete: handleSharedAppDelete,
@@ -1486,6 +1488,33 @@ async function generateSuggestion(apiKey: string, assistantText: string): Promis
 
   const firstLine = raw.split('\n')[0].trim();
   return firstLine || null;
+}
+
+// ─── App open handler ───────────────────────────────────────────────────────
+
+function handleAppOpenRequest(msg: { appId: string }, socket: net.Socket, ctx: HandlerContext): void {
+  const appId = msg.appId;
+  if (!appId) {
+    ctx.send(socket, { type: 'error', message: 'app_open_request requires appId' });
+    return;
+  }
+
+  const app = getApp(appId);
+  if (!app) {
+    ctx.send(socket, { type: 'error', message: `App not found: ${appId}` });
+    return;
+  }
+
+  const surfaceId = `app-open-${uuid()}`;
+  ctx.send(socket, {
+    type: 'ui_surface_show',
+    sessionId: 'app-panel',
+    surfaceId,
+    surfaceType: 'dynamic_page',
+    title: app.name,
+    data: { html: app.htmlDefinition, appId: app.id },
+    display: 'panel',
+  } as UiSurfaceShow);
 }
 
 // ─── Apps list handler ──────────────────────────────────────────────────────

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -245,6 +245,11 @@ export interface AppsListRequest {
   type: 'apps_list';
 }
 
+export interface AppOpenRequest {
+  type: 'app_open_request';
+  appId: string;
+}
+
 export interface SharedAppsListRequest {
   type: 'shared_apps_list';
 }
@@ -422,6 +427,7 @@ export type ClientMessage =
   | UpdateTrustRule
   | BundleAppRequest
   | AppsListRequest
+  | AppOpenRequest
   | SharedAppsListRequest
   | SharedAppDeleteRequest
   | OpenBundleRequest

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -4,7 +4,6 @@ import type { Message, ContentBlock, ImageContent } from '../providers/types.js'
 import { INTERACTIVE_SURFACE_TYPES } from './ipc-protocol.js';
 import type { ServerMessage, UsageStats, UserMessageAttachment, SurfaceType, SurfaceData, DynamicPageSurfaceData, FileUploadSurfaceData, UiSurfaceShow } from './ipc-protocol.js';
 import { getQdrantClient } from '../memory/qdrant-client.js';
-import type { DeletedMemoryIds } from '../memory/conversation-store.js';
 import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { CheckpointDecision } from '../agent/loop.js';

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -40,8 +40,18 @@ final class MainWindow {
 
         let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let windowWidth = min(1100.0, screenFrame.width * 0.75)
+        let windowHeight = min(750.0, screenFrame.height * 0.75)
+        let windowRect = NSRect(
+            x: screenFrame.midX - windowWidth / 2,
+            y: screenFrame.midY - windowHeight / 2,
+            width: windowWidth,
+            height: windowHeight
+        )
+
         let window = NSWindow(
-            contentRect: NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900),
+            contentRect: windowRect,
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -53,9 +63,6 @@ final class MainWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
-
-        let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        window.setFrame(screenFrame, display: true)
 
         // Keep regular activation policy — the main window should appear in Dock and Cmd+Tab
         NSApp.setActivationPolicy(.regular)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -143,9 +143,17 @@ struct GeneratedPanel: View {
             RoundedRectangle(cornerRadius: VRadius.md)
                 .stroke(item.isShared ? Violet._700.opacity(0.4) : Emerald._700.opacity(0.4), lineWidth: 1)
         )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            openApp(item)
+        }
         .onHover { hovering in
             withAnimation(VAnimation.fast) {
-                hoveredAppId = hovering ? item.id : nil
+                if hovering {
+                    hoveredAppId = item.id
+                } else if !showShareSheet {
+                    hoveredAppId = nil
+                }
             }
         }
     }
@@ -349,6 +357,35 @@ struct GeneratedPanel: View {
         }
 
         displayItems = items
+    }
+
+    // MARK: - Open App
+
+    private func openApp(_ item: DisplayAppItem) {
+        if let localId = item.localAppId {
+            // Local apps: ask the daemon to open via ui_surface_show
+            try? daemonClient.sendAppOpen(appId: localId)
+        } else if let uuid = item.sharedUUID {
+            // Shared apps: construct surface from unpacked files on disk
+            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/index.html"
+            let html = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><title>\(item.name)</title></head>
+            <body><script>window.location.href = '\(entryURL)';</script></body>
+            </html>
+            """
+            let surfaceMsg = UiSurfaceShowMessage(
+                sessionId: "shared-app",
+                surfaceId: "shared-app-\(uuid)",
+                surfaceType: "dynamic_page",
+                title: item.name,
+                data: AnyCodable(["html": html]),
+                actions: nil,
+                display: "panel"
+            )
+            daemonClient.onSurfaceShow?(surfaceMsg)
+        }
     }
 
     // MARK: - Bundle & Share

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -208,20 +208,14 @@ struct GeneratedPanel: View {
                         set: { showShareSheet = $0 }
                     )
                 )
-                .frame(width: 28, height: 28)
+                .frame(width: 0, height: 0)
+                .opacity(0)
 
-                Button(action: {
+                VIconButton(label: "Share", icon: "square.and.arrow.up", iconOnly: true) {
                     bundleAndShare(appId: localId, itemId: item.id)
-                }) {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 13))
-                        .foregroundColor(Emerald._400)
-                        .frame(width: 28, height: 28)
                 }
-                .buttonStyle(.plain)
             }
         } else if item.isShared, let uuid = item.sharedUUID {
-            // Shared apps can be re-shared — reconstruct from unpacked files
             ZStack {
                 ShareSheetButton(
                     items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
@@ -230,31 +224,20 @@ struct GeneratedPanel: View {
                         set: { showShareSheet = $0 }
                     )
                 )
-                .frame(width: 28, height: 28)
+                .frame(width: 0, height: 0)
+                .opacity(0)
 
-                Button(action: {
+                VIconButton(label: "Share", icon: "square.and.arrow.up", iconOnly: true) {
                     reshareApp(uuid: uuid, itemId: item.id)
-                }) {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 13))
-                        .foregroundColor(Violet._400)
-                        .frame(width: 28, height: 28)
                 }
-                .buttonStyle(.plain)
             }
         }
     }
 
     private func deleteButton(for item: DisplayAppItem) -> some View {
-        Button(action: {
+        VIconButton(label: "Delete", icon: "trash", iconOnly: true) {
             deleteSharedApp(item)
-        }) {
-            Image(systemName: "trash")
-                .font(.system(size: 12))
-                .foregroundColor(Rose._400)
-                .frame(width: 24, height: 24)
         }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Data Fetching

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -119,6 +119,13 @@ struct GeneratedPanel: View {
                         ProgressView()
                             .controlSize(.mini)
                             .frame(width: 24, height: 24)
+
+                        // Keep the ShareSheetButton in the view tree during
+                        // bundling so the NSButton stays attached to a window.
+                        // It's hidden but will be ready when bundling completes.
+                        shareButton(for: item)
+                            .frame(width: 0, height: 0)
+                            .opacity(0)
                     } else {
                         shareButton(for: item)
 

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -27,6 +27,7 @@ struct BundleConfirmationView: View {
             // Footer buttons
             footerSection
         }
+        .frame(minWidth: 420, maxWidth: 420, minHeight: 350)
         .background(VColor.background)
     }
 

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -22,10 +22,19 @@ struct ShareSheetButton: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSButton, context: Context) {
         context.coordinator.items = items
-        if isPresented {
+        if isPresented && !context.coordinator.isPickerVisible {
+            // Delay presentation until the next run-loop iteration so the
+            // NSButton is fully attached to its window. Showing a picker on
+            // a view without a window crashes NSSharingServicePicker.
             DispatchQueue.main.async {
+                guard nsView.window != nil else {
+                    self.isPresented = false
+                    return
+                }
+                context.coordinator.onDismiss = {
+                    self.isPresented = false
+                }
                 context.coordinator.showPicker(nsView)
-                self.isPresented = false
             }
         }
     }
@@ -36,6 +45,8 @@ struct ShareSheetButton: NSViewRepresentable {
 
     class Coordinator: NSObject, NSSharingServicePickerDelegate {
         var items: [Any]
+        var isPickerVisible = false
+        var onDismiss: (() -> Void)?
 
         init(items: [Any]) {
             self.items = items
@@ -44,7 +55,55 @@ struct ShareSheetButton: NSViewRepresentable {
         @objc func showPicker(_ sender: NSView) {
             let picker = NSSharingServicePicker(items: items)
             picker.delegate = self
+            isPickerVisible = true
             picker.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        }
+
+        func sharingServicePicker(
+            _ sharingServicePicker: NSSharingServicePicker,
+            sharingServicesForItems items: [Any],
+            proposedSharingServices proposedServices: [NSSharingService]
+        ) -> [NSSharingService] {
+            let slackService = NSSharingService(
+                title: "Slack",
+                image: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"),
+                alternateImage: nil
+            ) { [weak self] in
+                guard let self else { return }
+                self.handleSlackShare(items: items)
+            }
+            return [slackService] + proposedServices
+        }
+
+        func sharingServicePicker(_ sharingServicePicker: NSSharingServicePicker, didChoose service: NSSharingService?) {
+            // Called when the user picks a service or dismisses the picker (service == nil).
+            isPickerVisible = false
+            onDismiss?()
+            onDismiss = nil
+        }
+
+        private func handleSlackShare(items: [Any]) {
+            // Find the first file URL in the shared items
+            guard let fileURL = items.compactMap({ $0 as? URL }).first(where: { $0.isFileURL }) else {
+                return
+            }
+
+            let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+            let destinationURL = downloadsURL.appendingPathComponent(fileURL.lastPathComponent)
+
+            // Copy to Downloads if not already there
+            if fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
+                try? FileManager.default.removeItem(at: destinationURL)
+                try? FileManager.default.copyItem(at: fileURL, to: destinationURL)
+            }
+
+            // Open Slack
+            if let slackURL = URL(string: "slack://") {
+                NSWorkspace.shared.open(slackURL)
+            }
+
+            // Reveal the file in Finder so the user can drag it into Slack
+            NSWorkspace.shared.activateFileViewerSelecting([destinationURL])
         }
     }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -509,6 +509,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Apps
 
+    /// Request opening an app by ID. The daemon responds with a `ui_surface_show` message.
+    public func sendAppOpen(appId: String) throws {
+        try send(AppOpenRequestMessage(appId: appId))
+    }
+
     /// Request the list of all apps from the daemon.
     public func sendAppsList() throws {
         try send(AppsListRequestMessage())

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -281,6 +281,17 @@ public struct AppDataRequestMessage: Encodable, Sendable {
     }
 }
 
+/// Sent to request opening an app by ID.
+/// Wire type: `"app_open_request"`
+public struct AppOpenRequestMessage: Encodable, Sendable {
+    public let type: String = "app_open_request"
+    public let appId: String
+
+    public init(appId: String) {
+        self.appId = appId
+    }
+}
+
 /// Sent to request the list of all apps.
 /// Wire type: `"apps_list"`
 public struct AppsListRequestMessage: Encodable, Sendable {


### PR DESCRIPTION
The purpose of this PR is to improve the app sharing and discovery experience with Slack integration, clickable app rows, and a rewritten app builder skill that produces professional-quality apps.

## Changes Made
- **Slack in share picker**: Add custom Slack `NSSharingService` that copies `.vellumapp` to Downloads, opens Slack, and reveals file in Finder for drag-and-drop
- **Clickable apps in Generated panel**: Add `app_open_request` IPC message so tapping an app row opens it (local apps via daemon, shared apps via `vellumapp://` scheme)
- **Fix share sheet reliability**: Guard against missing window, track picker visibility, preserve hover state while picker is open
- **Improve window sizing**: Main window opens at 75% of screen (centered) instead of filling it entirely; fix bundle confirmation window sizing
- **Rewrite app builder skill**: Remove artificial simplicity constraints, correct localStorage guidance (available via polyfill), add advanced web API techniques (Canvas, SVG, animations, Web Audio), raise the bar to professional-quality apps

## Testing
- Manual testing of share picker with Slack option
- Manual testing of app row click-to-open for local and shared apps
- Verified window sizing on launch
- Build passes for both Swift client and daemon

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
