### PR TITLE
feat(session): resolve known slash commands before persistence

### DIFF
--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent, CheckpointInfo, CheckpointDecision } from '../agent/loop.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede the Session import so Bun applies them at load time.
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+    memory: { retrieval: { injectionStrategy: 'inline' } },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => [],
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: 'conv-1' }),
+  listConversations: () => [],
+  addMessage: (_convId: string, _role: string, _content: string) => {
+    return { id: `msg-${Date.now()}` };
+  },
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+// Mock skill catalog to provide a known slash skill
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [
+    {
+      id: 'start-the-day',
+      name: 'Start the Day',
+      description: 'Morning routine skill',
+      directoryPath: '/skills/start-the-day',
+      skillFilePath: '/skills/start-the-day/SKILL.md',
+      userInvocable: true,
+      disableModelInvocation: false,
+      source: 'managed',
+    },
+  ],
+  loadSkillBySelector: () => null,
+  ensureSkillIcon: () => {},
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: (catalog: any[]) => catalog.map((s: any) => ({
+    summary: s,
+    state: 'enabled',
+    degraded: false,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Controllable AgentLoop mock that captures the content passed to run().
+// ---------------------------------------------------------------------------
+
+interface PendingRun {
+  resolve: (history: Message[]) => void;
+  messages: Message[];
+  onEvent: (event: AgentEvent) => void;
+}
+
+let pendingRuns: PendingRun[] = [];
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(
+      messages: Message[],
+      onEvent: (event: AgentEvent) => void,
+      _signal?: AbortSignal,
+      _requestId?: string,
+      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+    ): Promise<Message[]> {
+      return new Promise<Message[]>((resolve) => {
+        pendingRuns.push({ resolve, messages, onEvent });
+      });
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import Session AFTER mocks are registered.
+// ---------------------------------------------------------------------------
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: 'mock',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+async function waitForPendingRun(count: number, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (pendingRuns.length < count) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for ${count} pending runs (have ${pendingRuns.length})`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function resolveRun(index: number) {
+  const run = pendingRuns[index];
+  if (!run) throw new Error(`No pending run at index ${index}`);
+  const assistantMsg: Message = {
+    role: 'assistant',
+    content: [{ type: 'text', text: `reply-${index}` }],
+  };
+  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+  run.onEvent({ type: 'message_complete', message: assistantMsg });
+  run.resolve([...run.messages, assistantMsg]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Session slash command — known', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('known slash command rewrites content before agent run', async () => {
+    const session = makeSession();
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+
+    // Send a known slash command
+    const promise = session.processMessage('/start-the-day', [], onEvent);
+    await waitForPendingRun(1);
+
+    // The message passed to agent loop should be rewritten
+    const lastUserMsg = pendingRuns[0].messages[pendingRuns[0].messages.length - 1];
+    expect(lastUserMsg.role).toBe('user');
+    const text = lastUserMsg.content
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('');
+    expect(text).toContain('slash command');
+    expect(text).toContain('start-the-day');
+    expect(text).toContain('Start the Day');
+    // Should NOT contain the raw `/start-the-day` as the entire content
+    expect(text).not.toBe('/start-the-day');
+
+    resolveRun(0);
+    await promise;
+  });
+
+  test('non-slash content is unchanged', async () => {
+    const session = makeSession();
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+
+    const promise = session.processMessage('hello world', [], onEvent);
+    await waitForPendingRun(1);
+
+    const lastUserMsg = pendingRuns[0].messages[pendingRuns[0].messages.length - 1];
+    expect(lastUserMsg.role).toBe('user');
+    const text = lastUserMsg.content
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('');
+    expect(text).toContain('hello world');
+
+    resolveRun(0);
+    await promise;
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -46,6 +46,13 @@ import {
 } from '../memory/retriever.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
 import type { UsageActor } from '../usage/actors.js';
+import { loadSkillCatalog } from '../config/skills.js';
+import { resolveSkillStates } from '../config/skill-state.js';
+import {
+  buildInvocableSlashCatalog,
+  resolveSlashSkillCommand,
+  rewriteKnownSlashCommandPrompt,
+} from '../skills/slash-commands.js';
 
 const log = getLogger('session');
 
@@ -860,17 +867,44 @@ export class Session {
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
   ): Promise<string> {
+    // Resolve slash commands before persistence
+    const resolvedContent = this.resolveSlashContent(content);
+
     let userMessageId: string;
     try {
-      userMessageId = this.persistUserMessage(content, attachments, requestId);
+      userMessageId = this.persistUserMessage(resolvedContent, attachments, requestId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       onEvent({ type: 'error', message });
       return '';
     }
 
-    await this.runAgentLoop(content, userMessageId, onEvent);
+    await this.runAgentLoop(resolvedContent, userMessageId, onEvent);
     return userMessageId;
+  }
+
+  /**
+   * If the content is a known slash command, rewrite it into a model-facing
+   * skill invocation prompt. Otherwise return the content unchanged.
+   */
+  private resolveSlashContent(content: string): string {
+    const config = getConfig();
+    const catalog = loadSkillCatalog();
+    const resolved = resolveSkillStates(catalog, config);
+    const invocable = buildInvocableSlashCatalog(catalog, resolved);
+    const resolution = resolveSlashSkillCommand(content, invocable);
+
+    if (resolution.kind === 'known') {
+      const skill = invocable.get(resolution.skillId.toLowerCase());
+      return rewriteKnownSlashCommandPrompt({
+        rawInput: content,
+        skillId: resolution.skillId,
+        skillName: skill?.name ?? resolution.skillId,
+        trailingArgs: resolution.trailingArgs,
+      });
+    }
+
+    return content;
   }
 
   handleSurfaceAction(surfaceId: string, actionId: string, data?: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
- Add `resolveSlashContent()` private method to Session that rewrites known `/skill-id` commands into model-facing skill invocation prompts
- Integration in `processMessage()` before `persistUserMessage` — known commands are rewritten, everything else passes through unchanged
- 2 integration tests verifying rewrite and passthrough behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
