### PR TITLE
fix(session): guard unknown-slash persistence and preserve attachments

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -836,24 +836,31 @@ export class Session {
 
     // Unknown slash — persist the exchange and continue draining
     if (slashResult.kind === 'unknown') {
-      const userMsg = createUserMessage(next.content, []);
-      this.messages.push(userMsg);
-      conversationStore.addMessage(
-        this.conversationId,
-        'user',
-        JSON.stringify(userMsg.content),
-      );
+      try {
+        const userMsg = createUserMessage(next.content, next.attachments);
+        this.messages.push(userMsg);
+        conversationStore.addMessage(
+          this.conversationId,
+          'user',
+          JSON.stringify(userMsg.content),
+        );
 
-      const assistantMsg = createAssistantMessage(slashResult.message);
-      this.messages.push(assistantMsg);
-      conversationStore.addMessage(
-        this.conversationId,
-        'assistant',
-        JSON.stringify(assistantMsg.content),
-      );
+        const assistantMsg = createAssistantMessage(slashResult.message);
+        this.messages.push(assistantMsg);
+        conversationStore.addMessage(
+          this.conversationId,
+          'assistant',
+          JSON.stringify(assistantMsg.content),
+        );
 
-      next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
-      next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
+        next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
+        next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist unknown-slash exchange');
+        next.onEvent({ type: 'error', message });
+      }
+      // Continue draining regardless of success/failure
       this.drainQueue();
       return;
     }
@@ -903,7 +910,7 @@ export class Session {
     // messageId is real.  Without persistence, callers like the channel inbound
     // path would see "success" but find a stale assistant reply in the DB.
     if (slashResult.kind === 'unknown') {
-      const userMsg = createUserMessage(content, []);
+      const userMsg = createUserMessage(content, attachments);
       this.messages.push(userMsg);
       const persisted = conversationStore.addMessage(
         this.conversationId,


### PR DESCRIPTION
## Summary

Addresses Codex P1 and P2 feedback on #1959:

- **P1 — Error handling**: Wrapped the `drainQueue` unknown-slash persistence path in a `try/catch` that emits an `error` event and continues draining remaining queued messages, matching the pattern used for `persistUserMessage` failures. Previously, a DB error (e.g. FK violation, transient SQLite write error) would escape `drainQueue`, strand all remaining queued messages, and leave the unknown-slash request without an error or completion event.

- **P2 — Attachments**: Changed `createUserMessage(content, [])` to `createUserMessage(content, attachments)` in both `drainQueue` and `processMessage` unknown-slash branches. Previously, any attachment IDs submitted with an unrecognized slash command were silently dropped from the persisted user turn.

## Files modified

- `assistant/src/daemon/session.ts`

## Test plan

- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Verify that a DB failure during unknown-slash persistence in `drainQueue` emits an error event and does not strand subsequent queued messages
- [ ] Verify that attachments submitted with an unknown slash command are preserved in the persisted user message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
