### PR TITLE
feat(daemon): bypass classifier for slash task submissions

### DIFF
--- a/assistant/src/__tests__/handlers-task-submit-slash.test.ts
+++ b/assistant/src/__tests__/handlers-task-submit-slash.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { parseSlashCandidate } from '../skills/slash-commands.js';
+
+/**
+ * Tests for the slash candidate bypass logic used in handleTaskSubmit.
+ *
+ * In handleTaskSubmit, a slash candidate bypasses the classifier and
+ * routes directly to text_qa. These tests verify the detection logic
+ * that drives that bypass.
+ */
+describe('task_submit slash candidate bypass', () => {
+  test('slash candidate bypasses classifier (routes to text_qa)', () => {
+    const result = parseSlashCandidate('/start-the-day');
+    expect(result.kind).toBe('candidate');
+    // In handleTaskSubmit: candidate → text_qa, no classifyInteraction call
+  });
+
+  test('slash candidate with args bypasses classifier', () => {
+    const result = parseSlashCandidate('/start-the-day weather in SF');
+    expect(result.kind).toBe('candidate');
+  });
+
+  test('non-slash task still calls classifier', () => {
+    const result = parseSlashCandidate('open my email');
+    expect(result.kind).toBe('none');
+    // In handleTaskSubmit: none → calls classifyInteraction normally
+  });
+
+  test('path-like task does not trigger bypass', () => {
+    const result = parseSlashCandidate('/Users/sidd/project');
+    expect(result.kind).toBe('none');
+  });
+
+  test('empty task does not trigger bypass', () => {
+    const result = parseSlashCandidate('');
+    expect(result.kind).toBe('none');
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -58,6 +58,7 @@ import { classifyInteraction } from './classifier.js';
 import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, listApps, getApp } from '../memory/app-store.js';
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
+import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 
@@ -1297,8 +1298,12 @@ async function handleTaskSubmit(
   const rlog = log.child({ requestId });
 
   try {
-    const interactionType = await classifyInteraction(msg.task, msg.source);
-    rlog.info({ interactionType, task: msg.task }, 'Task classified');
+    // Slash candidates always route to text_qa — bypass classifier
+    const slashCandidate = parseSlashCandidate(msg.task);
+    const interactionType = slashCandidate.kind === 'candidate'
+      ? 'text_qa' as const
+      : await classifyInteraction(msg.task, msg.source);
+    rlog.info({ interactionType, slashBypass: slashCandidate.kind === 'candidate', task: msg.task }, 'Task classified');
 
     if (interactionType === 'computer_use') {
       // Create CU session (reuse handleCuSessionCreate logic)


### PR DESCRIPTION
## Summary
- Detect slash candidates in `handleTaskSubmit` using `parseSlashCandidate`
- Route slash candidates directly to `text_qa` without calling `classifyInteraction`
- Prevents `/skill-id` tasks from being misrouted to `computer_use`
- 5 unit tests validating bypass detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
