### PR TITLE
Don't mark history loaded when skipping late history_response

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -1017,7 +1017,10 @@ final class ChatViewModel: ObservableObject {
     func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
         let hasUserSentMessages = messages.contains { $0.role == .user }
         if hasUserSentMessages {
-            isHistoryLoaded = true
+            // Don't set isHistoryLoaded here — the user sent a message before
+            // history arrived, so we skipped populating. Leaving the flag false
+            // allows ThreadManager.loadHistoryForActiveThreadIfNeeded() to
+            // retry on the next tab switch.
             return
         }
 


### PR DESCRIPTION
## Summary

When a user sends a message before `history_response` arrives, `populateFromHistory()` returned early but still set `isHistoryLoaded = true`. This prevented `ThreadManager.loadHistoryForActiveThreadIfNeeded()` from ever retrying (due to `guard !viewModel.isHistoryLoaded`), permanently losing prior messages in the UI for that restored thread.

## Fix

Leave `isHistoryLoaded = false` on the early-return path so that the next tab switch triggers a fresh history request.

Addresses review feedback on #1853.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
