### PR TITLE
fix(ui): move composer action buttons to bottom row like ChatGPT

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -100,7 +100,8 @@ struct ChatView: View {
     private var composerReservedHeight: CGFloat {
         let editorClamped = min(max(editorContentHeight, 14), 200)
         let contentHeight = max(editorClamped, 28)
-        let base: CGFloat = VSpacing.md * 2 + VSpacing.sm * 2 + contentHeight + 4
+        // text area + button row (28pt) + button top padding (xs) + outer padding
+        let base: CGFloat = VSpacing.md * 2 + VSpacing.sm * 2 + contentHeight + 28 + VSpacing.xs
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
         let error: CGFloat = errorText != nil ? 36 : 0
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
@@ -358,13 +359,10 @@ struct ChatView: View {
                 attachmentStrip
             }
 
-            HStack(alignment: .center, spacing: VSpacing.sm) {
-                // Scrollable text input — TextField centers text natively;
-                // ScrollView adds scrolling when content exceeds 200pt.
+            // Scrollable text input area
+            ZStack(alignment: .bottom) {
                 ScrollView(.vertical, showsIndicators: false) {
                     ZStack(alignment: .leading) {
-                        // Suppress the built-in prompt when a ghost suggestion is
-                        // visible so the placeholder and ghost text don't overlap.
                         if ghostSuffix != nil {
                             TextField("", text: $inputText, axis: .vertical)
                                 .font(VFont.body)
@@ -407,16 +405,7 @@ struct ChatView: View {
                                 )
                         }
 
-                        // Ghost text overlay — shows the suggested suffix so users
-                        // know what Tab will insert. Uses Text concatenation (`+`)
-                        // so the suffix renders at the end of the last line, not to
-                        // the right of the entire text block.
                         if let ghostSuffix {
-                            // Text `+` concatenation requires each operand to be
-                            // a `Text` value (modifiers like `.font` and
-                            // `.foregroundColor` return `Text`, but `.lineSpacing`
-                            // returns `some View`), so `.lineSpacing` is applied
-                            // after the concatenation.
                             (Text(inputText)
                                 .font(VFont.body)
                                 .foregroundColor(.clear)
@@ -425,8 +414,6 @@ struct ChatView: View {
                                 .foregroundColor(VColor.textMuted.opacity(0.5)))
                                 .lineSpacing(4)
                                 .lineLimit(1...)
-                                // Prevent the ghost text from expanding the composer —
-                                // sizing is driven solely by the TextField's content.
                                 .fixedSize(horizontal: false, vertical: true)
                                 .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: .topLeading)
                                 .clipped()
@@ -438,35 +425,47 @@ struct ChatView: View {
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .frame(height: min(max(editorContentHeight, 28), 200))
-                .onKeyPress(.tab, phases: .down) { keyPress in
-                    if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
-                        onAcceptSuggestion()
-                        return .handled
-                    }
-                    return .ignored
-                }
-                .onKeyPress(.return, phases: .down) { keyPress in
-                    // Only intercept bare Return (no modifiers); any modifier
-                    // (Shift, Cmd, Option, Ctrl) inserts a newline.
-                    guard keyPress.modifiers.isEmpty else { return .ignored }
-                    // Strip any trailing newline inserted before this handler fired.
-                    inputText = inputText.replacingOccurrences(
-                        of: "\\n$", with: "", options: .regularExpression
+
+                // Fade at bottom of text area when content is scrollable
+                if editorContentHeight > 60 {
+                    LinearGradient(
+                        colors: [VColor.surface.opacity(0), VColor.surface],
+                        startPoint: .top,
+                        endPoint: .bottom
                     )
-                    if canSend {
-                        onSend()
-                    }
+                    .frame(height: 20)
+                    .allowsHitTesting(false)
+                }
+            }
+            .onKeyPress(.tab, phases: .down) { keyPress in
+                if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
+                    onAcceptSuggestion()
                     return .handled
                 }
-                .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.command) {
-                        onPaste()
-                        return .ignored
-                    }
+                return .ignored
+            }
+            .onKeyPress(.return, phases: .down) { keyPress in
+                guard keyPress.modifiers.isEmpty else { return .ignored }
+                inputText = inputText.replacingOccurrences(
+                    of: "\\n$", with: "", options: .regularExpression
+                )
+                if canSend {
+                    onSend()
+                }
+                return .handled
+            }
+            .onKeyPress(characters: CharacterSet(charactersIn: "v"), phases: .down) { keyPress in
+                if keyPress.modifiers.contains(.command) {
+                    onPaste()
                     return .ignored
                 }
+                return .ignored
+            }
 
-                // Action buttons — bottom-aligned, consistent 28pt height
+            // Bottom action row — pinned below text area like ChatGPT
+            HStack(spacing: VSpacing.sm) {
+                Spacer()
+
                 if isSending {
                     Button(action: onStop) {
                         ZStack {
@@ -482,7 +481,6 @@ struct ChatView: View {
                     .frame(height: 28)
                     .accessibilityLabel("Stop generation")
                 } else {
-                    // Send button (when text present) or Mic button
                     if canSend {
                         Button(action: onSend) {
                             ZStack {
@@ -517,6 +515,7 @@ struct ChatView: View {
                 }
             }
             .animation(VAnimation.spring, value: canSend)
+            .padding(.top, VSpacing.xs)
         }
         .padding(.vertical, VSpacing.sm)
         .padding(.leading, VSpacing.xl)


### PR DESCRIPTION
## Summary
- Restructure composer from HStack (text + buttons side by side) to VStack with text area on top and dedicated bottom action row
- Buttons (mic/send/attachment) pinned to bottom-right like ChatGPT
- Gradient fade at bottom of text area when content is multi-line so text fades into the button row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
