### PR TITLE
Create iOS app target with basic structure

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
         .executable(
             name: "vellum-assistant",
             targets: ["vellum-assistant"]
+        ),
+        .executable(
+            name: "vellum-assistant-ios",
+            targets: ["vellum-assistant-ios"]
         )
     ],
     dependencies: [
@@ -73,6 +77,19 @@ let package = Package(
             name: "vellum-assistantTests",
             dependencies: ["VellumAssistantLib"],
             path: "macos/vellum-assistantTests"
+        ),
+        .executableTarget(
+            name: "vellum-assistant-ios",
+            dependencies: ["VellumAssistantShared"],
+            path: "macos/vellum-assistant-ios",
+            exclude: ["Resources/Info.plist"],
+            resources: [
+                .process("Resources/Assets.xcassets")
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit", .when(platforms: [.iOS])),
+                .linkedFramework("SwiftUI", .when(platforms: [.iOS]))
+            ]
         )
     ]
 )

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -2,6 +2,17 @@
 
 A native macOS menu bar app that controls your Mac via accessibility APIs and CGEvent input injection, powered by Claude via the Anthropic Messages API with tool use.
 
+## iOS Target
+
+This repository also includes an iOS app target (`vellum-assistant-ios`) that shares ~45-50% of code with the macOS app through the `VellumAssistantShared` library. The iOS app is a chat-focused client that connects to a network-accessible daemon via TCP.
+
+**Status:** Basic structure in place (PR 4 of 13). The iOS target requires xcodebuild with iOS SDK to build - it cannot be built with `swift build` on macOS due to UIKit dependencies.
+
+**Shared code:**
+- `clients/shared/` — Shared library (IPC layer, chat models/ViewModels, design system)
+- `clients/macos/vellum-assistant/` — macOS-specific code (accessibility, CGEvent, computer-use)
+- `clients/macos/vellum-assistant-ios/` — iOS-specific code (UIKit app structure)
+
 ## Requirements
 
 - macOS 14.0 (Sonoma) or later

--- a/clients/macos/vellum-assistant-ios/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant-ios/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import VellumAssistantShared
 
+@MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
     let daemonClient: DaemonClient
 

--- a/clients/macos/vellum-assistant-ios/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant-ios/App/AppDelegate.swift
@@ -1,0 +1,21 @@
+import UIKit
+import VellumAssistantShared
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    let daemonClient: DaemonClient
+
+    override init() {
+        self.daemonClient = DaemonClient(config: .default)
+        super.init()
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        Task {
+            try? await daemonClient.connect()
+        }
+        return true
+    }
+}

