### PR TITLE
fix(hooks): detect unstaged IPC generated files in pre-commit

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -36,7 +36,8 @@ Automatically checks for plain text keys and secrets before allowing a commit.
 - ✅ Blocks commits containing potential secrets
 - ✅ Provides detailed feedback on what was detected and where
 - ✅ Allows clean commits to proceed without interruption
-- ✅ When IPC contract files are staged, verifies the generated Swift models are up to date
+- ✅ When IPC contract files are staged, verifies the generated Swift models and inventory snapshot are up to date
+- ✅ Catches unstaged generated output files (e.g., regenerated but not `git add`-ed)
 
 **Bypass (not recommended):**
 If you need to bypass this check in exceptional cases:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -173,6 +173,34 @@ if [ $IPC_CHANGED -eq 1 ]; then
             exit 1
         fi
         echo "✅ IPC contract inventory is up to date"
+
+        # Verify generated output files are staged (not just regenerated on disk).
+        # The checks above compare against the working tree, so if a developer
+        # regenerates but forgets to `git add`, the hook would pass while the
+        # commit still contains stale content.
+        IPC_OUTPUT_FILES=(
+            "clients/shared/IPC/Generated/IPCContractGenerated.swift"
+            "assistant/src/daemon/ipc-contract-inventory.json"
+        )
+        UNSTAGED=0
+        for OUTPUT_FILE in "${IPC_OUTPUT_FILES[@]}"; do
+            if git diff --name-only -- "$OUTPUT_FILE" | grep -q .; then
+                if [ $UNSTAGED -eq 0 ]; then
+                    echo ""
+                    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                    echo -e "${RED}Generated IPC files have unstaged changes!${NC}"
+                    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                fi
+                echo -e "  ${YELLOW}$OUTPUT_FILE${NC} differs between index and working tree"
+                UNSTAGED=1
+            fi
+        done
+        if [ $UNSTAGED -eq 1 ]; then
+            echo ""
+            echo "Stage the updated files with: git add ${IPC_OUTPUT_FILES[*]}"
+            echo "Then commit again."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
Addresses review feedback from PR #2082.

## Problem

The pre-commit hook's IPC generation checks (`check:ipc-generated` and `ipc:inventory`) compare generator output against the **working tree** file, not the **staged (index)** content. If a developer regenerates the output files but forgets to `git add` them, the hook passes while the commit still contains stale staged content — pushing the failure to CI.

## Fix

Added a post-check after the generation/inventory validations pass that verifies the two generated output files (`IPCContractGenerated.swift` and `ipc-contract-inventory.json`) have no unstaged changes (`git diff --name-only`). If they differ between the index and working tree, the hook fails with a clear message telling the developer to stage them.

## Files changed
- `.githooks/pre-commit` — added unstaged-output-file detection
- `.githooks/README.md` — updated behavior description
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
