### PR TITLE
feat(platform): add sandbox filesystem path helpers

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+import {
+  ensureDataDir,
+  getDataDir,
+  getRootDir,
+  getSandboxRootDir,
+  getSandboxWorkingDir,
+} from '../util/platform.js';
+
+const originalBaseDataDir = process.env.BASE_DATA_DIR;
+
+afterEach(() => {
+  if (originalBaseDataDir == null) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = originalBaseDataDir;
+  }
+});
+
+describe('platform sandbox paths', () => {
+  test('sandbox helpers are anchored under data dir', () => {
+    const base = join(tmpdir(), `platform-test-${randomBytes(4).toString('hex')}`);
+    process.env.BASE_DATA_DIR = base;
+
+    expect(getRootDir()).toBe(join(base, '.vellum'));
+    expect(getDataDir()).toBe(join(base, '.vellum', 'data'));
+    expect(getSandboxRootDir()).toBe(join(base, '.vellum', 'data', 'sandbox'));
+    expect(getSandboxWorkingDir()).toBe(join(base, '.vellum', 'data', 'sandbox', 'fs'));
+  });
+
+  test('ensureDataDir creates sandbox directories', () => {
+    const base = join(tmpdir(), `platform-test-${randomBytes(4).toString('hex')}`);
+    process.env.BASE_DATA_DIR = base;
+    const rootDir = getRootDir();
+
+    if (existsSync(rootDir)) {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+
+    ensureDataDir();
+
+    expect(existsSync(getSandboxRootDir())).toBe(true);
+    expect(existsSync(getSandboxWorkingDir())).toBe(true);
+
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+});

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -52,6 +52,22 @@ export function getDataDir(): string {
   return join(getRootDir(), 'data');
 }
 
+/**
+ * Returns the sandbox root directory (~/.vellum/data/sandbox).
+ * Global sandbox state lives under this directory.
+ */
+export function getSandboxRootDir(): string {
+  return join(getDataDir(), 'sandbox');
+}
+
+/**
+ * Returns the default sandbox working directory (~/.vellum/data/sandbox/fs).
+ * Tool working directories should use this path unless explicitly overridden.
+ */
+export function getSandboxWorkingDir(): string {
+  return join(getSandboxRootDir(), 'fs');
+}
+
 export function getSocketPath(): string {
   const override = process.env.VELLUM_DAEMON_SOCKET?.trim();
   if (override) {
@@ -117,6 +133,8 @@ export function ensureDataDir(): void {
     join(data, 'memory'),
     join(data, 'memory', 'knowledge'),
     join(data, 'apps'),
+    join(data, 'sandbox'),
+    join(data, 'sandbox', 'fs'),
   ];
   for (const dir of dirs) {
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- add `getSandboxRootDir()` and `getSandboxWorkingDir()` path helpers in platform utilities
- extend `ensureDataDir()` to create sandbox directories under `~/.vellum/data/sandbox/fs`
- add focused platform tests for sandbox helper paths and directory bootstrap

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/platform.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
