### PR TITLE
fix(filesystem): return NOT_A_FILE for EISDIR in editFileSafe

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -191,7 +191,7 @@ describe('FileSystemOps.editFileSafe', () => {
     expect(result.error.code).toBe('NOT_FOUND');
   });
 
-  test('returns IO_ERROR (not NOT_FOUND) when path is a directory', () => {
+  test('returns NOT_A_FILE when target is a directory', () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, 'subdir'));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
@@ -204,8 +204,7 @@ describe('FileSystemOps.editFileSafe', () => {
     });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('IO_ERROR');
-    expect(result.error.message).toContain('EISDIR');
+    expect(result.error.code).toBe('NOT_A_FILE');
   });
 
   test('returns MATCH_NOT_FOUND when old_string is absent', () => {

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -156,7 +156,13 @@ export class FileSystemOps {
     try {
       content = readFileSync(filePath, 'utf-8');
     } catch (err) {
-      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      const code = err instanceof Error && 'code' in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+      if (code === 'EISDIR') {
+        return { ok: false, error: Err.notAFile(filePath) };
+      }
+      if (code === 'ENOENT') {
         return { ok: false, error: Err.notFound(filePath) };
       }
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
Addresses remaining review feedback from PR #2093 (M7: Build shared FileSystemOps service).

The `sizeLimitExceeded` garbled message fix was already merged. The ENOENT/IO_ERROR distinction was also partially addressed. This PR completes the Codex review feedback by adding EISDIR handling:

- `editFileSafe()` now returns `NOT_A_FILE` (not `IO_ERROR`) when the target path is a directory, consistent with `readFileSafe()`'s behavior
- Updated test to expect `NOT_A_FILE` error code for directory targets

## Test plan
- [x] Updated `editFileSafe` directory test to verify `NOT_A_FILE` code
- [x] All 27 tests pass across both test files (0 regressions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
