### PR TITLE
feat(trace): add TraceEmitter utility for bounded trace event emission

### DIFF
--- a/assistant/src/__tests__/trace-emitter.test.ts
+++ b/assistant/src/__tests__/trace-emitter.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { TraceEmitter } from '../daemon/trace-emitter.js';
+import type { ServerMessage, TraceEvent } from '../daemon/ipc-protocol.js';
+
+function createEmitter() {
+  const sent: TraceEvent[] = [];
+  const sendToClient = mock((msg: ServerMessage) => {
+    sent.push(msg as TraceEvent);
+  });
+  const emitter = new TraceEmitter('sess-1', sendToClient);
+  return { emitter, sent, sendToClient };
+}
+
+describe('TraceEmitter', () => {
+  it('emits a trace event with correct structure', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'Running bash');
+
+    expect(sent).toHaveLength(1);
+    const event = sent[0];
+    expect(event.type).toBe('trace_event');
+    expect(event.sessionId).toBe('sess-1');
+    expect(event.kind).toBe('tool_started');
+    expect(event.summary).toBe('Running bash');
+    expect(typeof event.eventId).toBe('string');
+    expect(typeof event.timestampMs).toBe('number');
+    expect(event.sequence).toBe(0);
+  });
+
+  it('increments sequence monotonically', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'first');
+    emitter.emit('tool_finished', 'second');
+    emitter.emit('message_complete', 'third');
+
+    expect(sent.map((e) => e.sequence)).toEqual([0, 1, 2]);
+  });
+
+  it('generates unique eventIds', () => {
+    const { emitter, sent } = createEmitter();
+    for (let i = 0; i < 10; i++) {
+      emitter.emit('tool_started', `event-${i}`);
+    }
+    const ids = sent.map((e) => e.eventId);
+    expect(new Set(ids).size).toBe(10);
+  });
+
+  it('truncates summary to 200 characters', () => {
+    const { emitter, sent } = createEmitter();
+    const longSummary = 'x'.repeat(300);
+    emitter.emit('tool_started', longSummary);
+
+    expect(sent[0].summary).toHaveLength(200);
+    expect(sent[0].summary).toBe('x'.repeat(200));
+  });
+
+  it('does not truncate summary within the limit', () => {
+    const { emitter, sent } = createEmitter();
+    const summary = 'x'.repeat(200);
+    emitter.emit('tool_started', summary);
+
+    expect(sent[0].summary).toHaveLength(200);
+  });
+
+  it('passes through requestId and status', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_finished', 'Done', {
+      requestId: 'req-42',
+      status: 'success',
+    });
+
+    expect(sent[0].requestId).toBe('req-42');
+    expect(sent[0].status).toBe('success');
+  });
+
+  it('normalizes primitive attribute values', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'test', {
+      attributes: {
+        strVal: 'hello',
+        numVal: 42,
+        boolVal: true,
+        nullVal: null,
+      },
+    });
+
+    expect(sent[0].attributes).toEqual({
+      strVal: 'hello',
+      numVal: 42,
+      boolVal: true,
+      nullVal: null,
+    });
+  });
+
+  it('coerces undefined attribute values to null', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'test', {
+      attributes: { key: undefined },
+    });
+
+    expect(sent[0].attributes).toEqual({ key: null });
+  });
+
+  it('coerces object attribute values to JSON strings', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'test', {
+      attributes: { obj: { nested: true }, arr: [1, 2, 3] },
+    });
+
+    expect(sent[0].attributes!.obj).toBe('{"nested":true}');
+    expect(sent[0].attributes!.arr).toBe('[1,2,3]');
+  });
+
+  it('truncates long attribute string values to 500 chars', () => {
+    const { emitter, sent } = createEmitter();
+    const longValue = 'y'.repeat(600);
+    emitter.emit('tool_started', 'test', {
+      attributes: { big: longValue },
+    });
+
+    expect(sent[0].attributes!.big).toHaveLength(500);
+  });
+
+  it('truncates long serialized object attribute values', () => {
+    const { emitter, sent } = createEmitter();
+    const bigObj = { data: 'z'.repeat(600) };
+    emitter.emit('tool_started', 'test', {
+      attributes: { obj: bigObj },
+    });
+
+    const val = sent[0].attributes!.obj as string;
+    expect(val.length).toBeLessThanOrEqual(500);
+  });
+
+  it('handles non-serializable attribute values gracefully', () => {
+    const { emitter, sent } = createEmitter();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    emitter.emit('tool_started', 'test', {
+      attributes: { bad: circular },
+    });
+
+    expect(sent[0].attributes!.bad).toBe('[non-serializable]');
+  });
+
+  it('omits attributes when none provided', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'test');
+
+    expect(sent[0].attributes).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -25,6 +25,7 @@ import { generateScopeOptions } from '../permissions/checker.js';
 import { getConfig } from '../config/loader.js';
 import { estimateCost, resolvePricing } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
