### PR TITLE
docs(skills): document slash command behavior

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -70,3 +70,31 @@ Resolution order:
 3. Unique skill id prefix
 
 If the selector is ambiguous or missing, `skill_load` returns an error.
+
+## Slash Skill Commands
+
+Users can invoke skills directly from any chat surface using slash commands:
+
+```
+/skill-id [optional arguments]
+```
+
+### Behavior
+
+- **Matching**: Exact skill ID only (case-insensitive). No fuzzy matching, prefix matching, or name aliasing.
+- **Parse**: Happens on send — the first whitespace-delimited token is inspected. If it starts with `/` and is a valid skill ID, it's treated as a slash command.
+- **Known command**: Content is rewritten into a model-facing prompt that instructs the assistant to invoke the skill. Trailing arguments are preserved verbatim.
+- **Unknown command**: A deterministic assistant response is returned listing available slash commands. No model call occurs.
+- **Path-like tokens**: Tokens with multiple slashes (e.g. `/tmp/file`, `/Users/sidd`) are ignored and treated as normal text.
+- **Task submit**: Slash candidates in `task_submit` bypass the interaction classifier and route directly to `text_qa`, preventing misrouting to `computer_use`.
+
+### Eligibility
+
+A skill appears as a slash command when:
+
+1. `userInvocable` is `true` in its configuration.
+2. Its resolved state is not `disabled`.
+
+### Valid Skill IDs
+
+Slash skill IDs must start with an alphanumeric character and contain only `[A-Za-z0-9._-]`.


### PR DESCRIPTION
## Summary
- Add "Slash Skill Commands" section to `assistant/docs/skills.md`
- Covers syntax, exact-ID matching, known/unknown behavior, path-like token handling, task_submit classifier bypass, eligibility criteria, and valid ID format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
