### PR TITLE
feat(skills): add slash resolution result model

### DIFF
--- a/assistant/src/__tests__/slash-commands-resolver.test.ts
+++ b/assistant/src/__tests__/slash-commands-resolver.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildInvocableSlashCatalog,
+  formatUnknownSlashSkillMessage,
+  resolveSlashSkillCommand,
+} from '../skills/slash-commands.js';
+import type { SkillSummary } from '../config/skills.js';
+import type { ResolvedSkill } from '../config/skill-state.js';
+
+function makeSkill(id: string, overrides?: Partial<SkillSummary>): SkillSummary {
+  return {
+    id,
+    name: overrides?.name ?? id,
+    description: `Description for ${id}`,
+    directoryPath: `/skills/${id}`,
+    skillFilePath: `/skills/${id}/SKILL.md`,
+    userInvocable: overrides?.userInvocable ?? true,
+    disableModelInvocation: false,
+    source: 'managed',
+  };
+}
+
+function makeResolved(skill: SkillSummary, state: ResolvedSkill['state']): ResolvedSkill {
+  return {
+    summary: skill,
+    state,
+    degraded: state === 'degraded',
+  };
+}
+
+function buildCatalog(skills: SkillSummary[]): Map<string, any> {
+  const resolved = skills.map((s) => makeResolved(s, 'enabled'));
+  return buildInvocableSlashCatalog(skills, resolved);
+}
+
+describe('resolveSlashSkillCommand', () => {
+  test('returns none for normal text', () => {
+    const catalog = buildCatalog([makeSkill('start-the-day')]);
+    expect(resolveSlashSkillCommand('hello world', catalog)).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for empty input', () => {
+    const catalog = buildCatalog([]);
+    expect(resolveSlashSkillCommand('', catalog)).toEqual({ kind: 'none' });
+  });
+
+  test('returns none for path-like /tmp/file', () => {
+    const catalog = buildCatalog([makeSkill('tmp')]);
+    expect(resolveSlashSkillCommand('/tmp/file', catalog)).toEqual({ kind: 'none' });
+  });
+
+  test('returns known for exact ID match', () => {
+    const catalog = buildCatalog([makeSkill('start-the-day')]);
+    const result = resolveSlashSkillCommand('/start-the-day', catalog);
+    expect(result).toEqual({ kind: 'known', skillId: 'start-the-day', trailingArgs: '' });
+  });
+
+  test('returns known with trailing args', () => {
+    const catalog = buildCatalog([makeSkill('start-the-day')]);
+    const result = resolveSlashSkillCommand('/start-the-day weather in SF', catalog);
+    expect(result).toEqual({
+      kind: 'known',
+      skillId: 'start-the-day',
+      trailingArgs: 'weather in SF',
+    });
+  });
+
+  test('known match is case-insensitive but returns canonical ID', () => {
+    const catalog = buildCatalog([makeSkill('Start-The-Day')]);
+    const result = resolveSlashSkillCommand('/start-the-day', catalog);
+    expect(result.kind).toBe('known');
+    if (result.kind === 'known') {
+      expect(result.skillId).toBe('Start-The-Day');
+    }
+  });
+
+  test('returns unknown for unrecognized slash command', () => {
+    const catalog = buildCatalog([makeSkill('start-the-day')]);
+    const result = resolveSlashSkillCommand('/not-a-skill', catalog);
+    expect(result.kind).toBe('unknown');
+    if (result.kind === 'unknown') {
+      expect(result.requestedId).toBe('not-a-skill');
+      expect(result.message).toContain('Unknown command `/not-a-skill`');
+      expect(result.message).toContain('`/start-the-day`');
+    }
+  });
+
+  test('unknown message lists available skills sorted', () => {
+    const catalog = buildCatalog([makeSkill('zebra'), makeSkill('alpha'), makeSkill('mid')]);
+    const result = resolveSlashSkillCommand('/nope', catalog);
+    expect(result.kind).toBe('unknown');
+    if (result.kind === 'unknown') {
+      const lines = result.message.split('\n');
+      const skillLines = lines.filter((l) => l.startsWith('- `'));
+      expect(skillLines[0]).toContain('/alpha');
+      expect(skillLines[1]).toContain('/mid');
+      expect(skillLines[2]).toContain('/zebra');
+    }
+  });
+
+  test('handles leading whitespace in input', () => {
+    const catalog = buildCatalog([makeSkill('start-the-day')]);
+    const result = resolveSlashSkillCommand('   /start-the-day   foo bar', catalog);
+    expect(result).toEqual({
+      kind: 'known',
+      skillId: 'start-the-day',
+      trailingArgs: 'foo bar',
+    });
+  });
+});
+
+describe('formatUnknownSlashSkillMessage', () => {
+  test('includes requested ID and available skills', () => {
+    const msg = formatUnknownSlashSkillMessage('bad-cmd', ['alpha', 'beta']);
+    expect(msg).toContain('Unknown command `/bad-cmd`');
+    expect(msg).toContain('- `/alpha`');
+    expect(msg).toContain('- `/beta`');
+  });
+
+  test('shows no-commands message when catalog is empty', () => {
+    const msg = formatUnknownSlashSkillMessage('bad-cmd', []);
+    expect(msg).toContain('Unknown command `/bad-cmd`');
+    expect(msg).toContain('No slash commands are currently available.');
+  });
+});

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -80,3 +80,72 @@ export function buildInvocableSlashCatalog(
   }
   return result;
 }
