### PR TITLE
M3: Introduce shared filesystem contracts and error model

### DIFF
--- a/assistant/src/__tests__/shared-filesystem-errors.test.ts
+++ b/assistant/src/__tests__/shared-filesystem-errors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  invalidPath,
+  pathOutOfBounds,
+  pathNotAbsolute,
+  notFound,
+  notAFile,
+  sizeLimitExceeded,
+  matchNotFound,
+  matchAmbiguous,
+  ioError,
+  type FsErrorCode,
+} from '../tools/shared/filesystem/errors.js';
+
+describe('shared filesystem error helpers', () => {
+  it('invalidPath sets code and includes reason', () => {
+    const err = invalidPath('/foo', 'contains null bytes');
+    expect(err.code).toBe('INVALID_PATH' satisfies FsErrorCode);
+    expect(err.path).toBe('/foo');
+    expect(err.message).toContain('null bytes');
+  });
+
+  it('pathOutOfBounds includes path and boundary', () => {
+    const err = pathOutOfBounds('../secret', '/sandbox');
+    expect(err.code).toBe('PATH_OUT_OF_BOUNDS' satisfies FsErrorCode);
+    expect(err.message).toContain('../secret');
+    expect(err.message).toContain('/sandbox');
+    expect(err.path).toBe('../secret');
+  });
+
+  it('pathNotAbsolute includes the offending path', () => {
+    const err = pathNotAbsolute('relative/path');
+    expect(err.code).toBe('PATH_NOT_ABSOLUTE' satisfies FsErrorCode);
+    expect(err.message).toContain('relative/path');
+    expect(err.path).toBe('relative/path');
+  });
+
+  it('notFound includes the path', () => {
+    const err = notFound('/missing.txt');
+    expect(err.code).toBe('NOT_FOUND' satisfies FsErrorCode);
+    expect(err.message).toContain('/missing.txt');
+  });
+
+  it('notAFile includes the path', () => {
+    const err = notAFile('/some/dir');
+    expect(err.code).toBe('NOT_A_FILE' satisfies FsErrorCode);
+    expect(err.message).toContain('/some/dir');
+  });
+
+  it('sizeLimitExceeded includes size and limit', () => {
+    const err = sizeLimitExceeded('/big.bin', '200 MB', '100 MB');
+    expect(err.code).toBe('SIZE_LIMIT_EXCEEDED' satisfies FsErrorCode);
+    expect(err.message).toContain('200 MB');
+    expect(err.message).toContain('100 MB');
+    expect(err.path).toBe('/big.bin');
+  });
+
+  it('matchNotFound includes the path', () => {
+    const err = matchNotFound('/file.ts');
+    expect(err.code).toBe('MATCH_NOT_FOUND' satisfies FsErrorCode);
+    expect(err.message).toContain('/file.ts');
+  });
+
+  it('matchAmbiguous includes count and path', () => {
+    const err = matchAmbiguous('/file.ts', 3);
+    expect(err.code).toBe('MATCH_AMBIGUOUS' satisfies FsErrorCode);
+    expect(err.message).toContain('3 times');
+    expect(err.message).toContain('/file.ts');
+    expect(err.message).toContain('replace_all');
+  });
+
+  it('ioError includes detail', () => {
+    const err = ioError('/file.ts', 'EACCES: permission denied');
+    expect(err.code).toBe('IO_ERROR' satisfies FsErrorCode);
+    expect(err.message).toContain('EACCES');
+    expect(err.path).toBe('/file.ts');
+  });
+});

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+export type FsErrorCode =
+  | 'INVALID_PATH'
+  | 'PATH_OUT_OF_BOUNDS'
+  | 'PATH_NOT_ABSOLUTE'
+  | 'NOT_FOUND'
+  | 'NOT_A_FILE'
+  | 'SIZE_LIMIT_EXCEEDED'
+  | 'MATCH_NOT_FOUND'
+  | 'MATCH_AMBIGUOUS'
+  | 'IO_ERROR';
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export interface FsError {
+  code: FsErrorCode;
+  message: string;
+  /** The path that caused the error, when applicable. */
+  path?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+export function invalidPath(path: string, reason: string): FsError {
+  return { code: 'INVALID_PATH', message: reason, path };
+}
+
+export function pathOutOfBounds(path: string, boundary: string): FsError {
+  return {
+    code: 'PATH_OUT_OF_BOUNDS',
+    message: `Path "${path}" resolves outside the allowed boundary "${boundary}"`,
+    path,
+  };
+}
+
+export function pathNotAbsolute(path: string): FsError {
+  return {
+    code: 'PATH_NOT_ABSOLUTE',
+    message: `Path must be absolute: ${path}`,
+    path,
+  };
+}
+
+export function notFound(path: string): FsError {
+  return { code: 'NOT_FOUND', message: `File not found: ${path}`, path };
+}
+
+export function notAFile(path: string): FsError {
+  return { code: 'NOT_A_FILE', message: `Not a regular file: ${path}`, path };
+}
+
+export function sizeLimitExceeded(path: string, size: string, limit: string): FsError {
+  return {
+    code: 'SIZE_LIMIT_EXCEEDED',
+    message: `File size (${size}) exceeds the ${limit} limit: ${path}`,
+    path,
+  };
+}
+
+export function matchNotFound(path: string): FsError {
+  return {
+    code: 'MATCH_NOT_FOUND',
+    message: `old_string not found in ${path}`,
+    path,
+  };
+}
+
+export function matchAmbiguous(path: string, count: number): FsError {
+  return {
+    code: 'MATCH_AMBIGUOUS',
+    message: `old_string appears ${count} times in ${path}. Provide more surrounding context to make it unique, or set replace_all to true.`,
+    path,
+  };
+}
+
+export function ioError(path: string, detail: string): FsError {
+  return { code: 'IO_ERROR', message: detail, path };
+}

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -1,0 +1,74 @@
+import type { FsError } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export interface ReadInput {
+  path: string;
+  /** 1-indexed line number to start reading from. */
+  offset?: number;
+  /** Maximum number of lines to read. */
+  limit?: number;
+}
+
+export interface ReadOutput {
+  /** The (possibly line-numbered) file content. */
+  content: string;
+}
+
+export type ReadResult =
+  | { ok: true; value: ReadOutput }
+  | { ok: false; error: FsError };
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+export interface WriteInput {
+  path: string;
+  content: string;
+}
+
+export interface WriteOutput {
+  /** Absolute path that was written to. */
+  filePath: string;
+  /** True when the file did not exist before this write. */
+  isNewFile: boolean;
+  /** Previous content (empty string for new files or unreadable files). */
+  oldContent: string;
+  /** The content that was written. */
+  newContent: string;
+}
+
+export type WriteResult =
+  | { ok: true; value: WriteOutput }
+  | { ok: false; error: FsError };
+
+// ---------------------------------------------------------------------------
+// Edit
+// ---------------------------------------------------------------------------
+
+export interface EditInput {
+  path: string;
+  oldString: string;
+  newString: string;
+  replaceAll: boolean;
+}
+
+export interface EditOutput {
+  /** Absolute path that was edited. */
+  filePath: string;
+  /** Number of replacements made. */
+  matchCount: number;
+  /** File content before the edit. */
+  oldContent: string;
+  /** File content after the edit. */
+  newContent: string;
+  /** How the match was found (exact, whitespace-normalized, or fuzzy). */
+  matchMethod: 'exact' | 'whitespace' | 'fuzzy';
+}
+
+export type EditResult =
+  | { ok: true; value: EditOutput }
+  | { ok: false; error: FsError };


### PR DESCRIPTION
## Summary
- Create shared filesystem types (`ReadInput`/`ReadOutput`, `WriteInput`/`WriteOutput`, `EditInput`/`EditOutput`) with discriminated `Result` unions
- Create normalized `FsError` type with 9 error codes (`INVALID_PATH`, `PATH_OUT_OF_BOUNDS`, `PATH_NOT_ABSOLUTE`, `NOT_FOUND`, `NOT_A_FILE`, `SIZE_LIMIT_EXCEEDED`, `MATCH_NOT_FOUND`, `MATCH_AMBIGUOUS`, `IO_ERROR`) and helper constructors
- Foundation for shared `FileSystemOps` service in later PRs
- No wiring to existing tools yet

Part of #2009
Closes #2012

## Test plan
- [x] New types compile cleanly (`tsc --noEmit` passes)
- [x] Error helpers tested (9 tests, all passing)
- [x] Existing filesystem tests still pass (26 tests across 6 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
