### PR TITLE
refactor: introduce shared filesystem contracts and error model

### DIFF
--- a/assistant/src/tools/shared/filesystem/__tests__/errors.test.ts
+++ b/assistant/src/tools/shared/filesystem/__tests__/errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  FilesystemError,
+  invalidPath,
+  pathOutOfBounds,
+  pathNotAbsolute,
+  notFound,
+  notAFile,
+  sizeLimitExceeded,
+  matchNotFound,
+  matchAmbiguous,
+  ioError,
+} from '../errors.js';
+
+describe('FilesystemError helpers', () => {
+  test('invalidPath', () => {
+    const err = invalidPath('foo/../bar', 'contains traversal');
+    expect(err).toBeInstanceOf(FilesystemError);
+    expect(err.code).toBe('INVALID_PATH');
+    expect(err.message).toContain('foo/../bar');
+    expect(err.message).toContain('contains traversal');
+  });
+
+  test('invalidPath without reason', () => {
+    const err = invalidPath('');
+    expect(err.code).toBe('INVALID_PATH');
+    expect(err.message).not.toContain(':');
+  });
+
+  test('pathOutOfBounds', () => {
+    const err = pathOutOfBounds('/etc/passwd', '/home/user/project');
+    expect(err.code).toBe('PATH_OUT_OF_BOUNDS');
+    expect(err.message).toContain('/etc/passwd');
+    expect(err.message).toContain('/home/user/project');
+  });
+
+  test('pathNotAbsolute', () => {
+    const err = pathNotAbsolute('relative/path.txt');
+    expect(err.code).toBe('PATH_NOT_ABSOLUTE');
+    expect(err.message).toContain('relative/path.txt');
+  });
+
+  test('notFound', () => {
+    const err = notFound('/missing/file.ts');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toContain('/missing/file.ts');
+  });
+
+  test('notAFile', () => {
+    const err = notAFile('/some/directory');
+    expect(err.code).toBe('NOT_A_FILE');
+    expect(err.message).toContain('/some/directory');
+  });
+
+  test('sizeLimitExceeded', () => {
+    const err = sizeLimitExceeded('/big/file.bin', '150.0 MB', '100.0 MB');
+    expect(err.code).toBe('SIZE_LIMIT_EXCEEDED');
+    expect(err.message).toContain('150.0 MB');
+    expect(err.message).toContain('100.0 MB');
+  });
+
+  test('matchNotFound', () => {
+    const err = matchNotFound('/src/app.ts');
+    expect(err.code).toBe('MATCH_NOT_FOUND');
+    expect(err.message).toContain('/src/app.ts');
+  });
+
+  test('matchAmbiguous', () => {
+    const err = matchAmbiguous('/src/app.ts', 3);
+    expect(err.code).toBe('MATCH_AMBIGUOUS');
+    expect(err.message).toContain('3');
+    expect(err.message).toContain('/src/app.ts');
+  });
+
+  test('ioError', () => {
+    const err = ioError('/locked/file', 'permission denied');
+    expect(err.code).toBe('IO_ERROR');
+    expect(err.message).toContain('/locked/file');
+    expect(err.message).toContain('permission denied');
+  });
+
+  test('all errors have name "FilesystemError"', () => {
+    const errors = [
+      invalidPath('x'),
+      pathOutOfBounds('x', 'y'),
+      pathNotAbsolute('x'),
+      notFound('x'),
+      notAFile('x'),
+      sizeLimitExceeded('x', '1', '2'),
+      matchNotFound('x'),
+      matchAmbiguous('x', 2),
+      ioError('x', 'y'),
+    ];
+    for (const err of errors) {
+      expect(err.name).toBe('FilesystemError');
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -1,0 +1,71 @@
+// Normalized filesystem error codes and helper constructors.
+// Provides a structured error model shared by sandbox and host filesystem tools.
+
+export type FilesystemErrorCode =
+  | 'INVALID_PATH'
+  | 'PATH_OUT_OF_BOUNDS'
+  | 'PATH_NOT_ABSOLUTE'
+  | 'NOT_FOUND'
+  | 'NOT_A_FILE'
+  | 'SIZE_LIMIT_EXCEEDED'
+  | 'MATCH_NOT_FOUND'
+  | 'MATCH_AMBIGUOUS'
+  | 'IO_ERROR';
+
+export class FilesystemError extends Error {
+  readonly code: FilesystemErrorCode;
+
+  constructor(code: FilesystemErrorCode, message: string) {
+    super(message);
+    this.name = 'FilesystemError';
+    this.code = code;
+  }
+}
+
+// ── Helper constructors ─────────────────────────────────
+
+export function invalidPath(path: string, reason?: string): FilesystemError {
+  const detail = reason ? `: ${reason}` : '';
+  return new FilesystemError('INVALID_PATH', `Invalid path "${path}"${detail}`);
+}
+
+export function pathOutOfBounds(path: string, boundary: string): FilesystemError {
+  return new FilesystemError(
+    'PATH_OUT_OF_BOUNDS',
+    `Path "${path}" resolves outside the allowed boundary "${boundary}"`,
+  );
+}
+
+export function pathNotAbsolute(path: string): FilesystemError {
+  return new FilesystemError('PATH_NOT_ABSOLUTE', `Path must be absolute: ${path}`);
+}
+
+export function notFound(path: string): FilesystemError {
+  return new FilesystemError('NOT_FOUND', `File not found: ${path}`);
+}
+
+export function notAFile(path: string): FilesystemError {
+  return new FilesystemError('NOT_A_FILE', `Not a regular file: ${path}`);
+}
+
+export function sizeLimitExceeded(path: string, size: string, limit: string): FilesystemError {
+  return new FilesystemError(
+    'SIZE_LIMIT_EXCEEDED',
+    `File size (${size}) exceeds the ${limit} limit: ${path}`,
+  );
+}
+
+export function matchNotFound(path: string): FilesystemError {
+  return new FilesystemError('MATCH_NOT_FOUND', `old_string not found in ${path}`);
+}
+
+export function matchAmbiguous(path: string, count: number): FilesystemError {
+  return new FilesystemError(
+    'MATCH_AMBIGUOUS',
+    `old_string matches ${count} locations in ${path}. Provide more context to make it unique, or set replace_all to true.`,
+  );
+}
+
+export function ioError(path: string, cause: string): FilesystemError {
+  return new FilesystemError('IO_ERROR', `I/O error on "${path}": ${cause}`);
+}

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -1,0 +1,40 @@
+// Shared input/output contracts for filesystem operations.
+// Used by both sandbox and host filesystem tools.
+
+// ── Read ────────────────────────────────────────────────
+
+export interface FileReadInput {
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface FileReadOutput {
+  content: string;
+}
+
+// ── Write ───────────────────────────────────────────────
+
+export interface FileWriteInput {
+  path: string;
+  content: string;
+}
+
+export interface FileWriteOutput {
+  filePath: string;
+}
+
+// ── Edit ────────────────────────────────────────────────
+
+export interface FileEditInput {
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+export interface FileEditOutput {
+  filePath: string;
+  replacementCount: number;
+  matchMethod: 'exact' | 'whitespace' | 'fuzzy';
+}


### PR DESCRIPTION
Part of #2009. Closes #2012.

Introduces shared filesystem contracts and error model for use by both sandbox and host filesystem tools.

## Changes

- **`assistant/src/tools/shared/filesystem/types.ts`** — Core input/output types for read, write, and edit operations (`FileReadInput`, `FileWriteInput`, `FileEditInput` and their output counterparts)
- **`assistant/src/tools/shared/filesystem/errors.ts`** — Normalized `FilesystemError` class with typed error codes (`INVALID_PATH`, `PATH_OUT_OF_BOUNDS`, `PATH_NOT_ABSOLUTE`, `NOT_FOUND`, `NOT_A_FILE`, `SIZE_LIMIT_EXCEEDED`, `MATCH_NOT_FOUND`, `MATCH_AMBIGUOUS`, `IO_ERROR`) and helper constructors
- **`assistant/src/tools/shared/filesystem/__tests__/errors.test.ts`** — Unit tests for all error helper constructors (11 tests, all passing)

Not wired into tools yet — that happens in M4+.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
