### PR TITLE
fix(filesystem): preserve I/O error details and fix size-limit messages

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -191,6 +191,23 @@ describe('FileSystemOps.editFileSafe', () => {
     expect(result.error.code).toBe('NOT_FOUND');
   });
 
+  test('returns IO_ERROR (not NOT_FOUND) when path is a directory', () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, 'subdir'));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = ops.editFileSafe({
+      path: 'subdir',
+      oldString: 'a',
+      newString: 'b',
+      replaceAll: false,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('IO_ERROR');
+    expect(result.error.message).toContain('EISDIR');
+  });
+
   test('returns MATCH_NOT_FOUND when old_string is absent', () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, 'file.txt'), 'hello world');

--- a/assistant/src/__tests__/shared-filesystem-errors.test.ts
+++ b/assistant/src/__tests__/shared-filesystem-errors.test.ts
@@ -47,11 +47,11 @@ describe('shared filesystem error helpers', () => {
     expect(err.message).toContain('/some/dir');
   });
 
-  it('sizeLimitExceeded includes size and limit', () => {
-    const err = sizeLimitExceeded('/big.bin', '200 MB', '100 MB');
+  it('sizeLimitExceeded passes through detail message', () => {
+    const detail = 'File size (200 MB) exceeds the 100 MB limit: /big.bin';
+    const err = sizeLimitExceeded('/big.bin', detail);
     expect(err.code).toBe('SIZE_LIMIT_EXCEEDED' satisfies FsErrorCode);
-    expect(err.message).toContain('200 MB');
-    expect(err.message).toContain('100 MB');
+    expect(err.message).toBe(detail);
     expect(err.path).toBe('/big.bin');
   });
 

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -56,10 +56,10 @@ export function notAFile(path: string): FsError {
   return { code: 'NOT_A_FILE', message: `Not a regular file: ${path}`, path };
 }
 
-export function sizeLimitExceeded(path: string, size: string, limit: string): FsError {
+export function sizeLimitExceeded(path: string, detail: string): FsError {
   return {
     code: 'SIZE_LIMIT_EXCEEDED',
-    message: `File size (${size}) exceeds the ${limit} limit: ${path}`,
+    message: detail,
     path,
   };
 }

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -57,7 +57,7 @@ export class FileSystemOps {
 
     const sizeErr = checkFileSizeOnDisk(filePath);
     if (sizeErr) {
-      return { ok: false, error: Err.sizeLimitExceeded(filePath, `${stat.size}`, sizeErr) };
+      return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
     try {
@@ -95,7 +95,7 @@ export class FileSystemOps {
 
     const sizeErr = checkContentSize(input.content, filePath);
     if (sizeErr) {
-      return { ok: false, error: Err.sizeLimitExceeded(filePath, 'content', sizeErr) };
+      return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
     try {
@@ -146,7 +146,7 @@ export class FileSystemOps {
     try {
       const sizeErr = checkFileSizeOnDisk(filePath);
       if (sizeErr) {
-        return { ok: false, error: Err.sizeLimitExceeded(filePath, 'file', sizeErr) };
+        return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
       }
     } catch {
       // Fall through — the readFileSync below will surface NOT_FOUND.
@@ -155,8 +155,12 @@ export class FileSystemOps {
     let content: string;
     try {
       content = readFileSync(filePath, 'utf-8');
-    } catch {
-      return { ok: false, error: Err.notFound(filePath) };
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { ok: false, error: Err.notFound(filePath) };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: Err.ioError(filePath, msg) };
     }
 
     const result = applyEdit(content, input.oldString, input.newString, input.replaceAll);


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #2099.

- **editFileSafe**: The `readFileSync` catch block was mapping all errors to `NOT_FOUND`. Now it distinguishes `ENOENT` (genuinely not found) from other I/O errors like `EISDIR` and `EACCES`, surfacing the real cause.
- **sizeLimitExceeded**: The error constructor was double-wrapping the message — `checkFileSizeOnDisk`/`checkContentSize` already return fully formatted strings, but `sizeLimitExceeded()` was wrapping them again with its own template. Simplified to pass through the pre-formatted message.
- Added test for editing a directory returning `IO_ERROR` with `EISDIR`.

## Test plan
- [x] shared-filesystem-errors.test.ts passes (8/8)
- [x] file-ops-service.test.ts passes (19/19) — includes new EISDIR test
- [x] file-read-tool.test.ts passes (4/4)
- [x] file-write-tool.test.ts passes (5/5)
- [x] file-edit-tool.test.ts passes (5/5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
