### PR TITLE
fix(ui): center placeholder text vertically in compact chatbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -539,6 +539,7 @@ struct ChatView: View {
                 .textFieldStyle(.plain)
                 .lineLimit(1...)
                 .disabled(!hasAPIKey)
+                .fixedSize(horizontal: false, vertical: true)
                 .accessibilityLabel("Message")
                 .background(
                     GeometryReader { geo in


### PR DESCRIPTION
## Summary
- Add `fixedSize(horizontal: false, vertical: true)` to the composer TextField so it uses its intrinsic content height instead of expanding to fill the 28pt minimum frame
- The ZStack's default vertical centering now properly centers the placeholder text in the empty/compact state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
