### PR TITLE
Fix daemon startup crash from package.json require

### DIFF
--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -21,11 +21,8 @@ import { getLogger } from '../util/logger.js';
 
 const bundlerLog = getLogger('app-bundler');
 
-/** Read the package version at import time. */
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const packageJson = require('../../package.json') as { version: string };
-const PACKAGE_VERSION = packageJson.version;
+import { APP_VERSION } from '../version.js';
+const PACKAGE_VERSION = APP_VERSION;
 
 const MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB
 


### PR DESCRIPTION
## Summary
- `app-bundler.ts` used `require('../../package.json')` at import time to read the version
- When compiled into a standalone bun binary, the relative path resolves inside bun's virtual filesystem (`/$bunfs/root/`) where `package.json` doesn't exist
- This crashes the daemon on every launch: `Cannot find module '../../package.json'`
- Fix: use the existing `APP_VERSION` from `version.ts` (already set at compile time via `--define`)

## Test plan
- [x] Compiled daemon binary locally, confirmed it starts and stays running
- [x] Verified old binary crashes with `Cannot find module` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
