### PR TITLE
fix(skills): pin locale to 'en' for slash command ID sorting

### DIFF
--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -121,7 +121,7 @@ export function resolveSlashSkillCommand(
 
   const availableIds = Array.from(catalog.values())
     .map((s) => s.canonicalId)
-    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    .sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
   return {
     kind: 'unknown',
     requestedId,


### PR DESCRIPTION
Address Codex P2 feedback on PR #1944: the comparator `a.localeCompare(b, undefined, { sensitivity: 'base' })` makes ordering dependent on the process locale/ICU data, so environments with different casing rules (e.g., Turkish I/i) can produce different command ordering.

**Fix:** Change `undefined` to `'en'` to pin the locale for deterministic sorting regardless of environment.

Resolves review feedback from #1944.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
