### PR TITLE
fix(ui): include extraLineFragmentRect in composer height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -128,6 +128,7 @@ struct ChatView: View {
         storage.addLayoutManager(layoutManager)
         layoutManager.ensureLayout(for: container)
         let textHeight = layoutManager.usedRect(for: container).height
+            + layoutManager.extraLineFragmentRect.height
         // Add vertical padding matching the TextEditor's internal insets
         let newHeight = textHeight + 16
         withAnimation(VAnimation.spring) {


### PR DESCRIPTION
Fixes composer underestimating height by one line when input ends with a trailing newline.

The previous calculation used only `layoutManager.usedRect(for:)` which excludes TextKit's `extraLineFragmentRect`. When input ends with `"\n"` (inserted via modifier-Return), the composer doesn't grow until another character is typed, causing the caret/blank line to be clipped at the bottom.

Adding `extraLineFragmentRect.height` fixes this. When there is no trailing newline, the value is 0, so the normal case is unaffected.

Follow-up to #1991.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/1992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
