### PR TITLE
Persist screenshot images through history and cache decoded NSImage

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -206,6 +206,8 @@ export interface HistoryToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
+  imageData?: string;
 }
 
 export interface RenderedHistoryContent {
@@ -259,12 +261,26 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
       const resultContent = typeof block.content === 'string' ? block.content : '';
       const isError = block.is_error === true;
+      // Extract base64 image data from persisted contentBlocks (e.g. browser_screenshot)
+      let imageData: string | undefined;
+      if (Array.isArray(block.contentBlocks)) {
+        const imgBlock = block.contentBlocks.find(
+          (b: Record<string, unknown>) => isRecord(b) && b.type === 'image',
+        );
+        if (imgBlock && isRecord(imgBlock) && isRecord(imgBlock.source)) {
+          const src = imgBlock.source as Record<string, unknown>;
+          if (typeof src.data === 'string') {
+            imageData = src.data;
+          }
+        }
+      }
       const matched = toolUseId ? pendingToolUses.get(toolUseId) : null;
       if (matched) {
         matched.result = resultContent;
         matched.isError = isError;
+        if (imageData) matched.imageData = imageData;
       } else {
-        toolCalls.push({ name: 'unknown', input: {}, result: resultContent, isError });
+        toolCalls.push({ name: 'unknown', input: {}, result: resultContent, isError, ...(imageData ? { imageData } : {}) });
       }
       continue;
     }
@@ -710,6 +726,7 @@ export function mergeToolResults(messages: ParsedHistoryMessage[]): ParsedHistor
           if (unresolved) {
             unresolved.result = resultEntry.result;
             unresolved.isError = resultEntry.isError;
+            if (resultEntry.imageData) unresolved.imageData = resultEntry.imageData;
           }
         }
       }

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -543,6 +543,8 @@ export interface HistoryResponseToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
+  imageData?: string;
 }
 
 export interface HistoryResponse {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMessage.swift
@@ -78,6 +78,18 @@ struct ToolCallData: Identifiable, Equatable {
     var isComplete: Bool
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     var imageData: String?
+    /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
+    var cachedImage: NSImage?
+
+    static func == (lhs: ToolCallData, rhs: ToolCallData) -> Bool {
+        lhs.id == rhs.id
+            && lhs.toolName == rhs.toolName
+            && lhs.inputSummary == rhs.inputSummary
+            && lhs.result == rhs.result
+            && lhs.isError == rhs.isError
+            && lhs.isComplete == rhs.isComplete
+            && lhs.imageData == rhs.imageData
+    }
 
     init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, imageData: String? = nil) {
         self.id = id
@@ -87,6 +99,13 @@ struct ToolCallData: Identifiable, Equatable {
         self.isError = isError
         self.isComplete = isComplete
         self.imageData = imageData
+        self.cachedImage = Self.decodeImage(from: imageData)
+    }
+
+    /// Decode base64 image data into an NSImage. Returns nil if data is absent or invalid.
+    static func decodeImage(from base64String: String?) -> NSImage? {
+        guard let base64String, let data = Data(base64Encoded: base64String) else { return nil }
+        return NSImage(data: data)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -694,6 +694,7 @@ final class ChatViewModel: ObservableObject {
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
                 messages[msgIndex].toolCalls[tcIndex].imageData = msg.imageData
+                messages[msgIndex].toolCalls[tcIndex].cachedImage = ToolCallData.decodeImage(from: msg.imageData)
             }
 
         case .uiSurfaceShow(let msg):
@@ -1035,7 +1036,8 @@ final class ChatViewModel: ObservableObject {
                         inputSummary: summarizeToolInput(tc.input),
                         result: tc.result,
                         isError: tc.isError ?? false,
-                        isComplete: true
+                        isComplete: true,
+                        imageData: tc.imageData
                     )
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -63,9 +63,7 @@ struct ToolCallChip: View {
             if isExpanded, hasExpandableContent {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // Image preview (for browser_screenshot etc.)
-                    if let imageData = toolCall.imageData,
-                       let data = Data(base64Encoded: imageData),
-                       let nsImage = NSImage(data: data) {
+                    if let nsImage = toolCall.cachedImage {
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fit)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -950,6 +950,8 @@ public struct HistoryResponseMessage: Decodable, Sendable {
         public let input: [String: AnyCodable]
         public let result: String?
         public let isError: Bool?
+        /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
+        public let imageData: String?
     }
     public struct HistoryMessageItem: Decodable, Sendable {
         public let role: String


### PR DESCRIPTION
## Summary

Addresses two pieces of review feedback from PR #1863:

1. **Thread imageData through history hydration**: Screenshot image data was only forwarded on the live `tool_result` stream path. After reopening a session, `history_response` payloads didn't include image bytes, so screenshot previews disappeared. Now `renderHistoryContent` extracts base64 image data from persisted `contentBlocks` on `tool_result` blocks, carries it through `mergeToolResults`, and includes it in the `history_response` wire format. The Swift client's `populateFromHistory` passes `imageData` to `ToolCallData`.

2. **Cache decoded screenshot image outside SwiftUI body**: Previously, `ToolCallChip` decoded base64 into `Data` and `NSImage` directly inside `body`, causing repeated heavy work on every SwiftUI re-render. Now `ToolCallData` has a `cachedImage: NSImage?` property that's decoded once at init time (or when `imageData` is assigned on tool result), and the view reuses the cached image.

## Files changed

- `assistant/src/daemon/handlers.ts` — Extract imageData from contentBlocks in `renderHistoryContent`, carry through `mergeToolResults`
- `assistant/src/daemon/ipc-protocol.ts` — Add `imageData` to `HistoryResponseToolCall`
- `clients/shared/IPC/IPCMessages.swift` — Add `imageData` to `HistoryToolCallItem`
- `clients/macos/.../ChatMessage.swift` — Add `cachedImage` to `ToolCallData`, decode once at init
- `clients/macos/.../ChatViewModel.swift` — Pass `imageData` in `populateFromHistory`, set `cachedImage` on live tool_result
- `clients/macos/.../ToolCallChip.swift` — Use cached `NSImage` instead of decoding in `body`

## Test plan

- [x] TypeScript type-check passes
- [x] Existing history render tests pass (16/16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
