### PR TITLE
Deduplicate late-arriving history messages in populateFromHistory

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -1049,9 +1049,19 @@ final class ChatViewModel: ObservableObject {
         let hasUserSentMessages = messages.contains { $0.role == .user }
         if hasUserSentMessages {
             // History arrived after the user already sent messages.
-            // Prepend history before existing messages so the user sees
-            // the full conversation context.
-            self.messages = chatMessages + self.messages
+            // The history payload includes ALL persisted messages — including
+            // ones the user sent (and any assistant replies) before the
+            // history_response arrived. Deduplicate by only prepending
+            // history messages whose timestamps precede the earliest
+            // existing message.
+            let earliestExisting = self.messages.map(\.timestamp).min()
+            let uniqueHistory: [ChatMessage]
+            if let earliest = earliestExisting {
+                uniqueHistory = chatMessages.filter { $0.timestamp < earliest }
+            } else {
+                uniqueHistory = chatMessages
+            }
+            self.messages = uniqueHistory + self.messages
         } else {
             self.messages = chatMessages
         }


### PR DESCRIPTION
## Summary

Fixes duplicate messages when a `history_response` arrives after the user has already sent messages. The daemon's history payload includes ALL persisted messages — including ones the user sent and any assistant replies that streamed in before the history loaded. Previously, `populateFromHistory` blindly prepended all history messages, causing duplicates.

Now filters history messages by timestamp: only messages with timestamps strictly before the earliest existing message are prepended.

Addresses review feedback from Devin on #1909.

## Test plan

- [ ] Send a message before history loads in a restored thread — verify no duplicate messages appear
- [ ] Wait for history to load normally (no user message sent) — verify behavior unchanged
- [ ] Send multiple messages before history arrives — verify all show once with correct ordering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
