### PR TITLE
M9: Add explicit NOT_FOUND handling in host_file_read

### DIFF
--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -52,6 +52,8 @@ class HostFileReadTool implements Tool {
     if (!result.ok) {
       const { error } = result;
       switch (error.code) {
+        case 'NOT_FOUND':
+          return { content: `Error: File not found: ${error.path}`, isError: true };
         case 'NOT_A_FILE':
           return { content: `Error: ${error.path} is not a regular file`, isError: true };
         case 'IO_ERROR': {


### PR DESCRIPTION
## Context
Part of #2009: Filesystem Tools Consolidation. Closes #2018.

The host_file_* tools were already migrated to FileSystemOps in a previous PR. This adds the one remaining improvement: an explicit NOT_FOUND error case in host_file_read so the error message is intentional rather than falling through to the default handler.

## Changes
- Add explicit NOT_FOUND case to host_file_read error handler for clearer error messages
- All existing tests pass unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
