### PR TITLE
feat(ui): add browser-style zoom (Cmd+=/Cmd-/Cmd+0)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -92,6 +92,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     let secretPromptManager = SecretPromptManager()
     private let daemonLauncher = DaemonLauncher()
     private let updateManager = UpdateManager()
+    let zoomManager = ZoomManager()
 
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
@@ -128,6 +129,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         setupDaemonClient()
         setupMenuBar()
+        setupViewMenu()
         setupHotKey()
         setupEscapeMonitor()
         setupVoiceInput()
@@ -388,6 +390,35 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             button.target = self
         }
     }
+
+    private func setupViewMenu() {
+        guard let mainMenu = NSApp.mainMenu else { return }
+
+        let viewMenu = NSMenu(title: "View")
+
+        let zoomInItem = NSMenuItem(title: "Zoom In", action: #selector(handleZoomIn), keyEquivalent: "=")
+        zoomInItem.keyEquivalentModifierMask = .command
+        zoomInItem.target = self
+        viewMenu.addItem(zoomInItem)
+
+        let zoomOutItem = NSMenuItem(title: "Zoom Out", action: #selector(handleZoomOut), keyEquivalent: "-")
+        zoomOutItem.keyEquivalentModifierMask = .command
+        zoomOutItem.target = self
+        viewMenu.addItem(zoomOutItem)
+
+        let resetItem = NSMenuItem(title: "Actual Size", action: #selector(handleZoomReset), keyEquivalent: "0")
+        resetItem.keyEquivalentModifierMask = .command
+        resetItem.target = self
+        viewMenu.addItem(resetItem)
+
+        let viewMenuItem = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
+        viewMenuItem.submenu = viewMenu
+        mainMenu.addItem(viewMenuItem)
+    }
+
+    @objc private func handleZoomIn() { zoomManager.zoomIn() }
+    @objc private func handleZoomOut() { zoomManager.zoomOut() }
+    @objc private func handleZoomReset() { zoomManager.resetZoom() }
 
     private func configureMenuBarIcon(_ button: NSStatusBarButton) {
         let iconSize: CGFloat = 18
@@ -761,6 +792,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.onboardingWindow = nil
 
             self?.setupMenuBar()
+            self?.setupViewMenu()
             self?.setupHotKey()
             self?.setupEscapeMonitor()
             self?.setupVoiceInput()
@@ -839,7 +871,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.show()
             return
         }
-        let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent)
+        let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent, zoomManager: zoomManager)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -601,8 +601,9 @@ private struct ChatBubble: View {
                     bubbleContent
                 }
 
-                // Tool calls render outside the bubble as compact chips
-                if !isUser && !message.toolCalls.isEmpty {
+                // Tool calls render outside the bubble as compact chips.
+                // Hidden when inline surfaces are present — the dynamic UI replaces the tool output.
+                if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(message.toolCalls) { toolCall in
                             ToolCallChip(toolCall: toolCall)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -6,6 +6,7 @@ import SwiftUI
 final class MainWindow {
     private let daemonClient: DaemonClient
     private let ambientAgent: AmbientAgent
+    private let zoomManager: ZoomManager
     private var window: NSWindow?
     let threadManager: ThreadManager
     var onMicrophoneToggle: (() -> Void)?
@@ -20,9 +21,10 @@ final class MainWindow {
         threadManager.activeViewModel
     }
 
-    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent) {
+    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent, zoomManager: ZoomManager) {
         self.daemonClient = daemonClient
         self.ambientAgent = ambientAgent
+        self.zoomManager = zoomManager
         self.threadManager = ThreadManager(daemonClient: daemonClient)
     }
 
@@ -31,14 +33,14 @@ final class MainWindow {
         if let existing = window {
             // Rebuild the SwiftUI view hierarchy so it picks up any
             // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
             existing.makeKeyAndOrderFront(nil)
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let windowWidth = min(1100.0, screenFrame.width * 0.75)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var zoomManager: ZoomManager
     @State private var activePanel: SidePanelType?
     @State private var isDynamicExpanded = false
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
@@ -11,8 +12,9 @@ struct MainWindowView: View {
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, zoomManager: ZoomManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
+        self.zoomManager = zoomManager
         self.daemonClient = daemonClient
         self.ambientAgent = ambientAgent
         self.onMicrophoneToggle = onMicrophoneToggle
@@ -94,8 +96,21 @@ struct MainWindowView: View {
             }
             .ignoresSafeArea(edges: .top)
             .background(VColor.background.ignoresSafeArea())
+            .frame(width: geometry.size.width / zoomManager.zoomLevel,
+                   height: geometry.size.height / zoomManager.zoomLevel)
+            .scaleEffect(zoomManager.zoomLevel, anchor: .topLeading)
+            .frame(width: geometry.size.width, height: geometry.size.height,
+                   alignment: .topLeading)
         }
         .frame(minWidth: 800, minHeight: 600)
+        .overlay(alignment: .top) {
+            if zoomManager.showZoomIndicator {
+                ZoomIndicatorView(percentage: zoomManager.zoomPercentage)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .padding(.top, VSpacing.xxl + VSpacing.xl)
+            }
+        }
+        .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
         .onAppear {
             refreshAPIKeyState()
         }
@@ -185,9 +200,27 @@ struct MainWindowView: View {
     }
 }
 
+private struct ZoomIndicatorView: View {
+    let percentage: Int
+
+    var body: some View {
+        Text("\(percentage)%")
+            .font(VFont.bodyMedium)
+            .foregroundStyle(VColor.textPrimary)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.surface)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+    }
+}
+
 #Preview {
     let dc = DaemonClient()
-    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), daemonClient: dc, ambientAgent: AmbientAgent())
+    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), daemonClient: dc, ambientAgent: AmbientAgent())
         .frame(width: 900, height: 600)
         .padding(.top, 36)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+@MainActor
