### PR TITLE
Add doc comment explaining intentional inline surface bubble hiding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -576,6 +576,11 @@ private struct ChatBubble: View {
     /// Whether the text/attachment bubble should be rendered.
     /// Tool calls for assistant messages render outside the bubble as separate chips,
     /// so only show the bubble when there's actual text or attachment content.
+    ///
+    /// NOTE: When inline surfaces are present, the bubble is intentionally hidden
+    /// even if the message also contains text. This is by design — the assistant's
+    /// text in these cases is typically a preamble (e.g. "Here's what I built:")
+    /// that should not appear above the rendered dynamic UI surface.
     private var shouldShowBubble: Bool {
         if isUser { return true }
         if !message.inlineSurfaces.isEmpty { return false }


### PR DESCRIPTION
## Summary
- Adds a clarifying doc comment to `shouldShowBubble` in `ChatView.swift` explaining that hiding the text bubble when inline surfaces are present is **intentional behavior**, not a bug.
- This addresses review feedback on PR #1915 from Devin and Codex, which flagged the check order as potentially suppressing text/attachments. The behavior was explicitly requested by the user — when a dynamic UI surface is rendered, the assistant's text preamble (e.g. "Here's what I built:") should not appear above it.

## Test plan
- [x] Comment-only change; no logic modified
- [x] No build verification needed (doc comment in Swift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
