### PR TITLE
Guard wireEscalationHandler in handleSessionSwitch

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -541,7 +541,12 @@ async function handleSessionSwitch(
   }
   ctx.socketToSession.set(socket, msg.sessionId);
   const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
-  wireEscalationHandler(session, socket, ctx);
+  // Only wire the escalation handler if one isn't already set — handleTaskSubmit
+  // sets a handler with the client's actual screen dimensions, and overwriting it
+  // here would replace those dimensions with the daemon's defaults.
+  if (!session.hasEscalationHandler()) {
+    wireEscalationHandler(session, socket, ctx);
+  }
   ctx.send(socket, {
     type: 'session_info',
     sessionId: conversation.id,


### PR DESCRIPTION
## Summary

- `handleSessionSwitch` unconditionally called `wireEscalationHandler`, overwriting escalation handler screen dimensions with defaults (1920x1080) when switching back to a `task_submit` session that had custom dimensions
- Applied the same `hasEscalationHandler()` guard already used in `handleUserMessage` (from PR #1850)

Addresses review feedback on #1850.

## Test plan

- Verify that switching to a `task_submit` session preserves the client's custom screen dimensions
- Verify that switching to a regular session (without prior `task_submit`) still gets an escalation handler wired
- Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
