### PR TITLE
fix(permissions): add host_bash to classifyRisk and normalize host file paths

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -166,7 +166,12 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
 
   const fileTarget = getStringField(input, 'path', 'file_path');
   if (toolName === 'host_file_read' || toolName === 'host_file_write' || toolName === 'host_file_edit') {
-    return [`${toolName}:${fileTarget}`];
+    const normalized = fileTarget ? resolve(fileTarget) : fileTarget;
+    const candidates = [`${toolName}:${normalized}`];
+    if (normalized !== fileTarget) {
+      candidates.push(`${toolName}:${fileTarget}`);
+    }
+    return candidates;
   }
 
   const resolved = fileTarget ? resolve(workingDir, fileTarget) : fileTarget;
@@ -198,7 +203,7 @@ export async function classifyRisk(toolName: string, input: Record<string, unkno
   if (toolName === 'browser_extract') return RiskLevel.Low;
   if (toolName === 'skill_load') return RiskLevel.Low;
 
-  if (toolName === 'bash') {
+  if (toolName === 'bash' || toolName === 'host_bash') {
     const command = (input.command as string) ?? '';
     if (!command.trim()) return RiskLevel.Low;
 


### PR DESCRIPTION
## Summary
- Add `host_bash` to the `classifyRisk` condition so dangerous commands (`sudo`, `rm -rf`, `kill`, etc.) executed via `host_bash` are correctly classified as High risk instead of falling through to the registry default of Medium. This prevents trust rules from auto-approving dangerous host commands.
- Normalize `host_file_*` paths with `path.resolve()` in `buildCommandCandidates` before matching trust rules, so paths like `/etc/../etc/hosts` correctly match rules written for the canonical `/etc/hosts`. The raw path is also included as a fallback candidate.

Addresses review feedback on PR #1940.

## Verification
```
export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bunx tsc --noEmit
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