+
+// ─── Slash command resolution ────────────────────────────────────────────────
+
+export type SlashResolution =
+  | { kind: 'none' }
+  | { kind: 'known'; skillId: string; trailingArgs: string }
+  | { kind: 'unknown'; requestedId: string; message: string };
+
+/**
+ * Resolve user input against the invocable slash catalog.
+ *
+ * Returns:
+ * - `none` if input is not a slash candidate (normal text, path, etc.)
+ * - `known` if the slash ID matches an invocable skill (case-insensitive)
+ * - `unknown` if it's a valid slash candidate but no matching skill exists
+ */
+export function resolveSlashSkillCommand(
+  input: string,
+  catalog: Map<string, InvocableSlashSkill>,
+): SlashResolution {
+  const candidate = parseSlashCandidate(input);
+  if (candidate.kind === 'none') {
+    return { kind: 'none' };
+  }
+
+  const token = candidate.token!;
+  const requestedId = token.slice(1);
+  const lookupKey = requestedId.toLowerCase();
+
+  // Extract trailing args: everything after the first token
+  const trimmed = input.trimStart();
+  const firstSpaceIdx = trimmed.search(/\s/);
+  const trailingArgs = firstSpaceIdx === -1 ? '' : trimmed.slice(firstSpaceIdx).trim();
+
+  const match = catalog.get(lookupKey);
+  if (match) {
+    return { kind: 'known', skillId: match.canonicalId, trailingArgs };
+  }
+
+  const availableIds = Array.from(catalog.values())
+    .map((s) => s.canonicalId)
+    .sort();
+  return {
+    kind: 'unknown',
+    requestedId,
+    message: formatUnknownSlashSkillMessage(requestedId, availableIds),
+  };
+}
+
+/**
+ * Build a deterministic error message for an unknown slash command.
+ */
+export function formatUnknownSlashSkillMessage(
+  requestedId: string,
+  availableSkillIds: string[],
+): string {
+  const lines = [`Unknown command \`/${requestedId}\`.`];
+  if (availableSkillIds.length > 0) {
+    lines.push('');
+    lines.push('Available slash commands:');
+    for (const id of availableSkillIds) {
+      lines.push(`- \`/${id}\``);
+    }
+  } else {
+    lines.push('');
+    lines.push('No slash commands are currently available.');
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add `resolveSlashSkillCommand()` that resolves user input against the invocable catalog, returning `none | known | unknown`
- Add `formatUnknownSlashSkillMessage()` for deterministic error messages listing available slash commands
- Case-insensitive matching with canonical ID output; 11 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
