### PR TITLE
M8: Migrate skills and app-bundle domain to generated Swift types

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -694,14 +694,10 @@ public typealias MissingRequirements = IPCSkillsListResponseSkillMissingRequirem
 /// Backed by generated `IPCSkillsListResponseSkill`.
 public typealias SkillInfo = IPCSkillsListResponseSkill
 
-extension IPCSkillsListResponseSkill: Identifiable {
-    // The generated struct has both `id` and `name` fields from the contract.
-    // Keep Identifiable using the `id` field (auto-synthesized).
-}
+extension IPCSkillsListResponseSkill: Identifiable {}
 
 extension IPCSkillsListResponseSkill {
-    /// Backward-compatible init that mirrors the old hand-written `SkillInfo`.
-    /// `id` defaults to `name` (matching the old computed `id` behavior).
+    /// Backward-compatible init that defaults `id` to `name`.
     public init(name: String, description: String, emoji: String?, homepage: String?, source: String, state: String, degraded: Bool, missingRequirements: IPCSkillsListResponseSkillMissingRequirements?, installedVersion: String?, latestVersion: String?, updateAvailable: Bool, userInvocable: Bool, clawhub: IPCSkillsListResponseSkillClawhub?) {
         self.init(id: name, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: state, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub)
     }


### PR DESCRIPTION
## Summary

Closes #2004

Replace manual struct definitions in `IPCMessages.swift` with typealiases to auto-generated types from `IPCContractGenerated.swift` for the skills, apps, bundle, and signing domains.

### What changed

- **Skills client requests** (13 messages): `SkillsListRequestMessage`, `SkillDetailRequestMessage`, `SkillsEnableMessage`, `SkillsDisableMessage`, `SkillsConfigureMessage`, `SkillsInstallMessage`, `SkillsUninstallMessage`, `SkillsUpdateMessage`, `SkillsCheckUpdatesMessage`, `SkillsSearchMessage`, `SkillsInspectMessage`
- **Skills server responses**: `SkillInfo`, `ClawhubInfo`, `MissingRequirements`, `SkillsListResponseMessage`, `SkillDetailResponseMessage`, `SkillStateChangedMessage`, `SkillsInspectResponseMessage`, all `ClawhubInspect*` types
- **Signing messages**: `SignBundlePayloadResponseMessage`, `GetSigningIdentityResponseMessage`
- **App types**: `AppItem`, `AppsListResponseMessage`, `SharedAppItem`, `SharedAppsListResponseMessage`, `SharedAppDeleteResponseMessage`, `BundleAppResponseMessage`
- **Bundle types**: `OpenBundleResponseMessage` with nested `Manifest`/`ScanResult`/`SignatureResult`, `SignBundlePayloadMessage`

### Backward compatibility

- `SkillInfo` convenience init without `id` (defaults `id = name`)
- `skillMdContentString` computed property on `ClawhubInspectData` (generated field is `AnyCodable?`)
- camelCase computed properties on `OpenBundleResponseManifest` (`formatVersion`, `createdAt`, `createdBy`)
- `Identifiable` conformance on `AppItem`, `SharedAppItem`, `SkillInfo`, `TrustRuleItem`

### Types intentionally kept manual

- `SkillsUpdatesAvailableMessage` (no TS contract equivalent)
- `ClawhubSkillItem`, `ClawhubSearchData`, `SkillsOperationResponseMessage` (decoded from `AnyCodable` data field)

### Validation

- `swift build --product vellum-assistant` passes
- TS type-check shows only pre-existing sandbox test errors (unrelated)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
