### PR TITLE
M3: Request + Queue + Terminal Trace Emission

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -35,6 +35,8 @@ mock.module('../config/loader.js', () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},
+    skills: { entries: {}, allowBundled: true },
+    memory: { retrieval: { injectionStrategy: 'inline' } },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
@@ -43,6 +45,23 @@ mock.module('../config/loader.js', () => ({
 
 mock.module('../config/system-prompt.js', () => ({
   buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module('../skills/slash-commands.js', () => ({
+  buildInvocableSlashCatalog: () => new Map(),
+  resolveSlashSkillCommand: () => ({ kind: 'not_slash' }),
+  rewriteKnownSlashCommandPrompt: () => '',
+  parseSlashCandidate: () => ({ kind: 'not_slash' }),
 }));
 
 mock.module('../permissions/trust-store.js', () => ({

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -452,6 +452,12 @@ async function handleUserMessage(
 
     const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
 
+    session.traceEmitter.emit('request_received', 'User message received', {
+      requestId,
+      status: 'info',
+      attributes: { source: 'user_message' },
+    });
+
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
@@ -465,12 +471,18 @@ async function handleUserMessage(
       return;
     }
     if (result.queued) {
-      rlog.info({ position: session.getQueueDepth() }, 'Message queued (session busy)');
+      const position = session.getQueueDepth();
+      rlog.info({ position }, 'Message queued (session busy)');
+      session.traceEmitter.emit('request_queued', `Message queued at position ${position}`, {
+        requestId,
+        status: 'info',
+        attributes: { position },
+      });
       ctx.send(socket, {
         type: 'message_queued',
         sessionId: msg.sessionId,
         requestId,
-        position: session.getQueueDepth(),
+        position,
       });
       return; // Don't await — message will be processed when current one finishes
     }
@@ -782,6 +794,10 @@ async function handleRegenerate(
   }
 
   const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+  session.traceEmitter.emit('request_received', 'Regenerate requested', {
+    status: 'info',
+    attributes: { source: 'regenerate' },
+  });
   try {
     await session.regenerate(sendEvent);
   } catch (err) {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -775,6 +775,11 @@ export class Session {
       });
 
       if (yieldedForHandoff) {
+        this.traceEmitter.emit('generation_handoff', 'Handing off to next queued message', {
+          requestId: reqId,
+          status: 'info',
+          attributes: { queuedCount: this.getQueueDepth() },
+        });
         onEvent({
           type: 'generation_handoff',
           sessionId: this.conversationId,
@@ -782,8 +787,16 @@ export class Session {
           queuedCount: this.getQueueDepth(),
         });
       } else if (abortController.signal.aborted) {
+        this.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
+          requestId: reqId,
+          status: 'warning',
+        });
         onEvent({ type: 'generation_cancelled' });
       } else {
+        this.traceEmitter.emit('message_complete', 'Message processing complete', {
+          requestId: reqId,
+          status: 'success',
+        });
         onEvent({ type: 'message_complete', sessionId: this.conversationId });
       }
 
@@ -798,10 +811,20 @@ export class Session {
       // AbortError is expected when user cancels — don't treat as an error
       if (isUserCancellation(err, errorCtx)) {
         rlog.info('Generation cancelled by user');
+        this.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
+          requestId: reqId,
+          status: 'warning',
+        });
         onEvent({ type: 'generation_cancelled' });
       } else {
         const message = err instanceof Error ? err.message : String(err);
+        const errorClass = err instanceof Error ? err.constructor.name : 'Error';
         rlog.error({ err }, 'Session processing error');
+        this.traceEmitter.emit('request_error', message.slice(0, 200), {
+          requestId: reqId,
+          status: 'error',
+          attributes: { errorClass, message: message.slice(0, 500) },
+        });
         onEvent({ type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, errorCtx);
         onEvent(buildSessionErrorMessage(this.conversationId, classified));
@@ -840,6 +863,11 @@ export class Session {
     if (!next) return;
 
     log.info({ conversationId: this.conversationId, requestId: next.requestId, reason }, 'Dequeuing message');
+    this.traceEmitter.emit('request_dequeued', `Message dequeued (${reason})`, {
+      requestId: next.requestId,
+      status: 'info',
+      attributes: { reason },
+    });
     next.onEvent({
       type: 'message_dequeued',
       sessionId: this.conversationId,
@@ -1018,15 +1046,27 @@ export class Session {
     const requestId = uuid();
     const onEvent = (msg: ServerMessage) => this.sendToClient(msg);
 
+    this.traceEmitter.emit('request_received', 'Surface action received', {
+      requestId,
+      status: 'info',
+      attributes: { source: 'surface_action', surfaceId, actionId },
+    });
+
     const result = this.enqueueMessage(content, [], onEvent, requestId);
     if (result.queued) {
+      const position = this.getQueueDepth();
       this.pendingSurfaceActions.delete(surfaceId);
       log.info({ surfaceId, actionId, requestId }, 'Surface action queued (session busy)');
+      this.traceEmitter.emit('request_queued', `Surface action queued at position ${position}`, {
+        requestId,
+        status: 'info',
+        attributes: { position },
+      });
       onEvent({
         type: 'message_queued',
         sessionId: this.conversationId,
         requestId,
-        position: this.getQueueDepth(),
+        position,
       });
       return;
     }


### PR DESCRIPTION
## Summary
- Emit `request_received` trace events in `handleUserMessage`, `handleRegenerate`, and `Session.handleSurfaceAction` with source attribution
- Emit `request_queued` and `request_dequeued` trace events with queue position and drain reason
- Emit terminal trace events (`generation_handoff`, `message_complete`, `generation_cancelled`, `request_error`) in `Session.runAgentLoop`
- Fix pre-existing session-queue test failures by adding missing skills/slash-commands mocks

Closes #2049

## Test plan
- [x] All 22 session-queue tests pass
- [x] All 13 trace-emitter tests pass
- [x] TypeScript type-check passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
