### PR TITLE
Fix dual-sheet race in trust rules settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -221,7 +221,7 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                daemonClient?.isTrustRulesSheetOpen = true
+                                isTrustRulesSheetOpen = true
                             }
                             .disabled(isTrustRulesSheetOpen)
                         }
@@ -256,14 +256,7 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             refreshAPIKeyState()
         }
-        .onReceive(
-            daemonClient.map { $0.$isTrustRulesSheetOpen.eraseToAnyPublisher() } ?? Empty().eraseToAnyPublisher()
-        ) { newValue in
-            isTrustRulesSheetOpen = newValue
-        }
-        .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
-            daemonClient?.isTrustRulesSheetOpen = false
-        }) {
+        .sheet(isPresented: $isTrustRulesSheetOpen) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -218,7 +218,7 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            daemonClient.isTrustRulesSheetOpen = true
+                            isTrustRulesSheetOpen = true
                         }
                         .disabled(isTrustRulesSheetOpen)
                     }
@@ -256,14 +256,7 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .onReceive(
-            daemonClient.map { $0.$isTrustRulesSheetOpen.eraseToAnyPublisher() } ?? Empty().eraseToAnyPublisher()
-        ) { newValue in
-            isTrustRulesSheetOpen = newValue
-        }
-        .sheet(isPresented: $isTrustRulesSheetOpen, onDismiss: {
-            daemonClient?.isTrustRulesSheetOpen = false
-        }) {
+        .sheet(isPresented: $isTrustRulesSheetOpen) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -28,11 +28,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published public var isConnected: Bool = false
 
-    /// Shared flag so only one TrustRulesView sheet is open at a time across SettingsPanel and SettingsView.
-    /// Both surfaces bind to this instead of local @State, preventing the second sheet from overwriting
-    /// the first sheet's `onTrustRulesListResponse` callback on DaemonClient.
-    @Published public var isTrustRulesSheetOpen: Bool = false
-
     // MARK: - Surface Event Callbacks
 
     /// Called when the daemon sends a `ui_surface_show` message.


### PR DESCRIPTION
## Summary

Fixes the dual-sheet race condition identified in the code review of PR #1848.

Both `SettingsPanel` and `SettingsView` were mirroring `daemonClient.$isTrustRulesSheetOpen` into local `@State`, which meant that when one surface opened the trust rules sheet, the other surface's local state would also flip to `true`, causing two sheets to appear simultaneously. The two `TrustRulesView` instances would then race on the single shared `daemonClient.onTrustRulesListResponse` callback.

**Fix:** Each settings surface now manages its own sheet state independently via local `@State`. The "Manage..." button sets the local state directly instead of going through the shared `DaemonClient` property. The now-unused `@Published isTrustRulesSheetOpen` property is removed from `DaemonClient`.

## Changes

- `SettingsPanel.swift` — button sets local `isTrustRulesSheetOpen` directly; removed `.onReceive` subscriber and `onDismiss` callback
- `SettingsView.swift` — same fix
- `DaemonClient.swift` — removed unused `isTrustRulesSheetOpen` `@Published` property

## Test plan

- [ ] Open Settings panel in MainWindow, click "Manage..." — trust rules sheet appears
- [ ] Close the sheet — button re-enables
- [ ] Open standalone Settings window, click "Manage Trust Rules..." — sheet appears
- [ ] With both settings surfaces open, trigger trust rules from one — only one sheet appears
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
