### PR TITLE
feat(ipc): handle session_error in secondary flows (M5)

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -179,6 +179,11 @@ final class ComputerUseSession: ObservableObject {
                     self.logger.finishSession(result: "failed: \(error.message)")
                     return
 
+                case .sessionError(let error) where error.sessionId == self.id:
+                    self.state = .failed(reason: error.userMessage)
+                    self.logger.finishSession(result: "failed: \(error.userMessage)")
+                    return
+
                 default:
                     break // ignore messages for other sessions
                 }

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -128,6 +128,10 @@ final class TextSession: ObservableObject {
                     self.state = .failed(reason: error.message)
                     return
 
+                case .sessionError(let error) where error.sessionId == self.daemonSessionId && self.daemonSessionId != nil:
+                    self.state = .failed(reason: error.userMessage)
+                    return
+
                 default:
                     break
                 }
@@ -197,6 +201,10 @@ final class TextSession: ObservableObject {
 
                 case .cuError(let error) where error.sessionId == sessionId:
                     self.state = .failed(reason: error.message)
+                    return
+
+                case .sessionError(let error) where error.sessionId == sessionId:
+                    self.state = .failed(reason: error.userMessage)
                     return
 
                 default:

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -205,6 +205,16 @@ final class FirstMeetingIntroductionViewModel {
                     ))
                     return
 
+                case .sessionError(let error) where error.sessionId == self.sessionId && self.sessionId != nil:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("First meeting start failed (session_error): \(error.userMessage)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "I'm having trouble connecting. Please try again in a moment."
+                    ))
+                    return
+
                 default:
                     break
                 }
@@ -333,6 +343,16 @@ final class FirstMeetingIntroductionViewModel {
                     self.isThinking = false
                     self.streamingText = ""
                     log.error("Session error during follow-up: \(error.message)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "Something went wrong. Please try again."
+                    ))
+                    return
+
+                case .sessionError(let error) where error.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("Session error during follow-up (session_error): \(error.userMessage)")
                     self.messages.append(InterviewMessage(
                         role: .assistant,
                         text: "Something went wrong. Please try again."

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -183,6 +183,16 @@ final class InterviewViewModel {
                     ))
                     return
 
+                case .sessionError(let error) where error.sessionId == self.sessionId && self.sessionId != nil:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("Interview start failed (session_error): \(error.userMessage)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "I'm having trouble connecting. Please try again in a moment."
+                    ))
+                    return
+
                 default:
                     break
                 }
@@ -306,6 +316,16 @@ final class InterviewViewModel {
                     self.isThinking = false
                     self.streamingText = ""
                     log.error("Session error during follow-up: \(error.message)")
+                    self.messages.append(InterviewMessage(
+                        role: .assistant,
+                        text: "Something went wrong. Please try again."
+                    ))
+                    return
+
+                case .sessionError(let error) where error.sessionId == sessionId:
+                    self.isThinking = false
+                    self.streamingText = ""
+                    log.error("Session error during follow-up (session_error): \(error.userMessage)")
                     self.messages.append(InterviewMessage(
                         role: .assistant,
                         text: "Something went wrong. Please try again."

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -154,6 +154,10 @@ final class ProfileExtractor {
                 log.error("Extraction session error: \(error.message)")
                 return
 
+            case .sessionError(let error) where error.sessionId == sessionId:
+                log.error("Extraction session error (session_error): \(error.userMessage)")
+                return
+
             default:
                 break
             }


### PR DESCRIPTION
Part of #2037. Closes #2043.

## Summary

- **TextSession**: handles `.sessionError` in both `run()` and `sendFollowUp()` message loops, mapping to `.failed(reason:)` for matching session IDs
- **ComputerUseSession**: handles `.sessionError` alongside existing `.cuError`, logging the failure and transitioning to `.failed` state
- **InterviewViewModel**: handles `.sessionError` in `startInterview()` and `sendMessage()` flows with user-friendly error messages
- **FirstMeetingIntroductionViewModel**: same pattern for `startConversation()` and `sendMessage()`
- **ProfileExtractor**: logs and returns on `.sessionError` during background extraction
- **Panel stability**: `GeneratedPanel` uses callback-based `onError`/`onSessionError` from `DaemonClient` which already dispatches both message types independently — no changes needed

All consumers remain stream-driven via `subscribe()` with session ID filtering. No singleton callbacks introduced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
