### PR TITLE
Document iOS build issue and provide xcodebuild workaround

### DIFF
--- a/clients/build-ios.sh
+++ b/clients/build-ios.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Build script for Vellum Assistant iOS app
+# This script uses xcodebuild to properly build the iOS app with bundle configuration
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Default to iPhone 15 simulator
+SIMULATOR_NAME="${SIMULATOR_NAME:-iPhone 15}"
+
+echo "Building Vellum Assistant iOS app for $SIMULATOR_NAME..."
+
+# Build using xcodebuild (properly handles iOS app bundles)
+xcodebuild \
+  -scheme vellum-assistant-ios \
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME" \
+  -derivedDataPath .build \
+  build
+
+echo "Build complete!"
+echo ""
+echo "To run the app:"
+echo "1. Open Xcode: open Package.swift"
+echo "2. Select 'vellum-assistant-ios' scheme"
+echo "3. Choose '$SIMULATOR_NAME' or another simulator"
+echo "4. Press ⌘R to run"

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -1,0 +1,42 @@
+# Vellum Assistant iOS App
+
+## Building and Running
+
+### Issue with SPM Executable Targets
+
+Swift Package Manager's `executableTarget` type doesn't properly support iOS app bundles. iOS apps require proper bundle configuration including Info.plist processing, which SPM doesn't handle for executable targets.
+
+### Recommended Build Method
+
+**Option 1: Open in Xcode (Recommended)**
+
+1. Open `clients/Package.swift` in Xcode:
+   ```bash
+   open clients/Package.swift
+   ```
+
+2. In Xcode's scheme selector, choose `vellum-assistant-ios`
+
+3. Select your target iOS Simulator
+
+4. Build and run (⌘R)
+
+**Option 2: Use xcodebuild**
+
+```bash
+cd clients
+xcodebuild -scheme vellum-assistant-ios \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -derivedDataPath .build \
+  build
+```
+
+### Known Issues
+
+- The iOS app cannot be built with `swift build` directly
+- The bundle identifier crash occurs when SPM's auto-generated Info.plist is used
+- The `ios/Resources/Info.plist` file is excluded from the SPM build and must be handled by Xcode
+
+### Future Work
+
+Consider migrating to a proper Xcode project structure for the iOS app to avoid SPM limitations.


### PR DESCRIPTION
## Summary

Fixes the iOS bundle identifier crash (`__BKSHIDEvent__BUNDLE_IDENTIFIER_FOR_CURRENT_PROCESS_IS_NIL__`) by documenting the SPM limitation and providing proper build tooling.

## Background

Swift Package Manager's `executableTarget` type doesn't properly support iOS app bundles. iOS apps require proper bundle configuration including Info.plist processing, which SPM doesn't handle for executable targets. This causes bundle identifier crashes when running the app.

## Changes

- **clients/ios/README.md**: Documents the SPM limitation and recommends two build methods:
  - Option 1: Open in Xcode (recommended)
  - Option 2: Use xcodebuild command-line
- **clients/build-ios.sh**: Build script that uses xcodebuild to properly handle iOS app bundles

## Why xcodebuild?

xcodebuild properly processes Info.plist and handles iOS app bundle configuration, which `swift build` cannot do for executable targets. This prevents the bundle identifier crash.

## Testing

```bash
cd clients
./build-ios.sh  # Uses xcodebuild
# Or open in Xcode and run directly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
