### PR TITLE
feat(skills): add slash command prompt rewrite utility

### DIFF
--- a/assistant/src/__tests__/slash-commands-rewrite.test.ts
+++ b/assistant/src/__tests__/slash-commands-rewrite.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { rewriteKnownSlashCommandPrompt } from '../skills/slash-commands.js';
+
+describe('rewriteKnownSlashCommandPrompt', () => {
+  test('produces prompt without trailing args', () => {
+    const result = rewriteKnownSlashCommandPrompt({
+      rawInput: '/start-the-day',
+      skillId: 'start-the-day',
+      skillName: 'Start the Day',
+      trailingArgs: '',
+    });
+    expect(result).toContain('`/start-the-day`');
+    expect(result).toContain('"Start the Day" skill');
+    expect(result).toContain('ID: start-the-day');
+    expect(result).not.toContain('User arguments');
+  });
+
+  test('includes trailing args verbatim', () => {
+    const result = rewriteKnownSlashCommandPrompt({
+      rawInput: '/start-the-day weather in SF',
+      skillId: 'start-the-day',
+      skillName: 'Start the Day',
+      trailingArgs: 'weather in SF',
+    });
+    expect(result).toContain('`/start-the-day`');
+    expect(result).toContain('User arguments: weather in SF');
+  });
+
+  test('preserves args payload exactly (no trimming of internal whitespace)', () => {
+    const args = '  multiple   spaces  here  ';
+    const result = rewriteKnownSlashCommandPrompt({
+      rawInput: `/my-skill ${args}`,
+      skillId: 'my-skill',
+      skillName: 'My Skill',
+      trailingArgs: args,
+    });
+    expect(result).toContain(`User arguments: ${args}`);
+  });
+});

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -149,3 +149,26 @@ export function formatUnknownSlashSkillMessage(
   }
   return lines.join('\n');
 }
+
+// ─── Prompt rewrite for known slash commands ─────────────────────────────────
+
+/**
+ * Rewrite user input for a known slash command into a model-facing prompt
+ * that explicitly instructs the model to invoke the skill.
+ */
+export function rewriteKnownSlashCommandPrompt(params: {
+  rawInput: string;
+  skillId: string;
+  skillName: string;
+  trailingArgs: string;
+}): string {
+  const lines = [
+    `The user invoked the slash command \`/${params.skillId}\`.`,
+    `Please invoke the "${params.skillName}" skill (ID: ${params.skillId}).`,
+  ];
+  if (params.trailingArgs) {
+    lines.push('');
+    lines.push(`User arguments: ${params.trailingArgs}`);
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add `rewriteKnownSlashCommandPrompt()` that rewrites user slash input into a model-facing prompt
- Explicitly instructs model to invoke skill by canonical ID with trailing args preserved verbatim
- 3 unit tests covering no-args, with-args, and whitespace preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
