### PR TITLE
docs: fix sandbox docs accuracy per PR #2132 feedback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -831,8 +831,10 @@ The `request_computer_control` tool is a proxy tool available only to text_qa se
 graph TB
     CALL["Model tool call"] --> EXEC["ToolExecutor"]
 
-    EXEC -->|"file_read / file_write / file_edit / bash"| SB_TOOLS["Sandbox-scoped tools"]
-    SB_TOOLS --> WRAP["wrapCommand()<br/>sandbox.ts"]
+    EXEC -->|"file_read / file_write / file_edit"| SB_FS_TOOLS["Sandbox filesystem tools<br/>(path-scoped to sandbox root)"]
+    SB_FS_TOOLS --> SB_FS
+
+    EXEC -->|"bash"| WRAP["wrapCommand()<br/>sandbox.ts"]
 
     WRAP --> BACKEND_CHECK{"sandbox.backend?"}
     BACKEND_CHECK -->|"native (default)"| NATIVE["NativeBackend"]
@@ -859,7 +861,7 @@ graph TB
 ```
 
 - **Backend selection**: The `sandbox.backend` config option (`"native"` or `"docker"`) determines how `bash` commands are sandboxed. The default is `"native"`.
-- **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root.
+- **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root, `/tmp`, and `/var/folders` (macOS) or a writable `/tmp` bind-mount (Linux).
 - **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is pinned with a `sha256` digest.
 - **Fail-closed**: Both backends refuse to execute unsandboxed if their prerequisites are unavailable. The Docker backend runs preflight checks (CLI, daemon, image, mount probe) and throws `ToolError` with actionable messages on failure. Positive preflight results are cached; negative results are rechecked on every call.
 - **Host tools unchanged**: `host_bash`, `host_file_read`, `host_file_write`, and `host_file_edit` always execute directly on the host regardless of which sandbox backend is active.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ When `sandbox.backend` is set to `"docker"`, the daemon wraps every sandbox `bas
   node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9
   ```
   Pull it with: `docker pull node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9`
+- The `ubuntu:22.04` image is also required. The preflight mount probe uses this image (regardless of `sandbox.docker.image`) to verify bind-mount support before running any commands. Pull it with: `docker pull ubuntu:22.04`
 
 **Docker configuration options** (all under `sandbox.docker`):
 


### PR DESCRIPTION
Addresses review feedback from PR #2132.

## Changes

Three corrections from Codex review:

1. **ARCHITECTURE.md** - Corrected native backend write-scope description to include `/tmp` and `/var/folders` (macOS) and writable `/tmp` bind-mount (Linux), matching the actual SBPL profile and bwrap arguments.

2. **ARCHITECTURE.md** - Separated file tools from the `wrapCommand` flow in the Mermaid diagram. Only `bash` routes through `wrapCommand()`/backend selection; `file_read`/`file_write`/`file_edit` use path-scoped filesystem tools directly.

3. **README.md** - Documented that the Docker preflight mount probe requires `ubuntu:22.04` in addition to the configured sandbox image, since `checkMountProbe()` hardcodes this image regardless of `sandbox.docker.image`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
