### PR TITLE
feat(sandbox): cut over default backend from native to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The platform has two main components:
 └── .github/           # GitHub Actions workflows
 ```
 
+## Prerequisites
+
+- **Docker** is required. The sandbox uses Docker as its default backend for container-level isolation. Install [Docker Desktop](https://docs.docker.com/get-docker/) (macOS/Windows) or Docker Engine (Linux) and ensure the daemon is running before starting the assistant.
+
 ## Local Development
 
 ```bash
@@ -62,21 +66,21 @@ The `sandbox.backend` config option controls how the `bash` tool executes comman
 
 | Backend | Value | Description |
 |---------|-------|-------------|
-| **Native** | `"native"` (default) | Uses OS-level sandboxing: `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. No extra dependencies on macOS. |
-| **Docker** | `"docker"` | Runs each command in an ephemeral `docker run --rm` container with the sandbox filesystem bind-mounted to `/workspace`. |
+| **Docker** | `"docker"` (default) | Runs each command in an ephemeral `docker run --rm` container with the sandbox filesystem bind-mounted to `/workspace`. Requires Docker Desktop or Docker Engine. |
+| **Native** | `"native"` | Uses OS-level sandboxing: `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. No extra dependencies on macOS. |
 
-The **native** backend is the default because it works out of the box with no additional dependencies. The Docker backend is available as **opt-in hardening** for environments where stronger container-level isolation is needed (e.g., running untrusted code, shared servers, CI environments). Docker requires Docker Desktop or Docker Engine to be installed and running.
+The **Docker** backend is the default because it provides stronger container-level isolation with a hardened security posture (all capabilities dropped, read-only root filesystem, network disabled by default). Docker Desktop or Docker Engine must be installed and running. The native backend is available as a **fallback** for environments where Docker is not available.
 
-To switch to the Docker backend:
-
-```bash
-vellum config set sandbox.backend '"docker"'
-```
-
-To switch back to native:
+To switch to the native backend:
 
 ```bash
 vellum config set sandbox.backend '"native"'
+```
+
+To switch back to Docker:
+
+```bash
+vellum config set sandbox.backend '"docker"'
 ```
 
 ### Docker Backend

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -82,7 +82,7 @@ describe('AssistantConfigSchema', () => {
     });
     expect(result.sandbox).toEqual({
       enabled: true,
-      backend: 'native',
+      backend: 'docker',
       docker: {
         image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
         cpus: 1,
@@ -281,21 +281,21 @@ describe('AssistantConfigSchema', () => {
     }
   });
 
-  // SANDBOX M11: native is the deliberate default — Docker is opt-in hardening.
-  // These tests guard against an accidental cutover.
-  test('default sandbox backend is native (not docker)', () => {
+  // SANDBOX M11 cutover: Docker is now the default backend for stronger
+  // container-level isolation. Native is available as opt-in fallback.
+  test('default sandbox backend is docker', () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.sandbox.backend).toBe('native');
+    expect(result.sandbox.backend).toBe('docker');
   });
 
-  test('DEFAULT_CONFIG sandbox backend is native', () => {
-    expect(DEFAULT_CONFIG.sandbox.backend).toBe('native');
+  test('DEFAULT_CONFIG sandbox backend is docker', () => {
+    expect(DEFAULT_CONFIG.sandbox.backend).toBe('docker');
   });
 
   test('backward compatibility: sandbox with only enabled still parses', () => {
     const result = AssistantConfigSchema.parse({ sandbox: { enabled: false } });
     expect(result.sandbox.enabled).toBe(false);
-    expect(result.sandbox.backend).toBe('native');
+    expect(result.sandbox.backend).toBe('docker');
     expect(result.sandbox.docker.memoryMb).toBe(512);
   });
 
@@ -522,7 +522,7 @@ describe('loadConfig with schema validation', () => {
     writeConfig({ sandbox: { enabled: false } });
     const config = loadConfig();
     expect(config.sandbox.enabled).toBe(false);
-    expect(config.sandbox.backend).toBe('native');
+    expect(config.sandbox.backend).toBe('docker');
     expect(config.sandbox.docker.memoryMb).toBe(512);
   });
 
@@ -543,7 +543,7 @@ describe('loadConfig with schema validation', () => {
   test('falls back for invalid sandbox.backend', () => {
     writeConfig({ sandbox: { backend: 'podman' } });
     const config = loadConfig();
-    expect(config.sandbox.backend).toBe('native');
+    expect(config.sandbox.backend).toBe('docker');
   });
 
   test('falls back for invalid contextWindow relationship', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,13 +87,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
   },
   sandbox: {
     enabled: true,
-    // Default to 'native' (macOS sandbox-exec). Docker backend is available as
-    // opt-in hardening for environments where stronger isolation is needed, but
-    // requires Docker Desktop/Engine — a dependency most developers won't have.
-    // See SANDBOX M11 decision: native remains the default until Docker
-    // integration is stable, startup UX is acceptable, and host tool workflows
-    // have no regressions.
-    backend: 'native',
+    // SANDBOX M11 cutover: Docker is now the default backend. It provides
+    // stronger container-level isolation via ephemeral containers. Docker
+    // Desktop/Engine must be installed and running. Users without Docker can
+    // opt into the native backend via `sandbox.backend = "native"`.
+    backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
       cpus: 1,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -59,7 +59,7 @@ export const SandboxConfigSchema = z.object({
     .enum(VALID_SANDBOX_BACKENDS, {
       error: `sandbox.backend must be one of: ${VALID_SANDBOX_BACKENDS.join(', ')}`,
     })
-    .default('native'),
+    .default('docker'),
   docker: DockerConfigSchema.default({
     image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
     cpus: 1,
@@ -568,7 +568,7 @@ export const AssistantConfigSchema = z.object({
   }),
   sandbox: SandboxConfigSchema.default({
     enabled: true,
-    backend: 'native',
+    backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
       cpus: 1,

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -91,7 +91,6 @@ function getActiveBackendReason(sandboxConfig: SandboxConfig): string {
   if (sandboxConfig.backend === 'docker') {
     return 'Docker backend selected in configuration (sandbox.backend = "docker")';
   }
-  // native is the default
   return 'Native backend selected in configuration (sandbox.backend = "native")';
 }
 
@@ -105,7 +104,7 @@ export function runSandboxDiagnostics(): SandboxDiagnostics {
 
   const checks: SandboxCheckResult[] = [];
 
-  // Always check native backend since it is the default
+  // Always check native backend availability as a diagnostic signal
   checks.push(checkNativeBackend());
 
   // Docker checks: CLI, daemon, image, container execution


### PR DESCRIPTION
## Summary
- Changes the default `sandbox.backend` from `native` to `docker` for stronger container-level isolation
- Updates Zod schema defaults, `DEFAULT_CONFIG`, and all related tests to reflect the new default
- Adds Docker as a prerequisite in README quickstart and updates the Sandbox Backend Selection documentation
- Updates sandbox diagnostics comments to remove native-as-default assumptions

Closes #2033

## Test plan
- [x] All 48 config-schema tests pass with new default expectations
- [x] Sandbox diagnostics tests pass (29 tests)
- [x] Terminal sandbox tests pass (13 tests)
- [x] Backward compatibility tests updated: `sandbox: { enabled: false }` now defaults to `docker` backend
- [x] Invalid backend fallback test updated: invalid value falls back to `docker` (new default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
