### PR TITLE
feat(chat): typed session error state and recovery actions (M3)

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1111,4 +1111,212 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.sessionId, "test-session", "Should accept session_info when no correlationId was set")
     }
+
+    // MARK: - Session Error (Typed)
+
+    func testSessionErrorFromDifferentSessionIsIgnored() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        let error = SessionErrorMessage(
+            sessionId: "other-session",
+            code: .providerNetwork,
+            userMessage: "Network error",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+
+        // Should be ignored — different session
+        XCTAssertNil(viewModel.activeSessionError, "Session error from different session should be ignored")
+        XCTAssertTrue(viewModel.isThinking)
+        XCTAssertTrue(viewModel.isSending)
+    }
+
+    func testSessionErrorMatchingSetsTypedErrorAndStopsStreaming() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Start streaming an assistant message
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
+        XCTAssertTrue(viewModel.messages[1].isStreaming)
+
+        let error = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerApi,
+            userMessage: "API error occurred",
+            retryable: false,
+            debugDetails: "trace-id: abc-123"
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+
+        // Typed error should be set
+        XCTAssertNotNil(viewModel.activeSessionError)
+        XCTAssertEqual(viewModel.activeSessionError?.code, .providerApi)
+        XCTAssertEqual(viewModel.activeSessionError?.userMessage, "API error occurred")
+        XCTAssertEqual(viewModel.activeSessionError?.debugDetails, "trace-id: abc-123")
+        // Streaming should be stopped
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.isSending)
+        // errorText should NOT be set — session errors use activeSessionError
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    func testSessionErrorDuringCancellationSuppressesError() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Start streaming
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
+
+        // User cancels
+        viewModel.stopGenerating()
+
+        // Session error arrives during cancellation
+        let error = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .sessionAborted,
+            userMessage: "Session was aborted",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+
+        // Should NOT show the error during cancellation
+        XCTAssertNil(viewModel.activeSessionError, "Session error during cancellation should be suppressed")
+    }
+
+    func testRetryFromActiveErrorCallsRegenerate() {
+        viewModel.sessionId = "my-session"
+
+        // Set a retryable session error
+        let error = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerRateLimit,
+            userMessage: "Rate limited",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+        XCTAssertNotNil(viewModel.activeSessionError)
+
+        // Retry should clear the error and call regenerate
+        viewModel.retryFromActiveError()
+
+        XCTAssertNil(viewModel.activeSessionError, "Retry should clear active session error")
+        // regenerateLastMessage sets isSending and isThinking
+        XCTAssertTrue(viewModel.isSending)
+        XCTAssertTrue(viewModel.isThinking)
+    }
+
+    func testRetryFromActiveErrorNoOpWhenNotRetryable() {
+        viewModel.sessionId = "my-session"
+
+        let error = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerApi,
+            userMessage: "Fatal error",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+
+        viewModel.retryFromActiveError()
+
+        // Error should still be present — retry was blocked
+        XCTAssertNotNil(viewModel.activeSessionError, "Non-retryable error should not be cleared by retry")
+        XCTAssertFalse(viewModel.isSending)
+    }
+
+    func testRetryFromActiveErrorNoOpWhenAlreadySending() {
+        viewModel.sessionId = "my-session"
+        viewModel.isSending = true
+
+        viewModel.activeSessionError = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerRateLimit,
+            userMessage: "Rate limited",
+            retryable: true
+        )
+
+        viewModel.retryFromActiveError()
+
+        // Should be a no-op since isSending is true
+        XCTAssertNotNil(viewModel.activeSessionError, "Retry should no-op when already sending")
+    }
+
+    func testCopyActiveErrorDebugDetailsNoOpWhenNil() {
+        // Should not crash when no error or no debug details
+        viewModel.copyActiveErrorDebugDetails()
+
+        viewModel.activeSessionError = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerApi,
+            userMessage: "Error",
+            retryable: false,
+            debugDetails: nil
+        )
+        viewModel.copyActiveErrorDebugDetails()
+        // No crash = success
+    }
+
+    func testDismissActiveSessionErrorClearsError() {
+        viewModel.activeSessionError = SessionErrorMessage(
+            sessionId: "my-session",
+            code: .providerNetwork,
+            userMessage: "Network error",
+            retryable: true
+        )
+        viewModel.errorText = "Some local error"
+
+        viewModel.dismissActiveSessionError()
+
+        XCTAssertNil(viewModel.activeSessionError, "Dismiss should clear active session error")
+        // errorText should be unaffected
+        XCTAssertEqual(viewModel.errorText, "Some local error", "Dismiss session error should not clear local errorText")
+    }
+
+    func testSendMessageClearsActiveSessionError() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+
+        viewModel.activeSessionError = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "Previous error",
+            retryable: false
+        )
+
+        viewModel.inputText = "New message"
+        viewModel.sendMessage()
+
+        XCTAssertNil(viewModel.activeSessionError, "Sending a new message should clear active session error")
+    }
+
+    func testSessionErrorResetsProcessingMessagesToSent() {
+        viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
+
+        viewModel.inputText = "Message A"
+        viewModel.sendMessage()
+        viewModel.inputText = "Message B"
+        viewModel.sendMessage()
+
+        // Queue and dequeue B so it's in .processing state
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response A")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
+        XCTAssertEqual(viewModel.messages[2].status, .processing)
+
+        // Session error arrives while B is processing
+        let error = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .sessionProcessingFailed,
+            userMessage: "Processing failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(error))
+
+        XCTAssertEqual(viewModel.messages[2].status, .sent, "Session error should reset processing messages to .sent")
+        XCTAssertNotNil(viewModel.activeSessionError)
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -23,6 +23,7 @@ public final class ChatViewModel: ObservableObject {
     @Published public var pendingAttachments: [ChatAttachment] = []
     @Published public var isRecording: Bool = false
     @Published public var pendingSkillInvocation: SkillInvocationData?
+    @Published public var activeSessionError: SessionErrorMessage?
 
     /// Maximum file size per attachment (20 MB).
     private static let maxFileSize = 20 * 1024 * 1024
@@ -313,6 +314,7 @@ public final class ChatViewModel: ObservableObject {
         suggestion = nil
         pendingSuggestionRequestId = nil
         errorText = nil
+        activeSessionError = nil
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
@@ -838,6 +840,30 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
 
+        case .sessionError(let error):
+            guard belongsToSession(error.sessionId) else { return }
+            // Stop all in-flight UI state
+            isThinking = false
+            if let existingId = currentAssistantMessageId,
+               let index = messages.firstIndex(where: { $0.id == existingId }) {
+                messages[index].isStreaming = false
+            }
+            currentAssistantMessageId = nil
+            // Reset processing messages to sent
+            for i in messages.indices {
+                if messages[i].role == .user && messages[i].status == .processing {
+                    messages[i].status = .sent
+                }
+            }
+            if pendingQueuedCount == 0 {
+                isSending = false
+            }
+            // During active cancellation, treat as silent terminal cleanup
+            if !isCancelling {
+                activeSessionError = error
+            }
+            isCancelling = false
+
         default:
             break
         }
@@ -1007,6 +1033,30 @@ public final class ChatViewModel: ObservableObject {
 
     public func dismissError() {
         errorText = nil
+    }
+
+    /// Clear the typed session error without affecting local validation errors.
+    public func dismissActiveSessionError() {
+        activeSessionError = nil
+    }
+
+    /// Retry the last message if the active session error is retryable.
+    public func retryFromActiveError() {
+        guard let error = activeSessionError, error.retryable, !isSending else { return }
+        activeSessionError = nil
+        regenerateLastMessage()
+    }
+
+    /// Copy the debug details from the active session error to the system clipboard.
+    public func copyActiveErrorDebugDetails() {
+        guard let details = activeSessionError?.debugDetails else { return }
+        #if os(macOS)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(details, forType: .string)
+        #elseif os(iOS)
+        UIPasteboard.general.string = details
+        #endif
     }
 
     /// Respond to a tool confirmation request displayed inline in the chat.


### PR DESCRIPTION
Part of #2037. Adds `@Published activeSessionError` to ChatViewModel, handles `.sessionError` with session-scoped routing, and adds retry/copy/dismiss recovery actions. Includes comprehensive tests.

## Changes

### ChatViewModel (`clients/shared/Features/Chat/ChatViewModel.swift`)
- Add `@Published var activeSessionError: SessionErrorMessage?` for typed session errors
- Handle `.sessionError` in `handleServerMessage` with `belongsToSession` session-scoped filtering
- On session error: stop thinking/streaming, reset processing messages, clear `isSending` when queue is empty
- Suppress error storage during active cancellation (matches existing `.error` pattern)
- Add `retryFromActiveError()` — calls `regenerateLastMessage()` when error is retryable and not already sending
- Add `copyActiveErrorDebugDetails()` — copies debug details to system clipboard (macOS/iOS)
- Add `dismissActiveSessionError()` — clears typed error without affecting `errorText`
- Clear `activeSessionError` on new message send

### Tests (`clients/macos/vellum-assistantTests/ChatViewModelTests.swift`)
- Session mismatch ignores `session_error`
- Matching session sets typed error and stops streaming state
- Cancellation suppresses session error
- Retry calls expected path when retryable
- Retry no-ops when not retryable or already sending
- Copy no-ops safely when debug payload is missing
- Dismiss clears error independently from errorText
- Send clears active session error
- Session error resets processing messages to sent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
