### PR TITLE
refactor(fs): extract shared path policy module

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { sandboxPolicy, hostPolicy } from '../tools/shared/filesystem/path-policy.js';
+
+// ---------------------------------------------------------------------------
+// Shared temp sandbox for sandbox policy tests
+// ---------------------------------------------------------------------------
+
+let sandbox: string;
+let realSandbox: string;
+
+beforeAll(() => {
+  // macOS /tmp is a symlink to /private/tmp — resolve it for assertions
+  sandbox = mkdtempSync(join(tmpdir(), 'path-policy-'));
+  const { realpathSync } = require('node:fs');
+  realSandbox = realpathSync(sandbox);
+
+  // Create a file and subdirectory inside the sandbox
+  mkdirSync(join(sandbox, 'sub'));
+  writeFileSync(join(sandbox, 'sub', 'file.txt'), 'hello');
+
+  // Symlink inside sandbox that points outside
+  symlinkSync('/tmp', join(sandbox, 'escape-link'));
+
+  // Symlink directory inside sandbox that points outside
+  mkdirSync(join(sandbox, 'parent-escape'));
+  symlinkSync('/tmp', join(sandbox, 'parent-escape', 'link-dir'));
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox policy
+// ---------------------------------------------------------------------------
+
+describe('sandboxPolicy', () => {
+  it('accepts a relative path within the sandbox', () => {
+    const result = sandboxPolicy('sub/file.txt', sandbox);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(sandbox, 'sub', 'file.txt'));
+    }
+  });
+
+  it('rejects traversal via ../..', () => {
+    const result = sandboxPolicy('../../etc/passwd', sandbox);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
+      expect(result.error.path).toBe('../../etc/passwd');
+    }
+  });
+
+  it('rejects traversal via sub/../../..', () => {
+    const result = sandboxPolicy('sub/../../..', sandbox);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
+    }
+  });
+
+  it('rejects symlink escape (symlink pointing outside boundary)', () => {
+    const result = sandboxPolicy('escape-link/somefile', sandbox);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
+    }
+  });
+
+  it('rejects symlink escape with mustExist: false (parent symlink)', () => {
+    // parent-escape/link-dir is a symlink to /tmp, so writing
+    // parent-escape/link-dir/new-file.txt should be caught
+    const result = sandboxPolicy(
+      'parent-escape/link-dir/new-file.txt',
+      sandbox,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
+    }
+  });
+
+  it('accepts a new file path within the sandbox (mustExist: false)', () => {
+    const result = sandboxPolicy('sub/new-file.txt', sandbox, { mustExist: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(sandbox, 'sub', 'new-file.txt'));
+    }
+  });
+
+  it('accepts the sandbox root itself', () => {
+    const result = sandboxPolicy('.', sandbox);
+    expect(result.ok).toBe(true);
+  });
+
+  it('error message includes the boundary path', () => {
+    const result = sandboxPolicy('../..', sandbox);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain(realSandbox);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host policy
+// ---------------------------------------------------------------------------
+
+describe('hostPolicy', () => {
+  it('rejects a relative path', () => {
+    const result = hostPolicy('relative/path.txt');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_NOT_ABSOLUTE');
+      expect(result.error.path).toBe('relative/path.txt');
+    }
+  });
+
+  it('rejects a bare filename', () => {
+    const result = hostPolicy('file.txt');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('PATH_NOT_ABSOLUTE');
+    }
+  });
+
+  it('accepts an absolute path', () => {
+    const result = hostPolicy('/usr/local/bin/thing');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/usr/local/bin/thing');
+    }
+  });
+
+  it('accepts root path', () => {
+    const result = hostPolicy('/');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe('/');
+    }
+  });
+});

