### PR TITLE
Fix debug logger fallback to cap total output bytes

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -17,7 +17,7 @@ MAX_OUTPUT=200000
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "(jq not found — install jq for formatted output)" >&2
-  printf '%s' "$data" | cut -c1-"$MAX_OUTPUT" >&2
+  printf '%s' "$data" | head -c "$MAX_OUTPUT" >&2
   echo "" >&2
   echo "════════════════════════════════════════════════════════════════" >&2
   echo "" >&2


### PR DESCRIPTION
## Summary

- Replace `cut -c1-$MAX_OUTPUT` with `head -c $MAX_OUTPUT` in the debug prompt logger's jq-missing fallback path
- `cut -c` truncates each line independently, so multi-line input could exceed the 200KB cap
- `head -c` truncates the total byte stream, correctly enforcing the intended limit

Addresses review feedback on #1902.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
