### PR TITLE
feat(tracing): emit LLM turn and usage trace events (#2050)

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -314,12 +314,13 @@ describe('AgentLoop', () => {
 
     const usageEvents = events.filter((e) => e.type === 'usage');
     expect(usageEvents).toHaveLength(1);
-    expect(usageEvents[0]).toEqual({
-      type: 'usage',
-      inputTokens: 10,
-      outputTokens: 5,
-      model: 'mock-model',
-    });
+    const usage = usageEvents[0] as Extract<AgentEvent, { type: 'usage' }>;
+    expect(usage.type).toBe('usage');
+    expect(usage.inputTokens).toBe(10);
+    expect(usage.outputTokens).toBe(5);
+    expect(usage.model).toBe('mock-model');
+    expect(typeof usage.providerDurationMs).toBe('number');
+    expect(usage.providerDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   test('emits message_complete events', async () => {

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -111,7 +111,7 @@ mock.module('../agent/loop.js', () => ({
         ],
       };
       history.push(assistantMessage);
-      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 20, model: 'mock' });
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 20, model: 'mock', providerDurationMs: 50 });
       onEvent({ type: 'message_complete', message: assistantMessage });
 
       // First tool completes — fires tool_result event

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -87,7 +87,7 @@ mock.module('../agent/loop.js', () => ({
     async run(messages: Message[], onEvent: (event: Record<string, unknown>) => void): Promise<Message[]> {
       capturedRunMessages = messages;
       // Emit usage event so processMessage doesn't error
-      onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock' });
+      onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock', providerDurationMs: 0 });
       // Return messages with an assistant response appended
       return [
         ...messages,

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -102,7 +102,7 @@ mock.module('../agent/loop.js', () => ({
 
       if (shouldEmitOrderingError && agentLoopRunCount === 1) {
         // First call: simulate provider ordering error (no messages appended)
-        onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock' });
+        onEvent({ type: 'usage', inputTokens: 0, outputTokens: 0, model: 'mock', providerDurationMs: 0 });
         onEvent({
           type: 'error',
           error: new Error('tool_result blocks that are not immediately after a tool_use block'),
@@ -111,7 +111,7 @@ mock.module('../agent/loop.js', () => ({
       }
 
       // Second call (retry) or non-error: succeed normally
-      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 20, model: 'mock' });
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 20, model: 'mock', providerDurationMs: 50 });
       const history = [...messages];
       const assistantMsg: Message = {
         role: 'assistant',

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -202,7 +202,7 @@ function resolveRun(index: number) {
     role: 'assistant',
     content: [{ type: 'text', text: `reply-${index}` }],
   };
-  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
   run.onEvent({ type: 'message_complete', message: assistantMsg });
   // Return updated history with the assistant message appended
   run.resolve([...run.messages, assistantMsg]);

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -190,7 +190,7 @@ function resolveRun(index: number) {
     role: 'assistant',
     content: [{ type: 'text', text: `reply-${index}` }],
   };
-  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
   run.onEvent({ type: 'message_complete', message: assistantMsg });
   run.resolve([...run.messages, assistantMsg]);
 }

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -190,7 +190,7 @@ function resolveRun(index: number) {
     role: 'assistant',
     content: [{ type: 'text', text: `reply-${index}` }],
   };
-  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+  run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
   run.onEvent({ type: 'message_complete', message: assistantMsg });
   run.resolve([...run.messages, assistantMsg]);
 }

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -147,7 +147,7 @@ mock.module('../agent/loop.js', () => ({
         role: 'assistant',
         content: [{ type: 'text', text: 'reply' }],
       };
-      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock' });
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
       onEvent({ type: 'message_complete', message: assistantMsg });
       return [...messages, assistantMsg];
     }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -28,7 +28,7 @@ export type AgentEvent =
   | { type: 'tool_output_chunk'; toolUseId: string; chunk: string }
   | { type: 'tool_result'; toolUseId: string; content: string; isError: boolean; diff?: { filePath: string; oldContent: string; newContent: string; isNewFile: boolean }; status?: string; contentBlocks?: ContentBlock[] }
   | { type: 'error'; error: Error }
-  | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string };
+  | { type: 'usage'; inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; model: string; providerDurationMs: number };
 
 const DEFAULT_CONFIG: AgentLoopConfig = {
   maxTokens: 64000,
@@ -163,6 +163,7 @@ export class AgentLoop {
           cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
+          providerDurationMs,
         });
 
         void getHookManager().trigger('post-llm-call', {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -603,13 +603,37 @@ export class Session {
       let deferredOrderingError: string | null = null;
       let preRunHistoryLength = runMessages.length;
 
+      // Track whether llm_call_started has been emitted for the current provider turn.
+      // Reset on each usage event (which marks the end of a provider call).
+      let llmCallStartedEmitted = false;
+
       const buildEventHandler = () => (event: import('../agent/loop.js').AgentEvent) => {
         switch (event.type) {
           case 'text_delta':
+            // Emit llm_call_started on the first streaming token of each provider call
+            if (!llmCallStartedEmitted) {
+              llmCallStartedEmitted = true;
+              this.traceEmitter.emit('llm_call_started', `LLM call to ${this.provider.name}`, {
+                requestId: reqId,
+                status: 'info',
+                attributes: { provider: this.provider.name, model: model || 'unknown' },
+              });
+            }
             onEvent({ type: 'assistant_text_delta', text: event.text, sessionId: this.conversationId });
             if (isFirstMessage) firstAssistantText += event.text;
             break;
           case 'thinking_delta':
+            // Emit llm_call_started on first thinking token if not already emitted.
+            // Thinking content itself is NOT included in traces to avoid leaking
+            // extended-thinking data.
+            if (!llmCallStartedEmitted) {
+              llmCallStartedEmitted = true;
+              this.traceEmitter.emit('llm_call_started', `LLM call to ${this.provider.name}`, {
+                requestId: reqId,
+                status: 'info',
+                attributes: { provider: this.provider.name, model: model || 'unknown' },
+              });
+            }
             onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
             break;
           case 'tool_use':
@@ -662,12 +686,43 @@ export class Session {
               'assistant',
               JSON.stringify(event.message.content),
             );
+
+            // Emit assistant_message trace with content metrics.
+            // Char count only includes text blocks; thinking blocks are
+            // explicitly excluded from traces.
+            const charCount = event.message.content
+              .filter((b) => b.type === 'text')
+              .reduce((sum, b) => sum + ((b as { type: 'text'; text: string }).text?.length ?? 0), 0);
+            const toolUseCount = event.message.content
+              .filter((b) => b.type === 'tool_use')
+              .length;
+            this.traceEmitter.emit('assistant_message', 'Assistant message complete', {
+              requestId: reqId,
+              status: 'success',
+              attributes: { charCount, toolUseCount },
+            });
             break;
           }
           case 'usage':
             exchangeInputTokens += event.inputTokens;
             exchangeOutputTokens += event.outputTokens;
             model = event.model;
+
+            // Emit llm_call_finished trace with token and latency metrics
+            this.traceEmitter.emit('llm_call_finished', `LLM call to ${this.provider.name} finished`, {
+              requestId: reqId,
+              status: 'success',
+              attributes: {
+                provider: this.provider.name,
+                model: event.model,
+                inputTokens: event.inputTokens,
+                outputTokens: event.outputTokens,
+                latencyMs: event.providerDurationMs,
+              },
+            });
+            // Reset flag so the next provider call in this agent loop run
+            // gets its own llm_call_started trace
+            llmCallStartedEmitted = false;
             break;
         }
       };


### PR DESCRIPTION
## Summary
- Extend AgentEvent.usage with providerDurationMs so the session layer can report per-call latency
- Emit llm_call_started trace on the first streaming token (text_delta or thinking_delta) of each provider call
- Emit llm_call_finished trace on each usage event with provider, model, inputTokens, outputTokens, and latencyMs
- Emit assistant_message trace on message_complete with charCount (text blocks only) and toolUseCount
- Explicitly exclude thinking_delta content from traces
- Update all session-related tests to include providerDurationMs in mock usage events

## Test plan
- [x] bun test agent-loop.test.ts -- 30/30 pass (providerDurationMs validated)
- [x] bun test session-queue.test.ts -- 22/22 pass
- [x] bun test tool-trace-listener.test.ts -- 9/9 pass
- [x] bunx tsc --noEmit -- clean type check
- [x] All session-related tests pass (slash-known, slash-queue, slash-unknown, pre-run-repair, abort-tool-results)
- [x] Pre-existing test failures confirmed on main (session-provider-retry-repair)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
