### PR TITLE
SANDBOX M11: Default backend cutover decision (native → docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The `sandbox.backend` config option controls how the `bash` tool executes comman
 | **Native** | `"native"` (default) | Uses OS-level sandboxing: `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. No extra dependencies on macOS. |
 | **Docker** | `"docker"` | Runs each command in an ephemeral `docker run --rm` container with the sandbox filesystem bind-mounted to `/workspace`. |
 
+The **native** backend is the default because it works out of the box with no additional dependencies. The Docker backend is available as **opt-in hardening** for environments where stronger container-level isolation is needed (e.g., running untrusted code, shared servers, CI environments). Docker requires Docker Desktop or Docker Engine to be installed and running.
+
 To switch to the Docker backend:
 
 ```bash

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -44,6 +44,7 @@ import { _setStorePath } from '../security/encrypted-store.js';
 import { _setBackend } from '../security/secure-keys.js';
 import { loadConfig, invalidateConfigCache } from '../config/loader.js';
 import { AssistantConfigSchema } from '../config/schema.js';
+import { DEFAULT_CONFIG } from '../config/defaults.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -278,6 +279,17 @@ describe('AssistantConfigSchema', () => {
       expect(messages.some(m => m.includes('positive'))).toBe(true);
       expect(messages.some(m => m.includes('redact') && m.includes('warn') && m.includes('block'))).toBe(true);
     }
+  });
+
+  // SANDBOX M11: native is the deliberate default — Docker is opt-in hardening.
+  // These tests guard against an accidental cutover.
+  test('default sandbox backend is native (not docker)', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.sandbox.backend).toBe('native');
+  });
+
+  test('DEFAULT_CONFIG sandbox backend is native', () => {
+    expect(DEFAULT_CONFIG.sandbox.backend).toBe('native');
   });
 
   test('backward compatibility: sandbox with only enabled still parses', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,6 +87,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   sandbox: {
     enabled: true,
+    // Default to 'native' (macOS sandbox-exec). Docker backend is available as
+    // opt-in hardening for environments where stronger isolation is needed, but
+    // requires Docker Desktop/Engine — a dependency most developers won't have.
+    // See SANDBOX M11 decision: native remains the default until Docker
+    // integration is stable, startup UX is acceptable, and host tool workflows
+    // have no regressions.
     backend: 'native',
     docker: {
       image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',


### PR DESCRIPTION
## Context
Part of #2021: Sandbox Runtime V2. Closes #2033.

## Changes
- Keep default sandbox.backend as native (Docker is opt-in hardening mode)
- Add SANDBOX M11 decision rationale comment in defaults.ts explaining why native remains the default
- Add explicit tests guarding against accidental backend cutover (both schema default and DEFAULT_CONFIG constant)
- Document sandbox backend options and Docker opt-in configuration in README

## Decision Rationale
Docker backend adds a runtime dependency (Docker Desktop/Engine) that most developers won't have installed. The native backend (macOS sandbox-exec) works out of the box with no additional dependencies. Docker is documented as opt-in for environments needing stronger isolation (untrusted code, shared servers, CI).

## Test plan
- [x] bun test src/__tests__/config-schema.test.ts - all 48 tests pass (including 2 new M11 guard tests)
- [x] Verified schema default is native (schema.ts line 62)
- [x] Verified DEFAULT_CONFIG constant uses native (defaults.ts line 90)
- [x] README documents both backends with opt-in config example
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
