### PR TITLE
Redesign stop button as clean circle-and-square icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -360,9 +360,14 @@ struct ChatView: View {
                 // Attachment / Stop button
                 if isSending {
                     Button(action: onStop) {
-                        Image(systemName: "stop.circle.fill")
-                            .font(.system(size: 20, weight: .medium))
-                            .foregroundColor(VColor.error)
+                        ZStack {
+                            Circle()
+                                .fill(VColor.textPrimary)
+                                .frame(width: 28, height: 28)
+                            RoundedRectangle(cornerRadius: VRadius.xs)
+                                .fill(VColor.surface)
+                                .frame(width: 10, height: 10)
+                        }
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Stop generation")


### PR DESCRIPTION
## Summary
- Replace the harsh red `stop.circle.fill` SF Symbol with a custom-drawn button: a 28×28 near-white circle with a 10×10 dark rounded square inside
- Matches the clean, minimal stop button pattern from ChatGPT, adapted for our dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
