### PR TITLE
fix(ui): improve composer padding for readability and centering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -100,7 +100,7 @@ struct ChatView: View {
     private var composerReservedHeight: CGFloat {
         let editorClamped = min(max(editorContentHeight, 14), 200)
         let contentHeight = max(editorClamped, 28)
-        let base: CGFloat = VSpacing.md * 2 + VSpacing.xs * 2 + contentHeight + 4
+        let base: CGFloat = VSpacing.md * 2 + VSpacing.sm * 2 + contentHeight + 4
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
         let error: CGFloat = errorText != nil ? 36 : 0
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
@@ -486,8 +486,9 @@ struct ChatView: View {
             }
             .animation(VAnimation.spring, value: canSend)
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.vertical, VSpacing.sm)
+        .padding(.leading, VSpacing.xl)
+        .padding(.trailing, VSpacing.lg)
         .background(VColor.surface)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xxl))
         .overlay(


### PR DESCRIPTION
## Summary
- Increase inner vertical padding from 4pt to 8pt (symmetric) so text and icons are vertically centered in the empty state, with more breathing room when there's lots of text
- Increase left (leading) padding from 16pt to 24pt so text isn't pressed against the edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
