### PR TITLE
Vellum design system CSS for app builder WebView

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -55,38 +55,62 @@ Write a complete, self-contained HTML document. The HTML is rendered inside a sa
 - Design for a window that is roughly 400-600px wide but should resize gracefully
 - The WebView blocks all navigation, so links and form submissions with `action` attributes will not work
 
-#### Design philosophy
+#### Injected design system
 
-Build apps that look and feel like professional native software. Every app you create should feel like something someone would pay for.
+Every app automatically has the Vellum design system CSS injected into the WebView.
+You do NOT need to include base styles — they are applied to bare HTML elements by default.
+The design system supports both light and dark mode via `@media (prefers-color-scheme)`.
 
-- **Typography**: Use the system font stack. Establish clear hierarchy with size, weight, and color. Don't make everything the same size.
-- **Color**: Use restrained, intentional palettes. 1-2 accent colors max. Use color to convey meaning (status, priority, categories), not decoration.
-- **Layout**: Use CSS Grid and Flexbox. Give content room to breathe with generous whitespace. Align elements precisely.
-- **Motion**: Add subtle transitions on interactive elements (150-250ms). Animate state changes. Use `transform` and `opacity` for smooth 60fps animations.
-- **Interaction**: Every clickable element needs hover and active states. Add focus styles for keyboard navigation. Provide immediate visual feedback for all actions.
-- **Empty states**: Design thoughtful empty states that guide the user — not just "No items."
-- **Details**: Rounded corners, subtle shadows, smooth gradients. Polish the small things.
+**What you get for free (no classes needed):**
+- `body` — system font, proper colors, padding (24px), line-height (1.5), flex centering
+- `button` — reset to inherit font, no border/background, cursor pointer
+- `input`, `textarea`, `select` — bordered, rounded, proper sizing, focus ring
+- `h1`–`h6` — sized headings with proper weight and spacing
+- `a` — accent-colored links
+- `code`, `pre` — monospace font, surface background
+- `table`, `th`, `td` — bordered, padded
 
-Use CSS variables for theming:
+**Available component classes (opt-in):**
+- `.v-button`, `.v-button.secondary`, `.v-button.danger`, `.v-button.ghost` — button variants
+- `.v-card` — surface background with border, shadow, and padding
+- `.v-input-row` — flex row for input + button combos (gap: 8px)
+- `.v-list` + `.v-list-item` — hoverable list rows with padding
+- `.v-badge`, `.v-badge.success`, `.v-badge.danger`, `.v-badge.warning` — small pill labels
+- `.v-empty-state` — centered muted placeholder text
+- `.v-toggle` — CSS-only toggle switch (use with label + hidden checkbox + `.v-toggle-track`)
+
+**Available utility classes:**
+- Layout: `.v-flex`, `.v-flex-col`, `.v-flex-wrap`, `.v-items-center`, `.v-justify-between`, `.v-justify-center`
+- Gaps: `.v-gap-xs` (4px), `.v-gap-sm` (8px), `.v-gap-md` (12px), `.v-gap-lg` (16px), `.v-gap-xl` (24px)
+- Text: `.v-text-secondary`, `.v-text-muted`, `.v-text-accent`, `.v-text-sm`, `.v-text-xs`, `.v-text-lg`
+- Other: `.v-font-mono`, `.v-truncate`, `.v-w-full`, `.v-sr-only`
+
+**Available color palettes (as CSS variables):**
+All six Vellum color scales are available as `--v-{palette}-{stop}` variables:
+- Slate: `--v-slate-950` through `--v-slate-50`
+- Emerald: `--v-emerald-950` through `--v-emerald-100`
+- Violet: `--v-violet-950` through `--v-violet-100`
+- Indigo: `--v-indigo-950` through `--v-indigo-100`
+- Rose: `--v-rose-950` through `--v-rose-100`
+- Amber: `--v-amber-950` through `--v-amber-100`
+
+**Customizing the theme:**
+To change the look, override `--v-*` CSS custom properties in your `<style>` tag:
 ```css
 :root {
-  --bg: #ffffff;
-  --surface: #f5f5f7;
-  --text: #1d1d1f;
-  --text-secondary: #86868b;
-  --accent: #007aff;
-  --accent-hover: #0056b3;
-  --border: #d2d2d7;
-  --danger: #ff3b30;
-  --success: #34c759;
-  --warning: #ff9500;
-  --radius: 10px;
-  --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
-  --shadow-lg: 0 4px 12px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.06);
+  --v-accent: #e91e63;
+  --v-bg: #1a1a2e;
+  --v-text: #eaeaea;
+  --v-radius-md: 16px;
 }
 ```
