### PR TITLE
fix(ui): fine-tune traffic light button padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -127,8 +127,8 @@ final class MainWindow {
         guard let closeButton = window.standardWindowButton(.closeButton),
               let containerView = closeButton.superview else { return }
         containerView.setFrameOrigin(NSPoint(
-            x: containerView.frame.origin.x + 6,
-            y: containerView.frame.origin.y - 8
+            x: containerView.frame.origin.x + 2,
+            y: containerView.frame.origin.y - 2.5
         ))
     }
 


### PR DESCRIPTION
## Summary
- Adjust traffic light button offset to 2px horizontal and 2.5px vertical for better visual centering in the titlebar area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
