### PR TITLE
fix(ui): scale side panel width by zoom level

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -41,7 +41,7 @@ struct MainWindowView: View {
                         daemonClient: daemonClient
                     )
                 } else {
-                    VSplitView(panelWidth: geometry.size.width * 0.5, showPanel: activePanel != nil, main: {
+                    VSplitView(panelWidth: geometry.size.width / zoomManager.zoomLevel * 0.5, showPanel: activePanel != nil, main: {
                         if let viewModel = threadManager.activeViewModel {
                             ChatView(
                                 messages: viewModel.messages,


### PR DESCRIPTION
## Summary
- Fixed panelWidth calculation in `MainWindowView` to account for zoom level
- Previously, `panelWidth: geometry.size.width * 0.5` used raw window width, but the containing VStack frame uses `geometry.size.width / zoomManager.zoomLevel` (logical width)
- At zoom 1.5x with a 1000px window, the panel consumed 75% instead of 50%; at 2.0x it consumed 100%, completely hiding the chat
- Changed to `geometry.size.width / zoomManager.zoomLevel * 0.5` so the panel is always half the logical content width

## Test plan
- [ ] Build succeeds (`./build.sh` passes)
- [ ] At zoom 1.0x, side panel takes up ~50% of the window (unchanged behavior)
- [ ] At zoom 1.5x, side panel still takes up ~50% of the logical viewport
- [ ] At zoom 2.0x, side panel still takes up ~50% of the logical viewport, chat remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
