### PR TITLE
fix(docker): make shell configurable instead of hardcoding bash

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -108,13 +108,13 @@ describe('DockerBackend — argument construction', () => {
     expect(result.args).toContain('ubuntu:22.04');
   });
 
-  test('wraps command with bash -c --', () => {
+  test('wraps command with sh -c -- by default', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const cmd = 'cat /etc/passwd | wc -l';
     const result = backend.wrap(cmd, sandboxRoot);
-    const bashIdx = result.args.indexOf('bash');
-    expect(bashIdx).toBeGreaterThan(0);
-    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', '--', cmd]);
+    const shIdx = result.args.indexOf('sh');
+    expect(shIdx).toBeGreaterThan(0);
+    expect(result.args.slice(shIdx)).toEqual(['sh', '-c', '--', cmd]);
   });
 });
 
@@ -333,6 +333,19 @@ describe('DockerBackend — custom config', () => {
     expect(result.args).toContain('--cpus=4');
     expect(result.args).toContain('--memory=1024m');
     expect(result.args).toContain('--pids-limit=512');
+  });
+
+  test('accepts custom shell', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { shell: 'bash' },
+      1000,
+      1000,
+    );
+    const result = backend.wrap('echo hi', sandboxRoot);
+    const bashIdx = result.args.indexOf('bash');
+    expect(bashIdx).toBeGreaterThan(0);
+    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', '--', 'echo hi']);
   });
 
   test('accepts custom network mode', () => {

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -9,6 +9,8 @@ const log = getLogger('docker-sandbox');
 
 export interface DockerConfig {
   image?: string;
+  /** Shell binary used to interpret commands (default: 'sh' for POSIX portability). */
+  shell?: string;
   cpus?: number;
   memoryMb?: number;
   pidsLimit?: number;
@@ -17,6 +19,7 @@ export interface DockerConfig {
 
 const DEFAULTS: Required<DockerConfig> = {
   image: 'ubuntu:22.04',
+  shell: 'sh',
   cpus: 2,
   memoryMb: 512,
   pidsLimit: 256,
@@ -199,7 +202,7 @@ export class DockerBackend implements SandboxBackend {
     const containerWorkDir =
       relPath === '' ? '/workspace' : posix.join('/workspace', relPath);
 
-    const { image, cpus, memoryMb, pidsLimit, network } = this.config;
+    const { image, shell, cpus, memoryMb, pidsLimit, network } = this.config;
 
     // Every flag is a separate argv segment — no shell interpolation occurs.
     const args: string[] = [
@@ -222,7 +225,7 @@ export class DockerBackend implements SandboxBackend {
       '--user',
       `${this.uid}:${this.gid}`,
       image,
-      'bash',
+      shell,
       '-c',
       '--',
       command,


### PR DESCRIPTION
## Summary

Addresses review feedback on #2080: the Docker backend hardcoded `bash -c` as the command interpreter, which breaks images that don't ship Bash (e.g., `alpine:3.19`).

- Added `shell` option to `DockerConfig` (default: `'sh'` for POSIX portability)
- Updated `wrap()` to use the configured shell instead of hardcoded `bash`
- Updated tests: default shell assertion now checks for `sh`, added test for custom shell override

## Test plan

- [x] `bun test src/__tests__/terminal-sandbox-docker.test.ts` — 52/52 pass
- [x] `bunx tsc --noEmit` — no new errors in changed files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
