### PR TITLE
feat(daemon): add session_error emission and error mapper (M2)

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -455,7 +455,6 @@ async function handleUserMessage(
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
-      ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
         code: 'QUEUE_FULL',
         userMessage: 'The message queue is full. Please wait and try again.',
@@ -480,16 +479,12 @@ async function handleUserMessage(
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
     session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
-      ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
       const classified = classifySessionError(err, { phase: 'agent_loop' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');
-    ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
     const classified = classifySessionError(err, { phase: 'handler' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -785,9 +780,7 @@ async function handleRegenerate(
   try {
     await session.regenerate(sendEvent);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');
-    ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
     const classified = classifySessionError(err, { phase: 'regenerate' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -1354,9 +1347,7 @@ async function handleTaskSubmit(
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
       }, requestId).catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
-        ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, { phase: 'agent_loop' });
         ctx.send(socket, buildSessionErrorMessage(conversation.id, classified));
       });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -323,7 +323,6 @@ export class Session {
 
       // Clear queued messages and notify each caller
       for (const queued of this.messageQueue) {
-        queued.onEvent({ type: 'error', message: 'Session aborted — queued message discarded' });
         queued.onEvent(buildSessionErrorMessage(this.conversationId, {
           code: 'SESSION_ABORTED',
           userMessage: 'The request was interrupted. You can try sending your message again.',
@@ -493,7 +492,9 @@ export class Session {
           this.messages.pop();
           conversationStore.deleteMessageById(userMessageId);
         }
-        onEvent({ type: 'error', message: `Message blocked by hook "${preMessageResult.blockedBy}"` });
+        onEvent(buildSessionErrorMessage(this.conversationId,
+          classifySessionError(new Error(`Message blocked by hook "${preMessageResult.blockedBy}"`), { phase: 'agent_loop' }),
+        ));
         return;
       }
 
@@ -630,7 +631,9 @@ export class Session {
               // Defer the error event — only forward if retry also fails
               deferredOrderingError = event.error.message;
             } else {
-              onEvent({ type: 'error', message: event.error.message });
+              onEvent(buildSessionErrorMessage(this.conversationId,
+                classifySessionError(event.error, { phase: 'agent_loop' }),
+              ));
             }
             break;
           case 'message_complete': {
@@ -720,7 +723,9 @@ export class Session {
 
       // Forward the deferred ordering error to the client if retry failed or was not attempted
       if (deferredOrderingError) {
-        onEvent({ type: 'error', message: deferredOrderingError });
+        onEvent(buildSessionErrorMessage(this.conversationId,
+          classifySessionError(new Error(deferredOrderingError), { phase: 'agent_loop' }),
+        ));
       }
 
       // Reconcile synthesized cancellation tool_results from history tail.
@@ -802,7 +807,6 @@ export class Session {
       } else {
         const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Session processing error');
-        onEvent({ type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, errorCtx);
         onEvent(buildSessionErrorMessage(this.conversationId, classified));
         void getHookManager().trigger('on-error', {
@@ -873,9 +877,10 @@ export class Session {
         next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
         next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
         log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist unknown-slash exchange');
-        next.onEvent({ type: 'error', message });
+        next.onEvent(buildSessionErrorMessage(this.conversationId,
+          classifySessionError(err, { phase: 'persist' }),
+        ));
       }
       // Continue draining regardless of success/failure
       this.drainQueue();
@@ -892,9 +897,10 @@ export class Session {
     try {
       userMessageId = this.persistUserMessage(resolvedContent, next.attachments, next.requestId);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
       log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
-      next.onEvent({ type: 'error', message });
+      next.onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(err, { phase: 'persist' }),
+      ));
       // Continue draining — don't strand remaining messages
       this.drainQueue();
       return;
@@ -904,9 +910,10 @@ export class Session {
     // so subsequent messages will still be enqueued. runAgentLoop's
     // finally block will call drainQueue when this run completes.
     this.runAgentLoop(resolvedContent, userMessageId, next.onEvent).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
       log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Error processing queued message');
-      next.onEvent({ type: 'error', message: `Failed to process queued message: ${message}` });
+      next.onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(err, { phase: 'agent_loop' }),
+      ));
     });
   }
 
@@ -954,8 +961,9 @@ export class Session {
     try {
       userMessageId = this.persistUserMessage(resolvedContent, attachments, requestId);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      onEvent({ type: 'error', message });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(err, { phase: 'persist' }),
+      ));
       return '';
     }
 
@@ -1033,16 +1041,19 @@ export class Session {
 
     if (result.rejected) {
       log.error({ surfaceId, actionId }, 'Surface action rejected — queue full');
-      onEvent({ type: 'error', message: 'Surface action rejected — session queue is full' });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(new Error('Surface action rejected — session queue is full'), { phase: 'queue' }),
+      ));
       return;
     }
 
     this.pendingSurfaceActions.delete(surfaceId);
     log.info({ surfaceId, actionId, requestId }, 'Processing surface action as follow-up');
     this.processMessage(content, [], onEvent, requestId).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
       log.error({ err, surfaceId, actionId }, 'Error processing surface action');
-      onEvent({ type: 'error', message: `Failed to process surface action: ${message}` });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(err, { phase: 'agent_loop' }),
+      ));
     });
   }
 
@@ -1097,7 +1108,9 @@ export class Session {
    */
   async regenerate(onEvent: (msg: ServerMessage) => void): Promise<void> {
     if (this.processing) {
-      onEvent({ type: 'error', message: 'Cannot regenerate while processing' });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(new Error('Cannot regenerate while processing'), { phase: 'regenerate' }),
+      ));
       return;
     }
 
@@ -1105,13 +1118,17 @@ export class Session {
     // assistant's exchange that we want to regenerate.
     const lastUserIdx = findLastUndoableUserMessageIndex(this.messages);
     if (lastUserIdx === -1) {
-      onEvent({ type: 'error', message: 'No messages to regenerate' });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(new Error('No messages to regenerate'), { phase: 'regenerate' }),
+      ));
       return;
     }
 
     // There must be at least one message after the user message (the assistant reply).
     if (lastUserIdx >= this.messages.length - 1) {
-      onEvent({ type: 'error', message: 'No assistant response to regenerate' });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(new Error('No assistant response to regenerate'), { phase: 'regenerate' }),
+      ));
       return;
     }
 
@@ -1137,7 +1154,9 @@ export class Session {
     }
 
     if (dbUserMsgIdx === -1) {
-      onEvent({ type: 'error', message: 'No user message found in DB' });
+      onEvent(buildSessionErrorMessage(this.conversationId,
+        classifySessionError(new Error('No user message found in DB'), { phase: 'regenerate' }),
+      ));
       return;
     }
 


### PR DESCRIPTION
## Summary
- Replace all generic `{ type: 'error' }` emissions in session-bound code paths (`session.ts`, `handlers.ts`) with structured `session_error` messages
- Use centralized `classifySessionError` / `buildSessionErrorMessage` API from `session-error.ts` for consistent error classification
- Non-session/global error paths (model_set, apps_list, session_switch, etc.) correctly retain generic `{ type: 'error' }` since they lack session context
- Preserve cancel UX: user-initiated cancellation continues to emit `generation_cancelled`, not `session_error`

## Changes
- **`session.ts`**: All `{ type: 'error' }` emissions replaced with `buildSessionErrorMessage()` calls using appropriate `ErrorContext` phases (`agent_loop`, `queue`, `persist`, `regenerate`)
- **`handlers.ts`**: Removed dual-emit anti-pattern (was sending both old `error` and new `session_error`); now only emits `session_error` for session-bound failures

## Test plan
- [x] All 37 existing `session-error.test.ts` tests pass
- [x] TypeScript type-check passes (`bunx tsc --noEmit`)
- [x] No remaining `{ type: 'error' }` in `session.ts`
- [x] All remaining `{ type: 'error' }` in `handlers.ts` are in non-session handlers

Closes #2040

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
