### PR TITLE
feat(skills): add pure slash token parser

### DIFF
--- a/assistant/src/__tests__/slash-commands-parser.test.ts
+++ b/assistant/src/__tests__/slash-commands-parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { extractLeadingToken, parseSlashCandidate } from '../skills/slash-commands.js';
+
+describe('extractLeadingToken', () => {
+  test('returns null for empty string', () => {
+    expect(extractLeadingToken('')).toBeNull();
+  });
+
+  test('returns null for whitespace-only string', () => {
+    expect(extractLeadingToken('   ')).toBeNull();
+    expect(extractLeadingToken('\t\n')).toBeNull();
+  });
+
+  test('returns the first token for normal text', () => {
+    expect(extractLeadingToken('hello world')).toBe('hello');
+  });
+
+  test('returns the first token with leading whitespace', () => {
+    expect(extractLeadingToken('   hello world')).toBe('hello');
+  });
+
+  test('returns slash token', () => {
+    expect(extractLeadingToken('/start-the-day')).toBe('/start-the-day');
+  });
+
+  test('returns slash token with trailing args', () => {
+    expect(extractLeadingToken('   /start-the-day   foo')).toBe('/start-the-day');
+  });
+});
+
+describe('parseSlashCandidate', () => {
+  test('returns none for empty input', () => {
+    expect(parseSlashCandidate('')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for whitespace-only input', () => {
+    expect(parseSlashCandidate('   ')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for normal text', () => {
+    expect(parseSlashCandidate('hello world')).toEqual({ kind: 'none' });
+  });
+
+  test('returns candidate for /start-the-day', () => {
+    expect(parseSlashCandidate('/start-the-day')).toEqual({
+      kind: 'candidate',
+      token: '/start-the-day',
+    });
+  });
+
+  test('returns candidate for /start-the-day with leading whitespace and args', () => {
+    expect(parseSlashCandidate('   /start-the-day   foo')).toEqual({
+      kind: 'candidate',
+      token: '/start-the-day',
+    });
+  });
+});

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -1,0 +1,24 @@
+/**
+ * Parse whether user input starts with a slash-like command token.
+ *
+ * Rules:
+ * - Trim leading whitespace.
+ * - Only inspect the first whitespace-delimited token.
+ * - A candidate token must begin with `/`.
+ * - Return `none` for empty input.
+ */
+
+export function extractLeadingToken(input: string): string | null {
+  const trimmed = input.trimStart();
+  if (!trimmed) return null;
+  const firstToken = trimmed.split(/\s/)[0];
+  return firstToken || null;
+}
+
+export function parseSlashCandidate(input: string): { kind: 'none' | 'candidate'; token?: string } {
+  const token = extractLeadingToken(input);
+  if (!token || !token.startsWith('/')) {
+    return { kind: 'none' };
+  }
+  return { kind: 'candidate', token };
+}


### PR DESCRIPTION
## Summary
- Add `extractLeadingToken()` and `parseSlashCandidate()` to `assistant/src/skills/slash-commands.ts`
- Pure utility to detect whether user input starts with a slash-like command token
- Fully tested in `slash-commands-parser.test.ts` (11 tests)
- No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
