### PR TITLE
feat(sandbox): fail closed when sandbox cannot be applied

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realChildProcess from 'node:child_process';
+
+let platform = 'linux';
+
+const execSyncMock = mock((_command: string) => {
+  throw new Error('bwrap unavailable');
+});
+
+mock.module('../util/platform.js', () => ({
+  isMacOS: () => platform === 'darwin',
+  isLinux: () => platform === 'linux',
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  execSync: execSyncMock,
+}));
+
+const { wrapCommand } = await import('../tools/terminal/sandbox.js');
+const { ToolError } = await import('../util/errors.js');
+
+describe('terminal sandbox fail-closed behavior', () => {
+  beforeEach(() => {
+    platform = 'linux';
+    execSyncMock.mockImplementation((_command: string) => {
+      throw new Error('bwrap unavailable');
+    });
+  });
+
+  test('throws when sandbox is enabled and bwrap is unavailable on linux', () => {
+    expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(ToolError);
+    expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(
+      'Sandbox is enabled but bwrap is not available or cannot create namespaces.',
+    );
+  });
+
+  test('enabled=false still returns unsandboxed bash command', () => {
+    const wrapped = wrapCommand('pwd', '/tmp', false);
+    expect(wrapped).toEqual({
+      command: 'bash',
+      args: ['-c', '--', 'pwd'],
+      sandboxed: false,
+    });
+  });
+
+  test('throws when sandbox is enabled on unsupported platforms', () => {
+    platform = 'win32';
+    expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(
+      'Sandbox is enabled but not supported on this platform (',
+    );
+  });
+});

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -152,8 +152,8 @@ export interface SandboxResult {
  *
  * On macOS, wraps with sandbox-exec using an SBPL profile.
  * On Linux, wraps with bwrap (bubblewrap) if available.
- * On unsupported platforms or when bwrap is missing, returns the
- * command unchanged with a warning.
+ * If sandboxing is enabled and the backend cannot be applied, fails closed
+ * by throwing ToolError instead of executing unsandboxed.
  */
 export function wrapCommand(
   command: string,
@@ -186,12 +186,9 @@ export function wrapCommand(
 
   if (isLinux()) {
     if (!isBwrapAvailable()) {
-      log.warn('Sandbox is enabled but bwrap is not available or cannot create namespaces. Running unsandboxed. Install bubblewrap: apt install bubblewrap');
-      return {
-        command: 'bash',
-        args: ['-c', '--', command],
-        sandboxed: false,
-      };
+      const msg = 'Sandbox is enabled but bwrap is not available or cannot create namespaces. Refusing to execute unsandboxed. Install bubblewrap (for example: apt install bubblewrap), or disable sandboxing.';
+      log.error(msg);
+      throw new ToolError(msg, 'bash');
     }
     return {
       command: 'bwrap',
@@ -200,10 +197,7 @@ export function wrapCommand(
     };
   }
 
-  log.warn('Sandbox is enabled but not supported on this platform. Running unsandboxed.');
-  return {
-    command: 'bash',
-    args: ['-c', '--', command],
-    sandboxed: false,
-  };
+  const msg = `Sandbox is enabled but not supported on this platform (${process.platform}). Refusing to execute unsandboxed. Disable sandboxing to run shell commands.`;
+  log.error(msg);
+  throw new ToolError(msg, 'bash');
 }


### PR DESCRIPTION
## Summary
- change shell sandbox wrapping to fail closed when sandbox is enabled but cannot be applied
- replace Linux bwrap fallback and unsupported-platform fallback with actionable `ToolError` failures
- add focused `wrapCommand` tests for Linux unavailable backend, unsupported platform, and unchanged enabled=false behavior

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/terminal-sandbox.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
