### PR TITLE
Add vellum doctor sandbox backend diagnostics (#2031)

### DIFF
--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -1,0 +1,401 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realChildProcess from 'node:child_process';
+
+const execSyncMock = mock((_command: string, _opts?: unknown): unknown => undefined);
+const execFileSyncMock = mock(
+  (_file: string, _args?: readonly string[], _opts?: unknown): unknown => undefined,
+);
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  execSync: execSyncMock,
+  execFileSync: execFileSyncMock,
+}));
+
+// Mock platform detection — default to macOS
+let mockIsMacOS = true;
+let mockIsLinux = false;
+
+mock.module('../util/platform.js', () => ({
+  isMacOS: () => mockIsMacOS,
+  isLinux: () => mockIsLinux,
+  getRootDir: () => '/tmp/vellum-test',
+  getDataDir: () => '/tmp/vellum-test/data',
+  getSocketPath: () => '/tmp/vellum-test/vellum.sock',
+  getDbPath: () => '/tmp/vellum-test/data/db/assistant.db',
+  getLogPath: () => '/tmp/vellum-test/data/logs/daemon.log',
+  getSandboxRootDir: () => '/tmp/vellum-test/sandbox',
+  getSandboxWorkingDir: () => '/tmp/vellum-test/sandbox/workspace',
+  ensureDataDir: () => {},
+  getHistoryPath: () => '/tmp/vellum-test/data/history',
+  getHooksDir: () => '/tmp/vellum-test/hooks',
+  getPidPath: () => '/tmp/vellum-test/data/daemon.pid',
+}));
+
+// Mock config loader — return a config with sandbox settings
+let mockSandboxConfig = {
+  enabled: true,
+  backend: 'native' as const,
+  docker: {
+    image: 'node:20-slim',
+    cpus: 1,
+    memoryMb: 512,
+    pidsLimit: 256,
+    network: 'none' as const,
+  },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    sandbox: mockSandboxConfig,
+  }),
+  loadRawConfig: () => ({}),
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { runSandboxDiagnostics } = await import(
+  '../tools/terminal/sandbox-diagnostics.js'
+);
+
+beforeEach(() => {
+  execSyncMock.mockReset();
+  execFileSyncMock.mockReset();
+  mockIsMacOS = true;
+  mockIsLinux = false;
+  mockSandboxConfig = {
+    enabled: true,
+    backend: 'native',
+    docker: {
+      image: 'node:20-slim',
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: 'none',
+    },
+  };
+  // Default: all commands succeed. execSync with encoding returns a string,
+  // so we must return a string to avoid .trim() throwing on undefined.
+  execSyncMock.mockImplementation(() => 'Docker version 24.0.7, build afdd53b');
+  execFileSyncMock.mockImplementation(() => 'ok\n');
+});
+
+describe('runSandboxDiagnostics — config reporting', () => {
+  test('reports sandbox enabled state', () => {
+    const result = runSandboxDiagnostics();
+    expect(result.config.enabled).toBe(true);
+  });
+
+  test('reports sandbox disabled state', () => {
+    mockSandboxConfig.enabled = false;
+    const result = runSandboxDiagnostics();
+    expect(result.config.enabled).toBe(false);
+  });
+
+  test('reports configured backend', () => {
+    const result = runSandboxDiagnostics();
+    expect(result.config.backend).toBe('native');
+  });
+
+  test('reports docker backend when configured', () => {
+    mockSandboxConfig.backend = 'docker';
+    const result = runSandboxDiagnostics();
+    expect(result.config.backend).toBe('docker');
+  });
+
+  test('reports docker image', () => {
+    const result = runSandboxDiagnostics();
+    expect(result.config.dockerImage).toBe('node:20-slim');
+  });
+});
+
+describe('runSandboxDiagnostics — active backend reason', () => {
+  test('explains native backend selection', () => {
+    const result = runSandboxDiagnostics();
+    expect(result.activeBackendReason).toContain('Native backend');
+  });
+
+  test('explains docker backend selection', () => {
+    mockSandboxConfig.backend = 'docker';
+    const result = runSandboxDiagnostics();
+    expect(result.activeBackendReason).toContain('Docker backend');
+  });
+
+  test('explains when sandbox is disabled', () => {
+    mockSandboxConfig.enabled = false;
+    const result = runSandboxDiagnostics();
+    expect(result.activeBackendReason).toContain('disabled');
+  });
+});
+
+describe('runSandboxDiagnostics — native backend check (macOS)', () => {
+  test('passes when sandbox-exec works on macOS', () => {
+    const result = runSandboxDiagnostics();
+    const nativeCheck = result.checks.find((c) => c.label.includes('Native sandbox'));
+    expect(nativeCheck).toBeDefined();
+    expect(nativeCheck!.ok).toBe(true);
+    expect(nativeCheck!.label).toContain('macOS');
+  });
+
+  test('fails when sandbox-exec does not work on macOS', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('sandbox-exec')) {
+        throw new Error('not available');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const nativeCheck = result.checks.find((c) => c.label.includes('Native sandbox'));
+    expect(nativeCheck).toBeDefined();
+    expect(nativeCheck!.ok).toBe(false);
+  });
+});
+
+describe('runSandboxDiagnostics — native backend check (Linux)', () => {
+  test('passes when bwrap works on Linux', () => {
+    mockIsMacOS = false;
+    mockIsLinux = true;
+    const result = runSandboxDiagnostics();
+    const nativeCheck = result.checks.find((c) => c.label.includes('Native sandbox'));
+    expect(nativeCheck).toBeDefined();
+    expect(nativeCheck!.ok).toBe(true);
+    expect(nativeCheck!.label).toContain('Linux');
+  });
+
+  test('fails when bwrap is not available on Linux', () => {
+    mockIsMacOS = false;
+    mockIsLinux = true;
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('bwrap')) {
+        throw new Error('not found');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const nativeCheck = result.checks.find((c) => c.label.includes('Native sandbox'));
+    expect(nativeCheck).toBeDefined();
+    expect(nativeCheck!.ok).toBe(false);
+    expect(nativeCheck!.detail).toContain('bubblewrap');
+  });
+});
+
+describe('runSandboxDiagnostics — native backend check (unsupported OS)', () => {
+  test('reports unsupported when neither macOS nor Linux', () => {
+    mockIsMacOS = false;
+    mockIsLinux = false;
+    const result = runSandboxDiagnostics();
+    const nativeCheck = result.checks.find((c) => c.label.includes('Native sandbox'));
+    expect(nativeCheck).toBeDefined();
+    expect(nativeCheck!.ok).toBe(false);
+    expect(nativeCheck!.detail).toContain('not supported');
+  });
+});
+
+describe('runSandboxDiagnostics — Docker CLI check', () => {
+  test('passes when docker CLI is available', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker --version') {
+        return 'Docker version 24.0.7, build afdd53b';
+      }
+      return undefined;
+    });
+    const result = runSandboxDiagnostics();
+    const cliCheck = result.checks.find((c) => c.label === 'Docker CLI installed');
+    expect(cliCheck).toBeDefined();
+    expect(cliCheck!.ok).toBe(true);
+    expect(cliCheck!.detail).toContain('Docker version');
+  });
+
+  test('fails when docker CLI is not found', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker --version') {
+        throw new Error('command not found: docker');
+      }
+      return undefined;
+    });
+    const result = runSandboxDiagnostics();
+    const cliCheck = result.checks.find((c) => c.label === 'Docker CLI installed');
+    expect(cliCheck).toBeDefined();
+    expect(cliCheck!.ok).toBe(false);
+    expect(cliCheck!.detail).toContain('not found');
+  });
+});
+
+describe('runSandboxDiagnostics — Docker daemon check', () => {
+  test('passes when daemon is reachable', () => {
+    const result = runSandboxDiagnostics();
+    const daemonCheck = result.checks.find((c) => c.label === 'Docker daemon running');
+    expect(daemonCheck).toBeDefined();
+    expect(daemonCheck!.ok).toBe(true);
+  });
+
+  test('fails when daemon is not running', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker info') {
+        throw new Error('Cannot connect to the Docker daemon');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const daemonCheck = result.checks.find((c) => c.label === 'Docker daemon running');
+    expect(daemonCheck).toBeDefined();
+    expect(daemonCheck!.ok).toBe(false);
+  });
+
+  test('skipped when CLI is not available', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('command not found');
+      }
+      return undefined;
+    });
+    const result = runSandboxDiagnostics();
+    const daemonCheck = result.checks.find((c) => c.label === 'Docker daemon running');
+    expect(daemonCheck).toBeUndefined();
+  });
+});
+
+describe('runSandboxDiagnostics — Docker image check', () => {
+  test('passes when image is available locally', () => {
+    const result = runSandboxDiagnostics();
+    const imageCheck = result.checks.find((c) => c.label.includes('Docker image available'));
+    expect(imageCheck).toBeDefined();
+    expect(imageCheck!.ok).toBe(true);
+  });
+
+  test('fails when image is not available', () => {
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (file === 'docker' && Array.isArray(args) && args.includes('inspect')) {
+          throw new Error('No such image');
+        }
+        return 'ok\n';
+      },
+    );
+    const result = runSandboxDiagnostics();
+    const imageCheck = result.checks.find((c) => c.label.includes('Docker image available'));
+    expect(imageCheck).toBeDefined();
+    expect(imageCheck!.ok).toBe(false);
+    expect(imageCheck!.detail).toContain('docker pull');
+  });
+
+  test('includes configured image name in label', () => {
+    mockSandboxConfig.docker.image = 'alpine:3.19';
+    const result = runSandboxDiagnostics();
+    const imageCheck = result.checks.find((c) => c.label.includes('Docker image available'));
+    expect(imageCheck).toBeDefined();
+    expect(imageCheck!.label).toContain('alpine:3.19');
+  });
+
+  test('skipped when daemon is not running', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker info') {
+        throw new Error('Cannot connect');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const imageCheck = result.checks.find((c) => c.label.includes('Docker image available'));
+    expect(imageCheck).toBeUndefined();
+  });
+});
+
+describe('runSandboxDiagnostics — Docker container execution check', () => {
+  test('passes when container runs successfully', () => {
+    const result = runSandboxDiagnostics();
+    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
+    expect(runCheck).toBeDefined();
+    expect(runCheck!.ok).toBe(true);
+  });
+
+  test('fails when container execution errors', () => {
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (file === 'docker' && Array.isArray(args) && args.includes('run')) {
+          throw new Error('container failed');
+        }
+        return 'ok\n';
+      },
+    );
+    const result = runSandboxDiagnostics();
+    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
+    expect(runCheck).toBeDefined();
+    expect(runCheck!.ok).toBe(false);
+  });
+
+  test('fails when container output is unexpected', () => {
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (file === 'docker' && Array.isArray(args) && args.includes('run')) {
+          return 'unexpected\n';
+        }
+        return 'ok\n';
+      },
+    );
+    const result = runSandboxDiagnostics();
+    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
+    expect(runCheck).toBeDefined();
+    expect(runCheck!.ok).toBe(false);
+    expect(runCheck!.detail).toContain('unexpected');
+  });
+
+  test('skipped when daemon is not running', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker info') {
+        throw new Error('Cannot connect');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
+    expect(runCheck).toBeUndefined();
+  });
+});
+
+describe('runSandboxDiagnostics — check cascade', () => {
+  test('Docker daemon, image, and run checks are skipped when CLI is missing', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('docker')) {
+        throw new Error('not found');
+      }
+      return undefined;
+    });
+    const result = runSandboxDiagnostics();
+    const labels = result.checks.map((c) => c.label);
+    expect(labels).toContain('Docker CLI installed');
+    expect(labels).not.toContain('Docker daemon running');
+    expect(labels.find((l) => l.includes('Docker image'))).toBeUndefined();
+    expect(labels).not.toContain('Docker container execution');
+  });
+
+  test('image and run checks are skipped when daemon is down', () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd === 'docker info') {
+        throw new Error('Cannot connect');
+      }
+      return 'Docker version 24.0.7';
+    });
+    const result = runSandboxDiagnostics();
+    const labels = result.checks.map((c) => c.label);
+    expect(labels).toContain('Docker CLI installed');
+    expect(labels).toContain('Docker daemon running');
+    expect(labels.find((l) => l.includes('Docker image'))).toBeUndefined();
+    expect(labels).not.toContain('Docker container execution');
+  });
+
+  test('all Docker checks run when everything works', () => {
+    const result = runSandboxDiagnostics();
+    const labels = result.checks.map((c) => c.label);
+    expect(labels).toContain('Docker CLI installed');
+    expect(labels).toContain('Docker daemon running');
+    expect(labels.find((l) => l.includes('Docker image'))).toBeDefined();
+    expect(labels).toContain('Docker container execution');
+  });
+});

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -898,6 +898,24 @@ program
     } else {
       fail('Browser runtime', browserStatus.error ?? 'Chromium not installed');
     }
