### PR TITLE
feat(trust): default ask rules for cu_* and request_computer_control

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -357,6 +357,36 @@ describe('Permission Checker', () => {
       expect(result.matchedRule?.id).toBe('default:ask-host_bash-global');
     });
 
+    test('cu_click prompts by default via computer-use ask rule', async () => {
+      const result = await check('cu_click', { reasoning: 'Click the save button' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-cu_click-global');
+    });
+
+    test('request_computer_control prompts by default via computer-use ask rule', async () => {
+      const result = await check('request_computer_control', { task: 'Open system settings' }, '/tmp');
+      expect(result.decision).toBe('prompt');
+      expect(result.reason).toContain('ask rule');
+      expect(result.matchedRule?.id).toBe('default:ask-request_computer_control-global');
+    });
+
+    test('higher-priority allow rule can override default cu ask rule', async () => {
+      addRule('cu_click', 'cu_click:*', 'everywhere', 'allow', 2000);
+      const result = await check('cu_click', { reasoning: 'Click confirm' }, '/tmp');
+      expect(result.decision).toBe('allow');
+      expect(result.matchedRule?.decision).toBe('allow');
+      expect(result.matchedRule?.priority).toBe(2000);
+    });
+
+    test('higher-priority deny rule can override default cu ask rule', async () => {
+      addRule('cu_click', 'cu_click:*', 'everywhere', 'deny', 2001);
+      const result = await check('cu_click', { reasoning: 'Click confirm' }, '/tmp');
+      expect(result.decision).toBe('deny');
+      expect(result.matchedRule?.decision).toBe('deny');
+      expect(result.matchedRule?.priority).toBe(2001);
+    });
+
     test('deny rule for skill_load matches specific skill selectors', async () => {
       addRule('skill_load', 'skill_load:dangerous-skill', 'everywhere', 'deny');
       const result = await check('skill_load', { skill: 'dangerous-skill' }, '/tmp');

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -594,6 +594,18 @@ describe('Trust Store', () => {
         .map((r) => r.tool)
         .sort();
       expect(defaultTools).toEqual([
+        'cu_click',
+        'cu_done',
+        'cu_double_click',
+        'cu_drag',
+        'cu_key',
+        'cu_open_app',
+        'cu_respond',
+        'cu_right_click',
+        'cu_run_applescript',
+        'cu_scroll',
+        'cu_type_text',
+        'cu_wait',
         'file_edit',
         'file_read',
         'file_write',
@@ -601,6 +613,7 @@ describe('Trust Store', () => {
         'host_file_edit',
         'host_file_read',
         'host_file_write',
+        'request_computer_control',
       ]);
     });
 
@@ -705,6 +718,22 @@ describe('Trust Store', () => {
       const match = findHighestPriorityRule('host_bash', ['ls'], '/tmp');
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:ask-host_bash-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
+    });
+
+    test('findHighestPriorityRule matches default ask for cu_click', () => {
+      const match = findHighestPriorityRule('cu_click', ['cu_click:'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-cu_click-global');
+      expect(match!.decision).toBe('ask');
+      expect(match!.priority).toBe(1000);
+    });
+
+    test('findHighestPriorityRule matches default ask for request_computer_control', () => {
+      const match = findHighestPriorityRule('request_computer_control', ['request_computer_control:'], '/tmp');
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe('default:ask-request_computer_control-global');
       expect(match!.decision).toBe('ask');
       expect(match!.priority).toBe(1000);
     });

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -13,6 +13,21 @@ export interface DefaultRuleTemplate {
 /** Tools that directly access the filesystem by path. */
 const FILE_TOOLS = ['file_read', 'file_write', 'file_edit'] as const;
 const HOST_FILE_TOOLS = ['host_file_read', 'host_file_write', 'host_file_edit'] as const;
+const COMPUTER_USE_TOOLS = [
+  'cu_click',
+  'cu_double_click',
+  'cu_right_click',
+  'cu_type_text',
+  'cu_key',
+  'cu_scroll',
+  'cu_drag',
+  'cu_wait',
+  'cu_open_app',
+  'cu_run_applescript',
+  'cu_done',
+  'cu_respond',
+  'request_computer_control',
+] as const;
 
 /**
  * Returns default trust rules shipped with the assistant.
@@ -52,5 +67,14 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 1000,
   };
 
-  return [...protectedFileRules, ...hostFileRules, hostShellRule];
+  const computerUseRules = COMPUTER_USE_TOOLS.map((tool) => ({
+    id: `default:ask-${tool}-global`,
+    tool,
+    pattern: `${tool}:*`,
+    scope: 'everywhere',
+    decision: 'ask' as const,
+    priority: 1000,
+  }));
+
+  return [...protectedFileRules, ...hostFileRules, hostShellRule, ...computerUseRules];
 }


### PR DESCRIPTION
## Summary
- add default ask templates for all `cu_*` tools and `request_computer_control` with stable IDs and ordering
- keep the new computer-use defaults global (`scope: everywhere`) and idempotent under trust-store backfill
- add checker tests covering prompt-by-default behavior for `cu_click` and `request_computer_control`, plus higher-priority allow/deny overrides
- extend trust-store tests to assert computer-use defaults are present and matched by `findHighestPriorityRule`

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/trust-store.test.ts src/__tests__/checker.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
