### PR TITLE
fix(ui): hide tool call chips when inline surface is present

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -160,6 +160,17 @@ struct ChatView: View {
 
     // MARK: - Message List
 
+    /// Check if the next assistant message after `index` has inline surfaces,
+    /// meaning tool call chips at `index` should be hidden.
+    private func nextAssistantHasSurfaces(after index: Int) -> Bool {
+        for i in (index + 1)..<messages.count {
+            let m = messages[i]
+            if m.role == .user { break }
+            if !m.inlineSurfaces.isEmpty { return true }
+        }
+        return false
+    }
+
     private func shouldShowTimestamp(at index: Int) -> Bool {
         if index == 0 { return true }
         let current = messages[index].timestamp
@@ -189,7 +200,11 @@ struct ChatView: View {
                             .id(message.id)
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                         } else {
-                            ChatBubble(message: message, onSurfaceAction: onSurfaceAction)
+                            ChatBubble(
+                                message: message,
+                                hideToolCalls: nextAssistantHasSurfaces(after: index),
+                                onSurfaceAction: onSurfaceAction
+                            )
                                 .id(message.id)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
@@ -527,6 +542,8 @@ struct ChatView: View {
 
 private struct ChatBubble: View {
     let message: ChatMessage
+    /// When true, tool call chips are suppressed because a nearby message has inline surfaces.
+    let hideToolCalls: Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
 
     private var isUser: Bool { message.role == .user }
@@ -602,8 +619,8 @@ private struct ChatBubble: View {
                 }
 
                 // Tool calls render outside the bubble as compact chips.
-                // Hidden when inline surfaces are present — the dynamic UI replaces the tool output.
-                if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty {
+                // Hidden when inline surfaces are present (same or adjacent message).
+                if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(message.toolCalls) { toolCall in
                             ToolCallChip(toolCall: toolCall)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -797,6 +797,10 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].inlineSurfaces.append(inlineSurface)
+            } else if let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant }) {
+                // Attach to the last assistant message so the surface lives alongside
+                // its tool call, letting the rendering logic hide the tool call chip.
+                messages[lastAssistantIndex].inlineSurfaces.append(inlineSurface)
             } else {
                 let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
                 currentAssistantMessageId = newMsg.id


### PR DESCRIPTION
## Summary
- When a tool like `get_weather` returns a text result AND the model renders a dynamic UI widget (via `ui_show`), the raw tool call chip was still visible above the widget
- **Data fix**: attach `uiSurfaceShow` events to the last assistant message when `currentAssistantMessageId` is already cleared, so the surface and tool call share a message and the existing hiding logic works
- **Rendering fix**: add `nextAssistantHasSurfaces()` check to hide tool call chips when a subsequent assistant message in the same turn has inline surfaces (defense in depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