+This overrides the injected defaults — all elements and component classes update automatically.
+You can also write fully custom CSS or ignore the design system entirely.
 
-Use system fonts: `font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;`
+#### Styling guidelines
+- Use flexbox or grid for layout
+- Keep the design clean, minimal, and functional -- follow macOS/Apple design sensibilities
+- Add subtle transitions for interactive elements (hover states, adding/removing items)
 
 #### Advanced techniques you should use
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -71,7 +71,11 @@ Build apps that look and feel like professional native software. Every app you c
 
 Every app automatically has the Vellum design system CSS injected into the WebView. It provides sensible defaults for all bare HTML elements (body, headings, inputs, buttons, tables, etc.) and supports both light and dark mode via `@media (prefers-color-scheme)`.
 
-You do NOT need to include base styles — they are already applied. The design system also provides opt-in component classes (prefixed with `v-`, e.g. `.v-button`, `.v-card`, `.v-badge`), utility classes, and CSS custom properties (`--v-*`) for colors, spacing, radius, and shadows.
+You do NOT need to include base styles — they are already applied. Use the provided CSS variables for colors so your custom styles respect light/dark mode automatically.
+
+**Key CSS variables:** `--v-bg`, `--v-surface`, `--v-surface-border`, `--v-text`, `--v-text-secondary`, `--v-text-muted`, `--v-accent`, `--v-accent-hover`, `--v-danger`, `--v-success`, `--v-warning`, `--v-radius-sm`/`md`/`lg`, `--v-shadow-sm`/`md`/`lg`, `--v-spacing-xs`/`sm`/`md`/`lg`/`xl`. Color palettes: `--v-slate-{950..50}`, `--v-emerald-*`, `--v-violet-*`, `--v-indigo-*`, `--v-rose-*`, `--v-amber-*`.
+
+**Key component classes:** `.v-button` (+ `.secondary`, `.danger`, `.ghost`), `.v-card`, `.v-list` + `.v-list-item`, `.v-badge` (+ `.success`, `.danger`, `.warning`), `.v-input-row`, `.v-empty-state`, `.v-toggle`.
 
 To customize the theme, override `--v-*` variables in your `<style>` tag. You can also write fully custom CSS or ignore the design system entirely.
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -69,15 +69,11 @@ Build apps that look and feel like professional native software. Every app you c
 
 #### Injected design system
 
-Every app automatically has the Vellum design system CSS injected into the WebView. It provides sensible defaults for all bare HTML elements (body, headings, inputs, buttons, tables, etc.) and supports both light and dark mode via `@media (prefers-color-scheme)`.
+A design system CSS is auto-injected inside a `@layer`, so your app's styles always override it. It provides element defaults (body, inputs, buttons, etc.) and light/dark mode via `prefers-color-scheme`.
 
-You do NOT need to include base styles — they are already applied. Use the provided CSS variables for colors so your custom styles respect light/dark mode automatically.
+**Default look:** Use `--v-*` variables and `.v-*` classes — no base styles needed. Variables: `--v-bg`, `--v-surface`, `--v-surface-border`, `--v-text`, `--v-text-secondary`, `--v-text-muted`, `--v-accent`, `--v-danger`, `--v-success`, `--v-warning`, `--v-radius-sm`/`md`/`lg`, `--v-shadow-sm`/`md`/`lg`, `--v-spacing-xs`/`sm`/`md`/`lg`/`xl`. Palettes: `--v-slate-{950..50}`, `--v-emerald-*`, `--v-violet-*`, `--v-rose-*`, `--v-amber-*`. Classes: `.v-button` (`.secondary`/`.danger`/`.ghost`), `.v-card`, `.v-list`/`.v-list-item`, `.v-badge`, `.v-input-row`, `.v-empty-state`, `.v-toggle`.
 
-**Key CSS variables:** `--v-bg`, `--v-surface`, `--v-surface-border`, `--v-text`, `--v-text-secondary`, `--v-text-muted`, `--v-accent`, `--v-accent-hover`, `--v-danger`, `--v-success`, `--v-warning`, `--v-radius-sm`/`md`/`lg`, `--v-shadow-sm`/`md`/`lg`, `--v-spacing-xs`/`sm`/`md`/`lg`/`xl`. Color palettes: `--v-slate-{950..50}`, `--v-emerald-*`, `--v-violet-*`, `--v-indigo-*`, `--v-rose-*`, `--v-amber-*`.
-
-**Key component classes:** `.v-button` (+ `.secondary`, `.danger`, `.ghost`), `.v-card`, `.v-list` + `.v-list-item`, `.v-badge` (+ `.success`, `.danger`, `.warning`), `.v-input-row`, `.v-empty-state`, `.v-toggle`.
-
-To customize the theme, override `--v-*` variables in your `<style>` tag. You can also write fully custom CSS or ignore the design system entirely.
+**Custom themes:** When the user wants a specific visual style, write complete CSS with hardcoded colors — do NOT use `--v-*` variables (they switch between light/dark mode). Explicitly style `body`, `input`/`textarea`/`select`, `button`, headings, and links with your own colors.
 
 #### Advanced techniques you should use
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -55,62 +55,25 @@ Write a complete, self-contained HTML document. The HTML is rendered inside a sa
 - Design for a window that is roughly 400-600px wide but should resize gracefully
 - The WebView blocks all navigation, so links and form submissions with `action` attributes will not work
 
