### PR TITLE
feat: ChatViewModel typed error state and recovery logic (#2041)

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1111,4 +1111,248 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.sessionId, "test-session", "Should accept session_info when no correlationId was set")
     }
+
+    // MARK: - Session Error (Typed Error State)
+
+    func testSessionErrorSetsTypedErrorState() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerRateLimit,
+            userMessage: "Rate limit exceeded",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNotNil(viewModel.sessionError)
+        XCTAssertEqual(viewModel.sessionError?.category, .rateLimit)
+        XCTAssertEqual(viewModel.sessionError?.message, "Rate limit exceeded")
+        XCTAssertTrue(viewModel.sessionError?.isRetryable == true)
+        XCTAssertEqual(viewModel.sessionError?.sessionId, "sess-1")
+    }
+
+    func testSessionErrorSetsRecoverySuggestion() {
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerNetwork,
+            userMessage: "Connection failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNotNil(viewModel.sessionError?.recoverySuggestion)
+        XCTAssertTrue(viewModel.sessionError!.recoverySuggestion.contains("internet"),
+                       "Network error should suggest checking internet connection")
+    }
+
+    func testSessionErrorClearsThinkingAndSendingState() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "API error",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testSessionErrorAlsoSetsErrorText() {
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "Provider returned 500",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertEqual(viewModel.errorText, "Provider returned 500",
+                       "session_error should populate errorText for backward compatibility")
+    }
+
+    func testSessionErrorFromDifferentSessionIsIgnored() {
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-other",
+            code: .providerNetwork,
+            userMessage: "Connection failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNil(viewModel.sessionError,
+                      "session_error from a different session should be ignored")
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    func testSessionErrorFinalizesStreamingMessage() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .sessionProcessingFailed,
+            userMessage: "Processing failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertFalse(viewModel.messages[1].isStreaming,
+                        "session_error should finalize streaming assistant message")
+        XCTAssertEqual(viewModel.messages[1].text, "Partial",
+                        "Partial text should be preserved")
+    }
+
+    func testSessionErrorResetsProcessingMessagesToSent() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing)
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .sessionProcessingFailed,
+            userMessage: "Processing failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertEqual(viewModel.messages[2].status, .sent,
+                        "session_error should reset processing messages to .sent")
+    }
+
+    func testDismissSessionErrorClearsBothErrorStates() {
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerRateLimit,
+            userMessage: "Rate limited",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNotNil(viewModel.sessionError)
+        XCTAssertNotNil(viewModel.errorText)
+
+        viewModel.dismissSessionError()
+
+        XCTAssertNil(viewModel.sessionError)
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    func testSendMessageClearsSessionError() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "API error",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+        XCTAssertNotNil(viewModel.sessionError)
+
+        viewModel.inputText = "Retry"
+        viewModel.sendMessage()
+
+        XCTAssertNil(viewModel.sessionError,
+                      "Sending a new message should clear the session error")
+    }
+
+    func testAllErrorCategoriesHaveRecoverySuggestions() {
+        // Every SessionErrorCode should produce a non-empty recovery suggestion
+        for code in SessionErrorCode.allCases {
+            let category = SessionErrorCategory(from: code)
+            XCTAssertFalse(category.recoverySuggestion.isEmpty,
+                           "\(code) should produce a non-empty recovery suggestion")
+        }
+    }
+
+    func testSessionErrorDuringCancellationSuppressesErrorText() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
+        viewModel.stopGenerating()
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .sessionAborted,
+            userMessage: "Session aborted",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        // errorText should be suppressed during cancellation (user-initiated)
+        XCTAssertNil(viewModel.errorText,
+                      "session_error during cancellation should not display errorText")
+        // But the typed sessionError should still be set for UI inspection
+        XCTAssertNotNil(viewModel.sessionError)
+    }
+
+    func testSessionErrorNonRetryableFlag() {
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .queueFull,
+            userMessage: "Queue is full",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertEqual(viewModel.sessionError?.isRetryable, false)
+        XCTAssertEqual(viewModel.sessionError?.category, .queueFull)
+    }
+
+    func testSessionErrorReplacedBySubsequentError() {
+        viewModel.sessionId = "sess-1"
+
+        let firstError = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerNetwork,
+            userMessage: "Network error",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(firstError))
+        XCTAssertEqual(viewModel.sessionError?.category, .providerNetwork)
+
+        let secondError = SessionErrorMessagePayload(
+            sessionId: "sess-1",
+            code: .providerRateLimit,
+            userMessage: "Rate limited",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(secondError))
+        XCTAssertEqual(viewModel.sessionError?.category, .rateLimit,
+                        "Latest session_error should replace previous one")
+        XCTAssertEqual(viewModel.sessionError?.message, "Rate limited")
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -11,6 +11,86 @@ import UIKit
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel")
 
