### PR TITLE
chore(security): remove no-sandbox runtime override behavior

### DIFF
--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -15,6 +15,7 @@ let lastCreatedWorkingDir: string | undefined;
 class MockSession {
   public readonly conversationId: string;
   public updateClientCalls = 0;
+  public setSandboxOverrideCalls = 0;
   private stale = false;
   private processing = false;
 
@@ -36,7 +37,9 @@ class MockSession {
     this.updateClientCalls += 1;
   }
 
-  setSandboxOverride(): void {}
+  setSandboxOverride(): void {
+    this.setSandboxOverrideCalls += 1;
+  }
 
   isProcessing(): boolean {
     return this.processing;
@@ -208,5 +211,20 @@ describe('DaemonServer initial session hydration', () => {
     await internal.sendInitialSession(socket);
 
     expect(lastCreatedWorkingDir).toBe('/tmp/sandbox/fs');
+  });
+
+  test('ignores deprecated sandbox_set runtime override messages', async () => {
+    const server = new DaemonServer();
+    const internal = asDaemonServerTestAccess(server);
+    const { socket } = createFakeSocket();
+
+    await internal.sendInitialSession(socket);
+    const session = internal.sessions.get(conversation.id);
+    expect(session).toBeDefined();
+    expect(session!.setSandboxOverrideCalls).toBe(0);
+
+    internal.dispatchMessage({ type: 'sandbox_set', enabled: false }, socket);
+
+    expect(session!.setSandboxOverrideCalls).toBe(0);
   });
 });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -22,10 +22,6 @@ const HEARTBEAT_TIMEOUT_MS = 10_000;
 const RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 
-export interface CliOptions {
-  noSandbox?: boolean;
-}
-
 export function sanitizeUrlForDisplay(rawUrl: unknown): string {
   const value = typeof rawUrl === 'string' ? rawUrl : String(rawUrl ?? '');
   if (!value) return '';
@@ -43,7 +39,7 @@ export function sanitizeUrlForDisplay(rawUrl: unknown): string {
   }
 }
 
-export async function startCli(options: CliOptions = {}): Promise<void> {
+export async function startCli(): Promise<void> {
   const socketPath = getSocketPath();
   let socket: net.Socket;
   let parser = createMessageParser();
@@ -632,9 +628,6 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
       try {
         if (shouldAutoStartDaemon()) await ensureDaemonRunning();
         await connect();
-        if (options.noSandbox) {
-          send({ type: 'sandbox_set', enabled: false });
-        }
         reconnecting = false;
         return;
       } catch {
@@ -834,8 +827,4 @@ export async function startCli(options: CliOptions = {}): Promise<void> {
   // Initial connection
   await connect();
 
-  // Send sandbox override if --no-sandbox was passed
-  if (options.noSandbox) {
-    send({ type: 'sandbox_set', enabled: false });
-  }
 }

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -659,20 +659,13 @@ function handleModelSet(
 
 function handleSandboxSet(
   msg: SandboxSetRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
+  _socket: net.Socket,
+  _ctx: HandlerContext,
 ): void {
-  // Per-socket override: store the sandbox preference for this client only.
-  // The override is applied to the session so it doesn't affect other clients.
-  ctx.socketSandboxOverride.set(socket, msg.enabled);
-  const sessionId = ctx.socketToSession.get(socket);
-  if (sessionId) {
-    const session = ctx.sessions.get(sessionId);
-    if (session) {
-      session.setSandboxOverride(msg.enabled);
-    }
-  }
-  log.info({ enabled: msg.enabled }, 'Sandbox override applied (per-session)');
+  log.warn(
+    { enabled: msg.enabled },
+    'Received deprecated sandbox_set message. Runtime sandbox overrides are ignored.',
+  );
 }
 
 export interface ParsedHistoryMessage {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -101,12 +101,11 @@ program
   .name('vellum')
   .description('Local AI assistant')
   .version(version)
-  .option('--no-sandbox', 'Disable sandbox for this session (runtime override, not persisted)')
-  .action(async (opts: { sandbox?: boolean }) => {
+  .action(async () => {
     if (shouldAutoStartDaemon()) {
       await ensureDaemonRunning();
     }
-    await startCli({ noSandbox: opts.sandbox === false });
+    await startCli();
   });
 
 const daemon = program.command('daemon').description('Manage the daemon process');
@@ -955,7 +954,7 @@ _vellum_completions() {
     _init_completion || return
 
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "${topLevel.join(' ')} --help --version --no-sandbox" -- "$cur") )
+        COMPREPLY=( $(compgen -W "${topLevel.join(' ')} --help --version" -- "$cur") )
         return
     fi
 
@@ -999,7 +998,7 @@ _vellum() {
 
     if (( CURRENT == 2 )); then
         _describe 'command' commands
-        _arguments '--help[Show help]' '--version[Show version]' '--no-sandbox[Disable sandbox]'
+        _arguments '--help[Show help]' '--version[Show version]'
         return
     fi
 
@@ -1046,7 +1045,6 @@ function generateFishCompletion(
   }
   script += `complete -c vellum -n '__fish_use_subcommand' -l help -d 'Show help'\n`;
   script += `complete -c vellum -n '__fish_use_subcommand' -l version -d 'Show version'\n`;
-  script += `complete -c vellum -n '__fish_use_subcommand' -l no-sandbox -d 'Disable sandbox'\n`;
 
   // Subcommands
   for (const [cmd, subs] of Object.entries(subcommands)) {


### PR DESCRIPTION
## Summary
- remove `--no-sandbox` from CLI entrypoint behavior and generated shell completions
- stop sending `sandbox_set` overrides from the interactive CLI
- keep `sandbox_set` IPC compatibility but handle it as a deprecated no-op with warning logs
- add daemon-session test coverage asserting deprecated `sandbox_set` does not apply runtime overrides

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/daemon-server-session-init.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/ipc-snapshot.test.ts src/__tests__/cli.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && for shell in bash zsh fish; do if BASE_DATA_DIR=/tmp bun run src/index.ts completions $shell | rg -q "no-sandbox"; then echo "$shell: found no-sandbox"; else echo "$shell: no no-sandbox flag"; fi; done

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
