### PR TITLE
fix(tools): reject non-regular files in host_file_read

### DIFF
--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -52,8 +52,8 @@ class HostFileReadTool implements Tool {
     }
 
     const stat = statSync(filePath);
-    if (stat.isDirectory()) {
-      return { content: `Error: ${filePath} is a directory, not a file`, isError: true };
+    if (!stat.isFile()) {
+      return { content: `Error: ${filePath} is not a regular file`, isError: true };
     }
 
     const sizeError = checkFileSizeOnDisk(filePath);


### PR DESCRIPTION
## Summary

Addresses P1 feedback from Codex on #1935.

The host_file_read tool previously only rejected directories before calling `readFileSync`. Other non-regular filesystem nodes (named pipes, character devices, sockets like `/dev/zero`) could still reach the read path, risking hangs or unbounded memory consumption.

**Fix:** Replace `stat.isDirectory()` check with `!stat.isFile()` to reject anything that isn't a regular file.

## Changes

- `assistant/src/tools/host-filesystem/read.ts`: Changed directory-only guard to reject all non-regular files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
