### PR TITLE
refactor(fs): introduce shared filesystem contracts and error model

### DIFF
--- a/assistant/src/__tests__/filesystem-errors.test.ts
+++ b/assistant/src/__tests__/filesystem-errors.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  FilesystemError,
+  FilesystemErrorCode,
+  invalidPath,
+  pathOutOfBounds,
+  pathNotAbsolute,
+  notFound,
+  notAFile,
+  sizeLimitExceeded,
+  matchNotFound,
+  matchAmbiguous,
+  ioError,
+} from '../tools/shared/filesystem/errors.js';
+
+describe('FilesystemError', () => {
+  it('extends Error with code and path', () => {
+    const err = new FilesystemError(FilesystemErrorCode.NOT_FOUND, 'gone', '/tmp/x');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('FilesystemError');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.path).toBe('/tmp/x');
+    expect(err.message).toBe('gone');
+  });
+
+  it('path is optional', () => {
+    const err = new FilesystemError(FilesystemErrorCode.INVALID_PATH, 'bad');
+    expect(err.path).toBeUndefined();
+  });
+});
+
+describe('helper constructors', () => {
+  it('invalidPath', () => {
+    const err = invalidPath('path must be a string');
+    expect(err.code).toBe(FilesystemErrorCode.INVALID_PATH);
+    expect(err.message).toBe('path must be a string');
+    expect(err.path).toBeUndefined();
+  });
+
+  it('pathOutOfBounds', () => {
+    const err = pathOutOfBounds('../secret', '/etc/secret', '/home/user');
+    expect(err.code).toBe(FilesystemErrorCode.PATH_OUT_OF_BOUNDS);
+    expect(err.message).toContain('../secret');
+    expect(err.message).toContain('/etc/secret');
+    expect(err.message).toContain('/home/user');
+    expect(err.path).toBe('/etc/secret');
+  });
+
+  it('pathNotAbsolute', () => {
+    const err = pathNotAbsolute('relative/path');
+    expect(err.code).toBe(FilesystemErrorCode.PATH_NOT_ABSOLUTE);
+    expect(err.message).toContain('relative/path');
+    expect(err.path).toBe('relative/path');
+  });
+
+  it('notFound', () => {
+    const err = notFound('/tmp/missing.txt');
+    expect(err.code).toBe(FilesystemErrorCode.NOT_FOUND);
+    expect(err.message).toContain('/tmp/missing.txt');
+    expect(err.path).toBe('/tmp/missing.txt');
+  });
+
+  it('notAFile', () => {
+    const err = notAFile('/tmp/dir');
+    expect(err.code).toBe(FilesystemErrorCode.NOT_A_FILE);
+    expect(err.message).toContain('directory');
+    expect(err.path).toBe('/tmp/dir');
+  });
+
+  it('sizeLimitExceeded formats bytes', () => {
+    const err = sizeLimitExceeded('/big.bin', 200 * 1024 * 1024, 100 * 1024 * 1024);
+    expect(err.code).toBe(FilesystemErrorCode.SIZE_LIMIT_EXCEEDED);
+    expect(err.message).toContain('200.0 MB');
+    expect(err.message).toContain('100.0 MB');
+    expect(err.path).toBe('/big.bin');
+  });
+
+  it('sizeLimitExceeded formats KB', () => {
+    const err = sizeLimitExceeded('/f', 2048, 1024);
+    expect(err.message).toContain('2.0 KB');
+    expect(err.message).toContain('1.0 KB');
+  });
+
+  it('sizeLimitExceeded formats raw bytes', () => {
+    const err = sizeLimitExceeded('/f', 500, 256);
+    expect(err.message).toContain('500 B');
+    expect(err.message).toContain('256 B');
+  });
+
+  it('matchNotFound', () => {
+    const err = matchNotFound('/tmp/file.ts');
+    expect(err.code).toBe(FilesystemErrorCode.MATCH_NOT_FOUND);
+    expect(err.message).toContain('old_string not found');
+    expect(err.path).toBe('/tmp/file.ts');
+  });
+
+  it('matchAmbiguous includes count', () => {
+    const err = matchAmbiguous('/tmp/file.ts', 3);
+    expect(err.code).toBe(FilesystemErrorCode.MATCH_AMBIGUOUS);
+    expect(err.message).toContain('3 times');
+    expect(err.message).toContain('replace_all');
+    expect(err.path).toBe('/tmp/file.ts');
+  });
+
+  it('ioError wraps Error cause', () => {
+    const cause = new Error('EACCES: permission denied');
+    const err = ioError('/protected', cause);
+    expect(err.code).toBe(FilesystemErrorCode.IO_ERROR);
+    expect(err.message).toContain('EACCES');
+    expect(err.path).toBe('/protected');
+  });
+
+  it('ioError wraps string cause', () => {
+    const err = ioError('/file', 'something broke');
+    expect(err.code).toBe(FilesystemErrorCode.IO_ERROR);
+    expect(err.message).toContain('something broke');
+  });
+});
+
+describe('FilesystemErrorCode exhaustiveness', () => {
+  it('contains all expected codes', () => {
+    const codes = Object.values(FilesystemErrorCode);
+    expect(codes).toContain('INVALID_PATH');
+    expect(codes).toContain('PATH_OUT_OF_BOUNDS');
+    expect(codes).toContain('PATH_NOT_ABSOLUTE');
+    expect(codes).toContain('NOT_FOUND');
+    expect(codes).toContain('NOT_A_FILE');
+    expect(codes).toContain('SIZE_LIMIT_EXCEEDED');
+    expect(codes).toContain('MATCH_NOT_FOUND');
+    expect(codes).toContain('MATCH_AMBIGUOUS');
+    expect(codes).toContain('IO_ERROR');
+    expect(codes).toHaveLength(9);
+  });
+});

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -1,0 +1,125 @@
+/**
+ * Normalized error codes and structured error type for filesystem operations.
+ *
+ * Every filesystem error is represented as a FilesystemError with a code that
+ * allows callers to branch on the failure reason without parsing message strings.
+ */
+
+export const FilesystemErrorCode = {
+  /** The path argument is missing or not a string. */
+  INVALID_PATH: 'INVALID_PATH',
+  /** The resolved path escapes the allowed working directory boundary. */
+  PATH_OUT_OF_BOUNDS: 'PATH_OUT_OF_BOUNDS',
+  /** An absolute path was required but a relative path was provided. */
+  PATH_NOT_ABSOLUTE: 'PATH_NOT_ABSOLUTE',
+  /** The target file or directory does not exist. */
+  NOT_FOUND: 'NOT_FOUND',
+  /** The path points to a directory when a file was expected. */
+  NOT_A_FILE: 'NOT_A_FILE',
+  /** The file or content exceeds the configured size limit. */
+  SIZE_LIMIT_EXCEEDED: 'SIZE_LIMIT_EXCEEDED',
+  /** The search string was not found in the file (edit operation). */
+  MATCH_NOT_FOUND: 'MATCH_NOT_FOUND',
+  /** The search string matches multiple locations and a unique match was required. */
+  MATCH_AMBIGUOUS: 'MATCH_AMBIGUOUS',
+  /** A low-level I/O error (permission denied, read-only FS, etc.). */
+  IO_ERROR: 'IO_ERROR',
+} as const;
+
+export type FilesystemErrorCode = (typeof FilesystemErrorCode)[keyof typeof FilesystemErrorCode];
+
+export class FilesystemError extends Error {
+  readonly code: FilesystemErrorCode;
+  /** The path involved in the error, if available. */
+  readonly path?: string;
+
+  constructor(code: FilesystemErrorCode, message: string, path?: string) {
+    super(message);
+    this.name = 'FilesystemError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper constructors — one per error code for concise call sites.
+// ---------------------------------------------------------------------------
+
+export function invalidPath(detail: string): FilesystemError {
+  return new FilesystemError(FilesystemErrorCode.INVALID_PATH, detail);
+}
+
+export function pathOutOfBounds(rawPath: string, resolved: string, boundary: string): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.PATH_OUT_OF_BOUNDS,
+    `Path "${rawPath}" resolves to "${resolved}" which is outside the working directory "${boundary}"`,
+    resolved,
+  );
+}
+
+export function pathNotAbsolute(rawPath: string): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.PATH_NOT_ABSOLUTE,
+    `Expected an absolute path but received "${rawPath}"`,
+    rawPath,
+  );
+}
+
+export function notFound(filePath: string): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.NOT_FOUND,
+    `File not found: ${filePath}`,
+    filePath,
+  );
+}
+
+export function notAFile(filePath: string): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.NOT_A_FILE,
+    `${filePath} is a directory, not a file`,
+    filePath,
+  );
+}
+
+export function sizeLimitExceeded(filePath: string, actualBytes: number, limitBytes: number): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.SIZE_LIMIT_EXCEEDED,
+    `Size (${formatBytes(actualBytes)}) exceeds the ${formatBytes(limitBytes)} limit: ${filePath}`,
+    filePath,
+  );
+}
+
+export function matchNotFound(filePath: string): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.MATCH_NOT_FOUND,
+    `old_string not found in ${filePath}`,
+    filePath,
+  );
+}
+
+export function matchAmbiguous(filePath: string, count: number): FilesystemError {
+  return new FilesystemError(
+    FilesystemErrorCode.MATCH_AMBIGUOUS,
+    `old_string appears ${count} times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
+    filePath,
+  );
+}
+
+export function ioError(filePath: string, cause: unknown): FilesystemError {
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  return new FilesystemError(
+    FilesystemErrorCode.IO_ERROR,
+    `I/O error on "${filePath}": ${msg}`,
+    filePath,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared input/output contracts for filesystem tools (read, write, edit).
+ *
+ * These types define the normalized shape of tool inputs after validation
+ * and the structured results returned by the shared operation layer.
+ * Both sandbox and host filesystem tools will converge on these contracts.
+ */
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export interface FileReadInput {
+  /** Resolved absolute path to the file. */
+  path: string;
+  /** 1-indexed line number to start reading from (default: 1). */
+  offset?: number;
+  /** Maximum number of lines to return. */
+  limit?: number;
+}
+
+export interface FileReadOutput {
+  /** The file content (may be line-numbered depending on the caller). */
+  content: string;
+  /** Total number of lines in the file. */
+  totalLines: number;
+  /** 1-indexed start line of the returned window. */
+  startLine: number;
+  /** Number of lines returned. */
+  linesReturned: number;
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+export interface FileWriteInput {
+  /** Resolved absolute path to the file. */
+  path: string;
+  /** The content to write. */
+  content: string;
+}
+
+export interface FileWriteOutput {
+  /** The resolved path that was written to. */
+  path: string;
+  /** Whether the file was newly created (vs. overwritten). */
+  created: boolean;
+  /** Number of bytes written. */
+  bytesWritten: number;
+}
+
+// ---------------------------------------------------------------------------
+// Edit
+// ---------------------------------------------------------------------------
+
+export interface FileEditInput {
+  /** Resolved absolute path to the file. */
+  path: string;
+  /** The exact text to find in the file. */
+  oldString: string;
+  /** The replacement text. */
+  newString: string;
+  /** Replace all occurrences instead of requiring a unique match. */
+  replaceAll?: boolean;
+}
+
+export interface FileEditOutput {
+  /** The resolved path that was edited. */
+  path: string;
+  /** Number of replacements made. */
+  replacements: number;
+  /** How the match was found (exact, whitespace-normalized, or fuzzy). */
+  matchMethod: 'exact' | 'whitespace' | 'fuzzy';
+  /** Similarity score for fuzzy matches (1.0 for exact/whitespace). */
+  similarity: number;
+}


### PR DESCRIPTION
Part of #2009. Adds shared types and error codes for filesystem tool consolidation.

## Changes
- `assistant/src/tools/shared/filesystem/types.ts` — Shared input/output contracts for read, write, and edit operations
- `assistant/src/tools/shared/filesystem/errors.ts` — Normalized `FilesystemError` class with typed error codes (`INVALID_PATH`, `PATH_OUT_OF_BOUNDS`, `PATH_NOT_ABSOLUTE`, `NOT_FOUND`, `NOT_A_FILE`, `SIZE_LIMIT_EXCEEDED`, `MATCH_NOT_FOUND`, `MATCH_AMBIGUOUS`, `IO_ERROR`) and helper constructors
- `assistant/src/__tests__/filesystem-errors.test.ts` — 15 focused unit tests for error helpers

## Validation
- `bunx tsc --noEmit` passes
- All 15 new tests pass
- These are standalone type definitions — no existing tools are modified

Closes #2012
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
