### PR TITLE
fix(ui): auto-scroll composer to bottom when text overflows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -530,6 +530,7 @@ struct ChatView: View {
     }
 
     private var composerTextField: some View {
+        ScrollViewReader { proxy in
         ScrollView(.vertical, showsIndicators: false) {
             ZStack(alignment: .leading) {
                 TextField(
@@ -574,8 +575,18 @@ struct ChatView: View {
                 }
             }
             .frame(minHeight: 28, maxHeight: .infinity, alignment: .center)
+
+            // Invisible anchor for auto-scroll
+            Color.clear
+                .frame(height: 1)
+                .id("composer-bottom")
         }
         .scrollBounceBehavior(.basedOnSize)
+        .onChange(of: inputText) {
+            if editorContentHeight > 200 {
+                proxy.scrollTo("composer-bottom", anchor: .bottom)
+            }
+        }
         .onKeyPress(.tab, phases: .down) { keyPress in
             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                 onAcceptSuggestion()
@@ -600,6 +611,7 @@ struct ChatView: View {
             }
             return .ignored
         }
+        } // ScrollViewReader
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Wraps the composer's existing `ScrollView` in a `ScrollViewReader` with an invisible bottom anchor
- Auto-scrolls to bottom on text change when content exceeds the 200pt max height, keeping the cursor visible
- Zero modifications to existing logic — all keyboard shortcuts, ghost text, layout modes, and styling preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