+#### Design philosophy
+
+Build apps that look and feel like professional native software. Every app you create should feel like something someone would pay for.
+
+- **Typography**: Use the system font stack. Establish clear hierarchy with size, weight, and color. Don't make everything the same size.
+- **Color**: Use restrained, intentional palettes. 1-2 accent colors max. Use color to convey meaning (status, priority, categories), not decoration.
+- **Layout**: Use CSS Grid and Flexbox. Give content room to breathe with generous whitespace. Align elements precisely.
+- **Motion**: Add subtle transitions on interactive elements (150-250ms). Animate state changes. Use `transform` and `opacity` for smooth 60fps animations.
+- **Interaction**: Every clickable element needs hover and active states. Add focus styles for keyboard navigation. Provide immediate visual feedback for all actions.
+- **Empty states**: Design thoughtful empty states that guide the user — not just "No items."
+- **Details**: Rounded corners, subtle shadows, smooth gradients. Polish the small things.
+
 #### Injected design system
 
-Every app automatically has the Vellum design system CSS injected into the WebView.
-You do NOT need to include base styles — they are applied to bare HTML elements by default.
-The design system supports both light and dark mode via `@media (prefers-color-scheme)`.
+Every app automatically has the Vellum design system CSS injected into the WebView. It provides sensible defaults for all bare HTML elements (body, headings, inputs, buttons, tables, etc.) and supports both light and dark mode via `@media (prefers-color-scheme)`.
 
-**What you get for free (no classes needed):**
-- `body` — system font, proper colors, padding (24px), line-height (1.5), flex centering
-- `button` — reset to inherit font, no border/background, cursor pointer
-- `input`, `textarea`, `select` — bordered, rounded, proper sizing, focus ring
-- `h1`–`h6` — sized headings with proper weight and spacing
-- `a` — accent-colored links
-- `code`, `pre` — monospace font, surface background
-- `table`, `th`, `td` — bordered, padded
+You do NOT need to include base styles — they are already applied. The design system also provides opt-in component classes (prefixed with `v-`, e.g. `.v-button`, `.v-card`, `.v-badge`), utility classes, and CSS custom properties (`--v-*`) for colors, spacing, radius, and shadows.
 
