### PR TITLE
fix(session): persist unknown slash exchanges instead of synthetic messageId

### DIFF
--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -54,6 +54,8 @@ mock.module('../security/secret-allowlist.js', () => ({
   resetAllowlist: () => {},
 }));
 
+const addMessageCalls: Array<{ convId: string; role: string; content: string }> = [];
+
 mock.module('../memory/conversation-store.js', () => ({
   getMessages: () => [],
   getConversation: () => ({
@@ -66,7 +68,8 @@ mock.module('../memory/conversation-store.js', () => ({
   }),
   createConversation: () => ({ id: 'conv-1' }),
   listConversations: () => [],
-  addMessage: (_convId: string, _role: string, _content: string) => {
+  addMessage: (convId: string, role: string, content: string) => {
+    addMessageCalls.push({ convId, role, content });
     return { id: `msg-${Date.now()}` };
   },
   updateConversationUsage: () => {},
@@ -179,6 +182,7 @@ function makeSession(): Session {
 describe('Session slash command — unknown', () => {
   beforeEach(() => {
     agentLoopRunCalled = false;
+    addMessageCalls.length = 0;
   });
 
   test('unknown slash emits deterministic assistant response', async () => {
@@ -212,6 +216,19 @@ describe('Session slash command — unknown', () => {
     const session = makeSession();
     await session.processMessage('/not-a-skill', [], () => {});
     expect(agentLoopRunCalled).toBe(false);
+  });
+
+  test('unknown slash persists both user and assistant messages', async () => {
+    const session = makeSession();
+    await session.processMessage('/not-a-skill', [], () => {});
+
+    // Should persist exactly two messages: user + assistant
+    const roles = addMessageCalls.map((c) => c.role);
+    expect(roles).toEqual(['user', 'assistant']);
+
+    // The assistant message content should contain the unknown-command text
+    const assistantContent = addMessageCalls[1].content;
+    expect(assistantContent).toContain('Unknown command');
   });
 
   test('normal messages still go through standard path', async () => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -8,7 +8,7 @@ import { repairHistory, deepRepairHistory } from './history-repair.js';
 import { AgentLoop } from '../agent/loop.js';
 import type { CheckpointDecision } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
-import { createUserMessage } from '../agent/message-types.js';
+import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
 import { getApp } from '../memory/app-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
@@ -834,8 +834,24 @@ export class Session {
     // Resolve slash commands for queued messages
     const slashResult = this.resolveSlash(next.content);
 
-    // Unknown slash — emit deterministic response and continue draining
+    // Unknown slash — persist the exchange and continue draining
     if (slashResult.kind === 'unknown') {
+      const userMsg = createUserMessage(next.content, []);
+      this.messages.push(userMsg);
+      conversationStore.addMessage(
+        this.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+      );
+
+      const assistantMsg = createAssistantMessage(slashResult.message);
+      this.messages.push(assistantMsg);
+      conversationStore.addMessage(
+        this.conversationId,
+        'assistant',
+        JSON.stringify(assistantMsg.content),
+      );
+
       next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
       next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
       this.drainQueue();
@@ -883,13 +899,29 @@ export class Session {
     // Resolve slash commands before persistence
     const slashResult = this.resolveSlash(content);
 
-    // Unknown slash command — emit deterministic response without agent loop.
-    // Return a synthetic messageId so callers (e.g. server.ts) don't treat
-    // this as a persistence failure.
+    // Unknown slash command — persist the exchange (user + assistant) so the
+    // messageId is real.  Without persistence, callers like the channel inbound
+    // path would see "success" but find a stale assistant reply in the DB.
     if (slashResult.kind === 'unknown') {
+      const userMsg = createUserMessage(content, []);
+      this.messages.push(userMsg);
+      const persisted = conversationStore.addMessage(
+        this.conversationId,
+        'user',
+        JSON.stringify(userMsg.content),
+      );
+
+      const assistantMsg = createAssistantMessage(slashResult.message);
+      this.messages.push(assistantMsg);
+      conversationStore.addMessage(
+        this.conversationId,
+        'assistant',
+        JSON.stringify(assistantMsg.content),
+      );
+
       onEvent({ type: 'assistant_text_delta', text: slashResult.message });
       onEvent({ type: 'message_complete', sessionId: this.conversationId });
-      return uuid();
+      return persisted.id;
     }
 
     const resolvedContent = slashResult.content;


### PR DESCRIPTION
## Summary
- Addresses Codex P2 feedback on #1948: the synthetic UUID for unknown slash commands made `DaemonServer.processMessage` report success without any persisted data, causing the channel inbound path to surface stale assistant replies
- Now persists both the user message and the deterministic assistant response to the conversation store, so the messageId is real and the DB has the correct reply
- Updated both `processMessage` and `drainQueue` paths in `session.ts`
- Added test verifying that unknown slash commands persist both user and assistant messages

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 5 unknown slash tests pass (including new persistence test)
- [x] All 9 slash tests pass across 3 test files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
