### PR TITLE
SANDBOX M10: Docs + architecture updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -713,9 +713,23 @@ graph TB
     CALL["Model tool call"] --> EXEC["ToolExecutor"]
 
     EXEC -->|"file_read / file_write / file_edit / bash"| SB_TOOLS["Sandbox-scoped tools"]
-    SB_TOOLS --> SB_FS["Sandbox filesystem root<br/>~/.vellum/data/sandbox/fs"]
+    SB_TOOLS --> WRAP["wrapCommand()<br/>sandbox.ts"]
 
-    EXEC -->|"host_file_* / host_bash / cu_* / request_computer_control"| HOST_TOOLS["Host-target tools"]
+    WRAP --> BACKEND_CHECK{"sandbox.backend?"}
+    BACKEND_CHECK -->|"native (default)"| NATIVE["NativeBackend"]
+    BACKEND_CHECK -->|"docker"| DOCKER["DockerBackend"]
+
+    NATIVE -->|"macOS"| SBPL["sandbox-exec<br/>SBPL profile<br/>deny-default + allow workdir"]
+    NATIVE -->|"Linux"| BWRAP["bwrap<br/>bubblewrap<br/>ro-root + rw-workdir<br/>unshare-net + unshare-pid"]
+    SBPL --> SB_FS["Sandbox filesystem root<br/>~/.vellum/data/sandbox/fs"]
+    BWRAP --> SB_FS
+
+    DOCKER --> PREFLIGHT["Preflight checks<br/>CLI → daemon → image → mount"]
+    PREFLIGHT -->|"all pass"| CONTAINER["docker run --rm<br/>bind-mount /workspace<br/>--cap-drop=ALL<br/>--read-only<br/>--network=none"]
+    PREFLIGHT -->|"any fail"| FAIL_CLOSED["ToolError<br/>(fail closed, no fallback)"]
+    CONTAINER --> SB_FS
+
+    EXEC -->|"host_file_* / host_bash / cu_* / request_computer_control"| HOST_TOOLS["Host-target tools<br/>(unchanged by backend choice)"]
     HOST_TOOLS --> CHECK["Permission checker + trust-store"]
     CHECK --> DEFAULTS["Default rules<br/>ask for host_* + cu_*"]
     CHECK -->|"allow"| HOST_EXEC["Execute on host filesystem / shell / computer control"]
