### PR TITLE
fix(trace): update TraceEmitter sender when session client changes

### DIFF
--- a/assistant/src/__tests__/trace-emitter.test.ts
+++ b/assistant/src/__tests__/trace-emitter.test.ts
@@ -149,4 +149,25 @@ describe('TraceEmitter', () => {
 
     expect(sent[0].attributes).toBeUndefined();
   });
+
+  it('updateSender redirects subsequent events to the new callback', () => {
+    const { emitter, sent } = createEmitter();
+    emitter.emit('tool_started', 'before');
+    expect(sent).toHaveLength(1);
+
+    const newSent: TraceEvent[] = [];
+    const newSender = mock((msg: ServerMessage) => {
+      newSent.push(msg as TraceEvent);
+    });
+    emitter.updateSender(newSender);
+
+    emitter.emit('tool_finished', 'after');
+    // Old sender should not receive the new event
+    expect(sent).toHaveLength(1);
+    // New sender should receive it
+    expect(newSent).toHaveLength(1);
+    expect(newSent[0].summary).toBe('after');
+    // Sequence continues from where it left off
+    expect(newSent[0].sequence).toBe(1);
+  });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -280,6 +280,7 @@ export class Session {
     this.sendToClient = sendToClient;
     this.prompter.updateSender(sendToClient);
     this.secretPrompter.updateSender(sendToClient);
+    this.traceEmitter.updateSender(sendToClient);
   }
 
   setSandboxOverride(enabled: boolean | undefined): void {

--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -22,8 +22,12 @@ export class TraceEmitter {
 
   constructor(
     private readonly sessionId: string,
-    private readonly sendToClient: (msg: ServerMessage) => void,
+    private sendToClient: (msg: ServerMessage) => void,
   ) {}
+
+  updateSender(sendToClient: (msg: ServerMessage) => void): void {
+    this.sendToClient = sendToClient;
+  }
 
   emit(kind: TraceEventKind, summary: string, opts?: TraceEmitOptions): void {
     const eventId = uuid();


### PR DESCRIPTION
Addresses review feedback from PR #2083.

## Problem

`TraceEmitter` captured the initial `sendToClient` callback as `private readonly` and was never updated when `Session.updateClient()` rebinds the sender. After client reconnects (server.ts:462) or orchestrator rebinds (run-orchestrator.ts:88), trace events would be sent to the stale/disconnected callback and silently lost.

## Fix

- Add `updateSender()` method to `TraceEmitter` (matching the existing `PermissionPrompter` pattern)
- Change `sendToClient` from `private readonly` to `private` so it can be reassigned
- Call `this.traceEmitter.updateSender(sendToClient)` in `Session.updateClient()` alongside the existing prompter updates
- Add test verifying that events route to the new sender after `updateSender()`

## Files changed

- `assistant/src/daemon/trace-emitter.ts` — add `updateSender()`, relax readonly
- `assistant/src/daemon/session.ts` — wire `traceEmitter.updateSender` into `updateClient()`
- `assistant/src/__tests__/trace-emitter.test.ts` — new test for `updateSender` behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
