### PR TITLE
ci: add IPC contract generation enforcement in CI and pre-commit

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { realpathSync, mkdirSync, existsSync } from 'node:fs';
+import * as realChildProcess from 'node:child_process';
+
+const execSyncMock = mock((_command: string, _opts?: unknown): unknown => undefined);
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  execSync: execSyncMock,
+}));
 
 mock.module('../util/logger.js', () => ({
   getLogger: () => ({
@@ -10,7 +18,7 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
-const { DockerBackend } = await import(
+const { DockerBackend, _resetDockerChecks } = await import(
   '../tools/terminal/backends/docker.js'
 );
 const { ToolError } = await import('../util/errors.js');
@@ -18,40 +26,52 @@ const { ToolError } = await import('../util/errors.js');
 // Use a real temp dir so realpathSync resolves correctly.
 const sandboxRoot = realpathSync('/tmp');
 
-describe('DockerBackend — argument construction', () => {
-  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+beforeEach(() => {
+  _resetDockerChecks();
+  execSyncMock.mockReset();
+  // Default: all preflight checks pass.
+  execSyncMock.mockImplementation(() => undefined);
+});
 
+describe('DockerBackend — argument construction', () => {
   test('returns docker as the command', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('echo hi', sandboxRoot);
     expect(result.command).toBe('docker');
   });
 
   test('sandboxed flag is always true', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('pwd', sandboxRoot);
     expect(result.sandboxed).toBe(true);
   });
 
   test('uses --rm for ephemeral containers', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--rm');
   });
 
   test('drops all capabilities', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--cap-drop=ALL');
   });
 
   test('sets no-new-privileges security option', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--security-opt=no-new-privileges');
   });
 
   test('disables network by default', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--network=none');
   });
 
   test('applies default resource limits', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--cpus=2');
     expect(result.args).toContain('--memory=512m');
@@ -59,6 +79,7 @@ describe('DockerBackend — argument construction', () => {
   });
 
   test('passes host UID:GID via --user', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--user');
     const userIdx = result.args.indexOf('--user');
@@ -66,6 +87,7 @@ describe('DockerBackend — argument construction', () => {
   });
 
   test('bind-mounts sandbox root to /workspace', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--mount');
     const mountIdx = result.args.indexOf('--mount');
@@ -75,11 +97,13 @@ describe('DockerBackend — argument construction', () => {
   });
 
   test('uses default image ubuntu:22.04', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('ubuntu:22.04');
   });
 
   test('wraps command with bash -c --', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const cmd = 'cat /etc/passwd | wc -l';
     const result = backend.wrap(cmd, sandboxRoot);
     const bashIdx = result.args.indexOf('bash');
@@ -89,15 +113,15 @@ describe('DockerBackend — argument construction', () => {
 });
 
 describe('DockerBackend — path mapping', () => {
-  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
-
   test('maps sandbox root to /workspace workdir', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('pwd', sandboxRoot);
     const wdIdx = result.args.indexOf('--workdir');
     expect(result.args[wdIdx + 1]).toBe('/workspace');
   });
 
   test('maps subdirectory to /workspace/<subdir>', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const subDir = `${sandboxRoot}/docker-sandbox-test-sub`;
     if (!existsSync(subDir)) {
       mkdirSync(subDir, { recursive: true });
@@ -109,9 +133,8 @@ describe('DockerBackend — path mapping', () => {
 });
 
 describe('DockerBackend — fail-closed on escape', () => {
-  const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
-
   test('throws ToolError when workdir is outside sandbox root', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     // /var is not under /tmp
     const outsideDir = realpathSync('/var');
     expect(() => backend.wrap('ls', outsideDir)).toThrow(ToolError);
@@ -156,5 +179,248 @@ describe('DockerBackend — custom config', () => {
     );
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('--network=bridge');
+  });
+});
+
+describe('DockerBackend — preflight: Docker CLI check', () => {
+  test('throws ToolError with install hint when docker CLI is missing', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('command not found: docker');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'Docker CLI is not installed',
+    );
+  });
+
+  test('caches successful CLI check', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    backend.wrap('ls', sandboxRoot);
+    backend.wrap('ls', sandboxRoot);
+
+    // docker --version should only be called once (cached after success).
+    const versionCalls = execSyncMock.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0] === 'docker --version',
+    );
+    expect(versionCalls.length).toBe(1);
+  });
+});
+
+describe('DockerBackend — preflight: Docker daemon check', () => {
+  test('throws ToolError with start hint when daemon is unreachable', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker info') {
+        throw new Error('Cannot connect to the Docker daemon');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'Docker daemon is not running',
+    );
+  });
+
+  test('caches successful daemon check', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    backend.wrap('ls', sandboxRoot);
+    backend.wrap('ls', sandboxRoot);
+
+    const infoCalls = execSyncMock.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0] === 'docker info',
+    );
+    expect(infoCalls.length).toBe(1);
+  });
+});
+
+describe('DockerBackend — preflight: image availability check', () => {
+  test('throws ToolError with pull hint when image is missing', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker image inspect')) {
+        throw new Error('No such image');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'docker pull ubuntu:22.04',
+    );
+  });
+
+  test('includes image name in error message', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker image inspect')) {
+        throw new Error('No such image');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { image: 'alpine:3.19' },
+      1000,
+      1000,
+    );
+    try {
+      backend.wrap('ls', sandboxRoot);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toContain('alpine:3.19');
+    }
+  });
+
+  test('caches successful image check per image', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    backend.wrap('ls', sandboxRoot);
+    backend.wrap('ls', sandboxRoot);
+
+    const inspectCalls = execSyncMock.mock.calls.filter(
+      (args) =>
+        typeof args[0] === 'string' && args[0].includes('docker image inspect'),
+    );
+    expect(inspectCalls.length).toBe(1);
+  });
+});
+
+describe('DockerBackend — preflight: mount probe', () => {
+  test('throws ToolError with file sharing hint when mount fails', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker run --rm')) {
+        throw new Error('mount failed');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'File Sharing',
+    );
+  });
+
+  test('includes sandbox root path in error message', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker run --rm')) {
+        throw new Error('mount failed');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    try {
+      backend.wrap('ls', sandboxRoot);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toContain(sandboxRoot);
+    }
+  });
+
+  test('caches successful mount probe per sandbox root', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    backend.wrap('ls', sandboxRoot);
+    backend.wrap('ls', sandboxRoot);
+
+    const mountCalls = execSyncMock.mock.calls.filter(
+      (args) =>
+        typeof args[0] === 'string' && args[0].includes('docker run --rm'),
+    );
+    expect(mountCalls.length).toBe(1);
+  });
+});
+
+describe('DockerBackend — preflight check order', () => {
+  test('checks CLI before daemon', () => {
+    // All docker commands fail, but we expect the CLI error first.
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('docker not available');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    try {
+      backend.wrap('ls', sandboxRoot);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolError);
+      expect((err as Error).message).toContain('Docker CLI is not installed');
+    }
+  });
+
+  test('does not retry positive checks on subsequent calls', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    // First call succeeds and caches all checks.
+    backend.wrap('ls', sandboxRoot);
+
+    // Now make all docker commands fail.
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('docker unavailable');
+      }
+      return undefined;
+    });
+
+    // Should still succeed — all checks are cached.
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.command).toBe('docker');
+    expect(result.sandboxed).toBe(true);
+  });
+
+  test('re-checks negative results on subsequent calls', () => {
+    // Start with CLI failing.
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker --version') {
+        throw new Error('not found');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'Docker CLI is not installed',
+    );
+
+    // Now make it succeed.
+    execSyncMock.mockImplementation(() => undefined);
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.command).toBe('docker');
+  });
+});
+
+describe('DockerBackend — no unsandboxed fallback', () => {
+  test('wrap never returns sandboxed=false', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('ls', sandboxRoot);
+    expect(result.sandboxed).toBe(true);
+  });
+
+  test('preflight failure always throws, never returns unsandboxed result', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('not available');
+      }
+      return undefined;
+    });
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    let threw = false;
+    try {
+      backend.wrap('ls', sandboxRoot);
+    } catch (err) {
+      threw = true;
+      expect(err).toBeInstanceOf(ToolError);
+    }
+    expect(threw).toBe(true);
   });
 });

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { relative, posix } from 'node:path';
 import { ToolError } from '../../../util/errors.js';
