### PR TITLE
fix(macos): normalize test filter and guard reopen during onboarding

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -50,7 +50,7 @@ CMD="${1:-build}"
 case "$CMD" in
     test)
         echo "Running tests..."
-        swift test --filter vellum-assistantTests
+        swift test --filter vellum_assistantTests
         exit 0
         ;;
     lint)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -374,6 +374,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Don't show the main window while onboarding is active — the app
+        // isn't fully initialized yet and showing it would let users bypass
+        // the onboarding flow with partially initialized state.
+        guard onboardingWindow == nil else { return true }
+
         // Always show the main window on reopen (e.g. Spotlight, Dock click).
         // Even when hasVisibleWindows is true, the window may be behind other apps
         // and the user expects it to come to the front.


### PR DESCRIPTION
## Summary
- Fixed `build.sh` test filter from `vellum-assistantTests` to `vellum_assistantTests` — SwiftPM normalizes hyphens to underscores in module names, so the old filter silently matched zero tests and reported success
- Added onboarding guard in `applicationShouldHandleReopen` so Dock/Spotlight reopens during first-launch onboarding don't bypass the flow and show the main window with partially initialized state
- Addresses feedback from PR #1984

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