--- a/assistant/src/tools/filesystem/path-guard.ts
+++ b/assistant/src/tools/filesystem/path-guard.ts
@@ -1,68 +1,19 @@
-import { resolve, relative, dirname, basename, join } from 'node:path';
-import { realpathSync } from 'node:fs';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 /**
- * Resolve a user-supplied path against the working directory and verify
- * that the result stays within the allowed boundary (workingDir by default).
+ * Compatibility shim — forwards to the shared sandbox path policy.
  *
- * Returns the resolved absolute path on success, or an error message string.
- *
- * For existing paths, symlinks are resolved via realpathSync so a symlink
- * pointing outside the boundary is caught. For new paths (file_write),
- * the caller should pass `mustExist: false` — the nearest existing ancestor
- * directory is resolved via realpathSync to catch symlinks in parent dirs.
+ * All new code should import `sandboxPolicy` or `hostPolicy` from
+ * `tools/shared/filesystem/path-policy.js` directly.
  */
 export function validateFilePath(
   rawPath: string,
   workingDir: string,
   options?: { mustExist?: boolean },
 ): { ok: true; resolved: string } | { ok: false; error: string } {
-  const mustExist = options?.mustExist ?? true;
-
-  const resolved = resolve(workingDir, rawPath);
-
-  // Resolve symlinks to catch symlink-based escapes.
-  // For mustExist=false (file_write), walk up to the nearest existing
-  // ancestor and resolve it, then re-append the trailing components.
-  // This prevents symlink directories from escaping the boundary.
-  let realResolved = resolved;
-  if (mustExist) {
-    try {
-      realResolved = realpathSync(resolved);
-    } catch {
-      // File doesn't exist — will be caught by the tool's own existence check
-      realResolved = resolved;
-    }
-  } else {
-    let current = resolved;
-    const trailing: string[] = [];
-    while (current !== dirname(current)) {
-      try {
-        const real = realpathSync(current);
-        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
-        break;
-      } catch {
-        trailing.unshift(basename(current));
-        current = dirname(current);
-      }
-    }
+  const result = sandboxPolicy(rawPath, workingDir, options);
+  if (result.ok) {
+    return result;
   }
-
-  // Resolve the working directory's real path too (in case it's a symlink)
-  let realWorkingDir: string;
-  try {
-    realWorkingDir = realpathSync(workingDir);
-  } catch {
-    realWorkingDir = workingDir;
-  }
-
-  const rel = relative(realWorkingDir, realResolved);
-  if (rel.startsWith('..') || resolve(realWorkingDir, rel) !== realResolved) {
-    return {
-      ok: false,
-      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realWorkingDir}"`,
-    };
-  }
-
-  return { ok: true, resolved };
+  return { ok: false, error: result.error.message };
 }

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,0 +1,79 @@
+import { resolve, relative, dirname, basename, join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import type { FsError } from './errors.js';
+import { pathOutOfBounds, pathNotAbsolute } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export type PathCheckResult =
+  | { ok: true; resolved: string }
+  | { ok: false; error: FsError };
+
+// ---------------------------------------------------------------------------
+// Sandbox policy — resolves a path against a boundary directory and rejects
+// anything that escapes via `..` traversal or symlink indirection.
+// ---------------------------------------------------------------------------
+
+export function sandboxPolicy(
+  rawPath: string,
+  boundary: string,
+  options?: { mustExist?: boolean },
+): PathCheckResult {
+  const mustExist = options?.mustExist ?? true;
+
+  const resolved = resolve(boundary, rawPath);
+
+  // Resolve symlinks to catch symlink-based escapes.
+  // For mustExist=false (file writes), walk up to the nearest existing
+  // ancestor and resolve it, then re-append the trailing components.
+  let realResolved = resolved;
+  if (mustExist) {
+    try {
+      realResolved = realpathSync(resolved);
+    } catch {
+      // File doesn't exist — will be caught by the tool's own existence check
+      realResolved = resolved;
+    }
+  } else {
+    let current = resolved;
+    const trailing: string[] = [];
+    while (current !== dirname(current)) {
+      try {
+        const real = realpathSync(current);
+        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
+        break;
+      } catch {
+        trailing.unshift(basename(current));
+        current = dirname(current);
+      }
+    }
+  }
+
+  // Resolve the boundary's real path too (in case it's a symlink)
+  let realBoundary: string;
+  try {
+    realBoundary = realpathSync(boundary);
+  } catch {
+    realBoundary = boundary;
+  }
+
+  const rel = relative(realBoundary, realResolved);
+  if (rel.startsWith('..') || resolve(realBoundary, rel) !== realResolved) {
+    return { ok: false, error: pathOutOfBounds(rawPath, realBoundary) };
+  }
+
+  return { ok: true, resolved };
+}
+
+// ---------------------------------------------------------------------------
+// Host policy — only enforces that the path is absolute (no sandbox boundary).
+// ---------------------------------------------------------------------------
+
+export function hostPolicy(rawPath: string): PathCheckResult {
+  if (!rawPath.startsWith('/')) {
+    return { ok: false, error: pathNotAbsolute(rawPath) };
+  }
+  return { ok: true, resolved: resolve(rawPath) };
+}


### PR DESCRIPTION
Part of #2009. Extracts sandbox/host path policies into a shared module with comprehensive tests.

## Changes

- **New**: `assistant/src/tools/shared/filesystem/path-policy.ts` — `sandboxPolicy()` (boundary-confined path resolution with symlink-safe checks) and `hostPolicy()` (absolute-path enforcement)
- **Updated**: `assistant/src/tools/filesystem/path-guard.ts` — converted to a compatibility shim that forwards to `sandboxPolicy`, preserving the existing `validateFilePath(...)` signature and string-error return type
- **New**: `assistant/src/__tests__/path-policy.test.ts` — 12 tests covering traversal rejection, symlink escapes, mustExist:false parent symlink handling, host relative/absolute path validation

## Validation

- `bunx tsc --noEmit` — passes
- `bun test src/__tests__/path-policy.test.ts` — 12/12 pass
- Full suite — pre-existing failures only, no regressions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
