### PR TITLE
fix(ui): use keyboard shortcut for Return-to-send in composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -436,11 +436,6 @@ struct ChatView: View {
                     }
                     return .ignored
                 }
-                .onKeyPress(.return, phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.shift) { return .ignored }
-                    if canSend { onSend() }
-                    return .handled
-                }
                 .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
                     if keyPress.modifiers.contains(.command) {
                         onPaste()
@@ -500,6 +495,17 @@ struct ChatView: View {
                 }
             }
             .animation(VAnimation.spring, value: canSend)
+
+            // Hidden button intercepts bare Return at the window/menu level,
+            // before NSTextView's insertNewline: fires. Shift+Return still
+            // inserts a newline because the shortcut only matches unmodified Return.
+            Button("") {
+                if canSend { onSend() }
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .allowsHitTesting(false)
         }
         .padding(.horizontal, VSpacing.xl)
         .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
## Summary

- Replace `onKeyPress(.return)` with a hidden `Button` using `.keyboardShortcut(.return, modifiers: [])` in the chat composer
- Fixes bug where `TextEditor` (backed by `NSTextView`) inserts a newline via `insertNewline:` at the AppKit level before SwiftUI's `onKeyPress` handler fires, causing every sent message to contain a trailing `\n`
- Follows the existing pattern from `TaskInputView.swift` where a hidden button with keyboard shortcut intercepts Return at the window/menu level, before NSTextView can process it
- Shift+Return continues to work for inserting newlines since the shortcut only matches unmodified Return

Addresses feedback from PR #1969.

## Test plan

- [ ] Type a message and press Return — message sends without trailing newline
- [ ] Press Shift+Return — inserts newline in the text editor as expected
- [ ] Verify the send button still works when clicked
- [ ] Verify empty input still does not send on Return

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
