### PR TITLE
Actionable toast UI for typed session errors in main chat (#2042)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -29,6 +29,9 @@ struct ChatView: View {
     let onAddTrustRule: (String, String, String, String) -> Bool
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onRegenerate: () -> Void
+    let sessionError: SessionError?
+    let onRetry: () -> Void
+    let onDismissSessionError: () -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -103,14 +106,16 @@ struct ChatView: View {
         // text area + button row (28pt) + button top padding (xs) + outer padding
         let base: CGFloat = VSpacing.md * 2 + VSpacing.sm * 2 + contentHeight + 28 + VSpacing.xs
         let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 44
-        let error: CGFloat = errorText != nil ? 36 : 0
+        let error: CGFloat = sessionError != nil ? 60 : (errorText != nil ? 36 : 0)
         let queue: CGFloat = pendingQueuedCount > 0 ? 24 : 0
         return base + attachments + error + queue
     }
 
     private var composerOverlay: some View {
         VStack(spacing: 0) {
-            if let errorText {
+            if let sessionError {
+                sessionErrorToast(sessionError)
+            } else if let errorText {
                 errorBanner(errorText)
             }
             queueSummary
@@ -329,6 +334,113 @@ struct ChatView: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .background(VColor.error)
+    }
+
+    // MARK: - Session Error Toast
+
+    private func sessionErrorToast(_ error: SessionError) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: sessionErrorIcon(error.category))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(sessionErrorAccent(error.category))
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(error.message)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+
+                Text(error.recoverySuggestion)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if error.isRetryable {
+                Button(action: onRetry) {
+                    Text(sessionErrorActionLabel(error.category))
+                        .font(VFont.captionMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(sessionErrorAccent(error.category))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(sessionErrorActionLabel(error.category))
+            }
+
+            Button {
+                onDismissSessionError()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+        .background(sessionErrorAccent(error.category).opacity(0.1))
+        .overlay(
+            Rectangle()
+                .fill(sessionErrorAccent(error.category))
+                .frame(width: 3),
+            alignment: .leading
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    /// SF Symbol icon appropriate for each error category.
+    private func sessionErrorIcon(_ category: SessionErrorCategory) -> String {
+        switch category {
+        case .providerNetwork:
+            return "wifi.exclamationmark"
+        case .rateLimit:
+            return "clock.badge.exclamationmark"
+        case .providerApi:
+            return "exclamationmark.icloud.fill"
+        case .queueFull:
+            return "tray.full.fill"
+        case .sessionAborted:
+            return "stop.circle.fill"
+        case .processingFailed, .regenerateFailed:
+            return "arrow.triangle.2.circlepath"
+        case .unknown:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    /// Accent color for each error category -- warm for transient/retryable,
+    /// red for hard failures.
+    private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
+        switch category {
+        case .rateLimit, .queueFull:
+            return VColor.warning
+        case .providerNetwork:
+            return Amber._500
+        case .sessionAborted:
+            return VColor.textSecondary
+        default:
+            return VColor.error
+        }
+    }
+
+    /// Action button label tailored to the error category.
+    private func sessionErrorActionLabel(_ category: SessionErrorCategory) -> String {
+        switch category {
+        case .rateLimit:
+            return "Retry"
+        case .regenerateFailed:
+            return "Retry"
+        case .providerNetwork:
+            return "Retry"
+        default:
+            return "Retry"
+        }
     }
 
     // MARK: - Queue Summary
@@ -1112,7 +1224,10 @@ private struct ChatViewPreviewWrapper: View {
                 onConfirmationDeny: { _ in },
                 onAddTrustRule: { _, _, _, _ in true },
                 onSurfaceAction: { _, _, _ in },
-                onRegenerate: {}
+                onRegenerate: {},
+                sessionError: nil,
+                onRetry: {},
+                onDismissSessionError: {}
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -88,7 +88,10 @@ struct MainWindowView: View {
                                 onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
                                 onAddTrustRule: { toolName, pattern, scope, decision in return viewModel.addTrustRule(toolName: toolName, pattern: pattern, scope: scope, decision: decision) },
                                 onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
-                                onRegenerate: { viewModel.regenerateLastMessage() }
+                                onRegenerate: { viewModel.regenerateLastMessage() },
+                                sessionError: viewModel.sessionError,
+                                onRetry: { viewModel.regenerateLastMessage() },
+                                onDismissSessionError: { viewModel.dismissSessionError() }
                             )
                         }
                     }, panel: {

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1119,7 +1119,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isSending = true
         viewModel.isThinking = true
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerRateLimit,
             userMessage: "Rate limit exceeded",
@@ -1137,7 +1137,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSessionErrorSetsRecoverySuggestion() {
         viewModel.sessionId = "sess-1"
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerNetwork,
             userMessage: "Connection failed",
@@ -1155,7 +1155,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isSending = true
         viewModel.isThinking = true
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerApi,
             userMessage: "API error",
@@ -1170,7 +1170,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSessionErrorAlsoSetsErrorText() {
         viewModel.sessionId = "sess-1"
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerApi,
             userMessage: "Provider returned 500",
@@ -1185,7 +1185,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSessionErrorFromDifferentSessionIsIgnored() {
         viewModel.sessionId = "sess-1"
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-other",
             code: .providerNetwork,
             userMessage: "Connection failed",
@@ -1206,7 +1206,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial")))
         XCTAssertTrue(viewModel.messages[1].isStreaming)
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .sessionProcessingFailed,
             userMessage: "Processing failed",
@@ -1234,7 +1234,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         XCTAssertEqual(viewModel.messages[2].status, .processing)
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .sessionProcessingFailed,
             userMessage: "Processing failed",
@@ -1249,7 +1249,7 @@ final class ChatViewModelTests: XCTestCase {
     func testDismissSessionErrorClearsBothErrorStates() {
         viewModel.sessionId = "sess-1"
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerRateLimit,
             userMessage: "Rate limited",
@@ -1269,7 +1269,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSendMessageClearsSessionError() {
         viewModel.handleServerMessage(.sessionInfo(SessionInfoMessage(sessionId: "sess-1", title: "Chat")))
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerApi,
             userMessage: "API error",
@@ -1302,7 +1302,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
         viewModel.stopGenerating()
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .sessionAborted,
             userMessage: "Session aborted",
@@ -1320,7 +1320,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSessionErrorNonRetryableFlag() {
         viewModel.sessionId = "sess-1"
 
-        let errorMsg = SessionErrorMessagePayload(
+        let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
             code: .queueFull,
             userMessage: "Queue is full",
@@ -1335,7 +1335,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSessionErrorReplacedBySubsequentError() {
         viewModel.sessionId = "sess-1"
 
-        let firstError = SessionErrorMessagePayload(
+        let firstError = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerNetwork,
             userMessage: "Network error",
@@ -1344,7 +1344,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.sessionError(firstError))
         XCTAssertEqual(viewModel.sessionError?.category, .providerNetwork)
 
-        let secondError = SessionErrorMessagePayload(
+        let secondError = SessionErrorMessage(
             sessionId: "sess-1",
             code: .providerRateLimit,
             userMessage: "Rate limited",

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -74,7 +74,7 @@ public struct SessionError: Equatable {
     public let recoverySuggestion: String
     public let sessionId: String
 
-    public init(from msg: SessionErrorMessagePayload) {
+    public init(from msg: SessionErrorMessage) {
         self.category = SessionErrorCategory(from: msg.code)
         self.message = msg.userMessage
         self.isRetryable = msg.retryable

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -128,7 +128,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
     /// Called when the daemon sends a `session_error` message with typed error information.
-    public var onSessionError: ((SessionErrorMessagePayload) -> Void)?
+    public var onSessionError: ((SessionErrorMessage) -> Void)?
 
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?


### PR DESCRIPTION
## Summary
- Adds a rich sessionErrorToast view in ChatView that binds to the ChatViewModel typed SessionError state from M3
- Shows category-appropriate SF Symbol icons (wifi, clock, cloud, tray, etc.) and accent colors (amber for transient errors, rose for hard failures)
- Displays the error message with a recovery suggestion subtitle
- Provides a Retry action button for retryable errors (triggers regenerateLastMessage)
- Dismissible via X button with slide+fade animation
- Non-blocking: sits above the composer overlay, does not prevent continued chat interaction
- Falls back to the existing simple error banner when only legacy errorText is set (no typed sessionError)
- Fixes SessionErrorMessagePayload to SessionErrorMessage type mismatch from M3 that prevented shared targets from compiling

## Test plan
- [x] swift build --target vellum-assistant passes
- [x] swift build --target VellumAssistantLib passes
- [x] swift build --target VellumAssistantShared passes
- [x] swift build --target vellum-assistantTests passes
- [ ] Verify toast appears on rate limit / provider errors
- [ ] Verify retry button triggers regeneration
- [ ] Verify dismiss button clears both sessionError and errorText
- [ ] Verify legacy errorText-only errors still show the old banner

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
