### PR TITLE
Restart daemon after sessions clear to reset Qdrant state

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -331,6 +331,15 @@ sessions
       console.log('Qdrant collection not found or not reachable (skipped)');
     }
 
+    // Restart the daemon so its in-memory Qdrant client drops the stale
+    // collectionReady flag and will re-create the collection on next use.
+    const status = getDaemonStatus();
+    if (status.running) {
+      await stopDaemon();
+      await startDaemon();
+      console.log('Daemon restarted');
+    }
+
     console.log('Done.');
   });
 


### PR DESCRIPTION
## Summary
- After `vellum sessions clear` deletes the Qdrant collection, restart the daemon if it's running
- This ensures the daemon's in-memory `VellumQdrantClient` drops its stale `collectionReady=true` flag
- Without this, subsequent `search`/`upsert` calls fail with collection-not-found until manual restart

Addresses review feedback on #1862.

## Test plan
- [ ] Run `vellum sessions clear` while daemon is running — daemon should restart and subsequent memory operations should work
- [ ] Run `vellum sessions clear` while daemon is NOT running — no restart attempt, no error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
