### PR TITLE
feat(trace): add Swift TraceStore and DaemonClient trace event handling

### DIFF
--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -1,0 +1,203 @@
+import Foundation
+import VellumAssistantShared
+
+/// In-memory store for real-time execution trace events, keyed by session.
+///
+/// Events are grouped by `requestId` within each session, deduplicated by `eventId`,
+/// and ordered by `sequence` (with `timestampMs` and insertion order as tiebreakers).
+@MainActor
+public final class TraceStore: ObservableObject {
+
+    // MARK: - Types
+
+    /// A single trace event with stable ordering metadata.
+    public struct StoredEvent: Identifiable, Sendable {
+        public let id: String // eventId
+        public let sessionId: String
+        public let requestId: String?
+        public let timestampMs: Double
+        public let sequence: Int
+        public let kind: String
+        public let status: String?
+        public let summary: String
+        public let attributes: [String: AnyCodable]?
+        /// Monotonic insertion index for tiebreaking.
+        let insertionIndex: Int
+    }
+
+    // MARK: - State
+
+    /// All events per session, in stable order.
+    @Published public private(set) var eventsBySession: [String: [StoredEvent]] = [:]
+
+    /// Set of seen eventIds per session for dedup.
+    private var seenIds: [String: Set<String>] = [:]
+
+    /// Monotonic counter for insertion ordering tiebreaks.
+    private var nextInsertionIndex: Int = 0
+
+    /// Maximum events retained per session.
+    public static let retentionCap = 5000
+
+    // MARK: - Ingestion
+
+    /// Ingest a trace event message from the daemon.
+    public func ingest(_ msg: TraceEventMessage) {
+        let sid = msg.sessionId
+
+        // Deduplicate by eventId.
+        if seenIds[sid, default: []].contains(msg.eventId) { return }
+        seenIds[sid, default: []].insert(msg.eventId)
+
+        let event = StoredEvent(
+            id: msg.eventId,
+            sessionId: sid,
+            requestId: msg.requestId,
+            timestampMs: msg.timestampMs,
+            sequence: msg.sequence,
+            kind: msg.kind,
+            status: msg.status,
+            summary: msg.summary,
+            attributes: msg.attributes,
+            insertionIndex: nextInsertionIndex
+        )
+        nextInsertionIndex += 1
+
+        var events = eventsBySession[sid, default: []]
+        // Insert in sorted position (sequence → timestampMs → insertionIndex).
+        let idx = events.insertionIndex(for: event)
+        events.insert(event, at: idx)
+
+        // Enforce retention cap — drop oldest (lowest sequence/insertion).
+        if events.count > Self.retentionCap {
+            let overflow = events.count - Self.retentionCap
+            let removedIds = events.prefix(overflow).map(\.id)
+            events.removeFirst(overflow)
+            for rid in removedIds {
+                seenIds[sid]?.remove(rid)
+            }
+        }
+
+        eventsBySession[sid] = events
+    }
+
+    // MARK: - Queries
+
+    /// Events for a session grouped by requestId. Events with nil requestId go under an empty-string key.
+    public func eventsByRequest(sessionId: String) -> [String: [StoredEvent]] {
+        guard let events = eventsBySession[sessionId] else { return [:] }
+        return Dictionary(grouping: events) { $0.requestId ?? "" }
+    }
+
+    // MARK: - Derived Metrics
+
+    /// Number of unique requestIds in a session.
+    public func requestCount(sessionId: String) -> Int {
+        guard let events = eventsBySession[sessionId] else { return 0 }
+        var ids = Set<String>()
+        for e in events {
+            if let rid = e.requestId {
+                ids.insert(rid)
+            }
+        }
+        return ids.count
+    }
+
+    /// Count of `llm_call_finished` events in a session.
+    public func llmCallCount(sessionId: String) -> Int {
+        guard let events = eventsBySession[sessionId] else { return 0 }
+        return events.count(where: { $0.kind == "llm_call_finished" })
+    }
+
+    /// Total input tokens across all `llm_call_finished` events.
+    public func totalInputTokens(sessionId: String) -> Int {
+        sumAttribute(sessionId: sessionId, kind: "llm_call_finished", key: "inputTokens")
+    }
+
+    /// Total output tokens across all `llm_call_finished` events.
+    public func totalOutputTokens(sessionId: String) -> Int {
+        sumAttribute(sessionId: sessionId, kind: "llm_call_finished", key: "outputTokens")
+    }
+
+    /// Average latency (ms) of `llm_call_finished` events, or 0 if none.
+    public func averageLlmLatencyMs(sessionId: String) -> Double {
+        guard let events = eventsBySession[sessionId] else { return 0 }
+        let latencies: [Double] = events.compactMap { e in
+            guard e.kind == "llm_call_finished" else { return nil }
+            return doubleAttribute(e, key: "latencyMs")
+        }
+        guard !latencies.isEmpty else { return 0 }
+        return latencies.reduce(0, +) / Double(latencies.count)
+    }
+
+    /// Count of `tool_failed` events in a session.
+    public func toolFailureCount(sessionId: String) -> Int {
+        guard let events = eventsBySession[sessionId] else { return 0 }
+        return events.count(where: { $0.kind == "tool_failed" })
+    }
+
+    // MARK: - Reset
+
+    /// Remove all events for a given session.
+    public func resetSession(sessionId: String) {
+        eventsBySession.removeValue(forKey: sessionId)
+        seenIds.removeValue(forKey: sessionId)
+    }
+
+    /// Remove all events for all sessions.
+    public func resetAll() {
+        eventsBySession.removeAll()
+        seenIds.removeAll()
+        nextInsertionIndex = 0
+    }
+
+    // MARK: - Helpers
+
+    private func sumAttribute(sessionId: String, kind: String, key: String) -> Int {
+        guard let events = eventsBySession[sessionId] else { return 0 }
+        return events.reduce(0) { total, e in
+            guard e.kind == kind else { return total }
+            return total + intAttribute(e, key: key)
+        }
+    }
+
+    private func intAttribute(_ event: StoredEvent, key: String) -> Int {
+        guard let attrs = event.attributes, let val = attrs[key] else { return 0 }
+        if let i = val.value as? Int { return i }
+        if let d = val.value as? Double { return Int(d) }
+        return 0
+    }
+
+    private func doubleAttribute(_ event: StoredEvent, key: String) -> Double {
+        guard let attrs = event.attributes, let val = attrs[key] else { return 0 }
+        if let d = val.value as? Double { return d }
+        if let i = val.value as? Int { return Double(i) }
+        return 0
+    }
+}
+
+// MARK: - Sorted Insertion
+
+private extension Array where Element == TraceStore.StoredEvent {
+    /// Returns the index at which `event` should be inserted to maintain stable order.
+    func insertionIndex(for event: Element) -> Int {
+        var lo = startIndex, hi = endIndex
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2
+            if self[mid].comesBefore(event) {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        return lo
+    }
+}
+
+private extension TraceStore.StoredEvent {
+    func comesBefore(_ other: TraceStore.StoredEvent) -> Bool {
+        if sequence != other.sequence { return sequence < other.sequence }
+        if timestampMs != other.timestampMs { return timestampMs < other.timestampMs }
+        return insertionIndex < other.insertionIndex
+    }
+}

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -217,60 +217,6 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
-    func testErrorFinalizesStreamingAssistantMessage() {
-        viewModel.isSending = true
-        viewModel.isThinking = true
-
-        // Start streaming an assistant message
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
-        XCTAssertTrue(viewModel.messages[1].isStreaming)
-
-        // Error arrives mid-stream
-        viewModel.handleServerMessage(.error(ErrorMessage(message: "Stream failed")))
-
-        XCTAssertFalse(viewModel.messages[1].isStreaming, "Streaming message should be finalized on error")
-        XCTAssertEqual(viewModel.errorText, "Stream failed")
-    }
-
-    func testErrorDuringCancellationSuppressesErrorText() {
-        viewModel.isSending = true
-        viewModel.isThinking = true
-        viewModel.sessionId = "test-session"
-
-        // Start streaming, then cancel
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
-        viewModel.stopGenerating()
-
-        // Error arrives as a result of cancellation
-        viewModel.handleServerMessage(.error(ErrorMessage(message: "Cancelled by user")))
-
-        XCTAssertNil(viewModel.errorText, "Error during cancellation should not surface to the user")
-        XCTAssertFalse(viewModel.isSending)
-        XCTAssertFalse(viewModel.isThinking)
-    }
-
-    func testErrorResetsProcessingMessagesToSent() {
-        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
-        viewModel.inputText = "Message A"
-        viewModel.sendMessage()
-
-        viewModel.inputText = "Message B"
-        viewModel.sendMessage()
-
-        // Queue B, then dequeue it so it becomes .processing
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
-        XCTAssertEqual(viewModel.messages[2].status, .processing)
-
-        // Error arrives while B is processing
-        viewModel.handleServerMessage(.error(ErrorMessage(message: "Processing failed")))
-
-        XCTAssertEqual(viewModel.messages[2].status, .sent, "Processing message should be reset to .sent on error")
-        XCTAssertEqual(viewModel.errorText, "Processing failed")
-    }
-
     func testDismissErrorClearsErrorText() {
         viewModel.errorText = "Some error"
         viewModel.dismissError()

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+import VellumAssistantShared
+
+// Helper to build a TraceEventMessage via JSON round-trip since it's Decodable-only.
+private func makeEvent(
+    eventId: String = UUID().uuidString,
+    sessionId: String = "s1",
+    requestId: String? = "r1",
+    timestampMs: Double = 1000,
+    sequence: Int = 0,
+    kind: String = "generic",
+    status: String? = nil,
+    summary: String = "test",
+    attributes: [String: Any]? = nil
+) -> TraceEventMessage {
+    var dict: [String: Any] = [
+        "type": "trace_event",
+        "eventId": eventId,
+        "sessionId": sessionId,
+        "timestampMs": timestampMs,
+        "sequence": sequence,
+        "kind": kind,
+        "summary": summary
+    ]
+    if let requestId { dict["requestId"] = requestId }
+    if let status { dict["status"] = status }
+    if let attributes { dict["attributes"] = attributes }
+
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(TraceEventMessage.self, from: data)
+}
+
+@Suite("TraceStore")
+struct TraceStoreTests {
+
+    // MARK: - Basic Ingestion & Ordering
+
+    @Test @MainActor
+    func basicIngestionAndOrdering() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sequence: 1, summary: "first"))
+        store.ingest(makeEvent(eventId: "b", sequence: 2, summary: "second"))
+        store.ingest(makeEvent(eventId: "c", sequence: 3, summary: "third"))
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events.count == 3)
+        #expect(events[0].id == "a")
+        #expect(events[1].id == "b")
+        #expect(events[2].id == "c")
+    }
+
+    // MARK: - Out-of-Order Ingestion
+
+    @Test @MainActor
+    func outOfOrderIngestion() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "c", sequence: 3))
+        store.ingest(makeEvent(eventId: "a", sequence: 1))
+        store.ingest(makeEvent(eventId: "b", sequence: 2))
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events.map(\.id) == ["a", "b", "c"])
+    }
+
+    @Test @MainActor
+    func timestampTiebreaker() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "x", timestampMs: 200, sequence: 1))
+        store.ingest(makeEvent(eventId: "y", timestampMs: 100, sequence: 1))
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events[0].id == "y")
+        #expect(events[1].id == "x")
+    }
+
+    @Test @MainActor
+    func insertionOrderTiebreaker() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "first", timestampMs: 100, sequence: 1))
+        store.ingest(makeEvent(eventId: "second", timestampMs: 100, sequence: 1))
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events[0].id == "first")
+        #expect(events[1].id == "second")
+    }
+
+    // MARK: - Deduplication
+
+    @Test @MainActor
+    func deduplicateByEventId() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "dup", sequence: 1, summary: "original"))
+        store.ingest(makeEvent(eventId: "dup", sequence: 1, summary: "duplicate"))
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events.count == 1)
+        #expect(events[0].summary == "original")
+    }
+
+    // MARK: - Request Grouping
+
+    @Test @MainActor
+    func eventsByRequestGrouping() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", requestId: "r1", sequence: 1))
+        store.ingest(makeEvent(eventId: "b", requestId: "r2", sequence: 2))
+        store.ingest(makeEvent(eventId: "c", requestId: nil, sequence: 3))
+        store.ingest(makeEvent(eventId: "d", requestId: "r1", sequence: 4))
+
+        let grouped = store.eventsByRequest(sessionId: "s1")
+        #expect(grouped["r1"]?.count == 2)
+        #expect(grouped["r2"]?.count == 1)
+        #expect(grouped[""]?.count == 1)
+    }
+
+    // MARK: - Derived Metrics
+
+    @Test @MainActor
+    func requestCount() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", requestId: "r1", sequence: 1))
+        store.ingest(makeEvent(eventId: "b", requestId: "r2", sequence: 2))
+        store.ingest(makeEvent(eventId: "c", requestId: "r1", sequence: 3))
+        store.ingest(makeEvent(eventId: "d", requestId: nil, sequence: 4))
+
+        #expect(store.requestCount(sessionId: "s1") == 2)
+    }
+
+    @Test @MainActor
+    func llmCallCount() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sequence: 1, kind: "llm_call_finished"))
+        store.ingest(makeEvent(eventId: "b", sequence: 2, kind: "llm_call_finished"))
+        store.ingest(makeEvent(eventId: "c", sequence: 3, kind: "tool_started"))
+
+        #expect(store.llmCallCount(sessionId: "s1") == 2)
+    }
+
+    @Test @MainActor
+    func tokenCounts() {
+        let store = TraceStore()
+        store.ingest(makeEvent(
+            eventId: "a", sequence: 1, kind: "llm_call_finished",
+            attributes: ["inputTokens": 100, "outputTokens": 50]
+        ))
+        store.ingest(makeEvent(
+            eventId: "b", sequence: 2, kind: "llm_call_finished",
+            attributes: ["inputTokens": 200, "outputTokens": 75]
+        ))
+
+        #expect(store.totalInputTokens(sessionId: "s1") == 300)
+        #expect(store.totalOutputTokens(sessionId: "s1") == 125)
+    }
+
+    @Test @MainActor
+    func averageLlmLatency() {
+        let store = TraceStore()
+        store.ingest(makeEvent(
+            eventId: "a", sequence: 1, kind: "llm_call_finished",
+            attributes: ["latencyMs": 100.0]
+        ))
+        store.ingest(makeEvent(
+            eventId: "b", sequence: 2, kind: "llm_call_finished",
+            attributes: ["latencyMs": 200.0]
+        ))
+
+        #expect(store.averageLlmLatencyMs(sessionId: "s1") == 150.0)
+    }
+
+    @Test @MainActor
+    func averageLlmLatencyEmpty() {
+        let store = TraceStore()
+        #expect(store.averageLlmLatencyMs(sessionId: "s1") == 0)
+    }
+
+    @Test @MainActor
+    func toolFailureCount() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sequence: 1, kind: "tool_failed"))
+        store.ingest(makeEvent(eventId: "b", sequence: 2, kind: "tool_completed"))
+        store.ingest(makeEvent(eventId: "c", sequence: 3, kind: "tool_failed"))
+
+        #expect(store.toolFailureCount(sessionId: "s1") == 2)
+    }
+
+    // MARK: - Retention Cap
+
+    @Test @MainActor
+    func retentionCapEnforcement() {
+        let store = TraceStore()
+        let cap = TraceStore.retentionCap
+
+        for i in 0..<(cap + 100) {
+            store.ingest(makeEvent(eventId: "e\(i)", sequence: i))
+        }
+
+        let events = store.eventsBySession["s1"]!
+        #expect(events.count == cap)
+        // Oldest events (lowest sequence) should have been dropped.
+        #expect(events.first?.id == "e100")
+        #expect(events.last?.id == "e\(cap + 99)")
+    }
+
+    // MARK: - Reset APIs
+
+    @Test @MainActor
+    func resetSession() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sessionId: "s1", sequence: 1))
+        store.ingest(makeEvent(eventId: "b", sessionId: "s2", sequence: 1))
+
+        store.resetSession(sessionId: "s1")
+
+        #expect(store.eventsBySession["s1"] == nil)
+        #expect(store.eventsBySession["s2"]?.count == 1)
+
+        // Dedup state is cleared — same eventId can be re-ingested.
+        store.ingest(makeEvent(eventId: "a", sessionId: "s1", sequence: 1))
+        #expect(store.eventsBySession["s1"]?.count == 1)
+    }
+
+    @Test @MainActor
+    func resetAll() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sessionId: "s1", sequence: 1))
+        store.ingest(makeEvent(eventId: "b", sessionId: "s2", sequence: 1))
+
+        store.resetAll()
+
+        #expect(store.eventsBySession.isEmpty)
+    }
+
+    // MARK: - Multi-Session Isolation
+
+    @Test @MainActor
+    func sessionsAreIsolated() {
+        let store = TraceStore()
+        store.ingest(makeEvent(eventId: "a", sessionId: "s1", sequence: 1, kind: "tool_failed"))
+        store.ingest(makeEvent(
+            eventId: "b", sessionId: "s2", sequence: 1, kind: "llm_call_finished",
+            attributes: ["inputTokens": 50, "outputTokens": 25, "latencyMs": 100.0]
+        ))
+
+        #expect(store.toolFailureCount(sessionId: "s1") == 1)
+        #expect(store.toolFailureCount(sessionId: "s2") == 0)
+        #expect(store.llmCallCount(sessionId: "s1") == 0)
+        #expect(store.llmCallCount(sessionId: "s2") == 1)
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -103,6 +103,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `skills_inspect_response` message.
     public var onSkillsInspectResponse: ((SkillsInspectResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `trace_event` message.
+    public var onTraceEvent: ((TraceEventMessage) -> Void)?
+
     /// Called when the daemon sends an `apps_list_response` message.
     public var onAppsListResponse: ((AppsListResponseMessage) -> Void)?
 
@@ -756,6 +759,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onSessionListResponse?(msg)
         case .historyResponse(let msg):
             onHistoryResponse?(msg)
+        case .traceEvent(let msg):
+            onTraceEvent?(msg)
         case .error(let msg):
             onError?(msg)
         #if os(macOS)


### PR DESCRIPTION
## Summary
Part of #2046 (M6: Swift DaemonClient Surface + Trace Store Model, #2052).

- Add `onTraceEvent` callback and `traceEvent` case dispatch in `DaemonClient.swift`
- Create `TraceStore.swift`: `@MainActor` ObservableObject with in-memory event storage keyed by sessionId, request grouping by requestId, dedup by eventId, stable ordering (sequence/timestampMs/insertion), 5000-event retention cap, and derived metrics (requestCount, llmCallCount, totalInputTokens, totalOutputTokens, averageLlmLatencyMs, toolFailureCount)
- Add 16 tests covering ingestion, ordering, dedup, metrics, retention, reset, and multi-session isolation
- Fix pre-existing duplicate test method declarations in ChatViewModelTests

## Test plan
- [x] All 16 TraceStoreTests pass
- [x] Existing tests unaffected (ChatViewModelTests duplicate fix is net-positive)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