@@ -23,11 +24,88 @@ const DEFAULTS: Required<DockerConfig> = {
 };
 
 /**
+ * Cache positive preflight results only, matching the bwrap pattern in native.ts.
+ * Negative results are not cached so that installing/starting Docker after the
+ * daemon starts takes effect without a restart.
+ */
+let dockerCliAvailable = false;
+let dockerDaemonReachable = false;
+const imageAvailableCache = new Set<string>();
+const mountProbeCache = new Set<string>();
+
+/** Exported for tests to reset cached state between runs. */
+export function _resetDockerChecks(): void {
+  dockerCliAvailable = false;
+  dockerDaemonReachable = false;
+  imageAvailableCache.clear();
+  mountProbeCache.clear();
+}
+
+function checkDockerCli(): void {
+  if (dockerCliAvailable) return;
+  try {
+    execSync('docker --version', { stdio: 'ignore', timeout: 5000 });
+    dockerCliAvailable = true;
+  } catch {
+    throw new ToolError(
+      'Docker CLI is not installed or not in PATH. Install Docker: https://docs.docker.com/get-docker/',
+      'bash',
+    );
+  }
+}
+
+function checkDockerDaemon(): void {
+  if (dockerDaemonReachable) return;
+  try {
+    execSync('docker info', { stdio: 'ignore', timeout: 10000 });
+    dockerDaemonReachable = true;
+  } catch {
+    throw new ToolError(
+      'Docker daemon is not running. Start Docker Desktop or run "sudo systemctl start docker".',
+      'bash',
+    );
+  }
+}
+
+function checkImageAvailable(image: string): void {
+  if (imageAvailableCache.has(image)) return;
+  try {
+    execSync(`docker image inspect ${image}`, { stdio: 'ignore', timeout: 10000 });
+    imageAvailableCache.add(image);
+  } catch {
+    throw new ToolError(
+      `Docker image "${image}" is not available locally. Pull it first: docker pull ${image}`,
+      'bash',
+    );
+  }
+}
+
+function checkMountProbe(sandboxRoot: string): void {
+  if (mountProbeCache.has(sandboxRoot)) return;
+  try {
+    execSync(
+      `docker run --rm --mount type=bind,src=${sandboxRoot},dst=/workspace ubuntu:22.04 test -w /workspace`,
+      { stdio: 'ignore', timeout: 15000 },
+    );
+    mountProbeCache.add(sandboxRoot);
+  } catch {
+    throw new ToolError(
+      `Cannot bind-mount "${sandboxRoot}" into a Docker container or /workspace is not writable. ` +
+      'If using Docker Desktop, enable file sharing for this path in Settings > Resources > File Sharing.',
+      'bash',
+    );
+  }
+}
+
+/**
  * Docker sandbox backend that wraps commands in ephemeral containers.
  *
  * Each invocation produces a single `docker run --rm` command — no long-lived
  * container state. The sandbox filesystem root is bind-mounted to /workspace
  * and the host UID:GID is forwarded to prevent permission drift.
+ *
+ * On first use, runs preflight checks (CLI, daemon, image, mount probe) and
+ * fails closed with actionable error messages if any check fails.
  */
 export class DockerBackend implements SandboxBackend {
   private readonly sandboxRoot: string;
@@ -47,7 +125,21 @@ export class DockerBackend implements SandboxBackend {
     this.gid = gid ?? process.getgid!();
   }
 
+  /**
+   * Run preflight checks in dependency order. Each check is cached
+   * on success; failures re-check on every call.
+   */
+  preflight(): void {
+    checkDockerCli();
+    checkDockerDaemon();
+    checkImageAvailable(this.config.image);
+    checkMountProbe(this.sandboxRoot);
+  }
+
   wrap(command: string, workingDir: string): SandboxResult {
+    // Preflight: fail closed if Docker is not usable.
+    this.preflight();
+
     const realWorkDir = realpathSync(workingDir);
     const realRoot = this.sandboxRoot;
 


### PR DESCRIPTION
Part of #2000 (IPC Contract Autogeneration: TS → Swift) and #1996.

## Changes

### CI workflow (`.github/workflows/ci-assistant.yml`)
- Added two new steps before typecheck:
  - **Verify IPC generated code is up to date** — runs `bun run check:ipc-generated` (the `--check` mode of `generate-swift.ts`)
  - **Verify IPC contract inventory is up to date** — runs `bun run ipc:inventory`
- Expanded `paths` trigger to include `clients/shared/IPC/Generated/**` so PRs that touch generated Swift output also trigger the workflow

### Pre-commit hook (`.githooks/pre-commit`)
- Added conditional IPC generation check that only runs when contract-related files are staged
- Monitors: `ipc-contract.ts`, `ipc-contract-inventory.ts`, generator scripts, inventory snapshot JSON, and generated Swift output
- Checks both Swift codegen (`check:ipc-generated`) and inventory snapshot (`ipc:inventory`)
- Gracefully skips if `bun` is not available (falls back to `~/.bun/bin/bun`)
- Clear error messages with remediation commands on failure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
