### PR TITLE
feat(tools): add host_file_write tool

### DIFF
--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { hostFileWriteTool } from '../tools/host-filesystem/write.js';
+import type { ToolContext } from '../tools/types.js';
+
+const testDirs: string[] = [];
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('host_file_write tool', () => {
+  test('rejects relative paths', async () => {
+    const result = await hostFileWriteTool.execute({ path: 'relative.txt', content: 'hi' }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path must be absolute');
+  });
+
+  test('rejects non-string content', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'out.txt');
+
+    const result = await hostFileWriteTool.execute({ path: filePath, content: 42 }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('content is required and must be a string');
+  });
+
+  test('writes new file and returns diff', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'nested', 'new.txt');
+
+    const result = await hostFileWriteTool.execute({ path: filePath, content: 'new content' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, 'utf-8')).toBe('new content');
+    expect(result.diff).toEqual({
+      filePath,
+      oldContent: '',
+      newContent: 'new content',
+      isNewFile: true,
+    });
+  });
+
+  test('overwrites existing file and returns previous content in diff', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-write-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'existing.txt');
+
+    await hostFileWriteTool.execute({ path: filePath, content: 'old' }, makeContext());
+    const result = await hostFileWriteTool.execute({ path: filePath, content: 'updated' }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(readFileSync(filePath, 'utf-8')).toBe('updated');
+    expect(result.diff).toEqual({
+      filePath,
+      oldContent: 'old',
+      newContent: 'updated',
+      isNewFile: false,
+    });
+  });
+});

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -1,0 +1,88 @@
+import { dirname, isAbsolute } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { checkContentSize } from '../filesystem/size-guard.js';
+
+class HostFileWriteTool implements Tool {
+  name = 'host_file_write';
+  description = 'Write content to a file on the host filesystem, creating it if it does not exist';
+  category = 'host-filesystem';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute host path to the file to write',
+          },
+          content: {
+            type: 'string',
+            description: 'The content to write to the file',
+          },
+        },
+        required: ['path', 'content'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const rawPath = input.path as string;
+    if (!rawPath || typeof rawPath !== 'string') {
+      return { content: 'Error: path is required and must be a string', isError: true };
+    }
+    if (!isAbsolute(rawPath)) {
+      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
+    }
+    const filePath = rawPath;
+
+    const fileContent = input.content;
+    if (typeof fileContent !== 'string') {
+      return { content: 'Error: content is required and must be a string', isError: true };
+    }
+
+    const sizeError = checkContentSize(fileContent, filePath);
+    if (sizeError) {
+      return { content: `Error: ${sizeError}`, isError: true };
+    }
+
+    try {
+      const dir = dirname(filePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      let oldContent: string | null = null;
+      const isNewFile = !existsSync(filePath);
+      if (!isNewFile) {
+        try {
+          oldContent = readFileSync(filePath, 'utf-8');
+        } catch {
+          // Keep oldContent null when host file is unreadable.
+        }
+      }
+
+      writeFileSync(filePath, fileContent);
+      return {
+        content: `Successfully wrote to ${filePath}`,
+        isError: false,
+        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent, isNewFile },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const hint = msg.includes('ENOENT') ? ' (parent directory does not exist)'
+        : msg.includes('EACCES') ? ' (permission denied)'
+        : msg.includes('EROFS') ? ' (read-only file system)'
+        : '';
+      return { content: `Error writing file "${input.path}"${hint}: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const hostFileWriteTool: Tool = new HostFileWriteTool();


### PR DESCRIPTION
## Summary
- add a new unregistered `host_file_write` tool module for explicit host filesystem writes
- require absolute host paths while preserving diff generation and size-guard behavior
- add focused unit tests for relative-path rejection, content validation, and write/overwrite flows

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/host-file-write-tool.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
