### PR TITLE
fix(ui): address ghost text overlay review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -382,28 +382,30 @@ struct ChatView: View {
                     }
 
                     // Ghost text overlay — shows the suggested suffix so users
-                    // know what Tab will insert.
+                    // know what Tab will insert. Uses Text concatenation (`+`)
+                    // so the suffix renders at the end of the last line, not to
+                    // the right of the entire text block.
                     if let ghostSuffix {
-                        Text(inputText + ghostSuffix)
+                        // Text `+` concatenation requires each operand to be
+                        // a `Text` value (modifiers like `.font` and
+                        // `.foregroundColor` return `Text`, but `.lineSpacing`
+                        // returns `some View`), so `.lineSpacing` is applied
+                        // after the concatenation.
+                        (Text(inputText)
                             .font(VFont.body)
-                            .lineSpacing(4)
                             .foregroundColor(.clear)
+                        + Text(ghostSuffix)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted.opacity(0.5)))
+                            .lineSpacing(4)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 8)
-                            .overlay(alignment: .topLeading) {
-                                HStack(spacing: 0) {
-                                    Text(inputText)
-                                        .font(VFont.body)
-                                        .lineSpacing(4)
-                                        .foregroundColor(.clear)
-                                    Text(ghostSuffix)
-                                        .font(VFont.body)
-                                        .lineSpacing(4)
-                                        .foregroundColor(VColor.textMuted.opacity(0.5))
-                                }
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 8)
-                            }
+                            // Prevent the ghost text from expanding the composer —
+                            // sizing is driven solely by the real inputText measurer
+                            // in the background modifier below.
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxHeight: min(max(editorContentHeight, 20), 200), alignment: .topLeading)
+                            .clipped()
                             .allowsHitTesting(false)
                             .accessibilityHidden(true)
                     }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1321,35 +1321,6 @@ public struct OpenBundleResponseMessage: Decodable, Sendable {
     public let bundleSizeBytes: Int
 }
 
-/// Structured error code for session-level errors.
-public enum SessionErrorCode: String, Codable, Sendable {
-    case providerNetwork = "PROVIDER_NETWORK"
-    case providerRateLimit = "PROVIDER_RATE_LIMIT"
-    case providerApi = "PROVIDER_API"
-    case queueFull = "QUEUE_FULL"
-    case sessionAborted = "SESSION_ABORTED"
-    case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
-    case regenerateFailed = "REGENERATE_FAILED"
-    case unknown = "UNKNOWN"
-}
-
-/// Typed session-level error from the daemon.
-/// Wire type: `"session_error"`
-public struct SessionErrorMessagePayload: Decodable, Sendable {
-    public let sessionId: String
-    public let code: SessionErrorCode
-    public let userMessage: String
-    public let retryable: Bool
-    public let debugDetails: String?
-
-    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil) {
-        self.sessionId = sessionId
-        self.code = code
-        self.userMessage = userMessage
-        self.retryable = retryable
-        self.debugDetails = debugDetails
-    }
-}
 
 /// Discriminated union of all server → client message types relevant to the macOS client.
 /// Decodes via the `"type"` field in the JSON payload.
@@ -1357,7 +1328,7 @@ public enum ServerMessage: Decodable, Sendable {
     case cuAction(CuActionMessage)
     case cuComplete(CuCompleteMessage)
     case cuError(CuErrorMessage)
-    case sessionError(SessionErrorMessagePayload)
+    case sessionError(SessionErrorMessage)
     case assistantTextDelta(AssistantTextDeltaMessage)
     case assistantThinkingDelta(AssistantThinkingDeltaMessage)
     case messageComplete(MessageCompleteMessage)
@@ -1396,7 +1367,6 @@ public enum ServerMessage: Decodable, Sendable {
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
-    case sessionError(SessionErrorMessage)
     case signBundlePayload(SignBundlePayloadMessage)
     case getSigningIdentity
     case pong
@@ -1421,7 +1391,7 @@ public enum ServerMessage: Decodable, Sendable {
             let message = try CuErrorMessage(from: decoder)
             self = .cuError(message)
         case "session_error":
-            let message = try SessionErrorMessagePayload(from: decoder)
+            let message = try SessionErrorMessage(from: decoder)
             self = .sessionError(message)
         case "assistant_text_delta":
             let message = try AssistantTextDeltaMessage(from: decoder)
@@ -1537,9 +1507,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "trace_event":
             let message = try TraceEventMessage(from: decoder)
             self = .traceEvent(message)
-        case "session_error":
-            let message = try SessionErrorMessage(from: decoder)
-            self = .sessionError(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Replace HStack-based ghost text overlay with SwiftUI Text concatenation (`+` operator) so the ghost suffix renders at the end of the last line for multiline input, not to the right of the entire text block
- Constrain ghost overlay height to `editorContentHeight` so long suggestions don't expand the composer beyond what the actual input text needs
- Remove duplicate `SessionErrorCode` enum and `SessionErrorMessagePayload` struct that were introduced by concurrent PR merges, which broke the build

Addresses review feedback from Devin and Codex on #2065.

Note: The prompt suppression fix (Codex P2 item 1) was already implemented in #2065 -- the placeholder condition at line 373 (`inputText.isEmpty && ghostSuffix == nil`) correctly hides the prompt when a ghost suggestion is visible.

## Test plan
- [x] Build passes (`./build.sh`)
- [ ] Verify ghost text aligns at end of last line for multiline input
- [ ] Verify long ghost suggestions don't expand the composer height
- [ ] Verify placeholder is hidden when ghost suggestion is shown on empty input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
