### PR TITLE
fix(sandbox): only cache positive bwrap availability checks

### DIFF
--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -88,8 +88,11 @@ function getProfilePath(workingDir: string): string {
   return path;
 }
 
-/** Cache bwrap usability check so we only shell out once. */
-let bwrapAvailable: boolean | null = null;
+/**
+ * Cache positive bwrap results only. Negative results are not cached so that
+ * installing bwrap after the daemon starts takes effect without a restart.
+ */
+let bwrapAvailable = false;
 
 /**
  * Check whether bwrap is installed AND functional (can create namespaces).
@@ -99,16 +102,19 @@ let bwrapAvailable: boolean | null = null;
  * or when user namespaces are disabled). We run a minimal sandbox that
  * exercises all namespace types used by buildBwrapArgs() (mount, network,
  * PID) to verify end-to-end functionality.
+ *
+ * Only positive results are cached — if bwrap is unavailable, we re-check
+ * on every call so that a mid-session install is picked up immediately.
  */
 function isBwrapAvailable(): boolean {
-  if (bwrapAvailable !== null) return bwrapAvailable;
+  if (bwrapAvailable) return true;
   try {
     execSync('bwrap --ro-bind / / --unshare-net --unshare-pid true', { stdio: 'ignore', timeout: 5000 });
     bwrapAvailable = true;
+    return true;
   } catch {
-    bwrapAvailable = false;
+    return false;
   }
-  return bwrapAvailable;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback from PR #1961.

`isBwrapAvailable()` previously memoized both positive and negative results. This meant a user who installed bubblewrap after the daemon started would still get "bwrap is not available" errors until restarting the daemon — making the remediation guidance misleading.

**Fix:** Only cache positive results. Negative results now trigger a re-check on every call, so a mid-session `apt install bubblewrap` is picked up immediately without a daemon restart.

## Changes

- `assistant/src/tools/terminal/sandbox.ts`: Changed `bwrapAvailable` from a nullable boolean to a simple boolean flag. The `isBwrapAvailable()` function now returns `false` without caching on failure, while still caching `true` on success to avoid repeated `execSync` calls once bwrap is confirmed working.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
