### PR TITLE
fix(ui): restore ghost text overlay for Tab autocomplete cue

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -359,26 +359,53 @@ struct ChatView: View {
             }
 
             HStack(alignment: .center, spacing: VSpacing.sm) {
-                // Text input with built-in placeholder and vertical centering
-                TextField("What would you like to do?", text: $inputText, axis: .vertical)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .lineSpacing(4)
-                    .textFieldStyle(.plain)
-                    .lineLimit(1...10)
-                    .disabled(!hasAPIKey)
-                    .accessibilityLabel("Message")
-                    .background(
-                        GeometryReader { geo in
-                            Color.clear
-                                .onAppear { editorContentHeight = geo.size.height }
-                                .onChange(of: geo.size.height) { _, h in
-                                    withAnimation(VAnimation.spring) {
-                                        editorContentHeight = h
+                // Text input with ghost text overlay and vertical centering
+                ZStack(alignment: .leading) {
+                    TextField("What would you like to do?", text: $inputText, axis: .vertical)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineSpacing(4)
+                        .textFieldStyle(.plain)
+                        .lineLimit(1...10)
+                        .disabled(!hasAPIKey)
+                        .accessibilityLabel("Message")
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear
+                                    .onAppear { editorContentHeight = geo.size.height }
+                                    .onChange(of: geo.size.height) { _, h in
+                                        withAnimation(VAnimation.spring) {
+                                            editorContentHeight = h
+                                        }
                                     }
+                            }
+                        )
+
+                    // Ghost text overlay — shows the suggested suffix so users
+                    // know what Tab will insert. Without this visual cue, Tab
+                    // must not silently mutate the draft.
+                    if let ghostSuffix {
+                        Text(inputText + ghostSuffix)
+                            .font(VFont.body)
+                            .lineSpacing(4)
+                            .foregroundColor(.clear)
+                            .lineLimit(1...10)
+                            .overlay(alignment: .leading) {
+                                HStack(spacing: 0) {
+                                    Text(inputText)
+                                        .font(VFont.body)
+                                        .lineSpacing(4)
+                                        .foregroundColor(.clear)
+                                    Text(ghostSuffix)
+                                        .font(VFont.body)
+                                        .lineSpacing(4)
+                                        .foregroundColor(VColor.textMuted.opacity(0.5))
                                 }
-                        }
-                    )
+                            }
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+                }
                 .onKeyPress(.tab, phases: .down) { keyPress in
                     if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                         onAcceptSuggestion()


### PR DESCRIPTION
## Summary
- Restores the ghost text overlay that was removed in #2035 when TextEditor was replaced with TextField
- The overlay shows the suggested suffix in muted text so users can see what Tab will insert before pressing it
- Without this visual cue, Tab silently mutated the draft — unexpected for macOS where Tab is commonly used for focus navigation

## Context
Addresses Codex review feedback on #2035: "Gate Tab autocomplete behind a visible suggestion cue."

## Test plan
- [ ] Verify ghost text appears when a suggestion is available and input text is a prefix of the suggestion
- [ ] Verify pressing Tab accepts the suggestion when ghost text is visible
- [ ] Verify Tab does not accept suggestions when no ghost text is displayed
- [ ] Verify the ghost text styling matches the previous implementation (muted color at 50% opacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
