### PR TITLE
fix(ipc): address review feedback on swift codegen

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -98,15 +98,26 @@ function generateSchemas(): Record<string, SchemaDef> {
   const symbols = generator.getMainFileSymbols(program, [CONTRACT_PATH]);
   const result: Record<string, SchemaDef> = {};
 
+  const skipped: string[] = [];
+
   for (const symbol of symbols) {
     if (SKIP_TYPES.has(symbol)) continue;
     try {
       const schema = generator.getSchemaForSymbol(symbol) as SchemaDef | null;
       if (schema) {
         result[symbol] = schema;
+      } else {
+        skipped.push(symbol);
       }
     } catch {
-      // const values or complex type aliases may not produce schemas
+      skipped.push(symbol);
+    }
+  }
+
+  if (skipped.length > 0) {
+    console.warn(`Warning: skipped ${skipped.length} symbol(s) that could not produce schemas:`);
+    for (const s of skipped) {
+      console.warn(`  - ${s}`);
     }
   }
 
@@ -263,7 +274,7 @@ function capitalize(s: string): string {
 function singularize(s: string): string {
   // Crude singularization for array item names
   if (s.endsWith('ies')) return s.slice(0, -3) + 'y';
-  if (s.endsWith('ses') || s.endsWith('xes') || s.endsWith('zes')) return s.slice(0, -2);
+  if (s.endsWith('ches') || s.endsWith('shes') || s.endsWith('ses') || s.endsWith('xes') || s.endsWith('zes')) return s.slice(0, -2);
   if (s.endsWith('s') && !s.endsWith('ss')) return s.slice(0, -1);
   return s;
 }
@@ -311,8 +322,6 @@ function buildAllStructs(
 
   for (const [name, def] of Object.entries(allDefs).sort(([a], [b]) => a.localeCompare(b))) {
     if (def.type !== 'object' || !def.properties) continue;
-    // Skip pure string enum definitions
-    if (def.type === 'string' && def.enum) continue;
 
     const ipcName = `IPC${name}`;
     const required = new Set(def.required ?? []);

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -472,11 +472,11 @@ public struct IPCSandboxSetRequest: Codable, Sendable {
 public struct IPCSecretDetected: Codable, Sendable {
     public let type: String
     public let toolName: String
-    public let matches: [IPCSecretDetectedMatche]
+    public let matches: [IPCSecretDetectedMatch]
     public let action: String
 }
 
-public struct IPCSecretDetectedMatche: Codable, Sendable {
+public struct IPCSecretDetectedMatch: Codable, Sendable {
     public let type: String
     public let redactedValue: String
 }
@@ -504,15 +504,6 @@ public struct IPCSessionCreateRequest: Codable, Sendable {
     public let systemPromptOverride: String?
     public let maxResponseTokens: Int?
     public let correlationId: String?
-}
-
-public struct IPCSessionErrorMessage: Codable, Sendable {
-    public let type: String
-    public let sessionId: String
-    public let code: String
-    public let userMessage: String
-    public let retryable: Bool
-    public let debugDetails: String?
 }
 
 public struct IPCSessionInfo: Codable, Sendable {
@@ -852,19 +843,6 @@ public struct IPCToolUseStart: Codable, Sendable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let sessionId: String?
-}
-
-public struct IPCTraceEvent: Codable, Sendable {
-    public let type: String
-    public let eventId: String
-    public let sessionId: String
-    public let requestId: String?
-    public let timestampMs: Double
-    public let sequence: Double
-    public let kind: String
-    public let status: String?
-    public let summary: String
-    public let attributes: [String: AnyCodable]?
 }
 
 public struct IPCTrustRulesList: Codable, Sendable {


### PR DESCRIPTION
Addresses review feedback from #2072.

## Changes

1. **Report skipped symbols** (Codex feedback): `generateSchemas()` now logs warnings when symbols fail schema generation instead of silently swallowing errors, so CI surfaces incomplete IPC model generation.

2. **Fix singularize()** (Devin feedback): Added `-ches` and `-shes` to the list of plural endings that strip 2 chars. Previously "matches" produced "matche" → now correctly produces "match". Fixes `IPCSecretDetectedMatche` → `IPCSecretDetectedMatch`.

3. **Remove dead code** (Devin feedback): Removed unreachable `def.type === 'string'` check that sat after a `def.type !== 'object'` guard in `buildAllStructs()`.

4. **Regenerated Swift output** with corrected struct names and up-to-date SKIP_TYPES.

## Validation

- `bun run generate:ipc` runs cleanly with no warnings
- `bunx tsc --noEmit` passes (pre-existing test-file errors only)
- Generated Swift output has correct `IPCSecretDetectedMatch` struct name
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
