### PR TITLE
Delete legacy DB files during scrub to prevent re-migration

### DIFF
--- a/.claude/commands/scrub.md
+++ b/.claude/commands/scrub.md
@@ -19,9 +19,10 @@ Kill the running Vellum app, delete all persistent data so the next launch behav
    rm -f ~/Library/Application\ Support/vellum-assistant/knowledge.json
    ```
 
-3. Remove the daemon database (conversations, messages, etc.):
+3. Remove the daemon database (conversations, messages, etc.), including legacy paths that the migration would otherwise re-populate:
    ```bash
    rm -f ~/.vellum/data/db/assistant.db ~/.vellum/data/db/assistant.db-shm ~/.vellum/data/db/assistant.db-wal
+   rm -f ~/.vellum/data/assistant.db ~/.vellum/data/assistant.db-shm ~/.vellum/data/assistant.db-wal
    ```
 
 4. Remove caches:


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #1847.

PR #1852 already fixed the scrub command to delete the active DB at `~/.vellum/data/db/assistant.db*`. However, legacy DB files at `~/.vellum/data/assistant.db*` were not being cleaned up. The migration logic in `migrateToDataLayout()` (`assistant/src/util/platform.ts:156-159`) would re-migrate these legacy files into the active DB path on next daemon start, defeating the scrub's "clean first run" goal.

This adds deletion of the legacy DB files (`~/.vellum/data/assistant.db*`) alongside the active ones.

## Test plan

- [ ] Run `/scrub` with legacy DB files present at `~/.vellum/data/assistant.db` — verify they are deleted
- [ ] Confirm daemon starts fresh without re-migrating old data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