+
+    // 13. Sandbox backend diagnostics
+    const { runSandboxDiagnostics } = await import('./tools/terminal/sandbox-diagnostics.js');
+    const sandbox = runSandboxDiagnostics();
+    console.log(`\n  Sandbox:   ${sandbox.config.enabled ? 'enabled' : 'disabled'}`);
+    console.log(`  Backend:   ${sandbox.config.backend}`);
+    console.log(`  Reason:    ${sandbox.activeBackendReason}`);
+    if (sandbox.config.backend === 'docker') {
+      console.log(`  Image:     ${sandbox.config.dockerImage}`);
+    }
+    console.log('');
+    for (const check of sandbox.checks) {
+      if (check.ok) {
+        pass(check.label);
+      } else {
+        fail(check.label, check.detail);
+      }
+    }
   });
 
 // --- Hooks commands ---

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -1,0 +1,134 @@
+import { execSync, execFileSync } from 'node:child_process';
+import { isMacOS, isLinux } from '../../util/platform.js';
+import { getConfig } from '../../config/loader.js';
+import type { SandboxConfig } from '../../config/schema.js';
+
+export interface SandboxCheckResult {
+  label: string;
+  ok: boolean;
+  detail?: string;
+}
+
+export interface SandboxDiagnostics {
+  config: {
+    enabled: boolean;
+    backend: string;
+    dockerImage: string;
+  };
+  /** Why the active backend was selected (config vs platform default). */
+  activeBackendReason: string;
+  checks: SandboxCheckResult[];
+}
+
+function checkDockerCli(): SandboxCheckResult {
+  try {
+    const out = execSync('docker --version', { stdio: 'pipe', timeout: 5000, encoding: 'utf-8' }).trim();
+    return { label: 'Docker CLI installed', ok: true, detail: out };
+  } catch {
+    return { label: 'Docker CLI installed', ok: false, detail: 'docker not found in PATH' };
+  }
+}
+
+function checkDockerDaemon(): SandboxCheckResult {
+  try {
+    execSync('docker info', { stdio: 'pipe', timeout: 10000 });
+    return { label: 'Docker daemon running', ok: true };
+  } catch {
+    return { label: 'Docker daemon running', ok: false, detail: 'daemon not reachable — start Docker Desktop or run "sudo systemctl start docker"' };
+  }
+}
+
+function checkDockerImage(image: string): SandboxCheckResult {
+  try {
+    execFileSync('docker', ['image', 'inspect', image], { stdio: 'pipe', timeout: 10000 });
+    return { label: `Docker image available (${image})`, ok: true };
+  } catch {
+    return { label: `Docker image available (${image})`, ok: false, detail: `pull with: docker pull ${image}` };
+  }
+}
+
+function checkDockerRun(): SandboxCheckResult {
+  try {
+    const out = execFileSync(
+      'docker',
+      ['run', '--rm', 'ubuntu:22.04', 'echo', 'ok'],
+      { stdio: 'pipe', timeout: 15000, encoding: 'utf-8' },
+    ).trim();
+    if (out === 'ok') {
+      return { label: 'Docker container execution', ok: true };
+    }
+    return { label: 'Docker container execution', ok: false, detail: `unexpected output: ${out}` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown error';
+    return { label: 'Docker container execution', ok: false, detail: msg };
+  }
+}
+
+function checkNativeBackend(): SandboxCheckResult {
+  if (isMacOS()) {
+    try {
+      execSync('sandbox-exec -n no-network true', { stdio: 'pipe', timeout: 5000 });
+      return { label: 'Native sandbox (macOS sandbox-exec)', ok: true };
+    } catch {
+      return { label: 'Native sandbox (macOS sandbox-exec)', ok: false, detail: 'sandbox-exec not functional' };
+    }
+  }
+  if (isLinux()) {
+    try {
+      execSync('bwrap --ro-bind / / --unshare-net --unshare-pid true', { stdio: 'pipe', timeout: 5000 });
+      return { label: 'Native sandbox (Linux bwrap)', ok: true };
+    } catch {
+      return { label: 'Native sandbox (Linux bwrap)', ok: false, detail: 'bwrap not available — install bubblewrap' };
+    }
+  }
+  return { label: 'Native sandbox', ok: false, detail: `not supported on ${process.platform}` };
+}
+
+function getActiveBackendReason(sandboxConfig: SandboxConfig): string {
+  if (!sandboxConfig.enabled) {
+    return 'Sandbox is disabled in configuration';
+  }
+  if (sandboxConfig.backend === 'docker') {
+    return 'Docker backend selected in configuration (sandbox.backend = "docker")';
+  }
+  // native is the default
+  return 'Native backend selected in configuration (sandbox.backend = "native")';
+}
+
+/**
+ * Run sandbox backend diagnostics. Checks Docker availability,
+ * native backend availability, and reports current configuration.
+ */
+export function runSandboxDiagnostics(): SandboxDiagnostics {
+  const config = getConfig();
+  const sandboxConfig = config.sandbox;
+
+  const checks: SandboxCheckResult[] = [];
+
+  // Always check native backend since it is the default
+  checks.push(checkNativeBackend());
+
+  // Docker checks: CLI, daemon, image, container execution
+  const cliResult = checkDockerCli();
+  checks.push(cliResult);
+
+  if (cliResult.ok) {
+    const daemonResult = checkDockerDaemon();
+    checks.push(daemonResult);
+
+    if (daemonResult.ok) {
+      checks.push(checkDockerImage(sandboxConfig.docker.image));
+      checks.push(checkDockerRun());
+    }
+  }
+
+  return {
+    config: {
+      enabled: sandboxConfig.enabled,
+      backend: sandboxConfig.backend,
+      dockerImage: sandboxConfig.docker.image,
+    },
+    activeBackendReason: getActiveBackendReason(sandboxConfig),
+    checks,
+  };
+}


### PR DESCRIPTION
## Summary
- Add sandbox backend diagnostics as section 13 of the vellum doctor command
- Reports sandbox configuration (enabled/disabled, backend, Docker image)
- Explains why the active backend was selected
- Runs cascading diagnostic checks:
  - **Native backend**: tests sandbox-exec (macOS) or bwrap (Linux)
  - **Docker CLI**: checks if docker is installed and reports version
  - **Docker daemon**: checks if the daemon is reachable (skipped if CLI missing)
  - **Docker image**: checks if the configured image is available locally (skipped if daemon down)
  - **Docker container execution**: runs a test container (skipped if daemon down)
- Adds 29 tests covering all diagnostic paths and cascade behavior

## Test plan
- [x] All 29 new sandbox diagnostics tests pass
- [x] All 141 existing sandbox-related tests still pass
- [x] No regressions in pre-existing test suite

Closes #2031

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
