### PR TITLE
fix(ui): replace opaque composer background with gentle transparent fade

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -109,27 +109,25 @@ struct ChatView: View {
 
     private var composerOverlay: some View {
         VStack(spacing: 0) {
-            // Gradient fade so messages dissolve behind the composer
+            if let errorText {
+                errorBanner(errorText)
+            }
+            queueSummary
+            composerArea
+        }
+        .background(
+            // Gentle fade that never becomes fully opaque — background stays visible
             LinearGradient(
                 stops: [
                     .init(color: VColor.chatBackground.opacity(0), location: 0),
-                    .init(color: VColor.chatBackground.opacity(0.85), location: 1.0)
+                    .init(color: VColor.chatBackground.opacity(0.5), location: 0.5),
+                    .init(color: VColor.chatBackground.opacity(0.65), location: 1.0)
                 ],
                 startPoint: .top,
                 endPoint: .bottom
             )
-            .frame(height: 16)
             .allowsHitTesting(false)
-
-            VStack(spacing: 0) {
-                if let errorText {
-                    errorBanner(errorText)
-                }
-                queueSummary
-                composerArea
-            }
-            .background(VColor.chatBackground.opacity(0.85))
-        }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Removed the solid 0.85 opacity background behind the composer area
- Removed the separate 16pt gradient element
- Replaced both with a single gradient background on the entire composer overlay (transparent → 0.5 → 0.65) so the chat window background shows through naturally without any fully opaque region

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
