### PR TITLE
fix(macos): always show window on Spotlight/Dock reopen and scope builds to macOS product

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -50,12 +50,12 @@ CMD="${1:-build}"
 case "$CMD" in
     test)
         echo "Running tests..."
-        swift test
+        swift test --filter vellum-assistantTests
         exit 0
         ;;
     lint)
         echo "Linting (strict concurrency)..."
-        swift build -Xswiftc -strict-concurrency=complete
+        swift build --product "$APP_NAME" -Xswiftc -strict-concurrency=complete
         echo "Lint passed."
         exit 0
         ;;
@@ -85,6 +85,9 @@ fi
 
 # 1. Build with SPM
 echo "Building ($CONFIG)..."
+# Only build the macOS product — the shared Package.swift also contains an iOS
+# target that cannot compile on macOS (UIKit), so we must scope the build.
+SWIFT_FLAGS="$SWIFT_FLAGS --product $APP_NAME"
 # Get bin path first (fast, doesn't rebuild)
 BIN_PATH=$(swift build $SWIFT_FLAGS --show-bin-path)
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -374,9 +374,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag {
-            mainWindow?.show()
-        }
+        // Always show the main window on reopen (e.g. Spotlight, Dock click).
+        // Even when hasVisibleWindows is true, the window may be behind other apps
+        // and the user expects it to come to the front.
+        showMainWindow()
         return true
     }
 


### PR DESCRIPTION
## Summary
- Fix `applicationShouldHandleReopen` to unconditionally call `showMainWindow()` so Spotlight and Dock clicks always bring the window to front (previously did nothing when `hasVisibleWindows` was true)
- Scope `build.sh` build/test/lint commands to `--product vellum-assistant` so the iOS target (which imports UIKit) isn't compiled on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
