### PR TITLE
Merge history messages on late arrival instead of retrying forever

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -1013,18 +1013,10 @@ final class ChatViewModel: ObservableObject {
     }
 
     /// Populate messages from history data returned by the daemon.
-    /// Only replaces messages if the user hasn't sent any new messages yet,
-    /// preventing a late history_response from overwriting live conversation.
+    /// If the user hasn't sent any messages yet, replaces messages entirely.
+    /// If the user already sent messages (late history_response), prepends
+    /// history before the existing messages so the user sees full context.
     func populateFromHistory(_ historyMessages: [HistoryResponseMessage.HistoryMessageItem]) {
-        let hasUserSentMessages = messages.contains { $0.role == .user }
-        if hasUserSentMessages {
-            // Don't set isHistoryLoaded here — the user sent a message before
-            // history arrived, so we skipped populating. Leaving the flag false
-            // allows ThreadManager.loadHistoryForActiveThreadIfNeeded() to
-            // retry on the next tab switch.
-            return
-        }
-
         var chatMessages: [ChatMessage] = []
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user
@@ -1052,7 +1044,16 @@ final class ChatViewModel: ObservableObject {
             )
             chatMessages.append(chatMsg)
         }
-        self.messages = chatMessages
+
+        let hasUserSentMessages = messages.contains { $0.role == .user }
+        if hasUserSentMessages {
+            // History arrived after the user already sent messages.
+            // Prepend history before existing messages so the user sees
+            // the full conversation context.
+            self.messages = chatMessages + self.messages
+        } else {
+            self.messages = chatMessages
+        }
         self.isHistoryLoaded = true
     }
 


### PR DESCRIPTION
## Summary

Fixes the infinite history retry loop flagged in PR #1903 review feedback.

When `populateFromHistory` receives a `history_response` after the user has already sent messages, it now **prepends the history messages before the existing messages** instead of returning early with `isHistoryLoaded = false`. This:

- Gives the user full conversation context (prior history + their new messages)
- Sets `isHistoryLoaded = true` so `ThreadManager.loadHistoryForActiveThreadIfNeeded()` stops retrying
- Eliminates the infinite cycle of futile `history_request` IPC calls on every tab switch

Addresses review feedback from both Codex and Devin on #1903.

## Test plan

- [ ] Restore a thread with prior history, send a message before history loads, verify history appears prepended above the sent message
- [ ] Switch tabs after history loads and verify no repeated `history_request` IPC traffic
- [ ] Restore a thread and wait for history to load normally (no user message sent) — verify behavior unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
