### PR TITLE
feat(permissions): add executionTarget metadata to confirmation flow

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -447,6 +447,7 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
     "newContent": "new",
     "oldContent": "old",
   },
+  "executionTarget": "sandbox",
   "input": {
     "command": "rm -rf /tmp/test",
   },

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -292,6 +292,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     toolName: 'bash',
     input: { command: 'rm -rf /tmp/test' },
     riskLevel: 'high',
+    executionTarget: 'sandbox',
     allowlistOptions: [
       { label: 'Allow rm commands', description: 'Allow rm commands', pattern: 'bash:rm *' },
     ],

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -122,12 +122,14 @@ describe('ToolExecutor lifecycle events', () => {
     expect(events[0]).toMatchObject({
       type: 'start',
       toolName: 'file_read',
+      executionTarget: 'sandbox',
       conversationId: 'conversation-1',
       sessionId: 'session-1',
       workingDir: '/tmp/project',
     });
     const executed = events[1];
     if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.executionTarget).toBe('sandbox');
     expect(executed.riskLevel).toBe('low');
     expect(executed.result).toEqual({ content: 'ok', isError: false });
     expect(executed.durationMs).toBeGreaterThanOrEqual(0);
@@ -154,6 +156,7 @@ describe('ToolExecutor lifecycle events', () => {
 
     const promptEvent = events[1];
     if (promptEvent.type !== 'permission_prompt') throw new Error('Expected permission_prompt event');
+    expect(promptEvent.executionTarget).toBe('sandbox');
     expect(promptEvent.riskLevel).toBe('medium');
     expect(promptEvent.reason).toBe('medium risk: requires approval');
     expect(promptEvent.sandboxed).toBe(true);
@@ -162,8 +165,25 @@ describe('ToolExecutor lifecycle events', () => {
 
     const deniedEvent = events[2];
     if (deniedEvent.type !== 'permission_denied') throw new Error('Expected permission_denied event');
+    expect(deniedEvent.executionTarget).toBe('sandbox');
     expect(deniedEvent.decision).toBe('deny');
     expect(deniedEvent.reason).toBe('Permission denied by user');
+  });
+
+  test('emits host executionTarget for host tools', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute('host_file_read', { path: '/tmp/file.txt' }, makeContext(events));
+
+    expect(result).toEqual({ content: 'ok', isError: false });
+    expect(events.map((event) => event.type)).toEqual(['start', 'executed']);
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('host');
+    const executed = events[1];
+    if (executed.type !== 'executed') throw new Error('Expected executed event');
+    expect(executed.executionTarget).toBe('host');
   });
 
   test('emits permission_denied when blocked by deny rule', async () => {

--- a/assistant/src/daemon/ipc-protocol.ts
+++ b/assistant/src/daemon/ipc-protocol.ts
@@ -482,6 +482,7 @@ export interface ConfirmationRequest {
   toolName: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  executionTarget?: 'sandbox' | 'host';
   allowlistOptions: Array<{ label: string; description: string; pattern: string }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean };

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import type { ServerMessage } from '../daemon/ipc-protocol.js';
 import type { UserDecision, AllowlistOption, ScopeOption } from './types.js';
+import type { ExecutionTarget } from '../tools/types.js';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
 import { AssistantError, ErrorCode } from '../util/errors.js';
@@ -34,6 +35,7 @@ export class PermissionPrompter {
     diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean },
     sandboxed?: boolean,
     sessionId?: string,
+    executionTarget?: ExecutionTarget,
   ): Promise<{ decision: UserDecision; selectedPattern?: string; selectedScope?: string }> {
     const requestId = uuid();
 
@@ -58,6 +60,7 @@ export class PermissionPrompter {
         diff,
         sandboxed,
         sessionId,
+        executionTarget,
       });
     });
   }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { getTool, getAllTools } from './registry.js';
