### PR TITLE
feat(config): set sandbox.enabled default to true

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -79,7 +79,7 @@ describe('AssistantConfigSchema', () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
     });
-    expect(result.sandbox).toEqual({ enabled: false });
+    expect(result.sandbox).toEqual({ enabled: true });
     expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
     expect(result.secretDetection).toEqual({ enabled: true, action: 'warn', entropyThreshold: 4.0 });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
@@ -397,7 +397,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back for invalid sandbox.enabled', () => {
     writeConfig({ sandbox: { enabled: 'yes' } });
     const config = loadConfig();
-    expect(config.sandbox.enabled).toBe(false);
+    expect(config.sandbox.enabled).toBe(true);
   });
 
   test('falls back for invalid contextWindow relationship', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -86,7 +86,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     permissionTimeoutSec: 300,
   },
   sandbox: {
-    enabled: false,
+    enabled: true,
   },
   rateLimit: {
     maxRequestsPerMinute: 0,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -26,7 +26,7 @@ export const TimeoutConfigSchema = z.object({
 export const SandboxConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'sandbox.enabled must be a boolean' })
-    .default(false),
+    .default(true),
 });
 
 export const RateLimitConfigSchema = z.object({
@@ -527,7 +527,7 @@ export const AssistantConfigSchema = z.object({
     permissionTimeoutSec: 300,
   }),
   sandbox: SandboxConfigSchema.default({
-    enabled: false,
+    enabled: true,
   }),
   rateLimit: RateLimitConfigSchema.default({
     maxRequestsPerMinute: 0,


### PR DESCRIPTION
## Summary
- switch config defaults so `sandbox.enabled` is `true` by default
- update schema defaults at both sandbox field and top-level assistant config defaults
- update config-schema tests to assert default/fallback sandbox behavior now resolves to true

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/config-schema.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
