### PR TITLE
feat(runtime): include executionTarget in run pendingConfirmation

### DIFF
--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+import type { Session } from '../daemon/session.js';
+
+const testDir = mkdtempSync(join(tmpdir(), 'run-orchestrator-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb, resetDb } from '../memory/db.js';
+import { createConversation } from '../memory/conversation-store.js';
+import { createRun, getRun, setRunConfirmation } from '../memory/runs-store.js';
+import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+
+initializeDb();
+
+function makeSessionWithConfirmation(message: ServerMessage): Session {
+  let clientHandler: (msg: ServerMessage) => void = () => {};
+  return {
+    isProcessing: () => false,
+    // Return undefined so createRun stores messageId as null and avoids
+    // a foreign-key dependency on the conversation-store message table.
+    persistUserMessage: () => undefined as unknown as string,
+    updateClient: (handler: (msg: ServerMessage) => void) => {
+      clientHandler = handler;
+    },
+    runAgentLoop: async () => {
+      clientHandler(message);
+      return await new Promise<void>(() => {});
+    },
+    handleConfirmationResponse: () => {},
+  } as unknown as Session;
+}
+
+describe('run approval state executionTarget', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  afterAll(() => {
+    resetDb();
+    try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  test('stores pending confirmation executionTarget when provided', () => {
+    const conversation = createConversation('run test');
+    const run = createRun('assistant-1', conversation.id);
+
+    setRunConfirmation(run.id, {
+      toolName: 'host_file_read',
+      toolUseId: 'req-1',
+      input: { path: '/etc/hosts' },
+      riskLevel: 'medium',
+      executionTarget: 'host',
+      allowlistOptions: [{ label: '/etc/hosts', pattern: 'host_file_read:/etc/hosts' }],
+      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+    });
+
+    const stored = getRun(run.id);
+    expect(stored?.status).toBe('needs_confirmation');
+    expect(stored?.pendingConfirmation?.executionTarget).toBe('host');
+  });
+
+  test('parses pending confirmations without executionTarget for legacy rows', () => {
+    const conversation = createConversation('legacy run test');
+    const run = createRun('assistant-1', conversation.id);
+
+    setRunConfirmation(run.id, {
+      toolName: 'bash',
+      toolUseId: 'req-legacy',
+      input: { command: 'ls' },
+      riskLevel: 'medium',
+      allowlistOptions: [{ label: 'ls', pattern: 'ls' }],
+      scopeOptions: [{ label: '/tmp', scope: '/tmp' }],
+    });
+
+    const stored = getRun(run.id);
+    expect(stored?.status).toBe('needs_confirmation');
+    expect(stored?.pendingConfirmation?.executionTarget).toBeUndefined();
+  });
+
+  test('run orchestrator persists executionTarget from confirmation_request', async () => {
+    const conversation = createConversation('orchestrator run test');
+    const session = makeSessionWithConfirmation({
+      type: 'confirmation_request',
+      requestId: 'req-2',
+      toolName: 'host_bash',
+      input: { command: 'pwd' },
+      riskLevel: 'medium',
+      executionTarget: 'host',
+      allowlistOptions: [{ label: 'pwd', description: 'This exact command', pattern: 'pwd' }],
+      scopeOptions: [{ label: 'everywhere', scope: 'everywhere' }],
+    });
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Run host command');
+    const stored = orchestrator.getRun(run.id);
+    expect(stored?.status).toBe('needs_confirmation');
+    expect(stored?.pendingConfirmation?.executionTarget).toBe('host');
+  });
+});

--- a/assistant/src/memory/runs-store.ts
+++ b/assistant/src/memory/runs-store.ts
@@ -21,6 +21,7 @@ export interface PendingConfirmation {
   toolUseId: string;
   input: Record<string, unknown>;
   riskLevel: string;
+  executionTarget?: 'sandbox' | 'host';
   allowlistOptions?: Array<{ label: string; pattern: string }>;
   scopeOptions?: Array<{ label: string; scope: string }>;
 }

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -92,6 +92,7 @@ export class RunOrchestrator {
           toolUseId: msg.requestId,
           input: msg.input,
           riskLevel: msg.riskLevel,
+          executionTarget: msg.executionTarget,
           allowlistOptions: msg.allowlistOptions,
           scopeOptions: msg.scopeOptions,
         });


### PR DESCRIPTION
## Summary
- extend `PendingConfirmation` in `runs-store` with optional `executionTarget`
- persist `executionTarget` from intercepted `confirmation_request` messages in `run-orchestrator`
- add focused run-state tests covering stored execution targets, legacy rows without targets, and orchestrator interception flow

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/run-orchestrator.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
