### PR TITLE
fix(ui): clean up composer measurement text and spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,27 +363,12 @@ struct ChatView: View {
             HStack(alignment: .bottom, spacing: VSpacing.sm) {
                 // Text editor with ghost text / placeholder overlay
                 ZStack(alignment: .topLeading) {
-                    // Invisible sizing text — measures content height
-                    Text(inputText.isEmpty ? " " : inputText)
-                        .font(VFont.body)
-                        .lineSpacing(4)
-                        .foregroundColor(.clear)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 8)
-                        .accessibilityHidden(true)
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
-                            }
-                        )
-
                     TextEditor(text: $inputText)
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                         .lineSpacing(4)
                         .scrollContentBackground(.hidden)
                         .scrollDisabled(editorContentHeight <= 200)
-                        .frame(height: min(max(editorContentHeight, 36), 200))
                         .disabled(!hasAPIKey)
                         .accessibilityLabel("Message")
 
@@ -425,6 +410,21 @@ struct ChatView: View {
                             .accessibilityHidden(true)
                     }
                 }
+                .frame(height: min(max(editorContentHeight, 36), 200))
+                .background(
+                    Text(inputText.isEmpty ? " " : inputText)
+                        .font(VFont.body)
+                        .lineSpacing(4)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 8)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .hidden()
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
+                            }
+                        )
+                )
                 .onPreferenceChange(ContentHeightKey.self) { height in
                     withAnimation(VAnimation.spring) {
                         editorContentHeight = height
@@ -512,7 +512,7 @@ struct ChatView: View {
             .animation(VAnimation.spring, value: canSend)
         }
         .padding(.horizontal, VSpacing.xl)
-        .padding(.vertical, VSpacing.sm)
+        .padding(.vertical, VSpacing.md)
         .background(VColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xxl))
         .overlay(


### PR DESCRIPTION
## Summary
- Move the sizing `Text` from inside the ZStack to a `.background()` modifier using `.hidden()` — cleaner than `.foregroundColor(.clear)` + `.accessibilityHidden(true)`, fully removes from both rendering and accessibility
- Move `.frame(height:)` from the TextEditor to the container ZStack for correct height sizing
- Bump composer vertical padding from `.sm` to `.md` for better spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
