### PR TITLE
Support drag-and-drop of screenshots and image data into chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -21,6 +21,7 @@ struct ChatView: View {
     let onAttach: () -> Void
     let onRemoveAttachment: (String) -> Void
     let onDropFiles: ([URL]) -> Void
+    let onDropImageData: (Data) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
     let onConfirmationAllow: (String) -> Void
@@ -46,20 +47,50 @@ struct ChatView: View {
         return (last?.text.count ?? 0) + (last?.toolCalls.count ?? 0) + (last?.inlineSurfaces.count ?? 0)
     }
 
+    @State private var isDropTargeted = false
+
     var body: some View {
-        VStack(spacing: 0) {
-            apiKeyBanner
-            messageList
-            if let errorText {
-                errorBanner(errorText)
+        ZStack {
+            VStack(spacing: 0) {
+                apiKeyBanner
+                messageList
+                if let errorText {
+                    errorBanner(errorText)
+                }
+                queueSummary
+                composerArea
             }
-            queueSummary
-            composerArea
+            .background(alignment: .bottom) {
+                chatBackground
+            }
+            .background(VColor.chatBackground)
+
+            // Drop target overlay
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.accent, style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(VColor.accent.opacity(0.08))
+                    )
+                    .overlay {
+                        VStack(spacing: VSpacing.sm) {
+                            Image(systemName: "arrow.down.doc.fill")
+                                .font(.system(size: 28, weight: .medium))
+                                .foregroundColor(VColor.accent)
+                            Text("Drop files here")
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.accent)
+                        }
+                    }
+                    .padding(VSpacing.lg)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+            }
         }
-        .background(alignment: .bottom) {
-            chatBackground
+        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers: providers)
         }
-        .background(VColor.chatBackground)
     }
 
     @ViewBuilder
@@ -71,6 +102,59 @@ struct ChatView: View {
                 .scaledToFit()
                 .allowsHitTesting(false)
         }
+    }
+
+    /// Handle dropped items — supports both file URLs and raw image data.
+    private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        var urls: [URL] = []
+        var imageDataItems: [NSItemProvider] = []
+        let group = DispatchGroup()
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                // File URL drop (e.g. dragging a saved file)
+                group.enter()
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    DispatchQueue.main.async {
+                        if let url { urls.append(url) }
+                        group.leave()
+                    }
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                // Raw image data drop (e.g. dragging a screenshot thumbnail)
+                imageDataItems.append(provider)
+            }
+        }
+
+        // Load image data items
+        for provider in imageDataItems {
+            // Try PNG first, then TIFF, then generic image
+            let typeIdentifier: String
+            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
+                typeIdentifier = UTType.png.identifier
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                typeIdentifier = UTType.tiff.identifier
+            } else {
+                typeIdentifier = UTType.image.identifier
+            }
+
+            group.enter()
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                DispatchQueue.main.async {
+                    if let data {
+                        onDropImageData(data)
+                    }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .main) {
+            if !urls.isEmpty { onDropFiles(urls) }
+        }
+        return true
     }
 
     // MARK: - Message List
@@ -309,23 +393,6 @@ struct ChatView: View {
         .padding(.vertical, VSpacing.lg)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
-        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-            var urls: [URL] = []
-            let group = DispatchGroup()
-            for provider in providers {
-                group.enter()
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    DispatchQueue.main.async {
-                        if let url { urls.append(url) }
-                        group.leave()
-                    }
-                }
-            }
-            group.notify(queue: .main) {
-                if !urls.isEmpty { onDropFiles(urls) }
-            }
-            return true
-        }
     }
 
     // MARK: - Attachment Preview Strip
@@ -900,6 +967,7 @@ private struct ChatViewPreviewWrapper: View {
                 onAttach: {},
                 onRemoveAttachment: { _ in },
                 onDropFiles: { _ in },
+                onDropImageData: { _ in },
                 onPaste: {},
                 onMicrophoneToggle: {},
                 onConfirmationAllow: { _ in },

--- a/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatViewModel.swift
@@ -138,26 +138,41 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
+        addAttachment(imageData: imageData, filename: "Pasted Image.png")
+    }
+
+    /// Add an attachment from raw image data (e.g. drag-and-drop, pasteboard).
+    /// Converts TIFF to PNG if needed.
+    func addAttachment(imageData: Data, filename: String = "Dropped Image.png") {
         guard pendingAttachments.count < Self.maxAttachments else {
             errorText = "Maximum \(Self.maxAttachments) attachments per message."
             return
         }
 
-        // Convert to PNG if needed
+        // Convert to PNG if needed — raw image data may be TIFF
         let pngData: Data
-        if pasteboard.data(forType: .png) != nil {
-            pngData = imageData
-        } else if let bitmapRep = NSBitmapImageRep(data: imageData),
-                  let converted = bitmapRep.representation(using: .png, properties: [:]) {
-            pngData = converted
+        if let _ = NSImage(data: imageData) {
+            // Check if already PNG by looking at magic bytes
+            let pngMagic: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            let headerBytes = [UInt8](imageData.prefix(4))
+            if headerBytes == pngMagic {
+                pngData = imageData
+            } else if let bitmapRep = NSBitmapImageRep(data: imageData),
+                      let converted = bitmapRep.representation(using: .png, properties: [:]) {
+                pngData = converted
+            } else {
+                log.error("Failed to convert dropped image to PNG")
+                errorText = "Could not process image."
+                return
+            }
         } else {
-            log.error("Failed to convert pasted image to PNG")
-            errorText = "Could not process pasted image."
+            log.error("Dropped data is not a valid image")
+            errorText = "Could not process image."
             return
         }
 
         guard pngData.count <= Self.maxFileSize else {
-            errorText = "Pasted image exceeds 20 MB limit."
+            errorText = "Image exceeds 20 MB limit."
             return
         }
 
@@ -166,7 +181,7 @@ final class ChatViewModel: ObservableObject {
 
         let attachment = ChatAttachment(
             id: UUID().uuidString,
-            filename: "Pasted Image.png",
+            filename: filename,
             mimeType: "image/png",
             data: base64,
             thumbnailData: thumbnail,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -59,6 +59,7 @@ struct MainWindowView: View {
                             onAttach: { Self.openFilePicker(viewModel: viewModel) },
                             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                             onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
+                            onDropImageData: { data in viewModel.addAttachment(imageData: data) },
                             onPaste: { viewModel.addAttachmentFromPasteboard() },
                             onMicrophoneToggle: onMicrophoneToggle,
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },


### PR DESCRIPTION
## Summary
- Expand the drop zone from just the composer area to the entire chat view, so files can be dropped anywhere
- Add support for raw image data drops (PNG/TIFF), not just file URLs — enables dragging screenshots directly from the macOS screenshot tool thumbnail
- Show a visual drop target overlay (dashed accent border + icon) when dragging over the chat
- Extract reusable `addAttachment(imageData:)` method in ChatViewModel for both paste and drag-and-drop image handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
