### PR TITLE
fix(ui): move measurement text inline and clip overflow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,6 +363,20 @@ struct ChatView: View {
             HStack(alignment: .bottom, spacing: VSpacing.sm) {
                 // Text editor with ghost text / placeholder overlay
                 ZStack(alignment: .topLeading) {
+                    // Sizing text — measures content height via GeometryReader
+                    Text(inputText.isEmpty ? " " : inputText)
+                        .font(VFont.body)
+                        .lineSpacing(4)
+                        .foregroundColor(.clear)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 8)
+                        .accessibilityHidden(true)
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
+                            }
+                        )
+
                     TextEditor(text: $inputText)
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
@@ -411,20 +425,7 @@ struct ChatView: View {
                     }
                 }
                 .frame(height: min(max(editorContentHeight, 36), 200))
-                .background(
-                    Text(inputText.isEmpty ? " " : inputText)
-                        .font(VFont.body)
-                        .lineSpacing(4)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 8)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .hidden()
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
-                            }
-                        )
-                )
+                .clipped()
                 .onPreferenceChange(ContentHeightKey.self) { height in
                     withAnimation(VAnimation.spring) {
                         editorContentHeight = height


### PR DESCRIPTION
## Summary
- Move the sizing `Text` back inside the ZStack for more reliable height measurement (inline with `.foregroundColor(.clear)` + `.accessibilityHidden(true)`)
- Replace the `.background()` wrapper with `.clipped()` to prevent text overflow from bleeding outside the composer bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