@@ -725,6 +739,11 @@ graph TB
     USER --> CHECK
 ```
 
+- **Backend selection**: The `sandbox.backend` config option (`"native"` or `"docker"`) determines how `bash` commands are sandboxed. The default is `"native"`.
+- **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root.
+- **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is pinned with a `sha256` digest.
+- **Fail-closed**: Both backends refuse to execute unsandboxed if their prerequisites are unavailable. The Docker backend runs preflight checks (CLI, daemon, image, mount probe) and throws `ToolError` with actionable messages on failure. Positive preflight results are cached; negative results are rechecked on every call.
+- **Host tools unchanged**: `host_bash`, `host_file_read`, `host_file_write`, and `host_file_edit` always execute directly on the host regardless of which sandbox backend is active.
 - Sandbox defaults: `file_*` and `bash` execute within `~/.vellum/data/sandbox/fs`.
 - Host access is explicit: `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash` are separate tools.
 - Prompt defaults: host tools, `request_computer_control`, and `cu_*` actions default to `ask` unless a trust rule allowlists/denylists them.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,87 @@ bun run src/index.ts daemon start
 - Host/computer-use prompts: `host_*`, `request_computer_control`, and `cu_*` default to `ask` unless allowlisted/denylisted in trust rules.
 - Runtime override removal: CLI `--no-sandbox` is removed; legacy `sandbox_set` IPC messages are accepted but ignored (deprecated no-op).
 
+### Sandbox Backend Selection
+
+The `sandbox.backend` config option controls how the `bash` tool executes commands inside the sandbox. Two backends are available:
+
+| Backend | Value | Description |
+|---------|-------|-------------|
+| **Native** | `"native"` (default) | Uses OS-level sandboxing: `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. No extra dependencies on macOS. |
+| **Docker** | `"docker"` | Runs each command in an ephemeral `docker run --rm` container with the sandbox filesystem bind-mounted to `/workspace`. |
+
+To switch to the Docker backend:
+
+```bash
+vellum config set sandbox.backend '"docker"'
+```
+
+To switch back to native:
+
+```bash
+vellum config set sandbox.backend '"native"'
+```
+
+### Docker Backend
+
+When `sandbox.backend` is set to `"docker"`, the daemon wraps every sandbox `bash` invocation in an ephemeral Docker container. The container is created with `docker run --rm` and destroyed after each command.
+
+**Prerequisites:**
+
+- Docker installed and the `docker` CLI available in `PATH`.
+- Docker daemon running (Docker Desktop on macOS/Windows, or `systemd` service on Linux).
+- The configured image pulled locally. The default image is pinned with a `sha256` digest for reproducibility:
+  ```
+  node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9
+  ```
+  Pull it with: `docker pull node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9`
+
+**Docker configuration options** (all under `sandbox.docker`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `image` | `node:20-slim@sha256:...` | Container image (pinned with sha256 digest) |
+| `cpus` | `1` | CPU limit per container |
+| `memoryMb` | `512` | Memory limit in MB |
+| `pidsLimit` | `256` | Maximum number of processes |
+| `network` | `"none"` | Network mode (`"none"` or `"bridge"`) |
+
+**Container security posture:**
+
+- All capabilities dropped (`--cap-drop=ALL`)
+- No new privileges (`--security-opt=no-new-privileges`)
+- Read-only container root filesystem (`--read-only`)
+- Writable tmpfs for `/tmp` only
+- Network disabled by default (`--network=none`)
+- Host UID:GID forwarded to prevent permission drift
+
+**Fail-closed behavior:**
+
+If Docker is unavailable, commands fail immediately with actionable error messages rather than falling back to unsandboxed execution. The preflight checks run in dependency order:
+
+1. Docker CLI installed
+2. Docker daemon reachable
+3. Configured image available locally
+4. Bind-mount probe succeeds
+
+Positive preflight results are cached for the lifetime of the daemon process. Negative results are never cached, so installing or starting Docker mid-session takes effect without a daemon restart.
+
+### Host Tools
+
+Host tools (`host_bash`, `host_file_read`, `host_file_write`, `host_file_edit`) are unchanged regardless of which sandbox backend is active. They always execute directly on the host and are subject to trust rules and permission prompts.
+
+### Troubleshooting (Sandbox)
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Docker CLI is not installed or not in PATH` | Docker is not installed | Install Docker: https://docs.docker.com/get-docker/ |
+| `Docker daemon is not running` | Docker Desktop is not started or systemd service is stopped | Start Docker Desktop, or run `sudo systemctl start docker` on Linux |
+| `Docker image "..." is not available locally` | The configured image has not been pulled | Run `docker pull <image>` with the full image reference including the sha256 digest |
+| `Cannot bind-mount the sandbox root into a Docker container` | Docker Desktop file sharing does not include the sandbox data directory | Open Docker Desktop > Settings > Resources > File Sharing and add the `~/.vellum/data/sandbox/fs` path (or your custom `dataDir` path) |
+| `bwrap is not available or cannot create namespaces` (native backend, Linux) | bubblewrap is not installed or user namespaces are disabled | Install bubblewrap: `apt install bubblewrap` (Debian/Ubuntu) or `dnf install bubblewrap` (Fedora) |
+
+Run `vellum doctor` for a full diagnostic check including sandbox backend status.
+
 ## Remote Access
 
 Access a remote assistant daemon from your local machine via SSH.


### PR DESCRIPTION
## Context
Part of #2021: Sandbox Runtime V2. Closes #2032.

## Changes
- Document sandbox.backend config option in README (native vs Docker)
- Add Docker backend prerequisites, configuration options, and security posture
- Document fail-closed behavior with actionable error messages
- Update ARCHITECTURE.md Mermaid diagram with sandbox backend selection flow (native/docker paths, preflight checks, fail-closed)
- Add troubleshooting section covering Docker unavailable, image missing, and mount/file-sharing failures
- Document that host tools are unchanged regardless of backend choice
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
