### PR TITLE
M2: Inject design system CSS into WKWebView

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -50,7 +50,8 @@ let package = Package(
                 .process("Resources/background.png"),
                 .process("Resources/Fonts"),
                 .copy("Resources/Recipes"),
-                .process("Resources/Onboarding")
+                .process("Resources/Onboarding"),
+                .process("Resources/vellum-design-system.css")
             ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -5,6 +5,24 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DynamicPage")
 
+extension DynamicPageSurfaceView {
+    /// CSS design system loaded once from the resource bundle and escaped for JS injection.
+    static let designSystemCSS: String = {
+        guard let url = ResourceBundle.bundle.url(
+            forResource: "vellum-design-system", withExtension: "css"
+        ), let css = try? String(contentsOf: url) else {
+            log.error("Failed to load vellum-design-system.css from resource bundle")
+            assertionFailure("vellum-design-system.css not found in resource bundle")
+            return ""
+        }
+        return css
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "`", with: "\\`")
+            .replacingOccurrences(of: "${", with: "\\${")
+            .replacingOccurrences(of: "\r", with: "")
+    }()
+}
+
 struct DynamicPageSurfaceView: NSViewRepresentable {
     let data: DynamicPageSurfaceData
     let onAction: (String, Any?) -> Void
@@ -128,21 +146,22 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             forMainFrameOnly: true
         )
 
-        let centeringScript = WKUserScript(
+        let designSystemScript = WKUserScript(
             source: """
                 (function() {
                     var style = document.createElement('style');
-                    style.textContent = 'body { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; margin: 0; }';
+                    style.id = 'vellum-design-system';
+                    style.textContent = `\(Self.designSystemCSS)`;
                     (document.head || document.documentElement).appendChild(style);
                 })();
                 """,
-            injectionTime: .atDocumentEnd,
+            injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
 
         let contentController = WKUserContentController()
         contentController.addUserScript(userScript)
-        contentController.addUserScript(centeringScript)
+        contentController.addUserScript(designSystemScript)
         contentController.add(context.coordinator, name: "vellumBridge")
 
         let configuration = WKWebViewConfiguration()

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -166,8 +166,11 @@ final class SurfaceManager: ObservableObject {
         panel.contentViewController = hostingController
 
         // Re-measure fittingSize for non-dynamic panels now that the view is attached to a window.
+        // For dynamic pages, restore the intended size because setting contentViewController
+        // resizes the panel to the hosting controller's fittingSize, which is nearly zero
+        // for a WKWebView that hasn't loaded content yet.
         if case .dynamicPage = surface.data {
-            // Dynamic pages handle their own sizing via webView didFinish.
+            panel.setContentSize(NSSize(width: surfacePanelWidth, height: surfacePanelHeight))
         } else if let fittingSize = panel.contentView?.fittingSize {
             let maxH = (NSScreen.main?.visibleFrame.height ?? 800) - 40
             let newHeight = min(max(fittingSize.height, 150), maxH)


### PR DESCRIPTION
## Summary
- Load `vellum-design-system.css` from the Swift resource bundle and inject it into every WKWebView via `WKUserScript` at document start
- Add the CSS file to `Package.swift` resources
- Fix dynamic page panel sizing after `contentViewController` assignment resets the frame

## Changes
- `DynamicPageSurfaceView.swift`: Added `designSystemCSS` static property, replaced centering script with design system CSS injection
- `Package.swift`: Added `.process("Resources/vellum-design-system.css")` to resources
- `SurfaceManager.swift`: Restore intended panel size for dynamic pages after contentViewController assignment

Part of #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
