### PR TITLE
fix(ui): left-align attachment strip with composer placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -713,7 +713,6 @@ struct ChatView: View {
                     attachmentChip(attachment)
                 }
             }
-            .padding(.horizontal, VSpacing.sm)
             .padding(.top, VSpacing.sm)
             .padding(.bottom, VSpacing.xs)
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -229,6 +229,18 @@ public final class ChatViewModel: ObservableObject {
     public func addAttachmentFromPasteboard() {
         #if os(macOS)
         let pasteboard = NSPasteboard.general
+
+        // Prefer file URLs — preserves the original filename
+        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true,
+        ]) as? [URL], !urls.isEmpty {
+            for url in urls {
+                addAttachment(url: url)
+            }
+            return
+        }
+
+        // Fall back to raw image data (e.g. screenshot to clipboard)
         guard let imageData = pasteboard.data(forType: .png) ?? pasteboard.data(forType: .tiff) else {
             return
         }


### PR DESCRIPTION
## Summary
- Remove extra `.padding(.horizontal, VSpacing.sm)` from the attachment strip so chips left-align with the placeholder text
- Prefer file URLs from pasteboard to preserve original filenames when pasting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
