### PR TITLE
M6: Extract shared edit engine and reuse in executor preview

### DIFF
--- a/assistant/src/__tests__/edit-engine.test.ts
+++ b/assistant/src/__tests__/edit-engine.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test';
+import { applyEdit } from '../tools/shared/filesystem/edit-engine.js';
+
+describe('edit engine', () => {
+  // -----------------------------------------------------------------------
+  // Exact unique replacement
+  // -----------------------------------------------------------------------
+
+  test('exact unique replacement', () => {
+    const content = 'hello world\n';
+    const result = applyEdit(content, 'hello world', 'updated', false);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.updatedContent).toBe('updated\n');
+    expect(result.matchCount).toBe(1);
+    expect(result.matchMethod).toBe('exact');
+  });
+
+  test('exact replacement in multi-line content', () => {
+    const content = 'line one\nline two\nline three\n';
+    const result = applyEdit(content, 'line two', 'replaced', false);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.updatedContent).toBe('line one\nreplaced\nline three\n');
+    expect(result.matchMethod).toBe('exact');
+  });
+
+  // -----------------------------------------------------------------------
+  // Whitespace/fuzzy match behavior
+  // -----------------------------------------------------------------------
+
+  test('whitespace-normalized match when exact fails', () => {
+    // Content has extra leading whitespace vs. the search string
+    const content = '  function foo() {\n    return 1;\n  }\n';
+    const oldString = 'function foo() {\n  return 1;\n}';
+    const newString = 'function bar() {\n  return 2;\n}';
+    const result = applyEdit(content, oldString, newString, false);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.matchMethod).toBe('whitespace');
+    expect(result.matchCount).toBe(1);
+    // The indentation should be adjusted
+    expect(result.updatedContent).toContain('function bar()');
+  });
+
+  test('fuzzy match when whitespace match also fails', () => {
+    // Content has a slightly different line from oldString (typo-level difference)
+    const content = 'function fooo() {\n  return 1;\n}\n';
+    const oldString = 'function foo() {\n  return 1;\n}';
+    const newString = 'function bar() {\n  return 2;\n}';
+    const result = applyEdit(content, oldString, newString, false);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.matchMethod).toBe('fuzzy');
+    expect(result.matchCount).toBe(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Ambiguous behavior
+  // -----------------------------------------------------------------------
+
+  test('ambiguous: returns error when old_string appears multiple times', () => {
+    const content = 'repeat\nrepeat\n';
+    const result = applyEdit(content, 'repeat', 'new', false);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ambiguous');
+    if (result.reason !== 'ambiguous') return;
+    expect(result.matchCount).toBe(2);
+  });
+
+  test('ambiguous: three occurrences reports correct count', () => {
+    const content = 'x\nx\nx\n';
+    const result = applyEdit(content, 'x', 'y', false);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ambiguous');
+    if (result.reason !== 'ambiguous') return;
+    expect(result.matchCount).toBe(3);
+  });
+
+  // -----------------------------------------------------------------------
+  // Not found
+  // -----------------------------------------------------------------------
+
+  test('not found: returns error when old_string is absent', () => {
+    const content = 'hello world\n';
+    const result = applyEdit(content, 'nonexistent', 'replacement', false);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('not_found');
+  });
+
+  // -----------------------------------------------------------------------
+  // replace_all count correctness
+  // -----------------------------------------------------------------------
+
+  test('replace_all: replaces all occurrences and reports correct count', () => {
+    const content = 'x\ny\nx\nz\nx\n';
+    const result = applyEdit(content, 'x', 'replaced', true);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.updatedContent).toBe('replaced\ny\nreplaced\nz\nreplaced\n');
+    expect(result.matchCount).toBe(3);
+    expect(result.matchMethod).toBe('exact');
+  });
+
+  test('replace_all: single occurrence reports count of 1', () => {
+    const content = 'a b c\n';
+    const result = applyEdit(content, 'b', 'B', true);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.updatedContent).toBe('a B c\n');
+    expect(result.matchCount).toBe(1);
+  });
+
+  test('replace_all: not found returns error', () => {
+    const content = 'hello world\n';
+    const result = applyEdit(content, 'missing', 'nope', true);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('not_found');
+  });
+
+  // -----------------------------------------------------------------------
+  // Executor preview parity: same engine, same output
+  // -----------------------------------------------------------------------
+
+  test('executor preview parity: computed preview matches actual edit output', () => {
+    // Simulate what both the executor preview and tool execution do:
+    // both call applyEdit with the same inputs and should get identical results.
+    const content = 'function hello() {\n  console.log("hi");\n}\n';
+    const oldString = 'console.log("hi")';
+    const newString = 'console.log("bye")';
+
+    // "Preview" call (what computePreviewDiff does)
+    const preview = applyEdit(content, oldString, newString, false);
+    // "Execution" call (what the edit tool does)
+    const execution = applyEdit(content, oldString, newString, false);
+
+    expect(preview.ok).toBe(true);
+    expect(execution.ok).toBe(true);
+    if (!preview.ok || !execution.ok) return;
+
+    expect(preview.updatedContent).toBe(execution.updatedContent);
+    expect(preview.matchCount).toBe(execution.matchCount);
+    expect(preview.matchMethod).toBe(execution.matchMethod);
+  });
+
+  test('executor preview parity: replace_all mode', () => {
+    const content = 'TODO\nsome code\nTODO\n';
+    const oldString = 'TODO';
+    const newString = 'DONE';
+
+    const preview = applyEdit(content, oldString, newString, true);
+    const execution = applyEdit(content, oldString, newString, true);
+
+    expect(preview.ok).toBe(true);
+    expect(execution.ok).toBe(true);
+    if (!preview.ok || !execution.ok) return;
+
+    expect(preview.updatedContent).toBe(execution.updatedContent);
+    expect(preview.matchCount).toBe(execution.matchCount);
+  });
+});

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -7,8 +7,8 @@ import { addRule } from '../permissions/trust-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { ToolError, PermissionDeniedError } from '../util/errors.js';
 import { getLogger } from '../util/logger.js';