-**Available component classes (opt-in):**
-- `.v-button`, `.v-button.secondary`, `.v-button.danger`, `.v-button.ghost` — button variants
-- `.v-card` — surface background with border, shadow, and padding
-- `.v-input-row` — flex row for input + button combos (gap: 8px)
-- `.v-list` + `.v-list-item` — hoverable list rows with padding
-- `.v-badge`, `.v-badge.success`, `.v-badge.danger`, `.v-badge.warning` — small pill labels
-- `.v-empty-state` — centered muted placeholder text
-- `.v-toggle` — CSS-only toggle switch (use with label + hidden checkbox + `.v-toggle-track`)
-
-**Available utility classes:**
-- Layout: `.v-flex`, `.v-flex-col`, `.v-flex-wrap`, `.v-items-center`, `.v-justify-between`, `.v-justify-center`
-- Gaps: `.v-gap-xs` (4px), `.v-gap-sm` (8px), `.v-gap-md` (12px), `.v-gap-lg` (16px), `.v-gap-xl` (24px)
-- Text: `.v-text-secondary`, `.v-text-muted`, `.v-text-accent`, `.v-text-sm`, `.v-text-xs`, `.v-text-lg`
-- Other: `.v-font-mono`, `.v-truncate`, `.v-w-full`, `.v-sr-only`
-
-**Available color palettes (as CSS variables):**
-All six Vellum color scales are available as `--v-{palette}-{stop}` variables:
-- Slate: `--v-slate-950` through `--v-slate-50`
-- Emerald: `--v-emerald-950` through `--v-emerald-100`
-- Violet: `--v-violet-950` through `--v-violet-100`
-- Indigo: `--v-indigo-950` through `--v-indigo-100`
-- Rose: `--v-rose-950` through `--v-rose-100`
-- Amber: `--v-amber-950` through `--v-amber-100`
-
-**Customizing the theme:**
-To change the look, override `--v-*` CSS custom properties in your `<style>` tag:
-```css
-:root {
-  --v-accent: #e91e63;
-  --v-bg: #1a1a2e;
-  --v-text: #eaeaea;
-  --v-radius-md: 16px;
-}
-```
-This overrides the injected defaults — all elements and component classes update automatically.
-You can also write fully custom CSS or ignore the design system entirely.
-
-#### Styling guidelines
-- Use flexbox or grid for layout
-- Keep the design clean, minimal, and functional -- follow macOS/Apple design sensibilities
-- Add subtle transitions for interactive elements (hover states, adding/removing items)
+To customize the theme, override `--v-*` variables in your `<style>` tag. You can also write fully custom CSS or ignore the design system entirely.
 
 #### Advanced techniques you should use
 

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -50,7 +50,8 @@ let package = Package(
                 .process("Resources/background.png"),
                 .process("Resources/Fonts"),
                 .copy("Resources/Recipes"),
-                .process("Resources/Onboarding")
+                .process("Resources/Onboarding"),
+                .process("Resources/vellum-design-system.css")
             ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -5,6 +5,24 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DynamicPage")
 
+extension DynamicPageSurfaceView {
+    /// CSS design system loaded once from the resource bundle and escaped for JS injection.
+    static let designSystemCSS: String = {
+        guard let url = ResourceBundle.bundle.url(
+            forResource: "vellum-design-system", withExtension: "css"
+        ), let css = try? String(contentsOf: url) else {
+            log.error("Failed to load vellum-design-system.css from resource bundle")
+            assertionFailure("vellum-design-system.css not found in resource bundle")
+            return ""
+        }
+        return css
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "`", with: "\\`")
+            .replacingOccurrences(of: "${", with: "\\${")
+            .replacingOccurrences(of: "\r", with: "")
+    }()
+}
+
 struct DynamicPageSurfaceView: NSViewRepresentable {
     let data: DynamicPageSurfaceData
     let onAction: (String, Any?) -> Void
@@ -128,21 +146,22 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             forMainFrameOnly: true
         )
 
