### PR TITLE
feat(ipc): add trace_event message type to IPC protocol

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1015,3 +1015,23 @@ exports[`IPC message snapshots ServerMessage types get_signing_identity serializ
   "type": "get_signing_identity",
 }
 `;
+
+exports[`IPC message snapshots ServerMessage types trace_event serializes to expected JSON 1`] = `
+{
+  "attributes": {
+    "command": "ls -la",
+    "riskLevel": "low",
+    "sandboxed": true,
+    "toolName": "bash",
+  },
+  "eventId": "evt-001",
+  "kind": "tool_started",
+  "requestId": "req-001",
+  "sequence": 1,
+  "sessionId": "sess-001",
+  "status": "info",
+  "summary": "Running bash: ls -la",
+  "timestampMs": 1700000000000,
+  "type": "trace_event",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -640,6 +640,18 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   get_signing_identity: {
     type: 'get_signing_identity',
   },
+  trace_event: {
+    type: 'trace_event',
+    eventId: 'evt-001',
+    sessionId: 'sess-001',
+    requestId: 'req-001',
+    timestampMs: 1700000000000,
+    sequence: 1,
+    kind: 'tool_started',
+    status: 'info',
+    summary: 'Running bash: ls -la',
+    attributes: { toolName: 'bash', command: 'ls -la', riskLevel: 'low', sandboxed: true },
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -92,6 +92,7 @@
     "ToolOutputChunk",
     "ToolResult",
     "ToolUseStart",
+    "TraceEvent",
     "TrustRulesListResponse",
     "UiSurfaceDismiss",
     "UiSurfaceShow",

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -878,6 +878,37 @@ export interface TimerCompleted {
   durationMinutes: number;
 }
 
+export type TraceEventKind =
+  | 'request_received'
+  | 'request_queued'
+  | 'request_dequeued'
+  | 'llm_call_started'
+  | 'llm_call_finished'
+  | 'assistant_message'
+  | 'tool_started'
+  | 'tool_permission_requested'
+  | 'tool_permission_decided'
+  | 'tool_finished'
+  | 'tool_failed'
+  | 'secret_detected'
+  | 'generation_handoff'
+  | 'message_complete'
+  | 'generation_cancelled'
+  | 'request_error';
+
+export interface TraceEvent {
+  type: 'trace_event';
+  eventId: string;
+  sessionId: string;
+  requestId?: string;
+  timestampMs: number;
+  sequence: number;
+  kind: TraceEventKind;
+  status?: 'info' | 'success' | 'warning' | 'error';
+  summary: string;
+  attributes?: Record<string, string | number | boolean | null>;
+}
+
 /** Common fields shared by all UiSurfaceShow variants. */
 interface UiSurfaceShowBase {
   type: 'ui_surface_show';
@@ -995,7 +1026,8 @@ export type ServerMessage =
   | SharedAppDeleteResponse
   | OpenBundleResponse
   | SignBundlePayloadRequest
-  | GetSigningIdentityRequest;
+  | GetSigningIdentityRequest
+  | TraceEvent;
 
 // === Contract schema ===
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1033,6 +1033,20 @@ public struct SignBundlePayloadMessage: Decodable, Sendable {
     public let payload: String
 }
 
+/// Real-time execution trace event from the daemon.
+/// Wire type: `"trace_event"`
+public struct TraceEventMessage: Decodable, Sendable {
+    public let eventId: String
+    public let sessionId: String
+    public let requestId: String?
+    public let timestampMs: Double
+    public let sequence: Int
+    public let kind: String
+    public let status: String?
+    public let summary: String
+    public let attributes: [String: AnyCodable]?
+}
+
 /// Timer completed notification from daemon.
 /// Wire type: `"timer_completed"`
 public struct TimerCompletedMessage: Decodable, Sendable {
@@ -1314,6 +1328,7 @@ public enum ServerMessage: Decodable, Sendable {
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
     case timerCompleted(TimerCompletedMessage)
+    case traceEvent(TraceEventMessage)
     case trustRulesListResponse(TrustRulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
     case sharedAppsListResponse(SharedAppsListResponseMessage)
@@ -1454,6 +1469,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "open_bundle_response":
             let message = try OpenBundleResponseMessage(from: decoder)
             self = .openBundleResponse(message)
+        case "trace_event":
+            let message = try TraceEventMessage(from: decoder)
+            self = .traceEvent(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
Part of #2046. Adds `trace_event` message to the TS protocol (`ServerMessage` union) and Swift decoder for real-time execution tracing.

### Changes
- **TS**: Added `TraceEventKind` type and `TraceEvent` interface to `ipc-contract.ts`, added to `ServerMessage` union
- **Swift**: Added `TraceEventMessage` struct, `ServerMessage.traceEvent` case, and decoder switch for `"trace_event"`
- **Tests**: Added canonical `trace_event` fixture to snapshot tests
- **Inventory**: Updated `ipc-contract-inventory.json` with `TraceEvent`

### Data Contract
The `trace_event` message carries: `eventId`, `sessionId`, `requestId?`, `timestampMs`, `sequence`, `kind` (16 event kinds), `status?`, `summary`, `attributes?`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
