### PR TITLE
IPC M6: Migrate queue and history message domain to generated types (#2002)

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -49,6 +49,12 @@ const SKIP_TYPES = new Set([
   'UiSurfaceShow',
   'UiSurfaceShowBase',
   'INTERACTIVE_SURFACE_TYPES',
+  // String-union types that need hand-written Swift enums
+  'SessionErrorCode',
+  'TraceEventKind',
+  // Uses SessionErrorCode and TraceEventKind which are hand-maintained enums
+  'SessionErrorMessage',
+  'TraceEvent',
 ]);
 
 // --- JSON Schema type definitions ---

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -651,6 +651,7 @@ public struct GenerationCancelledMessage: Decodable, Sendable {
 }
 
 /// Notifies client that active generation yielded to queued work at a checkpoint.
+/// Backed by generated `IPCGenerationHandoff`.
 public typealias GenerationHandoffMessage = IPCGenerationHandoff
 
 extension IPCGenerationHandoff {
@@ -660,6 +661,7 @@ extension IPCGenerationHandoff {
 }
 
 /// Notifies client that a message has been queued for processing.
+/// Backed by generated `IPCMessageQueued`.
 public typealias MessageQueuedMessage = IPCMessageQueued
 
 extension IPCMessageQueued {
@@ -669,6 +671,7 @@ extension IPCMessageQueued {
 }
 
 /// Notifies client that a queued message has been dequeued and is now being processed.
+/// Backed by generated `IPCMessageDequeued`.
 public typealias MessageDequeuedMessage = IPCMessageDequeued
 
 extension IPCMessageDequeued {
@@ -895,24 +898,14 @@ public struct SkillsInspectResponseMessage: Decodable, Sendable {
 public typealias SessionListResponseMessage = IPCSessionListResponse
 
 /// Response containing message history for a session.
-/// Wire type: `"history_response"`
-public struct HistoryResponseMessage: Decodable, Sendable {
-    public let sessionId: String
-    public struct HistoryToolCallItem: Decodable, Sendable {
-        public let name: String
-        public let input: [String: AnyCodable]
-        public let result: String?
-        public let isError: Bool?
-        /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
-        public let imageData: String?
-    }
-    public struct HistoryMessageItem: Decodable, Sendable {
-        public let role: String
-        public let text: String
-        public let timestamp: Int
-        public let toolCalls: [HistoryToolCallItem]?
-    }
-    public let messages: [HistoryMessageItem]
+/// Backed by generated `IPCHistoryResponse`.
+public typealias HistoryResponseMessage = IPCHistoryResponse
+
+extension IPCHistoryResponse {
+    /// Backward-compatible alias for the nested message item type.
+    public typealias HistoryMessageItem = IPCHistoryResponseMessage
+    /// Backward-compatible alias for the nested tool call type.
+    public typealias HistoryToolCallItem = IPCHistoryResponseToolCall
 }
 
 /// A single trust rule item returned from the daemon.


### PR DESCRIPTION
## Summary
- Replace hand-maintained Swift structs for MessageQueuedMessage, MessageDequeuedMessage, GenerationHandoffMessage, and HistoryResponseMessage with typealiases to their generated IPC counterparts
- Add convenience initializers on the generated types to preserve backward-compatible call sites (tests, view models)
- Add backward-compatible nested type aliases (HistoryMessageItem, HistoryToolCallItem) on IPCHistoryResponse so existing code like HistoryResponseMessage.HistoryMessageItem continues to compile
- Add SessionErrorCode, TraceEventKind, SessionErrorMessage, and TraceEvent to the generator SKIP_TYPES for clarity, since these string-union types require hand-written Swift enums

## Test plan
- [x] bun run scripts/ipc/generate-swift.ts produces unchanged generated file
- [x] swift build has no new errors (pre-existing SessionErrorMessagePayload errors remain)
- [x] All existing call sites (ChatViewModel, tests) reference the typealias names unchanged

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
