### PR TITLE
fix(fs): preserve OS error details in editFileSafe

### DIFF
--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -155,8 +155,12 @@ export class FileSystemOps {
     let content: string;
     try {
       content = readFileSync(filePath, 'utf-8');
-    } catch {
-      return { ok: false, error: Err.notFound(filePath) };
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { ok: false, error: Err.notFound(filePath) };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: Err.ioError(filePath, msg) };
     }
 
     const result = applyEdit(content, input.oldString, input.newString, input.replaceAll);


### PR DESCRIPTION
## Summary
- Fix `editFileSafe` in `FileSystemOps` to distinguish ENOENT from other I/O errors (EISDIR, EACCES, etc.)
- Previously, the `readFileSync` catch block collapsed all errors into `NOT_FOUND`, losing the actual OS error message
- Now only ENOENT maps to `NOT_FOUND`; other failures surface as `IO_ERROR` with the original OS message preserved

Addresses feedback from #2106.

## Test plan
- [x] `file-ops-service.test.ts` passes (17 tests)
- [x] `host-file-edit-tool.test.ts` passes (4 tests)
- [x] TypeScript type-check passes (no new errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
