### PR TITLE
Fix Gemini provider mixing inlineData with functionResponse

### DIFF
--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -158,21 +158,28 @@ export class GeminiProvider implements Provider {
 
     for (const msg of messages) {
       const role = msg.role === 'assistant' ? 'model' : 'user';
-      const parts = this.toGeminiParts(msg.content, toolCallNames);
+      const { parts, toolResultImageParts } = this.toGeminiParts(msg.content, toolCallNames);
       if (parts.length > 0) {
         result.push({ role, parts });
+      }
+      // Gemini requires that a Content with functionResponse parts must not
+      // contain non-functionResponse parts. Emit tool-result images in a
+      // separate user Content entry.
+      if (toolResultImageParts.length > 0) {
+        result.push({ role: 'user', parts: toolResultImageParts });
       }
     }
 
     return result;
   }
 
-  /** Convert ContentBlock[] to Gemini Part[]. */
+  /** Convert ContentBlock[] to Gemini Part[] and any tool-result image parts. */
   private toGeminiParts(
     blocks: ContentBlock[],
     toolCallNames: Map<string, string>,
-  ): genai.Part[] {
+  ): { parts: genai.Part[]; toolResultImageParts: genai.Part[] } {
     const parts: genai.Part[] = [];
+    const toolResultImageParts: genai.Part[] = [];
 
     for (const block of blocks) {
       switch (block.type) {
@@ -220,12 +227,11 @@ export class GeminiProvider implements Provider {
             if (extraText.length > 0) {
               outputText = outputText + '\n' + extraText.join('\n');
             }
-            // Include images as inline data parts alongside the function response
-            // (Gemini function responses only support text, but images can be
-            // added as sibling parts in the same user message).
+            // Collect images separately — Gemini rejects mixing inlineData
+            // with functionResponse in the same Content entry.
             for (const cb of block.contentBlocks) {
               if (cb.type === 'image') {
-                parts.push({
+                toolResultImageParts.push({
                   inlineData: {
                     mimeType: cb.source.media_type,
                     data: cb.source.data,
@@ -247,7 +253,7 @@ export class GeminiProvider implements Provider {
       }
     }
 
-    return parts;
+    return { parts, toolResultImageParts };
   }
 
   private supportsGeminiInlineFile(mimeType: string): boolean {


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1864.

The Gemini API rejects Content entries that mix inlineData parts with functionResponse parts. Previously, tool-result images were pushed into the same parts array as functionResponse, causing API errors.

This fix separates tool-result image parts from functionResponse parts by emitting them in a separate user Content entry, matching how the OpenAI provider handles this case.

## Changes

- `toGeminiParts` now returns both `parts` and `toolResultImageParts`
- `toGeminiContents` emits tool-result images as a separate user Content entry after the functionResponse Content
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
