### PR TITLE
Invalidate live daemon sessions after sessions clear

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -361,6 +361,12 @@ exports[`IPC message snapshots ClientMessage types secret_response serializes to
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types sessions_clear serializes to expected JSON 1`] = `
+{
+  "type": "sessions_clear",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types assistant_text_delta serializes to expected JSON 1`] = `
 {
   "sessionId": "sess-001",
@@ -490,6 +496,13 @@ exports[`IPC message snapshots ServerMessage types session_list_response seriali
     },
   ],
   "type": "session_list_response",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types sessions_clear_response serializes to expected JSON 1`] = `
+{
+  "cleared": 3,
+  "type": "sessions_clear_response",
 }
 `;
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -234,6 +234,9 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     requestId: 'req-secret-001',
     value: 'ghp_test_token_value',
   },
+  sessions_clear: {
+    type: 'sessions_clear',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -320,6 +323,10 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
       { id: 'sess-001', title: 'First session', updatedAt: 1700000000 },
       { id: 'sess-002', title: 'Second session', updatedAt: 1700001000 },
     ],
+  },
+  sessions_clear_response: {
+    type: 'sessions_clear_response',
+    cleared: 3,
   },
   error: {
     type: 'error',

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -324,6 +324,7 @@ export interface HandlerContext {
   updateConfigFingerprint(): void;
   send(socket: net.Socket, msg: ServerMessage): void;
   broadcast(msg: ServerMessage): void;
+  clearAllSessions(): number;
   getOrCreateSession(
     conversationId: string,
     socket?: net.Socket,
@@ -349,6 +350,7 @@ const handlers: DispatchMap = {
   secret_response: handleSecretResponse,
   session_list: (_msg, socket, ctx) => handleSessionList(socket, ctx),
   session_create: handleSessionCreate,
+  sessions_clear: (_msg, socket, ctx) => handleSessionsClear(socket, ctx),
   session_switch: handleSessionSwitch,
   cancel: handleCancel,
   model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
@@ -524,6 +526,11 @@ function handleSessionList(socket: net.Socket, ctx: HandlerContext): void {
       updatedAt: c.updatedAt,
     })),
   });
+}
+
+function handleSessionsClear(socket: net.Socket, ctx: HandlerContext): void {
+  const cleared = ctx.clearAllSessions();
+  ctx.send(socket, { type: 'sessions_clear_response', cleared });
 }
 
 async function handleSessionCreate(

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -203,6 +203,10 @@ export interface SkillsSearchRequest {
   query: string;
 }
 
+export interface SessionsClearRequest {
+  type: 'sessions_clear';
+}
+
 export interface SkillsInspectRequest {
   type: 'skills_inspect';
   slug: string;
@@ -432,7 +436,8 @@ export type ClientMessage =
   | SharedAppDeleteRequest
   | OpenBundleRequest
   | SignBundlePayloadResponse
-  | GetSigningIdentityResponse;
+  | GetSigningIdentityResponse
+  | SessionsClearRequest;
 
 // === Server → Client messages ===
 
@@ -510,6 +515,11 @@ export interface SessionInfo {
 export interface SessionListResponse {
   type: 'session_list_response';
   sessions: Array<{ id: string; title: string; updatedAt: number }>;
+}
+
+export interface SessionsClearResponse {
+  type: 'sessions_clear_response';
+  cleared: number;
 }
 
 export interface ErrorMessage {
@@ -958,6 +968,7 @@ export type ServerMessage =
   | MessageComplete
   | SessionInfo
   | SessionListResponse
+  | SessionsClearResponse
   | ErrorMessage
   | PongMessage
   | GenerationCancelled

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -212,6 +212,21 @@ export class DaemonServer {
     });
   }
 
+  /**
+   * Dispose and remove all in-memory sessions unconditionally.
+   * Called after `sessions clear` wipes the database so that stale
+   * sessions don't reference deleted conversation rows.
+   */
+  clearAllSessions(): number {
+    const count = this.sessions.size;
+    for (const session of this.sessions.values()) {
+      session.dispose();
+    }
+    this.sessions.clear();
+    this.sessionOptions.clear();
+    return count;
+  }
+
   private evictSessionsForReload(): void {
     for (const [id, session] of this.sessions) {
       if (!session.isProcessing()) {
@@ -534,6 +549,7 @@ export class DaemonServer {
       },
       send: (socket, msg) => this.send(socket, msg),
       broadcast: (msg) => this.broadcast(msg),
+      clearAllSessions: () => this.clearAllSessions(),
       getOrCreateSession: (id, socket?, rebind?, options?) =>
         this.getOrCreateSession(id, socket, rebind, options),
     };

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -315,6 +315,14 @@ sessions
     const result = clearAllConversations();
     console.log(`Cleared ${result.conversations} conversations, ${result.messages} messages`);
 
+    // Notify a running daemon to drop its in-memory sessions so it
+    // doesn't keep serving stale history from deleted conversation rows.
+    try {
+      await sendOneMessage({ type: 'sessions_clear' });
+    } catch {
+      // Daemon may not be running — that's fine, no sessions to invalidate.
+    }
+
     const config = getConfig();
     const qdrantUrl = process.env.QDRANT_URL?.trim() || config.memory.qdrant.url;
     const qdrant = initQdrantClient({


### PR DESCRIPTION
## Summary

Addresses feedback from Codex review on #1911: after `sessions clear` deletes all conversation rows from the DB, the running daemon's in-memory `Session` instances were left alive, causing stale history and FK violation crashes on the next message.

**Changes:**
- Added `sessions_clear` IPC message type (client -> server) and `sessions_clear_response` (server -> client)
- Added `clearAllSessions()` method on `DaemonServer` that disposes all in-memory sessions and clears the session options map
- After `clearAllConversations()` in the `sessions clear` CLI handler, sends the new IPC message to notify the daemon (silently skipped if daemon isn't running)
- Updated IPC snapshot tests for the new message types

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] IPC snapshot tests updated and passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
