### PR TITLE
fix(ui): use topLeading alignment for ghost overlay to prevent clipping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -567,7 +567,7 @@ struct ChatView: View {
                         .lineSpacing(4)
                         .lineLimit(1...)
                         .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: isComposerExpanded ? .topLeading : .leading)
+                        .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: .topLeading)
                         .clipped()
                         .allowsHitTesting(false)
                         .accessibilityHidden(true)


### PR DESCRIPTION
## Summary
- Reverts the conditional ghost overlay alignment from PR #2136 to always use `.topLeading`
- In compact mode (single-line composer), the `.leading` alignment vertically centered multi-line ghost text inside the fixed 28pt frame, clipping both top and bottom of wrapped suggestions
- The ghost Text view already has `.fixedSize(horizontal: false, vertical: true)` which matches the TextField's sizing strategy, so `.topLeading` alignment is sufficient

## Test plan
- [ ] Verify ghost completion renders correctly in compact mode with a single-line suggestion
- [ ] Verify ghost completion with a long wrapping suffix in compact mode is not clipped at the top
- [ ] Verify ghost completion renders correctly in expanded (multi-line) mode

Addresses feedback from #2136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
