### PR TITLE
feat(trace): session switching, reset semantics, and edge cases (#2054)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import VellumAssistantShared
 import SwiftUI
 
@@ -11,6 +12,10 @@ final class MainWindow {
     let threadManager: ThreadManager
     let traceStore = TraceStore()
     var onMicrophoneToggle: (() -> Void)?
+
+    /// Tracks daemon reconnects so trace state can be reset on stream restart.
+    private var connectionCancellable: AnyCancellable?
+    private var hasConnectedOnce = false
 
     /// Whether the main window is currently visible on screen.
     var isVisible: Bool {
@@ -32,6 +37,24 @@ final class MainWindow {
                 self?.traceStore.ingest(msg)
             }
         }
+        observeDaemonReconnects()
+    }
+
+    /// Reset trace state when the daemon reconnects after a disconnect.
+    /// The trace event stream is ephemeral; a reconnect means the daemon
+    /// restarted and any in-flight trace context is stale.
+    private func observeDaemonReconnects() {
+        connectionCancellable = daemonClient.$isConnected
+            .removeDuplicates()
+            .sink { [weak self] connected in
+                guard let self else { return }
+                if connected {
+                    if self.hasConnectedOnce {
+                        self.traceStore.resetAll()
+                    }
+                    self.hasConnectedOnce = true
+                }
+            }
     }
 
     func show() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -76,15 +76,27 @@ struct TraceTimelineView: View {
 
     @ViewBuilder
     private func requestGroup(_ requestId: String, events: [TraceStore.StoredEvent]) -> some View {
+        let groupStatus = traceStore.requestGroupStatus(sessionId: sessionId, requestId: requestId)
+
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             HStack(spacing: VSpacing.sm) {
-                Image(systemName: "arrow.right.circle")
+                Image(systemName: groupStatusIcon(groupStatus))
                     .font(.system(size: 10))
-                    .foregroundColor(Emerald._400)
+                    .foregroundColor(groupStatusColor(groupStatus))
 
                 Text(requestId.isEmpty ? "System" : "Request \(requestId.prefix(8))")
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textSecondary)
+
+                if groupStatus == .cancelled {
+                    Text("Cancelled")
+                        .font(VFont.small)
+                        .foregroundColor(Amber._500)
+                } else if groupStatus == .error {
+                    Text("Error")
+                        .font(VFont.small)
+                        .foregroundColor(Rose._500)
+                }
 
                 Rectangle()
                     .fill(VColor.surfaceBorder)
@@ -94,6 +106,24 @@ struct TraceTimelineView: View {
             ForEach(events) { event in
                 eventRow(event)
             }
+        }
+    }
+
+    private func groupStatusIcon(_ status: TraceStore.RequestGroupStatus) -> String {
+        switch status {
+        case .active: return "arrow.right.circle"
+        case .completed: return "checkmark.circle.fill"
+        case .cancelled: return "xmark.circle.fill"
+        case .error: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func groupStatusColor(_ status: TraceStore.RequestGroupStatus) -> Color {
+        switch status {
+        case .active: return Emerald._400
+        case .completed: return Emerald._400
+        case .cancelled: return Amber._500
+        case .error: return Rose._500
         }
     }
 

--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -89,6 +89,47 @@ public final class TraceStore: ObservableObject {
         return Dictionary(grouping: events) { $0.requestId ?? "" }
     }
 
+    // MARK: - Request Group Status
+
+    /// Terminal status for a request group.
+    public enum RequestGroupStatus: Sendable {
+        case active
+        case completed
+        case cancelled
+        case error
+    }
+
+    /// Determines the terminal status of a request group by inspecting its events.
+    ///
+    /// A request is considered terminal when it contains a `request_finished`,
+    /// `request_cancelled`, or `request_failed` event. If none of those are present
+    /// but any event has `status == "error"`, the group is marked as error.
+    public func requestGroupStatus(sessionId: String, requestId: String) -> RequestGroupStatus {
+        let key = requestId.isEmpty ? "" : requestId
+        let grouped = eventsByRequest(sessionId: sessionId)
+        guard let events = grouped[key] else { return .active }
+
+        for event in events {
+            switch event.kind {
+            case "request_cancelled":
+                return .cancelled
+            case "request_failed":
+                return .error
+            case "request_finished":
+                return .completed
+            default:
+                break
+            }
+        }
+
+        // Fall back to checking individual event status fields.
+        if events.contains(where: { $0.status == "error" }) {
+            return .error
+        }
+
+        return .active
+    }
+
     // MARK: - Derived Metrics
 
     /// Number of unique requestIds in a session.

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -248,4 +248,194 @@ struct TraceStoreTests {
         #expect(store.llmCallCount(sessionId: "s1") == 0)
         #expect(store.llmCallCount(sessionId: "s2") == 1)
     }
+
+    // MARK: - Session Switching Shows Correct Traces
+
+    @Test @MainActor
+    func sessionSwitchingShowsCorrectTraces() {
+        let store = TraceStore()
+
+        // Populate two sessions with distinct events.
+        store.ingest(makeEvent(eventId: "s1-a", sessionId: "session-A", requestId: "rA", sequence: 1, kind: "request_started", summary: "Start A"))
+        store.ingest(makeEvent(eventId: "s1-b", sessionId: "session-A", requestId: "rA", sequence: 2, kind: "llm_call_finished", summary: "LLM A"))
+
+        store.ingest(makeEvent(eventId: "s2-a", sessionId: "session-B", requestId: "rB", sequence: 1, kind: "request_started", summary: "Start B"))
+        store.ingest(makeEvent(eventId: "s2-b", sessionId: "session-B", requestId: "rB", sequence: 2, kind: "tool_started", summary: "Tool B"))
+        store.ingest(makeEvent(eventId: "s2-c", sessionId: "session-B", requestId: "rB", sequence: 3, kind: "tool_failed", summary: "Fail B"))
+
+        // "Switch" to session-A — only its events are visible.
+        let eventsA = store.eventsBySession["session-A"] ?? []
+        #expect(eventsA.count == 2)
+        #expect(eventsA.allSatisfy { $0.sessionId == "session-A" })
+
+        // "Switch" to session-B — only its events are visible.
+        let eventsB = store.eventsBySession["session-B"] ?? []
+        #expect(eventsB.count == 3)
+        #expect(eventsB.allSatisfy { $0.sessionId == "session-B" })
+
+        // Metrics are scoped correctly.
+        #expect(store.llmCallCount(sessionId: "session-A") == 1)
+        #expect(store.llmCallCount(sessionId: "session-B") == 0)
+        #expect(store.toolFailureCount(sessionId: "session-A") == 0)
+        #expect(store.toolFailureCount(sessionId: "session-B") == 1)
+    }
+
+    // MARK: - No Cross-Session Trace Contamination
+
+    @Test @MainActor
+    func noCrossSessionContamination() {
+        let store = TraceStore()
+
+        // Session 1 events.
+        store.ingest(makeEvent(eventId: "e1", sessionId: "s1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", sessionId: "s1", requestId: "r1", sequence: 2, kind: "llm_call_finished",
+                               attributes: ["inputTokens": 100, "outputTokens": 50]))
+
+        // Session 2 events.
+        store.ingest(makeEvent(eventId: "e3", sessionId: "s2", requestId: "r2", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e4", sessionId: "s2", requestId: "r2", sequence: 2, kind: "tool_failed"))
+
+        // Session 1 must not see session 2's events.
+        let grouped1 = store.eventsByRequest(sessionId: "s1")
+        #expect(grouped1.count == 1)
+        #expect(grouped1["r1"]?.count == 2)
+        #expect(grouped1["r2"] == nil)
+
+        // Session 2 must not see session 1's events.
+        let grouped2 = store.eventsByRequest(sessionId: "s2")
+        #expect(grouped2.count == 1)
+        #expect(grouped2["r2"]?.count == 2)
+        #expect(grouped2["r1"] == nil)
+
+        // Adding more events to one session does not affect the other.
+        store.ingest(makeEvent(eventId: "e5", sessionId: "s1", requestId: "r1", sequence: 3, kind: "request_finished"))
+        #expect(store.eventsBySession["s1"]?.count == 3)
+        #expect(store.eventsBySession["s2"]?.count == 2)
+    }
+
+    // MARK: - Cancellation Terminal Event
+
+    @Test @MainActor
+    func cancellationTerminalEvent() {
+        let store = TraceStore()
+
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
+        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "request_cancelled", summary: "Cancelled by user"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .cancelled)
+    }
+
+    // MARK: - Error Terminal Event
+
+    @Test @MainActor
+    func errorTerminalEvent() {
+        let store = TraceStore()
+
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
+        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "request_failed", status: "error", summary: "API error"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .error)
+    }
+
+    // MARK: - Completed Terminal Event
+
+    @Test @MainActor
+    func completedTerminalEvent() {
+        let store = TraceStore()
+
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "request_finished"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .completed)
+    }
+
+    // MARK: - Active Request Group (no terminal event)
+
+    @Test @MainActor
+    func activeRequestGroup() {
+        let store = TraceStore()
+
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .active)
+    }
+
+    // MARK: - Error Status Fallback
+
+    @Test @MainActor
+    func errorStatusFallback() {
+        let store = TraceStore()
+
+        // No terminal kind event, but an event with status "error".
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "tool_failed", status: "error", summary: "tool crashed"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .error)
+    }
+
+    // MARK: - Unknown Request Group Returns Active
+
+    @Test @MainActor
+    func unknownRequestGroupReturnsActive() {
+        let store = TraceStore()
+        let status = store.requestGroupStatus(sessionId: "nonexistent", requestId: "r1")
+        #expect(status == .active)
+    }
+
+    // MARK: - Daemon Reconnect Resets Trace State
+
+    @Test @MainActor
+    func daemonReconnectResetsTraceState() {
+        let store = TraceStore()
+
+        // Populate with events from two sessions.
+        store.ingest(makeEvent(eventId: "e1", sessionId: "s1", sequence: 1))
+        store.ingest(makeEvent(eventId: "e2", sessionId: "s2", sequence: 1))
+        #expect(store.eventsBySession.count == 2)
+
+        // Simulate daemon reconnect by calling resetAll().
+        store.resetAll()
+
+        #expect(store.eventsBySession.isEmpty)
+
+        // New events can be ingested after reset, even with the same eventIds
+        // (dedup state was also cleared).
+        store.ingest(makeEvent(eventId: "e1", sessionId: "s1", sequence: 1, summary: "post-reset"))
+        #expect(store.eventsBySession["s1"]?.count == 1)
+        #expect(store.eventsBySession["s1"]?.first?.summary == "post-reset")
+    }
+
+    // MARK: - Historical Traces Retained Per Session
+
+    @Test @MainActor
+    func historicalTracesRetainedPerSession() {
+        let store = TraceStore()
+
+        // Build up events across multiple sessions.
+        for i in 0..<10 {
+            store.ingest(makeEvent(eventId: "s1-\(i)", sessionId: "s1", requestId: "r1", sequence: i))
+            store.ingest(makeEvent(eventId: "s2-\(i)", sessionId: "s2", requestId: "r2", sequence: i))
+            store.ingest(makeEvent(eventId: "s3-\(i)", sessionId: "s3", requestId: "r3", sequence: i))
+        }
+
+        // All three sessions' traces are retained simultaneously.
+        #expect(store.eventsBySession.count == 3)
+        #expect(store.eventsBySession["s1"]?.count == 10)
+        #expect(store.eventsBySession["s2"]?.count == 10)
+        #expect(store.eventsBySession["s3"]?.count == 10)
+
+        // Resetting one session preserves the others.
+        store.resetSession(sessionId: "s2")
+        #expect(store.eventsBySession.count == 2)
+        #expect(store.eventsBySession["s1"]?.count == 10)
+        #expect(store.eventsBySession["s3"]?.count == 10)
+    }
 }


### PR DESCRIPTION
## Summary
- Add requestGroupStatus() to TraceStore for detecting terminal states (cancelled, error, completed, active) in request groups
- Wire daemon reconnect to traceStore.resetAll() in MainWindow so stale trace state is cleared when the event stream restarts
- Show terminal status indicators (Cancelled/Error labels, distinct icons and colors) on request groups in TraceTimelineView
- Add comprehensive tests for session switching, cross-session contamination prevention, cancellation/error terminal events, daemon reconnect reset, and historical trace retention

## Test plan
- [x] swift build --target VellumAssistantLib passes
- [x] swift build --target vellum-assistantTests compiles all new tests
- [x] Tests cover: session switching shows correct traces, no cross-session contamination, cancellation/error/completed terminal events, error status fallback, unknown request group, daemon reconnect reset, historical trace retention

Closes #2054
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
