### PR TITLE
Fix hasExpandableContent to check cachedImage instead of imageData

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ToolCallChip.swift
@@ -10,7 +10,7 @@ struct ToolCallChip: View {
     }
 
     private var hasExpandableContent: Bool {
-        toolCall.result != nil || toolCall.imageData != nil
+        toolCall.result != nil || toolCall.cachedImage != nil
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

Fixes inconsistency in `ToolCallChip.hasExpandableContent` flagged by Devin review on PR #1905.

- `hasExpandableContent` was checking `toolCall.imageData != nil`, but the actual rendering (line 66) uses `toolCall.cachedImage`
- If `imageData` contains invalid base64, `cachedImage` would be `nil` while `imageData` is non-nil, showing a chevron for an empty expandable area
- Changed to check `toolCall.cachedImage != nil` to stay consistent with what actually renders

## Test plan

- [x] Verified the fix aligns the expandability check with the rendering path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
