### PR TITLE
fix(executor): derive executionTarget from tool metadata for proxy tools

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -405,6 +405,12 @@ function resolveExecutionTarget(toolName: string): ExecutionTarget {
   if (toolName.startsWith('host_') || toolName.startsWith('cu_') || toolName === 'request_computer_control') {
     return 'host';
   }
+  // Check the tool's executionMode metadata — proxy tools run on the connected
+  // client (host), not inside the sandbox.
+  const tool = getTool(toolName);
+  if (tool?.executionMode === 'proxy') {
+    return 'host';
+  }
   return 'sandbox';
 }
 


### PR DESCRIPTION
## Summary

`resolveExecutionTarget` previously hard-coded host detection to `host_*`, `cu_*`, and `request_computer_control` name prefixes, defaulting everything else to `sandbox`. This misclassified proxy tools like `app_open` and `ui_*` tools (declared with `executionMode: 'proxy'`) which actually run on the connected client (host), not in the sandbox.

The function now also looks up the tool's `executionMode` from the registry. Tools with `executionMode: 'proxy'` correctly return `'host'` as their execution target, fixing permission/audit events that previously reported the wrong execution context.

Addresses feedback from PR #1951.

## Changes

- `assistant/src/tools/executor.ts`: Added `getTool` lookup in `resolveExecutionTarget` to check `executionMode === 'proxy'` and return `'host'` for proxy tools.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
