### PR TITLE
test: baseline tests and acceptance harness for sandbox backend

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -20,6 +20,9 @@ const mockConfig = {
   auditLog: { retentionDays: 0 },
 };
 
+// Track whether wrapCommand was ever called — host_bash must never invoke it
+let wrapCommandCallCount = 0;
+
 mock.module('../config/loader.js', () => ({
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
@@ -35,6 +38,13 @@ mock.module('../util/logger.js', () => ({
   getLogger: () => new Proxy({} as Record<string, unknown>, {
     get: () => () => {},
   }),
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (...args: unknown[]) => {
+    wrapCommandCallCount++;
+    return { command: 'bash', args: ['-c', '--', args[0]], sandboxed: false };
+  },
 }));
 
 import { hostShellTool } from '../tools/host-terminal/host-shell.js';
@@ -84,5 +94,41 @@ describe('host_bash tool', () => {
     const result = await hostShellTool.execute({ command: 'exit 12' }, makeContext());
     expect(result.isError).toBe(true);
     expect(result.content).toContain('<command_exit code="12" />');
+  });
+
+  test('does not route through sandbox wrapCommand', async () => {
+    wrapCommandCallCount = 0;
+
+    const dir = mkdtempSync(join(tmpdir(), 'host-shell-nosandbox-'));
+    testDirs.push(dir);
+
+    const result = await hostShellTool.execute({
+      command: 'echo isolation-test',
+      working_dir: dir,
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe('isolation-test');
+    // The sandbox wrapCommand must never be called for host_bash
+    expect(wrapCommandCallCount).toBe(0);
+  });
+
+  test('spawns plain bash without sandbox-exec or bwrap', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-shell-plain-'));
+    testDirs.push(dir);
+
+    // Verify the tool executes successfully even when sandbox is enabled in config,
+    // proving it bypasses the sandbox entirely
+    expect(mockConfig.sandbox.enabled).toBe(true);
+
+    const result = await hostShellTool.execute({
+      command: 'echo $0',
+      working_dir: dir,
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    // bash reports its own name — if sandboxed via sandbox-exec or bwrap,
+    // the process tree would be different
+    expect(result.content.trim()).toContain('bash');
   });
 });

--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realChildProcess from 'node:child_process';
+import * as realFs from 'node:fs';
 
 let platform = 'linux';
 
-const execSyncMock = mock((_command: string) => {
+const execSyncMock = mock((_command: string): unknown => {
   throw new Error('bwrap unavailable');
 });
 
@@ -26,10 +27,51 @@ mock.module('node:child_process', () => ({
   execSync: execSyncMock,
 }));
 
+const writeFileSyncMock = mock((..._args: unknown[]) => {});
+const existsSyncMock = mock((_path: string) => true);
+const mkdirSyncMock = mock((..._args: unknown[]) => {});
+
+mock.module('node:fs', () => ({
+  ...realFs,
+  writeFileSync: writeFileSyncMock,
+  existsSync: existsSyncMock,
+  mkdirSync: mkdirSyncMock,
+}));
+
 const { wrapCommand } = await import('../tools/terminal/sandbox.js');
 const { ToolError } = await import('../util/errors.js');
 
-describe('terminal sandbox fail-closed behavior', () => {
+describe('terminal sandbox — disabled behavior', () => {
+  beforeEach(() => {
+    platform = 'linux';
+  });
+
+  test('returns unsandboxed bash -c wrapper when disabled', () => {
+    const result = wrapCommand('pwd', '/tmp', false);
+    expect(result).toEqual({
+      command: 'bash',
+      args: ['-c', '--', 'pwd'],
+      sandboxed: false,
+    });
+  });
+
+  test('sandboxed flag is false when disabled regardless of platform', () => {
+    for (const p of ['linux', 'darwin', 'win32']) {
+      platform = p;
+      const result = wrapCommand('echo hi', '/tmp', false);
+      expect(result.sandboxed).toBe(false);
+      expect(result.command).toBe('bash');
+    }
+  });
+
+  test('preserves the original command string in args when disabled', () => {
+    const cmd = 'cat /etc/passwd | wc -l';
+    const result = wrapCommand(cmd, '/home/user', false);
+    expect(result.args).toEqual(['-c', '--', cmd]);
+  });
+});
+
+describe('terminal sandbox — enabled fail-closed behavior', () => {
   beforeEach(() => {
     platform = 'linux';
     execSyncMock.mockImplementation((_command: string) => {
@@ -37,27 +79,91 @@ describe('terminal sandbox fail-closed behavior', () => {
     });
   });
 
-  test('throws when sandbox is enabled and bwrap is unavailable on linux', () => {
+  test('throws ToolError when bwrap is unavailable on linux', () => {
     expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(ToolError);
     expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(
       'Sandbox is enabled but bwrap is not available or cannot create namespaces.',
     );
   });
 
-  test('enabled=false still returns unsandboxed bash command', () => {
-    const wrapped = wrapCommand('pwd', '/tmp', false);
-    expect(wrapped).toEqual({
-      command: 'bash',
-      args: ['-c', '--', 'pwd'],
-      sandboxed: false,
-    });
+  test('returns bwrap wrapper when bwrap is available on linux', () => {
+    execSyncMock.mockImplementation(() => undefined);
+    const result = wrapCommand('echo hello', '/home/user/project', true);
+    expect(result.command).toBe('bwrap');
+    expect(result.sandboxed).toBe(true);
+    expect(result.args).toContain('--ro-bind');
+    expect(result.args).toContain('--unshare-net');
+    expect(result.args).toContain('--unshare-pid');
+    // The user command runs via bash inside the sandbox
+    const bashIdx = result.args.indexOf('bash');
+    expect(bashIdx).toBeGreaterThan(0);
+    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', '--', 'echo hello']);
   });
 
-  test('throws when sandbox is enabled on unsupported platforms', () => {
+  test('bind-mounts working directory read-write in bwrap args', () => {
+    execSyncMock.mockImplementation(() => undefined);
+    const workDir = '/home/user/my-project';
+    const result = wrapCommand('ls', workDir, true);
+    // The args should contain --bind workDir workDir for read-write access
+    const bindIdx = result.args.indexOf('--bind');
+    expect(bindIdx).toBeGreaterThan(-1);
+    expect(result.args[bindIdx + 1]).toBe(workDir);
+    expect(result.args[bindIdx + 2]).toBe(workDir);
+  });
+});
+
+describe('terminal sandbox — unsupported platform fail-closed behavior', () => {
+  test('throws ToolError on unsupported platforms when enabled', () => {
     platform = 'win32';
     expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(ToolError);
     expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(
       'Sandbox is enabled but not supported on this platform (',
     );
+  });
+
+  test('error message includes refusing to execute unsandboxed', () => {
+    platform = 'win32';
+    try {
+      wrapCommand('pwd', '/tmp', true);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toContain('Refusing to execute unsandboxed');
+    }
+  });
+});
+
+describe('terminal sandbox — macOS sandbox-exec behavior', () => {
+  beforeEach(() => {
+    platform = 'darwin';
+    writeFileSyncMock.mockClear();
+    existsSyncMock.mockImplementation(() => true);
+  });
+
+  test('returns sandbox-exec wrapper on macOS when enabled', () => {
+    const result = wrapCommand('echo hello', '/tmp/project', true);
+    expect(result.command).toBe('sandbox-exec');
+    expect(result.sandboxed).toBe(true);
+    expect(result.args[0]).toBe('-f');
+    // Profile path is the second arg
+    expect(result.args[1]).toContain('sandbox-profile-');
+    // bash -c -- command follows the profile
+    expect(result.args.slice(2)).toEqual(['bash', '-c', '--', 'echo hello']);
+  });
+
+  test('throws ToolError for working dirs with SBPL metacharacters', () => {
+    expect(() => wrapCommand('pwd', '/tmp/bad"dir', true)).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp/bad(dir', true)).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp/bad;dir', true)).toThrow(ToolError);
+  });
+
+  test('SBPL metacharacter error mentions unsafe characters', () => {
+    try {
+      wrapCommand('pwd', '/tmp/bad"dir', true);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toContain('SBPL metacharacters');
+    }
   });
 });

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -256,6 +256,32 @@ describe('ToolExecutor lifecycle events', () => {
     expect(errorEvent.isExpected).toBe(true);
   });
 
+  test('bash tool resolves to sandbox executionTarget', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute('bash', { command: 'echo hello' }, makeContext(events));
+
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('sandbox');
+    const executedEvent = events.find((e) => e.type === 'executed' || e.type === 'error');
+    expect(executedEvent?.executionTarget).toBe('sandbox');
+  });
+
+  test('host_bash tool resolves to host executionTarget', async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute('host_bash', { command: 'echo hello' }, makeContext(events));
+
+    const startEvent = events[0];
+    if (startEvent.type !== 'start') throw new Error('Expected start event');
+    expect(startEvent.executionTarget).toBe('host');
+    const executedEvent = events.find((e) => e.type === 'executed' || e.type === 'error');
+    expect(executedEvent?.executionTarget).toBe('host');
+  });
+
   test('does not block tool execution on unresolved lifecycle callbacks', async () => {
     const executor = new ToolExecutor(makePrompter());
     const timeoutMs = 100;


### PR DESCRIPTION
Part of #2022. Freezes current terminal sandbox behavior with explicit assertions for disabled, enabled, and unsupported platform paths. Adds executionTarget assertions and host-shell isolation test.

## Changes

### terminal-sandbox.test.ts
- Disabled behavior: asserts sandboxed=false across all platforms, preserves command string
- Enabled fail-closed: bwrap unavailable throws ToolError, bwrap success returns proper wrapper with --ro-bind/--unshare-net/--unshare-pid, bind-mounts working dir read-write
- Unsupported platform: ToolError with Refusing to execute unsandboxed message
- macOS sandbox-exec: returns sandbox-exec -f profile wrapper, rejects SBPL metacharacters in working dir

### tool-executor-lifecycle-events.test.ts
- Explicit executionTarget assertions: bash -> sandbox, host_bash -> host

### host-shell-tool.test.ts
- Verifies host_bash never calls wrapCommand (sandbox module)
- Confirms plain bash spawning even when sandbox.enabled=true in config
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
