### PR TITLE
fix(filesystem): fix garbled size-limit errors and edit read-failure classification

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -191,6 +191,22 @@ describe('FileSystemOps.editFileSafe', () => {
     expect(result.error.code).toBe('NOT_FOUND');
   });
 
+  test('returns NOT_A_FILE when target is a directory', () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, 'subdir'));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = ops.editFileSafe({
+      path: 'subdir',
+      oldString: 'a',
+      newString: 'b',
+      replaceAll: false,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('NOT_A_FILE');
+  });
+
   test('returns MATCH_NOT_FOUND when old_string is absent', () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, 'file.txt'), 'hello world');

--- a/assistant/src/__tests__/shared-filesystem-errors.test.ts
+++ b/assistant/src/__tests__/shared-filesystem-errors.test.ts
@@ -47,11 +47,11 @@ describe('shared filesystem error helpers', () => {
     expect(err.message).toContain('/some/dir');
   });
 
-  it('sizeLimitExceeded includes size and limit', () => {
-    const err = sizeLimitExceeded('/big.bin', '200 MB', '100 MB');
+  it('sizeLimitExceeded includes detail message', () => {
+    const detail = 'File size (200 MB) exceeds the 100 MB limit: /big.bin';
+    const err = sizeLimitExceeded('/big.bin', detail);
     expect(err.code).toBe('SIZE_LIMIT_EXCEEDED' satisfies FsErrorCode);
-    expect(err.message).toContain('200 MB');
-    expect(err.message).toContain('100 MB');
+    expect(err.message).toBe(detail);
     expect(err.path).toBe('/big.bin');
   });
 

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -56,10 +56,10 @@ export function notAFile(path: string): FsError {
   return { code: 'NOT_A_FILE', message: `Not a regular file: ${path}`, path };
 }
 
-export function sizeLimitExceeded(path: string, size: string, limit: string): FsError {
+export function sizeLimitExceeded(path: string, detail: string): FsError {
   return {
     code: 'SIZE_LIMIT_EXCEEDED',
-    message: `File size (${size}) exceeds the ${limit} limit: ${path}`,
+    message: detail,
     path,
   };
 }

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -57,7 +57,7 @@ export class FileSystemOps {
 
     const sizeErr = checkFileSizeOnDisk(filePath);
     if (sizeErr) {
-      return { ok: false, error: Err.sizeLimitExceeded(filePath, `${stat.size}`, sizeErr) };
+      return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
     try {
@@ -95,7 +95,7 @@ export class FileSystemOps {
 
     const sizeErr = checkContentSize(input.content, filePath);
     if (sizeErr) {
-      return { ok: false, error: Err.sizeLimitExceeded(filePath, 'content', sizeErr) };
+      return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
     try {
@@ -146,7 +146,7 @@ export class FileSystemOps {
     try {
       const sizeErr = checkFileSizeOnDisk(filePath);
       if (sizeErr) {
-        return { ok: false, error: Err.sizeLimitExceeded(filePath, 'file', sizeErr) };
+        return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
       }
     } catch {
       // Fall through — the readFileSync below will surface NOT_FOUND.
@@ -155,8 +155,12 @@ export class FileSystemOps {
     let content: string;
     try {
       content = readFileSync(filePath, 'utf-8');
-    } catch (err) {
-      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EISDIR') {
+        return { ok: false, error: Err.notAFile(filePath) };
+      }
+      if (code === 'ENOENT') {
         return { ok: false, error: Err.notFound(filePath) };
       }
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #2093 (M7: Build shared FileSystemOps service):

- **Fix garbled SIZE_LIMIT_EXCEEDED error messages** (Devin review): `sizeLimitExceeded()` was double-wrapping the size-guard error string inside its own template, producing messages like `File size (12345) exceeds the File size (104.9 MB) exceeds the 100.0 MB limit: /path limit: /path`. Changed the function signature from `(path, size, limit)` to `(path, detail)` to pass the pre-formatted size-guard message directly.

- **Distinguish edit read failures from missing files** (Codex review): `editFileSafe()` was mapping every `readFileSync` failure to `NOT_FOUND`, which is incorrect for directories (EISDIR) and permission errors (EACCES). Now branches on error code to return `NOT_A_FILE`, `NOT_FOUND`, or `IO_ERROR` as appropriate.

## Test plan
- [x] Updated `shared-filesystem-errors.test.ts` for new `sizeLimitExceeded` signature
- [x] Added `editFileSafe` test for directory target returning `NOT_A_FILE`
- [x] All 27 tests pass across both test files (0 regressions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
