### PR TITLE
fix(ui): make chat composer scrollable when content overflows

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -14,6 +14,7 @@ struct InputBarView: View {
                 .textFieldStyle(.plain)
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
+                .lineLimit(1...8)
                 .padding(VSpacing.md)
                 .background(VColor.surface)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -358,28 +358,29 @@ struct ChatView: View {
                 attachmentStrip
             }
 
-            HStack(alignment: .center, spacing: VSpacing.sm) {
-                // Text input with ghost text overlay and vertical centering
-                ZStack(alignment: .leading) {
-                    TextField("What would you like to do?", text: $inputText, axis: .vertical)
+            HStack(alignment: .bottom, spacing: VSpacing.sm) {
+                // Text editor with ghost text overlay and scrollable content
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $inputText)
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                         .lineSpacing(4)
-                        .textFieldStyle(.plain)
-                        .lineLimit(1...10)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 20, maxHeight: 200)
                         .disabled(!hasAPIKey)
                         .accessibilityLabel("Message")
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear
-                                    .onAppear { editorContentHeight = geo.size.height }
-                                    .onChange(of: geo.size.height) { _, h in
-                                        withAnimation(VAnimation.spring) {
-                                            editorContentHeight = h
-                                        }
-                                    }
-                            }
-                        )
+
+                    // Placeholder
+                    if inputText.isEmpty && ghostSuffix == nil {
+                        Text("What would you like to do?")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted)
+                            .lineSpacing(4)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 8)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
 
                     // Ghost text overlay — shows the suggested suffix so users
                     // know what Tab will insert. Without this visual cue, Tab
@@ -389,8 +390,11 @@ struct ChatView: View {
                             .font(VFont.body)
                             .lineSpacing(4)
                             .foregroundColor(.clear)
-                            .lineLimit(1...10)
-                            .overlay(alignment: .leading) {
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 8)
+                            .frame(maxHeight: 200, alignment: .topLeading)
+                            .clipped()
+                            .overlay(alignment: .topLeading) {
                                 HStack(spacing: 0) {
                                     Text(inputText)
                                         .font(VFont.body)
@@ -401,11 +405,24 @@ struct ChatView: View {
                                         .lineSpacing(4)
                                         .foregroundColor(VColor.textMuted.opacity(0.5))
                                 }
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 8)
                             }
                             .allowsHitTesting(false)
                             .accessibilityHidden(true)
                     }
                 }
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { editorContentHeight = geo.size.height }
+                            .onChange(of: geo.size.height) { _, h in
+                                withAnimation(VAnimation.spring) {
+                                    editorContentHeight = h
+                                }
+                            }
+                    }
+                )
                 .onKeyPress(.tab, phases: .down) { keyPress in
                     if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                         onAcceptSuggestion()


### PR DESCRIPTION
## Summary

- Replace `TextField(axis: .vertical)` with `TextEditor` + placeholder overlay in macOS chat composer — `TextField` wraps `NSTextField` which clips content after `lineLimit`, while `TextEditor` wraps `NSTextView + NSScrollView` giving native scroll behavior when content exceeds the 200pt max height
- Uses the same `frame(minHeight: 20, maxHeight: 200)` pattern as the `VTextEditor` design system component
- Changes HStack alignment from `.center` to `.bottom` so action buttons stay at the bottom when the editor grows tall
- Adds `.lineLimit(1...8)` to iOS `InputBarView` to cap vertical growth

## Test plan

- [ ] Type multiline text (10+ lines) in the macOS chat composer — verify content scrolls after filling the max height
- [ ] Verify placeholder "What would you like to do?" appears when input is empty
- [ ] Verify placeholder disappears when typing
- [ ] Verify Enter sends message, Shift+Enter inserts newline
- [ ] Verify Tab accepts ghost suggestion
- [ ] Verify Cmd+V paste still works
- [ ] Verify action buttons (send, mic, attach) stay at bottom of composer
- [ ] Verify iOS input bar caps at ~8 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
