### PR TITLE
feat(registry): register host filesystem and host shell tools

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -5,7 +5,7 @@ import type { ToolDefinition } from '../providers/types.js';
 
 // We cannot import the private LazyTool class directly, so we test through
 // registerLazyTool + getTool which exercise the same code path.
-import { registerLazyTool, getTool } from '../tools/registry.js';
+import { registerLazyTool, getTool, getAllToolDefinitions, initializeTools } from '../tools/registry.js';
 
 function makeFakeTool(name: string): Tool {
   return {
@@ -63,5 +63,24 @@ describe('LazyTool', () => {
     expect(result.content).toBe('ok');
     expect(result.isError).toBe(false);
     expect(callCount).toBe(2);
+  });
+});
+
+describe('tool registry host tools', () => {
+  test('registers host tools and exposes them in tool definitions', async () => {
+    await initializeTools();
+
+    const hostToolNames = ['host_file_read', 'host_file_write', 'host_file_edit', 'host_bash'] as const;
+
+    for (const toolName of hostToolNames) {
+      const tool = getTool(toolName);
+      expect(tool).toBeDefined();
+      expect(tool?.defaultRiskLevel).toBe(RiskLevel.Medium);
+    }
+
+    const definitionNames = getAllToolDefinitions().map((def) => def.name);
+    for (const toolName of hostToolNames) {
+      expect(definitionNames).toContain(toolName);
+    }
   });
 });

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -5,6 +5,10 @@ import { getLogger } from '../util/logger.js';
 import { registerComputerUseTools } from './computer-use/registry.js';
 import { registerUiSurfaceTools } from './ui-surface/registry.js';
 import { registerAppTools } from './apps/registry.js';
+import { hostFileReadTool } from './host-filesystem/read.js';
+import { hostFileWriteTool } from './host-filesystem/write.js';
+import { hostFileEditTool } from './host-filesystem/edit.js';
+import { hostShellTool } from './host-terminal/host-shell.js';
 
 const log = getLogger('tool-registry');
 
@@ -115,6 +119,13 @@ export async function initializeTools(): Promise<void> {
   await import('./schedule/list.js');
   await import('./schedule/update.js');
   await import('./schedule/delete.js');
+
+  // Host tools are registered explicitly so host access stays opt-in until
+  // this point in startup, rather than as module side effects.
+  registerTool(hostFileReadTool);
+  registerTool(hostFileWriteTool);
+  registerTool(hostFileEditTool);
+  registerTool(hostShellTool);
 
   // Computer-use proxy tools — registered so ToolExecutor can look them up
   // and forward execution to the connected macOS client.  They are excluded


### PR DESCRIPTION
## Summary
- register `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash` during tool initialization
- keep host tools non-proxy so they are included by `getAllToolDefinitions()` for regular chat sessions
- add registry tests that assert host tools are discoverable with medium default risk and appear in tool definitions

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/registry.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
