### PR TITLE
Skip pre-message hook rollback during regenerate to prevent data loss

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -439,11 +439,17 @@ export class Session {
   /**
    * Run the agent loop after a user message has been persisted via
    * `persistUserMessage`. Clears the `processing` flag when done.
+   *
+   * @param options.skipPreMessageRollback - When true, the pre-message hook
+   *   blocked path will NOT delete the user message from in-memory history or
+   *   the DB. Used by `regenerate()` where the user message is the original
+   *   (not freshly persisted) and must be preserved.
    */
   async runAgentLoop(
     content: string,
     userMessageId: string,
     onEvent: (msg: ServerMessage) => void,
+    options?: { skipPreMessageRollback?: boolean },
   ): Promise<void> {
     if (!this.abortController) {
       throw new Error('runAgentLoop called without prior persistUserMessage');
@@ -460,12 +466,14 @@ export class Session {
       });
 
       if (preMessageResult.blocked) {
-        // Roll back the user message from both in-memory history and the DB.
-        // We use deleteMessageById (not deleteLastExchange) because it NULLs
-        // nullable FK references (message_runs, channel_inbound_events) before
-        // deleting the message row, so the run record survives.
-        this.messages.pop();
-        conversationStore.deleteMessageById(userMessageId);
+        if (!options?.skipPreMessageRollback) {
+          // Roll back the user message from both in-memory history and the DB.
+          // We use deleteMessageById (not deleteLastExchange) because it NULLs
+          // nullable FK references (message_runs, channel_inbound_events) before
+          // deleting the message row, so the run record survives.
+          this.messages.pop();
+          conversationStore.deleteMessageById(userMessageId);
+        }
         onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
         return;
       }
@@ -1054,7 +1062,7 @@ export class Session {
     this.abortController = new AbortController();
     this.currentRequestId = uuid();
 
-    await this.runAgentLoop(content, existingUserMessageId, onEvent);
+    await this.runAgentLoop(content, existingUserMessageId, onEvent, { skipPreMessageRollback: true });
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #1906 (from both Codex and Devin).

When `regenerate()` calls `runAgentLoop()` directly, the pre-message hook rollback logic (`this.messages.pop()` + `conversationStore.deleteMessageById()`) would destroy the **original** user message. During normal `processMessage`, this rollback correctly undoes a freshly-persisted message, but during regeneration the message ID refers to the original user message — causing irreversible data loss.

**Fix:** Added a `skipPreMessageRollback` option to `runAgentLoop`. When `regenerate()` calls it, the rollback is skipped so the original user message is preserved. The hook-blocked error event is still sent to the client.

## Files modified

- `assistant/src/daemon/session.ts` — Add `options.skipPreMessageRollback` parameter to `runAgentLoop`; guard rollback behind the flag; pass the flag from `regenerate()`

## Test plan

- [ ] Trigger regenerate with a pre-message hook that blocks — verify original user message is preserved in both memory and DB
- [ ] Trigger normal processMessage with a blocking pre-message hook — verify rollback still works as before
- [ ] Type-check passes (`bunx tsc --noEmit`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
