### PR TITLE
fix(permissions): use standalone globstar for computer-use default rules

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -68,12 +68,15 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 50,
   };
 
-  // Use "**" (globstar) so the pattern still matches when buildCommandCandidates
-  // appends a path containing "/" (e.g. "cu_click:/tmp/foo").
+  // Standalone "**" globstar — minimatch only treats ** as globstar when it is
+  // its own path segment, so a "tool:**" prefix would collapse to single-star
+  // behavior and fail to match candidates containing "/".  The tool is already
+  // filtered by `findHighestPriorityRule` (rule.tool !== tool), so a prefix is
+  // unnecessary.
   const computerUseRules = COMPUTER_USE_TOOLS.map((tool) => ({
     id: `default:ask-${tool}-global`,
     tool,
-    pattern: `${tool}:**`,
+    pattern: '**',
     scope: 'everywhere',
     decision: 'ask' as const,
     priority: 1000,


### PR DESCRIPTION
## Summary

Fixes the computer-use default trust rule patterns in `defaults.ts` to use standalone `**` (globstar) instead of `${tool}:**`.

**Problem:** `minimatch` only treats `**` as globstar when it is its own path segment (between `/` separators). The `${tool}:**` pattern placed `**` in the same segment as the tool prefix, so it collapsed to single-star behavior and failed to match candidates containing `/` (e.g. `cu_click:/tmp/foo`). This meant the default `ask` rule wouldn't match and requests could fall through to auto-allow.

**Fix:** Change the pattern to standalone `**`, matching how `host_bash` already works. The tool is already filtered by `findHighestPriorityRule` (`rule.tool !== tool`), so no tool-name prefix in the pattern is needed. The migration from PR #1970 (`backfillDefaults` in `trust-store.ts`) will automatically update existing users' persisted rules when the pattern differs from the template.

Addresses feedback from PR #1960.

## Changed files
- `assistant/src/permissions/defaults.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
