### PR TITLE
M4: Extract shared path policy module

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { sandboxPolicy, hostPolicy } from '../tools/shared/filesystem/path-policy.js';
+
+const testDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'path-policy-test-')));
+  testDirs.push(dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox policy
+// ---------------------------------------------------------------------------
+
+describe('sandboxPolicy', () => {
+  test('rejects traversal escape via ../', () => {
+    const boundary = makeTempDir();
+    const result = sandboxPolicy('../../etc/passwd', boundary);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('outside the working directory');
+    }
+  });
+
+  test('rejects deep traversal escape', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'a', 'b'), { recursive: true });
+    const result = sandboxPolicy('a/b/../../../../etc/shadow', boundary);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('outside the working directory');
+    }
+  });
+
+  test('rejects symlink that escapes the boundary', () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+
+    // Create a symlink inside the boundary that points outside
+    symlinkSync(outside, join(boundary, 'escape-link'));
+
+    const result = sandboxPolicy('escape-link', boundary);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('outside the working directory');
+    }
+  });
+
+  test('rejects parent dir symlink escape in mustExist=false flow', () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+
+    // Create a symlink directory inside boundary pointing outside
+    symlinkSync(outside, join(boundary, 'link-dir'));
+
+    // Writing a new file under link-dir should be caught
+    const result = sandboxPolicy('link-dir/new-file.txt', boundary, { mustExist: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('outside the working directory');
+    }
+  });
+
+  test('accepts valid relative path within boundary', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'sub'));
+
+    const result = sandboxPolicy('sub/file.txt', boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, 'sub', 'file.txt'));
+    }
+  });
+
+  test('accepts absolute path within boundary', () => {
+    const boundary = makeTempDir();
+    const filePath = join(boundary, 'file.txt');
+
+    const result = sandboxPolicy(filePath, boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(filePath);
+    }
+  });
+
+  test('accepts new file path with mustExist=false', () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, 'subdir'));
+
+    const result = sandboxPolicy('subdir/new-file.txt', boundary, { mustExist: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, 'subdir', 'new-file.txt'));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host policy
+// ---------------------------------------------------------------------------
+
+describe('hostPolicy', () => {
+  test('rejects relative path', () => {
+    const result = hostPolicy('relative/path.txt');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be absolute');
+      expect(result.error).toContain('relative/path.txt');
+    }
+  });
+
+  test('rejects bare filename', () => {
+    const result = hostPolicy('file.txt');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be absolute');
+    }
+  });
+
+  test('accepts absolute path', () => {
+    const result = hostPolicy('/usr/local/bin/something');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/usr/local/bin/something');
+    }
+  });
+
+  test('accepts root path', () => {
+    const result = hostPolicy('/');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/');
+    }
+  });
+});

