### PR TITLE
fix(ui): restore fixedSize on measurement text for unconstrained height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,13 +363,16 @@ struct ChatView: View {
             HStack(alignment: .bottom, spacing: VSpacing.sm) {
                 // Text editor with ghost text / placeholder overlay
                 ZStack(alignment: .topLeading) {
-                    // Sizing text — measures content height via GeometryReader
+                    // Sizing text — measures content height via GeometryReader.
+                    // fixedSize lets this text grow beyond the clamped ZStack frame
+                    // so ContentHeightKey always reflects true multiline content height.
                     Text(inputText.isEmpty ? " " : inputText)
                         .font(VFont.body)
                         .lineSpacing(4)
                         .foregroundColor(.clear)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 8)
+                        .fixedSize(horizontal: false, vertical: true)
                         .accessibilityHidden(true)
                         .background(
                             GeometryReader { geo in


### PR DESCRIPTION
## Summary
- Adds `.fixedSize(horizontal: false, vertical: true)` back to the sizing `Text` in the composer `ZStack`
- Without this, the measurement text was constrained by the clamped frame height, causing `ContentHeightKey` to stop reflecting true multiline content height
- The composer could fail to grow as users typed longer messages
- Addresses feedback from PR #1983

## Test plan
- [ ] Type a multi-line message in the composer and verify it grows correctly
- [ ] Verify the composer stops growing at the 200pt max height
- [ ] Verify single-line messages display at minimum 36pt height

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
