### PR TITLE
feat(ipc): add session_error message type for structured error handling

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1035,3 +1035,14 @@ exports[`IPC message snapshots ServerMessage types trace_event serializes to exp
   "type": "trace_event",
 }
 `;
+
+exports[`IPC message snapshots ServerMessage types session_error serializes to expected JSON 1`] = `
+{
+  "code": "PROVIDER_NETWORK",
+  "debugDetails": "ETIMEDOUT: connect to api.anthropic.com:443",
+  "retryable": true,
+  "sessionId": "sess-001",
+  "type": "session_error",
+  "userMessage": "Unable to reach the AI provider. Please check your connection and try again.",
+}
+`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -652,6 +652,14 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     summary: 'Running bash: ls -la',
     attributes: { toolName: 'bash', command: 'ls -la', riskLevel: 'low', sandboxed: true },
   },
+  session_error: {
+    type: 'session_error',
+    sessionId: 'sess-001',
+    code: 'PROVIDER_NETWORK',
+    userMessage: 'Unable to reach the AI provider. Please check your connection and try again.',
+    retryable: true,
+    debugDetails: 'ETIMEDOUT: connect to api.anthropic.com:443',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -870,6 +870,25 @@ export interface GetSigningIdentityRequest {
   type: 'get_signing_identity';
 }
 
+export type SessionErrorCode =
+  | 'PROVIDER_NETWORK'
+  | 'PROVIDER_RATE_LIMIT'
+  | 'PROVIDER_API'
+  | 'QUEUE_FULL'
+  | 'SESSION_ABORTED'
+  | 'SESSION_PROCESSING_FAILED'
+  | 'REGENERATE_FAILED'
+  | 'UNKNOWN';
+
+export interface SessionErrorMessage {
+  type: 'session_error';
+  sessionId: string;
+  code: SessionErrorCode;
+  userMessage: string;
+  retryable: boolean;
+  debugDetails?: string;
+}
+
 export interface TimerCompleted {
   type: 'timer_completed';
   sessionId: string;
@@ -1027,7 +1046,8 @@ export type ServerMessage =
   | OpenBundleResponse
   | SignBundlePayloadRequest
   | GetSigningIdentityRequest
-  | TraceEvent;
+  | TraceEvent
+  | SessionErrorMessage;
 
 // === Contract schema ===
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1047,6 +1047,36 @@ public struct TraceEventMessage: Decodable, Sendable {
     public let attributes: [String: AnyCodable]?
 }
 
+/// Structured error codes for session-level errors.
+public enum SessionErrorCode: String, CaseIterable, Codable, Sendable {
+    case providerNetwork = "PROVIDER_NETWORK"
+    case providerRateLimit = "PROVIDER_RATE_LIMIT"
+    case providerApi = "PROVIDER_API"
+    case queueFull = "QUEUE_FULL"
+    case sessionAborted = "SESSION_ABORTED"
+    case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
+    case regenerateFailed = "REGENERATE_FAILED"
+    case unknown = "UNKNOWN"
+}
+
+/// Structured session-level error from the daemon.
+/// Wire type: `"session_error"`
+public struct SessionErrorMessage: Decodable, Sendable {
+    public let sessionId: String
+    public let code: SessionErrorCode
+    public let userMessage: String
+    public let retryable: Bool
+    public let debugDetails: String?
+
+    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil) {
+        self.sessionId = sessionId
+        self.code = code
+        self.userMessage = userMessage
+        self.retryable = retryable
+        self.debugDetails = debugDetails
+    }
+}
+
 /// Timer completed notification from daemon.
 /// Wire type: `"timer_completed"`
 public struct TimerCompletedMessage: Decodable, Sendable {
@@ -1335,6 +1365,7 @@ public enum ServerMessage: Decodable, Sendable {
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
+    case sessionError(SessionErrorMessage)
     case signBundlePayload(SignBundlePayloadMessage)
     case getSigningIdentity
     case pong
@@ -1472,6 +1503,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "trace_event":
             let message = try TraceEventMessage(from: decoder)
             self = .traceEvent(message)
+        case "session_error":
+            let message = try SessionErrorMessage(from: decoder)
+            self = .sessionError(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
Part of #2037.

Adds `SessionErrorCode` enum and `SessionErrorMessage` to the IPC protocol in both TypeScript and Swift, with snapshot test coverage.

### Changes
- **`assistant/src/daemon/ipc-contract.ts`**: Added `SessionErrorCode` type and `SessionErrorMessage` interface, added to `ServerMessage` union
- **`clients/shared/IPC/IPCMessages.swift`**: Added `SessionErrorCode` enum (String, CaseIterable, Codable), `SessionErrorMessage` struct, `.sessionError` case to `ServerMessage` with decoder
- **`assistant/src/__tests__/ipc-snapshot.test.ts`**: Added `session_error` fixture with snapshot
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
