### PR TITLE
feat(tools): add host_file_read tool

### DIFF
--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { hostFileReadTool } from '../tools/host-filesystem/read.js';
+import type { ToolContext } from '../tools/types.js';
+
+const testDirs: string[] = [];
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('host_file_read tool', () => {
+  test('rejects relative paths', async () => {
+    const result = await hostFileReadTool.execute({ path: 'relative.txt' }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path must be absolute');
+  });
+
+  test('reads file with line numbers', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'first\nsecond\nthird\n');
+
+    const result = await hostFileReadTool.execute({ path: filePath, offset: 2, limit: 2 }, makeContext());
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('2  second');
+    expect(result.content).toContain('3  third');
+  });
+
+  test('returns error when file does not exist', async () => {
+    const filePath = join(tmpdir(), `host-file-read-missing-${Date.now()}.txt`);
+    const result = await hostFileReadTool.execute({ path: filePath }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('File not found');
+  });
+
+  test('returns error when path is a directory', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-read-test-'));
+    testDirs.push(dir);
+    const nestedDir = join(dir, 'nested');
+    mkdirSync(nestedDir, { recursive: true });
+
+    const result = await hostFileReadTool.execute({ path: nestedDir }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('is a directory, not a file');
+  });
+});

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { checkFileSizeOnDisk } from '../filesystem/size-guard.js';
+
+class HostFileReadTool implements Tool {
+  name = 'host_file_read';
+  description = 'Read the contents of a file on the host filesystem';
+  category = 'host-filesystem';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute path to the host file to read',
+          },
+          offset: {
+            type: 'number',
+            description: 'Line number to start reading from (1-indexed)',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum number of lines to read',
+          },
+        },
+        required: ['path'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const rawPath = input.path as string;
+    if (!rawPath || typeof rawPath !== 'string') {
+      return { content: 'Error: path is required and must be a string', isError: true };
+    }
+
+    if (!isAbsolute(rawPath)) {
+      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
+    }
+    const filePath = rawPath;
+
+    if (!existsSync(filePath)) {
+      return { content: `Error: File not found: ${filePath}`, isError: true };
+    }
+
+    const stat = statSync(filePath);
+    if (stat.isDirectory()) {
+      return { content: `Error: ${filePath} is a directory, not a file`, isError: true };
+    }
+
+    const sizeError = checkFileSizeOnDisk(filePath);
+    if (sizeError) {
+      return { content: `Error: ${sizeError}`, isError: true };
+    }
+
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+
+      const offset = (typeof input.offset === 'number' ? input.offset : 1) - 1;
+      const limit = typeof input.limit === 'number' ? input.limit : lines.length;
+      const selectedLines = lines.slice(Math.max(0, offset), offset + limit);
+
+      const numbered = selectedLines.map((line, i) => {
+        const lineNum = offset + i + 1;
+        return `${String(lineNum).padStart(6)}  ${line}`;
+      }).join('\n');
+
+      return { content: numbered, isError: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const hint = msg.includes('ENOENT') ? ' (file does not exist)'
+        : msg.includes('EACCES') ? ' (permission denied)'
+        : msg.includes('EISDIR') ? ' (path is a directory, not a file)'
+        : '';
+      return { content: `Error reading file "${input.path}"${hint}: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const hostFileReadTool: Tool = new HostFileReadTool();


### PR DESCRIPTION
## Summary
- add a new unregistered `host_file_read` tool module for explicit host filesystem reads
- require absolute host paths and preserve existing line-number/offset/limit behavior
- add focused unit tests for relative-path rejection and core read error/success paths

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/host-file-read-tool.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
