### PR TITLE
M5: Tool lifecycle trace emission from domain events

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -79,7 +79,17 @@ describe('AssistantConfigSchema', () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
     });
-    expect(result.sandbox).toEqual({ enabled: true });
+    expect(result.sandbox).toEqual({
+      enabled: true,
+      backend: 'native',
+      docker: {
+        image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+        cpus: 1,
+        memoryMb: 512,
+        pidsLimit: 256,
+        network: 'none',
+      },
+    });
     expect(result.rateLimit).toEqual({ maxRequestsPerMinute: 0, maxTokensPerSession: 0 });
     expect(result.secretDetection).toEqual({ enabled: true, action: 'warn', entropyThreshold: 4.0 });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
@@ -269,6 +279,102 @@ describe('AssistantConfigSchema', () => {
       expect(messages.some(m => m.includes('redact') && m.includes('warn') && m.includes('block'))).toBe(true);
     }
   });
+
+  test('backward compatibility: sandbox with only enabled still parses', () => {
+    const result = AssistantConfigSchema.parse({ sandbox: { enabled: false } });
+    expect(result.sandbox.enabled).toBe(false);
+    expect(result.sandbox.backend).toBe('native');
+    expect(result.sandbox.docker.memoryMb).toBe(512);
+  });
+
+  test('accepts docker backend with custom limits', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: {
+        enabled: true,
+        backend: 'docker',
+        docker: {
+          image: 'ubuntu:22.04',
+          cpus: 2,
+          memoryMb: 1024,
+          pidsLimit: 512,
+          network: 'bridge',
+        },
+      },
+    });
+    expect(result.sandbox.backend).toBe('docker');
+    expect(result.sandbox.docker.image).toBe('ubuntu:22.04');
+    expect(result.sandbox.docker.cpus).toBe(2);
+    expect(result.sandbox.docker.memoryMb).toBe(1024);
+    expect(result.sandbox.docker.pidsLimit).toBe(512);
+    expect(result.sandbox.docker.network).toBe('bridge');
+  });
+
+  test('applies docker defaults when backend is docker but docker config omitted', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: { backend: 'docker' },
+    });
+    expect(result.sandbox.backend).toBe('docker');
+    expect(result.sandbox.docker.cpus).toBe(1);
+    expect(result.sandbox.docker.memoryMb).toBe(512);
+    expect(result.sandbox.docker.pidsLimit).toBe(256);
+    expect(result.sandbox.docker.network).toBe('none');
+  });
+
+  test('accepts partial docker config with defaults for missing fields', () => {
+    const result = AssistantConfigSchema.parse({
+      sandbox: {
+        backend: 'docker',
+        docker: { memoryMb: 2048 },
+      },
+    });
+    expect(result.sandbox.docker.memoryMb).toBe(2048);
+    expect(result.sandbox.docker.cpus).toBe(1);
+    expect(result.sandbox.docker.pidsLimit).toBe(256);
+    expect(result.sandbox.docker.network).toBe('none');
+  });
+
+  test('rejects invalid sandbox.backend', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { backend: 'podman' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('sandbox.backend'))).toBe(true);
+    }
+  });
+
+  test('rejects invalid docker.network', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { network: 'host' } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map(i => i.message);
+      expect(msgs.some(m => m.includes('sandbox.docker.network'))).toBe(true);
+    }
+  });
+
+  test('rejects non-positive docker.memoryMb', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { memoryMb: 0 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-integer docker.pidsLimit', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { pidsLimit: 3.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects negative docker.cpus', () => {
+    const result = AssistantConfigSchema.safeParse({
+      sandbox: { docker: { cpus: -1 } },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -398,6 +504,34 @@ describe('loadConfig with schema validation', () => {
     writeConfig({ sandbox: { enabled: 'yes' } });
     const config = loadConfig();
     expect(config.sandbox.enabled).toBe(true);
+  });
+
+  test('loads sandbox with only enabled (backward compatibility)', () => {
+    writeConfig({ sandbox: { enabled: false } });
+    const config = loadConfig();
+    expect(config.sandbox.enabled).toBe(false);
+    expect(config.sandbox.backend).toBe('native');
+    expect(config.sandbox.docker.memoryMb).toBe(512);
+  });
+
+  test('loads sandbox docker backend config', () => {
+    writeConfig({
+      sandbox: {
+        backend: 'docker',
+        docker: { memoryMb: 2048, network: 'bridge' },
+      },
+    });
+    const config = loadConfig();
+    expect(config.sandbox.backend).toBe('docker');
+    expect(config.sandbox.docker.memoryMb).toBe(2048);
+    expect(config.sandbox.docker.network).toBe('bridge');
+    expect(config.sandbox.docker.cpus).toBe(1);
+  });
+
+  test('falls back for invalid sandbox.backend', () => {
+    writeConfig({ sandbox: { backend: 'podman' } });
+    const config = loadConfig();
+    expect(config.sandbox.backend).toBe('native');
   });
 
   test('falls back for invalid contextWindow relationship', () => {

--- a/assistant/src/__tests__/tool-trace-listener.test.ts
+++ b/assistant/src/__tests__/tool-trace-listener.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { EventBus } from '../events/bus.js';
+import type { AssistantDomainEvents } from '../events/domain-events.js';
+import { registerToolTraceListener } from '../events/tool-trace-listener.js';
+import type { TraceEmitter, TraceEmitOptions } from '../daemon/trace-emitter.js';
+import type { TraceEventKind } from '../daemon/ipc-protocol.js';
+
+interface EmittedTrace {
+  kind: TraceEventKind;
+  summary: string;
+  opts?: TraceEmitOptions;
+}
+
+let traces: EmittedTrace[];
+
+function createMockTraceEmitter(): TraceEmitter {
+  return {
+    emit(kind: TraceEventKind, summary: string, opts?: TraceEmitOptions) {
+      traces.push({ kind, summary, opts });
+    },
+  } as TraceEmitter;
+}
+
+describe('registerToolTraceListener', () => {
+  let bus: EventBus<AssistantDomainEvents>;
+  let emitter: TraceEmitter;
+
+  beforeEach(() => {
+    traces = [];
+    bus = new EventBus<AssistantDomainEvents>();
+    emitter = createMockTraceEmitter();
+    registerToolTraceListener(bus, emitter);
+  });
+
+  test('emits tool_started trace on tool.execution.started', async () => {
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-1',
+      toolName: 'file_read',
+      input: { path: '/tmp/test.txt' },
+      startedAtMs: 1000,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_started');
+    expect(traces[0].summary).toBe('Tool file_read started');
+    expect(traces[0].opts?.requestId).toBe('req-1');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'file_read' });
+  });
+
+  test('emits tool_permission_requested trace with riskLevel', async () => {
+    await bus.emit('tool.permission.requested', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-2',
+      toolName: 'bash',
+      riskLevel: 'high',
+      requestedAtMs: 2000,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_permission_requested');
+    expect(traces[0].summary).toBe('Permission requested for bash');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'bash', riskLevel: 'high' });
+  });
+
+  test('emits tool_permission_decided trace with decision', async () => {
+    await bus.emit('tool.permission.decided', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-3',
+      toolName: 'bash',
+      decision: 'deny',
+      riskLevel: 'high',
+      decidedAtMs: 3000,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_permission_decided');
+    expect(traces[0].summary).toBe('Permission deny for bash');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'bash', decision: 'deny' });
+  });
+
+  test('emits tool_finished trace with durationMs', async () => {
+    await bus.emit('tool.execution.finished', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-4',
+      toolName: 'file_read',
+      decision: 'allow',
+      riskLevel: 'low',
+      isError: false,
+      durationMs: 42,
+      finishedAtMs: 4042,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_finished');
+    expect(traces[0].summary).toBe('Tool file_read finished in 42ms');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'file_read', durationMs: 42 });
+  });
+
+  test('emits tool_failed trace with error status', async () => {
+    await bus.emit('tool.execution.failed', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-5',
+      toolName: 'bash',
+      decision: 'allow',
+      riskLevel: 'high',
+      durationMs: 100,
+      error: 'Command not found',
+      isExpected: false,
+      failedAtMs: 5100,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('tool_failed');
+    expect(traces[0].summary).toBe('Tool bash failed after 100ms');
+    expect(traces[0].opts?.status).toBe('error');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'bash', durationMs: 100 });
+  });
+
+  test('emits secret_detected trace with warning status', async () => {
+    await bus.emit('tool.secret.detected', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'req-6',
+      toolName: 'file_read',
+      action: 'redact',
+      matches: [{ type: 'AWS Key', redactedValue: '<redacted />' }],
+      detectedAtMs: 6000,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].kind).toBe('secret_detected');
+    expect(traces[0].summary).toBe('Secret detected in file_read output');
+    expect(traces[0].opts?.status).toBe('warning');
+    expect(traces[0].opts?.attributes).toEqual({ toolName: 'file_read' });
+  });
+
+  test('passes requestId from domain event payload', async () => {
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      requestId: 'my-request-id',
+      toolName: 'file_read',
+      input: {},
+      startedAtMs: 7000,
+    });
+
+    expect(traces[0].opts?.requestId).toBe('my-request-id');
+  });
+
+  test('handles missing requestId gracefully', async () => {
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      input: {},
+      startedAtMs: 8000,
+    });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].opts?.requestId).toBeUndefined();
+  });
+
+  test('ignores non-tool domain events', async () => {
+    await bus.emit('daemon.lifecycle.started', {
+      pid: 123,
+      socketPath: '/tmp/test.sock',
+      startedAtMs: 9000,
+    });
+
+    expect(traces).toHaveLength(0);
+  });
+
+  test('subscription can be disposed to stop receiving events', async () => {
+    bus.dispose();
+    bus = new EventBus<AssistantDomainEvents>();
+    const subscription = registerToolTraceListener(bus, emitter);
+
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      input: {},
+      startedAtMs: 10000,
+    });
+    expect(traces).toHaveLength(1);
+
+    subscription.dispose();
+    traces.length = 0;
+
+    await bus.emit('tool.execution.started', {
+      conversationId: 'conv-1',
+      sessionId: 'sess-1',
+      toolName: 'file_read',
+      input: {},
+      startedAtMs: 11000,
+    });
+    expect(traces).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,6 +87,14 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   sandbox: {
     enabled: true,
+    backend: 'native',
+    docker: {
+      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: 'none' as const,
+    },
   },
   rateLimit: {
     maxRequestsPerMinute: 0,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -4,6 +4,8 @@ import { getDataDir } from '../util/platform.js';
 const VALID_PROVIDERS = ['anthropic', 'openai', 'gemini', 'ollama', 'fireworks'] as const;
 const VALID_SECRET_ACTIONS = ['redact', 'warn', 'block'] as const;
 const VALID_MEMORY_EMBEDDING_PROVIDERS = ['auto', 'local', 'openai', 'gemini', 'ollama'] as const;
+const VALID_SANDBOX_BACKENDS = ['native', 'docker'] as const;
+const VALID_DOCKER_NETWORKS = ['none', 'bridge'] as const;
 
 export const TimeoutConfigSchema = z.object({
   shellMaxTimeoutSec: z
@@ -23,10 +25,48 @@ export const TimeoutConfigSchema = z.object({
     .default(300),
 });
 
+export const DockerConfigSchema = z.object({
+  image: z
+    .string({ error: 'sandbox.docker.image must be a string' })
+    .default('node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9'),
+  cpus: z
+    .number({ error: 'sandbox.docker.cpus must be a number' })
+    .finite('sandbox.docker.cpus must be finite')
+    .positive('sandbox.docker.cpus must be a positive number')
+    .default(1),
+  memoryMb: z
+    .number({ error: 'sandbox.docker.memoryMb must be a number' })
+    .int('sandbox.docker.memoryMb must be an integer')
+    .positive('sandbox.docker.memoryMb must be a positive integer')
+    .default(512),
+  pidsLimit: z
+    .number({ error: 'sandbox.docker.pidsLimit must be a number' })
+    .int('sandbox.docker.pidsLimit must be an integer')
+    .positive('sandbox.docker.pidsLimit must be a positive integer')
+    .default(256),
+  network: z
+    .enum(VALID_DOCKER_NETWORKS, {
+      error: `sandbox.docker.network must be one of: ${VALID_DOCKER_NETWORKS.join(', ')}`,
+    })
+    .default('none'),
+});
+
 export const SandboxConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'sandbox.enabled must be a boolean' })
     .default(true),
+  backend: z
+    .enum(VALID_SANDBOX_BACKENDS, {
+      error: `sandbox.backend must be one of: ${VALID_SANDBOX_BACKENDS.join(', ')}`,
+    })
+    .default('native'),
+  docker: DockerConfigSchema.default({
+    image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+    cpus: 1,
+    memoryMb: 512,
+    pidsLimit: 256,
+    network: 'none',
+  }),
 });
 
 export const RateLimitConfigSchema = z.object({
@@ -528,6 +568,14 @@ export const AssistantConfigSchema = z.object({
   }),
   sandbox: SandboxConfigSchema.default({
     enabled: true,
+    backend: 'native',
+    docker: {
+      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: 'none',
+    },
   }),
   rateLimit: RateLimitConfigSchema.default({
     maxRequestsPerMinute: 0,
@@ -570,6 +618,7 @@ export const AssistantConfigSchema = z.object({
 export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
+export type DockerConfig = z.infer<typeof DockerConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -2,6 +2,7 @@ export type {
   AssistantConfig,
   TimeoutConfig,
   SandboxConfig,
+  DockerConfig,
   RateLimitConfig,
   SecretDetectionConfig,
   AuditLogConfig,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -32,6 +32,7 @@ import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier, pru
 import { createToolDomainEventPublisher } from '../events/tool-domain-event-publisher.js';
 import { registerToolMetricsLoggingListener } from '../events/tool-metrics-listener.js';
 import { registerToolNotificationListener } from '../events/tool-notification-listener.js';
+import { registerToolTraceListener } from '../events/tool-trace-listener.js';
 import { createToolAuditListener } from '../events/tool-audit-listener.js';
 import {
   ContextWindowManager,
@@ -137,6 +138,7 @@ export class Session {
     this.executor = new ToolExecutor(this.prompter);
     registerToolMetricsLoggingListener(this.eventBus);
     registerToolNotificationListener(this.eventBus, (msg) => this.sendToClient(msg));
+    registerToolTraceListener(this.eventBus, this.traceEmitter);
     const auditToolLifecycleEvent = createToolAuditListener();
     const publishToolDomainEvent = createToolDomainEventPublisher(this.eventBus);
     const handleToolLifecycleEvent: ToolLifecycleEventHandler = (event) => {

--- a/assistant/src/events/index.ts
+++ b/assistant/src/events/index.ts
@@ -15,3 +15,4 @@ export type {
 export { createToolDomainEventPublisher } from './tool-domain-event-publisher.js';
 export { registerToolMetricsLoggingListener } from './tool-metrics-listener.js';
 export { registerToolNotificationListener } from './tool-notification-listener.js';
+export { registerToolTraceListener } from './tool-trace-listener.js';

--- a/assistant/src/events/tool-trace-listener.ts
+++ b/assistant/src/events/tool-trace-listener.ts
@@ -1,0 +1,73 @@
+import type { EventBus, Subscription } from './bus.js';
+import type { AssistantDomainEvents } from './domain-events.js';
+import type { TraceEmitter } from '../daemon/trace-emitter.js';
+
+export function registerToolTraceListener(
+  eventBus: EventBus<AssistantDomainEvents>,
+  traceEmitter: TraceEmitter,
+): Subscription {
+  return eventBus.onAny((event) => {
+    switch (event.type) {
+      case 'tool.execution.started':
+        traceEmitter.emit('tool_started', `Tool ${event.payload.toolName} started`, {
+          requestId: event.payload.requestId,
+          attributes: { toolName: event.payload.toolName },
+        });
+        return;
+
+      case 'tool.permission.requested':
+        traceEmitter.emit('tool_permission_requested', `Permission requested for ${event.payload.toolName}`, {
+          requestId: event.payload.requestId,
+          attributes: {
+            toolName: event.payload.toolName,
+            riskLevel: event.payload.riskLevel,
+          },
+        });
+        return;
+
+      case 'tool.permission.decided':
+        traceEmitter.emit('tool_permission_decided', `Permission ${event.payload.decision} for ${event.payload.toolName}`, {
+          requestId: event.payload.requestId,
+          attributes: {
+            toolName: event.payload.toolName,
+            decision: event.payload.decision,
+          },
+        });
+        return;
+
+      case 'tool.execution.finished':
+        traceEmitter.emit('tool_finished', `Tool ${event.payload.toolName} finished in ${event.payload.durationMs}ms`, {
+          requestId: event.payload.requestId,
+          attributes: {
+            toolName: event.payload.toolName,
+            durationMs: event.payload.durationMs,
+          },
+        });
+        return;
+
+      case 'tool.execution.failed':
+        traceEmitter.emit('tool_failed', `Tool ${event.payload.toolName} failed after ${event.payload.durationMs}ms`, {
+          requestId: event.payload.requestId,
+          status: 'error',
+          attributes: {
+            toolName: event.payload.toolName,
+            durationMs: event.payload.durationMs,
+          },
+        });
+        return;
+
+      case 'tool.secret.detected':
+        traceEmitter.emit('secret_detected', `Secret detected in ${event.payload.toolName} output`, {
+          requestId: event.payload.requestId,
+          status: 'warning',
+          attributes: {
+            toolName: event.payload.toolName,
+          },
+        });
+        return;
+
+      default:
+        return;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Created `tool-trace-listener.ts` that subscribes to the event bus and converts all six tool domain events (`tool.execution.started`, `tool.permission.requested`, `tool.permission.decided`, `tool.execution.finished`, `tool.execution.failed`, `tool.secret.detected`) into trace events for the debug panel timeline
- Registered the listener in `Session` constructor alongside existing metric and notification listeners
- Includes 10 tests covering all event types, requestId forwarding, missing requestId handling, non-tool event filtering, and subscription disposal

Closes #2051

## Test plan
- [x] `bun test src/__tests__/tool-trace-listener.test.ts` — 10/10 pass
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing duplicate `SessionErrorCode` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
