### PR TITLE
feat(session): return deterministic assistant response for unknown slash

### DIFF
--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent, CheckpointInfo, CheckpointDecision } from '../agent/loop.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede the Session import so Bun applies them at load time.
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      maxInputTokens: 100000,
+      thresholdTokens: 80000,
+      preserveRecentMessages: 6,
+      summaryModel: 'mock-model',
+      maxSummaryTokens: 512,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+    memory: { retrieval: { injectionStrategy: 'inline' } },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => [],
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: 'conv-1' }),
+  listConversations: () => [],
+  addMessage: (_convId: string, _role: string, _content: string) => {
+    return { id: `msg-${Date.now()}` };
+  },
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+// Mock skill catalog — only "start-the-day" is available
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [
+    {
+      id: 'start-the-day',
+      name: 'Start the Day',
+      description: 'Morning routine skill',
+      directoryPath: '/skills/start-the-day',
+      skillFilePath: '/skills/start-the-day/SKILL.md',
+      userInvocable: true,
+      disableModelInvocation: false,
+      source: 'managed',
+    },
+  ],
+  loadSkillBySelector: () => null,
+  ensureSkillIcon: () => {},
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: (catalog: any[]) => catalog.map((s: any) => ({
+    summary: s,
+    state: 'enabled',
+    degraded: false,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// AgentLoop mock — tracks whether run() was called
+// ---------------------------------------------------------------------------
+
+let agentLoopRunCalled = false;
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(
+      messages: Message[],
+      onEvent: (event: AgentEvent) => void,
+      _signal?: AbortSignal,
+      _requestId?: string,
+      _onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+    ): Promise<Message[]> {
+      agentLoopRunCalled = true;
+      const assistantMsg: Message = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'reply' }],
+      };
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+      onEvent({ type: 'message_complete', message: assistantMsg });
+      return [...messages, assistantMsg];
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import Session AFTER mocks are registered.
+// ---------------------------------------------------------------------------
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: 'mock',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Session slash command — unknown', () => {
+  beforeEach(() => {
+    agentLoopRunCalled = false;
+  });
+
+  test('unknown slash emits deterministic assistant response', async () => {
+    const session = makeSession();
+    const events: ServerMessage[] = [];
+    const onEvent = (msg: ServerMessage) => events.push(msg);
+
+    await session.processMessage('/not-a-skill', [], onEvent);
+
+    // Should have emitted assistant_text_delta with the unknown message
+    const textDeltas = events.filter((e) => e.type === 'assistant_text_delta');
+    expect(textDeltas.length).toBe(1);
+    const delta = textDeltas[0] as any;
+    expect(delta.text).toContain('Unknown command `/not-a-skill`');
+    expect(delta.text).toContain('/start-the-day');
+
+    // Should have emitted message_complete
+    const completes = events.filter((e) => e.type === 'message_complete');
+    expect(completes.length).toBe(1);
+  });
+
+  test('no agent loop execution occurs for unknown slash', async () => {
+    const session = makeSession();
+    await session.processMessage('/not-a-skill', [], () => {});
+    expect(agentLoopRunCalled).toBe(false);
+  });
+
+  test('normal messages still go through standard path', async () => {
+    const session = makeSession();
+    const events: ServerMessage[] = [];
+    await session.processMessage('hello world', [], (msg) => events.push(msg));
+    expect(agentLoopRunCalled).toBe(true);
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -868,7 +868,16 @@ export class Session {
     requestId?: string,
   ): Promise<string> {
     // Resolve slash commands before persistence
-    const resolvedContent = this.resolveSlashContent(content);
+    const slashResult = this.resolveSlash(content);
+
+    // Unknown slash command — emit deterministic response without agent loop
+    if (slashResult.kind === 'unknown') {
+      onEvent({ type: 'assistant_text_delta', text: slashResult.message });
+      onEvent({ type: 'message_complete', sessionId: this.conversationId });
+      return '';
+    }
+
+    const resolvedContent = slashResult.content;
 
     let userMessageId: string;
     try {
@@ -884,10 +893,10 @@ export class Session {
   }
 
   /**
-   * If the content is a known slash command, rewrite it into a model-facing
-   * skill invocation prompt. Otherwise return the content unchanged.
+   * Resolve slash commands against the current skill catalog.
+   * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
    */
-  private resolveSlashContent(content: string): string {
+  private resolveSlash(content: string): { kind: 'passthrough' | 'rewritten'; content: string } | { kind: 'unknown'; message: string } {
     const config = getConfig();
     const catalog = loadSkillCatalog();
     const resolved = resolveSkillStates(catalog, config);
@@ -896,15 +905,22 @@ export class Session {
 
     if (resolution.kind === 'known') {
       const skill = invocable.get(resolution.skillId.toLowerCase());
-      return rewriteKnownSlashCommandPrompt({
-        rawInput: content,
-        skillId: resolution.skillId,
-        skillName: skill?.name ?? resolution.skillId,
-        trailingArgs: resolution.trailingArgs,
-      });
+      return {
+        kind: 'rewritten',
+        content: rewriteKnownSlashCommandPrompt({
+          rawInput: content,
+          skillId: resolution.skillId,
+          skillName: skill?.name ?? resolution.skillId,
+          trailingArgs: resolution.trailingArgs,
+        }),
+      };
     }
 
-    return content;
+    if (resolution.kind === 'unknown') {
+      return { kind: 'unknown', message: resolution.message };
+    }
+
+    return { kind: 'passthrough', content };
   }
 
   handleSurfaceAction(surfaceId: string, actionId: string, data?: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
- Unknown `/command` in `processMessage` now emits a deterministic `assistant_text_delta` listing available slash commands followed by `message_complete`
- No agent loop execution or message persistence occurs for unknown slash commands
- Refactored `resolveSlashContent` → `resolveSlash` returning a tagged union (passthrough/rewritten/unknown)
- 3 integration tests: unknown response content, no agent loop, normal passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
