### PR TITLE
fix(session): return synthetic messageId for unknown slash commands

### DIFF
--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -200,6 +200,14 @@ describe('Session slash command — unknown', () => {
     expect(completes.length).toBe(1);
   });
 
+  test('unknown slash returns a non-empty messageId', async () => {
+    const session = makeSession();
+    const messageId = await session.processMessage('/not-a-skill', [], () => {});
+    expect(messageId).toBeTruthy();
+    expect(typeof messageId).toBe('string');
+    expect(messageId.length).toBeGreaterThan(0);
+  });
+
   test('no agent loop execution occurs for unknown slash', async () => {
     const session = makeSession();
     await session.processMessage('/not-a-skill', [], () => {});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -883,11 +883,13 @@ export class Session {
     // Resolve slash commands before persistence
     const slashResult = this.resolveSlash(content);
 
-    // Unknown slash command — emit deterministic response without agent loop
+    // Unknown slash command — emit deterministic response without agent loop.
+    // Return a synthetic messageId so callers (e.g. server.ts) don't treat
+    // this as a persistence failure.
     if (slashResult.kind === 'unknown') {
       onEvent({ type: 'assistant_text_delta', text: slashResult.message });
       onEvent({ type: 'message_complete', sessionId: this.conversationId });
-      return '';
+      return uuid();
     }
 
     const resolvedContent = slashResult.content;


### PR DESCRIPTION
## Summary
- Unknown slash commands in `processMessage` returned `''`, causing `server.ts` to throw "Failed to persist user message" since it checks `if (!messageId)`
- Now returns a generated UUID so callers can distinguish between a handled unknown-slash and an actual persistence failure
- The `drainQueue` unknown-slash handling was already fixed in a prior PR (#1928)
- Added test verifying the unknown slash path returns a non-empty messageId

Addresses feedback from Codex (P2) and Devin (RED) on #1927.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 4 unknown slash tests pass (`bun test session-slash-unknown`)
- [x] Existing tests unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
