### PR TITLE
fix(a11y): hide measurement text from assistive technologies

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -370,6 +370,7 @@ struct ChatView: View {
                         .foregroundColor(.clear)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 8)
+                        .accessibilityHidden(true)
                         .background(
                             GeometryReader { geo in
                                 Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)


### PR DESCRIPTION
## Summary

- Adds `.accessibilityHidden(true)` to the invisible sizing `Text` in the composer area of `ChatView.swift`
- The sizing text uses `.foregroundColor(.clear)` to measure content height but was still exposed in the accessibility tree, causing VoiceOver to announce duplicate content while composing

Addresses feedback from PR #1974.

## Test plan

- [ ] Build succeeds (`swift build --target vellum-assistant`)
- [ ] VoiceOver no longer announces duplicate content in the message composer
- [ ] Composer height measurement still works correctly (text area grows as content increases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
