### PR TITLE
feat(ui): add trace timeline to Debug Panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -9,6 +9,7 @@ final class MainWindow {
     private let zoomManager: ZoomManager
     private var window: NSWindow?
     let threadManager: ThreadManager
+    let traceStore = TraceStore()
     var onMicrophoneToggle: (() -> Void)?
 
     /// Whether the main window is currently visible on screen.
@@ -26,6 +27,11 @@ final class MainWindow {
         self.ambientAgent = ambientAgent
         self.zoomManager = zoomManager
         self.threadManager = ThreadManager(daemonClient: daemonClient)
+        daemonClient.onTraceEvent = { [weak self] msg in
+            Task { @MainActor in
+                self?.traceStore.ingest(msg)
+            }
+        }
     }
 
     func show() {
@@ -44,7 +50,7 @@ final class MainWindow {
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let windowWidth = min(1100.0, screenFrame.width * 0.75)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
     @ObservedObject var zoomManager: ZoomManager
+    @ObservedObject var traceStore: TraceStore
     @State private var activePanel: SidePanelType?
     @State private var isDynamicExpanded = false
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
@@ -12,9 +13,10 @@ struct MainWindowView: View {
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, zoomManager: ZoomManager, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.zoomManager = zoomManager
+        self.traceStore = traceStore
         self.daemonClient = daemonClient
         self.ambientAgent = ambientAgent
         self.onMicrophoneToggle = onMicrophoneToggle
@@ -192,7 +194,11 @@ struct MainWindowView: View {
             case .directory:
                 DirectoryPanel(onClose: { activePanel = nil })
             case .debug:
-                DebugPanel(onClose: { activePanel = nil })
+                DebugPanel(
+                    traceStore: traceStore,
+                    activeSessionId: threadManager.activeViewModel?.sessionId,
+                    onClose: { activePanel = nil }
+                )
             case .doctor:
                 DoctorPanel(onClose: { activePanel = nil })
             }
@@ -220,7 +226,7 @@ private struct ZoomIndicatorView: View {
 
 #Preview {
     let dc = DaemonClient()
-    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), daemonClient: dc, ambientAgent: AmbientAgent())
+    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, ambientAgent: AmbientAgent())
         .frame(width: 900, height: 600)
         .padding(.top, 36)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -2,14 +2,119 @@ import VellumAssistantShared
 import SwiftUI
 
 struct DebugPanel: View {
+    @ObservedObject var traceStore: TraceStore
+    let activeSessionId: String?
     var onClose: () -> Void
+
     var body: some View {
-        VSidePanel(title: "Debug", onClose: onClose) {
-            VEmptyState(title: "No debug info", subtitle: "Debug information will appear here", icon: "ant")
+        VSidePanel(title: "Debug", onClose: onClose, pinnedContent: {
+            if let sessionId = activeSessionId {
+                metricsStrip(sessionId: sessionId)
+                Divider().background(VColor.surfaceBorder)
+            }
+        }) {
+            if let sessionId = activeSessionId {
+                let events = traceStore.eventsBySession[sessionId] ?? []
+                if events.isEmpty {
+                    VEmptyState(
+                        title: "No trace events yet",
+                        subtitle: "Events will appear as the session runs",
+                        icon: "waveform.path"
+                    )
+                } else {
+                    TraceTimelineView(traceStore: traceStore, sessionId: sessionId)
+                }
+            } else {
+                VEmptyState(
+                    title: "No session selected",
+                    subtitle: "Start a conversation to see trace events",
+                    icon: "ant"
+                )
+            }
         }
+    }
+
+    // MARK: - Metrics Strip
+
+    @ViewBuilder
+    private func metricsStrip(sessionId: String) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: VSpacing.lg) {
+                metric(
+                    icon: "arrow.right.circle",
+                    label: "Requests",
+                    value: "\(traceStore.requestCount(sessionId: sessionId))"
+                )
+                metric(
+                    icon: "brain",
+                    label: "LLM Calls",
+                    value: "\(traceStore.llmCallCount(sessionId: sessionId))"
+                )
+                metric(
+                    icon: "text.word.spacing",
+                    label: "Tokens",
+                    value: formatTokens(
+                        input: traceStore.totalInputTokens(sessionId: sessionId),
+                        output: traceStore.totalOutputTokens(sessionId: sessionId)
+                    )
+                )
+                metric(
+                    icon: "clock",
+                    label: "Avg Latency",
+                    value: formatLatency(traceStore.averageLlmLatencyMs(sessionId: sessionId))
+                )
+
+                let failures = traceStore.toolFailureCount(sessionId: sessionId)
+                if failures > 0 {
+                    metric(
+                        icon: "exclamationmark.triangle.fill",
+                        label: "Failures",
+                        value: "\(failures)",
+                        color: Rose._500
+                    )
+                }
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.vertical, VSpacing.md)
+        }
+    }
+
+    @ViewBuilder
+    private func metric(icon: String, label: String, value: String, color: Color = Emerald._400) -> some View {
+        VStack(spacing: VSpacing.xxs) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: icon)
+                    .font(.system(size: 10))
+                    .foregroundColor(color)
+                Text(value)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
+            }
+            Text(label)
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+
+    // MARK: - Formatters
+
+    private func formatTokens(input: Int, output: Int) -> String {
+        let total = input + output
+        if total >= 1000 {
+            return String(format: "%.1fk", Double(total) / 1000)
+        }
+        return "\(total)"
+    }
+
+    private func formatLatency(_ ms: Double) -> String {
+        if ms <= 0 { return "--" }
+        if ms >= 1000 {
+            return String(format: "%.1fs", ms / 1000)
+        }
+        return String(format: "%.0fms", ms)
     }
 }
 
 #Preview {