-import type { ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
+import type { ExecutionTarget, ToolContext, ToolExecutionResult, ToolLifecycleEvent } from './types.js';
 import { RiskLevel } from '../permissions/types.js';
 import { check, classifyRisk, generateAllowlistOptions, generateScopeOptions } from '../permissions/checker.js';
 import { addRule } from '../permissions/trust-store.js';
@@ -32,10 +32,12 @@ export class ToolExecutor {
     const startTime = Date.now();
     let decision = 'allow';
     let riskLevel: string = RiskLevel.Low;
+    const executionTarget = resolveExecutionTarget(name);
 
     emitLifecycleEvent(context, {
       type: 'start',
       toolName: name,
+      executionTarget,
       input,
       workingDir: context.workingDir,
       sessionId: context.sessionId,
@@ -52,6 +54,7 @@ export class ToolExecutor {
       emitLifecycleEvent(context, {
         type: 'error',
         toolName: name,
+        executionTarget,
         input,
         workingDir: context.workingDir,
         sessionId: context.sessionId,
@@ -78,6 +81,7 @@ export class ToolExecutor {
         emitLifecycleEvent(context, {
           type: 'permission_denied',
           toolName: name,
+          executionTarget,
           input,
           workingDir: context.workingDir,
           sessionId: context.sessionId,
@@ -109,6 +113,7 @@ export class ToolExecutor {
         emitLifecycleEvent(context, {
           type: 'permission_prompt',
           toolName: name,
+          executionTarget,
           input,
           workingDir: context.workingDir,
           sessionId: context.sessionId,
@@ -138,6 +143,7 @@ export class ToolExecutor {
           previewDiff,
           sandboxed,
           context.conversationId,
+          executionTarget,
         );
 
         decision = response.decision;
@@ -154,6 +160,7 @@ export class ToolExecutor {
           emitLifecycleEvent(context, {
             type: 'permission_denied',
             toolName: name,
+            executionTarget,
             input,
             workingDir: context.workingDir,
             sessionId: context.sessionId,
@@ -176,6 +183,7 @@ export class ToolExecutor {
           emitLifecycleEvent(context, {
             type: 'permission_denied',
             toolName: name,
+            executionTarget,
             input,
             workingDir: context.workingDir,
             sessionId: context.sessionId,
@@ -209,6 +217,7 @@ export class ToolExecutor {
         emitLifecycleEvent(context, {
           type: 'error',
           toolName: name,
+          executionTarget,
           input,
           workingDir: context.workingDir,
           sessionId: context.sessionId,
@@ -232,6 +241,7 @@ export class ToolExecutor {
           emitLifecycleEvent(context, {
             type: 'error',
             toolName: name,
+            executionTarget,
             input,
             workingDir: context.workingDir,
             sessionId: context.sessionId,
@@ -269,6 +279,7 @@ export class ToolExecutor {
           emitLifecycleEvent(context, {
             type: 'secret_detected',
             toolName: name,
+            executionTarget,
             input,
             workingDir: context.workingDir,
             sessionId: context.sessionId,
@@ -298,6 +309,7 @@ export class ToolExecutor {
             emitLifecycleEvent(context, {
               type: 'executed',
               toolName: name,
+              executionTarget,
               input,
               workingDir: context.workingDir,
               sessionId: context.sessionId,
@@ -327,6 +339,7 @@ export class ToolExecutor {
       emitLifecycleEvent(context, {
         type: 'executed',
         toolName: name,
+        executionTarget,
         input,
         workingDir: context.workingDir,
         sessionId: context.sessionId,
@@ -356,6 +369,7 @@ export class ToolExecutor {
       emitLifecycleEvent(context, {
         type: 'error',
         toolName: name,
+        executionTarget,
         input,
         workingDir: context.workingDir,
         sessionId: context.sessionId,
@@ -385,6 +399,13 @@ export class ToolExecutor {
       return { content: `Tool "${name}" encountered an unexpected error: ${msg}`, isError: true };
     }
   }
+}
+
+function resolveExecutionTarget(toolName: string): ExecutionTarget {
+  if (toolName.startsWith('host_') || toolName.startsWith('cu_') || toolName === 'request_computer_control') {
+    return 'host';
+  }
+  return 'sandbox';
 }
 
 /**

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,6 +1,8 @@
 import type { RiskLevel, AllowlistOption, ScopeOption } from '../permissions/types.js';
 import type { ToolDefinition, ContentBlock } from '../providers/types.js';
 
+export type ExecutionTarget = 'sandbox' | 'host';
+
 interface ToolLifecycleEventBase {
   toolName: string;
   input: Record<string, unknown>;
@@ -8,6 +10,7 @@ interface ToolLifecycleEventBase {
   sessionId: string;
   conversationId: string;
   requestId?: string;
+  executionTarget?: ExecutionTarget;
 }
 
 export interface ToolExecutionStartEvent extends ToolLifecycleEventBase {
@@ -93,6 +96,7 @@ export interface ToolContext {
     toolName: string;
     input: Record<string, unknown>;
     riskLevel: string;
+    executionTarget?: ExecutionTarget;
   }) => Promise<{ decision: 'allow' | 'deny' }>;
   /** Prompt the user for a secret value via native SecureField UI. */
   requestSecret?: (params: {


### PR DESCRIPTION
## Summary
- add optional `executionTarget` to tool lifecycle events and confirmation request payloads (`sandbox` vs `host`)
- compute execution target in the tool executor (`host_*`, `cu_*`, and `request_computer_control` => host; everything else => sandbox)
- include `executionTarget` in permission prompt IPC messages via `PermissionPrompter`
- update IPC snapshot fixtures and lifecycle tests to assert execution target metadata

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test -u src/__tests__/ipc-snapshot.test.ts src/__tests__/tool-executor-lifecycle-events.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/secret-scanner-executor.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
