### PR TITLE
feat(daemon): run sessions from global sandbox filesystem

### DIFF
--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Provider } from '../providers/types.js';
+import type { CuObservation } from '../daemon/ipc-protocol.js';
+
+let capturedWorkingDir: string | undefined;
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => '/tmp',
+  getDataDir: () => '/tmp/data',
+  getSandboxRootDir: () => '/tmp/sandbox',
+  getSandboxWorkingDir: () => '/tmp/sandbox/fs',
+  getPlatformName: () => 'linux',
+  getClipboardCommand: () => null,
+  getSocketPath: () => '/tmp/test.sock',
+  getPidPath: () => '/tmp/test.pid',
+  getDbPath: () => '/tmp/data/db/assistant.db',
+  getLogPath: () => '/tmp/test.log',
+  getHistoryPath: () => '/tmp/data/history',
+  getHooksDir: () => '/tmp/hooks',
+  removeSocketFile: () => {},
+  ensureDataDir: () => {},
+  migrateToDataLayout: () => {},
+  isMacOS: () => false,
+  isLinux: () => true,
+  isWindows: () => false,
+}));
+
+mock.module('../tools/executor.js', () => ({
+  ToolExecutor: class {
+    constructor(..._args: unknown[]) {}
+
+    async execute(
+      _name: string,
+      _input: Record<string, unknown>,
+      context: { workingDir: string },
+    ) {
+      capturedWorkingDir = context.workingDir;
+      return { content: 'ok', isError: false };
+    }
+  },
+}));
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    private readonly runTool: (name: string, input: Record<string, unknown>) => Promise<unknown>;
+
+    constructor(
+      _provider: unknown,
+      _systemPrompt: unknown,
+      _options: unknown,
+      _toolDefs: unknown,
+      toolExecutor: (name: string, input: Record<string, unknown>) => Promise<unknown>,
+    ) {
+      this.runTool = toolExecutor;
+    }
+
+    async run(_messages: unknown, _onEvent: unknown, _signal?: AbortSignal): Promise<void> {
+      await this.runTool('cu_click', { element_id: 1 });
+    }
+  },
+}));
+
+const { ComputerUseSession } = await import('../daemon/computer-use-session.js');
+
+describe('ComputerUseSession working directory', () => {
+  beforeEach(() => {
+    capturedWorkingDir = undefined;
+  });
+
+  test('uses sandbox working directory for tool execution context', async () => {
+    const provider: Provider = {
+      name: 'mock-provider',
+      async sendMessage() {
+        return {
+          content: [{ type: 'text', text: 'unused' }],
+          model: 'mock-model',
+          usage: { inputTokens: 1, outputTokens: 1 },
+          stopReason: 'end_turn',
+        };
+      },
+    };
+
+    const session = new ComputerUseSession(
+      'cu-sandbox-1',
+      'test task',
+      1440,
+      900,
+      provider,
+      () => {},
+    );
+
+    const observation: CuObservation = {
+      type: 'cu_observation',
+      sessionId: 'cu-sandbox-1',
+      axTree: 'Window "Test" [1]',
+    };
+
+    await session.handleObservation(observation);
+
+    expect(capturedWorkingDir).toBe('/tmp/sandbox/fs');
+  });
+});

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -10,14 +10,24 @@ const conversation = {
   totalEstimatedCost: 0,
 };
 
+let lastCreatedWorkingDir: string | undefined;
+
 class MockSession {
   public readonly conversationId: string;
   public updateClientCalls = 0;
   private stale = false;
   private processing = false;
 
-  constructor(conversationId: string) {
+  constructor(
+    conversationId: string,
+    _provider?: unknown,
+    _systemPrompt?: string,
+    _maxResponseTokens?: number,
+    _sendToClient?: unknown,
+    workingDir?: string,
+  ) {
     this.conversationId = conversationId;
+    lastCreatedWorkingDir = workingDir;
   }
 
   async loadFromDb(): Promise<void> {}
@@ -60,6 +70,7 @@ mock.module('../util/logger.js', () => ({
 mock.module('../util/platform.js', () => ({
   getSocketPath: () => '/tmp/test.sock',
   getDataDir: () => '/tmp',
+  getSandboxWorkingDir: () => '/tmp/sandbox/fs',
 }));
 
 mock.module('../providers/registry.js', () => ({
@@ -155,6 +166,7 @@ function decodeMessages(writes: string[]): Array<Record<string, unknown>> {
 describe('DaemonServer initial session hydration', () => {
   beforeEach(() => {
     conversation.updatedAt = Date.now();
+    lastCreatedWorkingDir = undefined;
   });
 
   test('hydrates latest session before session_info so undo works after reconnect', async () => {
@@ -186,5 +198,15 @@ describe('DaemonServer initial session hydration', () => {
 
     expect(existingSession.updateClientCalls).toBe(0);
     expect(internal.socketToSession.size).toBe(0);
+  });
+
+  test('creates sessions with sandbox working dir by default', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+
+    expect(lastCreatedWorkingDir).toBe('/tmp/sandbox/fs');
   });
 });

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -18,6 +18,7 @@ import { SecretPrompter } from '../permissions/secret-prompter.js';
 import { allComputerUseTools } from '../tools/computer-use/definitions.js';
 import { allUiSurfaceTools } from '../tools/ui-surface/definitions.js';
 import { buildComputerUseSystemPrompt } from '../config/computer-use-prompt.js';
+import { getSandboxWorkingDir } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 
 const log = getLogger('computer-use-session');
@@ -404,7 +405,7 @@ export class ComputerUseSession {
       input: Record<string, unknown>,
     ): Promise<ToolExecutionResult> => {
       return executor.execute(name, input, {
-        workingDir: process.cwd(),
+        workingDir: getSandboxWorkingDir(),
         sessionId: this.sessionId,
         conversationId: this.sessionId,
         proxyToolResolver: proxyResolver,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 import { existsSync, chmodSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
-import { getSocketPath, getRootDir, removeSocketFile } from '../util/platform.js';
+import { getSocketPath, getRootDir, getSandboxWorkingDir, removeSocketFile } from '../util/platform.js';
 import { getLogger } from '../util/logger.js';
 import { getProvider, initializeProviders } from '../providers/registry.js';
 import { RateLimitProvider } from '../providers/ratelimit.js';
@@ -498,7 +498,7 @@ export class DaemonServer {
         if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
           provider = new RateLimitProvider(provider, rateLimit, this.sharedRequestTimestamps);
         }
-        const workingDir = process.cwd();
+        const workingDir = getSandboxWorkingDir();
 
         const systemPrompt = storedOptions?.systemPromptOverride ?? buildSystemPrompt();
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;


### PR DESCRIPTION
## Summary
- switch daemon text-session initialization from `process.cwd()` to `getSandboxWorkingDir()`
- switch computer-use tool execution context to the same sandbox working directory
- add/extend daemon and computer-use session tests to assert sandbox-root working dir behavior

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/daemon-server-session-init.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/computer-use-session-working-dir.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
