### PR TITLE
feat(error-handling): centralized error mapper and session_error emission (M2)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1046,14 +1046,3 @@ exports[`IPC message snapshots ServerMessage types trace_event serializes to exp
   "type": "trace_event",
 }
 `;
-
-exports[`IPC message snapshots ServerMessage types session_error serializes to expected JSON 1`] = `
-{
-  "code": "PROVIDER_NETWORK",
-  "debugDetails": "ETIMEDOUT: connect to api.anthropic.com:443",
-  "retryable": true,
-  "sessionId": "sess-001",
-  "type": "session_error",
-  "userMessage": "Unable to reach the AI provider. Please check your connection and try again.",
-}
-`;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -660,14 +660,6 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     summary: 'Running bash: ls -la',
     attributes: { toolName: 'bash', command: 'ls -la', riskLevel: 'low', sandboxed: true },
   },
-  session_error: {
-    type: 'session_error',
-    sessionId: 'sess-001',
-    code: 'PROVIDER_NETWORK',
-    userMessage: 'Unable to reach the AI provider. Please check your connection and try again.',
-    retryable: true,
-    debugDetails: 'ETIMEDOUT: connect to api.anthropic.com:443',
-  },
 };
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  classifySessionError,
+  isUserCancellation,
+  buildSessionErrorMessage,
+} from '../daemon/session-error.js';
+import type { ErrorContext } from '../daemon/session-error.js';
+
+describe('isUserCancellation', () => {
+  it('returns true when abort flag is set', () => {
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: true };
+    expect(isUserCancellation(new Error('something'), ctx)).toBe(true);
+  });
+
+  it('returns true for AbortError (DOMException-style)', () => {
+    const err = new DOMException('The operation was aborted', 'AbortError');
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    expect(isUserCancellation(err, ctx)).toBe(true);
+  });
+
+  it('returns true for AbortError (Error with name set)', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    expect(isUserCancellation(err, ctx)).toBe(true);
+  });
+
+  it('returns false for non-abort errors without abort flag', () => {
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    expect(isUserCancellation(new Error('network timeout'), ctx)).toBe(false);
+  });
+
+  it('returns false for non-Error values without abort flag', () => {
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    expect(isUserCancellation('some string error', ctx)).toBe(false);
+  });
+});
+
+describe('classifySessionError', () => {
+  const baseCtx: ErrorContext = { phase: 'agent_loop' };
+
+  describe('network errors', () => {
+    const cases = [
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'ENOTFOUND',
+      'socket hang up',
+      'fetch failed',
+      'Connection refused by server',
+      'connection reset',
+      'connection timeout',
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_NETWORK`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe('PROVIDER_NETWORK');
+        expect(result.retryable).toBe(true);
+      });
+    }
+  });
+
+  describe('rate limit errors', () => {
+    const cases = [
+      'Error 429: Too many requests',
+      'rate limit exceeded',
+      'Rate-limit hit',
+      'too many requests',
+      'overloaded',
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_RATE_LIMIT`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe('PROVIDER_RATE_LIMIT');
+        expect(result.retryable).toBe(true);
+      });
+    }
+  });
+
+  describe('provider API errors', () => {
+    const cases = [
+      'HTTP 500 Internal Server Error',
+      'server error',
+      'Bad gateway',
+      'Service unavailable',
+      'Gateway timeout',
+      '502 Bad Gateway',
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_API`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe('PROVIDER_API');
+        expect(result.retryable).toBe(true);
+      });
+    }
+  });
+
+  describe('abort/cancel errors (non-user-initiated)', () => {
+    it('classifies "aborted" as SESSION_ABORTED', () => {
+      const result = classifySessionError(new Error('Request aborted'), baseCtx);
+      expect(result.code).toBe('SESSION_ABORTED');
+      expect(result.retryable).toBe(true);
+    });
+
+    it('classifies "cancelled" as SESSION_ABORTED', () => {
+      const result = classifySessionError(new Error('Operation cancelled'), baseCtx);
+      expect(result.code).toBe('SESSION_ABORTED');
+      expect(result.retryable).toBe(true);
+    });
+  });
+
+  describe('queue phase', () => {
+    it('always returns QUEUE_FULL regardless of message content', () => {
+      const ctx: ErrorContext = { phase: 'queue' };
+      const result = classifySessionError(new Error('random error'), ctx);
+      expect(result.code).toBe('QUEUE_FULL');
+      expect(result.retryable).toBe(true);
+    });
+  });
+
+  describe('regenerate phase', () => {
+    it('returns REGENERATE_FAILED with nested classification info', () => {
+      const ctx: ErrorContext = { phase: 'regenerate' };
+      const result = classifySessionError(new Error('ECONNREFUSED'), ctx);
+      expect(result.code).toBe('REGENERATE_FAILED');
+      expect(result.retryable).toBe(true);
+      expect(result.userMessage).toContain('regenerate');
+    });
+
+    it('returns REGENERATE_FAILED for generic errors', () => {
+      const ctx: ErrorContext = { phase: 'regenerate' };
+      const result = classifySessionError(new Error('unknown issue'), ctx);
+      expect(result.code).toBe('REGENERATE_FAILED');
+      expect(result.retryable).toBe(true);
+    });
+  });
+
+  describe('generic errors', () => {
+    it('classifies unknown errors as SESSION_PROCESSING_FAILED', () => {
+      const result = classifySessionError(new Error('something completely unexpected'), baseCtx);
+      expect(result.code).toBe('SESSION_PROCESSING_FAILED');
+      expect(result.retryable).toBe(false);
+    });
+
+    it('includes debugDetails with stack trace', () => {
+      const err = new Error('test error');
+      const result = classifySessionError(err, baseCtx);
+      expect(result.debugDetails).toBeDefined();
+      expect(result.debugDetails).toContain('test error');
+    });
+
+    it('handles non-Error values', () => {
+      const result = classifySessionError('plain string error', baseCtx);
+      expect(result.code).toBe('SESSION_PROCESSING_FAILED');
+      expect(result.debugDetails).toBe('plain string error');
+    });
+  });
+
+  describe('cancel/abort should NOT produce false-positive session errors', () => {
+    it('user-initiated cancel should be caught by isUserCancellation, not classifySessionError', () => {
+      // If aborted flag is set, isUserCancellation returns true and
+      // classifySessionError should not be called. Verify the guard works.
+      const abortCtx: ErrorContext = { phase: 'agent_loop', aborted: true };
+      expect(isUserCancellation(new Error('The operation was aborted'), abortCtx)).toBe(true);
+    });
+
+    it('DOMException AbortError is caught by isUserCancellation', () => {
+      const err = new DOMException('The operation was aborted', 'AbortError');
+      const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+      expect(isUserCancellation(err, ctx)).toBe(true);
+    });
+  });
+});
+
+describe('buildSessionErrorMessage', () => {
+  it('builds a valid SessionErrorMessage', () => {
+    const msg = buildSessionErrorMessage('session-123', {
+      code: 'PROVIDER_NETWORK',
+      userMessage: 'Network error',
+      retryable: true,
+      debugDetails: 'ECONNREFUSED',
+    });
+
+    expect(msg.type).toBe('session_error');
+    expect(msg.sessionId).toBe('session-123');
+    expect(msg.code).toBe('PROVIDER_NETWORK');
+    expect(msg.userMessage).toBe('Network error');
+    expect(msg.retryable).toBe(true);
+    expect(msg.debugDetails).toBe('ECONNREFUSED');
+  });
+
+  it('omits debugDetails when not provided', () => {
+    const msg = buildSessionErrorMessage('session-456', {
+      code: 'UNKNOWN',
+      userMessage: 'Something went wrong',
+      retryable: false,
+    });
+
+    expect(msg.type).toBe('session_error');
+    expect(msg.debugDetails).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -61,6 +61,7 @@ import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, claw
 import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
+import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -455,6 +456,12 @@ async function handleUserMessage(
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
       ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
+      ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
+        code: 'QUEUE_FULL',
+        userMessage: 'The message queue is full. Please wait and try again.',
+        retryable: true,
+        debugDetails: 'Message rejected — session queue is full',
+      }));
       return;
     }
     if (result.queued) {
@@ -476,11 +483,15 @@ async function handleUserMessage(
       const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
       ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+      const classified = classifySessionError(err, { phase: 'agent_loop' });
+      ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');
     ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+    const classified = classifySessionError(err, { phase: 'handler' });
+    ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
 }
 
@@ -777,6 +788,8 @@ async function handleRegenerate(
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');
     ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
+    const classified = classifySessionError(err, { phase: 'regenerate' });
+    ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
 }
 
@@ -1344,6 +1357,8 @@ async function handleTaskSubmit(
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
         ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+        const classified = classifySessionError(err, { phase: 'agent_loop' });
+        ctx.send(socket, buildSessionErrorMessage(conversation.id, classified));
       });
     }
   } catch (err) {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -889,25 +889,6 @@ export interface GetSigningIdentityRequest {
   type: 'get_signing_identity';
 }
 
-export type SessionErrorCode =
-  | 'PROVIDER_NETWORK'
-  | 'PROVIDER_RATE_LIMIT'
-  | 'PROVIDER_API'
-  | 'QUEUE_FULL'
-  | 'SESSION_ABORTED'
-  | 'SESSION_PROCESSING_FAILED'
-  | 'REGENERATE_FAILED'
-  | 'UNKNOWN';
-
-export interface SessionErrorMessage {
-  type: 'session_error';
-  sessionId: string;
-  code: SessionErrorCode;
-  userMessage: string;
-  retryable: boolean;
-  debugDetails?: string;
-}
-
 export interface TimerCompleted {
   type: 'timer_completed';
   sessionId: string;
@@ -1066,8 +1047,7 @@ export type ServerMessage =
   | OpenBundleResponse
   | SignBundlePayloadRequest
   | GetSigningIdentityRequest
-  | TraceEvent
-  | SessionErrorMessage;
+  | TraceEvent;
 
 // === Contract schema ===
 

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -1,0 +1,181 @@
+import type { SessionErrorCode, SessionErrorMessage } from './ipc-protocol.js';
+
+/**
+ * Classified session error ready for IPC emission.
+ */
+export interface ClassifiedSessionError {
+  code: SessionErrorCode;
+  userMessage: string;
+  retryable: boolean;
+  debugDetails?: string;
+}
+
+// Network-level error patterns (connection refused, timeout, DNS, reset)
+const NETWORK_PATTERNS = [
+  /ECONNREFUSED/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /ENOTFOUND/i,
+  /socket hang up/i,
+  /network.*error/i,
+  /fetch failed/i,
+  /connection.*refused/i,
+  /connection.*reset/i,
+  /connection.*timeout/i,
+];
+
+// Rate limit patterns (HTTP 429 or explicit rate limit messages)
+const RATE_LIMIT_PATTERNS = [
+  /429/,
+  /rate.?limit/i,
+  /too many requests/i,
+  /overloaded/i,
+];
+
+// Provider API error patterns (5xx, server error, etc.)
+const PROVIDER_API_PATTERNS = [
+  /\b5\d{2}\b/,
+  /server error/i,
+  /internal server error/i,
+  /bad gateway/i,
+  /service unavailable/i,
+  /gateway timeout/i,
+];
+
+// User-initiated cancellation patterns — these should NOT produce session_error
+const CANCEL_PATTERNS = [
+  /abort/i,
+  /cancel/i,
+];
+
+/**
+ * Context about where the error occurred, used to refine classification.
+ */
+export interface ErrorContext {
+  /** Where in the processing pipeline the error occurred. */
+  phase: 'agent_loop' | 'queue' | 'regenerate' | 'handler' | 'persist';
+  /** Whether the abort signal was active when the error occurred. */
+  aborted?: boolean;
+}
+
+/**
+ * Returns true if the error looks like a user-initiated cancellation
+ * (AbortError or explicit cancel). These should use `generation_cancelled`
+ * instead of `session_error`.
+ */
+export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
+  if (ctx.aborted) return true;
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  if (error instanceof Error && error.name === 'AbortError') return true;
+  return false;
+}
+
+/**
+ * Classify an unknown error into a structured session error.
+ * Does NOT handle user-initiated cancellation — callers should check
+ * `isUserCancellation` first and emit `generation_cancelled` instead.
+ */
+export function classifySessionError(
+  error: unknown,
+  ctx: ErrorContext,
+): ClassifiedSessionError {
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  // Phase-specific overrides
+  if (ctx.phase === 'queue') {
+    return {
+      code: 'QUEUE_FULL',
+      userMessage: 'The message queue is full. Please wait and try again.',
+      retryable: true,
+      debugDetails: message,
+    };
+  }
+
+  if (ctx.phase === 'regenerate') {
+    const base = classifyByMessage(message);
+    return {
+      code: 'REGENERATE_FAILED',
+      userMessage: `Failed to regenerate response. ${base.userMessage}`,
+      retryable: true,
+      debugDetails: stack ?? message,
+    };
+  }
+
+  // Classify by error message content
+  const classified = classifyByMessage(message);
+  return {
+    ...classified,
+    debugDetails: stack ?? message,
+  };
+}
+
+function classifyByMessage(message: string): Omit<ClassifiedSessionError, 'debugDetails'> {
+  // Check rate limit first (before network, since 429 could match both)
+  for (const pattern of RATE_LIMIT_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'PROVIDER_RATE_LIMIT',
+        userMessage: 'The AI provider is rate limiting requests. Please wait a moment and try again.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Network errors
+  for (const pattern of NETWORK_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'PROVIDER_NETWORK',
+        userMessage: 'Unable to reach the AI provider. Check your connection and try again.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Provider API errors (5xx)
+  for (const pattern of PROVIDER_API_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'PROVIDER_API',
+        userMessage: 'The AI provider returned an error. This is usually temporary — try again shortly.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Non-user abort/failure (e.g. AbortError from internal logic, not user cancel)
+  for (const pattern of CANCEL_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: 'SESSION_ABORTED',
+        userMessage: 'The request was interrupted. You can try sending your message again.',
+        retryable: true,
+      };
+    }
+  }
+
+  // Default: processing failure
+  return {
+    code: 'SESSION_PROCESSING_FAILED',
+    userMessage: 'Something went wrong processing your message. Please try again.',
+    retryable: false,
+  };
+}
+
+/**
+ * Build a `session_error` IPC message from a classified error.
+ */
+export function buildSessionErrorMessage(
+  sessionId: string,
+  classified: ClassifiedSessionError,
+): SessionErrorMessage {
+  return {
+    type: 'session_error',
+    sessionId,
+    code: classified.code,
+    userMessage: classified.userMessage,
+    retryable: classified.retryable,
+    debugDetails: classified.debugDetails,
+  };
+}

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -26,6 +26,7 @@ import { getConfig } from '../config/loader.js';
 import { estimateCost, resolvePricing } from '../util/pricing.js';
 import { getLogger } from '../util/logger.js';
 import { TraceEmitter } from './trace-emitter.js';
+import { classifySessionError, isUserCancellation, buildSessionErrorMessage } from './session-error.js';
 import { EventBus } from '../events/bus.js';
 import type { AssistantDomainEvents } from '../events/domain-events.js';
 import { registerTimerCompletionNotifier, unregisterTimerCompletionNotifier, pruneSessionTimers } from '../tools/timer/pomodoro.js';
@@ -321,6 +322,12 @@ export class Session {
       // Clear queued messages and notify each caller
       for (const queued of this.messageQueue) {
         queued.onEvent({ type: 'error', message: 'Session aborted — queued message discarded' });
+        queued.onEvent(buildSessionErrorMessage(this.conversationId, {
+          code: 'SESSION_ABORTED',
+          userMessage: 'The request was interrupted. You can try sending your message again.',
+          retryable: true,
+          debugDetails: 'Session aborted — queued message discarded',
+        }));
       }
       this.messageQueue = [];
     }
@@ -785,14 +792,17 @@ export class Session {
         });
       }
     } catch (err) {
+      const errorCtx = { phase: 'agent_loop' as const, aborted: abortController.signal.aborted };
       // AbortError is expected when user cancels — don't treat as an error
-      if (abortController.signal.aborted) {
+      if (isUserCancellation(err, errorCtx)) {
         rlog.info('Generation cancelled by user');
         onEvent({ type: 'generation_cancelled' });
       } else {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Session processing error');
         onEvent({ type: 'error', message: `Failed to process message: ${message}` });
+        const classified = classifySessionError(err, errorCtx);
+        onEvent(buildSessionErrorMessage(this.conversationId, classified));
         void getHookManager().trigger('on-error', {
           error: err instanceof Error ? err.name : 'Error',
           message,


### PR DESCRIPTION
## Summary
- Create `session-error.ts` with `classifySessionError()` that maps unknown errors to `SessionErrorCode` values (PROVIDER_NETWORK, PROVIDER_RATE_LIMIT, PROVIDER_API, QUEUE_FULL, SESSION_ABORTED, SESSION_PROCESSING_FAILED, REGENERATE_FAILED)
- Add `isUserCancellation()` guard to prevent false-positive `session_error` on user-initiated cancellation (AbortError, abort signal)
- Emit `session_error` alongside existing `error` events at all key failure points in `session.ts` and `handlers.ts`
- Fix duplicate `SessionErrorCode`/`SessionErrorMessage` type definitions in `ipc-contract.ts` from M1

Closes #2040

## Files modified
- `assistant/src/daemon/session-error.ts` (new — centralized error mapper)
- `assistant/src/daemon/session.ts` (import mapper, emit session_error in runAgentLoop catch + abort cleanup)
- `assistant/src/daemon/handlers.ts` (import mapper, emit session_error in handleUserMessage, handleRegenerate, handleTaskSubmit)
- `assistant/src/daemon/ipc-contract.ts` (remove duplicate type definitions)
- `assistant/src/__tests__/session-error.test.ts` (new — 37 tests for mapper)
- `assistant/src/__tests__/ipc-snapshot.test.ts` (remove duplicate snapshot entry)
- `assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap` (updated)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] 37 new mapper tests pass covering all error codes, cancel/abort guards, and edge cases
- [x] IPC snapshot tests pass with updated snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
