### PR TITLE
feat(macos): show execution target in chat and floating confirmation UIs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/ToolConfirmationManager.swift
@@ -37,6 +37,7 @@ final class ToolConfirmationManager {
             diff: message.diff,
             allowlistOptions: message.allowlistOptions,
             scopeOptions: message.scopeOptions,
+            executionTarget: message.executionTarget,
             onAllow: { [weak self] in
                 self?.respond(requestId: message.requestId, decision: "allow", hasRuleOptions: hasRuleOptions) ?? false
             },
@@ -123,6 +124,7 @@ struct ToolConfirmationView: View {
     let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
     let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
+    let executionTarget: String?
     let onAllow: () -> Bool
     let onDeny: () -> Bool
     let onDismiss: () -> Void
@@ -140,6 +142,17 @@ struct ToolConfirmationView: View {
     @State private var selectedScope: String = ""
 
     private var isHighRisk: Bool { riskLevel.lowercased() == "high" }
+
+    private var normalizedExecutionTarget: String? {
+        guard let executionTarget else { return nil }
+        let normalized = executionTarget.lowercased()
+        guard normalized == "host" || normalized == "sandbox" else { return nil }
+        return normalized
+    }
+
+    private var isHostTarget: Bool {
+        normalizedExecutionTarget == "host"
+    }
 
     private var hasRuleOptions: Bool {
         !allowlistOptions.isEmpty && !scopeOptions.isEmpty
@@ -192,6 +205,11 @@ struct ToolConfirmationView: View {
                     Text("\(toolDisplayName) — \(riskLevel) risk")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
+                    if let normalizedExecutionTarget {
+                        Text("Target: \(normalizedExecutionTarget)")
+                            .font(VFont.caption)
+                            .foregroundColor(isHostTarget ? VColor.error : VColor.textSecondary)
+                    }
                 }
 
                 Spacer()

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -1078,6 +1078,36 @@ final class SessionTests: XCTestCase {
             XCTFail("Expected taskRouted, got \(message)")
         }
     }
+
+    @MainActor
+    func testConfirmationRequestDecodingWithExecutionTarget() async {
+        let json = """
+        {"type":"confirmation_request","requestId":"req-123","toolName":"host_bash","input":{"command":"ls"},"riskLevel":"medium","allowlistOptions":[],"scopeOptions":[],"executionTarget":"host"}
+        """
+        let data = json.data(using: .utf8)!
+        let message = try! JSONDecoder().decode(ServerMessage.self, from: data)
+        if case .confirmationRequest(let request) = message {
+            XCTAssertEqual(request.requestId, "req-123")
+            XCTAssertEqual(request.executionTarget, "host")
+        } else {
+            XCTFail("Expected confirmationRequest, got \(message)")
+        }
+    }
+
+    @MainActor
+    func testConfirmationRequestDecodingWithoutExecutionTarget() async {
+        let json = """
+        {"type":"confirmation_request","requestId":"req-456","toolName":"bash","input":{"command":"pwd"},"riskLevel":"low","allowlistOptions":[],"scopeOptions":[]}
+        """
+        let data = json.data(using: .utf8)!
+        let message = try! JSONDecoder().decode(ServerMessage.self, from: data)
+        if case .confirmationRequest(let request) = message {
+            XCTAssertEqual(request.requestId, "req-456")
+            XCTAssertNil(request.executionTarget)
+        } else {
+            XCTFail("Expected confirmationRequest, got \(message)")
+        }
+    }
 }
 
 /// Test elements with 3+ interactive elements (enough for screenshot skip)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -35,7 +35,16 @@ public struct ToolConfirmationData: Equatable {
     public let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
     public let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
     public let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
+    public let executionTarget: String?
     public var state: ToolConfirmationState = .pending
+
+    /// Normalized target label shown in confirmation UIs.
+    public var normalizedExecutionTarget: String? {
+        guard let executionTarget else { return nil }
+        let normalized = executionTarget.lowercased()
+        guard normalized == "host" || normalized == "sandbox" else { return nil }
+        return normalized
+    }
 
     /// Human-readable preview of the tool input (e.g. the bash command or file path).
     public var commandPreview: String {
@@ -61,7 +70,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -69,6 +78,7 @@ public struct ToolConfirmationData: Equatable {
         self.diff = diff
         self.allowlistOptions = allowlistOptions
         self.scopeOptions = scopeOptions
+        self.executionTarget = executionTarget
         self.state = state
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -724,7 +724,8 @@ public final class ChatViewModel: ObservableObject {
                 riskLevel: msg.riskLevel,
                 diff: msg.diff,
                 allowlistOptions: msg.allowlistOptions,
-                scopeOptions: msg.scopeOptions
+                scopeOptions: msg.scopeOptions,
+                executionTarget: msg.executionTarget
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -24,6 +24,14 @@ public struct ToolConfirmationBubble: View {
         !confirmation.allowlistOptions.isEmpty && !confirmation.scopeOptions.isEmpty
     }
 
+    private var executionTarget: String? {
+        confirmation.normalizedExecutionTarget
+    }
+
+    private var isHostTarget: Bool {
+        executionTarget == "host"
+    }
+
     private var toolDisplayName: String {
         switch confirmation.toolName {
         case "file_write": return "Write File"
@@ -55,6 +63,18 @@ public struct ToolConfirmationBubble: View {
                         RoundedRectangle(cornerRadius: VRadius.sm)
                             .fill((isHighRisk ? VColor.error : VColor.warning).opacity(0.15))
                     )
+
+                if let executionTarget {
+                    Text(executionTarget)
+                        .font(VFont.caption)
+                        .foregroundColor(isHostTarget ? VColor.error : VColor.textSecondary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill((isHostTarget ? VColor.error : VColor.surfaceBorder).opacity(0.15))
+                        )
+                }
 
                 Spacer()
             }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1100,6 +1100,8 @@ public struct ConfirmationRequestMessage: Decodable, Sendable {
     public let scopeOptions: [ConfirmationScopeOption]
     public let diff: ConfirmationDiffInfo?
     public let sandboxed: Bool?
+    /// Optional execution surface for the tool invocation (`"sandbox"` or `"host"`).
+    public let executionTarget: String?
     public let sessionId: String?
 
     public struct ConfirmationAllowlistOption: Decodable, Sendable, Equatable {


### PR DESCRIPTION
## Summary
- add optional `executionTarget` decoding to shared confirmation IPC messages
- thread execution target through shared chat confirmation models and display target badges in inline chat confirmation bubbles
- show a target label in the macOS floating confirmation panel and add SessionTests coverage for confirmation request decoding compatibility

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd clients && swift test --filter "SessionTests/testConfirmationRequestDecoding"

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