+/// Categorizes session errors for UI display and recovery suggestions.
+public enum SessionErrorCategory: Equatable, Sendable {
+    case providerNetwork
+    case rateLimit
+    case providerApi
+    case queueFull
+    case sessionAborted
+    case processingFailed
+    case regenerateFailed
+    case unknown
+
+    public init(from code: SessionErrorCode) {
+        switch code {
+        case .providerNetwork:
+            self = .providerNetwork
+        case .providerRateLimit:
+            self = .rateLimit
+        case .providerApi:
+            self = .providerApi
+        case .queueFull:
+            self = .queueFull
+        case .sessionAborted:
+            self = .sessionAborted
+        case .sessionProcessingFailed:
+            self = .processingFailed
+        case .regenerateFailed:
+            self = .regenerateFailed
+        case .unknown:
+            self = .unknown
+        }
+    }
+
+    /// User-facing recovery suggestion for this error category.
+    public var recoverySuggestion: String {
+        switch self {
+        case .providerNetwork:
+            return "Check your internet connection and try again."
+        case .rateLimit:
+            return "You've hit a rate limit. Please wait a moment before retrying."
+        case .providerApi:
+            return "The AI provider returned an error. Try again or check your API key."
+        case .queueFull:
+            return "Too many pending messages. Wait for current messages to finish processing."
+        case .sessionAborted:
+            return "The session was interrupted. Send a new message to continue."
+        case .processingFailed:
+            return "Message processing failed. Try sending your message again."
+        case .regenerateFailed:
+            return "Could not regenerate the response. Try again."
+        case .unknown:
+            return "An unexpected error occurred. Try again."
+        }
+    }
+}
+
+/// Typed error state for session-level errors from the daemon.
+public struct SessionError: Equatable {
+    public let category: SessionErrorCategory
+    public let message: String
+    public let isRetryable: Bool
+    public let recoverySuggestion: String
+    public let sessionId: String
+
+    public init(from msg: SessionErrorMessagePayload) {
+        self.category = SessionErrorCategory(from: msg.code)
+        self.message = msg.userMessage
+        self.isRetryable = msg.retryable
+        self.recoverySuggestion = self.category.recoverySuggestion
+        self.sessionId = msg.sessionId
+    }
+
+    public init(category: SessionErrorCategory, message: String, isRetryable: Bool, sessionId: String) {
+        self.category = category
+        self.message = message
+        self.isRetryable = isRetryable
+        self.recoverySuggestion = category.recoverySuggestion
+        self.sessionId = sessionId
+    }
+}
+
 @MainActor
 public final class ChatViewModel: ObservableObject {
     @Published public var messages: [ChatMessage] = []
@@ -18,6 +98,7 @@ public final class ChatViewModel: ObservableObject {
     @Published public var isThinking: Bool = false
     @Published public var isSending: Bool = false
     @Published public var errorText: String?
+    @Published public var sessionError: SessionError?
     @Published public var pendingQueuedCount: Int = 0
     @Published public var suggestion: String?
     @Published public var pendingAttachments: [ChatAttachment] = []
@@ -313,6 +394,7 @@ public final class ChatViewModel: ObservableObject {
         suggestion = nil
         pendingSuggestionRequestId = nil
         errorText = nil
+        sessionError = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -838,6 +920,46 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
 
+        case .sessionError(let msg):
+            guard belongsToSession(msg.sessionId) else { return }
+            let typedError = SessionError(from: msg)
+            log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
+            sessionError = typedError
+            // Mirror the same UI reset as the generic .error handler so the
+            // chat doesn't get stuck in a sending/thinking state.
+            isThinking = false
+            let wasCancelling = isCancelling
+            isCancelling = false
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+            // Also set errorText so existing UI that reads errorText still works.
+            if !wasCancelling {
+                errorText = msg.userMessage
+            }
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
+            if wasCancelling {
+                isSending = false
+                pendingQueuedCount = 0
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
+            } else if pendingQueuedCount == 0 {
+                isSending = false
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+            }
+
         default:
             break
         }
@@ -1006,6 +1128,13 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func dismissError() {
+        errorText = nil
+    }
+
+    /// Dismiss the typed session error state. Clears both the typed error
+    /// and any corresponding `errorText` so the UI can return to normal.
+    public func dismissSessionError() {
+        sessionError = nil
         errorText = nil
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -127,6 +127,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `history_response` message.
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
+    /// Called when the daemon sends a `session_error` message with typed error information.
+    public var onSessionError: ((SessionErrorMessagePayload) -> Void)?
+
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -761,6 +764,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onHistoryResponse?(msg)
         case .traceEvent(let msg):
             onTraceEvent?(msg)
+        case .sessionError(let msg):
+            onSessionError?(msg)
         case .error(let msg):
             onError?(msg)
         #if os(macOS)


### PR DESCRIPTION
## Summary
- Add SessionErrorCategory enum and SessionError struct to categorize daemon session_error messages by type (rate_limit, provider_network, provider_api, queue_full, etc.)
- Wire onSessionError callback through DaemonClient and handle .sessionError in ChatViewModel message handler with full UI state reset (mirrors existing .error behavior)
- Add @Published sessionError property with recovery suggestions per error category, plus dismissSessionError() for clearing both typed and legacy error state
- Add 13 comprehensive tests covering error state transitions, session filtering, cancellation suppression, recovery suggestions, error replacement, and cleanup

## Test plan
- [x] swift build --target VellumAssistantLib compiles without errors
- [x] swift build --target vellum-assistantTests compiles without errors
- [x] All new session error tests cover: setting typed state, recovery suggestions, clearing on send, cancellation suppression, session isolation, streaming finalization, processing status reset, dismiss logic, error replacement, retryable flag, and exhaustive category coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
