### PR TITLE
fix(ui): use single TextField with conditional prompt to preserve focus

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,47 +363,29 @@ struct ChatView: View {
             ZStack(alignment: .bottom) {
                 ScrollView(.vertical, showsIndicators: false) {
                     ZStack(alignment: .leading) {
-                        if ghostSuffix != nil {
-                            TextField("", text: $inputText, axis: .vertical)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textPrimary)
-                                .lineSpacing(4)
-                                .textFieldStyle(.plain)
-                                .lineLimit(1...)
-                                .disabled(!hasAPIKey)
-                                .accessibilityLabel("Message")
-                                .background(
-                                    GeometryReader { geo in
-                                        Color.clear
-                                            .onAppear { editorContentHeight = geo.size.height }
-                                            .onChange(of: geo.size.height) { _, h in
-                                                withAnimation(VAnimation.spring) {
-                                                    editorContentHeight = h
-                                                }
-                                            }
+                        TextField(
+                            ghostSuffix != nil ? "" : "What would you like to do?",
+                            text: $inputText,
+                            axis: .vertical
+                        )
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineSpacing(4)
+                        .textFieldStyle(.plain)
+                        .lineLimit(1...)
+                        .disabled(!hasAPIKey)
+                        .accessibilityLabel("Message")
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear
+                                    .onAppear { editorContentHeight = geo.size.height }
+                                    .onChange(of: geo.size.height) { _, h in
+                                        withAnimation(VAnimation.spring) {
+                                            editorContentHeight = h
+                                        }
                                     }
-                                )
-                        } else {
-                            TextField("What would you like to do?", text: $inputText, axis: .vertical)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textPrimary)
-                                .lineSpacing(4)
-                                .textFieldStyle(.plain)
-                                .lineLimit(1...)
-                                .disabled(!hasAPIKey)
-                                .accessibilityLabel("Message")
-                                .background(
-                                    GeometryReader { geo in
-                                        Color.clear
-                                            .onAppear { editorContentHeight = geo.size.height }
-                                            .onChange(of: geo.size.height) { _, h in
-                                                withAnimation(VAnimation.spring) {
-                                                    editorContentHeight = h
-                                                }
-                                            }
-                                    }
-                                )
-                        }
+                            }
+                        )
 
                         if let ghostSuffix {
                             (Text(inputText)


### PR DESCRIPTION
## Summary
- Replaces the `if ghostSuffix != nil { TextField(...) } else { TextField(...) }` branching in the composer area with a single `TextField` that uses a conditional prompt string
- This preserves the TextField's structural identity in SwiftUI's view tree, preventing focus loss when ghost suggestions appear or disappear
- Addresses review feedback from Devin on PR #2104

## Context
When `ghostSuffix` transitioned between `nil` and non-nil, SwiftUI treated the two `TextField` declarations as different views (different structural identities). This caused the old TextField to be destroyed and a new one created, which made the user lose keyboard focus every time a ghost text suggestion appeared or disappeared.

The fix collapses both branches into one `TextField` with a ternary expression for the prompt:
```swift
TextField(
    ghostSuffix != nil ? "" : "What would you like to do?",
    text: $inputText,
    axis: .vertical
)
```

## Test plan
- [x] Build succeeds (`./build.sh`)
- [ ] Verify typing in the composer with ghost suggestions enabled does not cause focus loss
- [ ] Verify placeholder text "What would you like to do?" still appears when there is no ghost suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
