### PR TITLE
fix(ui): left-align Dynamic panel fullscreen icon and compact chatbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -48,7 +48,7 @@ struct ChatView: View {
     }
 
     @State private var isDropTargeted = false
-    @State private var editorContentHeight: CGFloat = 28
+    @State private var editorContentHeight: CGFloat = 20
     @State private var editorWidth: CGFloat = 0
 
     var body: some View {
@@ -99,8 +99,9 @@ struct ChatView: View {
 
     /// Height reserved at the bottom of the scroll view so the last message isn't hidden behind the composer.
     private var composerReservedHeight: CGFloat {
-        let editorClamped = min(max(editorContentHeight, 28), 200)
-        let base: CGFloat = VSpacing.md * 2 + VSpacing.xs * 2 + editorClamped + 4
+        let editorClamped = min(max(editorContentHeight, 14), 200)
+        let contentHeight = max(editorClamped, 28)
+        let base: CGFloat = VSpacing.md * 2 + VSpacing.xs * 2 + contentHeight + 4
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
         let error: CGFloat = errorText != nil ? 36 : 0
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
@@ -129,8 +130,8 @@ struct ChatView: View {
         layoutManager.ensureLayout(for: container)
         let textHeight = layoutManager.usedRect(for: container).height
             + layoutManager.extraLineFragmentRect.height
-        // Add vertical padding matching the TextEditor's internal insets
-        let newHeight = textHeight + 16
+        // Tight fit — HStack .center alignment handles vertical centering
+        let newHeight = textHeight + 4
         withAnimation(VAnimation.spring) {
             editorContentHeight = newHeight
         }
@@ -392,6 +393,18 @@ struct ChatView: View {
             HStack(alignment: .center, spacing: VSpacing.sm) {
                 // Text editor with ghost text / placeholder overlay
                 ZStack(alignment: .topLeading) {
+                    // Placeholder — uses a matching TextEditor for pixel-perfect cursor alignment
+                    if inputText.isEmpty && ghostSuffix == nil {
+                        TextEditor(text: .constant("What would you like to do?"))
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .lineSpacing(4)
+                            .scrollContentBackground(.hidden)
+                            .scrollDisabled(true)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+
                     TextEditor(text: $inputText)
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
@@ -400,18 +413,6 @@ struct ChatView: View {
                         .scrollDisabled(editorContentHeight <= 200)
                         .disabled(!hasAPIKey)
                         .accessibilityLabel("Message")
-
-                    // Placeholder
-                    if inputText.isEmpty && ghostSuffix == nil {
-                        Text("What would you like to do?")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textMuted)
-                            .lineSpacing(4)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 6)
-                            .allowsHitTesting(false)
-                            .accessibilityHidden(true)
-                    }
 
                     // Ghost text overlay
                     if let ghostSuffix {
@@ -439,7 +440,7 @@ struct ChatView: View {
                             .accessibilityHidden(true)
                     }
                 }
-                .frame(height: min(max(editorContentHeight, 28), 200))
+                .frame(height: min(max(editorContentHeight, 14), 200))
                 .clipped()
                 .background(
                     GeometryReader { geo in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -49,7 +49,7 @@ struct GeneratedPanel: View {
                     Image(systemName: isExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(VColor.textMuted)
-                        .frame(width: 28, height: 28)
+                        .frame(width: 16, height: 28, alignment: .leading)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Left-align the fullscreen toggle icon in the Dynamic panel header so it aligns with the subtitle text below
- Carry forward chatbar compaction and placeholder alignment refinements from prior iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
