### PR TITLE
fix(permissions): lower host default priority and use globstar pattern

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -53,18 +53,19 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     pattern: `${tool}:/**`,
     scope: 'everywhere',
     decision: 'ask' as const,
-    priority: 1000,
+    priority: 50,
   }));
 
   // host_bash command candidates are raw commands ("ls", "npm test"), so the
-  // global default ask rule uses "*" instead of a "tool:*" prefix.
+  // global default ask rule uses "**" (globstar) instead of a "tool:*" prefix
+  // because commands often contain "/" (e.g. "cat /etc/hosts").
   const hostShellRule: DefaultRuleTemplate = {
     id: 'default:ask-host_bash-global',
     tool: 'host_bash',
-    pattern: '*',
+    pattern: '**',
     scope: 'everywhere',
     decision: 'ask',
-    priority: 1000,
+    priority: 50,
   };
 
   const computerUseRules = COMPUTER_USE_TOOLS.map((tool) => ({


### PR DESCRIPTION
## Summary

Addresses review feedback from Codex (P1) and Devin (YELLOW) on PR #1945.

**Two fixes in `assistant/src/permissions/defaults.ts`:**

- **Priority**: Lower host tool default ask rules from priority `1000` to `50` so that user-created allow rules (which default to priority `100`) can actually override them. Previously, "always allow" choices were saved but never took effect because the default ask rule always won.

- **Pattern**: Change `host_bash` default pattern from `*` to `**` (globstar) so it matches commands containing `/` (e.g. `cat /etc/hosts`). Minimatch's `*` only matches within a single path segment.

Protected file rules and computer use rules retain priority `1000` as intended.

Closes feedback on #1945.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
