### PR TITLE
Prevent dual trust rules sheets from racing on shared callback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -11,6 +11,8 @@ struct SettingsPanel: View {
     @State private var apiKeyText: String = ""
     @State private var hasKey: Bool = false
     @State private var isTrustRulesSheetOpen: Bool = false
+    /// Tracks whether trust rules are open from any surface (synced from DaemonClient).
+    @State private var trustRulesOpenElsewhere: Bool = false
     @State private var braveKeyText: String = ""
     @State private var hasBraveKey: Bool = false
     @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
@@ -223,7 +225,7 @@ struct SettingsPanel: View {
                             VButton(label: "Manage...", style: .ghost) {
                                 isTrustRulesSheetOpen = true
                             }
-                            .disabled(isTrustRulesSheetOpen)
+                            .disabled(isTrustRulesSheetOpen || trustRulesOpenElsewhere)
                         }
                     }
                     .padding(VSpacing.lg)
@@ -260,6 +262,10 @@ struct SettingsPanel: View {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
+        }
+        .onReceive(daemonClient?.$isTrustRulesSheetOpen.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { isOpen in
+            // Only track whether trust rules opened from another surface, not this one
+            trustRulesOpenElsewhere = isOpen && !isTrustRulesSheetOpen
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -6,6 +6,8 @@ public struct SettingsView: View {
     @State private var apiKeyText = ""
     @State private var hasKey = APIKeyManager.getKey() != nil
     @State private var isTrustRulesSheetOpen = false
+    /// Tracks whether trust rules are open from any surface (synced from DaemonClient).
+    @State private var trustRulesOpenElsewhere = false
     @State private var braveKeyText = ""
     @State private var hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
     @State private var maxSteps: Double = {
@@ -220,7 +222,7 @@ public struct SettingsView: View {
                         Button("Manage Trust Rules...") {
                             isTrustRulesSheetOpen = true
                         }
-                        .disabled(isTrustRulesSheetOpen)
+                        .disabled(isTrustRulesSheetOpen || trustRulesOpenElsewhere)
                     }
                 }
             }
@@ -260,6 +262,9 @@ public struct SettingsView: View {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
+        }
+        .onReceive(daemonClient?.$isTrustRulesSheetOpen.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { isOpen in
+            trustRulesOpenElsewhere = isOpen && !isTrustRulesSheetOpen
         }
         .sheet(isPresented: $showingPrivacy) {
             PrivacyDetailView()

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -61,6 +61,7 @@ struct TrustRulesView: View {
         }
         .frame(width: 600, height: 500)
         .onAppear {
+            daemonClient.isTrustRulesSheetOpen = true
             daemonClient.onTrustRulesListResponse = { items in
                 rules = items
                 isLoading = false
@@ -69,6 +70,7 @@ struct TrustRulesView: View {
         }
         .onDisappear {
             daemonClient.onTrustRulesListResponse = nil
+            daemonClient.isTrustRulesSheetOpen = false
         }
         .sheet(isPresented: $showingAddSheet) {
             TrustRuleFormView(daemonClient: daemonClient) {

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -28,6 +28,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published public var isConnected: Bool = false
 
+    /// Whether a TrustRulesView sheet is currently open from any settings surface.
+    /// Used to prevent multiple trust rules sheets from racing on the shared callback.
+    @Published public var isTrustRulesSheetOpen: Bool = false
+
     // MARK: - Surface Event Callbacks
 
     /// Called when the daemon sends a `ui_surface_show` message.


### PR DESCRIPTION
## Summary
- Adds a `@Published isTrustRulesSheetOpen` flag on `DaemonClient` as a cross-surface gate
- `TrustRulesView` sets the flag on `onAppear` and clears it on `onDisappear`
- Both `SettingsView` and `SettingsPanel` observe the flag via `.onReceive` and disable their "Manage" button when trust rules are already open from the other surface
- Prevents two `TrustRulesView` sheets from competing for the single `onTrustRulesListResponse` callback

Addresses review feedback from PR #1899.

## Test plan
- [ ] Open SettingsPanel in main window, click "Manage..." to open trust rules
- [ ] While trust rules sheet is open, open the standalone Settings window -- the "Manage Trust Rules..." button should be disabled
- [ ] Close the trust rules sheet -- both buttons should re-enable
- [ ] Repeat from the standalone Settings window first -- the SettingsPanel button should be disabled

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
