### PR TITLE
fix(chat): scope uiSurfaceShow fallback to current turn

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -797,10 +797,11 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].inlineSurfaces.append(inlineSurface)
-            } else if let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant }) {
-                // Attach to the last assistant message so the surface lives alongside
-                // its tool call, letting the rendering logic hide the tool call chip.
-                messages[lastAssistantIndex].inlineSurfaces.append(inlineSurface)
+            } else if let lastUserIndex = messages.lastIndex(where: { $0.role == .user }),
+                      let idx = messages[lastUserIndex...].lastIndex(where: { $0.role == .assistant }) {
+                // Scope to the current turn so we never attach to an assistant message
+                // from a previous conversation turn.
+                messages[idx].inlineSurfaces.append(inlineSurface)
             } else {
                 let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
                 currentAssistantMessageId = newMsg.id


### PR DESCRIPTION
## Summary
- Fixes bug where `uiSurfaceShow` fallback could attach an inline surface to an assistant message from a previous conversation turn
- Scopes the fallback search to only assistant messages after the last user message (current turn)
- If no assistant message exists in the current turn, falls through to creating a new message

Addresses review feedback on #1965.

## Test plan
- [ ] Verify surfaces still attach correctly to the current assistant message when `currentAssistantMessageId` is set
- [ ] Verify surfaces attach to the correct assistant message in the current turn when `currentAssistantMessageId` is nil
- [ ] Verify a new assistant message is created when no assistant message exists in the current turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
