### PR TITLE
M5: Extract shared size guard module

### DIFF
--- a/assistant/src/__tests__/size-guard.test.ts
+++ b/assistant/src/__tests__/size-guard.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  MAX_FILE_SIZE_BYTES,
+  checkFileSizeOnDisk,
+  checkContentSize,
+} from '../tools/shared/filesystem/size-guard.js';
+
+const testDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'size-guard-test-')));
+  testDirs.push(dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// MAX_FILE_SIZE_BYTES
+// ---------------------------------------------------------------------------
+
+describe('MAX_FILE_SIZE_BYTES', () => {
+  test('equals 100 MB', () => {
+    expect(MAX_FILE_SIZE_BYTES).toBe(100 * 1024 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkFileSizeOnDisk
+// ---------------------------------------------------------------------------
+
+describe('checkFileSizeOnDisk', () => {
+  test('returns undefined for a file within the default limit', () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'small.txt');
+    writeFileSync(filePath, 'hello');
+
+    expect(checkFileSizeOnDisk(filePath)).toBeUndefined();
+  });
+
+  test('returns error string for a file exceeding a custom limit', () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'big.txt');
+    writeFileSync(filePath, 'x'.repeat(200));
+
+    const result = checkFileSizeOnDisk(filePath, 100);
+    expect(result).toBeDefined();
+    expect(result).toContain('exceeds');
+    expect(result).toContain('limit');
+    expect(result).toContain(filePath);
+  });
+
+  test('returns undefined for a file exactly at the custom limit', () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'exact.txt');
+    writeFileSync(filePath, 'x'.repeat(100));
+
+    expect(checkFileSizeOnDisk(filePath, 100)).toBeUndefined();
+  });
+
+  test('uses default limit when none is provided', () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'tiny.txt');
+    writeFileSync(filePath, 'a');
+
+    // Should not error since 1 byte is well under 100 MB
+    expect(checkFileSizeOnDisk(filePath)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkContentSize
+// ---------------------------------------------------------------------------
+
+describe('checkContentSize', () => {
+  test('returns undefined for content within the default limit', () => {
+    expect(checkContentSize('hello', '/tmp/test.txt')).toBeUndefined();
+  });
+
+  test('returns error string for content exceeding a custom limit', () => {
+    const content = 'x'.repeat(200);
+    const result = checkContentSize(content, '/tmp/big.txt', 100);
+    expect(result).toBeDefined();
+    expect(result).toContain('exceeds');
+    expect(result).toContain('limit');
+    expect(result).toContain('/tmp/big.txt');
+  });
+
+  test('returns undefined for content exactly at the custom limit', () => {
+    const content = 'x'.repeat(100);
+    expect(checkContentSize(content, '/tmp/exact.txt', 100)).toBeUndefined();
+  });
+
+  test('measures byte length, not string length', () => {
+    // Multi-byte character: each emoji is 4 bytes in UTF-8
+    const emoji = '\u{1F600}'; // 4 bytes
+    expect(emoji.length).toBe(2); // JS string length (surrogate pair)
+    expect(Buffer.byteLength(emoji, 'utf-8')).toBe(4);
+
+    // Allow 3 bytes — the emoji should exceed it
+    const result = checkContentSize(emoji, '/tmp/emoji.txt', 3);
+    expect(result).toBeDefined();
+    expect(result).toContain('exceeds');
+  });
+
+  test('uses default limit when none is provided', () => {
+    expect(checkContentSize('a', '/tmp/test.txt')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-export shim backward compatibility
+// ---------------------------------------------------------------------------
+
+describe('backward-compatible re-export shim', () => {
+  test('old import path re-exports the same functions', async () => {
+    const shim = await import('../tools/filesystem/size-guard.js');
+    const shared = await import('../tools/shared/filesystem/size-guard.js');
+
+    expect(shim.MAX_FILE_SIZE_BYTES).toBe(shared.MAX_FILE_SIZE_BYTES);
+    expect(shim.checkFileSizeOnDisk).toBe(shared.checkFileSizeOnDisk);
+    expect(shim.checkContentSize).toBe(shared.checkContentSize);
+  });
+});

--- a/assistant/src/tools/filesystem/size-guard.ts
+++ b/assistant/src/tools/filesystem/size-guard.ts
@@ -1,41 +1,6 @@
-import { statSync } from 'node:fs';
-
-/** Default maximum file size: 100 MB */
-export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/**
- * Check whether a file on disk exceeds the size limit.
- * Returns an error string if the file is too large, or undefined if OK.
- */
-export function checkFileSizeOnDisk(
-  filePath: string,
-  limit: number = MAX_FILE_SIZE_BYTES,
-): string | undefined {
-  const stat = statSync(filePath);
-  if (stat.size > limit) {
-    return `File size (${formatBytes(stat.size)}) exceeds the ${formatBytes(limit)} limit: ${filePath}`;
-  }
-  return undefined;
-}
-
-/**
- * Check whether content to be written exceeds the size limit.
- * Returns an error string if the content is too large, or undefined if OK.
- */
-export function checkContentSize(
-  content: string,
-  filePath: string,
-  limit: number = MAX_FILE_SIZE_BYTES,
-): string | undefined {
-  const size = Buffer.byteLength(content, 'utf-8');
-  if (size > limit) {
-    return `Content size (${formatBytes(size)}) exceeds the ${formatBytes(limit)} limit for: ${filePath}`;
-  }
-  return undefined;
-}
+// Backward-compatible re-export — canonical module is shared/filesystem/size-guard.ts
+export {
+  MAX_FILE_SIZE_BYTES,
+  checkFileSizeOnDisk,
+  checkContentSize,
+} from '../shared/filesystem/size-guard.js';

--- a/assistant/src/tools/shared/filesystem/size-guard.ts
+++ b/assistant/src/tools/shared/filesystem/size-guard.ts
@@ -1,0 +1,41 @@
+import { statSync } from 'node:fs';
+
+/** Default maximum file size: 100 MB */
+export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Check whether a file on disk exceeds the size limit.
+ * Returns an error string if the file is too large, or undefined if OK.
+ */
+export function checkFileSizeOnDisk(
+  filePath: string,
+  limit: number = MAX_FILE_SIZE_BYTES,
+): string | undefined {
+  const stat = statSync(filePath);
+  if (stat.size > limit) {
+    return `File size (${formatBytes(stat.size)}) exceeds the ${formatBytes(limit)} limit: ${filePath}`;
+  }
+  return undefined;
+}
+
+/**
+ * Check whether content to be written exceeds the size limit.
+ * Returns an error string if the content is too large, or undefined if OK.
+ */
+export function checkContentSize(
+  content: string,
+  filePath: string,
+  limit: number = MAX_FILE_SIZE_BYTES,
+): string | undefined {
+  const size = Buffer.byteLength(content, 'utf-8');
+  if (size > limit) {
+    return `Content size (${formatBytes(size)}) exceeds the ${formatBytes(limit)} limit for: ${filePath}`;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Move MAX_FILE_SIZE_BYTES, checkFileSizeOnDisk, checkContentSize to shared filesystem module
- Convert old size-guard.ts to backward-compatible re-export shim
- Add comprehensive size guard tests

Part of #2009
Closes #2014

## Test plan
- [x] size-guard.test.ts passes (11 tests)
- [x] All host filesystem tests pass
- [x] All sandbox filesystem tests pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
