### PR TITLE
Fix iOS font descriptor keys (correct API names)

### DIFF
--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -29,10 +29,11 @@ public enum VFont {
         guard let uiFont = UIFont(name: name, size: size) else {
             return Font.custom(name, size: size)
         }
+        // iOS uses different key names: featureIdentifier = type, typeIdentifier = selector
         let descriptor = uiFont.fontDescriptor.addingAttributes([
             .featureSettings: [[
-                UIFontDescriptor.FeatureKey.typeIdentifier: kStylisticAlternativesType,
-                UIFontDescriptor.FeatureKey.selectorIdentifier: kStylisticAltFiveOnSelector,
+                UIFontDescriptor.FeatureKey.featureIdentifier: kStylisticAlternativesType,
+                UIFontDescriptor.FeatureKey.typeIdentifier: kStylisticAltFiveOnSelector,
             ]]
         ])
         return Font(UIFont(descriptor: descriptor, size: size))


### PR DESCRIPTION
## Summary

Fixes the previous fix (#2095) which used incorrect key names for iOS font descriptors.

## The Issue

iOS and macOS have different `FeatureKey` enum members:

**macOS** (`NSFontDescriptor.FeatureKey`):
- `.typeIdentifier` → feature type (e.g., `kStylisticAlternativesType`)
- `.selectorIdentifier` → feature selector (e.g., `kStylisticAltFiveOnSelector`)

**iOS** (`UIFontDescriptor.FeatureKey`):
- `.featureIdentifier` → feature type
- `.typeIdentifier` → feature selector (confusing naming!)

## Changes

Updated iOS section to use correct keys:
- `typeIdentifier` → `featureIdentifier` (for feature type)
- `selectorIdentifier` → `typeIdentifier` (for selector value)

## Testing

- iOS target now compiles without `has no member 'selectorIdentifier'` error
- macOS build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
