### PR TITLE
feat(skills): validate slash IDs and ignore path-like tokens

### DIFF
--- a/assistant/src/__tests__/slash-commands-parser.test.ts
+++ b/assistant/src/__tests__/slash-commands-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { extractLeadingToken, parseSlashCandidate } from '../skills/slash-commands.js';
+import { extractLeadingToken, isPathLikeSlashToken, isValidSlashSkillId, parseSlashCandidate } from '../skills/slash-commands.js';
 
 describe('extractLeadingToken', () => {
   test('returns null for empty string', () => {
@@ -53,5 +53,67 @@ describe('parseSlashCandidate', () => {
       kind: 'candidate',
       token: '/start-the-day',
     });
+  });
+
+  test('returns none for path-like /tmp/file', () => {
+    expect(parseSlashCandidate('/tmp/file')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for path-like /Users/sidd', () => {
+    expect(parseSlashCandidate('/Users/sidd')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for path-like /foo/bar', () => {
+    expect(parseSlashCandidate('/foo/bar')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for /.hidden (invalid ID)', () => {
+    expect(parseSlashCandidate('/.hidden')).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for /... (invalid ID)', () => {
+    expect(parseSlashCandidate('/...')).toEqual({ kind: 'none' });
+  });
+
+  test('returns candidate for valid /start_the.day-1', () => {
+    expect(parseSlashCandidate('/start_the.day-1')).toEqual({
+      kind: 'candidate',
+      token: '/start_the.day-1',
+    });
+  });
+});
+
+describe('isValidSlashSkillId', () => {
+  test('accepts alphanumeric with dots, hyphens, underscores', () => {
+    expect(isValidSlashSkillId('start-the-day')).toBe(true);
+    expect(isValidSlashSkillId('my_skill.v2')).toBe(true);
+    expect(isValidSlashSkillId('A1')).toBe(true);
+  });
+
+  test('rejects empty string', () => {
+    expect(isValidSlashSkillId('')).toBe(false);
+  });
+
+  test('rejects strings with dots only', () => {
+    expect(isValidSlashSkillId('...')).toBe(false);
+  });
+
+  test('rejects strings starting with dot', () => {
+    expect(isValidSlashSkillId('.hidden')).toBe(false);
+  });
+
+  test('rejects strings with slashes', () => {
+    expect(isValidSlashSkillId('foo/bar')).toBe(false);
+  });
+});
+
+describe('isPathLikeSlashToken', () => {
+  test('detects paths with multiple slashes', () => {
+    expect(isPathLikeSlashToken('/tmp/file')).toBe(true);
+    expect(isPathLikeSlashToken('/Users/sidd')).toBe(true);
+  });
+
+  test('single leading slash is not path-like', () => {
+    expect(isPathLikeSlashToken('/start-the-day')).toBe(false);
   });
 });

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -20,5 +20,24 @@ export function parseSlashCandidate(input: string): { kind: 'none' | 'candidate'
   if (!token || !token.startsWith('/')) {
     return { kind: 'none' };
   }
+  if (isPathLikeSlashToken(token)) {
+    return { kind: 'none' };
+  }
+  const id = token.slice(1);
+  if (!isValidSlashSkillId(id)) {
+    return { kind: 'none' };
+  }
   return { kind: 'candidate', token };
+}
+
+/** Validate that a slash skill ID starts with alphanumeric and contains only [A-Za-z0-9._-] */
+export function isValidSlashSkillId(id: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id);
+}
+
+/** Detect filesystem-like paths: tokens containing more than one `/` */
+export function isPathLikeSlashToken(token: string): boolean {
+  // Count slashes — a single leading `/` is expected, but any additional `/` means it's a path
+  const slashCount = token.split('/').length - 1;
+  return slashCount > 1;
 }


### PR DESCRIPTION
## Summary
- Add `isValidSlashSkillId()` requiring alphanumeric start + `[A-Za-z0-9._-]` chars
- Add `isPathLikeSlashToken()` detecting filesystem paths (multiple slashes)
- `parseSlashCandidate()` now returns `none` for path-like or invalid tokens
- 13 new test cases added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
