### PR TITLE
feat: add Docker sandbox backend command builder

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { realpathSync, mkdirSync, existsSync } from 'node:fs';
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { DockerBackend } = await import(
+  '../tools/terminal/backends/docker.js'
+);
+const { ToolError } = await import('../util/errors.js');
+
+// Use a real temp dir so realpathSync resolves correctly.
+const sandboxRoot = realpathSync('/tmp');
+
+describe('DockerBackend — argument construction', () => {
+  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+
+  test('returns docker as the command', () => {
+    const result = backend.wrap('echo hi', sandboxRoot);
+    expect(result.command).toBe('docker');
+  });
+
+  test('sandboxed flag is always true', () => {
+    const result = backend.wrap('pwd', sandboxRoot);
+    expect(result.sandboxed).toBe(true);
+  });
+
+  test('uses --rm for ephemeral containers', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--rm');
+  });
+
+  test('drops all capabilities', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--cap-drop=ALL');
+  });
+
+  test('sets no-new-privileges security option', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--security-opt=no-new-privileges');
+  });
+
+  test('disables network by default', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--network=none');
+  });
+
+  test('applies default resource limits', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--cpus=2');
+    expect(result.args).toContain('--memory=512m');
+    expect(result.args).toContain('--pids-limit=256');
+  });
+
+  test('passes host UID:GID via --user', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--user');
+    const userIdx = result.args.indexOf('--user');
+    expect(result.args[userIdx + 1]).toBe('1000:1000');
+  });
+
+  test('bind-mounts sandbox root to /workspace', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--mount');
+    const mountIdx = result.args.indexOf('--mount');
+    expect(result.args[mountIdx + 1]).toBe(
+      `type=bind,src=${sandboxRoot},dst=/workspace`,
+    );
+  });
+
+  test('uses default image ubuntu:22.04', () => {
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('ubuntu:22.04');
+  });
+
+  test('wraps command with bash -c --', () => {
+    const cmd = 'cat /etc/passwd | wc -l';
+    const result = backend.wrap(cmd, sandboxRoot);
+    const bashIdx = result.args.indexOf('bash');
+    expect(bashIdx).toBeGreaterThan(0);
+    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', '--', cmd]);
+  });
+});
+
+describe('DockerBackend — path mapping', () => {
+  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+
+  test('maps sandbox root to /workspace workdir', () => {
+    const result = backend.wrap('pwd', sandboxRoot);
+    const wdIdx = result.args.indexOf('--workdir');
+    expect(result.args[wdIdx + 1]).toBe('/workspace');
+  });
+
+  test('maps subdirectory to /workspace/<subdir>', () => {
+    const subDir = `${sandboxRoot}/docker-sandbox-test-sub`;
+    if (!existsSync(subDir)) {
+      mkdirSync(subDir, { recursive: true });
+    }
+    const result = backend.wrap('pwd', subDir);
+    const wdIdx = result.args.indexOf('--workdir');
+    expect(result.args[wdIdx + 1]).toBe('/workspace/docker-sandbox-test-sub');
+  });
+});
+
+describe('DockerBackend — fail-closed on escape', () => {
+  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+
+  test('throws ToolError when workdir is outside sandbox root', () => {
+    // /var is not under /tmp
+    const outsideDir = realpathSync('/var');
+    expect(() => backend.wrap('ls', outsideDir)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', outsideDir)).toThrow(
+      'outside the sandbox root',
+    );
+  });
+});
+
+describe('DockerBackend — custom config', () => {
+  test('accepts custom image', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { image: 'alpine:3.19' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('alpine:3.19');
+    expect(result.args).not.toContain('ubuntu:22.04');
+  });
+
+  test('accepts custom resource limits', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { cpus: 4, memoryMb: 1024, pidsLimit: 512 },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--cpus=4');
+    expect(result.args).toContain('--memory=1024m');
+    expect(result.args).toContain('--pids-limit=512');
+  });
+
+  test('accepts custom network mode', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { network: 'bridge' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.args).toContain('--network=bridge');
+  });
+});

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -1,0 +1,98 @@
+import { realpathSync } from 'node:fs';
+import { relative, posix } from 'node:path';
+import { ToolError } from '../../../util/errors.js';
+import { getLogger } from '../../../util/logger.js';
+import type { SandboxBackend, SandboxResult } from './types.js';
+
+const log = getLogger('docker-sandbox');
+
+export interface DockerConfig {
+  image?: string;
+  cpus?: number;
+  memoryMb?: number;
+  pidsLimit?: number;
+  network?: string;
+}
+
+const DEFAULTS: Required<DockerConfig> = {
+  image: 'ubuntu:22.04',
+  cpus: 2,
+  memoryMb: 512,
+  pidsLimit: 256,
+  network: 'none',
+};
+
+/**
+ * Docker sandbox backend that wraps commands in ephemeral containers.
+ *
+ * Each invocation produces a single `docker run --rm` command — no long-lived
+ * container state. The sandbox filesystem root is bind-mounted to /workspace
+ * and the host UID:GID is forwarded to prevent permission drift.
+ */
+export class DockerBackend implements SandboxBackend {
+  private readonly sandboxRoot: string;
+  private readonly config: Required<DockerConfig>;
+  private readonly uid: number;
+  private readonly gid: number;
+
+  constructor(
+    sandboxRoot: string,
+    config?: DockerConfig,
+    uid?: number,
+    gid?: number,
+  ) {
+    this.sandboxRoot = realpathSync(sandboxRoot);
+    this.config = { ...DEFAULTS, ...config };
+    this.uid = uid ?? process.getuid!();
+    this.gid = gid ?? process.getgid!();
+  }
+
+  wrap(command: string, workingDir: string): SandboxResult {
+    const realWorkDir = realpathSync(workingDir);
+    const realRoot = this.sandboxRoot;
+
+    // Fail closed: working dir must be inside sandbox root.
+    if (!realWorkDir.startsWith(realRoot + '/') && realWorkDir !== realRoot) {
+      log.error(
+        'Working directory %s is outside sandbox root %s',
+        realWorkDir,
+        realRoot,
+      );
+      throw new ToolError(
+        `Working directory "${realWorkDir}" is outside the sandbox root "${realRoot}". Refusing to execute.`,
+        'bash',
+      );
+    }
+
+    // Map host working dir to container path under /workspace.
+    const relPath = relative(realRoot, realWorkDir);
+    const containerWorkDir =
+      relPath === '' ? '/workspace' : posix.join('/workspace', relPath);
+
+    const { image, cpus, memoryMb, pidsLimit, network } = this.config;
+
+    const args: string[] = [
+      'run',
+      '--rm',
+      `--network=${network}`,
+      `--cpus=${cpus}`,
+      `--memory=${memoryMb}m`,
+      `--pids-limit=${pidsLimit}`,
+      '--cap-drop=ALL',
+      '--security-opt=no-new-privileges',
+      '--mount',
+      `type=bind,src=${realRoot},dst=/workspace`,
+      '--workdir',
+      containerWorkDir,
+      '--user',
+      `${this.uid}:${this.gid}`,
+      image,
+      'bash',
+      '-c',
+      '--',
+      command,
+    ];
+
+    return { command: 'docker', args, sandboxed: true };
+  }
+}


