### PR TITLE
fix(ui): align ghost completion baseline with centered TextField

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -567,7 +567,7 @@ struct ChatView: View {
                         .lineSpacing(4)
                         .lineLimit(1...)
                         .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: .topLeading)
+                        .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: isComposerExpanded ? .topLeading : .leading)
                         .clipped()
                         .allowsHitTesting(false)
                         .accessibilityHidden(true)


### PR DESCRIPTION
## Summary
- Fixes ghost completion overlay misalignment in compact/single-line composer mode
- The TextField uses `fixedSize(horizontal: false, vertical: true)` which centers it vertically in the 28pt frame, but the ghost completion overlay was pinned with `.topLeading` alignment, causing the suggested suffix to render above the typed text
- Changes the ghost overlay's frame alignment to `.leading` (vertically centered) for the compact state, keeping `.topLeading` for expanded multi-line state

## Context
Addresses Codex review feedback on #2134 (P2: "Keep ghost completion baseline aligned with input text").

## Test plan
- [ ] Open app with a suggestion visible in compact (single-line) composer mode
- [ ] Verify ghost completion text aligns with the baseline of the typed input text
- [ ] Expand composer to multi-line and verify ghost text still aligns at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
