### PR TITLE
fix(ui): restrict Return-to-send to bare Return and always strip newline

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -438,18 +438,18 @@ struct ChatView: View {
                     return .ignored
                 }
                 .onKeyPress(.return, phases: .down) { keyPress in
-                    // Shift+Return inserts a newline (handled by TextEditor); bare Return sends.
-                    guard !keyPress.modifiers.contains(.shift) else { return .ignored }
+                    // Only intercept bare Return (no modifiers); any modifier
+                    // (Shift, Cmd, Option, Ctrl) falls through to TextEditor.
+                    guard keyPress.modifiers.isEmpty else { return .ignored }
+                    // TextEditor inserts a newline before onKeyPress fires,
+                    // so always strip the trailing newline that was just added.
+                    inputText = inputText.replacingOccurrences(
+                        of: "\\n$", with: "", options: .regularExpression
+                    )
                     if canSend {
-                        // TextEditor inserts a newline before onKeyPress fires,
-                        // so strip the trailing newline that was just added.
-                        inputText = inputText.replacingOccurrences(
-                            of: "\\n$", with: "", options: .regularExpression
-                        )
                         onSend()
-                        return .handled
                     }
-                    return .ignored
+                    return .handled
                 }
                 .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
                     if keyPress.modifiers.contains(.command) {


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1979:

- **Modifier check too loose (Codex):** The `.onKeyPress(.return)` handler only excluded Shift, so Cmd+Return, Option+Return, and Ctrl+Return all incorrectly triggered `onSend()`. Changed to `keyPress.modifiers.isEmpty` so only unmodified bare Return triggers send.

- **Newline not stripped when canSend is false (Devin):** When `canSend` was false, bare Return inserted a newline (TextEditor processes it before onKeyPress fires) but the handler returned `.ignored`, causing the placeholder to disappear and the editor to grow with blank lines. Now always strips the trailing newline and returns `.handled` for bare Return, regardless of `canSend` state.

## Test plan

- [ ] Type text and press bare Return — message sends
- [ ] Press Shift+Return — newline inserted, no send
- [ ] Press Cmd+Return, Option+Return, Ctrl+Return — all fall through to TextEditor (no send)
- [ ] With empty input, press bare Return — no newline accumulates, placeholder stays visible
- [ ] With only whitespace input, press bare Return — no send, no newline accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
