### PR TITLE
feat(cli): show host vs sandbox target in confirmation prompts

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -164,6 +164,9 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
     process.stdout.write('\n');
     process.stdout.write(`\u250C ${req.toolName}: ${preview}\n`);
     process.stdout.write(`\u2502 Risk: ${req.riskLevel}${req.sandboxed ? '  [sandboxed]' : ''}\n`);
+    if (req.executionTarget) {
+      process.stdout.write(`\u2502 Target: ${req.executionTarget}\n`);
+    }
     if (req.diff) {
       const diffOutput = req.diff.isNewFile
         ? formatNewFileDiff(req.diff.newContent, req.diff.filePath)


### PR DESCRIPTION
## Summary
- render a `Target: <host|sandbox>` line in CLI confirmation prompts when `executionTarget` metadata is present
- keep backward compatibility for older confirmation payloads by omitting the target line when the field is absent

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/cli.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
