### PR TITLE
fix(session): persist before push to prevent state divergence

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -834,32 +834,30 @@ export class Session {
     // Resolve slash commands for queued messages
     const slashResult = this.resolveSlash(next.content);
 
-    // Unknown slash — persist the exchange and continue draining
+    // Unknown slash — persist the exchange and continue draining.
+    // Persist each message before pushing to this.messages so that a
+    // failed write never leaves an unpersisted message in memory.
     if (slashResult.kind === 'unknown') {
-      const msgCountBefore = this.messages.length;
       try {
         const userMsg = createUserMessage(next.content, next.attachments);
-        this.messages.push(userMsg);
         conversationStore.addMessage(
           this.conversationId,
           'user',
           JSON.stringify(userMsg.content),
         );
+        this.messages.push(userMsg);
 
         const assistantMsg = createAssistantMessage(slashResult.message);
-        this.messages.push(assistantMsg);
         conversationStore.addMessage(
           this.conversationId,
           'assistant',
           JSON.stringify(assistantMsg.content),
         );
+        this.messages.push(assistantMsg);
 
         next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
         next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
       } catch (err) {
-        // Roll back any messages pushed before the error so in-memory
-        // history stays consistent with what was actually persisted.
-        while (this.messages.length > msgCountBefore) this.messages.pop();
         const message = err instanceof Error ? err.message : String(err);
         log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist unknown-slash exchange');
         next.onEvent({ type: 'error', message });
@@ -911,24 +909,24 @@ export class Session {
     const slashResult = this.resolveSlash(content);
 
     // Unknown slash command — persist the exchange (user + assistant) so the
-    // messageId is real.  Without persistence, callers like the channel inbound
-    // path would see "success" but find a stale assistant reply in the DB.
+    // messageId is real.  Persist each message before pushing to this.messages
+    // so that a failed write never leaves an unpersisted message in memory.
     if (slashResult.kind === 'unknown') {
       const userMsg = createUserMessage(content, attachments);
-      this.messages.push(userMsg);
       const persisted = conversationStore.addMessage(
         this.conversationId,
         'user',
         JSON.stringify(userMsg.content),
       );
+      this.messages.push(userMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      this.messages.push(assistantMsg);
       conversationStore.addMessage(
         this.conversationId,
         'assistant',
         JSON.stringify(assistantMsg.content),
       );
+      this.messages.push(assistantMsg);
 
       onEvent({ type: 'assistant_text_delta', text: slashResult.message });
       onEvent({ type: 'message_complete', sessionId: this.conversationId });


### PR DESCRIPTION
## Summary

Addresses review feedback on #1986.

- **drainQueue**: Reordered unknown-slash handling to persist each message to SQLite *before* pushing to `this.messages`. Removed the `msgCountBefore` rollback loop since messages are never added to memory unless persistence succeeds. The try/catch still catches errors and continues draining.
- **processMessage**: Applied the same persist-then-push reordering to the unknown-slash branch, which previously had no error protection at all.

## Why

The previous push-then-persist pattern could discard an already-persisted user message on partial failure (e.g., if the user message persists but the assistant message write throws). The `msgCountBefore` rollback would pop *both* messages from memory even though the user message was already in the DB, causing in-memory state to diverge from persisted state.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 58 slash-related tests pass (`bun test --filter "slash"`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
