### PR TITLE
refactor(sandbox): extract SandboxBackend interface

### DIFF
--- a/assistant/src/tools/terminal/backends/types.ts
+++ b/assistant/src/tools/terminal/backends/types.ts
@@ -1,0 +1,16 @@
+export interface SandboxResult {
+  /** The command/args to use for spawning. */
+  command: string;
+  args: string[];
+  /** Whether sandboxing was applied. */
+  sandboxed: boolean;
+}
+
+/**
+ * A sandbox backend knows how to wrap a shell command so it runs
+ * inside an OS-level sandbox (macOS sandbox-exec, Linux bwrap, Docker, etc.).
+ */
+export interface SandboxBackend {
+  /** Wrap a command for sandboxed execution in the given working directory. */
+  wrap(command: string, workingDir: string): SandboxResult;
+}

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 import { isMacOS, isLinux } from '../../util/platform.js';
 import { ToolError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
+import type { SandboxResult } from './backends/types.js';
+
+export type { SandboxResult, SandboxBackend } from './backends/types.js';
 
 const log = getLogger('sandbox');
 
@@ -143,14 +146,6 @@ function buildBwrapArgs(workingDir: string, command: string): string[] {
     // Run bash inside the sandbox
     'bash', '-c', '--', command,
   ];
-}
-
-export interface SandboxResult {
-  /** The command/args to use for spawning. */
-  command: string;
-  args: string[];
-  /** Whether sandboxing was applied. */
-  sandboxed: boolean;
 }
 
 /**


### PR DESCRIPTION
Part of #2021.

Extracts `SandboxBackend` interface and `SandboxResult` type into `backends/types.ts`, preparing the sandbox module for pluggable backends (Docker, etc.).

### Changes
- **New file** `assistant/src/tools/terminal/backends/types.ts` — defines `SandboxResult` and `SandboxBackend` interface
- **Updated** `assistant/src/tools/terminal/sandbox.ts` — imports `SandboxResult` from the new types file and re-exports both types so existing consumers are unaffected

### Validation
- `bunx tsc --noEmit` passes
- All 11 sandbox tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
