### PR TITLE
fix(docs): correct sandbox docs per PR #2132 review feedback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -831,12 +831,14 @@ The `request_computer_control` tool is a proxy tool available only to text_qa se
 graph TB
     CALL["Model tool call"] --> EXEC["ToolExecutor"]
 
-    EXEC -->|"file_read / file_write / file_edit / bash"| SB_TOOLS["Sandbox-scoped tools"]
-    SB_TOOLS --> WRAP["wrapCommand()<br/>sandbox.ts"]
+    EXEC -->|"file_read / file_write / file_edit"| SB_FILE_TOOLS["Sandbox file tools<br/>path-scoped to sandbox root"]
+    SB_FILE_TOOLS --> SB_FS
+
+    EXEC -->|"bash"| WRAP["wrapCommand()<br/>sandbox.ts"]
 
     WRAP --> BACKEND_CHECK{"sandbox.backend?"}
-    BACKEND_CHECK -->|"native (default)"| NATIVE["NativeBackend"]
-    BACKEND_CHECK -->|"docker"| DOCKER["DockerBackend"]
+    BACKEND_CHECK -->|"native"| NATIVE["NativeBackend"]
+    BACKEND_CHECK -->|"docker (default)"| DOCKER["DockerBackend"]
 
     NATIVE -->|"macOS"| SBPL["sandbox-exec<br/>SBPL profile<br/>deny-default + allow workdir"]
     NATIVE -->|"Linux"| BWRAP["bwrap<br/>bubblewrap<br/>ro-root + rw-workdir<br/>unshare-net + unshare-pid"]
@@ -858,9 +860,9 @@ graph TB
     USER --> CHECK
 ```
 
-- **Backend selection**: The `sandbox.backend` config option (`"native"` or `"docker"`) determines how `bash` commands are sandboxed. The default is `"native"`.
-- **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root.
-- **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is pinned with a `sha256` digest.
+- **Backend selection**: The `sandbox.backend` config option (`"native"` or `"docker"`) determines how `bash` commands are sandboxed. The default is `"docker"`.
+- **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root, `/tmp`, `/private/tmp`, and `/var/folders` (macOS) or the sandbox root and `/tmp` (Linux).
+- **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is `ubuntu:22.04`.
 - **Fail-closed**: Both backends refuse to execute unsandboxed if their prerequisites are unavailable. The Docker backend runs preflight checks (CLI, daemon, image, mount probe) and throws `ToolError` with actionable messages on failure. Positive preflight results are cached; negative results are rechecked on every call.
 - **Host tools unchanged**: `host_bash`, `host_file_read`, `host_file_write`, and `host_file_edit` always execute directly on the host regardless of which sandbox backend is active.
 - Sandbox defaults: `file_*` and `bash` execute within `~/.vellum/data/sandbox/fs`.

--- a/README.md
+++ b/README.md
@@ -91,18 +91,18 @@ When `sandbox.backend` is set to `"docker"`, the daemon wraps every sandbox `bas
 
 - Docker installed and the `docker` CLI available in `PATH`.
 - Docker daemon running (Docker Desktop on macOS/Windows, or `systemd` service on Linux).
-- The configured image pulled locally. The default image is pinned with a `sha256` digest for reproducibility:
+- The configured image pulled locally. The default image is `ubuntu:22.04`:
   ```
-  node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9
+  docker pull ubuntu:22.04
   ```
-  Pull it with: `docker pull node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9`
+- The `ubuntu:22.04` image must also be available locally — the preflight mount probe uses it regardless of `sandbox.docker.image`. In air-gapped or offline environments, ensure both `ubuntu:22.04` and your configured image (if different) are pulled.
 
 **Docker configuration options** (all under `sandbox.docker`):
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `image` | `node:20-slim@sha256:...` | Container image (pinned with sha256 digest) |
-| `cpus` | `1` | CPU limit per container |
+| `image` | `ubuntu:22.04` | Container image |
+| `cpus` | `2` | CPU limit per container |
 | `memoryMb` | `512` | Memory limit in MB |
 | `pidsLimit` | `256` | Maximum number of processes |
 | `network` | `"none"` | Network mode (`"none"` or `"bridge"`) |


### PR DESCRIPTION
## Context

Addresses review feedback on #2132 (SANDBOX M10: Docs + architecture updates).

## Changes

- **ARCHITECTURE.md**: Correct native backend write-scope — document that `/tmp`, `/private/tmp`, and `/var/folders` (macOS) or `/tmp` (Linux) are also writable, not just the sandbox root
- **ARCHITECTURE.md**: Separate file tools from `wrapCommand()` in the Mermaid diagram — only `bash` goes through backend selection; file tools are path-scoped directly to sandbox root
- **ARCHITECTURE.md**: Fix default backend from `"native"` to `"docker"` to match code
- **ARCHITECTURE.md**: Fix default image description from sha256-pinned to `ubuntu:22.04` to match code
- **README.md**: Fix default image from `node:20-slim@sha256:...` to `ubuntu:22.04` to match code
- **README.md**: Document `ubuntu:22.04` mount-probe image dependency for air-gapped setups
- **README.md**: Fix `cpus` default from `1` to `2` to match code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