-    DebugPanel(onClose: {})
+    DebugPanel(traceStore: TraceStore(), activeSessionId: nil, onClose: {})
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A single row in the trace timeline representing one trace event.
+struct TraceRowView: View {
+    let event: TraceStore.StoredEvent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(systemName: iconName)
+                .font(.system(size: 11))
+                .foregroundColor(statusColor)
+                .frame(width: 18, alignment: .center)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(event.summary)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+
+                Text(formattedTimestamp)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, VSpacing.xs)
+    }
+
+    // MARK: - Icon
+
+    private var iconName: String {
+        switch event.kind {
+        case "llm_call_started":
+            return "brain"
+        case "llm_call_finished":
+            return "brain.head.profile"
+        case "tool_started":
+            return "wrench.and.screwdriver"
+        case "tool_finished":
+            return "wrench.and.screwdriver.fill"
+        case "tool_failed":
+            return "exclamationmark.triangle.fill"
+        case "request_queued":
+            return "tray.and.arrow.down"
+        case "request_started":
+            return "play.circle"
+        case "request_finished":
+            return "checkmark.circle"
+        case "session_started":
+            return "bolt.circle"
+        case "session_ended":
+            return "stop.circle"
+        default:
+            return "circle.fill"
+        }
+    }
+
+    // MARK: - Status Color
+
+    private var statusColor: Color {
+        switch event.status {
+        case "error":
+            return Rose._500
+        case "warning":
+            return Amber._500
+        case "success":
+            return Emerald._400
+        default:
+            return Slate._400
+        }
+    }
+
+    // MARK: - Timestamp
+
+    private var formattedTimestamp: String {
+        let date = Date(timeIntervalSince1970: event.timestampMs / 1000)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter.string(from: date)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Scrollable trace event timeline grouped by requestId, with auto-scroll behavior
+/// that pauses when the user manually scrolls up.
+struct TraceTimelineView: View {
+    @ObservedObject var traceStore: TraceStore
+    let sessionId: String
+
+    @State private var autoScrollPaused = false
+    @State private var expandedEventIds: Set<String> = []
+
+    private var groupedEvents: [(key: String, events: [TraceStore.StoredEvent])] {
+        let byRequest = traceStore.eventsByRequest(sessionId: sessionId)
+        return byRequest.map { (key: $0.key, events: $0.value) }
+            .sorted { lhs, rhs in
+                let lhsFirst = lhs.events.first?.sequence ?? 0
+                let rhsFirst = rhs.events.first?.sequence ?? 0
+                return lhsFirst < rhsFirst
+            }
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
+                    ForEach(groupedEvents, id: \.key) { group in
+                        requestGroup(group.key, events: group.events)
+                    }
+
+                    // Invisible anchor for auto-scroll
+                    Color.clear
+                        .frame(height: 1)
+                        .id("trace-bottom")
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.md)
+            }
+            .onChange(of: traceStore.eventsBySession[sessionId]?.count) {
+                if !autoScrollPaused {
+                    withAnimation(VAnimation.fast) {
+                        proxy.scrollTo("trace-bottom", anchor: .bottom)
+                    }
+                }
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            autoScrollToggle
+        }
+    }
+
+    @ViewBuilder
+    private var autoScrollToggle: some View {
+        Button(action: { autoScrollPaused.toggle() }) {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: autoScrollPaused ? "play.fill" : "pause.fill")
+                    .font(.system(size: 9))
+                Text(autoScrollPaused ? "Resume" : "Auto-scroll")
+                    .font(VFont.small)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .foregroundColor(autoScrollPaused ? Amber._500 : VColor.textMuted)
+            .background(Slate._800)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(VSpacing.sm)
+    }
+
+    // MARK: - Request Group
+
+    @ViewBuilder
+    private func requestGroup(_ requestId: String, events: [TraceStore.StoredEvent]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: "arrow.right.circle")
+                    .font(.system(size: 10))
+                    .foregroundColor(Emerald._400)
+
+                Text(requestId.isEmpty ? "System" : "Request \(requestId.prefix(8))")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+
+                Rectangle()
+                    .fill(VColor.surfaceBorder)
+                    .frame(height: 1)
+            }
+
+            ForEach(events) { event in
+                eventRow(event)
+            }
+        }
+    }
+
+    // MARK: - Event Row (with expandable attributes)
+
+    @ViewBuilder
+    private func eventRow(_ event: TraceStore.StoredEvent) -> some View {
+        let isExpanded = expandedEventIds.contains(event.id)
+        let hasAttributes = event.attributes != nil && !(event.attributes?.isEmpty ?? true)
+
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: {
+                guard hasAttributes else { return }
+                withAnimation(VAnimation.fast) {
+                    if isExpanded {
+                        expandedEventIds.remove(event.id)
+                    } else {
+                        expandedEventIds.insert(event.id)
+                    }
+                }
+            }) {
+                HStack(spacing: 0) {
+                    TraceRowView(event: event)
+
+                    if hasAttributes {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 9))
+                            .foregroundColor(VColor.textMuted)
+                            .frame(width: 16)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded, let attrs = event.attributes, !attrs.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    ForEach(attrs.keys.sorted(), id: \.self) { key in
+                        HStack(spacing: VSpacing.sm) {
+                            Text(key)
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textMuted)
+                            Text(stringValue(attrs[key]))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.textSecondary)
+                                .lineLimit(3)
+                        }
+                    }
+                }
+                .padding(.leading, 26)
+                .padding(.vertical, VSpacing.xs)
+                .padding(.trailing, VSpacing.sm)
+                .background(Slate._800.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+        }
+    }
+
+    private func stringValue(_ value: AnyCodable?) -> String {
+        guard let value else { return "nil" }
+        if let s = value.value as? String { return s }
+        if let i = value.value as? Int { return "\(i)" }
+        if let d = value.value as? Double { return String(format: "%.2f", d) }
+        if let b = value.value as? Bool { return b ? "true" : "false" }
+        return String(describing: value.value)
+    }
+}

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1384,7 +1384,6 @@ public enum ServerMessage: Decodable, Sendable {
     case sharedAppDeleteResponse(SharedAppDeleteResponseMessage)
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
-    case sessionError(SessionErrorMessage)
     case signBundlePayload(SignBundlePayloadMessage)
     case getSigningIdentity
     case pong
@@ -1525,9 +1524,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "trace_event":
             let message = try TraceEventMessage(from: decoder)
             self = .traceEvent(message)
-        case "session_error":
-            let message = try SessionErrorMessage(from: decoder)
-            self = .sessionError(message)
         case "sign_bundle_payload":
             let message = try SignBundlePayloadMessage(from: decoder)
             self = .signBundlePayload(message)


### PR DESCRIPTION
## Summary
- Create `TraceRowView` and `TraceTimelineView` for rendering real-time execution trace events grouped by requestId with SF Symbol icons and status-based coloring
- Update `DebugPanel` to display a pinned metrics header strip (requests, LLM calls, tokens, avg latency, failures) and the trace timeline with expandable attribute details
- Wire `DaemonClient.onTraceEvent` to `TraceStore` in `MainWindow` and pass through `MainWindowView` to `DebugPanel`
- Fix pre-existing duplicate `sessionError` case in `ServerMessage` enum that broke builds

Closes #2053

## Test plan
- [x] `swift build --product vellum-assistant` passes cleanly
- [ ] Open Debug panel with no active session - shows "No session selected" empty state
- [ ] Open Debug panel with an active session but no trace events - shows "No trace events yet"
- [ ] Send a message and verify trace events appear grouped by requestId
- [ ] Verify metrics strip updates in real-time (request count, LLM calls, tokens, latency)
- [ ] Click on an event with attributes to expand/collapse details
- [ ] Toggle auto-scroll pause/resume button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
