### PR TITLE
SANDBOX M5: Add config schema/defaults for backend + Docker limits

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -79,7 +79,17 @@ describe('AssistantConfigSchema', () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
     });
-    expect(result.sandbox).toEqual({ enabled: true });
+    expect(result.sandbox).toEqual({
+      enabled: true,
+      backend: 'native',
+      docker: {
+        image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+        cpus: 1,
+        memoryMb: 512,
+        pidsLimit: 256,
+        network: 'none',
+      },
+    });
     expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
     expect(result.secretDetection).toEqual({ enabled: true, action: 'warn', entropyThreshold: 4.0 });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
@@ -269,6 +279,102 @@ describe('AssistantConfigSchema', () => {
       expect(messages.some(m => m.includes('redact') && m.includes('warn') && m.includes('block'))).toBe(true);
     }
   });
+
+  test('backward compatibility: sandbox with only enabled still parses', () => {
+    const result = AssistantConfigSchema.parse({ sandbox: { enabled: false } });
+    expect(result.sandbox.enabled).toBe(false);
+    expect(result.sandbox.backend).toBe('native');
+    expect(result.sandbox.docker.memoryMb).toBe(512);
+  });
+
+  test('accepts docker backend with custom limits', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: {
+        enabled: true,
+        backend: 'docker',
+        docker: {
+          image: 'ubuntu:22.04',
+          cpus: 2,
+          memoryMb: 1024,
+          pidsLimit: 512,
+          network: 'bridge',
+        },
+      },
+    });
+    expect(result.sandbox.backend).toBe('docker');
+    expect(result.sandbox.docker.image).toBe('ubuntu:22.04');
+    expect(result.sandbox.docker.cpus).toBe(2);
+    expect(result.sandbox.docker.memoryMb).toBe(1024);
+    expect(result.sandbox.docker.pidsLimit).toBe(512);
+    expect(result.sandbox.docker.network).toBe('bridge');
+  });
+
+  test('applies docker defaults when backend is docker but docker config omitted', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: { backend: 'docker' },
+    });
+    expect(result.sandbox.backend).toBe('docker');
+    expect(result.sandbox.docker.cpus).toBe(1);
+    expect(result.sandbox.docker.memoryMb).toBe(512);
+    expect(result.sandbox.docker.pidsLimit).toBe(256);
+    expect(result.sandbox.docker.network).toBe('none');
+  });
+
+  test('accepts partial docker config with defaults for missing fields', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: {
+        backend: 'docker',
+        docker: { memoryMb: 2048 },
+      },
+    });
+    expect(result.sandbox.docker.memoryMb).toBe(2048);
+    expect(result.sandbox.docker.cpus).toBe(1);
+    expect(result.sandbox.docker.pidsLimit).toBe(256);
+    expect(result.sandbox.docker.network).toBe('none');
+  });
+
+  test('rejects invalid sandbox.backend', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { backend: 'podman' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('sandbox.backend'))).toBe(true);
+    }
+  });
+
+  test('rejects invalid docker.network', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { network: 'host' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('sandbox.docker.network'))).toBe(true);
+    }
+  });
+
+  test('rejects non-positive docker.memoryMb', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { memoryMb: 0 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-integer docker.pidsLimit', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { pidsLimit: 3.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects negative docker.cpus', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { cpus: -1 } },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -398,6 +504,34 @@ describe('loadConfig with schema validation', () => {
     writeConfig({ sandbox: { enabled: 'yes' } });
     const config = loadConfig();
     expect(config.sandbox.enabled).toBe(true);
+  });
+
+  test('loads sandbox with only enabled (backward compatibility)', () => {
+    writeConfig({ sandbox: { enabled: false } });
+    const config = loadConfig();
+    expect(config.sandbox.enabled).toBe(false);
+    expect(config.sandbox.backend).toBe('native');
+    expect(config.sandbox.docker.memoryMb).toBe(512);
+  });
+
+  test('loads sandbox docker backend config', () => {
+    writeConfig({
+      sandbox: {
+        backend: 'docker',
+        docker: { memoryMb: 2048, network: 'bridge' },
+      },
+    });
+    const config = loadConfig();
+    expect(config.sandbox.backend).toBe('docker');
+    expect(config.sandbox.docker.memoryMb).toBe(2048);
+    expect(config.sandbox.docker.network).toBe('bridge');
+    expect(config.sandbox.docker.cpus).toBe(1);
+  });
+
+  test('falls back for invalid sandbox.backend', () => {
+    writeConfig({ sandbox: { backend: 'podman' } });
+    const config = loadConfig();
+    expect(config.sandbox.backend).toBe('native');
   });
 
   test('falls back for invalid contextWindow relationship', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,6 +87,14 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   sandbox: {
     enabled: true,
+    backend: 'native',
+    docker: {
+      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: 'none' as const,
+    },
   },
   rateLimit: {
     maxRequestsPerMinute: 0,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -4,6 +4,8 @@ import { getDataDir } from '../util/platform.js';
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
+const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
+const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -23,10 +25,48 @@ export const TimeoutConfigSchema = z.object({
     .default(300),
 });
 
+export const DockerConfigSchema = z.object({
+  image: z
+    .string({ error: 'sandbox.docker.image must be a string' })
+    .default('node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9'),
+  cpus: z
+    .number({ error: 'sandbox.docker.cpus must be a number' })
+    .finite('sandbox.docker.cpus must be finite')
+    .positive('sandbox.docker.cpus must be a positive number')
+    .default(1),
+  memoryMb: z
+    .number({ error: 'sandbox.docker.memoryMb must be a number' })
+    .int('sandbox.docker.memoryMb must be an integer')
+    .positive('sandbox.docker.memoryMb must be a positive integer')
+    .default(512),
+  pidsLimit: z
+    .number({ error: 'sandbox.docker.pidsLimit must be a number' })
+    .int('sandbox.docker.pidsLimit must be an integer')
+    .positive('sandbox.docker.pidsLimit must be a positive integer')
+    .default(256),
+  network: z
+    .enum(VALID_DOCKER_NETWORKS, {
+      error: `sandbox.docker.network must be one of: ${VALID_DOCKER_NETWORKS.join(', ')}`,
+    })
+    .default('none'),
+});
+
 export const SandboxConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'sandbox.enabled must be a boolean' })
     .default(true),
+  backend: z
+    .enum(VALID_SANDBOX_BACKENDS, {
+      error: `sandbox.backend must be one of: ${VALID_SANDBOX_BACKENDS.join(', ')}`,
+    })
+    .default('native'),
+  docker: DockerConfigSchema.default({
+    image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+    cpus: 1,
+    memoryMb: 512,
+    pidsLimit: 256,
+    network: 'none',
+  }),
 });
 
 export const RateLimitConfigSchema = z.object({
@@ -528,6 +568,14 @@ export const AssistantConfigSchema = z.object({
   }),
   sandbox: SandboxConfigSchema.default({
     enabled: true,
+    backend: 'native',
+    docker: {
+      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: 'none',
+    },
   }),
   rateLimit: RateLimitConfigSchema.default({
     maxRequestsPerMinute: 0,
@@ -570,6 +618,7 @@ export const AssistantConfigSchema = z.object({
 export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
+export type DockerConfig = z.infer<typeof DockerConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -2,6 +2,7 @@ export type {
   AssistantConfig,
   TimeoutConfig,
   SandboxConfig,
+  DockerConfig,
   RateLimitConfig,
   SecretDetectionConfig,
   AuditLogConfig,


### PR DESCRIPTION
## Summary
- Extend `SandboxConfigSchema` with `backend` (`native` | `docker`) and nested `docker` config (image, cpus, memoryMb, pidsLimit, network)
- Add `DockerConfigSchema` with sane defaults (1 CPU, 512 MB, 256 PIDs, `none` network)
- Maintain backward compatibility: configs with only `sandbox.enabled` still parse correctly
- Add comprehensive tests for new schema fields, validation, and loader fallback behavior

## Test plan
- [x] `bun test src/__tests__/config-schema.test.ts` — 46 tests pass
- [x] `bun test src/__tests__/terminal-sandbox.test.ts src/__tests__/terminal-sandbox-docker.test.ts` — 89 tests pass
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing ipc-contract issues only)

Closes #2027
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
