### PR TITLE
test: replace weak $0 assertion with spawn spy in host-shell test

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -2,6 +2,22 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import * as realChildProcess from 'node:child_process';
+
+// Capture the real spawn before mock.module replaces it
+const originalSpawn = realChildProcess.spawn;
+
+// Capture spawn calls to verify the host tool spawns 'bash' directly
+const spawnCalls: { command: string; args: string[] }[] = [];
+const spawnSpy = mock((...args: Parameters<typeof realChildProcess.spawn>) => {
+  spawnCalls.push({ command: args[0] as string, args: args[1] as string[] });
+  return (originalSpawn as Function)(...args);
+});
+
+mock.module('node:child_process', () => ({
+  ...realChildProcess,
+  spawn: spawnSpy,
+}));
 
 const mockConfig = {
   provider: 'anthropic',
@@ -121,14 +137,17 @@ describe('host_bash tool', () => {
     // proving it bypasses the sandbox entirely
     expect(mockConfig.sandbox.enabled).toBe(true);
 
+    spawnCalls.length = 0;
+
     const result = await hostShellTool.execute({
-      command: 'echo $0',
+      command: 'echo hello',
       working_dir: dir,
     }, makeContext());
 
     expect(result.isError).toBe(false);
-    // bash reports its own name — if sandboxed via sandbox-exec or bwrap,
-    // the process tree would be different
-    expect(result.content.trim()).toContain('bash');
+    // Verify spawn was called with 'bash' directly — not 'bwrap' or 'sandbox-exec'
+    expect(spawnCalls.length).toBe(1);
+    expect(spawnCalls[0].command).toBe('bash');
+    expect(spawnCalls[0].args).toEqual(['-c', '--', 'echo hello']);
   });
 });


### PR DESCRIPTION
Addresses review feedback from PR #2045.

## Problem

The `spawns plain bash without sandbox-exec or bwrap` test checked `echo $0` output for `bash`, but this is non-discriminating — both `bwrap` and `sandbox-exec` wrappers ultimately invoke `bash -c`, so `$0` would still print `bash` regardless of sandboxing.

## Fix

Replace the weak `echo $0` approach with a `spawn` spy that captures the actual command and args passed to `child_process.spawn()`. The test now directly asserts that `spawn` is called with `'bash'` (not `'bwrap'` or `'sandbox-exec'`) and the expected `['-c', '--', 'echo hello']` args.

## Files changed

- `assistant/src/__tests__/host-shell-tool.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