--- a/assistant/src/tools/filesystem/path-guard.ts
+++ b/assistant/src/tools/filesystem/path-guard.ts
@@ -1,68 +1,15 @@
-import { resolve, relative, dirname, basename, join } from 'node:path';
-import { realpathSync } from 'node:fs';
+import { sandboxPolicy, type PathResult } from '../shared/filesystem/path-policy.js';
 
 /**
- * Resolve a user-supplied path against the working directory and verify
- * that the result stays within the allowed boundary (workingDir by default).
+ * Compatibility shim — forwards to the shared sandbox policy.
  *
- * Returns the resolved absolute path on success, or an error message string.
- *
- * For existing paths, symlinks are resolved via realpathSync so a symlink
- * pointing outside the boundary is caught. For new paths (file_write),
- * the caller should pass `mustExist: false` — the nearest existing ancestor
- * directory is resolved via realpathSync to catch symlinks in parent dirs.
+ * All existing callers import this function; the actual implementation
+ * now lives in `shared/filesystem/path-policy.ts`.
  */
 export function validateFilePath(
   rawPath: string,
   workingDir: string,
   options?: { mustExist?: boolean },
-): { ok: true; resolved: string } | { ok: false; error: string } {
-  const mustExist = options?.mustExist ?? true;
-
-  const resolved = resolve(workingDir, rawPath);
-
-  // Resolve symlinks to catch symlink-based escapes.
-  // For mustExist=false (file_write), walk up to the nearest existing
-  // ancestor and resolve it, then re-append the trailing components.
-  // This prevents symlink directories from escaping the boundary.
-  let realResolved = resolved;
-  if (mustExist) {
-    try {
-      realResolved = realpathSync(resolved);
-    } catch {
-      // File doesn't exist — will be caught by the tool's own existence check
-      realResolved = resolved;
-    }
-  } else {
-    let current = resolved;
-    const trailing: string[] = [];
-    while (current !== dirname(current)) {
-      try {
-        const real = realpathSync(current);
-        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
-        break;
-      } catch {
-        trailing.unshift(basename(current));
-        current = dirname(current);
-      }
-    }
-  }
-
-  // Resolve the working directory's real path too (in case it's a symlink)
-  let realWorkingDir: string;
-  try {
-    realWorkingDir = realpathSync(workingDir);
-  } catch {
-    realWorkingDir = workingDir;
-  }
-
-  const rel = relative(realWorkingDir, realResolved);
-  if (rel.startsWith('..') || resolve(realWorkingDir, rel) !== realResolved) {
-    return {
-      ok: false,
-      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realWorkingDir}"`,
-    };
-  }
-
-  return { ok: true, resolved };
+): PathResult {
+  return sandboxPolicy(rawPath, workingDir, options);
 }

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,0 +1,94 @@
+import { resolve, relative, dirname, basename, join, isAbsolute } from 'node:path';
+import { realpathSync } from 'node:fs';
+
+/**
+ * Result type shared by both sandbox and host path policies.
+ */
+export type PathResult =
+  | { ok: true; resolved: string }
+  | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Sandbox policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a user-supplied path against a boundary directory and verify
+ * that the result stays within it.
+ *
+ * For existing paths, symlinks are resolved via realpathSync so a symlink
+ * pointing outside the boundary is caught. For new paths (e.g. file_write),
+ * pass `mustExist: false` — the nearest existing ancestor directory is
+ * resolved via realpathSync to catch symlinks in parent dirs.
+ */
+export function sandboxPolicy(
+  rawPath: string,
+  boundaryDir: string,
+  options?: { mustExist?: boolean },
+): PathResult {
+  const mustExist = options?.mustExist ?? true;
+
+  const resolved = resolve(boundaryDir, rawPath);
+
+  // Resolve symlinks to catch symlink-based escapes.
+  // For mustExist=false, walk up to the nearest existing ancestor and
+  // resolve it, then re-append the trailing components.
+  let realResolved = resolved;
+  if (mustExist) {
+    try {
+      realResolved = realpathSync(resolved);
+    } catch {
+      // File doesn't exist — will be caught by the tool's own existence check
+      realResolved = resolved;
+    }
+  } else {
+    let current = resolved;
+    const trailing: string[] = [];
+    while (current !== dirname(current)) {
+      try {
+        const real = realpathSync(current);
+        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
+        break;
+      } catch {
+        trailing.unshift(basename(current));
+        current = dirname(current);
+      }
+    }
+  }
+
+  // Resolve the boundary directory's real path too (in case it's a symlink)
+  let realBoundary: string;
+  try {
+    realBoundary = realpathSync(boundaryDir);
+  } catch {
+    realBoundary = boundaryDir;
+  }
+
+  const rel = relative(realBoundary, realResolved);
+  if (rel.startsWith('..') || resolve(realBoundary, rel) !== realResolved) {
+    return {
+      ok: false,
+      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realBoundary}"`,
+    };
+  }
+
+  return { ok: true, resolved };
+}
+
+// ---------------------------------------------------------------------------
+// Host policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a path for host filesystem access.
+ * Only requirement: the path must be absolute. No sandbox boundary check.
+ */
+export function hostPolicy(rawPath: string): PathResult {
+  if (!isAbsolute(rawPath)) {
+    return {
+      ok: false,
+      error: `path must be absolute for host file access: ${rawPath}`,
+    };
+  }
+  return { ok: true, resolved: rawPath };
+}


### PR DESCRIPTION
## Summary
- Create shared path policy module (`shared/filesystem/path-policy.ts`) with two distinct policies:
  - `sandboxPolicy`: boundary-scoped validation with symlink-safe checks (extracted from `validateFilePath`)
  - `hostPolicy`: absolute-path enforcement for host filesystem access
- Convert `path-guard.ts` into a thin compatibility shim forwarding to `sandboxPolicy`
- Add comprehensive path policy tests (11 test cases)
- No behavior changes for existing tools

Part of #2009
Closes #2013

## Test plan
- [x] path-policy.test.ts passes (11 tests)
- [x] tool-executor-lifecycle-events.test.ts passes
- [x] secret-scanner-executor.test.ts passes
- [x] All sandbox filesystem tests pass (file-read, file-write, file-edit)
- [x] All host filesystem tests pass (host-file-read, host-file-write, host-file-edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
