### PR TITLE
refactor: extract shared path policy module

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { sandboxPathPolicy, hostPathPolicy } from '../tools/shared/filesystem/path-policy.js';
+
+// ---------------------------------------------------------------------------
+// Temp directory setup
+// ---------------------------------------------------------------------------
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'path-policy-'));
+
+  // Create structure:
+  //   root/
+  //     sandbox/
+  //       allowed.txt
+  //       subdir/
+  //         nested.txt
+  //       link-escape -> /tmp (symlink pointing outside sandbox)
+  //       link-ok -> subdir (symlink staying inside sandbox)
+  //     outside/
+  //       secret.txt
+
+  mkdirSync(join(root, 'sandbox', 'subdir'), { recursive: true });
+  mkdirSync(join(root, 'outside'), { recursive: true });
+  writeFileSync(join(root, 'sandbox', 'allowed.txt'), 'ok');
+  writeFileSync(join(root, 'sandbox', 'subdir', 'nested.txt'), 'ok');
+  writeFileSync(join(root, 'outside', 'secret.txt'), 'secret');
+  symlinkSync(join(root, 'outside'), join(root, 'sandbox', 'link-escape'));
+  symlinkSync(join(root, 'sandbox', 'subdir'), join(root, 'sandbox', 'link-ok'));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// sandboxPathPolicy
+// ---------------------------------------------------------------------------
+
+describe('sandboxPathPolicy', () => {
+  describe('traversal rejection', () => {
+    it('rejects ../.. escape from sandbox', () => {
+      const result = sandboxPathPolicy('../../etc/passwd', join(root, 'sandbox'));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('outside the working directory');
+      }
+    });
+
+    it('rejects ../ at the start', () => {
+      const result = sandboxPathPolicy('../outside/secret.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects deeply nested traversal', () => {
+      const result = sandboxPathPolicy('subdir/../../outside/secret.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('symlink escape rejection', () => {
+    it('rejects symlink that points outside the sandbox', () => {
+      const result = sandboxPathPolicy('link-escape/secret.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('outside the working directory');
+      }
+    });
+
+    it('allows symlink that stays inside the sandbox', () => {
+      const result = sandboxPathPolicy('link-ok/nested.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('mustExist: false (write-to-new-file)', () => {
+    it('rejects parent symlink escape for new files', () => {
+      // link-escape -> outside/, so link-escape/new.txt should fail
+      const result = sandboxPathPolicy('link-escape/new.txt', join(root, 'sandbox'), { mustExist: false });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('outside the working directory');
+      }
+    });
+
+    it('allows writing a new file under an existing safe directory', () => {
+      const result = sandboxPathPolicy('subdir/newfile.txt', join(root, 'sandbox'), { mustExist: false });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.resolved).toBe(join(root, 'sandbox', 'subdir', 'newfile.txt'));
+      }
+    });
+
+    it('allows writing a new file in a not-yet-existing subdirectory', () => {
+      const result = sandboxPathPolicy('newdir/newfile.txt', join(root, 'sandbox'), { mustExist: false });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('valid paths', () => {
+    it('allows a file directly in the sandbox', () => {
+      const result = sandboxPathPolicy('allowed.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.resolved).toBe(join(root, 'sandbox', 'allowed.txt'));
+      }
+    });
+
+    it('allows a nested file', () => {
+      const result = sandboxPathPolicy('subdir/nested.txt', join(root, 'sandbox'));
+      expect(result.ok).toBe(true);
+    });
+
+    it('allows absolute path within sandbox', () => {
+      const absPath = join(root, 'sandbox', 'allowed.txt');
+      const result = sandboxPathPolicy(absPath, join(root, 'sandbox'));
+      expect(result.ok).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hostPathPolicy
+// ---------------------------------------------------------------------------
+
+describe('hostPathPolicy', () => {
+  it('rejects relative paths', () => {
+    const result = hostPathPolicy('relative/path.txt');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be absolute');
+      expect(result.error).toContain('relative/path.txt');
+    }
+  });
+
+  it('rejects bare filenames', () => {
+    const result = hostPathPolicy('file.txt');
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts absolute paths', () => {
+    const result = hostPathPolicy('/usr/local/bin/node');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/usr/local/bin/node');
+    }
+  });
+
+  it('accepts root path', () => {
+    const result = hostPathPolicy('/');
+    expect(result.ok).toBe(true);
+  });
+});

--- a/assistant/src/tools/filesystem/path-guard.ts
+++ b/assistant/src/tools/filesystem/path-guard.ts
@@ -1,68 +1,15 @@
-import { resolve, relative, dirname, basename, join } from 'node:path';
-import { realpathSync } from 'node:fs';
+import { sandboxPathPolicy, type PathPolicyResult } from '../shared/filesystem/path-policy.js';
 
 /**
- * Resolve a user-supplied path against the working directory and verify
- * that the result stays within the allowed boundary (workingDir by default).
+ * Compatibility shim — forwards to the shared sandbox path policy.
  *
- * Returns the resolved absolute path on success, or an error message string.
- *
- * For existing paths, symlinks are resolved via realpathSync so a symlink
- * pointing outside the boundary is caught. For new paths (file_write),
- * the caller should pass `mustExist: false` — the nearest existing ancestor
- * directory is resolved via realpathSync to catch symlinks in parent dirs.
+ * Existing callers continue to work without changes. New code should
+ * import directly from `tools/shared/filesystem/path-policy.js`.
  */
 export function validateFilePath(
   rawPath: string,
   workingDir: string,
   options?: { mustExist?: boolean },
-): { ok: true; resolved: string } | { ok: false; error: string } {
-  const mustExist = options?.mustExist ?? true;
-
-  const resolved = resolve(workingDir, rawPath);
-
-  // Resolve symlinks to catch symlink-based escapes.
-  // For mustExist=false (file_write), walk up to the nearest existing
-  // ancestor and resolve it, then re-append the trailing components.
-  // This prevents symlink directories from escaping the boundary.
-  let realResolved = resolved;
-  if (mustExist) {
-    try {
-      realResolved = realpathSync(resolved);
-    } catch {
-      // File doesn't exist — will be caught by the tool's own existence check
-      realResolved = resolved;
-    }
-  } else {
-    let current = resolved;
-    const trailing: string[] = [];
-    while (current !== dirname(current)) {
-      try {
-        const real = realpathSync(current);
-        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
-        break;
-      } catch {
-        trailing.unshift(basename(current));
-        current = dirname(current);
-      }
-    }
-  }
-
-  // Resolve the working directory's real path too (in case it's a symlink)
-  let realWorkingDir: string;
-  try {
-    realWorkingDir = realpathSync(workingDir);
-  } catch {
-    realWorkingDir = workingDir;
-  }
-
-  const rel = relative(realWorkingDir, realResolved);
-  if (rel.startsWith('..') || resolve(realWorkingDir, rel) !== realResolved) {
-    return {
-      ok: false,
-      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realWorkingDir}"`,
-    };
-  }
-
-  return { ok: true, resolved };
+): PathPolicyResult {
+  return sandboxPathPolicy(rawPath, workingDir, options);
 }

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,0 +1,93 @@
+import { resolve, relative, dirname, basename, join, isAbsolute } from 'node:path';
+import { realpathSync } from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export type PathPolicyResult =
+  | { ok: true; resolved: string }
+  | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Sandbox policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that a path stays within a sandbox boundary (workingDir).
+ *
+ * Resolves symlinks to prevent symlink-based escapes. For new files
+ * (mustExist: false), walks up to the nearest existing ancestor and
+ * resolves it, then re-appends trailing components.
+ */
+export function sandboxPathPolicy(
+  rawPath: string,
+  workingDir: string,
+  options?: { mustExist?: boolean },
+): PathPolicyResult {
+  const mustExist = options?.mustExist ?? true;
+
+  const resolved = resolve(workingDir, rawPath);
+
+  // Resolve symlinks to catch symlink-based escapes.
+  // For mustExist=false (file_write), walk up to the nearest existing
+  // ancestor and resolve it, then re-append the trailing components.
+  let realResolved = resolved;
+  if (mustExist) {
+    try {
+      realResolved = realpathSync(resolved);
+    } catch {
+      // File doesn't exist — will be caught by the tool's own existence check
+      realResolved = resolved;
+    }
+  } else {
+    let current = resolved;
+    const trailing: string[] = [];
+    while (current !== dirname(current)) {
+      try {
+        const real = realpathSync(current);
+        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
+        break;
+      } catch {
+        trailing.unshift(basename(current));
+        current = dirname(current);
+      }
+    }
+  }
+
+  // Resolve the working directory's real path too (in case it's a symlink)
+  let realWorkingDir: string;
+  try {
+    realWorkingDir = realpathSync(workingDir);
+  } catch {
+    realWorkingDir = workingDir;
+  }
+
+  const rel = relative(realWorkingDir, realResolved);
+  if (rel.startsWith('..') || resolve(realWorkingDir, rel) !== realResolved) {
+    return {
+      ok: false,
+      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realWorkingDir}"`,
+    };
+  }
+
+  return { ok: true, resolved };
+}
+
+// ---------------------------------------------------------------------------
+// Host policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that a path is absolute. Host filesystem tools operate without
+ * a sandbox boundary, but require absolute paths to avoid ambiguity.
+ */
+export function hostPathPolicy(rawPath: string): PathPolicyResult {
+  if (!isAbsolute(rawPath)) {
+    return {
+      ok: false,
+      error: `Path must be absolute: ${rawPath}`,
+    };
+  }
+  return { ok: true, resolved: rawPath };
+}


### PR DESCRIPTION
Part of #2009. Closes #2013.

Extracts shared path policy functions into `tools/shared/filesystem/path-policy.ts`:

- **`sandboxPathPolicy`** — validates paths stay within a sandbox boundary, with symlink-safe resolution (the existing `validateFilePath` behavior)
- **`hostPathPolicy`** — validates paths are absolute (for host filesystem tools that operate without a sandbox boundary)

Converts the existing `path-guard.ts` into a thin compatibility shim that forwards to `sandboxPathPolicy`, so all current callers continue to work unchanged.

## Files changed
- **New**: `assistant/src/tools/shared/filesystem/path-policy.ts` — shared policy functions
- **Updated**: `assistant/src/tools/filesystem/path-guard.ts` — now a compatibility shim
- **New**: `assistant/src/__tests__/path-policy.test.ts` — 16 tests covering sandbox traversal rejection, symlink escape rejection, mustExist:false parent symlink handling, host relative path rejection, and host absolute path acceptance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
