### PR TITLE
IPC M5: Migrate core session and chat messages to generated Swift types (#2001)

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -559,13 +559,12 @@ public struct CuErrorMessage: Decodable, Sendable {
 }
 
 /// Streamed text delta from the assistant's response.
-public struct AssistantTextDeltaMessage: Decodable, Sendable {
-    public let text: String
-    public let sessionId: String?
+/// Backed by generated `IPCAssistantTextDelta`.
+public typealias AssistantTextDeltaMessage = IPCAssistantTextDelta
 
+extension IPCAssistantTextDelta {
     public init(text: String, sessionId: String? = nil) {
-        self.text = text
-        self.sessionId = sessionId
+        self.init(type: "assistant_text_delta", text: text, sessionId: sessionId)
     }
 }
 
@@ -579,26 +578,22 @@ public struct AssistantThinkingDeltaMessage: Decodable, Sendable {
 }
 
 /// Signals that the assistant's message is complete.
-public struct MessageCompleteMessage: Decodable, Sendable {
-    public let sessionId: String?
+/// Backed by generated `IPCMessageComplete`.
+public typealias MessageCompleteMessage = IPCMessageComplete
 
+extension IPCMessageComplete {
     public init(sessionId: String? = nil) {
-        self.sessionId = sessionId
+        self.init(type: "message_complete", sessionId: sessionId)
     }
 }
 
 /// Session metadata from the server (e.g. generated title).
-public struct SessionInfoMessage: Decodable, Sendable {
-    public let sessionId: String
-    public let title: String
-    /// Echoed from the `session_create` request so the caller can match
-    /// this response to its specific request.
-    public let correlationId: String?
+/// Backed by generated `IPCSessionInfo`.
+public typealias SessionInfoMessage = IPCSessionInfo
 
+extension IPCSessionInfo {
     public init(sessionId: String, title: String, correlationId: String? = nil) {
-        self.sessionId = sessionId
-        self.title = title
-        self.correlationId = correlationId
+        self.init(type: "session_info", sessionId: sessionId, title: title, correlationId: correlationId)
     }
 }
 
@@ -720,11 +715,12 @@ public struct MessageDequeuedMessage: Decodable, Sendable {
 }
 
 /// Server-level error message.
-public struct ErrorMessage: Decodable, Sendable {
-    public let message: String
+/// Backed by generated `IPCErrorMessage`.
+public typealias ErrorMessage = IPCErrorMessage
 
+extension IPCErrorMessage {
     public init(message: String) {
-        self.message = message
+        self.init(type: "error", message: message)
     }
 }
 
@@ -932,15 +928,8 @@ public struct SkillsInspectResponseMessage: Decodable, Sendable {
 }
 
 /// Response containing the list of past sessions.
-/// Wire type: `"session_list_response"`
-public struct SessionListResponseMessage: Decodable, Sendable {
-    public struct SessionItem: Decodable, Sendable {
-        public let id: String
-        public let title: String
-        public let updatedAt: Int
-    }
-    public let sessions: [SessionItem]
-}
+/// Backed by generated `IPCSessionListResponse`.
+public typealias SessionListResponseMessage = IPCSessionListResponse
 
 /// Response containing message history for a session.
 /// Wire type: `"history_response"`


### PR DESCRIPTION
## Summary
- Replace manual struct definitions for `AssistantTextDeltaMessage`, `MessageCompleteMessage`, `SessionInfoMessage`, `ErrorMessage`, and `SessionListResponseMessage` with `typealias` to generated types from `IPCContractGenerated.swift`
- Add convenience `init` extensions on generated types to preserve backward-compatible constructors used by tests and existing call sites
- Encodable (client-to-server) types are intentionally kept as-is since they provide hardcoded `type` field defaults that generated types lack

## Test plan
- [x] `swift build --target vellum-assistantTests` passes with no errors
- [x] All existing constructor call sites (tests, view models) compile without changes

Closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
