### PR TITLE
feat(permissions): add host tool candidate and allowlist option support

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -301,6 +301,34 @@ describe('Permission Checker', () => {
       expect(result.matchedRule).toBeDefined();
     });
 
+    test('host_file_read with matching host rule → allow', async () => {
+      addRule('host_file_read', 'host_file_read:/etc/hosts', 'everywhere');
+      const result = await check('host_file_read', { path: '/etc/hosts' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.pattern).toBe('host_file_read:/etc/hosts');
+    });
+
+    test('host_file_write with matching host rule → allow', async () => {
+      addRule('host_file_write', 'host_file_write:/Users/test/project/*', 'everywhere');
+      const result = await check('host_file_write', { path: '/Users/test/project/output.txt' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.pattern).toBe('host_file_write:/Users/test/project/*');
+    });
+
+    test('host_file_edit with matching host rule → allow', async () => {
+      addRule('host_file_edit', 'host_file_edit:/opt/config/app.yml', 'everywhere');
+      const result = await check('host_file_edit', { path: '/opt/config/app.yml' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.pattern).toBe('host_file_edit:/opt/config/app.yml');
+    });
+
+    test('host_bash reuses bash-style command matching', async () => {
+      addRule('host_bash', 'npm *', 'everywhere');
+      const result = await check('host_bash', { command: 'npm test' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.pattern).toBe('npm *');
+    });
+
     test('deny rule for skill_load matches specific skill selectors', async () => {
       addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
       const result = await check('skill_load', { skill: 'dangerous-skill' }, '/tmp');
@@ -569,6 +597,29 @@ describe('Permission Checker', () => {
       expect(options[2].pattern).toBe('file_read:*');
     });
 
+    test('host_file_read: generates prefixed file, directory, and tool wildcard', () => {
+      const options = generateAllowlistOptions('host_file_read', { path: '/etc/hosts' });
+      expect(options).toHaveLength(3);
+      expect(options[0].pattern).toBe('host_file_read:/etc/hosts');
+      expect(options[1].pattern).toBe('host_file_read:/etc/*');
+      expect(options[2].pattern).toBe('host_file_read:*');
+    });
+
+    test('host_file_write with file_path key', () => {
+      const options = generateAllowlistOptions('host_file_write', { file_path: '/tmp/out.txt' });
+      expect(options[0].pattern).toBe('host_file_write:/tmp/out.txt');
+      expect(options[1].pattern).toBe('host_file_write:/tmp/*');
+      expect(options[2].pattern).toBe('host_file_write:*');
+    });
+
+    test('host_bash: generates exact, subcommand wildcard, and program wildcard', () => {
+      const options = generateAllowlistOptions('host_bash', { command: 'npm install express' });
+      expect(options).toHaveLength(3);
+      expect(options[0].pattern).toBe('npm install express');
+      expect(options[1].pattern).toBe('npm install *');
+      expect(options[2].pattern).toBe('npm *');
+    });
+
     test('file_write with file_path key', () => {
       const options = generateAllowlistOptions('file_write', { file_path: '/tmp/out.txt' });
       expect(options[0].pattern).toBe('file_write:/tmp/out.txt');
@@ -672,6 +723,13 @@ describe('Permission Checker', () => {
       const options = generateScopeOptions('/var/data/app');
       expect(options[0].label).toBe('/var/data/app');
       expect(options[1].label).toBe('/var/data/*');
+    });
+
+    test('host tools prioritize everywhere scope first', () => {
+      const options = generateScopeOptions('/var/data/app', 'host_file_read');
+      expect(options[0]).toEqual({ label: 'everywhere', scope: 'everywhere' });
+      expect(options[1].scope).toBe('/var/data/app');
+      expect(options[2].scope).toBe('/var/data');
     });
   });
 });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -124,7 +124,7 @@ function escapeMinimatchLiteral(value: string): string {
 }
 
 function buildCommandCandidates(toolName: string, input: Record<string, unknown>, workingDir: string): string[] {
-  if (toolName === 'bash') {
+  if (toolName === 'bash' || toolName === 'host_bash') {
     return [getStringField(input, 'command')];
   }
 
@@ -165,6 +165,10 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
   }
 
   const fileTarget = getStringField(input, 'path', 'file_path');
+  if (toolName === 'host_file_read' || toolName === 'host_file_write' || toolName === 'host_file_edit') {
+    return [`${toolName}:${fileTarget}`];
+  }
+
   const resolved = fileTarget ? resolve(workingDir, fileTarget) : fileTarget;
   const candidates = [`${toolName}:${resolved}`];
   // Also include the raw path if it differs, so user-created rules with
@@ -307,6 +311,9 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   file_read: 'file reads',
   file_write: 'file writes',
   file_edit: 'file edits',
+  host_file_read: 'host file reads',
+  host_file_write: 'host file writes',
+  host_file_edit: 'host file edits',
   web_fetch: 'URL fetches',
   browser_navigate: 'browser navigations',
 };
@@ -321,7 +328,7 @@ function friendlyHostname(url: URL): string {
 }
 
 export function generateAllowlistOptions(toolName: string, input: Record<string, unknown>): AllowlistOption[] {
-  if (toolName === 'bash') {
+  if (toolName === 'bash' || toolName === 'host_bash') {
     const command = ((input.command as string) ?? '').trim();
     const parts = command.split(/\s+/);
     const program = parts[0] ?? command;
@@ -354,7 +361,10 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
     });
   }
 
-  if (toolName === 'file_write' || toolName === 'file_read' || toolName === 'file_edit') {
+  if (
+    toolName === 'file_write' || toolName === 'file_read' || toolName === 'file_edit'
+    || toolName === 'host_file_write' || toolName === 'host_file_read' || toolName === 'host_file_edit'
+  ) {
     const filePath = (input.path as string) ?? (input.file_path as string) ?? '';
     const toolLabel = TOOL_DISPLAY_NAMES[toolName] ?? toolName;
     const options: AllowlistOption[] = [];
@@ -405,7 +415,7 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
   return [{ label: '*', description: 'Everything', pattern: '*' }];
 }
 
-export function generateScopeOptions(workingDir: string): ScopeOption[] {
+export function generateScopeOptions(workingDir: string, toolName?: string): ScopeOption[] {
   const home = homedir();
   const options: ScopeOption[] = [];
 
@@ -427,5 +437,11 @@ export function generateScopeOptions(workingDir: string): ScopeOption[] {
   // Everywhere
   options.push({ label: 'everywhere', scope: 'everywhere' });
 
-  return options;
+  if (!toolName?.startsWith('host_')) {
+    return options;
+  }
+
+  const everywhere = options.find((option) => option.scope === 'everywhere');
+  const scoped = options.filter((option) => option.scope !== 'everywhere');
+  return everywhere ? [everywhere, ...scoped] : options;
 }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -94,7 +94,7 @@ export class ToolExecutor {
       if (result.decision === 'prompt') {
         // Need user approval
         const allowlistOptions = generateAllowlistOptions(name, input);
-        const scopeOptions = generateScopeOptions(context.workingDir);
+        const scopeOptions = generateScopeOptions(context.workingDir, name);
 
         // Compute preview diff for file tools so the user sees what will change
         const previewDiff = computePreviewDiff(name, input, context.workingDir);


### PR DESCRIPTION
## Summary
- update permission candidate generation so `host_file_*` match host path patterns directly and `host_bash` reuses bash-style command matching
- extend allowlist option generation to cover `host_file_*` and `host_bash` with host-specific wildcard patterns
- prioritize `everywhere` first in scope options for `host_*` prompts and pass tool name through the executor when building scope choices
- add checker tests for host candidate matching, host allowlist options, host_bash command patterns, and host-first scope ordering

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/checker.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/tool-executor-lifecycle-events.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
