### PR TITLE
fix(ui): dismiss ghost suggestion when composer content exceeds max height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -34,8 +34,12 @@ struct ChatView: View {
     let onDismissSessionError: () -> Void
 
     /// The portion of the suggestion that extends beyond the current input.
+    /// Returns nil when the composer content exceeds the max height (200pt) because
+    /// the ghost text overlay is a sibling in the ZStack and would become misaligned
+    /// once the TextEditor scrolls internally.
     private var ghostSuffix: String? {
         guard let suggestion else { return nil }
+        guard editorContentHeight <= 200 else { return nil }
         if suggestion.hasPrefix(inputText) {
             let suffix = String(suggestion.dropFirst(inputText.count))
             return suffix.isEmpty ? nil : suffix


### PR DESCRIPTION
## Summary
- When the composer text exceeds the 200pt max height, the TextEditor scrolls internally but the ghost text overlay (a sibling in the ZStack) does not scroll with it, causing misalignment
- Added a guard in `ghostSuffix` that returns `nil` when `editorContentHeight > 200`, dismissing the ghost suggestion for this edge case
- This is the simplest fix since ghost suggestions on very long text are rare

Addresses review feedback from Devin on #2092.

## Test plan
- [ ] Type enough text in the composer to exceed the 200pt max height — ghost suggestion should disappear
- [ ] With short text, ghost suggestions should still appear and work normally
- [ ] Tab-to-accept should still work when ghost suggestion is visible (short text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
