### PR TITLE
Fix iOS build errors in shared library

### DIFF
--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -31,8 +31,8 @@ public enum VFont {
         }
         let descriptor = uiFont.fontDescriptor.addingAttributes([
             .featureSettings: [[
-                UIFontDescriptor.FeatureKey.featureIdentifier: kStylisticAlternativesType,
-                UIFontDescriptor.FeatureKey.typeIdentifier: kStylisticAltFiveOnSelector,
+                UIFontDescriptor.FeatureKey.typeIdentifier: kStylisticAlternativesType,
+                UIFontDescriptor.FeatureKey.selectorIdentifier: kStylisticAltFiveOnSelector,
             ]]
         ])
         return Font(UIFont(descriptor: descriptor, size: size))

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1321,18 +1321,6 @@ public struct OpenBundleResponseMessage: Decodable, Sendable {
     public let bundleSizeBytes: Int
 }
 
-/// Structured error code for session-level errors.
-public enum SessionErrorCode: String, Codable, Sendable {
-    case providerNetwork = "PROVIDER_NETWORK"
-    case providerRateLimit = "PROVIDER_RATE_LIMIT"
-    case providerApi = "PROVIDER_API"
-    case queueFull = "QUEUE_FULL"
-    case sessionAborted = "SESSION_ABORTED"
-    case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
-    case regenerateFailed = "REGENERATE_FAILED"
-    case unknown = "UNKNOWN"
-}
-
 /// Typed session-level error from the daemon.
 /// Wire type: `"session_error"`
 public struct SessionErrorMessagePayload: Decodable, Sendable {


### PR DESCRIPTION
## Summary

Fixes two compilation errors blocking iOS builds:
- **Duplicate SessionErrorCode enum** causing ambiguous type lookup in IPCMessages
- **Deprecated iOS font descriptor keys** in TypographyTokens

## Changes

1. **IPCMessages.swift**: Removed duplicate `SessionErrorCode` enum definition at line 1325 (kept the one at line 1051 with `CaseIterable`)
2. **TypographyTokens.swift**: Fixed iOS font feature settings to use correct keys:
   - `featureIdentifier` → `typeIdentifier`
   - Second `typeIdentifier` → `selectorIdentifier`

## Testing

- iOS target now compiles without errors
- macOS build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
