### PR TITLE
M11: Validate inbound IPC messages against contract schema (#2007)

### DIFF
--- a/assistant/src/__tests__/ipc-validate.test.ts
+++ b/assistant/src/__tests__/ipc-validate.test.ts
@@ -1,0 +1,310 @@
+import { describe, test, expect } from 'bun:test';
+import { validateClientMessage, isClientMessageEnvelope } from '../daemon/ipc-validate.js';
+
+describe('IPC Validate', () => {
+  describe('validateClientMessage', () => {
+    // ─── Envelope checks ───────────────────────────────────────────────
+
+    test('rejects null', () => {
+      const result = validateClientMessage(null);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('not a JSON object');
+    });
+
+    test('rejects undefined', () => {
+      const result = validateClientMessage(undefined);
+      expect(result.valid).toBe(false);
+    });
+
+    test('rejects arrays', () => {
+      const result = validateClientMessage([{ type: 'ping' }]);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('not a JSON object');
+    });
+
+    test('rejects primitives', () => {
+      expect(validateClientMessage('ping').valid).toBe(false);
+      expect(validateClientMessage(42).valid).toBe(false);
+      expect(validateClientMessage(true).valid).toBe(false);
+    });
+
+    test('rejects object without type field', () => {
+      const result = validateClientMessage({ sessionId: 'abc' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('missing a string "type" field');
+    });
+
+    test('rejects object with non-string type', () => {
+      const result = validateClientMessage({ type: 42 });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('missing a string "type" field');
+    });
+
+    test('rejects unknown message type', () => {
+      const result = validateClientMessage({ type: 'not_a_real_type' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('Unknown message type');
+    });
+
+    // ─── Valid simple messages ──────────────────────────────────────────
+
+    test('accepts ping', () => {
+      const result = validateClientMessage({ type: 'ping' });
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.message).toEqual({ type: 'ping' });
+    });
+
+    test('accepts session_list', () => {
+      const result = validateClientMessage({ type: 'session_list' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts cancel', () => {
+      const result = validateClientMessage({ type: 'cancel', sessionId: 'abc' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts model_get', () => {
+      const result = validateClientMessage({ type: 'model_get' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts sessions_clear', () => {
+      const result = validateClientMessage({ type: 'sessions_clear' });
+      expect(result.valid).toBe(true);
+    });
+
+    // ─── High-risk: user_message ────────────────────────────────────────
+
+    test('accepts valid user_message', () => {
+      const result = validateClientMessage({
+        type: 'user_message',
+        sessionId: 'session-1',
+        content: 'Hello',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts user_message with attachments', () => {
+      const result = validateClientMessage({
+        type: 'user_message',
+        sessionId: 'session-1',
+        attachments: [{ filename: 'f.txt', mimeType: 'text/plain', data: 'abc' }],
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('rejects user_message without sessionId', () => {
+      const result = validateClientMessage({ type: 'user_message', content: 'Hello' });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "sessionId"');
+    });
+
+    test('rejects user_message with empty sessionId', () => {
+      const result = validateClientMessage({ type: 'user_message', sessionId: '', content: 'Hi' });
+      expect(result.valid).toBe(false);
+    });
+
+    test('rejects user_message with non-string content', () => {
+      const result = validateClientMessage({
+        type: 'user_message',
+        sessionId: 'session-1',
+        content: 42,
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"content" must be a string');
+    });
+
+    test('rejects user_message with non-array attachments', () => {
+      const result = validateClientMessage({
+        type: 'user_message',
+        sessionId: 'session-1',
+        attachments: 'not-an-array',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"attachments" must be an array');
+    });
+
+    // ─── High-risk: session_create ──────────────────────────────────────
+
+    test('accepts valid session_create', () => {
+      const result = validateClientMessage({ type: 'session_create' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts session_create with optional fields', () => {
+      const result = validateClientMessage({
+        type: 'session_create',
+        title: 'My Session',
+        maxResponseTokens: 4096,
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('rejects session_create with non-string title', () => {
+      const result = validateClientMessage({ type: 'session_create', title: 42 });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"title" must be a string');
+    });
+
+    test('rejects session_create with non-number maxResponseTokens', () => {
+      const result = validateClientMessage({
+        type: 'session_create',
+        maxResponseTokens: 'big',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"maxResponseTokens" must be a number');
+    });
+
+    // ─── High-risk: confirmation_response ───────────────────────────────
+
+    test('accepts valid confirmation_response', () => {
+      const result = validateClientMessage({
+        type: 'confirmation_response',
+        requestId: 'req-1',
+        decision: 'allow',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts all valid decision values', () => {
+      for (const decision of ['allow', 'always_allow', 'deny', 'always_deny']) {
+        const result = validateClientMessage({
+          type: 'confirmation_response',
+          requestId: 'req-1',
+          decision,
+        });
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    test('rejects confirmation_response without requestId', () => {
+      const result = validateClientMessage({
+        type: 'confirmation_response',
+        decision: 'allow',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "requestId"');
+    });
+
+    test('rejects confirmation_response with invalid decision', () => {
+      const result = validateClientMessage({
+        type: 'confirmation_response',
+        requestId: 'req-1',
+        decision: 'maybe',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"decision" must be one of');
+    });
+
+    // ─── High-risk: secret_response ─────────────────────────────────────
+
+    test('accepts valid secret_response with value', () => {
+      const result = validateClientMessage({
+        type: 'secret_response',
+        requestId: 'req-1',
+        value: 'my-secret',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('accepts secret_response without value (cancelled)', () => {
+      const result = validateClientMessage({
+        type: 'secret_response',
+        requestId: 'req-1',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('rejects secret_response without requestId', () => {
+      const result = validateClientMessage({
+        type: 'secret_response',
+        value: 'my-secret',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "requestId"');
+    });
+
+    test('rejects secret_response with non-string value', () => {
+      const result = validateClientMessage({
+        type: 'secret_response',
+        requestId: 'req-1',
+        value: 42,
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('"value" must be a string');
+    });
+
+    // ─── High-risk: ui_surface_action ───────────────────────────────────
+
+    test('accepts valid ui_surface_action', () => {
+      const result = validateClientMessage({
+        type: 'ui_surface_action',
+        sessionId: 'session-1',
+        surfaceId: 'surface-1',
+        actionId: 'action-1',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test('rejects ui_surface_action without sessionId', () => {
+      const result = validateClientMessage({
+        type: 'ui_surface_action',
+        surfaceId: 'surface-1',
+        actionId: 'action-1',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "sessionId"');
+    });
+
+    test('rejects ui_surface_action without surfaceId', () => {
+      const result = validateClientMessage({
+        type: 'ui_surface_action',
+        sessionId: 'session-1',
+        actionId: 'action-1',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "surfaceId"');
+    });
+
+    test('rejects ui_surface_action without actionId', () => {
+      const result = validateClientMessage({
+        type: 'ui_surface_action',
+        sessionId: 'session-1',
+        surfaceId: 'surface-1',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toContain('non-empty string "actionId"');
+    });
+
+    // ─── Extra properties are tolerated ─────────────────────────────────
+
+    test('allows extra properties on known types', () => {
+      const result = validateClientMessage({
+        type: 'ping',
+        extraField: 'ignored',
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('isClientMessageEnvelope', () => {
+    test('returns true for valid messages', () => {
+      expect(isClientMessageEnvelope({ type: 'ping' })).toBe(true);
+    });
+
+    test('returns false for invalid messages', () => {
+      expect(isClientMessageEnvelope(null)).toBe(false);
+      expect(isClientMessageEnvelope({ type: 'bogus' })).toBe(false);
+      expect(isClientMessageEnvelope(42)).toBe(false);
+    });
+
+    test('narrows type to ClientMessage', () => {
+      const val: unknown = { type: 'ping' };
+      if (isClientMessageEnvelope(val)) {
+        // TypeScript narrows val to ClientMessage — access .type safely
+        expect(val.type).toBe('ping');
+      }
+    });
+  });
+});

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -1,0 +1,175 @@
+import type { ClientMessage } from './ipc-contract.js';
+
+/**
+ * All known ClientMessage `type` discriminator values, extracted from the
+ * ClientMessage union in ipc-contract.ts.
+ */
+const KNOWN_CLIENT_TYPES = new Set<string>([
+  'user_message',
+  'confirmation_response',
+  'secret_response',
+  'session_list',
+  'session_create',
+  'session_switch',
+  'ping',
+  'cancel',
+  'model_get',
+  'model_set',
+  'history_request',
+  'undo',
+  'regenerate',
+  'usage_request',
+  'sandbox_set',
+  'cu_session_create',
+  'cu_session_abort',
+  'cu_observation',
+  'ambient_observation',
+  'task_submit',
+  'ui_surface_action',
+  'app_data_request',
+  'skills_list',
+  'skill_detail',
+  'skills_enable',
+  'skills_disable',
+  'skills_configure',
+  'skills_install',
+  'skills_uninstall',
+  'skills_update',
+  'skills_check_updates',
+  'skills_search',
+  'skills_inspect',
+  'suggestion_request',
+  'add_trust_rule',
+  'trust_rules_list',
+  'remove_trust_rule',
+  'update_trust_rule',
+  'bundle_app',
+  'apps_list',
+  'app_open_request',
+  'shared_apps_list',
+  'shared_app_delete',
+  'open_bundle',
+  'sign_bundle_payload_response',
+  'get_signing_identity_response',
+  'sessions_clear',
+]);
+
+export type ValidationResult = {
+  valid: true;
+  message: ClientMessage;
+} | {
+  valid: false;
+  reason: string;
+};
+
+/**
+ * Validate that a parsed JSON value is a well-formed ClientMessage envelope.
+ *
+ * Checks:
+ * 1. Value is a non-null object
+ * 2. Has a string `type` property
+ * 3. `type` is in the known ClientMessage type set
+ * 4. For high-risk message types, validates required properties
+ */
+export function validateClientMessage(value: unknown): ValidationResult {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return { valid: false, reason: 'Message is not a JSON object' };
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (typeof obj.type !== 'string') {
+    return { valid: false, reason: 'Message is missing a string "type" field' };
+  }
+
+  if (!KNOWN_CLIENT_TYPES.has(obj.type)) {
+    return { valid: false, reason: `Unknown message type: "${obj.type}"` };
+  }
+
+  // Property-level validation for high-risk message types
+  const propError = validateHighRiskProperties(obj);
+  if (propError) {
+    return { valid: false, reason: propError };
+  }
+
+  return { valid: true, message: value as ClientMessage };
+}
+
+/**
+ * Type guard shorthand — returns true when `value` is a structurally valid
+ * ClientMessage, false otherwise.
+ */
+export function isClientMessageEnvelope(value: unknown): value is ClientMessage {
+  return validateClientMessage(value).valid;
+}
+
+// ─── Property-level validation for high-risk messages ────────────────────────
+
+type PropertyValidator = (obj: Record<string, unknown>) => string | null;
+
+const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
+  user_message: (obj) => {
+    if (typeof obj.sessionId !== 'string' || obj.sessionId === '') {
+      return 'user_message requires a non-empty string "sessionId"';
+    }
+    // content is optional (attachments-only messages are valid)
+    if (obj.content !== undefined && typeof obj.content !== 'string') {
+      return 'user_message "content" must be a string when present';
+    }
+    if (obj.attachments !== undefined && !Array.isArray(obj.attachments)) {
+      return 'user_message "attachments" must be an array when present';
+    }
+    return null;
+  },
+
+  session_create: (obj) => {
+    if (obj.title !== undefined && typeof obj.title !== 'string') {
+      return 'session_create "title" must be a string when present';
+    }
+    if (obj.maxResponseTokens !== undefined && typeof obj.maxResponseTokens !== 'number') {
+      return 'session_create "maxResponseTokens" must be a number when present';
+    }
+    return null;
+  },
+
+  confirmation_response: (obj) => {
+    if (typeof obj.requestId !== 'string' || obj.requestId === '') {
+      return 'confirmation_response requires a non-empty string "requestId"';
+    }
+    const validDecisions = ['allow', 'always_allow', 'deny', 'always_deny'];
+    if (typeof obj.decision !== 'string' || !validDecisions.includes(obj.decision)) {
+      return `confirmation_response "decision" must be one of: ${validDecisions.join(', ')}`;
+    }
+    return null;
+  },
+
+  secret_response: (obj) => {
+    if (typeof obj.requestId !== 'string' || obj.requestId === '') {
+      return 'secret_response requires a non-empty string "requestId"';
+    }
+    // value is optional (undefined = user cancelled)
+    if (obj.value !== undefined && typeof obj.value !== 'string') {
+      return 'secret_response "value" must be a string when present';
+    }
+    return null;
+  },
+
+  ui_surface_action: (obj) => {
+    if (typeof obj.sessionId !== 'string' || obj.sessionId === '') {
+      return 'ui_surface_action requires a non-empty string "sessionId"';
+    }
+    if (typeof obj.surfaceId !== 'string' || obj.surfaceId === '') {
+      return 'ui_surface_action requires a non-empty string "surfaceId"';
+    }
+    if (typeof obj.actionId !== 'string' || obj.actionId === '') {
+      return 'ui_surface_action requires a non-empty string "actionId"';
+    }
+    return null;
+  },
+};
+
+function validateHighRiskProperties(obj: Record<string, unknown>): string | null {
+  const validator = HIGH_RISK_VALIDATORS[obj.type as string];
+  if (!validator) return null;
+  return validator(obj);
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -20,6 +20,7 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from './ipc-protocol.js';
+import { validateClientMessage } from './ipc-validate.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
 
@@ -383,7 +384,14 @@ export class DaemonServer {
         return;
       }
       for (const msg of messages) {
-        this.dispatchMessage(msg as ClientMessage, socket);
+        const result = validateClientMessage(msg);
+        if (!result.valid) {
+          log.warn({ reason: result.reason }, 'Invalid IPC message, dropping client');
+          socket.write(serialize({ type: 'error', message: `Invalid message: ${result.reason}` }));
+          socket.destroy();
+          return;
+        }
+        this.dispatchMessage(result.message, socket);
       }
     });
 


### PR DESCRIPTION
## Summary

Closes #2007

Replaces the blind `msg as ClientMessage` type cast in the daemon's IPC dispatch path (`server.ts`) with runtime validation against the contract schema.

### Changes

- **New `ipc-validate.ts` module** — `validateClientMessage()` function and `isClientMessageEnvelope` type guard that:
  - Check parsed JSON has a string `type` field
  - Verify `type` is in the known set of 40+ `ClientMessage` type discriminators
  - Validate required properties for 5 high-risk message types: `user_message`, `session_create`, `confirmation_response`, `secret_response`, `ui_surface_action`
  - Return a discriminated `ValidationResult` union for typed error handling

- **Modified `server.ts`** — The `handleConnection` data handler now validates each parsed message before dispatching. Invalid messages trigger a structured log warning, an IPC error response, and socket close.

- **New `ipc-validate.test.ts`** — 38 tests covering envelope checks (null, undefined, arrays, missing type, unknown type), property-level validation for all 5 high-risk types, extra property tolerance, and the type guard.

### Before/After

**Before (server.ts:386):**
```typescript
this.dispatchMessage(msg as ClientMessage, socket);
```

**After:**
```typescript
const result = validateClientMessage(msg);
if (!result.valid) {
  log.warn({ reason: result.reason }, 'Invalid IPC message, dropping client');
  socket.write(serialize({ type: 'error', message: `Invalid message: ${result.reason}` }));
  socket.destroy();
  return;
}
this.dispatchMessage(result.message, socket);
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
