### PR TITLE
build(ipc): generate swift ipc models from ts contract

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -35,8 +35,10 @@
         "drizzle-kit": "^0.30.4",
         "eslint": "^10.0.0",
         "fast-check": "^4.5.3",
+        "quicktype-core": "^23.2.6",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.54.0",
+        "typescript-json-schema": "^0.67.1",
       },
     },
   },
@@ -48,6 +50,8 @@
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.8.2", "", {}, "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="],
 
     "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.3.1", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.8.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -117,6 +121,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.0", "", { "dependencies": { "@eslint/core": "^1.1.0", "levn": "^0.4.1" } }, "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ=="],
 
+    "@glideapps/ts-necessities": ["@glideapps/ts-necessities@2.2.3", "", {}, "sha512-gXi0awOZLHk3TbW55GZLCPP6O+y/b5X1pBXKBVckFONSwF1z1E5ND2BGJsghQFah+pW7pkkyFb2VhUQI2qhL5w=="],
+
     "@google/genai": ["@google/genai@1.41.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^7.1.1", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
@@ -184,6 +190,12 @@
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -289,6 +301,14 @@
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.38.0", "", { "dependencies": { "@sentry/core": "10.38.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-YPVhWfYmC7nD3EJqEHGtjp4fp5LwtAbE5rt9egQ4hqJlYFvr8YEz9sdoqSZxO0cZzgs2v97HFl/nmWAXe52G2Q=="],
 
+    "@tsconfig/node10": ["@tsconfig/node10@1.0.12", "", {}, "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ=="],
+
+    "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
+
+    "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
+
+    "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
+
     "@types/archiver": ["@types/archiver@7.0.0", "", { "dependencies": { "@types/readdir-glob": "*" } }, "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
@@ -345,19 +365,23 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
 
     "archiver-utils": ["archiver-utils@5.0.2", "", { "dependencies": { "glob": "^10.0.0", "graceful-fs": "^4.2.0", "is-stream": "^2.0.1", "lazystream": "^1.0.0", "lodash": "^4.17.15", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA=="],
+
+    "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -379,6 +403,8 @@
 
     "brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
+    "browser-or-node": ["browser-or-node@3.0.0", "", {}, "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ=="],
+
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
@@ -395,6 +421,10 @@
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "collection-utils": ["collection-utils@1.0.1", "", {}, "sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -407,13 +437,19 @@
 
     "compress-commons": ["compress-commons@6.0.2", "", { "dependencies": { "crc-32": "^1.2.0", "crc32-stream": "^6.0.0", "is-stream": "^2.0.1", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg=="],
 
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
 
+    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
+
     "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
+
+    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -435,6 +471,8 @@
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
+    "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
+
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
     "drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
@@ -445,7 +483,7 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -464,6 +502,8 @@
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -531,6 +571,8 @@
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
 
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -541,13 +583,15 @@
 
     "gel": ["gel@2.2.0", "", { "dependencies": { "@petamoriken/float16": "^3.8.7", "debug": "^4.3.4", "env-paths": "^3.0.0", "semver": "^7.6.2", "shell-quote": "^1.8.1", "which": "^4.0.0" }, "bin": { "gel": "dist/cli.mjs" } }, "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -591,6 +635,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -603,6 +649,8 @@
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
+    "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
+
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
@@ -610,6 +658,8 @@
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
@@ -642,6 +692,8 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
@@ -701,7 +753,11 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "path-equal": ["path-equal@1.2.5", "", {}, "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -728,6 +784,8 @@
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
@@ -757,11 +815,15 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
-    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+    "quicktype-core": ["quicktype-core@23.2.6", "", { "dependencies": { "@glideapps/ts-necessities": "2.2.3", "browser-or-node": "^3.0.0", "collection-utils": "^1.0.1", "cross-fetch": "^4.0.0", "is-url": "^1.2.4", "js-base64": "^3.7.7", "lodash": "^4.17.21", "pako": "^1.0.6", "pluralize": "^8.0.0", "readable-stream": "4.5.2", "unicode-properties": "^1.4.1", "urijs": "^1.19.1", "wordwrap": "^1.0.0", "yaml": "^2.4.1" } }, "sha512-asfeSv7BKBNVb9WiYhFRBvBZHcRutPRBwJMxW0pefluK4kkKu4lv0IvZBwFKvw2XygLcL1Rl90zxWDHYgkwCmA=="],
+
+    "readable-stream": ["readable-stream@4.5.2", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g=="],
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -807,13 +869,13 @@
 
     "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
-    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -827,6 +889,8 @@
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
@@ -834,6 +898,8 @@
     "tree-sitter-bash": ["tree-sitter-bash@0.25.1", "", { "dependencies": { "node-addon-api": "^8.2.1", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
+    "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -845,15 +911,27 @@
 
     "typescript-eslint": ["typescript-eslint@8.55.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.55.0", "@typescript-eslint/parser": "8.55.0", "@typescript-eslint/typescript-estree": "8.55.0", "@typescript-eslint/utils": "8.55.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw=="],
 
+    "typescript-json-schema": ["typescript-json-schema@0.67.1", "", { "dependencies": { "@types/json-schema": "^7.0.9", "@types/node": "^18.11.9", "glob": "^7.1.7", "path-equal": "^1.2.5", "safe-stable-stringify": "^2.2.0", "ts-node": "^10.9.1", "typescript": "~5.5.0", "vm2": "^3.10.0", "yargs": "^17.1.1" }, "bin": { "typescript-json-schema": "bin/typescript-json-schema" } }, "sha512-vKTZB/RoYTIBdVP7E7vrgHMCssBuhja91wQy498QIVhvfRimaOgjc98uwAXmZ7mbLUytJmOSbF11wPz+ByQeXg=="],
+
     "undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "urijs": ["urijs@1.19.11", "", {}, "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
+
+    "vm2": ["vm2@3.10.4", "", { "dependencies": { "acorn": "^8.14.1", "acorn-walk": "^8.3.4" }, "bin": { "vm2": "bin/vm2" } }, "sha512-Gl6r7MN3mkawGurFdp467yDJQ7HdragK2QVVWFbOCd3LPJXJLE2xZFwLCNhp04MTkHruPqLIOs3pYbJQJw/1aA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -867,7 +945,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -877,7 +957,17 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -891,6 +981,12 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
@@ -903,7 +999,17 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "archiver/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "archiver-utils/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
     "balanced-match/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
+
+    "compress-commons/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -913,7 +1019,7 @@
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -928,6 +1034,8 @@
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
@@ -959,19 +1067,15 @@
 
     "sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "typescript-json-schema/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "typescript-json-schema/typescript": ["typescript@5.5.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "zip-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
@@ -1019,17 +1123,25 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@sentry/node/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "archiver-utils/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "balanced-match/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
@@ -1037,18 +1149,24 @@
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "typescript-json-schema/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@sentry/node/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "readdir-glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -11,6 +11,8 @@
     "db:push": "drizzle-kit push",
     "ipc:inventory": "bun run scripts/ipc/check-contract-inventory.ts",
     "ipc:inventory:update": "bun run scripts/ipc/check-contract-inventory.ts --update",
+    "generate:ipc": "bun run scripts/ipc/generate-swift.ts",
+    "check:ipc-generated": "bun run scripts/ipc/generate-swift.ts --check",
     "lint": "eslint",
     "test": "bash scripts/test.sh"
   },
@@ -45,7 +47,9 @@
     "drizzle-kit": "^0.30.4",
     "eslint": "^10.0.0",
     "fast-check": "^4.5.3",
+    "quicktype-core": "^23.2.6",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.54.0"
+    "typescript-eslint": "^8.54.0",
+    "typescript-json-schema": "^0.67.1"
   }
 }

--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -1,0 +1,440 @@
+/**
+ * IPC contract → Swift code generator.
+ *
+ * Pipeline:
+ *   1. typescript-json-schema extracts JSON Schema from ipc-contract.ts
+ *   2. Schemas are walked to produce Swift Codable structs and enums
+ *   3. Output is written to clients/shared/IPC/Generated/IPCContractGenerated.swift
+ *
+ * The generated structs are standalone DTOs. The discriminated union enums
+ * (ClientMessage/ServerMessage) stay in the hand-written IPCMessages.swift
+ * since they require custom Decodable init logic.
+ *
+ * Usage:
+ *   bun run generate:ipc              # generate the file
+ *   bun run generate:ipc -- --check   # fail if output would differ (CI)
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import * as TJS from 'typescript-json-schema';
+
+const ROOT = path.resolve(import.meta.dirname ?? __dirname, '../..');
+const CONTRACT_PATH = path.join(ROOT, 'src/daemon/ipc-contract.ts');
+const OUTPUT_PATH = path.resolve(
+  ROOT,
+  '../clients/shared/IPC/Generated/IPCContractGenerated.swift',
+);
+
+const PREAMBLE = `// AUTO-GENERATED from assistant/src/daemon/ipc-contract.ts — DO NOT EDIT
+// Regenerate: cd assistant && bun run generate:ipc
+//
+// This file contains Swift Codable DTOs derived from the IPC contract.
+// The discriminated union enums (ClientMessage/ServerMessage) remain
+// in the hand-written IPCMessages.swift since they require custom
+// Decodable init logic that code generators cannot express cleanly.
+
+import Foundation
+`;
+
+// --- Config ---
+
+/** Types to skip entirely. */
+const SKIP_TYPES = new Set([
+  'ClientMessage',
+  'ServerMessage',
+  'IPCContractSchema',
+  'SurfaceData',
+  'SurfaceType',
+  'UiSurfaceShow',
+  'UiSurfaceShowBase',
+  'INTERACTIVE_SURFACE_TYPES',
+]);
+
+// --- JSON Schema type definitions ---
+
+interface SchemaDef {
+  type?: string;
+  properties?: Record<string, SchemaDef>;
+  required?: string[];
+  enum?: string[];
+  const?: string;
+  $ref?: string;
+  items?: SchemaDef;
+  anyOf?: SchemaDef[];
+  additionalProperties?: boolean | SchemaDef;
+  description?: string;
+  definitions?: Record<string, SchemaDef>;
+}
+
+// --- Step 1: Generate JSON Schema from TypeScript ---
+
+function generateSchemas(): Record<string, SchemaDef> {
+  const program = TJS.getProgramFromFiles([CONTRACT_PATH], {
+    strict: true,
+    target: 99,
+    module: 199,
+    moduleResolution: 99,
+    skipLibCheck: true,
+  });
+
+  const generator = TJS.buildGenerator(program, {
+    required: true,
+    noExtraProps: false,
+    strictNullChecks: true,
+    ref: true,
+  });
+
+  if (!generator) {
+    throw new Error('Failed to create schema generator');
+  }
+
+  const symbols = generator.getMainFileSymbols(program, [CONTRACT_PATH]);
+  const result: Record<string, SchemaDef> = {};
+
+  for (const symbol of symbols) {
+    if (SKIP_TYPES.has(symbol)) continue;
+    try {
+      const schema = generator.getSchemaForSymbol(symbol) as SchemaDef | null;
+      if (schema) {
+        result[symbol] = schema;
+      }
+    } catch {
+      // const values or complex type aliases may not produce schemas
+    }
+  }
+
+  return result;
+}
+
+// --- Step 2: Convert JSON Schema to Swift model ---
+
+/** Resolve "#/definitions/Foo" → "Foo". */
+function resolveRef(ref: string): string {
+  const match = ref.match(/^#\/definitions\/(.+)$/);
+  return match ? decodeURIComponent(match[1]) : ref;
+}
+
+/**
+ * Heuristic: properties whose names match these patterns should be Int, not Double.
+ * JSON Schema uses "number" for both, but the TS contract uses `number` for both
+ * int-like values (counts, sizes) and float-like values (cost, timestamps).
+ */
+const INT_PATTERNS = [
+  /[Tt]okens?$/,
+  /[Cc]ount$/,
+  /[Nn]umber$/,
+  /[Ss]tep\w*$/,
+  /[Pp]osition$/,
+  /[Pp]riority$/,
+  /[Ww]idth$/,
+  /[Hh]eight$/,
+  /[Ss]ize\w*$/,
+  /^format_version$/,
+  /At$/,
+  /[Ss]tars$/,
+  /[Ii]nstalls$/,
+  /[Dd]ownloads$/,
+  /[Vv]ersions$/,
+  /[Rr]eports$/,
+  /maxFiles$/,
+  /maxSizeBytes$/,
+  /removedCount$/,
+  /cleared$/,
+  /queuedCount$/,
+  /^maxResponseTokens$/,
+  /Messages$/,
+  /Calls$/,
+];
+
+function shouldBeInt(propName: string): boolean {
+  return INT_PATTERNS.some((p) => p.test(propName));
+}
+
+interface SwiftProperty {
+  swiftName: string;
+  jsonName: string;
+  swiftType: string;
+  isOptional: boolean;
+  doc?: string;
+}
+
+interface SwiftStruct {
+  name: string;
+  properties: SwiftProperty[];
+  doc?: string;
+}
+
+// Collector for extracted inline structs
+const extractedStructs: SwiftStruct[] = [];
+
+/**
+ * Convert a schema property to its Swift type string.
+ * When encountering inline objects, extracts them as separate named structs.
+ */
+function schemaToSwiftType(
+  prop: SchemaDef,
+  parentName: string,
+  propName: string,
+  allDefs: Record<string, SchemaDef>,
+): string {
+  // $ref → named type
+  if (prop.$ref) {
+    const refName = resolveRef(prop.$ref);
+
+    if (refName === 'Record<string,unknown>') return '[String: AnyCodable]';
+    if (refName === 'Record<string,string>') return '[String: String]';
+    if (refName.startsWith('Partial<')) return '[String: AnyCodable]';
+
+    return `IPC${refName}`;
+  }
+
+  // anyOf — union. Check nullable pattern: [T, {type: "null"}]
+  if (prop.anyOf) {
+    const nonNull = prop.anyOf.filter((v) => v.type !== 'null');
+    const hasNull = prop.anyOf.some((v) => v.type === 'null');
+
+    if (nonNull.length === 1) {
+      const inner = schemaToSwiftType(nonNull[0], parentName, propName, allDefs);
+      return hasNull ? `${inner}?` : inner;
+    }
+
+    // Multi-type union
+    return 'AnyCodable';
+  }
+
+  // Primitives
+  switch (prop.type) {
+    case 'string':
+      return 'String';
+    case 'number':
+      return shouldBeInt(propName) ? 'Int' : 'Double';
+    case 'integer':
+      return 'Int';
+    case 'boolean':
+      return 'Bool';
+
+    case 'object':
+      // Inline object with named properties → extract as a struct
+      if (prop.properties) {
+        const structName = `${parentName}${capitalize(propName)}`;
+        extractInlineStruct(structName, prop, allDefs);
+        return structName;
+      }
+      // Map type
+      if (prop.additionalProperties && typeof prop.additionalProperties === 'object') {
+        const valueType = schemaToSwiftType(prop.additionalProperties, parentName, propName, allDefs);
+        return `[String: ${valueType}]`;
+      }
+      return '[String: AnyCodable]';
+
+    case 'array':
+      if (prop.items) {
+        const itemType = schemaToSwiftType(prop.items, parentName, singularize(propName), allDefs);
+        return `[${itemType}]`;
+      }
+      return '[AnyCodable]';
+
+    case 'null':
+      return 'AnyCodable?';
+  }
+
+  return 'AnyCodable';
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function singularize(s: string): string {
+  // Crude singularization for array item names
+  if (s.endsWith('ies')) return s.slice(0, -3) + 'y';
+  if (s.endsWith('ses') || s.endsWith('xes') || s.endsWith('zes')) return s.slice(0, -2);
+  if (s.endsWith('s') && !s.endsWith('ss')) return s.slice(0, -1);
+  return s;
+}
+
+/**
+ * Extract an inline object as a separate named struct.
+ */
+function extractInlineStruct(
+  name: string,
+  schema: SchemaDef,
+  allDefs: Record<string, SchemaDef>,
+): void {
+  // Prevent duplicates
+  if (extractedStructs.some((s) => s.name === name)) return;
+
+  const required = new Set(schema.required ?? []);
+  const properties: SwiftProperty[] = [];
+
+  for (const [pName, pDef] of Object.entries(schema.properties ?? {})) {
+    let swiftType = schemaToSwiftType(pDef, name, pName, allDefs);
+
+    const isOptional = !required.has(pName);
+    if (isOptional && !swiftType.endsWith('?')) {
+      swiftType = `${swiftType}?`;
+    }
+
+    properties.push({
+      swiftName: pName,
+      jsonName: pName,
+      swiftType,
+      isOptional,
+      doc: pDef.description,
+    });
+  }
+
+  extractedStructs.push({ name, properties });
+}
+
+// --- Step 3: Build all structs ---
+
+function buildAllStructs(
+  allDefs: Record<string, SchemaDef>,
+): SwiftStruct[] {
+  const structs: SwiftStruct[] = [];
+
+  for (const [name, def] of Object.entries(allDefs).sort(([a], [b]) => a.localeCompare(b))) {
+    if (def.type !== 'object' || !def.properties) continue;
+    // Skip pure string enum definitions
+    if (def.type === 'string' && def.enum) continue;
+
+    const ipcName = `IPC${name}`;
+    const required = new Set(def.required ?? []);
+    const properties: SwiftProperty[] = [];
+
+    for (const [propName, propDef] of Object.entries(def.properties)) {
+      let swiftType = schemaToSwiftType(propDef, ipcName, propName, allDefs);
+
+      const isOptional = !required.has(propName);
+      if (isOptional && !swiftType.endsWith('?')) {
+        swiftType = `${swiftType}?`;
+      }
+
+      properties.push({
+        swiftName: propName,
+        jsonName: propName,
+        swiftType,
+        isOptional,
+        doc: propDef.description,
+      });
+    }
+
+    structs.push({
+      name: ipcName,
+      properties,
+      doc: def.description,
+    });
+  }
+
+  return structs;
+}
+
+// --- Step 4: Emit Swift code ---
+
+function needsCodingKeys(props: SwiftProperty[]): boolean {
+  return props.some((p) => p.jsonName !== p.swiftName);
+}
+
+function emitStruct(s: SwiftStruct): string {
+  const lines: string[] = [];
+
+  if (s.doc) {
+    lines.push(`/// ${s.doc}`);
+  }
+
+  lines.push(`public struct ${s.name}: Codable, Sendable {`);
+
+  for (const p of s.properties) {
+    if (p.doc) {
+      lines.push(`    /// ${p.doc}`);
+    }
+    lines.push(`    public let ${p.swiftName}: ${p.swiftType}`);
+  }
+
+  if (needsCodingKeys(s.properties)) {
+    lines.push('');
+    lines.push('    private enum CodingKeys: String, CodingKey {');
+    for (const p of s.properties) {
+      if (p.jsonName !== p.swiftName) {
+        lines.push(`        case ${p.swiftName} = "${p.jsonName}"`);
+      } else {
+        lines.push(`        case ${p.swiftName}`);
+      }
+    }
+    lines.push('    }');
+  }
+
+  lines.push('}');
+  return lines.join('\n');
+}
+
+// --- Main ---
+
+async function main(): Promise<void> {
+  const isCheck = process.argv.includes('--check');
+
+  console.log('Generating JSON Schema from ipc-contract.ts...');
+  const allDefs = generateSchemas();
+  console.log(`Found ${Object.keys(allDefs).length} type definitions`);
+
+  // Reset extracted inline structs
+  extractedStructs.length = 0;
+
+  // Build top-level structs (this also populates extractedStructs for inline objects)
+  const topLevelStructs = buildAllStructs(allDefs);
+
+  // Merge: top-level first, then extracted inline structs (deduped)
+  const allStructNames = new Set(topLevelStructs.map((s) => s.name));
+  const inlineOnly = extractedStructs.filter((s) => !allStructNames.has(s.name));
+  const allStructs = [...topLevelStructs, ...inlineOnly].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  console.log(
+    `Generated ${topLevelStructs.length} top-level structs, ${inlineOnly.length} inline structs`,
+  );
+
+  const sections: string[] = [PREAMBLE];
+
+  sections.push('// MARK: - Generated IPC types\n');
+  for (const s of allStructs) {
+    sections.push(emitStruct(s));
+    sections.push('');
+  }
+
+  const output = sections.join('\n');
+
+  // Ensure output directory exists
+  const outputDir = path.dirname(OUTPUT_PATH);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  if (isCheck) {
+    if (!fs.existsSync(OUTPUT_PATH)) {
+      console.error(`Generated file not found at ${OUTPUT_PATH}`);
+      console.error('Run `bun run generate:ipc` to create it.');
+      process.exit(1);
+    }
+
+    const existing = fs.readFileSync(OUTPUT_PATH, 'utf-8');
+    if (existing !== output) {
+      console.error('Generated Swift file is out of date.');
+      console.error('Run `bun run generate:ipc` to regenerate.');
+      process.exit(1);
+    }
+
+    console.log('Generated Swift file is up to date.');
+    return;
+  }
+
+  fs.writeFileSync(OUTPUT_PATH, output, 'utf-8');
+  console.log(`Wrote ${OUTPUT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1,0 +1,1028 @@
+// AUTO-GENERATED from assistant/src/daemon/ipc-contract.ts — DO NOT EDIT
+// Regenerate: cd assistant && bun run generate:ipc
+//
+// This file contains Swift Codable DTOs derived from the IPC contract.
+// The discriminated union enums (ClientMessage/ServerMessage) remain
+// in the hand-written IPCMessages.swift since they require custom
+// Decodable init logic that code generators cannot express cleanly.
+
+import Foundation
+
+// MARK: - Generated IPC types
+
+public struct IPCAddTrustRule: Codable, Sendable {
+    public let type: String
+    public let toolName: String
+    public let pattern: String
+    public let scope: String
+    public let decision: String
+}
+
+public struct IPCAmbientObservation: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let ocrText: String
+    public let appName: String?
+    public let windowTitle: String?
+    public let timestamp: Double
+}
+
+public struct IPCAmbientResult: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let decision: String
+    public let summary: String?
+    public let suggestion: String?
+}
+
+public struct IPCAppDataRequest: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let callId: String
+    public let method: String
+    public let appId: String
+    public let recordId: String?
+    public let data: [String: AnyCodable]?
+}
+
+public struct IPCAppDataResponse: Codable, Sendable {
+    public let type: String
+    public let surfaceId: String
+    public let callId: String
+    public let success: Bool
+    public let result: AnyCodable?
+    public let error: String?
+}
+
+public struct IPCAppOpenRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+}
+
+public struct IPCAppsListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCAppsListResponse: Codable, Sendable {
+    public let type: String
+    public let apps: [IPCAppsListResponseApp]
+}
+
+public struct IPCAppsListResponseApp: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String?
+    public let icon: String?
+    public let createdAt: Int
+}
+
+public struct IPCAssistantTextDelta: Codable, Sendable {
+    public let type: String
+    public let text: String
+    public let sessionId: String?
+}
+
+public struct IPCAssistantThinkingDelta: Codable, Sendable {
+    public let type: String
+    public let thinking: String
+}
+
+public struct IPCBundleAppRequest: Codable, Sendable {
+    public let type: String
+    public let appId: String
+}
+
+public struct IPCBundleAppResponse: Codable, Sendable {
+    public let type: String
+    public let bundlePath: String
+    public let manifest: IPCBundleAppResponseManifest
+}
+
+public struct IPCBundleAppResponseManifest: Codable, Sendable {
+    public let format_version: Int
+    public let name: String
+    public let description: String?
+    public let icon: String?
+    public let created_at: String
+    public let created_by: String
+    public let entry: String
+    public let capabilities: [String]
+}
+
+public struct IPCCancelRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String?
+}
+
+public struct IPCCardSurfaceData: Codable, Sendable {
+    public let title: String
+    public let subtitle: String?
+    public let body: String
+    public let metadata: [IPCCardSurfaceDataMetadata]?
+    /// Optional template name for specialized rendering (e.g. "weather_forecast").
+    public let template: String?
+    /// Arbitrary data consumed by the template renderer. Shape depends on template.
+    public let templateData: [String: AnyCodable]?
+}
+
+public struct IPCCardSurfaceDataMetadata: Codable, Sendable {
+    public let label: String
+    public let value: String
+}
+
+public struct IPCConfirmationRequest: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let toolName: String
+    public let input: [String: AnyCodable]
+    public let riskLevel: String
+    public let executionTarget: String?
+    public let allowlistOptions: [IPCConfirmationRequestAllowlistOption]
+    public let scopeOptions: [IPCConfirmationRequestScopeOption]
+    public let diff: IPCConfirmationRequestDiff?
+    public let sandboxed: Bool?
+    public let sessionId: String?
+}
+
+public struct IPCConfirmationRequestAllowlistOption: Codable, Sendable {
+    public let label: String
+    public let description: String
+    public let pattern: String
+}
+
+public struct IPCConfirmationRequestDiff: Codable, Sendable {
+    public let filePath: String
+    public let oldContent: String
+    public let newContent: String
+    public let isNewFile: Bool
+}
+
+public struct IPCConfirmationRequestScopeOption: Codable, Sendable {
+    public let label: String
+    public let scope: String
+}
+
+public struct IPCConfirmationResponse: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let decision: String
+    public let selectedPattern: String?
+    public let selectedScope: String?
+}
+
+public struct IPCConfirmationSurfaceData: Codable, Sendable {
+    public let message: String
+    public let detail: String?
+    public let confirmLabel: String?
+    public let cancelLabel: String?
+    public let destructive: Bool?
+}
+
+public struct IPCContextCompacted: Codable, Sendable {
+    public let type: String
+    public let previousEstimatedInputTokens: Int
+    public let estimatedInputTokens: Int
+    public let maxInputTokens: Int
+    public let thresholdTokens: Int
+    public let compactedMessages: Int
+    public let summaryCalls: Int
+    public let summaryInputTokens: Int
+    public let summaryOutputTokens: Int
+    public let summaryModel: String
+}
+
+public struct IPCCuAction: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let toolName: String
+    public let input: [String: AnyCodable]
+    public let reasoning: String?
+    public let stepNumber: Int
+}
+
+public struct IPCCuComplete: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let summary: String
+    public let stepCount: Int
+    public let isResponse: Bool?
+}
+
+public struct IPCCuError: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let message: String
+}
+
+public struct IPCCuObservation: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let axTree: String?
+    public let axDiff: String?
+    public let secondaryWindows: String?
+    public let screenshot: String?
+    public let executionResult: String?
+    public let executionError: String?
+}
+
+public struct IPCCuSessionAbort: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCCuSessionCreate: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let task: String
+    public let screenWidth: Int
+    public let screenHeight: Int
+    public let attachments: [IPCUserMessageAttachment]?
+    public let interactionType: String?
+}
+
+public struct IPCDynamicPageSurfaceData: Codable, Sendable {
+    public let html: String
+    public let width: Int?
+    public let height: Int?
+    public let appId: String?
+}
+
+public struct IPCErrorMessage: Codable, Sendable {
+    public let type: String
+    public let message: String
+}
+
+public struct IPCFileUploadSurfaceData: Codable, Sendable {
+    public let prompt: String
+    public let acceptedTypes: [String]?
+    public let maxFiles: Int?
+    public let maxSizeBytes: Int?
+}
+
+public struct IPCFormField: Codable, Sendable {
+    public let id: String
+    public let type: String
+    public let label: String
+    public let placeholder: String?
+    public let required: Bool?
+    public let defaultValue: AnyCodable?
+    public let options: [IPCFormFieldOption]?
+}
+
+public struct IPCFormFieldOption: Codable, Sendable {
+    public let label: String
+    public let value: String
+}
+
+public struct IPCFormSurfaceData: Codable, Sendable {
+    public let description: String?
+    public let fields: [IPCFormField]
+    public let submitLabel: String?
+}
+
+public struct IPCGenerationCancelled: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCGenerationHandoff: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String?
+    public let queuedCount: Int
+}
+
+public struct IPCGetSigningIdentityRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCGetSigningIdentityResponse: Codable, Sendable {
+    public let type: String
+    public let keyId: String
+    public let publicKey: String
+}
+
+public struct IPCHistoryRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCHistoryResponse: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let messages: [IPCHistoryResponseMessage]
+}
+
+public struct IPCHistoryResponseMessage: Codable, Sendable {
+    public let role: String
+    public let text: String
+    public let timestamp: Double
+    public let toolCalls: [IPCHistoryResponseToolCall]?
+}
+
+public struct IPCHistoryResponseToolCall: Codable, Sendable {
+    public let name: String
+    public let input: [String: AnyCodable]
+    public let result: String?
+    public let isError: Bool?
+    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
+    public let imageData: String?
+}
+
+public struct IPCListItem: Codable, Sendable {
+    public let id: String
+    public let title: String
+    public let subtitle: String?
+    public let icon: String?
+    public let selected: Bool?
+}
+
+public struct IPCListSurfaceData: Codable, Sendable {
+    public let items: [IPCListItem]
+    public let selectionMode: String
+}
+
+public struct IPCMemoryRecalled: Codable, Sendable {
+    public let type: String
+    public let provider: String
+    public let model: String
+    public let lexicalHits: Double
+    public let semanticHits: Double
+    public let recencyHits: Double
+    public let entityHits: Double
+    public let mergedCount: Int
+    public let selectedCount: Int
+    public let rerankApplied: Bool
+    public let injectedTokens: Int
+    public let latencyMs: Double
+    public let topCandidates: [IPCMemoryRecalledCandidateDebug]
+}
+
+public struct IPCMemoryRecalledCandidateDebug: Codable, Sendable {
+    public let key: String
+    public let type: String
+    public let kind: String
+    public let finalScore: Double
+    public let lexical: Double
+    public let semantic: Double
+    public let recency: Double
+}
+
+public struct IPCMemoryStatus: Codable, Sendable {
+    public let type: String
+    public let enabled: Bool
+    public let degraded: Bool
+    public let reason: String?
+    public let provider: String?
+    public let model: String?
+}
+
+public struct IPCMessageComplete: Codable, Sendable {
+    public let type: String
+    public let sessionId: String?
+}
+
+public struct IPCMessageDequeued: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String
+}
+
+public struct IPCMessageQueued: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String
+    public let position: Int
+}
+
+public struct IPCModelGetRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCModelInfo: Codable, Sendable {
+    public let type: String
+    public let model: String
+    public let provider: String
+}
+
+public struct IPCModelSetRequest: Codable, Sendable {
+    public let type: String
+    public let model: String
+}
+
+public struct IPCOpenBundleRequest: Codable, Sendable {
+    public let type: String
+    public let filePath: String
+}
+
+public struct IPCOpenBundleResponse: Codable, Sendable {
+    public let type: String
+    public let manifest: IPCOpenBundleResponseManifest
+    public let scanResult: IPCOpenBundleResponseScanResult
+    public let signatureResult: IPCOpenBundleResponseSignatureResult
+    public let bundleSizeBytes: Int
+}
+
+public struct IPCOpenBundleResponseManifest: Codable, Sendable {
+    public let format_version: Int
+    public let name: String
+    public let description: String?
+    public let icon: String?
+    public let created_at: String
+    public let created_by: String
+    public let entry: String
+    public let capabilities: [String]
+}
+
+public struct IPCOpenBundleResponseScanResult: Codable, Sendable {
+    public let passed: Bool
+    public let blocked: [String]
+    public let warnings: [String]
+}
+
+public struct IPCOpenBundleResponseSignatureResult: Codable, Sendable {
+    public let trustTier: String
+    public let signerKeyId: String?
+    public let signerDisplayName: String?
+    public let signerAccount: String?
+}
+
+public struct IPCPingMessage: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCPongMessage: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCRegenerateRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCRemoveTrustRule: Codable, Sendable {
+    public let type: String
+    public let id: String
+}
+
+public struct IPCSandboxSetRequest: Codable, Sendable {
+    public let type: String
+    public let enabled: Bool
+}
+
+public struct IPCSecretDetected: Codable, Sendable {
+    public let type: String
+    public let toolName: String
+    public let matches: [IPCSecretDetectedMatche]
+    public let action: String
+}
+
+public struct IPCSecretDetectedMatche: Codable, Sendable {
+    public let type: String
+    public let redactedValue: String
+}
+
+public struct IPCSecretRequest: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let service: String
+    public let field: String
+    public let label: String
+    public let description: String?
+    public let placeholder: String?
+    public let sessionId: String?
+}
+
+public struct IPCSecretResponse: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let value: String?
+}
+
+public struct IPCSessionCreateRequest: Codable, Sendable {
+    public let type: String
+    public let title: String?
+    public let systemPromptOverride: String?
+    public let maxResponseTokens: Int?
+    public let correlationId: String?
+}
+
+public struct IPCSessionInfo: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let title: String
+    public let correlationId: String?
+}
+
+public struct IPCSessionListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCSessionListResponse: Codable, Sendable {
+    public let type: String
+    public let sessions: [IPCSessionListResponseSession]
+}
+
+public struct IPCSessionListResponseSession: Codable, Sendable {
+    public let id: String
+    public let title: String
+    public let updatedAt: Int
+}
+
+public struct IPCSessionsClearRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCSessionsClearResponse: Codable, Sendable {
+    public let type: String
+    public let cleared: Int
+}
+
+public struct IPCSessionSwitchRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCSharedAppDeleteRequest: Codable, Sendable {
+    public let type: String
+    public let uuid: String
+}
+
+public struct IPCSharedAppDeleteResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+}
+
+public struct IPCSharedAppsListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCSharedAppsListResponse: Codable, Sendable {
+    public let type: String
+    public let apps: [IPCSharedAppsListResponseApp]
+}
+
+public struct IPCSharedAppsListResponseApp: Codable, Sendable {
+    public let uuid: String
+    public let name: String
+    public let description: String?
+    public let icon: String?
+    public let entry: String
+    public let trustTier: String
+    public let signerDisplayName: String?
+    public let bundleSizeBytes: Int
+    public let installedAt: String
+}
+
+public struct IPCSignBundlePayloadRequest: Codable, Sendable {
+    public let type: String
+    public let payload: String
+}
+
+public struct IPCSignBundlePayloadResponse: Codable, Sendable {
+    public let type: String
+    public let signature: String
+    public let keyId: String
+    public let publicKey: String
+}
+
+public struct IPCSkillDetailRequest: Codable, Sendable {
+    public let type: String
+    public let skillId: String
+}
+
+public struct IPCSkillDetailResponse: Codable, Sendable {
+    public let type: String
+    public let skillId: String
+    public let body: String
+    public let icon: String?
+    public let error: String?
+}
+
+public struct IPCSkillsCheckUpdatesRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCSkillsConfigureRequest: Codable, Sendable {
+    public let type: String
+    public let name: String
+    public let env: [String: String]?
+    public let apiKey: String?
+    public let config: [String: AnyCodable]?
+}
+
+public struct IPCSkillsDisableRequest: Codable, Sendable {
+    public let type: String
+    public let name: String
+}
+
+public struct IPCSkillsEnableRequest: Codable, Sendable {
+    public let type: String
+    public let name: String
+}
+
+public struct IPCSkillsInspectRequest: Codable, Sendable {
+    public let type: String
+    public let slug: String
+}
+
+public struct IPCSkillsInspectResponse: Codable, Sendable {
+    public let type: String
+    public let slug: String
+    public let data: IPCSkillsInspectResponseData?
+    public let error: String?
+}
+
+public struct IPCSkillsInspectResponseData: Codable, Sendable {
+    public let skill: IPCSkillsInspectResponseDataSkill
+    public let owner: IPCSkillsInspectResponseDataOwner?
+    public let stats: IPCSkillsInspectResponseDataStats?
+    public let createdAt: AnyCodable?
+    public let updatedAt: AnyCodable?
+    public let latestVersion: IPCSkillsInspectResponseDataLatestVersion?
+    public let files: [IPCSkillsInspectResponseDataFile]?
+    public let skillMdContent: AnyCodable?
+}
+
+public struct IPCSkillsInspectResponseDataFile: Codable, Sendable {
+    public let path: String
+    public let size: Int
+    public let contentType: String?
+}
+
+public struct IPCSkillsInspectResponseDataLatestVersion: Codable, Sendable {
+    public let version: String
+    public let changelog: String?
+}
+
+public struct IPCSkillsInspectResponseDataOwner: Codable, Sendable {
+    public let handle: String
+    public let displayName: String
+    public let image: String?
+}
+
+public struct IPCSkillsInspectResponseDataSkill: Codable, Sendable {
+    public let slug: String
+    public let displayName: String
+    public let summary: String
+}
+
+public struct IPCSkillsInspectResponseDataStats: Codable, Sendable {
+    public let stars: Int
+    public let installs: Int
+    public let downloads: Int
+    public let versions: Int
+}
+
+public struct IPCSkillsInstallRequest: Codable, Sendable {
+    public let type: String
+    public let slug: String
+    public let version: String?
+}
+
+public struct IPCSkillsListRequest: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCSkillsListResponse: Codable, Sendable {
+    public let type: String
+    public let skills: [IPCSkillsListResponseSkill]
+}
+
+public struct IPCSkillsListResponseSkill: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let emoji: String?
+    public let homepage: String?
+    public let source: String
+    public let state: String
+    public let degraded: Bool
+    public let missingRequirements: IPCSkillsListResponseSkillMissingRequirements?
+    public let installedVersion: String?
+    public let latestVersion: String?
+    public let updateAvailable: Bool
+    public let userInvocable: Bool
+    public let clawhub: IPCSkillsListResponseSkillClawhub?
+}
+
+public struct IPCSkillsListResponseSkillClawhub: Codable, Sendable {
+    public let author: String
+    public let stars: Int
+    public let installs: Int
+    public let reports: Int
+    public let publishedAt: String
+}
+
+public struct IPCSkillsListResponseSkillMissingRequirements: Codable, Sendable {
+    public let bins: [String]?
+    public let env: [String]?
+    public let permissions: [String]?
+}
+
+public struct IPCSkillsOperationResponse: Codable, Sendable {
+    public let type: String
+    public let operation: String
+    public let success: Bool
+    public let error: String?
+    public let data: AnyCodable?
+}
+
+public struct IPCSkillsSearchRequest: Codable, Sendable {
+    public let type: String
+    public let query: String
+}
+
+public struct IPCSkillStateChanged: Codable, Sendable {
+    public let type: String
+    public let name: String
+    public let state: String
+}
+
+public struct IPCSkillsUninstallRequest: Codable, Sendable {
+    public let type: String
+    public let name: String
+}
+
+public struct IPCSkillsUpdateRequest: Codable, Sendable {
+    public let type: String
+    public let name: String
+}
+
+public struct IPCSuggestionRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let requestId: String
+}
+
+public struct IPCSuggestionResponse: Codable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let suggestion: AnyCodable
+    public let source: String
+}
+
+public struct IPCSurfaceAction: Codable, Sendable {
+    public let id: String
+    public let label: String
+    public let style: String?
+}
+
+public struct IPCTableColumn: Codable, Sendable {
+    public let id: String
+    public let label: String
+    public let width: Int?
+}
+
+public struct IPCTableRow: Codable, Sendable {
+    public let id: String
+    public let cells: [String: String]
+    public let selectable: Bool?
+    public let selected: Bool?
+}
+
+public struct IPCTableSurfaceData: Codable, Sendable {
+    public let columns: [IPCTableColumn]
+    public let rows: [IPCTableRow]
+    public let selectionMode: String?
+    public let caption: String?
+}
+
+public struct IPCTaskRouted: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let interactionType: String
+    /// The task text passed to the escalated session.
+    public let task: String?
+    /// Set when a text_qa session escalates to computer_use via request_computer_control.
+    public let escalatedFrom: String?
+}
+
+public struct IPCTaskSubmit: Codable, Sendable {
+    public let type: String
+    public let task: String
+    public let screenWidth: Int
+    public let screenHeight: Int
+    public let attachments: [IPCUserMessageAttachment]?
+    public let source: String?
+}
+
+public struct IPCTimerCompleted: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let timerId: String
+    public let label: String
+    public let durationMinutes: Double
+}
+
+public struct IPCToolOutputChunk: Codable, Sendable {
+    public let type: String
+    public let chunk: String
+}
+
+public struct IPCToolResult: Codable, Sendable {
+    public let type: String
+    public let toolName: String
+    public let result: String
+    public let isError: Bool?
+    public let diff: IPCToolResultDiff?
+    public let status: String?
+    public let sessionId: String?
+    /// Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot).
+    public let imageData: String?
+}
+
+public struct IPCToolResultDiff: Codable, Sendable {
+    public let filePath: String
+    public let oldContent: String
+    public let newContent: String
+    public let isNewFile: Bool
+}
+
+public struct IPCToolUseStart: Codable, Sendable {
+    public let type: String
+    public let toolName: String
+    public let input: [String: AnyCodable]
+    public let sessionId: String?
+}
+
+public struct IPCTrustRulesList: Codable, Sendable {
+    public let type: String
+}
+
+public struct IPCTrustRulesListResponse: Codable, Sendable {
+    public let type: String
+    public let rules: [IPCTrustRulesListResponseRule]
+}
+
+public struct IPCTrustRulesListResponseRule: Codable, Sendable {
+    public let id: String
+    public let tool: String
+    public let pattern: String
+    public let scope: String
+    public let decision: String
+    public let priority: Int
+    public let createdAt: Int
+}
+
+public struct IPCUiSurfaceAction: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let actionId: String
+    public let data: [String: AnyCodable]?
+}
+
+public struct IPCUiSurfaceDismiss: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+}
+
+public struct IPCUiSurfaceShowCard: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCCardSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowConfirmation: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCConfirmationSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowDynamicPage: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCDynamicPageSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowFileUpload: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCFileUploadSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowForm: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCFormSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowList: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCListSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceShowTable: Codable, Sendable {
+    public let surfaceType: String
+    public let data: IPCTableSurfaceData
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let title: String?
+    public let actions: [IPCSurfaceAction]?
+    public let display: String?
+}
+
+public struct IPCUiSurfaceUpdate: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let surfaceId: String
+    public let data: [String: AnyCodable]
+}
+
+public struct IPCUndoComplete: Codable, Sendable {
+    public let type: String
+    public let removedCount: Int
+    public let sessionId: String?
+}
+
+public struct IPCUndoRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCUpdateTrustRule: Codable, Sendable {
+    public let type: String
+    public let id: String
+    public let tool: String?
+    public let pattern: String?
+    public let scope: String?
+    public let decision: String?
+    public let priority: Int?
+}
+
+public struct IPCUsageRequest: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+}
+
+public struct IPCUsageResponse: Codable, Sendable {
+    public let type: String
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let estimatedCost: Double
+    public let model: String
+}
+
+public struct IPCUsageStats: Codable, Sendable {
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let estimatedCost: Double
+}
+
+public struct IPCUsageUpdate: Codable, Sendable {
+    public let type: String
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let estimatedCost: Double
+    public let model: String
+}
+
+public struct IPCUserMessage: Codable, Sendable {
+    public let type: String
+    public let sessionId: String
+    public let content: String?
+    public let attachments: [IPCUserMessageAttachment]?
+}
+
+public struct IPCUserMessageAttachment: Codable, Sendable {
+    public let id: String?
+    public let filename: String
+    public let mimeType: String
+    public let data: String
+    public let extractedText: String?
+}


### PR DESCRIPTION
Part of #1996. Introduces the TypeScript → JSON Schema → Swift Codable generation pipeline.

## What

- New script `assistant/scripts/ipc/generate-swift.ts` that:
  1. Uses `typescript-json-schema` to extract JSON Schema from `ipc-contract.ts`
  2. Walks the schema to produce Swift `Codable, Sendable` structs
  3. Extracts inline anonymous objects (array items, nested objects) as separate named structs
  4. Maps `Record<string, unknown>` → `[String: AnyCodable]`, `Partial<T>` → `[String: AnyCodable]`
  5. Uses naming heuristics to map `number` to `Int` vs `Double`

- Adds `generate:ipc` and `check:ipc-generated` scripts to `package.json`
- Generated output: `clients/shared/IPC/Generated/IPCContractGenerated.swift` (144 structs)
- Output compiles in `VellumAssistantShared` target with no modifications needed

## What it doesn't do

- Discriminated union enums (`ClientMessage`/`ServerMessage`) remain in hand-written `IPCMessages.swift` — they require custom `Decodable init` logic that codegen can't express
- No runtime behavior change — existing manual types stay in use

## Validation

- `bun run generate:ipc` runs deterministically (same input → same output)
- `bun run check:ipc-generated` passes when file is up to date
- `swift build --target VellumAssistantShared` compiles successfully
- `bunx tsc --noEmit` passes
- Pre-existing lint/test failures unrelated to this PR

Closes #1999.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
