### PR TITLE
fix(session): roll back in-memory messages on unknown-slash persist failure

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -836,6 +836,7 @@ export class Session {
 
     // Unknown slash — persist the exchange and continue draining
     if (slashResult.kind === 'unknown') {
+      const msgCountBefore = this.messages.length;
       try {
         const userMsg = createUserMessage(next.content, next.attachments);
         this.messages.push(userMsg);
@@ -856,6 +857,9 @@ export class Session {
         next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
         next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
       } catch (err) {
+        // Roll back any messages pushed before the error so in-memory
+        // history stays consistent with what was actually persisted.
+        while (this.messages.length > msgCountBefore) this.messages.pop();
         const message = err instanceof Error ? err.message : String(err);
         log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist unknown-slash exchange');
         next.onEvent({ type: 'error', message });


### PR DESCRIPTION
## Summary

When `conversationStore.addMessage` throws in the `drainQueue` unknown-slash branch, any messages already pushed to `this.messages` were not rolled back. This left in-memory history inconsistent with persisted state, causing subsequent queued messages to run with unpersisted history.

**Fix:** Record `this.messages.length` before the try block and restore it in the catch block using `while (this.messages.length > msgCountBefore) this.messages.pop()`. This mirrors the existing rollback pattern in `persistUserMessage`.

Addresses P1 feedback from Codex and Devin on #1972.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