+import { TraceEmitter } from './trace-emitter.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
 import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier, pruneSessionTimers } from '../tools/timer/pomodoro.js';
@@ -106,6 +107,7 @@ export class Session {
   }>();
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
   private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
+  public readonly traceEmitter: TraceEmitter;
 
   constructor(
     conversationId: string,
@@ -119,6 +121,7 @@ export class Session {
     this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
+    this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
     this.secretPrompter = new SecretPrompter(sendToClient);
 

--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -1,0 +1,78 @@
+import { v4 as uuid } from 'uuid';
+import type { ServerMessage, TraceEventKind } from './ipc-protocol.js';
+
+export type TraceEventStatus = 'info' | 'success' | 'warning' | 'error';
+
+const SUMMARY_MAX_LENGTH = 200;
+const ATTRIBUTE_VALUE_MAX_LENGTH = 500;
+
+export interface TraceEmitOptions {
+  requestId?: string;
+  status?: TraceEventStatus;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Per-session utility that builds and sends TraceEvent messages to the client.
+ * Maintains a monotonic sequence counter so the UI can reconstruct event order
+ * even if timestamps collide.
+ */
+export class TraceEmitter {
+  private sequence = 0;
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly sendToClient: (msg: ServerMessage) => void,
+  ) {}
+
+  emit(kind: TraceEventKind, summary: string, opts?: TraceEmitOptions): void {
+    const eventId = uuid();
+    const truncatedSummary = truncate(summary, SUMMARY_MAX_LENGTH);
+    const attributes = opts?.attributes
+      ? normalizeAttributes(opts.attributes)
+      : undefined;
+
+    const event: ServerMessage = {
+      type: 'trace_event',
+      eventId,
+      sessionId: this.sessionId,
+      requestId: opts?.requestId,
+      timestampMs: Date.now(),
+      sequence: this.sequence++,
+      kind,
+      status: opts?.status,
+      summary: truncatedSummary,
+      attributes,
+    };
+
+    this.sendToClient(event);
+  }
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return value.slice(0, maxLength);
+}
+
+function normalizeAttributes(
+  attrs: Record<string, unknown>,
+): Record<string, string | number | boolean | null> {
+  const result: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    result[key] = normalizeValue(value);
+  }
+  return result;
+}
+
+function normalizeValue(value: unknown): string | number | boolean | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean' || typeof value === 'number') return value;
+  if (typeof value === 'string') return truncate(value, ATTRIBUTE_VALUE_MAX_LENGTH);
+  // Coerce non-primitives to string
+  try {
+    const str = JSON.stringify(value);
+    return truncate(str, ATTRIBUTE_VALUE_MAX_LENGTH);
+  } catch {
+    return '[non-serializable]';
+  }
+}


### PR DESCRIPTION
Part of #2046.

Adds a per-session `TraceEmitter` class that builds and sends `TraceEvent` IPC messages with:
- Monotonic sequence counter for deterministic event ordering
- Summary truncation (200 chars) and attribute value truncation (500 chars)
- Attribute normalization: coerces non-primitives to JSON strings, handles non-serializable values gracefully
- UUID-based eventId generation

Wired into `Session` constructor as a public `traceEmitter` field (no events emitted yet -- that comes in a follow-up PR).

Closes #2048
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
