### PR TITLE
M9: Migrate host host_file_* tools to thin wrappers

### DIFF
--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -1,10 +1,8 @@
-import { isAbsolute } from 'node:path';
-import { readFileSync, writeFileSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { checkFileSizeOnDisk } from '../filesystem/size-guard.js';
-import { applyEdit } from '../shared/filesystem/edit-engine.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { hostPolicy } from '../shared/filesystem/path-policy.js';
 
 class HostFileEditTool implements Tool {
   name = 'host_file_edit';
@@ -46,10 +44,6 @@ class HostFileEditTool implements Tool {
     if (!rawPath || typeof rawPath !== 'string') {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
-    if (!isAbsolute(rawPath)) {
-      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
-    }
-    const filePath = rawPath;
 
     const oldString = input.old_string;
     if (typeof oldString !== 'string') {
@@ -69,55 +63,55 @@ class HostFileEditTool implements Tool {
       return { content: 'Error: old_string and new_string must be different', isError: true };
     }
 
-    try {
-      const sizeError = checkFileSizeOnDisk(filePath);
-      if (sizeError) {
-        return { content: `Error: ${sizeError}`, isError: true };
+    const replaceAll = input.replace_all === true;
+
+    const ops = new FileSystemOps(hostPolicy);
+
+    const result = ops.editFileSafe({
+      path: rawPath,
+      oldString,
+      newString,
+      replaceAll,
+    });
+
+    if (!result.ok) {
+      const { error } = result;
+      switch (error.code) {
+        case 'MATCH_NOT_FOUND':
+          return { content: `Error: old_string not found in ${error.path}`, isError: true };
+        case 'MATCH_AMBIGUOUS':
+          return {
+            content: `Error: old_string appears multiple times in ${error.path}. Provide more surrounding context to make it unique, or set replace_all to true.`,
+            isError: true,
+          };
+        case 'IO_ERROR':
+          return { content: `Error editing file: ${error.message}`, isError: true };
+        default:
+          return { content: `Error: ${error.message}`, isError: true };
       }
-    } catch {
-      // The subsequent file read returns a clearer error for missing files.
     }
 
-    try {
-      const content = readFileSync(filePath, 'utf-8');
-      const replaceAll = input.replace_all === true;
-      const result = applyEdit(content, oldString, newString, replaceAll);
+    const { filePath, matchCount, oldContent, newContent, matchMethod } = result.value;
 
-      if (!result.ok) {
-        if (result.reason === 'not_found') {
-          return { content: `Error: old_string not found in ${filePath}`, isError: true };
-        }
-        return {
-          content: `Error: old_string appears multiple times in ${filePath}. Provide more surrounding context to make it unique, or set replace_all to true.`,
-          isError: true,
-        };
-      }
-
-      writeFileSync(filePath, result.updatedContent);
-
-      if (replaceAll) {
-        return {
-          content: `Successfully replaced ${result.matchCount} occurrence${result.matchCount > 1 ? 's' : ''} in ${filePath}`,
-          isError: false,
-          diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
-        };
-      }
-
-      const methodNote = result.matchMethod === 'exact'
-        ? ''
-        : result.matchMethod === 'whitespace'
-          ? ' (matched with whitespace normalization)'
-          : ' (fuzzy matched)';
-
+    if (replaceAll) {
       return {
-        content: `Successfully edited ${filePath}${methodNote}`,
+        content: `Successfully replaced ${matchCount} occurrence${matchCount > 1 ? 's' : ''} in ${filePath}`,
         isError: false,
-        diff: { filePath, oldContent: content, newContent: result.updatedContent, isNewFile: false },
+        diff: { filePath, oldContent, newContent, isNewFile: false },
       };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { content: `Error editing file: ${msg}`, isError: true };
     }
+
+    const methodNote = matchMethod === 'exact'
+      ? ''
+      : matchMethod === 'whitespace'
+        ? ' (matched with whitespace normalization)'
+        : ' (fuzzy matched)';
+
+    return {
+      content: `Successfully edited ${filePath}${methodNote}`,
+      isError: false,
+      diff: { filePath, oldContent, newContent, isNewFile: false },
+    };
   }
 }
 

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,9 +1,8 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
-import { isAbsolute } from 'node:path';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { checkFileSizeOnDisk } from '../filesystem/size-guard.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { hostPolicy } from '../shared/filesystem/path-policy.js';
 
 class HostFileReadTool implements Tool {
   name = 'host_file_read';
@@ -42,47 +41,33 @@ class HostFileReadTool implements Tool {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
 
-    if (!isAbsolute(rawPath)) {
-      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
+    const ops = new FileSystemOps(hostPolicy);
+
+    const result = ops.readFileSafe({
+      path: rawPath,
+      offset: typeof input.offset === 'number' ? input.offset : undefined,
+      limit: typeof input.limit === 'number' ? input.limit : undefined,
+    });
+
+    if (!result.ok) {
+      const { error } = result;
+      switch (error.code) {
+        case 'NOT_A_FILE':
+          return { content: `Error: ${error.path} is not a regular file`, isError: true };
+        case 'IO_ERROR': {
+          const msg = error.message;
+          const hint = msg.includes('ENOENT') ? ' (file does not exist)'
+            : msg.includes('EACCES') ? ' (permission denied)'
+            : msg.includes('EISDIR') ? ' (path is a directory, not a file)'
+            : '';
+          return { content: `Error reading file "${rawPath}"${hint}: ${msg}`, isError: true };
+        }
+        default:
+          return { content: `Error: ${error.message}`, isError: true };
+      }
     }
-    const filePath = rawPath;
 
-    if (!existsSync(filePath)) {
-      return { content: `Error: File not found: ${filePath}`, isError: true };
-    }
-
-    const stat = statSync(filePath);
-    if (!stat.isFile()) {
-      return { content: `Error: ${filePath} is not a regular file`, isError: true };
-    }
-
-    const sizeError = checkFileSizeOnDisk(filePath);
-    if (sizeError) {
-      return { content: `Error: ${sizeError}`, isError: true };
-    }
-
-    try {
-      const content = readFileSync(filePath, 'utf-8');
-      const lines = content.split('\n');
-
-      const offset = (typeof input.offset === 'number' ? input.offset : 1) - 1;
-      const limit = typeof input.limit === 'number' ? input.limit : lines.length;
-      const selectedLines = lines.slice(Math.max(0, offset), offset + limit);
-
-      const numbered = selectedLines.map((line, i) => {
-        const lineNum = offset + i + 1;
-        return `${String(lineNum).padStart(6)}  ${line}`;
-      }).join('\n');
-
-      return { content: numbered, isError: false };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const hint = msg.includes('ENOENT') ? ' (file does not exist)'
-        : msg.includes('EACCES') ? ' (permission denied)'
-        : msg.includes('EISDIR') ? ' (path is a directory, not a file)'
-        : '';
-      return { content: `Error reading file "${input.path}"${hint}: ${msg}`, isError: true };
-    }
+    return { content: result.value.content, isError: false };
   }
 }
 

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -1,9 +1,8 @@
-import { dirname, isAbsolute } from 'node:path';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { checkContentSize } from '../filesystem/size-guard.js';
+import { FileSystemOps } from '../shared/filesystem/file-ops-service.js';
+import { hostPolicy } from '../shared/filesystem/path-policy.js';
 
 class HostFileWriteTool implements Tool {
   name = 'host_file_write';
@@ -37,51 +36,35 @@ class HostFileWriteTool implements Tool {
     if (!rawPath || typeof rawPath !== 'string') {
       return { content: 'Error: path is required and must be a string', isError: true };
     }
-    if (!isAbsolute(rawPath)) {
-      return { content: `Error: path must be absolute for host file access: ${rawPath}`, isError: true };
-    }
-    const filePath = rawPath;
 
     const fileContent = input.content;
     if (typeof fileContent !== 'string') {
       return { content: 'Error: content is required and must be a string', isError: true };
     }
 
-    const sizeError = checkContentSize(fileContent, filePath);
-    if (sizeError) {
-      return { content: `Error: ${sizeError}`, isError: true };
+    const ops = new FileSystemOps(hostPolicy);
+
+    const result = ops.writeFileSafe({ path: rawPath, content: fileContent });
+
+    if (!result.ok) {
+      const { error } = result;
+      if (error.code === 'IO_ERROR') {
+        const msg = error.message;
+        const hint = msg.includes('ENOENT') ? ' (parent directory does not exist)'
+          : msg.includes('EACCES') ? ' (permission denied)'
+          : msg.includes('EROFS') ? ' (read-only file system)'
+          : '';
+        return { content: `Error writing file "${rawPath}"${hint}: ${msg}`, isError: true };
+      }
+      return { content: `Error: ${error.message}`, isError: true };
     }
 
-    try {
-      const dir = dirname(filePath);
-      if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-      }
-
-      let oldContent: string | null = null;
-      const isNewFile = !existsSync(filePath);
-      if (!isNewFile) {
-        try {
-          oldContent = readFileSync(filePath, 'utf-8');
-        } catch {
-          // Keep oldContent null when host file is unreadable.
-        }
-      }
-
-      writeFileSync(filePath, fileContent);
-      return {
-        content: `Successfully wrote to ${filePath}`,
-        isError: false,
-        diff: { filePath, oldContent: oldContent ?? '', newContent: fileContent, isNewFile },
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const hint = msg.includes('ENOENT') ? ' (parent directory does not exist)'
-        : msg.includes('EACCES') ? ' (permission denied)'
-        : msg.includes('EROFS') ? ' (read-only file system)'
-        : '';
-      return { content: `Error writing file "${input.path}"${hint}: ${msg}`, isError: true };
-    }
+    const { filePath, oldContent, newContent, isNewFile } = result.value;
+    return {
+      content: `Successfully wrote to ${filePath}`,
+      isError: false,
+      diff: { filePath, oldContent, newContent, isNewFile },
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Convert host_file_read, host_file_write, host_file_edit to thin wrappers over shared FileSystemOps service
- Use host path policy (absolute path enforcement) injection via `hostPolicy`
- Remove direct node:fs usage from host tool wrappers
- Preserve all existing error messages and host-specific behavior
- Permission/trust behavior unchanged

Part of #2009
Closes #2018

## Test plan
- [x] host-file-read-tool.test.ts passes (all 4 tests)
- [x] host-file-write-tool.test.ts passes (all 4 tests)
- [x] host-file-edit-tool.test.ts passes (all 4 tests)
- [x] checker.test.ts passes
- [x] trust-store.test.ts passes
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
