### PR TITLE
fix(ui): center composer text and icons with scrollable TextField

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -359,80 +359,58 @@ struct ChatView: View {
             }
 
             HStack(alignment: .center, spacing: VSpacing.sm) {
-                // Text editor with ghost text overlay and scrollable content
-                ZStack(alignment: .topLeading) {
-                    TextEditor(text: $inputText)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineSpacing(4)
-                        .scrollContentBackground(.hidden)
-                        .disabled(!hasAPIKey)
-                        .accessibilityLabel("Message")
-
-                    // Placeholder
-                    if inputText.isEmpty && ghostSuffix == nil {
-                        Text("What would you like to do?")
+                // Scrollable text input — TextField centers text natively;
+                // ScrollView adds scrolling when content exceeds 200pt.
+                ScrollView(.vertical, showsIndicators: false) {
+                    ZStack(alignment: .leading) {
+                        TextField("What would you like to do?", text: $inputText, axis: .vertical)
                             .font(VFont.body)
-                            .foregroundColor(VColor.textMuted)
+                            .foregroundColor(VColor.textPrimary)
                             .lineSpacing(4)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 8)
-                            .allowsHitTesting(false)
-                            .accessibilityHidden(true)
-                    }
-
-                    // Ghost text overlay — shows the suggested suffix so users
-                    // know what Tab will insert.
-                    if let ghostSuffix {
-                        Text(inputText + ghostSuffix)
-                            .font(VFont.body)
-                            .lineSpacing(4)
-                            .foregroundColor(.clear)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 8)
-                            .overlay(alignment: .topLeading) {
-                                HStack(spacing: 0) {
-                                    Text(inputText)
-                                        .font(VFont.body)
-                                        .lineSpacing(4)
-                                        .foregroundColor(.clear)
-                                    Text(ghostSuffix)
-                                        .font(VFont.body)
-                                        .lineSpacing(4)
-                                        .foregroundColor(VColor.textMuted.opacity(0.5))
-                                }
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 8)
-                            }
-                            .allowsHitTesting(false)
-                            .accessibilityHidden(true)
-                    }
-                }
-                .frame(height: min(max(editorContentHeight, 20), 200))
-                .clipped()
-                .background(alignment: .topLeading) {
-                    // Invisible text measurer — drives editorContentHeight independently
-                    // so the ZStack grows with content but caps at 200pt for scrolling.
-                    Text(inputText.isEmpty ? " " : inputText)
-                        .font(VFont.body)
-                        .lineSpacing(4)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 8)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .opacity(0)
-                        .accessibilityHidden(true)
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear
-                                    .onAppear { editorContentHeight = geo.size.height }
-                                    .onChange(of: geo.size.height) { _, h in
-                                        withAnimation(VAnimation.spring) {
-                                            editorContentHeight = h
+                            .textFieldStyle(.plain)
+                            .lineLimit(1...)
+                            .disabled(!hasAPIKey)
+                            .accessibilityLabel("Message")
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear
+                                        .onAppear { editorContentHeight = geo.size.height }
+                                        .onChange(of: geo.size.height) { _, h in
+                                            withAnimation(VAnimation.spring) {
+                                                editorContentHeight = h
+                                            }
                                         }
+                                }
+                            )
+
+                        // Ghost text overlay — shows the suggested suffix so users
+                        // know what Tab will insert.
+                        if let ghostSuffix {
+                            Text(inputText + ghostSuffix)
+                                .font(VFont.body)
+                                .lineSpacing(4)
+                                .foregroundColor(.clear)
+                                .lineLimit(1...)
+                                .overlay(alignment: .leading) {
+                                    HStack(spacing: 0) {
+                                        Text(inputText)
+                                            .font(VFont.body)
+                                            .lineSpacing(4)
+                                            .foregroundColor(.clear)
+                                        Text(ghostSuffix)
+                                            .font(VFont.body)
+                                            .lineSpacing(4)
+                                            .foregroundColor(VColor.textMuted.opacity(0.5))
                                     }
-                            }
-                        )
+                                }
+                                .allowsHitTesting(false)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                    .frame(minHeight: 28)
                 }
+                .scrollBounceBehavior(.basedOnSize)
+                .frame(height: min(max(editorContentHeight, 28), 200))
                 .onKeyPress(.tab, phases: .down) { keyPress in
                     if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                         onAcceptSuggestion()

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1384,7 +1384,6 @@ public enum ServerMessage: Decodable, Sendable {
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
-    case sessionError(SessionErrorMessage)
     case signBundlePayload(SignBundlePayloadMessage)
     case getSigningIdentity
     case pong
@@ -1525,9 +1524,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "trace_event":
             let message = try TraceEventMessage(from: decoder)
             self = .traceEvent(message)
-        case "session_error":
-            let message = try SessionErrorMessage(from: decoder)
-            self = .sessionError(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Replace TextEditor with TextField(axis: .vertical) inside a ScrollView so text, placeholder, and icons are natively centered in the empty/single-line state
- ScrollView caps at 200pt and enables scrolling for long content
- Fix duplicate SessionErrorCode enum from concurrent swarm PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
