### PR TITLE
fix(ui): scope Return-to-send to composer focus

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -436,6 +436,20 @@ struct ChatView: View {
                     }
                     return .ignored
                 }
+                .onKeyPress(.return, phases: .down) { keyPress in
+                    // Shift+Return inserts a newline (handled by TextEditor); bare Return sends.
+                    guard !keyPress.modifiers.contains(.shift) else { return .ignored }
+                    if canSend {
+                        // TextEditor inserts a newline before onKeyPress fires,
+                        // so strip the trailing newline that was just added.
+                        inputText = inputText.replacingOccurrences(
+                            of: "\\n$", with: "", options: .regularExpression
+                        )
+                        onSend()
+                        return .handled
+                    }
+                    return .ignored
+                }
                 .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
                     if keyPress.modifiers.contains(.command) {
                         onPaste()
@@ -495,17 +509,6 @@ struct ChatView: View {
                 }
             }
             .animation(VAnimation.spring, value: canSend)
-
-            // Hidden button intercepts bare Return at the window/menu level,
-            // before NSTextView's insertNewline: fires. Shift+Return still
-            // inserts a newline because the shortcut only matches unmodified Return.
-            Button("") {
-                if canSend { onSend() }
-            }
-            .keyboardShortcut(.return, modifiers: [])
-            .frame(width: 0, height: 0)
-            .opacity(0)
-            .allowsHitTesting(false)
         }
         .padding(.horizontal, VSpacing.xl)
         .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Replaces the hidden `Button` with `.keyboardShortcut(.return, modifiers: [])` — which registered Return as a **window-level** shortcut — with `.onKeyPress(.return)` on the TextEditor container
- This ensures the send action only fires when the composer has focus, preventing accidental sends from other text inputs (e.g. side panel fields)
- Strips the trailing newline that TextEditor inserts before `onKeyPress` fires, preserving the original fix from PR #1977

Addresses feedback from PR #1977.

## Test plan
- [ ] Type a message in the composer and press Return — message sends without trailing newline
- [ ] Press Shift+Return in the composer — newline is inserted, message is not sent
- [ ] Focus a text field in a side panel and press Return — verify `onSend` does NOT fire
- [ ] Verify empty composer does not send on Return

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
