### PR TITLE
Fix: Voice input no longer triggers on Control+C/Control+Z combos

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -15,6 +15,8 @@ final class VoiceInputManager {
     private var isRecording = false
     private var globalMonitor: Any?
     private var localMonitor: Any?
+    private var globalKeyDownMonitor: Any?
+    private var localKeyDownMonitor: Any?
     private var holdTask: Task<Void, Never>?
     private static let holdDelay: UInt64 = 300_000_000 // 300ms in nanoseconds
 
@@ -45,6 +47,14 @@ final class VoiceInputManager {
             NSEvent.removeMonitor(monitor)
             localMonitor = nil
         }
+        if let monitor = globalKeyDownMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalKeyDownMonitor = nil
+        }
+        if let monitor = localKeyDownMonitor {
+            NSEvent.removeMonitor(monitor)
+            localKeyDownMonitor = nil
+        }
         stopRecording()
     }
 
@@ -71,6 +81,20 @@ final class VoiceInputManager {
             }
             return event
         }
+
+        // Monitor keyDown events to detect when user types while holding activation key
+        // (e.g., Control+C, Control+Z) and cancel voice activation in those cases.
+        globalKeyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleKeyDown()
+            }
+        }
+        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            Task { @MainActor in
+                self?.handleKeyDown()
+            }
+            return event
+        }
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
@@ -82,6 +106,7 @@ final class VoiceInputManager {
 
         if keyPressed && !hasOtherModifiers && !isRecording {
             // Start a delayed hold — cancelled if key is released quickly (e.g. Fn+arrow combo)
+            // or if a regular key is pressed (e.g. Control+C, handled by handleKeyDown)
             holdTask?.cancel()
             holdTask = Task {
                 try? await Task.sleep(nanoseconds: Self.holdDelay)
@@ -99,6 +124,14 @@ final class VoiceInputManager {
                 stopRecording()
             }
         }
+    }
+
+    private func handleKeyDown() {
+        // If user types any key while holding the activation modifier (e.g. Control+C),
+        // they're using a keyboard shortcut, not trying to activate voice input.
+        // Cancel the pending voice activation timer.
+        holdTask?.cancel()
+        holdTask = nil
     }
 
     // MARK: - Recording


### PR DESCRIPTION
## Problem

When using **Control** as the voice activation key, pressing keyboard shortcuts like **Control+C** or **Control+Z** in the terminal would incorrectly trigger Vellum's voice input, causing permission popups and interrupting the user's workflow.

## Root Cause

`VoiceInputManager` only monitored `.flagsChanged` events (which fire when modifier keys change state), but did NOT monitor `.keyDown` events (regular key presses). 

**What happened:**
1. User presses **Control** → `flagsChanged` event fires → 300ms hold timer starts
2. User presses **C** → ❌ No event monitored → timer keeps running
3. After 300ms → Recording starts → Permission popup appears

The code checked for OTHER MODIFIERS (Cmd, Shift, etc.) but not for regular keys being pressed.

## Solution

Added `.keyDown` event monitors to `setupFnKeyMonitors()` that cancel the hold timer when any regular key is pressed while the activation modifier is held.

**Now:**
1. User presses **Control** → timer starts
2. User presses **C** → ✅ `keyDown` event fires → timer cancelled
3. Voice input does NOT activate

## Changes

- Added `globalKeyDownMonitor` and `localKeyDownMonitor` properties
- Added `.keyDown` event monitoring in `setupFnKeyMonitors()`
- Added `handleKeyDown()` method that cancels pending voice activation
- Updated `stop()` to remove keyDown monitors

## Testing

✅ Build succeeds
✅ Voice activation still works when Control is held alone for 300ms
✅ Control+C, Control+Z, and other keyboard shortcuts no longer trigger voice input

## Impact

Fixes user-reported issue where Control key activation mode was unusable in terminal workflows due to false-positive triggers on common keyboard shortcuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
