### PR TITLE
feat(ipc): add session_error contract types (M1)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1016,6 +1016,17 @@ exports[`IPC message snapshots ServerMessage types get_signing_identity serializ
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types session_error serializes to expected JSON 1`] = `
+{
+  "code": "PROVIDER_NETWORK",
+  "debugDetails": "ETIMEDOUT after 30000ms",
+  "retryable": true,
+  "sessionId": "sess-001",
+  "type": "session_error",
+  "userMessage": "Unable to reach the AI provider. Please try again.",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types trace_event serializes to expected JSON 1`] = `
 {
   "attributes": {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -640,6 +640,14 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   get_signing_identity: {
     type: 'get_signing_identity',
   },
+  session_error: {
+    type: 'session_error',
+    sessionId: 'sess-001',
+    code: 'PROVIDER_NETWORK',
+    userMessage: 'Unable to reach the AI provider. Please try again.',
+    retryable: true,
+    debugDetails: 'ETIMEDOUT after 30000ms',
+  },
   trace_event: {
     type: 'trace_event',
     eventId: 'evt-001',

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -671,6 +671,25 @@ export interface CuError {
   message: string;
 }
 
+export type SessionErrorCode =
+  | 'PROVIDER_NETWORK'
+  | 'PROVIDER_RATE_LIMIT'
+  | 'PROVIDER_API'
+  | 'QUEUE_FULL'
+  | 'SESSION_ABORTED'
+  | 'SESSION_PROCESSING_FAILED'
+  | 'REGENERATE_FAILED'
+  | 'UNKNOWN';
+
+export interface SessionErrorMessage {
+  type: 'session_error';
+  sessionId: string;
+  code: SessionErrorCode;
+  userMessage: string;
+  retryable: boolean;
+  debugDetails?: string;
+}
+
 export interface TaskRouted {
   type: 'task_routed';
   sessionId: string;
@@ -1004,6 +1023,7 @@ export type ServerMessage =
   | CuAction
   | CuComplete
   | CuError
+  | SessionErrorMessage
   | TaskRouted
   | AmbientResult
   | UiSurfaceShow

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -1095,6 +1095,42 @@ final class SessionTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionErrorDecoding() async {
+        let json = """
+        {"type":"session_error","sessionId":"sess-001","code":"PROVIDER_NETWORK","userMessage":"Unable to reach the AI provider.","retryable":true,"debugDetails":"ETIMEDOUT after 30000ms"}
+        """
+        let data = json.data(using: .utf8)!
+        let message = try! JSONDecoder().decode(ServerMessage.self, from: data)
+        if case .sessionError(let err) = message {
+            XCTAssertEqual(err.sessionId, "sess-001")
+            XCTAssertEqual(err.code, .providerNetwork)
+            XCTAssertEqual(err.userMessage, "Unable to reach the AI provider.")
+            XCTAssertTrue(err.retryable)
+            XCTAssertEqual(err.debugDetails, "ETIMEDOUT after 30000ms")
+        } else {
+            XCTFail("Expected sessionError, got \(message)")
+        }
+    }
+
+    @MainActor
+    func testSessionErrorDecoding_withoutOptionalFields() async {
+        let json = """
+        {"type":"session_error","sessionId":"sess-002","code":"UNKNOWN","userMessage":"Something went wrong.","retryable":false}
+        """
+        let data = json.data(using: .utf8)!
+        let message = try! JSONDecoder().decode(ServerMessage.self, from: data)
+        if case .sessionError(let err) = message {
+            XCTAssertEqual(err.sessionId, "sess-002")
+            XCTAssertEqual(err.code, .unknown)
+            XCTAssertEqual(err.userMessage, "Something went wrong.")
+            XCTAssertFalse(err.retryable)
+            XCTAssertNil(err.debugDetails)
+        } else {
+            XCTFail("Expected sessionError, got \(message)")
+        }
+    }
+
+    @MainActor
     func testConfirmationRequestDecodingWithoutExecutionTarget() async {
         let json = """
         {"type":"confirmation_request","requestId":"req-456","toolName":"bash","input":{"command":"pwd"},"riskLevel":"low","allowlistOptions":[],"scopeOptions":[]}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1291,12 +1291,43 @@ public struct OpenBundleResponseMessage: Decodable, Sendable {
     public let bundleSizeBytes: Int
 }
 
+/// Structured error code for session-level errors.
+public enum SessionErrorCode: String, Codable, Sendable {
+    case providerNetwork = "PROVIDER_NETWORK"
+    case providerRateLimit = "PROVIDER_RATE_LIMIT"
+    case providerApi = "PROVIDER_API"
+    case queueFull = "QUEUE_FULL"
+    case sessionAborted = "SESSION_ABORTED"
+    case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
+    case regenerateFailed = "REGENERATE_FAILED"
+    case unknown = "UNKNOWN"
+}
+
+/// Typed session-level error from the daemon.
+/// Wire type: `"session_error"`
+public struct SessionErrorMessagePayload: Decodable, Sendable {
+    public let sessionId: String
+    public let code: SessionErrorCode
+    public let userMessage: String
+    public let retryable: Bool
+    public let debugDetails: String?
+
+    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil) {
+        self.sessionId = sessionId
+        self.code = code
+        self.userMessage = userMessage
+        self.retryable = retryable
+        self.debugDetails = debugDetails
+    }
+}
+
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
 public enum ServerMessage: Decodable, Sendable {
     case cuAction(CuActionMessage)
     case cuComplete(CuCompleteMessage)
     case cuError(CuErrorMessage)
+    case sessionError(SessionErrorMessagePayload)
     case assistantTextDelta(AssistantTextDeltaMessage)
     case assistantThinkingDelta(AssistantThinkingDeltaMessage)
     case messageComplete(MessageCompleteMessage)
@@ -1358,6 +1389,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "cu_error":
             let message = try CuErrorMessage(from: decoder)
             self = .cuError(message)
+        case "session_error":
+            let message = try SessionErrorMessagePayload(from: decoder)
+            self = .sessionError(message)
         case "assistant_text_delta":
             let message = try AssistantTextDeltaMessage(from: decoder)
             self = .assistantTextDelta(message)


### PR DESCRIPTION
Part of #2037. Adds SessionErrorCode + SessionErrorMessage types to both TS and Swift IPC protocol, extending the ServerMessage union with session_error. Includes snapshot and decode tests.

## Changes

### TypeScript
- Added `SessionErrorCode` type union and `SessionErrorMessage` interface to `ipc-contract.ts`
- Added `SessionErrorMessage` to the `ServerMessage` union
- Added `session_error` snapshot fixture to `ipc-snapshot.test.ts`

### Swift
- Added `SessionErrorCode` enum (String, Codable) with matching cases
- Added `SessionErrorMessagePayload` struct (Decodable, Sendable)
- Added `.sessionError(SessionErrorMessagePayload)` case to `ServerMessage` enum
- Added decoder switch arm for `"session_error"` in `ServerMessage.init(from:)`
- Added two decode tests in `SessionTests.swift` (with and without optional fields)

## Verification
- TS type-check passes (`bunx tsc --noEmit`)
- TS snapshot tests pass with new fixture (106 tests, 0 failures)
- Swift macOS build passes (`swift build --target VellumAssistantLib`)
- Swift decode tests verified via standalone script (all 8 error codes decode correctly)

Closes #2039
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
