### PR TITLE
feat(trust): backfill default ask rules for host tools

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -301,32 +301,60 @@ describe('Permission Checker', () => {
       expect(result.matchedRule).toBeDefined();
     });
 
-    test('host_file_read with matching host rule → allow', async () => {
-      addRule('host_file_read', 'host_file_read:/etc/hosts', 'everywhere');
+    test('host_file_read with higher-priority host rule → allow', async () => {
+      addRule('host_file_read', 'host_file_read:/etc/hosts', 'everywhere', 'allow', 2000);
       const result = await check('host_file_read', { path: '/etc/hosts' }, '/tmp');
       expect(result.decision).toBe('allow');
       expect(result.matchedRule?.pattern).toBe('host_file_read:/etc/hosts');
     });
 
-    test('host_file_write with matching host rule → allow', async () => {
-      addRule('host_file_write', 'host_file_write:/Users/test/project/*', 'everywhere');
+    test('host_file_write with higher-priority host rule → allow', async () => {
+      addRule('host_file_write', 'host_file_write:/Users/test/project/*', 'everywhere', 'allow', 2000);
       const result = await check('host_file_write', { path: '/Users/test/project/output.txt' }, '/tmp');
       expect(result.decision).toBe('allow');
       expect(result.matchedRule?.pattern).toBe('host_file_write:/Users/test/project/*');
     });
 
-    test('host_file_edit with matching host rule → allow', async () => {
-      addRule('host_file_edit', 'host_file_edit:/opt/config/app.yml', 'everywhere');
+    test('host_file_edit with higher-priority host rule → allow', async () => {
+      addRule('host_file_edit', 'host_file_edit:/opt/config/app.yml', 'everywhere', 'allow', 2000);
       const result = await check('host_file_edit', { path: '/opt/config/app.yml' }, '/tmp');
       expect(result.decision).toBe('allow');
       expect(result.matchedRule?.pattern).toBe('host_file_edit:/opt/config/app.yml');
     });
 
     test('host_bash reuses bash-style command matching', async () => {
-      addRule('host_bash', 'npm *', 'everywhere');
+      addRule('host_bash', 'npm *', 'everywhere', 'allow', 2000);
       const result = await check('host_bash', { command: 'npm test' }, '/tmp');
       expect(result.decision).toBe('allow');
       expect(result.matchedRule?.pattern).toBe('npm *');
+    });
+
+    test('host_file_read prompts by default via host ask rule', async () => {
+      const result = await check('host_file_read', { path: '/etc/hosts' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-host_file_read-global');
+    });
+
+    test('host_file_write prompts by default via host ask rule', async () => {
+      const result = await check('host_file_write', { path: '/etc/hosts' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-host_file_write-global');
+    });
+
+    test('host_file_edit prompts by default via host ask rule', async () => {
+      const result = await check('host_file_edit', { path: '/etc/hosts' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-host_file_edit-global');
+    });
+
+    test('host_bash prompts by default via host ask rule', async () => {
+      const result = await check('host_bash', { command: 'ls' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-host_bash-global');
     });
 
     test('deny rule for skill_load matches specific skill selectors', async () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -578,17 +578,30 @@ describe('Trust Store', () => {
         expect(rule.decision).toBe('ask');
         expect(rule.priority).toBe(1000);
         expect(rule.scope).toBe('everywhere');
+      }
+
+      const protectedDefaults = defaults.filter((rule) => rule.id.endsWith('-protected'));
+      expect(protectedDefaults).toHaveLength(3);
+      for (const rule of protectedDefaults) {
         expect(rule.pattern).toContain(`${testDir}/protected/`);
       }
     });
 
-    test('default rules cover file_read, file_write, and file_edit', () => {
+    test('default rules cover file, host file, and host shell tools', () => {
       const rules = getAllRules();
       const defaultTools = rules
         .filter((r) => r.id.startsWith('default:'))
         .map((r) => r.tool)
         .sort();
-      expect(defaultTools).toEqual(['file_edit', 'file_read', 'file_write']);
+      expect(defaultTools).toEqual([
+        'file_edit',
+        'file_read',
+        'file_write',
+        'host_bash',
+        'host_file_edit',
+        'host_file_read',
+        'host_file_write',
+      ]);
     });
 
     test('default rules are not duplicated on reload', () => {
@@ -662,6 +675,38 @@ describe('Trust Store', () => {
       const match = findHighestPriorityRule('file_edit', [`file_edit:${protectedPath}`], '/tmp');
       expect(match).not.toBeNull();
       expect(match!.decision).toBe('ask');
+    });
+
+    test('findHighestPriorityRule matches default ask for host_file_read', () => {
+      const match = findHighestPriorityRule('host_file_read', ['host_file_read:/etc/hosts'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-host_file_read-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
+    });
+
+    test('findHighestPriorityRule matches default ask for host_file_write', () => {
+      const match = findHighestPriorityRule('host_file_write', ['host_file_write:/etc/hosts'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-host_file_write-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
+    });
+
+    test('findHighestPriorityRule matches default ask for host_file_edit', () => {
+      const match = findHighestPriorityRule('host_file_edit', ['host_file_edit:/etc/hosts'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-host_file_edit-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
+    });
+
+    test('findHighestPriorityRule matches default ask for host_bash', () => {
+      const match = findHighestPriorityRule('host_bash', ['ls'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-host_bash-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
     });
 
     test('default ask does not affect files outside protected directory', () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -12,6 +12,7 @@ export interface DefaultRuleTemplate {
 
 /** Tools that directly access the filesystem by path. */
 const FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
+const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
 
 /**
  * Returns default trust rules shipped with the assistant.
@@ -22,7 +23,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // (path.join produces backslashes on Windows, which minimatch treats as escapes).
   const protectedDir = join(getRootDir(), 'protected').replaceAll('\\', '/');
 
-  return FILE_TOOLS.map((tool) => ({
+  const protectedFileRules = FILE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-protected`,
     tool,
     pattern: `${tool}:${protectedDir}/**`,
@@ -30,4 +31,26 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     decision: 'ask' as const,
     priority: 1000,
   }));
+
+  const hostFileRules = HOST_FILE_TOOLS.map((tool) => ({
+    id: `default:ask-${tool}-global`,
+    tool,
+    pattern: `${tool}:/**`,
+    scope: 'everywhere',
+    decision: 'ask' as const,
+    priority: 1000,
+  }));
+
+  // host_bash command candidates are raw commands ("ls", "npm test"), so the
+  // global default ask rule uses "*" instead of a "tool:*" prefix.
+  const hostShellRule: DefaultRuleTemplate = {
+    id: 'default:ask-host_bash-global',
+    tool: 'host_bash',
+    pattern: '*',
+    scope: 'everywhere',
+    decision: 'ask',
+    priority: 1000,
+  };
+
+  return [...protectedFileRules, ...hostFileRules, hostShellRule];
 }


### PR DESCRIPTION
## Summary
- add default ask trust templates for `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash`
- keep host defaults global with stable template IDs and priority 1000 while preserving existing protected-directory defaults
- update checker tests so host rule-matching checks use higher-priority explicit allow rules, then assert host tools prompt by default via backfilled ask rules
- expand trust-store default-rule tests for host tool coverage and idempotent backfill behavior

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/trust-store.test.ts src/__tests__/checker.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
