### PR TITLE
fix(permissions): migrate stale default trust rules on load

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -59,6 +59,24 @@ function backfillDefaults(rules: TrustRule[]): boolean {
     }
   }
 
+  // Migrate existing default rules whose priority or pattern has changed
+  // in the template (e.g. host_bash pattern changed from '*' to '**',
+  // host tool priorities changed from 1000 to 50).
+  for (const template of getDefaultRuleTemplates()) {
+    if (existingIds.has(template.id)) {
+      const rule = rules.find((r) => r.id === template.id);
+      if (rule && (rule.priority !== template.priority || rule.pattern !== template.pattern)) {
+        log.info(
+          { ruleId: rule.id, oldPriority: rule.priority, newPriority: template.priority, oldPattern: rule.pattern, newPattern: template.pattern },
+          'Migrated default rule to updated template values',
+        );
+        rule.priority = template.priority;
+        rule.pattern = template.pattern;
+        changed = true;
+      }
+    }
+  }
+
   for (const template of getDefaultRuleTemplates()) {
     if (!existingIds.has(template.id)) {
       rules.push({


### PR DESCRIPTION
## Summary

Addresses feedback from PR #1957 (Codex P1 + Devin P1):

- Existing users who had `default:ask-host_*` rules persisted in `trust.json` kept old `priority: 1000` and `pattern: '*'` values because `backfillDefaults` only adds rules when their ID is missing
- Added a migration step in `backfillDefaults` that detects persisted default rules whose `priority` or `pattern` differs from the current template and updates them in-place
- This mirrors the pattern of the existing deny→ask migration (lines 47-60)

## Files changed

- `assistant/src/permissions/trust-store.ts` — added default rule template migration block

## Test plan

- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Verify existing tests pass
- [ ] Manual: create a trust.json with old default rule values (priority 1000, pattern '*'), restart daemon, confirm rules are updated to template values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
