### PR TITLE
Escape shared app name and UUID to prevent XSS

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -350,11 +350,16 @@ struct GeneratedPanel: View {
             try? daemonClient.sendAppOpen(appId: localId)
         } else if let uuid = item.sharedUUID {
             // Shared apps: construct surface from unpacked files on disk
-            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(uuid)/index.html"
+            // Sanitize to prevent XSS — name comes from external bundle metadata
+            let safeName = htmlEscape(item.name)
+            let sanitizedUUID = uuid
+                .replacingOccurrences(of: "\\", with: "")
+                .replacingOccurrences(of: "'", with: "")
+            let entryURL = "\(VellumAppSchemeHandler.scheme)://\(sanitizedUUID)/index.html"
             let html = """
             <!DOCTYPE html>
             <html>
-            <head><meta charset="utf-8"><title>\(item.name)</title></head>
+            <head><meta charset="utf-8"><title>\(safeName)</title></head>
             <body><script>window.location.href = '\(entryURL)';</script></body>
             </html>
             """
@@ -440,6 +445,15 @@ struct GeneratedPanel: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func htmlEscape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }
 


### PR DESCRIPTION
The purpose of this PR is to fix an XSS vulnerability flagged in #1882 where shared app names from external bundle metadata were interpolated unescaped into HTML.

## Changes Made
- HTML-escape `item.name` before interpolating into `<title>` tag when opening shared apps
- Sanitize UUID (strip backslashes and single quotes) before interpolating into JS string context
- Add `htmlEscape` helper to GeneratedPanel, matching the existing pattern in AppDelegate

## Testing
- Build passes
- Matches the same sanitization pattern already used in AppDelegate for bundle imports

---
*This PR was created with Claude Code*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