-        let centeringScript = WKUserScript(
+        let designSystemScript = WKUserScript(
             source: """
                 (function() {
                     var style = document.createElement('style');
-                    style.textContent = 'body { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; margin: 0; }';
+                    style.id = 'vellum-design-system';
+                    style.textContent = `\(Self.designSystemCSS)`;
                     (document.head || document.documentElement).appendChild(style);
                 })();
                 """,
-            injectionTime: .atDocumentEnd,
+            injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
 
         let contentController = WKUserContentController()
         contentController.addUserScript(userScript)
-        contentController.addUserScript(centeringScript)
+        contentController.addUserScript(designSystemScript)
         contentController.add(context.coordinator, name: "vellumBridge")
 
         let configuration = WKWebViewConfiguration()

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -152,7 +152,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     var style = document.createElement('style');
                     style.id = 'vellum-design-system';
                     style.textContent = `\(Self.designSystemCSS)`;
-                    (document.head || document.documentElement).appendChild(style);
+                    var target = document.head || document.documentElement;
+                    target.insertBefore(style, target.firstChild);
                 })();
                 """,
             injectionTime: .atDocumentStart,

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -166,8 +166,11 @@ final class SurfaceManager: ObservableObject {
         panel.contentViewController = hostingController
 
         // Re-measure fittingSize for non-dynamic panels now that the view is attached to a window.
+        // For dynamic pages, restore the intended size because setting contentViewController
+        // resizes the panel to the hosting controller's fittingSize, which is nearly zero
+        // for a WKWebView that hasn't loaded content yet.
         if case .dynamicPage = surface.data {
-            // Dynamic pages handle their own sizing via webView didFinish.
+            panel.setContentSize(NSSize(width: surfacePanelWidth, height: surfacePanelHeight))
         } else if let fittingSize = panel.contentView?.fittingSize {
             let maxH = (NSScreen.main?.visibleFrame.height ?? 800) - 40
             let newHeight = min(max(fittingSize.height, 150), maxH)

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -67,7 +67,7 @@
   --v-indigo-400: #9488FF;
   --v-indigo-300: #B8B4FF;
   --v-indigo-200: #D8D8FF;
-  --v-indigo-100: #EEEEEE;
+  --v-indigo-100: #EEEEFF;
 
   /* ── Palette: Rose ──────────────────────────────────────────── */
   --v-rose-950: #620F21;

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -3,14 +3,13 @@
    Translated from SwiftUI DesignSystem (ColorTokens, VColor,
    VSpacing, VRadius, VShadow, VAnimation, VFont)
    ============================================================
-   Layer 0: Reset
-   Layer 1: Tokens (CSS custom properties, light + dark)
-   Layer 2: Element defaults
-   Layer 3: Component classes (.v-*)
-   Layer 4: Utility classes
+   Wrapped in @layer so app-authored CSS always wins (un-layered
+   styles beat layered styles regardless of specificity/order).
    ============================================================ */
 
-/* ─── Layer 0: Reset ─────────────────────────────────────────── */
+@layer vellum-design-system {
+
+/* ─── Reset ──────────────────────────────────────────────────── */
 
 *,
 *::before,
@@ -466,3 +465,5 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   white-space: nowrap;
   border-width: 0;
 }
+
+} /* end @layer vellum-design-system */

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -1,0 +1,468 @@
+/* ============================================================
+   Vellum Design System — CSS Tokens & Components
+   Translated from SwiftUI DesignSystem (ColorTokens, VColor,
+   VSpacing, VRadius, VShadow, VAnimation, VFont)
+   ============================================================
+   Layer 0: Reset
+   Layer 1: Tokens (CSS custom properties, light + dark)
+   Layer 2: Element defaults
+   Layer 3: Component classes (.v-*)
+   Layer 4: Utility classes
+   ============================================================ */
+
+/* ─── Layer 0: Reset ─────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* ─── Layer 1: Tokens ────────────────────────────────────────── */
+
+:root {
+  /* ── Palette: Slate ─────────────────────────────────────────── */
+  --v-slate-950: #070D19;
+  --v-slate-900: #0F172A;
+  --v-slate-800: #1E293B;
+  --v-slate-700: #334155;
+  --v-slate-600: #475569;
+  --v-slate-500: #64748B;
+  --v-slate-400: #94A3B8;
+  --v-slate-300: #CBD5E1;
+  --v-slate-200: #E2E8F0;
+  --v-slate-100: #F1F5F9;
+  --v-slate-50:  #F8FAFC;
+
+  /* ── Palette: Emerald ───────────────────────────────────────── */
+  --v-emerald-950: #073D2E;
+  --v-emerald-900: #0A5843;
+  --v-emerald-800: #0C7356;
+  --v-emerald-700: #10906A;
+  --v-emerald-600: #18B07A;
+  --v-emerald-500: #38CF93;
+  --v-emerald-400: #6EE7B5;
+  --v-emerald-300: #A6F2D1;
+  --v-emerald-200: #D2F9E8;
+  --v-emerald-100: #ECFDF5;
+
+  /* ── Palette: Violet ────────────────────────────────────────── */
+  --v-violet-950: #321669;
+  --v-violet-900: #4A2390;
+  --v-violet-800: #5C2FB2;
+  --v-violet-700: #7240CC;
+  --v-violet-600: #8A5BE0;
+  --v-violet-500: #9878EA;
+  --v-violet-400: #B8A6F1;
+  --v-violet-300: #D4C8F7;
+  --v-violet-200: #E8E1FB;
+  --v-violet-100: #F4F0FD;
+
+  /* ── Palette: Indigo ────────────────────────────────────────── */
+  --v-indigo-950: #180F66;
+  --v-indigo-900: #261A96;
+  --v-indigo-800: #3525C4;
+  --v-indigo-700: #4636E8;
+  --v-indigo-600: #5B4EFF;
+  --v-indigo-500: #7B6BFF;
+  --v-indigo-400: #9488FF;
+  --v-indigo-300: #B8B4FF;
+  --v-indigo-200: #D8D8FF;
+  --v-indigo-100: #EEEEEE;
+
+  /* ── Palette: Rose ──────────────────────────────────────────── */
+  --v-rose-950: #620F21;
+  --v-rose-900: #85142F;
+  --v-rose-800: #A8183E;
+  --v-rose-700: #D02050;
+  --v-rose-600: #E84060;
+  --v-rose-500: #F06A86;
+  --v-rose-400: #F99AAE;
+  --v-rose-300: #FCBFC9;
+  --v-rose-200: #FFE1E6;
+  --v-rose-100: #FFF1F3;
+
+  /* ── Palette: Amber ─────────────────────────────────────────── */
+  --v-amber-950: #5E3207;
+  --v-amber-900: #7A4409;
+  --v-amber-800: #A35E0C;
+  --v-amber-700: #C97C10;
+  --v-amber-600: #E8A020;
+  --v-amber-500: #FAC426;
+  --v-amber-400: #FDD94E;
+  --v-amber-300: #FEEC94;
+  --v-amber-200: #FEF7CD;
+  --v-amber-100: #FEFCE8;
+
+  /* ── Semantic Colors (Light Mode — default) ─────────────────── */
+  --v-bg:             #FFFFFF;
+  --v-surface:        #F5F5F7;
+  --v-surface-border: #D2D2D7;
+  --v-text:           #1D1D1F;
+  --v-text-secondary: #86868B;
+  --v-text-muted:     #AEAEB2;
+  --v-accent:         var(--v-violet-600);
+  --v-accent-hover:   var(--v-violet-700);
+  --v-success:        var(--v-emerald-600);
+  --v-danger:         var(--v-rose-600);
+  --v-warning:        var(--v-amber-600);
+
+  /* ── Spacing (4pt grid) ─────────────────────────────────────── */
+  --v-spacing-xxs:  2px;
+  --v-spacing-xs:   4px;
+  --v-spacing-sm:   8px;
+  --v-spacing-md:   12px;
+  --v-spacing-lg:   16px;
+  --v-spacing-xl:   24px;
+  --v-spacing-xxl:  32px;
+  --v-spacing-xxxl: 48px;
+
+  /* ── Radius ─────────────────────────────────────────────────── */
+  --v-radius-xs:   2px;
+  --v-radius-sm:   4px;
+  --v-radius-md:   8px;
+  --v-radius-lg:   12px;
+  --v-radius-xl:   16px;
+  --v-radius-pill: 999px;
+
+  /* ── Shadows ────────────────────────────────────────────────── */
+  --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
+  --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.16);
+
+  /* ── Animation ──────────────────────────────────────────────── */
+  --v-duration-fast:     0.15s;
+  --v-duration-standard: 0.25s;
+  --v-duration-slow:     0.4s;
+
+  /* ── Typography ─────────────────────────────────────────────── */
+  --v-font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Helvetica Neue", sans-serif;
+  --v-font-mono: "SF Mono", SFMono-Regular, ui-monospace, Menlo,
+    Monaco, monospace;
+  --v-font-size-xs:   10px;
+  --v-font-size-sm:   11px;
+  --v-font-size-base: 14px;
+  --v-font-size-lg:   17px;
+  --v-font-size-xl:   22px;
+  --v-font-size-2xl:  26px;
+  --v-line-height:    1.5;
+}
+
+/* ── Dark Mode (matches SwiftUI VColor semantic values) ───────── */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --v-bg:             var(--v-slate-950);
+    --v-surface:        var(--v-slate-800);
+    --v-surface-border: var(--v-slate-700);
+    --v-text:           var(--v-slate-50);
+    --v-text-secondary: var(--v-slate-400);
+    --v-text-muted:     var(--v-slate-500);
+
+    --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
+    --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
+    --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5);
+  }
+}
+
+/* ─── Layer 2: Element Defaults ──────────────────────────────── */
+
+body {
+  margin: 0;
+  font-family: var(--v-font-family);
+  font-size: var(--v-font-size-base);
+  line-height: var(--v-line-height);
+  color: var(--v-text);
+  background: var(--v-bg);
+  padding: var(--v-spacing-xl);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.2;
+  margin: 0 0 var(--v-spacing-md) 0;
+  color: var(--v-text);
+}
+
+h1 { font-size: var(--v-font-size-2xl); font-weight: 700; }
+h2 { font-size: var(--v-font-size-xl); font-weight: 600; }
+h3 { font-size: var(--v-font-size-lg); font-weight: 600; }
+h4 { font-size: var(--v-font-size-base); font-weight: 600; }
+h5 { font-size: var(--v-font-size-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+h6 { font-size: var(--v-font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+
+p { margin: 0 0 var(--v-spacing-md) 0; }
+
+a {
+  color: var(--v-accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+button {
+  font-family: var(--v-font-family);
+  font-size: var(--v-font-size-base);
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+input, textarea, select {
+  font-family: var(--v-font-family);
+  font-size: var(--v-font-size-base);
+  padding: var(--v-spacing-sm) var(--v-spacing-md);
+  background: var(--v-bg);
+  color: var(--v-text);
+  border: 1px solid var(--v-surface-border);
+  border-radius: var(--v-radius-md);
+  outline: none;
+  transition: border-color var(--v-duration-fast) ease-out;
+}
+input:focus, textarea:focus, select:focus {
+  border-color: var(--v-accent);
+}
+
+textarea { resize: vertical; }
+
+code {
+  font-family: var(--v-font-mono);
+  font-size: 0.9em;
+  background: var(--v-surface);
+  padding: var(--v-spacing-xxs) var(--v-spacing-xs);
+  border-radius: var(--v-radius-sm);
+}
+
+pre {
+  font-family: var(--v-font-mono);
+  font-size: var(--v-font-size-sm);
+  background: var(--v-surface);
+  padding: var(--v-spacing-lg);
+  border-radius: var(--v-radius-md);
+  overflow-x: auto;
+  margin: 0 0 var(--v-spacing-md) 0;
+}
+pre code {
+  background: none;
+  padding: 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--v-surface-border);
+  margin: var(--v-spacing-xl) 0;
+}
+
+ul, ol { padding-left: var(--v-spacing-xl); margin: 0 0 var(--v-spacing-md) 0; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 var(--v-spacing-md) 0;
+}
+th, td {
+  text-align: left;
+  padding: var(--v-spacing-sm) var(--v-spacing-md);
+  border-bottom: 1px solid var(--v-surface-border);
+}
+th { font-weight: 600; color: var(--v-text-secondary); font-size: var(--v-font-size-sm); }
+
+/* ─── Layer 3: Component Classes ─────────────────────────────── */
+
+/* Button variants */
+.v-button {
+  font-family: var(--v-font-family);
+  font-size: var(--v-font-size-base);
+  font-weight: 500;
+  padding: var(--v-spacing-sm) var(--v-spacing-lg);
+  background: var(--v-accent);
+  color: white;
+  border: none;
+  border-radius: var(--v-radius-md);
+  cursor: pointer;
+  transition: filter var(--v-duration-fast) ease-out,
+              transform var(--v-duration-fast) ease-out;
+}
+.v-button:hover { filter: brightness(1.1); }
+.v-button:active { transform: scale(0.97); }
+.v-button:disabled { opacity: 0.4; cursor: not-allowed; filter: none; transform: none; }
+.v-button.secondary {
+  background: var(--v-surface);
+  color: var(--v-text);
+  border: 1px solid var(--v-surface-border);
+}
+.v-button.secondary:hover { filter: brightness(0.95); }
+.v-button.danger {
+  background: var(--v-danger);
+}
+.v-button.ghost {
+  background: transparent;
+  color: var(--v-accent);
+}
+.v-button.ghost:hover { background: var(--v-surface); filter: none; }
+
+/* Focus-visible for keyboard accessibility */
+.v-button:focus-visible {
+  outline: 2px solid var(--v-accent);
+  outline-offset: 2px;
+}
+input:focus-visible, textarea:focus-visible, select:focus-visible {
+  border-color: var(--v-accent);
+  outline: 2px solid var(--v-accent);
+  outline-offset: -1px;
+}
+
+/* Card */
+.v-card {
+  background: var(--v-surface);
+  border: 1px solid var(--v-surface-border);
+  border-radius: var(--v-radius-lg);
+  padding: var(--v-spacing-lg);
+  box-shadow: var(--v-shadow-sm);
+}
+
+/* Badge */
+.v-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--v-font-size-xs);
+  font-weight: 600;
+  padding: var(--v-spacing-xxs) var(--v-spacing-sm);
+  border-radius: var(--v-radius-pill);
+  background: var(--v-surface);
+  color: var(--v-text-secondary);
+}
+.v-badge.success { background: color-mix(in srgb, var(--v-success) 15%, transparent); color: var(--v-success); }
+.v-badge.danger  { background: color-mix(in srgb, var(--v-danger) 15%, transparent);  color: var(--v-danger); }
+.v-badge.warning { background: color-mix(in srgb, var(--v-warning) 15%, transparent); color: var(--v-warning); }
+
+/* List */
+.v-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.v-list-item {
+  padding: var(--v-spacing-md) var(--v-spacing-lg);
+  border-radius: var(--v-radius-md);
+  transition: background var(--v-duration-fast) ease-out;
+}
+.v-list-item:hover { background: var(--v-surface); }
+.v-list-item:focus-visible {
+  outline: 2px solid var(--v-accent);
+  outline-offset: -2px;
+}
+
+/* Empty state */
+.v-empty-state {
+  text-align: center;
+  color: var(--v-text-muted);
+  padding: var(--v-spacing-xxl) var(--v-spacing-lg);
+  font-size: var(--v-font-size-base);
+}
+
+/* Toggle switch */
+.v-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+}
+.v-toggle input {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
+}
+.v-toggle-track {
+  position: absolute;
+  inset: 0;
+  background: var(--v-surface-border);
+  border-radius: var(--v-radius-pill);
+  cursor: pointer;
+  transition: background var(--v-duration-fast) ease-out;
+}
+.v-toggle-track::after {
+  content: "";
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  background: white;
+  border-radius: 50%;
+  transition: transform var(--v-duration-fast) ease-out;
+}
+.v-toggle input:checked + .v-toggle-track {
+  background: var(--v-accent);
+}
+.v-toggle input:checked + .v-toggle-track::after {
+  transform: translateX(18px);
+}
+.v-toggle input:focus-visible + .v-toggle-track {
+  outline: 2px solid var(--v-accent);
+  outline-offset: 2px;
+}
+
+/* Input row (input + button combo) */
+.v-input-row {
+  display: flex;
+  gap: var(--v-spacing-sm);
+}
+.v-input-row input,
+.v-input-row .v-input {
+  flex: 1;
+}
+
+/* ─── Layer 4: Utility Classes ───────────────────────────────── */
+
+/* Flexbox */
+.v-flex       { display: flex; }
+.v-flex-col   { display: flex; flex-direction: column; }
+.v-flex-wrap  { flex-wrap: wrap; }
+.v-items-center    { align-items: center; }
+.v-justify-between { justify-content: space-between; }
+.v-justify-center  { justify-content: center; }
+
+/* Gap */
+.v-gap-xs  { gap: var(--v-spacing-xs); }
+.v-gap-sm  { gap: var(--v-spacing-sm); }
+.v-gap-md  { gap: var(--v-spacing-md); }
+.v-gap-lg  { gap: var(--v-spacing-lg); }
+.v-gap-xl  { gap: var(--v-spacing-xl); }
+
+/* Text */
+.v-text-secondary { color: var(--v-text-secondary); }
+.v-text-muted     { color: var(--v-text-muted); }
+.v-text-accent    { color: var(--v-accent); }
+.v-text-xs  { font-size: var(--v-font-size-xs); }
+.v-text-sm  { font-size: var(--v-font-size-sm); }
+.v-text-lg  { font-size: var(--v-font-size-lg); }
+.v-font-mono { font-family: var(--v-font-mono); }
+
+/* Layout */
+.v-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v-w-full { width: 100%; }
+
+/* Accessibility */
+.v-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
## Summary
Creates a CSS design system file that mirrors the SwiftUI DesignSystem tokens, injects it into all app builder WebViews as a default stylesheet, and documents the available classes and variables in the app-builder SKILL.md.

The design system is a sensible default — not a constraint. The assistant can use it as-is, customize via CSS custom property overrides, or ignore it entirely and write fully custom CSS.

## Changes
- **M1**: Created `vellum-design-system.css` (468 lines) with complete SwiftUI token coverage — all 6 color palettes (Slate, Emerald, Violet, Indigo, Rose, Amber) at 10+ stops each, semantic tokens with light/dark mode via `prefers-color-scheme`, spacing (4pt grid), radius, shadow, animation, and typography tokens. Includes element defaults, component classes (`.v-button`, `.v-card`, `.v-list`, `.v-badge`, `.v-toggle`, etc.), and utility classes.
- **M2**: Injected the CSS into every `WKWebView` via `WKUserScript` at document start. Added CSS to `Package.swift` resources. Fixed dynamic page panel sizing.
- **M3**: Documented the design system in `SKILL.md` — free element defaults, opt-in component classes, utility classes, color palettes, and theme customization.

## Milestone PRs (merged into feature branch)
- #1893: M1 — Create vellum-design-system.css with complete design tokens
- #1894: M2 — Inject design system CSS into WKWebView
- #1895: M3 — Document design system in app-builder SKILL.md

## Project issue
Closes #1886

## Test plan
- [ ] Build the macOS app (`./build.sh`) — verify CSS resource is included
- [ ] Create an app via the assistant — verify design system styles are applied
- [ ] Verify light and dark mode switching works via system preferences
- [ ] Verify the assistant can override design system variables in `<style>` tags
- [ ] Verify the assistant can write fully custom CSS without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<img width="2737" height="1057" alt="image" src="https://github.com/user-attachments/assets/12fe7885-65a4-455b-8e80-dfb25f6f42a8" />
<img width="2723" height="1059" alt="image" src="https://github.com/user-attachments/assets/70bcc775-749b-4f39-b1f6-f4a8477e86c5" />
<img width="2729" height="1055" alt="image" src="https://github.com/user-attachments/assets/fe14bd4a-7f35-4a89-b79f-f40473ad36e2" />
<img width="3016" height="1065" alt="image" src="https://github.com/user-attachments/assets/81d6b504-9a6a-46d7-a5f6-29c92a5b38d0" />