+final class ZoomManager: ObservableObject {
+    static let zoomSteps: [CGFloat] = [0.75, 0.80, 0.90, 1.00, 1.10, 1.25, 1.50, 1.75, 2.00]
+
+    @Published var zoomLevel: CGFloat {
+        didSet { UserDefaults.standard.set(zoomLevel, forKey: "windowZoomLevel") }
+    }
+    @Published var showZoomIndicator = false
+
+    private var dismissTask: Task<Void, Never>?
+
+    var zoomPercentage: Int {
+        Int(round(zoomLevel * 100))
+    }
+
+    init() {
+        let stored = UserDefaults.standard.double(forKey: "windowZoomLevel")
+        self.zoomLevel = stored > 0 ? stored : 1.0
+    }
+
+    func zoomIn() {
+        if let next = Self.zoomSteps.first(where: { $0 > zoomLevel + 0.001 }) {
+            zoomLevel = next
+            flashIndicator()
+        }
+    }
+
+    func zoomOut() {
+        if let prev = Self.zoomSteps.last(where: { $0 < zoomLevel - 0.001 }) {
+            zoomLevel = prev
+            flashIndicator()
+        }
+    }
+
+    func resetZoom() {
+        zoomLevel = 1.0
+        flashIndicator()
+    }
+
+    private func flashIndicator() {
+        dismissTask?.cancel()
+        showZoomIndicator = true
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            showZoomIndicator = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds browser-style viewport zoom to the main window using `scaleEffect()` + frame adjustment (Cmd+= to zoom in, Cmd+- to zoom out, Cmd+0 to reset)
- New `ZoomManager` persists zoom level to UserDefaults with 9 steps from 75% to 200%
- Shows a brief toast indicator with the current zoom percentage
- Adds View menu to the menu bar with Zoom In / Zoom Out / Actual Size items
- Hides tool call chips when inline surfaces are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
