### PR TITLE
feat(tools): add host_file_edit tool

### DIFF
--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { hostFileEditTool } from '../tools/host-filesystem/edit.js';
+import type { ToolContext } from '../tools/types.js';
+
+const testDirs: string[] = [];
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('host_file_edit tool', () => {
+  test('rejects relative paths', async () => {
+    const result = await hostFileEditTool.execute({
+      path: 'relative.txt',
+      old_string: 'a',
+      new_string: 'b',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('path must be absolute');
+  });
+
+  test('edits unique match', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'hello world\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'hello world',
+      new_string: 'updated',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(readFileSync(filePath, 'utf-8')).toBe('updated\n');
+    expect(result.diff?.isNewFile).toBe(false);
+  });
+
+  test('replace_all edits all matches', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'x\ny\nx\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'x',
+      new_string: 'z',
+      replace_all: true,
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(readFileSync(filePath, 'utf-8')).toBe('z\ny\nz\n');
+    expect(result.content).toContain('Successfully replaced 2 occurrences');
+  });
+
+  test('returns ambiguity error when old_string appears multiple times', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'repeat\nrepeat\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'repeat',
+      new_string: 'new',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('appears multiple times');
+  });
+});

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -1,0 +1,137 @@
+import { isAbsolute } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { findAllMatches, adjustIndentation } from '../filesystem/fuzzy-match.js';
+import { checkFileSizeOnDisk } from '../filesystem/size-guard.js';
+
+class HostFileEditTool implements Tool {
+  name = 'host_file_edit';
+  description = 'Replace exact text in a host filesystem file with new text';
+  category = 'host-filesystem';
+  defaultRiskLevel = RiskLevel.Medium;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute host path to the file to edit',
+          },
+          old_string: {
+            type: 'string',
+            description: 'The exact text to find in the file',
+          },
+          new_string: {
+            type: 'string',
+            description: 'The replacement text',
+          },
+          replace_all: {
+            type: 'boolean',
+            description: 'Replace all occurrences instead of requiring a unique match (default: false)',
+          },
+        },
+        required: ['path', 'old_string', 'new_string'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const rawPath = input.path as string;
+    if (!rawPath || typeof rawPath !== 'string') {
+      return { content: 'Error: path is required and must be a string', isError: true };
+    }
+    if (!isAbsolute(rawPath)) {
+      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
+    }
+    const filePath = rawPath;
+
+    const oldString = input.old_string;
+    if (typeof oldString !== 'string') {
+      return { content: 'Error: old_string is required and must be a string', isError: true };
+    }
+
+    const newString = input.new_string;
+    if (typeof newString !== 'string') {
+      return { content: 'Error: new_string is required and must be a string', isError: true };
+    }
+
+    if (oldString.length === 0) {
+      return { content: 'Error: old_string must not be empty', isError: true };
+    }
+
+    if (oldString === newString) {
+      return { content: 'Error: old_string and new_string must be different', isError: true };
+    }
+
+    try {
+      const sizeError = checkFileSizeOnDisk(filePath);
+      if (sizeError) {
+        return { content: `Error: ${sizeError}`, isError: true };
+      }
+    } catch {
+      // The subsequent file read returns a clearer error for missing files.
+    }
+
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const replaceAll = input.replace_all === true;
+
+      if (replaceAll) {
+        const firstIndex = content.indexOf(oldString);
+        if (firstIndex === -1) {
+          return { content: `Error: old_string not found in ${filePath}`, isError: true };
+        }
+        const updated = content.split(oldString).join(newString);
+        const count = content.split(oldString).length - 1;
+        writeFileSync(filePath, updated);
+        return {
+          content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`,
+          isError: false,
+          diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
+        };
+      }
+
+      const matches = findAllMatches(content, oldString);
+      if (matches.length === 0) {
+        return { content: `Error: old_string not found in ${filePath}`, isError: true };
+      }
+      if (matches.length > 1) {
+        return {
+          content: `Error: old_string appears multiple times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
+          isError: true,
+        };
+      }
+
+      const match = matches[0];
+      const adjustedNewString = match.method !== 'exact'
+        ? adjustIndentation(oldString, match.matched, newString)
+        : newString;
+
+      const updated = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
+      writeFileSync(filePath, updated);
+
+      const methodNote = match.method === 'exact'
+        ? ''
+        : match.method === 'whitespace'
+          ? ' (matched with whitespace normalization)'
+          : ` (fuzzy matched, similarity ${(match.similarity * 100).toFixed(0)}%)`;
+
+      return {
+        content: `Successfully edited ${filePath}${methodNote}`,
+        isError: false,
+        diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error editing file: ${msg}`, isError: true };
+    }
+  }
+}
+
+export const hostFileEditTool: Tool = new HostFileEditTool();


### PR DESCRIPTION
## Summary
- add a new unregistered `host_file_edit` tool module for explicit host filesystem edits
- enforce absolute host paths while preserving single-match, replace-all, and fuzzy matching behavior
- add focused tests for relative-path rejection, successful edits, replace-all, and ambiguity failures

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/host-file-edit-tool.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