--- a/clients/macos/vellum-assistant-ios/App/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-ios/App/VellumAssistantApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import VellumAssistantShared
+
+@main
+struct VellumAssistantApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appDelegate.daemonClient)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant-ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/clients/macos/vellum-assistant-ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/macos/vellum-assistant-ios/Resources/Assets.xcassets/Contents.json
+++ b/clients/macos/vellum-assistant-ios/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/clients/macos/vellum-assistant-ios/Resources/Info.plist
+++ b/clients/macos/vellum-assistant-ios/Resources/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Vellum Assistant</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.vellum.vellum-assistant-ios</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/clients/macos/vellum-assistant-ios/Views/ContentView.swift
+++ b/clients/macos/vellum-assistant-ios/Views/ContentView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct ContentView: View {
+    @EnvironmentObject var daemonClient: DaemonClient
+
+    var body: some View {
+        TabView {
+            Text("Chat")
+                .tabItem {
+                    Label("Chat", systemImage: "message")
+                }
+
+            Text("Settings")
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(DaemonClient(config: .default))
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -233,10 +233,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
         let endpoint = NWEndpoint.unix(path: self.config.socketPath)
         #elseif os(iOS)
-        log.info("Connecting to daemon at \(self.config.hostname):\(self.config.port)")
+        // Re-read UserDefaults on each connect() so reconnects pick up changed settings
+        // (Settings UI not yet implemented in PR 4; will be added in PR 6)
+        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
+        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
+        let port = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
+        log.info("Connecting to daemon at \(hostname):\(port)")
         let endpoint = NWEndpoint.hostPort(
-            host: NWEndpoint.Host(self.config.hostname),
-            port: NWEndpoint.Port(integerLiteral: self.config.port)
+            host: NWEndpoint.Host(hostname),
+            port: NWEndpoint.Port(integerLiteral: port)
         )
         #else
         #error("DaemonClient is only supported on macOS and iOS")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -161,9 +161,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
+    private let config: DaemonConfig
+
     // MARK: - Init
 
-    public init() {}
+    public init(config: DaemonConfig = .default) {
+        self.config = config
+    }
 
     deinit {
         // Swift 5.9+: deinit on @MainActor class is NOT guaranteed to run on main actor.
@@ -226,17 +230,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         shouldReconnect = true
 
         #if os(macOS)
-        let socketPath = Self.resolveSocketPath()
-        log.info("Connecting to daemon socket at \(socketPath)")
-        let endpoint = NWEndpoint.unix(path: socketPath)
+        log.info("Connecting to daemon socket at \(self.config.socketPath)")
+        let endpoint = NWEndpoint.unix(path: self.config.socketPath)
         #elseif os(iOS)
-        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
-        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
-        let port = UInt16(clamping: rawPort > 0 && rawPort <= 65535 ? rawPort : 8765)
-        log.info("Connecting to daemon at \(hostname):\(port)")
+        log.info("Connecting to daemon at \(self.config.hostname):\(self.config.port)")
         let endpoint = NWEndpoint.hostPort(
-            host: NWEndpoint.Host(hostname),
-            port: NWEndpoint.Port(integerLiteral: port)
+            host: NWEndpoint.Host(self.config.hostname),
+            port: NWEndpoint.Port(integerLiteral: self.config.port)
         )
         #else
         #error("DaemonClient is only supported on macOS and iOS")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -233,11 +233,24 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         log.info("Connecting to daemon socket at \(self.config.socketPath)")
         let endpoint = NWEndpoint.unix(path: self.config.socketPath)
         #elseif os(iOS)
-        // Re-read UserDefaults on each connect() so reconnects pick up changed settings
-        // (Settings UI not yet implemented in PR 4; will be added in PR 6)
-        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
+        // Check UserDefaults first to pick up runtime changes, fall back to config
+        // This allows reconnects to pick up changed settings while preserving custom configs for tests
+        let hostname: String
+        let port: UInt16
+
+        if let userHostname = UserDefaults.standard.string(forKey: "daemon_hostname"), !userHostname.isEmpty {
+            hostname = userHostname
+        } else {
+            hostname = self.config.hostname
+        }
+
         let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
-        let port = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
+        if rawPort > 0 && rawPort <= 65535 {
+            port = UInt16(rawPort)
+        } else {
+            port = self.config.port
+        }
+
         log.info("Connecting to daemon at \(hostname):\(port)")
         let endpoint = NWEndpoint.hostPort(
             host: NWEndpoint.Host(hostname),

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -4,6 +4,26 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DaemonClient")
 
+#if os(macOS)
+/// Resolve the Unix domain socket path for the daemon connection.
+/// Returns the path in priority order:
+/// 1. `VELLUM_DAEMON_SOCKET` environment variable (trimmed, with ~/ expansion)
+/// 2. `~/.vellum/vellum.sock`
+///
+/// Accepts an optional environment dictionary for testability.
+func resolveSocketPath(environment: [String: String]? = nil) -> String {
+    let env = environment ?? ProcessInfo.processInfo.environment
+    if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("~/") {
+            return NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
+        }
+        return trimmed
+    }
+    return NSHomeDirectory() + "/.vellum/vellum.sock"
+}
+#endif
+
 /// Protocol for daemon client communication, enabling dependency injection and testing.
 @MainActor
 public protocol DaemonClientProtocol {
@@ -196,22 +216,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Socket Path
 
-    /// Resolves the daemon socket path (macOS only):
-    /// 1. `VELLUM_DAEMON_SOCKET` environment variable (or override dictionary)
-    /// 2. `~/.vellum/vellum.sock`
-    ///
-    /// Accepts an optional environment dictionary for testability.
+    /// Resolves the daemon socket path (macOS only).
+    /// Delegates to the standalone `resolveSocketPath()` function for DRY.
     #if os(macOS)
     public static func resolveSocketPath(environment: [String: String]? = nil) -> String {
-        let env = environment ?? ProcessInfo.processInfo.environment
-        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("~/") {
-                return NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
-            }
-            return trimmed
-        }
-        return NSHomeDirectory() + "/.vellum/vellum.sock"
+        return VellumAssistantShared.resolveSocketPath(environment: environment)
     }
     #endif
 

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -26,12 +26,10 @@ public struct DaemonConfig {
     #elseif os(iOS)
     public let hostname: String
     public let port: UInt16
-    public let useTLS: Bool
 
-    public init(hostname: String, port: UInt16, useTLS: Bool = true) {
+    public init(hostname: String, port: UInt16) {
         self.hostname = hostname
         self.port = port
-        self.useTLS = useTLS
     }
 
     public static var `default`: DaemonConfig {
@@ -39,7 +37,7 @@ public struct DaemonConfig {
         let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
-        return DaemonConfig(hostname: hostname, port: finalPort, useTLS: true)
+        return DaemonConfig(hostname: hostname, port: finalPort)
     }
     #else
     #error("Unsupported platform")

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -9,9 +9,19 @@ public struct DaemonConfig {
     }
 
     public static var `default`: DaemonConfig {
+        // Socket path normalization logic (matches DaemonClient.resolveSocketPath):
+        // - Trim whitespace/newlines from env var
+        // - Fall back to default if empty or whitespace-only
+        // - Expand ~/ prefix
         let env = ProcessInfo.processInfo.environment
-        let path = env["VELLUM_DAEMON_SOCKET"] ?? "\(NSHomeDirectory())/.vellum/vellum.sock"
-        return DaemonConfig(socketPath: path)
+        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("~/") {
+                return DaemonConfig(socketPath: NSHomeDirectory() + "/" + String(trimmed.dropFirst(2)))
+            }
+            return DaemonConfig(socketPath: trimmed)
+        }
+        return DaemonConfig(socketPath: NSHomeDirectory() + "/.vellum/vellum.sock")
     }
     #elseif os(iOS)
     public let hostname: String
@@ -26,8 +36,9 @@ public struct DaemonConfig {
 
     public static var `default`: DaemonConfig {
         let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
-        let port = UInt16(UserDefaults.standard.integer(forKey: "daemon_port"))
-        let finalPort = port > 0 ? port : 8765
+        let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
+        // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
+        let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765
         return DaemonConfig(hostname: hostname, port: finalPort, useTLS: true)
     }
     #else

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public struct DaemonConfig {
+    #if os(macOS)
+    public let socketPath: String
+
+    public init(socketPath: String) {
+        self.socketPath = socketPath
+    }
+
+    public static var `default`: DaemonConfig {
+        let env = ProcessInfo.processInfo.environment
+        let path = env["VELLUM_DAEMON_SOCKET"] ?? "\(NSHomeDirectory())/.vellum/vellum.sock"
+        return DaemonConfig(socketPath: path)
+    }
+    #elseif os(iOS)
+    public let hostname: String
+    public let port: UInt16
+    public let useTLS: Bool
+
+    public init(hostname: String, port: UInt16, useTLS: Bool = true) {
+        self.hostname = hostname
+        self.port = port
+        self.useTLS = useTLS
+    }
+
+    public static var `default`: DaemonConfig {
+        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
+        let port = UInt16(UserDefaults.standard.integer(forKey: "daemon_port"))
+        let finalPort = port > 0 ? port : 8765
+        return DaemonConfig(hostname: hostname, port: finalPort, useTLS: true)
+    }
+    #else
+    #error("Unsupported platform")
+    #endif
+}

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -9,19 +9,8 @@ public struct DaemonConfig {
     }
 
     public static var `default`: DaemonConfig {
-        // Socket path normalization logic (matches DaemonClient.resolveSocketPath):
-        // - Trim whitespace/newlines from env var
-        // - Fall back to default if empty or whitespace-only
-        // - Expand ~/ prefix
-        let env = ProcessInfo.processInfo.environment
-        if let envPath = env["VELLUM_DAEMON_SOCKET"], !envPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("~/") {
-                return DaemonConfig(socketPath: NSHomeDirectory() + "/" + String(trimmed.dropFirst(2)))
-            }
-            return DaemonConfig(socketPath: trimmed)
-        }
-        return DaemonConfig(socketPath: NSHomeDirectory() + "/.vellum/vellum.sock")
+        // Delegate to resolveSocketPath() to avoid duplication
+        return DaemonConfig(socketPath: resolveSocketPath())
     }
     #elseif os(iOS)
     public let hostname: String
@@ -33,7 +22,8 @@ public struct DaemonConfig {
     }
 
     public static var `default`: DaemonConfig {
-        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname") ?? "localhost"
+        // Treat empty string as nil to ensure fallback to "localhost"
+        let hostname = UserDefaults.standard.string(forKey: "daemon_hostname").flatMap { $0.isEmpty ? nil : $0 } ?? "localhost"
         let rawPort = UserDefaults.standard.integer(forKey: "daemon_port")
         // Validate port is in valid UInt16 range (1-65535) before converting to avoid crash
         let finalPort: UInt16 = (rawPort > 0 && rawPort <= 65535) ? UInt16(rawPort) : 8765


### PR DESCRIPTION
## Summary

- Add iOS executable target to Package.swift with proper dependencies
- Create iOS app directory structure (App/, Views/, Resources/)
- Implement app entry point with UIApplicationDelegate pattern
- Create basic ContentView with tab bar (Chat and Settings placeholders)
- Extract DaemonConfig for platform-specific daemon connection configuration
- Update DaemonClient to use DaemonConfig for Unix socket (macOS) or TCP (iOS)

Part of plan: sharded-mapping-shannon.md (PR 4 of 13)

## Technical Details

**DaemonConfig:**
- macOS: Unix domain socket at `~/.vellum/vellum.sock` (or `VELLUM_DAEMON_SOCKET` env var)
- iOS: TCP connection to configurable hostname:port (from UserDefaults)

**iOS App Structure:**
- VellumAssistantApp.swift - SwiftUI app entry point
- AppDelegate.swift - Initializes DaemonClient and connects on launch
- ContentView.swift - Tab bar with Chat and Settings placeholders
- Resources/ - Info.plist and app icon assets

**Build Notes:**
- macOS app builds successfully via `swift build --product vellum-assistant`
- iOS target requires xcodebuild with iOS SDK (UIKit not available in macOS swift build)
- Shared library compiles for both platforms

## Testing

```bash
cd clients
swift build --product vellum-assistant  # Verify macOS app still works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
