### PR TITLE
fix(ui): reset isDynamicExpanded when panel changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -105,6 +105,13 @@ struct MainWindowView: View {
         .onReceive(daemonClient.$isConnected) { _ in
             refreshAPIKeyState()
         }
+        .onChange(of: activePanel) { _, newPanel in
+            // Reset expanded state when navigating away from the Dynamic panel
+            // via toolbar or tab bar buttons, which only modify activePanel.
+            if newPanel != .generated {
+                isDynamicExpanded = false
+            }
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Fixes a bug where `isDynamicExpanded` state was not reset when the Dynamic panel was toggled off via toolbar or tab bar buttons (which only modify `activePanel`)
- Adds an `.onChange(of: activePanel)` modifier in `MainWindowView` that resets `isDynamicExpanded = false` whenever the user navigates away from the `.generated` panel
- Addresses Devin's review feedback on PR #1933

## Test plan
- [ ] Open the Dynamic panel and expand it (isDynamicExpanded = true)
- [ ] Toggle the panel off using the toolbar button — verify the panel collapses properly on next open
- [ ] Switch to a different panel (e.g., Settings) while Dynamic is expanded — verify it resets
- [ ] Close the Dynamic panel using its own close button — verify existing behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
