### PR TITLE
Add size caps to debug prompt logger hook

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -12,18 +12,21 @@ echo "  PRE-LLM-CALL" >&2
 echo "════════════════════════════════════════════════════════════════" >&2
 echo "" >&2
 
+# Total output cap (bytes) — prevents unbounded stderr when jq is missing.
+MAX_OUTPUT=200000
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "(jq not found — install jq for formatted output)" >&2
-  printf '%s' "$data" >&2
+  printf '%s' "$data" | cut -c1-"$MAX_OUTPUT" >&2
   echo "" >&2
   echo "════════════════════════════════════════════════════════════════" >&2
   echo "" >&2
   exit 0
 fi
 
-# System prompt
+# System prompt (capped at 5000 chars to avoid flooding stderr)
 echo "── System Prompt ──────────────────────────────────────────────" >&2
-printf '%s' "$data" | jq -r '.systemPrompt // "N/A"' >&2
+printf '%s' "$data" | jq -r '.systemPrompt // "N/A" | if length > 5000 then .[:5000] + "\n…[truncated]" else . end' >&2
 echo "" >&2
 echo "" >&2
 
@@ -34,21 +37,25 @@ toolCount=$(printf '%s' "$data" | jq -r '.toolCount // 0')
 echo "Model: $model | Messages: $msgCount | Tools: $toolCount" >&2
 echo "" >&2
 
-# All messages
+# All messages — truncate per-field to keep output bounded.
+# Max chars per text/tool field (images/files already capped at 1000).
+MAX_FIELD=2000
+
 echo "── Messages ───────────────────────────────────────────────────" >&2
-printf '%s' "$data" | jq -r '
+printf '%s' "$data" | jq -r --argjson maxf "$MAX_FIELD" '
+  def trunc(n): if length > n then .[:n] + "…[truncated]" else . end;
   .messages[] |
   "\(.role): " + (
     if (.content | type) == "string" then
-      .content
+      .content | trunc($maxf)
     elif (.content | type) == "array" then
       [.content[] |
-        if .type == "text" then .text
+        if .type == "text" then (.text | trunc($maxf))
         elif .type == "image" then "[image: \(.source.media_type // "unknown")] \(.source.data[:1000])..."
         elif .type == "file" then "[file: \(.source.filename // "unknown")] \(.source.data[:1000])..."
-        elif .type == "tool_use" then "[tool_use: \(.name)] \(.input | tostring)"
-        elif .type == "tool_result" then "[tool_result: \(.content // "" | tostring)]"
-        else "[" + .type + "] " + (. | tostring)
+        elif .type == "tool_use" then "[tool_use: \(.name)] \(.input | tostring | trunc($maxf))"
+        elif .type == "tool_result" then "[tool_result: \(.content // "" | tostring | trunc($maxf))]"
+        else "[" + .type + "] " + (. | tostring | trunc($maxf))
         end
       ] | join(" | ")
     else


### PR DESCRIPTION
## Summary
- Adds per-field truncation (2000 chars) for text, tool_use input, and tool_result content in the debug prompt logger
- Caps system prompt output at 5000 chars
- Caps the jq-less fallback path at 200KB total output
- All messages are still shown (not limited to last 10) — only oversized individual fields are truncated
- Image/file base64 data remains capped at 1000 chars (unchanged from #1865)

Addresses codex review feedback on #1861: `runHookScript` buffers all hook stderr in memory and `pre-llm-call` hooks are awaited, so unbounded output from large conversations could cause large allocations and pre-call delays.

## Test plan
- [ ] Run with `VELLUM_DEBUG=1` in a long conversation and verify output is bounded
- [ ] Verify short messages appear in full (no unnecessary truncation)
- [ ] Verify truncated fields show `…[truncated]` marker

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