-import { findAllMatches, adjustIndentation } from './filesystem/fuzzy-match.js';
 import { validateFilePath } from './filesystem/path-guard.js';
+import { applyEdit } from './shared/filesystem/edit-engine.js';
 import { MAX_FILE_SIZE_BYTES } from './filesystem/size-guard.js';
 import { wrapCommand } from './terminal/sandbox.js';
 import { getConfig } from '../config/loader.js';
@@ -491,20 +491,9 @@ function computePreviewDiff(
       if (stat.size > MAX_FILE_SIZE_BYTES) return undefined;
       const content = readFileSync(filePath, 'utf-8');
       const replaceAll = input.replace_all === true;
-      let updated: string;
-      if (replaceAll) {
-        if (!content.includes(oldString)) return undefined;
-        updated = content.split(oldString).join(newString);
-      } else {
-        const matches = findAllMatches(content, oldString);
-        if (matches.length !== 1) return undefined;
-        const match = matches[0];
-        const adjustedNewString = match.method !== 'exact'
-          ? adjustIndentation(oldString, match.matched, newString)
-          : newString;
-        updated = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
-      }
-      return { filePath, oldContent: content, newContent: updated, isNewFile: false };
+      const result = applyEdit(content, oldString, newString, replaceAll);
+      if (!result.ok) return undefined;
+      return { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false };
     }
   } catch {
     // Preview is best-effort — don't block the prompt on errors

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -3,9 +3,9 @@ import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { findAllMatches, adjustIndentation } from './fuzzy-match.js';
 import { validateFilePath } from './path-guard.js';
 import { checkFileSizeOnDisk } from './size-guard.js';
+import { applyEdit } from '../shared/filesystem/edit-engine.js';
 
 class FileEditTool implements Tool {
   name = 'file_edit';
@@ -84,52 +84,37 @@ class FileEditTool implements Tool {
 
     try {
       const content = readFileSync(filePath, 'utf-8');
+      const result = applyEdit(content, oldString, newString, replaceAll);
 
-      // replace_all: exact-match-only to avoid ambiguous bulk replacements
-      if (replaceAll) {
-        const firstIndex = content.indexOf(oldString);
-        if (firstIndex === -1) {
+      if (!result.ok) {
+        if (result.reason === 'not_found') {
           return { content: `Error: old_string not found in ${filePath}`, isError: true };
         }
-        const updated = content.split(oldString).join(newString);
-        const count = content.split(oldString).length - 1;
-        writeFileSync(filePath, updated);
-        return {
-          content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`,
-          isError: false,
-          diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
-        };
-      }
-
-      // Single-match path: cascading exact → whitespace → fuzzy
-      const matches = findAllMatches(content, oldString);
-      if (matches.length === 0) {
-        return { content: `Error: old_string not found in ${filePath}`, isError: true };
-      }
-      if (matches.length > 1) {
         return {
           content: `Error: old_string appears multiple times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
           isError: true,
         };
       }
 
-      const match = matches[0];
-      const adjustedNewString = match.method !== 'exact'
-        ? adjustIndentation(oldString, match.matched, newString)
-        : newString;
+      writeFileSync(filePath, result.updatedContent);
 
-      const updated = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
-      writeFileSync(filePath, updated);
+      if (replaceAll) {
+        return {
+          content: `Successfully replaced ${result.matchCount} occurrence${result.matchCount > 1 ? 's' : ''} in ${filePath}`,
+          isError: false,
+          diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
+        };
+      }
 
-      const methodNote = match.method === 'exact'
+      const methodNote = result.matchMethod === 'exact'
         ? ''
-        : match.method === 'whitespace'
+        : result.matchMethod === 'whitespace'
           ? ' (matched with whitespace normalization)'
-          : ` (fuzzy matched, similarity ${(match.similarity * 100).toFixed(0)}%)`;
+          : ' (fuzzy matched)';
       return {
         content: `Successfully edited ${filePath}${methodNote}`,
         isError: false,
-        diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
+        diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -3,8 +3,8 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { findAllMatches, adjustIndentation } from '../filesystem/fuzzy-match.js';
 import { checkFileSizeOnDisk } from '../filesystem/size-guard.js';
+import { applyEdit } from '../shared/filesystem/edit-engine.js';
 
 class HostFileEditTool implements Tool {
   name = 'host_file_edit';
@@ -81,51 +81,38 @@ class HostFileEditTool implements Tool {
     try {
       const content = readFileSync(filePath, 'utf-8');
       const replaceAll = input.replace_all === true;
+      const result = applyEdit(content, oldString, newString, replaceAll);
 
-      if (replaceAll) {
-        const firstIndex = content.indexOf(oldString);
-        if (firstIndex === -1) {
+      if (!result.ok) {
+        if (result.reason === 'not_found') {
           return { content: `Error: old_string not found in ${filePath}`, isError: true };
         }
-        const updated = content.split(oldString).join(newString);
-        const count = content.split(oldString).length - 1;
-        writeFileSync(filePath, updated);
-        return {
-          content: `Successfully replaced ${count} occurrence${count > 1 ? 's' : ''} in ${filePath}`,
-          isError: false,
-          diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
-        };
-      }
-
-      const matches = findAllMatches(content, oldString);
-      if (matches.length === 0) {
-        return { content: `Error: old_string not found in ${filePath}`, isError: true };
-      }
-      if (matches.length > 1) {
         return {
           content: `Error: old_string appears multiple times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
           isError: true,
         };
       }
 
-      const match = matches[0];
-      const adjustedNewString = match.method !== 'exact'
-        ? adjustIndentation(oldString, match.matched, newString)
-        : newString;
+      writeFileSync(filePath, result.updatedContent);
 
-      const updated = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
-      writeFileSync(filePath, updated);
+      if (replaceAll) {
+        return {
+          content: `Successfully replaced ${result.matchCount} occurrence${result.matchCount > 1 ? 's' : ''} in ${filePath}`,
+          isError: false,
+          diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
+        };
+      }
 
-      const methodNote = match.method === 'exact'
+      const methodNote = result.matchMethod === 'exact'
         ? ''
-        : match.method === 'whitespace'
+        : result.matchMethod === 'whitespace'
           ? ' (matched with whitespace normalization)'
-          : ` (fuzzy matched, similarity ${(match.similarity * 100).toFixed(0)}%)`;
+          : ' (fuzzy matched)';
 
       return {
         content: `Successfully edited ${filePath}${methodNote}`,
         isError: false,
-        diff: { filePath, oldContent: content, newContent: updated, isNewFile: false },
+        diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/shared/filesystem/edit-engine.ts
+++ b/assistant/src/tools/shared/filesystem/edit-engine.ts
@@ -1,0 +1,56 @@
+import { findAllMatches, adjustIndentation } from '../../filesystem/fuzzy-match.js';
+import type { MatchMethod } from '../../filesystem/fuzzy-match.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EditEngineResult =
+  | { ok: true; updatedContent: string; matchCount: number; matchMethod: MatchMethod }
+  | { ok: false; reason: 'not_found' }
+  | { ok: false; reason: 'ambiguous'; matchCount: number };
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Core match/replace logic shared by both sandbox and host edit tools,
+ * and by the executor's preview-diff computation.
+ *
+ * This function is pure — it takes file content and edit parameters and
+ * returns the result without performing any I/O.
+ */
+export function applyEdit(
+  content: string,
+  oldString: string,
+  newString: string,
+  replaceAll: boolean,
+): EditEngineResult {
+  if (replaceAll) {
+    const firstIndex = content.indexOf(oldString);
+    if (firstIndex === -1) {
+      return { ok: false, reason: 'not_found' };
+    }
+    const count = content.split(oldString).length - 1;
+    const updatedContent = content.split(oldString).join(newString);
+    return { ok: true, updatedContent, matchCount: count, matchMethod: 'exact' };
+  }
+
+  // Single-match path: cascading exact -> whitespace -> fuzzy
+  const matches = findAllMatches(content, oldString);
+  if (matches.length === 0) {
+    return { ok: false, reason: 'not_found' };
+  }
+  if (matches.length > 1) {
+    return { ok: false, reason: 'ambiguous', matchCount: matches.length };
+  }
+
+  const match = matches[0];
+  const adjustedNewString = match.method !== 'exact'
+    ? adjustIndentation(oldString, match.matched, newString)
+    : newString;
+
+  const updatedContent = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
+  return { ok: true, updatedContent, matchCount: 1, matchMethod: match.method };
+}


### PR DESCRIPTION
## Summary
- Extract core match/replace logic into shared `edit-engine.ts` with a pure `applyEdit()` function
- Both sandbox and host edit tools now use the shared engine instead of duplicating logic
- Executor preview diff (`computePreviewDiff`) now uses the same engine for `file_edit`, guaranteeing preview-execution parity

Part of #2009
Closes #2015

## Test plan
- [x] edit-engine.test.ts passes (exact, whitespace, fuzzy, ambiguous, replace_all, preview parity)
- [x] fuzzy-match.test.ts passes
- [x] fuzzy-match-property.test.ts passes
- [x] tool-executor-lifecycle-events.test.ts passes
- [x] file-edit-tool.test.ts passes
- [x] host-file-edit-tool.test.ts passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
