### PR TITLE
refactor: extract terminal sandbox backend interface

### DIFF
--- a/assistant/src/tools/terminal/backends/types.ts
+++ b/assistant/src/tools/terminal/backends/types.ts
@@ -1,0 +1,14 @@
+/** Result returned by a sandbox backend after wrapping a command. */
+export interface SandboxResult {
+  /** The command/args to use for spawning. */
+  command: string;
+  args: string[];
+  /** Whether sandboxing was applied. */
+  sandboxed: boolean;
+}
+
+/** Narrow interface for shell sandbox backends. */
+export interface SandboxBackend {
+  /** Wrap a shell command for sandboxed execution. */
+  wrap(command: string, workingDir: string): SandboxResult;
+}

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 import { isMacOS, isLinux } from '../../util/platform.js';
 import { ToolError } from '../../util/errors.js';
 import { getLogger } from '../../util/logger.js';
+import type { SandboxResult, SandboxBackend } from './backends/types.js';
+
+export type { SandboxResult, SandboxBackend };
 
 const log = getLogger('sandbox');
 
@@ -143,14 +146,6 @@ function buildBwrapArgs(workingDir: string, command: string): string[] {
     // Run bash inside the sandbox
     'bash', '-c', '--', command,
   ];
-}
-
-export interface SandboxResult {
-  /** The command/args to use for spawning. */
-  command: string;
-  args: string[];
-  /** Whether sandboxing was applied. */
-  sandboxed: boolean;
 }
 
 /**


### PR DESCRIPTION
Part of #2021. Creates `SandboxBackend` interface and moves `SandboxResult` type to shared `backends/types.ts`. No behavior change.

## Changes
- New `assistant/src/tools/terminal/backends/types.ts` with `SandboxResult` and `SandboxBackend` interfaces
- `sandbox.ts` imports from and re-exports the shared types (no API churn)

## Verification
- `bun test src/__tests__/terminal-sandbox.test.ts` — 11/11 pass
- `bunx tsc --noEmit` — clean

Closes #2023
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
