### PR TITLE
Wire backend selection in shell + executor prompt metadata

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realChildProcess from 'node:child_process';
 import * as realFs from 'node:fs';
+import type { SandboxConfig } from '../config/schema.js';
 
 let platform = 'linux';
 
@@ -41,13 +42,23 @@ mock.module('node:fs', () => ({
 const { wrapCommand } = await import('../tools/terminal/sandbox.js');
 const { ToolError } = await import('../util/errors.js');
 
+const defaultDocker = { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const };
+
+function disabledConfig(): SandboxConfig {
+  return { enabled: false, backend: 'native', docker: defaultDocker };
+}
+
+function nativeConfig(): SandboxConfig {
+  return { enabled: true, backend: 'native', docker: defaultDocker };
+}
+
 describe('terminal sandbox — disabled behavior', () => {
   beforeEach(() => {
     platform = 'linux';
   });
 
   test('returns unsandboxed bash -c wrapper when disabled', () => {
-    const result = wrapCommand('pwd', '/tmp', false);
+    const result = wrapCommand('pwd', '/tmp', disabledConfig());
     expect(result).toEqual({
       command: 'bash',
       args: ['-c', '--', 'pwd'],
@@ -58,7 +69,7 @@ describe('terminal sandbox — disabled behavior', () => {
   test('sandboxed flag is false when disabled regardless of platform', () => {
     for (const p of ['linux', 'darwin', 'win32']) {
       platform = p;
-      const result = wrapCommand('echo hi', '/tmp', false);
+      const result = wrapCommand('echo hi', '/tmp', disabledConfig());
       expect(result.sandboxed).toBe(false);
       expect(result.command).toBe('bash');
     }
@@ -66,7 +77,7 @@ describe('terminal sandbox — disabled behavior', () => {
 
   test('preserves the original command string in args when disabled', () => {
     const cmd = 'cat /etc/passwd | wc -l';
-    const result = wrapCommand(cmd, '/home/user', false);
+    const result = wrapCommand(cmd, '/home/user', disabledConfig());
     expect(result.args).toEqual(['-c', '--', cmd]);
   });
 });
@@ -80,15 +91,15 @@ describe('terminal sandbox — enabled fail-closed behavior', () => {
   });
 
   test('throws ToolError when bwrap is unavailable on linux', () => {
-    expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(ToolError);
-    expect(() => wrapCommand('echo hello', '/tmp', true)).toThrow(
+    expect(() => wrapCommand('echo hello', '/tmp', nativeConfig())).toThrow(ToolError);
+    expect(() => wrapCommand('echo hello', '/tmp', nativeConfig())).toThrow(
       'Sandbox is enabled but bwrap is not available or cannot create namespaces.',
     );
   });
 
   test('returns bwrap wrapper when bwrap is available on linux', () => {
     execSyncMock.mockImplementation(() => undefined);
-    const result = wrapCommand('echo hello', '/home/user/project', true);
+    const result = wrapCommand('echo hello', '/home/user/project', nativeConfig());
     expect(result.command).toBe('bwrap');
     expect(result.sandboxed).toBe(true);
     expect(result.args).toContain('--ro-bind');
@@ -103,7 +114,7 @@ describe('terminal sandbox — enabled fail-closed behavior', () => {
   test('bind-mounts working directory read-write in bwrap args', () => {
     execSyncMock.mockImplementation(() => undefined);
     const workDir = '/home/user/my-project';
-    const result = wrapCommand('ls', workDir, true);
+    const result = wrapCommand('ls', workDir, nativeConfig());
     // The args should contain --bind workDir workDir for read-write access
     const bindIdx = result.args.indexOf('--bind');
     expect(bindIdx).toBeGreaterThan(-1);
@@ -115,8 +126,8 @@ describe('terminal sandbox — enabled fail-closed behavior', () => {
 describe('terminal sandbox — unsupported platform fail-closed behavior', () => {
   test('throws ToolError on unsupported platforms when enabled', () => {
     platform = 'win32';
-    expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(ToolError);
-    expect(() => wrapCommand('pwd', '/tmp', true)).toThrow(
+    expect(() => wrapCommand('pwd', '/tmp', nativeConfig())).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp', nativeConfig())).toThrow(
       'Sandbox is enabled but not supported on this platform (',
     );
   });
@@ -124,7 +135,7 @@ describe('terminal sandbox — unsupported platform fail-closed behavior', () =>
   test('error message includes refusing to execute unsandboxed', () => {
     platform = 'win32';
     try {
-      wrapCommand('pwd', '/tmp', true);
+      wrapCommand('pwd', '/tmp', nativeConfig());
       throw new Error('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(ToolError);
@@ -141,7 +152,7 @@ describe('terminal sandbox — macOS sandbox-exec behavior', () => {
   });
 
   test('returns sandbox-exec wrapper on macOS when enabled', () => {
-    const result = wrapCommand('echo hello', '/tmp/project', true);
+    const result = wrapCommand('echo hello', '/tmp/project', nativeConfig());
     expect(result.command).toBe('sandbox-exec');
     expect(result.sandboxed).toBe(true);
     expect(result.args[0]).toBe('-f');
@@ -152,18 +163,39 @@ describe('terminal sandbox — macOS sandbox-exec behavior', () => {
   });
 
   test('throws ToolError for working dirs with SBPL metacharacters', () => {
-    expect(() => wrapCommand('pwd', '/tmp/bad"dir', true)).toThrow(ToolError);
-    expect(() => wrapCommand('pwd', '/tmp/bad(dir', true)).toThrow(ToolError);
-    expect(() => wrapCommand('pwd', '/tmp/bad;dir', true)).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp/bad"dir', nativeConfig())).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp/bad(dir', nativeConfig())).toThrow(ToolError);
+    expect(() => wrapCommand('pwd', '/tmp/bad;dir', nativeConfig())).toThrow(ToolError);
   });
 
   test('SBPL metacharacter error mentions unsafe characters', () => {
     try {
-      wrapCommand('pwd', '/tmp/bad"dir', true);
+      wrapCommand('pwd', '/tmp/bad"dir', nativeConfig());
       throw new Error('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(ToolError);
       expect((err as Error).message).toContain('SBPL metacharacters');
     }
+  });
+});
+
+describe('terminal sandbox — backend selection', () => {
+  beforeEach(() => {
+    platform = 'darwin';
+    writeFileSyncMock.mockClear();
+    existsSyncMock.mockImplementation(() => true);
+  });
+
+  test('uses native backend when backend is "native"', () => {
+    const result = wrapCommand('echo hello', '/tmp/project', nativeConfig());
+    expect(result.command).toBe('sandbox-exec');
+    expect(result.sandboxed).toBe(true);
+  });
+
+  test('disabled config ignores backend setting', () => {
+    const config: SandboxConfig = { enabled: false, backend: 'docker', docker: defaultDocker };
+    const result = wrapCommand('echo hello', '/tmp/project', config);
+    expect(result.command).toBe('bash');
+    expect(result.sandboxed).toBe(false);
   });
 });

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -8,7 +8,7 @@ const mockConfig = {
   maxTokens: 4096,
   dataDir: '/tmp',
   timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600, permissionTimeoutSec: 300 },
-  sandbox: { enabled: false },
+  sandbox: { enabled: false, backend: 'native' as const, docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const } },
   rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   secretDetection: { enabled: false, action: 'warn' as const, entropyThreshold: 4.0 },
 };

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -105,8 +105,11 @@ export class ToolExecutor {
 
         let sandboxed: boolean | undefined;
         if (name === 'bash' && typeof input.command === 'string') {
-          const sandboxEnabled = context.sandboxOverride ?? getConfig().sandbox.enabled;
-          const wrapped = wrapCommand(input.command, context.workingDir, sandboxEnabled);
+          const cfg = getConfig();
+          const sandboxConfig = context.sandboxOverride != null
+            ? { ...cfg.sandbox, enabled: context.sandboxOverride }
+            : cfg.sandbox;
+          const wrapped = wrapCommand(input.command, context.workingDir, sandboxConfig);
           sandboxed = wrapped.sandboxed;
         }
 

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -1,5 +1,7 @@
 import { NativeBackend } from './backends/native.js';
+import { DockerBackend } from './backends/docker.js';
 import type { SandboxResult } from './backends/types.js';
+import type { SandboxConfig } from '../../config/schema.js';
 
 export type { SandboxResult, SandboxBackend } from './backends/types.js';
 
@@ -9,20 +11,25 @@ const nativeBackend = new NativeBackend();
  * Wrap a shell command for sandboxed execution.
  *
  * When sandboxing is disabled, returns a plain bash invocation.
- * When enabled, delegates to the native backend (macOS sandbox-exec
- * or Linux bwrap). Fails closed if the backend cannot be applied.
+ * When enabled, delegates to the configured backend (native or docker).
+ * Fails closed if the backend cannot be applied.
  */
 export function wrapCommand(
   command: string,
   workingDir: string,
-  enabled: boolean,
+  config: SandboxConfig,
 ): SandboxResult {
-  if (!enabled) {
+  if (!config.enabled) {
     return {
       command: 'bash',
       args: ['-c', '--', command],
       sandboxed: false,
     };
+  }
+
+  if (config.backend === 'docker') {
+    const backend = new DockerBackend(workingDir, config.docker);
+    return backend.wrap(command, workingDir);
   }
 
   return nativeBackend.wrap(command, workingDir);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -99,8 +99,10 @@ class ShellTool implements Tool {
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
-      const sandboxEnabled = context.sandboxOverride ?? config.sandbox.enabled;
-      const wrapped = wrapCommand(command, context.workingDir, sandboxEnabled);
+      const sandboxConfig = context.sandboxOverride != null
+        ? { ...config.sandbox, enabled: context.sandboxOverride }
+        : config.sandbox;
+      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig);
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env: buildSanitizedEnv(),


### PR DESCRIPTION
## Summary
- `wrapCommand` now accepts a `SandboxConfig` object instead of a boolean, selecting the configured backend (`native` or `docker`) at runtime
- Shell tool and executor build the config from `getConfig().sandbox` merged with any `sandboxOverride`
- Tests updated to pass `SandboxConfig` objects and include a new backend-selection describe block

## Test plan
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 13 pass
- [x] `bun test src/__tests__/tool-executor-lifecycle-events.test.ts` — 10 pass
- [x] `bunx tsc --noEmit` — no new errors (pre-existing IPC contract issues only)

Closes #2028
Part of #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
