### PR TITLE
fix(ui): center placeholder text in compact composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -573,7 +573,7 @@ struct ChatView: View {
                         .accessibilityHidden(true)
                 }
             }
-            .frame(minHeight: 28)
+            .frame(minHeight: 28, maxHeight: .infinity, alignment: .center)
         }
         .scrollBounceBehavior(.basedOnSize)
         .onKeyPress(.tab, phases: .down) { keyPress in


### PR DESCRIPTION
## Summary
- Use `maxHeight: .infinity, alignment: .center` on the composer ZStack frame so placeholder text is vertically centered within the ScrollView viewport in the compact/empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
