### PR TITLE
fix(skills): case-insensitive sort for slash command IDs

### DIFF
--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -121,7 +121,7 @@ export function resolveSlashSkillCommand(
 
   const availableIds = Array.from(catalog.values())
     .map((s) => s.canonicalId)
-    .sort();
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
   return {
     kind: 'unknown',
     requestedId,


### PR DESCRIPTION
## Summary
Use `localeCompare` with `sensitivity: 'base'` instead of default `.sort()` for the `availableIds` array in `resolveSlashSkillCommand()`. This ensures proper alphabetical ordering of slash command IDs in error messages regardless of casing.

Addresses review feedback from #1922.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
