### PR TITLE
M8: Migrate sandbox file_* tools to thin FileSystemOps wrappers

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,11 +1,9 @@
-import { readFileSync, writeFileSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { validateFilePath } from './path-guard.js';
-import { checkFileSizeOnDisk } from './size-guard.js';
-import { applyEdit } from '../shared/filesystem/edit-engine.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 class FileEditTool implements Tool {
   name = 'file_edit';
@@ -67,59 +65,48 @@ class FileEditTool implements Tool {
     }
 
     const replaceAll = input.replace_all === true;
-    const pathCheck = validateFilePath(rawPath, context.workingDir);
-    if (!pathCheck.ok) {
-      return { content: `Error: ${pathCheck.error}`, isError: true };
-    }
-    const filePath = pathCheck.resolved;
+    const ops = new FileSystemOps((path, opts) => sandboxPolicy(path, context.workingDir, opts));
+    const result = ops.editFileSafe({
+      path: rawPath,
+      oldString,
+      newString,
+      replaceAll,
+    });
 
-    try {
-      const sizeError = checkFileSizeOnDisk(filePath);
-      if (sizeError) {
-        return { content: `Error: ${sizeError}`, isError: true };
+    if (!result.ok) {
+      const err = result.error;
+      if (err.code === 'MATCH_NOT_FOUND') {
+        return { content: `Error: old_string not found in ${err.path}`, isError: true };
       }
-    } catch {
-      // File may not exist — will be caught by readFileSync below
-    }
-
-    try {
-      const content = readFileSync(filePath, 'utf-8');
-      const result = applyEdit(content, oldString, newString, replaceAll);
-
-      if (!result.ok) {
-        if (result.reason === 'not_found') {
-          return { content: `Error: old_string not found in ${filePath}`, isError: true };
-        }
+      if (err.code === 'MATCH_AMBIGUOUS') {
         return {
-          content: `Error: old_string appears multiple times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
+          content: `Error: old_string appears multiple times in ${err.path}. Provide more surrounding context to make it unique, or set replace_all to true.`,
           isError: true,
         };
       }
-
-      writeFileSync(filePath, result.updatedContent);
-
-      if (replaceAll) {
-        return {
-          content: `Successfully replaced ${result.matchCount} occurrence${result.matchCount > 1 ? 's' : ''} in ${filePath}`,
-          isError: false,
-          diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
-        };
-      }
-
-      const methodNote = result.matchMethod === 'exact'
-        ? ''
-        : result.matchMethod === 'whitespace'
-          ? ' (matched with whitespace normalization)'
-          : ' (fuzzy matched)';
-      return {
-        content: `Successfully edited ${filePath}${methodNote}`,
-        isError: false,
-        diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error editing file: ${msg}`, isError: true };
+      return { content: `Error: ${err.message}`, isError: true };
     }
+
+    const { filePath, matchCount, oldContent, newContent, matchMethod } = result.value;
+
+    if (replaceAll) {
+      return {
+        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}`,
+        isError: false,
+        diff: { filePath, oldContent, newContent, isNewFile: false },
+      };
+    }
+
+    const methodNote = matchMethod === 'exact'
+      ? ''
+      : matchMethod === 'whitespace'
+        ? ' (matched with whitespace normalization)'
+        : ' (fuzzy matched)';
+    return {
+      content: `Successfully edited ${filePath}${methodNote}`,
+      isError: false,
+      diff: { filePath, oldContent, newContent, isNewFile: false },
+    };
   }
 }
 

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -1,10 +1,9 @@
-import { readFileSync, existsSync, statSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { validateFilePath } from './path-guard.js';
-import { checkFileSizeOnDisk } from './size-guard.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 class FileReadTool implements Tool {
   name = 'file_read';
@@ -43,48 +42,22 @@ class FileReadTool implements Tool {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
 
-    const pathCheck = validateFilePath(rawPath, context.workingDir);
-    if (!pathCheck.ok) {
-      return { content: `Error: ${pathCheck.error}`, isError: true };
-    }
-    const filePath = pathCheck.resolved;
+    const ops = new FileSystemOps((path, opts) => sandboxPolicy(path, context.workingDir, opts));
+    const result = ops.readFileSafe({
+      path: rawPath,
+      offset: typeof input.offset === 'number' ? input.offset : undefined,
+      limit: typeof input.limit === 'number' ? input.limit : undefined,
+    });
 
-    if (!existsSync(filePath)) {
-      return { content: `Error: File not found: ${filePath}`, isError: true };
-    }
-
-    const stat = statSync(filePath);
-    if (stat.isDirectory()) {
-      return { content: `Error: ${filePath} is a directory, not a file`, isError: true };
-    }
-
-    const sizeError = checkFileSizeOnDisk(filePath);
-    if (sizeError) {
-      return { content: `Error: ${sizeError}`, isError: true };
+    if (!result.ok) {
+      const err = result.error;
+      if (err.code === 'NOT_A_FILE') {
+        return { content: `Error: ${err.path} is a directory, not a file`, isError: true };
+      }
+      return { content: `Error: ${err.message}`, isError: true };
     }
 
-    try {
-      const content = readFileSync(filePath, 'utf-8');
-      const lines = content.split('\n');
-
-      const offset = (typeof input.offset === 'number' ? input.offset : 1) - 1;
-      const limit = typeof input.limit === 'number' ? input.limit : lines.length;
-      const selectedLines = lines.slice(Math.max(0, offset), offset + limit);
-
-      const numbered = selectedLines.map((line, i) => {
-        const lineNum = offset + i + 1;
-        return `${String(lineNum).padStart(6)}  ${line}`;
-      }).join('\n');
-
-      return { content: numbered, isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const hint = msg.includes('ENOENT') ? ' (file does not exist)'
-        : msg.includes('EACCES') ? ' (permission denied)'
-        : msg.includes('EISDIR') ? ' (path is a directory, not a file)'
-        : '';
-      return { content: `Error reading file "${input.path}"${hint}: ${msg}`, isError: true };
-    }
+    return { content: result.value.content, isError: false };
   }
 }
 

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -1,11 +1,9 @@
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
-import { dirname } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
-import { validateFilePath } from './path-guard.js';
-import { checkContentSize } from './size-guard.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { sandboxPolicy } from '../shared/filesystem/path-policy.js';
 
 class FileWriteTool implements Tool {
   name = 'file_write';
@@ -45,43 +43,19 @@ class FileWriteTool implements Tool {
       return { content: 'Error: content is required and must be a string', isError: true };
     }
 
-    const pathCheck = validateFilePath(rawPath, context.workingDir, { mustExist: false });
-    if (!pathCheck.ok) {
-      return { content: `Error: ${pathCheck.error}`, isError: true };
-    }
-    const filePath = pathCheck.resolved;
+    const ops = new FileSystemOps((path, opts) => sandboxPolicy(path, context.workingDir, opts));
+    const result = ops.writeFileSafe({ path: rawPath, content: fileContent });
 
-    const sizeError = checkContentSize(fileContent, filePath);
-    if (sizeError) {
-      return { content: `Error: ${sizeError}`, isError: true };
+    if (!result.ok) {
+      return { content: `Error: ${result.error.message}`, isError: true };
     }
 
-    try {
-      const dir = dirname(filePath);
-      if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-      }
-
-      let oldContent: string | null = null;
-      const isNewFile = !existsSync(filePath);
-      if (!isNewFile) {
-        try { oldContent = readFileSync(filePath, 'utf-8'); } catch { /* unreadable */ }
-      }
-
-      writeFileSync(filePath, fileContent);
-      return {
-        content: `Successfully wrote to ${filePath}`,
-        isError: false,
-        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent, isNewFile },
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const hint = msg.includes('ENOENT') ? ' (parent directory does not exist)'
-        : msg.includes('EACCES') ? ' (permission denied)'
-        : msg.includes('EROFS') ? ' (read-only file system)'
-        : '';
-      return { content: `Error writing file "${input.path}"${hint}: ${msg}`, isError: true };
-    }
+    const { filePath, isNewFile, oldContent, newContent } = result.value;
+    return {
+      content: `Successfully wrote to ${filePath}`,
+      isError: false,
+      diff: { filePath, oldContent, newContent, isNewFile },
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaces direct `node:fs` + guard logic in `file_read`, `file_write`, and `file_edit` sandbox tools with calls to the shared `FileSystemOps` service
- Maps structured `FsError` codes to the same user-facing error strings currently expected by tests
- Removes all direct `node:fs` imports from the three sandbox tool wrappers (net -66 lines)
- Tool name, category, schema, risk level, and diff payload format are unchanged

## Test plan
- [x] All 36 tests pass across file-read-tool, file-write-tool, file-edit-tool, and tool-executor-lifecycle-events test suites
- [x] TypeScript type-check passes (only pre-existing ipc-contract errors remain)
- [x] Error message compatibility verified: `File not found`, `is a directory`, `outside the working directory`, `exceeds`, `old_string not found`, `appears multiple times` substrings all preserved

Closes #2017

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