### PR DESCRIPTION
Part of #2021. Closes #2025.

## Summary

Adds `DockerBackend` implementing the `SandboxBackend` interface that wraps shell commands in ephemeral `docker run --rm` containers with strict security defaults:

- **Network isolation**: `--network=none` by default
- **Capability stripping**: `--cap-drop=ALL`, `--security-opt=no-new-privileges`
- **Resource limits**: configurable CPU, memory, and PID limits
- **Filesystem isolation**: sandbox root bind-mounted to `/workspace` (rw), no other host paths accessible
- **UID:GID passthrough**: `--user <hostUid>:<hostGid>` prevents permission drift
- **Path mapping**: host working dir mapped to container-relative `/workspace/<subpath>`
- **Fail-closed**: throws `ToolError` if working dir is outside sandbox root

No wiring into runtime selection yet — that comes in a later milestone.

## Files

- `assistant/src/tools/terminal/backends/docker.ts` — new Docker backend
- `assistant/src/__tests__/terminal-sandbox-docker.test.ts` — 17 tests covering argument construction, path mapping, fail-closed behavior, and custom config

## Test plan

- [x] `bun test src/__tests__/terminal-sandbox-docker.test.ts` — 17/17 pass
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 11/11 pass (no regression)
- [x] `bunx tsc --noEmit` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
