### PR TITLE
Sanitize dropped image filenames for extension and path safety

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -59,7 +59,17 @@ struct MainWindowView: View {
                             onAttach: { Self.openFilePicker(viewModel: viewModel) },
                             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                             onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
-                            onDropImageData: { data, name in viewModel.addAttachment(imageData: data, filename: name ?? "Dropped Image.png") },
+                            onDropImageData: { data, name in
+                                let filename: String
+                                if let name {
+                                    let basename = (name as NSString).lastPathComponent
+                                    let base = (basename as NSString).deletingPathExtension
+                                    filename = base.isEmpty ? "Dropped Image.png" : "\(base).png"
+                                } else {
+                                    filename = "Dropped Image.png"
+                                }
+                                viewModel.addAttachment(imageData: data, filename: filename)
+                            },
                             onPaste: { viewModel.addAttachmentFromPasteboard() },
                             onMicrophoneToggle: onMicrophoneToggle,
                             onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },


### PR DESCRIPTION
## Summary
- Normalize dropped image filenames from `NSItemProvider.suggestedName` to always end with `.png` (since image data is always converted to PNG)
- Strip directory components via `lastPathComponent` to prevent path traversal in `openImageInPreview`
- Fall back to `"Dropped Image.png"` when name is nil or empty

Addresses review feedback on #1917 from Devin and Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
