### PR TITLE
test: add baseline error handling tests (M0)

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -217,6 +217,60 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
+    func testErrorFinalizesStreamingAssistantMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Start streaming an assistant message
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+
+        // Error arrives mid-stream
+        viewModel.handleServerMessage(.error(ErrorMessage(message: "Stream failed")))
+
+        XCTAssertFalse(viewModel.messages[1].isStreaming, "Streaming message should be finalized on error")
+        XCTAssertEqual(viewModel.errorText, "Stream failed")
+    }
+
+    func testErrorDuringCancellationSuppressesErrorText() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.sessionId = "test-session"
+
+        // Start streaming, then cancel
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+        viewModel.stopGenerating()
+
+        // Error arrives as a result of cancellation
+        viewModel.handleServerMessage(.error(ErrorMessage(message: "Cancelled by user")))
+
+        XCTAssertNil(viewModel.errorText, "Error during cancellation should not surface to the user")
+        XCTAssertFalse(viewModel.isSending)
+        XCTAssertFalse(viewModel.isThinking)
+    }
+
+    func testErrorResetsProcessingMessagesToSent() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        // Queue B, then dequeue it so it becomes .processing
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing)
+
+        // Error arrives while B is processing
+        viewModel.handleServerMessage(.error(ErrorMessage(message: "Processing failed")))
+
+        XCTAssertEqual(viewModel.messages[2].status, .sent, "Processing message should be reset to .sent on error")
+        XCTAssertEqual(viewModel.errorText, "Processing failed")
+    }
+
     func testDismissErrorClearsErrorText() {
         viewModel.errorText = "Some error"
         viewModel.dismissError()


### PR DESCRIPTION
Part of #2038. Adds baseline test coverage for existing generic error handling behavior in Swift ChatViewModelTests, establishing a safety net before protocol changes.

## Changes

Three new tests added to `ChatViewModelTests.swift`:

- **`testErrorFinalizesStreamingAssistantMessage`**: Verifies that when an error arrives while an assistant message is streaming, the message's `isStreaming` flag is set to false and `errorText` is populated.

- **`testErrorDuringCancellationSuppressesErrorText`**: Verifies that when the user cancels generation and an error arrives as a result, `errorText` is NOT set (cancellation errors should not surface to the user).

- **`testErrorResetsProcessingMessagesToSent`**: Verifies that user messages with `.processing` status are reset to `.sent` when an error occurs mid-processing.

The existing IPC snapshot tests already have full coverage for the generic `error` message type (snapshot + round-trip), confirmed passing.

## Test plan

- [x] TypeScript IPC snapshot tests pass (99/99)
- [x] TypeScript type-check clean
- [x] Swift test target compiles successfully
- [ ] Swift tests pass at runtime (note: `swift test` CLI cannot build the iOS target on macOS; tests verified via compilation only — runtime testing requires Xcode IDE)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
