### PR TITLE
fix(host_bash): validate working_dir null bytes and improve ENOENT diagnosis

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
@@ -86,6 +87,9 @@ class HostShellTool implements Tool {
     if (rawWorkingDir != null && typeof rawWorkingDir !== 'string') {
       return { content: 'Error: working_dir must be a string when provided', isError: true };
     }
+    if (typeof rawWorkingDir === 'string' && rawWorkingDir.includes('\0')) {
+      return { content: 'Error: working_dir contains null bytes', isError: true };
+    }
     if (typeof rawWorkingDir === 'string' && !isAbsolute(rawWorkingDir)) {
       return { content: `Error: working_dir must be absolute for host command execution: ${rawWorkingDir}`, isError: true };
     }
@@ -165,8 +169,14 @@ class HostShellTool implements Tool {
 
       child.on('error', (err) => {
         clearTimeout(timer);
+        let hint = '';
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          hint = !existsSync(workingDir)
+            ? `. The working directory does not exist: ${workingDir}`
+            : '. The command was not found — check that it is installed and in PATH.';
+        }
         resolve({
-          content: `Error spawning command: ${err.message}${(err as NodeJS.ErrnoException).code === 'ENOENT' ? '. The command was not found — check that it is installed and in PATH.' : ''}`,
+          content: `Error spawning command: ${err.message}${hint}`,
           isError: true,
         });
       });


### PR DESCRIPTION
## Summary

Addresses codex review feedback on #1938:

- **Null-byte validation for `working_dir`**: Added an explicit null-byte check (matching the existing `command` check) so that inputs like `/tmp\0bad` are rejected early with a clean error instead of causing `spawn` to throw `ERR_INVALID_ARG_VALUE`.

- **Accurate ENOENT error messages**: The `ENOENT` error handler now checks whether the `working_dir` actually exists before assuming the command was not found. If the cwd doesn't exist, the error message correctly reports the missing directory instead of a misleading "command was not found" hint.

## Changes

- `assistant/src/tools/host-terminal/host-shell.ts`

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Verify that passing a `working_dir` with null bytes returns `"Error: working_dir contains null bytes"`
- [ ] Verify that passing a non-existent `working_dir` returns an error mentioning the missing directory
- [ ] Verify that a missing command still shows the PATH hint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
