### PR TITLE
test: stabilize baseline filesystem/permission tests

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -111,7 +111,8 @@ describe('Trust Store', () => {
       addRule('bash', 'med *', '/tmp', 'allow', 1);
       const rules = getAllRules();
       // Default ask rules have higher priority than user rules
-      expect(rules[0].priority).toBe(1000);
+      const maxDefaultPriority = Math.max(...DEFAULT_TEMPLATES.map((t) => t.priority));
+      expect(rules[0].priority).toBe(maxDefaultPriority);
       const userRules = rules.filter((r) => !r.id.startsWith('default:'));
       expect(userRules[0].priority).toBe(2);
       expect(userRules[1].priority).toBe(1);
@@ -675,7 +676,7 @@ describe('Trust Store', () => {
       const match = findHighestPriorityRule('file_read', [`file_read:${protectedPath}`], '/tmp');
       expect(match).not.toBeNull();
       expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(1000);
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-file_read-protected')!);
     });
 
     test('findHighestPriorityRule matches default ask for protected file_write', () => {
@@ -729,7 +730,7 @@ describe('Trust Store', () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:ask-cu_click-global');
       expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(1000);
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-cu_click-global')!);
     });
 
     test('findHighestPriorityRule matches default ask for request_computer_control', () => {
@@ -737,7 +738,7 @@ describe('Trust Store', () => {
       expect(match).not.toBeNull();
       expect(match!.id).toBe('default:ask-request_computer_control-global');
       expect(match!.decision).toBe('ask');
-      expect(match!.priority).toBe(1000);
+      expect(match!.priority).toBe(DEFAULT_PRIORITY_BY_ID.get('default:ask-request_computer_control-global')!);
     });
 
     test('default ask does not affect files outside protected directory', () => {


### PR DESCRIPTION
Part of #2009. Closes #2010.

Replaces hardcoded priority `1000` assertions in trust-store tests with dynamic lookups from `getDefaultRuleTemplates()` so tests remain correct if default rule priorities change.

## Changes
- `trust-store.test.ts`: 4 hardcoded `.toBe(1000)` assertions replaced with `DEFAULT_PRIORITY_BY_ID.get(...)` or `Math.max(...DEFAULT_TEMPLATES.map(...))` derivations

## Validation
```bash
bun test assistant/src/__tests__/host-file-read-tool.test.ts assistant/src/__tests__/trust-store.test.ts assistant/src/__tests__/checker.test.ts
```
190 tests pass, 0 failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
