### PR TITLE
fix(macos): fix Spotlight/Dock activation by setting policy before window ops

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -29,13 +29,17 @@ final class MainWindow {
     }
 
     func show() {
+        // Switch to regular activation policy FIRST so macOS allows window
+        // foregrounding — calling makeKeyAndOrderFront while still .accessory
+        // can silently fail on Spotlight/Dock reopens.
+        NSApp.setActivationPolicy(.regular)
+
         // Reuse the existing window if one already exists
         if let existing = window {
-            // Rebuild the SwiftUI view hierarchy so it picks up any
-            // UserDefaults changes (e.g. assistantName set during onboarding replay)
-            existing.contentViewController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+            if existing.isMiniaturized {
+                existing.deminiaturize(nil)
+            }
             existing.makeKeyAndOrderFront(nil)
-            NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
@@ -65,9 +69,6 @@ final class MainWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
-
-        // Keep regular activation policy — the main window should appear in Dock and Cmd+Tab
-        NSApp.setActivationPolicy(.regular)
 
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
## Summary
- Move `setActivationPolicy(.regular)` to the top of `MainWindow.show()` so macOS allows window foregrounding — calling `makeKeyAndOrderFront` while still `.accessory` can silently fail on Spotlight/Dock reopens
- Deminiaturize window before bringing to front so minimized windows are properly restored
- Remove unnecessary `NSHostingController` rebuild on every reshow (the SwiftUI view hierarchy is already bound and picks up changes automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
