### PR TITLE
fix(ui): sync composerReservedHeight with vertical padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -99,7 +99,7 @@ struct ChatView: View {
     /// Height reserved at the bottom of the scroll view so the last message isn't hidden behind the composer.
     private var composerReservedHeight: CGFloat {
         let editorClamped = min(max(editorContentHeight, 36), 200)
-        let base: CGFloat = VSpacing.lg * 2 + VSpacing.sm * 2 + editorClamped + 8
+        let base: CGFloat = VSpacing.lg * 2 + VSpacing.md * 2 + editorClamped + 8
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
         let error: CGFloat = errorText != nil ? 36 : 0
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0


### PR DESCRIPTION
## Summary

- Updates `composerReservedHeight` in `ChatView.swift` to use `VSpacing.md * 2` instead of `VSpacing.sm * 2`, matching the vertical padding applied to the composer area.

## Context

PR #1980 changed the composer's vertical padding from `VSpacing.sm` to `VSpacing.md`, but the `composerReservedHeight` calculation was not updated. This caused the scroll view to under-reserve bottom space, allowing the last chat message to be partially obscured behind the floating composer overlay.

Addresses feedback from Devin on #1980.

## Test plan

- [ ] Verify the last chat message is fully visible above the composer overlay
- [ ] Confirm no layout regression with attachments, error banners, or queued messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
