### PR TITLE
fix(ui): use AppKit scroll tracking for composer scrollbar and polish styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -576,22 +576,13 @@ struct ChatView: View {
                 }
             }
             .frame(minHeight: min(max(editorContentHeight, 28), 200), maxHeight: .infinity, alignment: .center)
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(
-                        key: ComposerScrollOffsetKey.self,
-                        value: -geo.frame(in: .named("composerScroll")).minY
-                    )
-                }
-            )
+            .background(ScrollOffsetReader(offset: $composerScrollOffset))
 
             // Invisible anchor for auto-scroll
             Color.clear
                 .frame(height: 1)
                 .id("composer-bottom")
         }
-        .coordinateSpace(name: "composerScroll")
-        .onPreferenceChange(ComposerScrollOffsetKey.self) { composerScrollOffset = $0 }
         .overlay(alignment: .topTrailing) {
             composerScrollIndicator
         }
@@ -648,10 +639,10 @@ struct ChatView: View {
             let yOffset = 2 + progress * thumbTravel
 
             RoundedRectangle(cornerRadius: 2)
-                .fill(Violet._400.opacity(0.35))
+                .fill(Slate._400.opacity(0.5))
                 .frame(width: 4, height: thumbHeight)
                 .padding(.top, yOffset)
-                .padding(.trailing, 6)
+                .padding(.trailing, 4)
                 .frame(maxHeight: .infinity, alignment: .top)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
@@ -1305,9 +1296,41 @@ private struct ChatViewPreviewWrapper: View {
 
 // MARK: - Composer Scroll Tracking
 
-private struct ComposerScrollOffsetKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
+/// Reads the enclosing NSScrollView's content offset in real-time via AppKit notifications.
+private struct ScrollOffsetReader: NSViewRepresentable {
+    @Binding var offset: CGFloat
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            guard let scrollView = view.enclosingScrollView else { return }
+            scrollView.contentView.postsBoundsChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                context.coordinator,
+                selector: #selector(Coordinator.boundsDidChange(_:)),
+                name: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView
+            )
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(offset: $offset)
+    }
+
+    class Coordinator: NSObject {
+        var offset: Binding<CGFloat>
+
+        init(offset: Binding<CGFloat>) {
+            self.offset = offset
+        }
+
+        @objc func boundsDidChange(_ notification: Notification) {
+            guard let clipView = notification.object as? NSClipView else { return }
+            offset.wrappedValue = clipView.bounds.origin.y
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -15,6 +15,7 @@ final class MainWindow {
 
     /// Tracks daemon reconnects so trace state can be reset on stream restart.
     private var connectionCancellable: AnyCancellable?
+    private var layoutObserver: NSObjectProtocol?
     private var hasConnectedOnce = false
 
     /// Whether the main window is currently visible on screen.
@@ -99,10 +100,36 @@ final class MainWindow {
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
 
+        configureTrafficLightPadding(window)
+
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
+    }
+
+    // MARK: - Traffic Light Positioning
+
+    private func configureTrafficLightPadding(_ window: NSWindow) {
+        repositionTrafficLights(window)
+        layoutObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.repositionTrafficLights(window)
+            }
+        }
+    }
+
+    private func repositionTrafficLights(_ window: NSWindow) {
+        guard let closeButton = window.standardWindowButton(.closeButton),
+              let containerView = closeButton.superview else { return }
+        containerView.setFrameOrigin(NSPoint(
+            x: containerView.frame.origin.x + 6,
+            y: containerView.frame.origin.y - 8
+        ))
     }
 
     func close() {


### PR DESCRIPTION
## Summary
- Replace SwiftUI PreferenceKey scroll tracking with AppKit `NSScrollView.boundsDidChangeNotification` so the composer scrollbar thumb updates in real-time during active scrolling
- Change scrollbar color from violet to grey (`Slate._400.opacity(0.5)`) for better contrast
- Adjust trailing padding (6→4pt) to position scrollbar slightly closer to the right edge
- Add traffic light button repositioning in main window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
