### PR TITLE
feat(skills): add invocable slash skill catalog builder

### DIFF
--- a/assistant/src/__tests__/slash-commands-catalog.test.ts
+++ b/assistant/src/__tests__/slash-commands-catalog.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { buildInvocableSlashCatalog } from '../skills/slash-commands.js';
+import type { SkillSummary } from '../config/skills.js';
+import type { ResolvedSkill } from '../config/skill-state.js';
+
+function makeSkill(id: string, overrides?: Partial<SkillSummary>): SkillSummary {
+  return {
+    id,
+    name: overrides?.name ?? id,
+    description: `Description for ${id}`,
+    directoryPath: `/skills/${id}`,
+    skillFilePath: `/skills/${id}/SKILL.md`,
+    userInvocable: overrides?.userInvocable ?? true,
+    disableModelInvocation: false,
+    source: 'managed',
+  };
+}
+
+function makeResolved(skill: SkillSummary, state: ResolvedSkill['state']): ResolvedSkill {
+  return {
+    summary: skill,
+    state,
+    degraded: state === 'degraded',
+  };
+}
+
+describe('buildInvocableSlashCatalog', () => {
+  test('excludes disabled skill', () => {
+    const skill = makeSkill('my-skill');
+    const catalog = [skill];
+    const resolved = [makeResolved(skill, 'disabled')];
+
+    const result = buildInvocableSlashCatalog(catalog, resolved);
+    expect(result.size).toBe(0);
+  });
+
+  test('excludes userInvocable: false skill', () => {
+    const skill = makeSkill('hidden-skill', { userInvocable: false });
+    const catalog = [skill];
+    const resolved = [makeResolved(skill, 'enabled')];
+
+    const result = buildInvocableSlashCatalog(catalog, resolved);
+    expect(result.size).toBe(0);
+  });
+
+  test('includes enabled invocable skill', () => {
+    const skill = makeSkill('start-the-day', { name: 'Start the Day' });
+    const catalog = [skill];
+    const resolved = [makeResolved(skill, 'enabled')];
+
+    const result = buildInvocableSlashCatalog(catalog, resolved);
+    expect(result.size).toBe(1);
+    const entry = result.get('start-the-day');
+    expect(entry).toBeDefined();
+    expect(entry!.canonicalId).toBe('start-the-day');
+    expect(entry!.name).toBe('Start the Day');
+  });
+
+  test('includes degraded invocable skill', () => {
+    const skill = makeSkill('degraded-skill');
+    const catalog = [skill];
+    const resolved = [makeResolved(skill, 'degraded')];
+
+    const result = buildInvocableSlashCatalog(catalog, resolved);
+    expect(result.size).toBe(1);
+  });
+
+  test('case-insensitive lookup key', () => {
+    const skill = makeSkill('MySkill');
+    const catalog = [skill];
+    const resolved = [makeResolved(skill, 'enabled')];
+
+    const result = buildInvocableSlashCatalog(catalog, resolved);
+    expect(result.get('myskill')).toBeDefined();
+    expect(result.get('myskill')!.canonicalId).toBe('MySkill');
+  });
+});

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -1,3 +1,6 @@
+import type { SkillSummary } from '../config/skills.js';
+import type { ResolvedSkill } from '../config/skill-state.js';
+
 /**
  * Parse whether user input starts with a slash-like command token.
  *
@@ -40,4 +43,40 @@ export function isPathLikeSlashToken(token: string): boolean {
   // Count slashes — a single leading `/` is expected, but any additional `/` means it's a path
   const slashCount = token.split('/').length - 1;
   return slashCount > 1;
+}
+
+// ─── Invocable slash skill catalog ──────────────────────────────────────────
+
+export interface InvocableSlashSkill {
+  canonicalId: string;
+  name: string;
+  summary: SkillSummary;
+}
+
+/**
+ * Build a map of slash-invocable skills keyed by lowercase ID for
+ * case-insensitive lookup. Only includes skills that are `userInvocable`
+ * and whose resolved state is not `disabled`.
+ */
+export function buildInvocableSlashCatalog(
+  catalog: SkillSummary[],
+  resolvedStates: ResolvedSkill[],
+): Map<string, InvocableSlashSkill> {
+  const stateById = new Map<string, ResolvedSkill>();
+  for (const rs of resolvedStates) {
+    stateById.set(rs.summary.id, rs);
+  }
+
+  const result = new Map<string, InvocableSlashSkill>();
+  for (const skill of catalog) {
+    if (!skill.userInvocable) continue;
+    const resolved = stateById.get(skill.id);
+    if (resolved && resolved.state === 'disabled') continue;
+    result.set(skill.id.toLowerCase(), {
+      canonicalId: skill.id,
+      name: skill.name,
+      summary: skill,
+    });
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary
- Add `buildInvocableSlashCatalog()` pure function that builds a case-insensitive lookup map of slash-invocable skills
- Filters by `userInvocable` flag and resolved state (excludes disabled skills, includes enabled and degraded)
- Add 5 unit tests covering exclusion/inclusion logic and case-insensitive lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
