### PR TITLE
fix(ipc): add fallback decoding for SessionErrorCode

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -811,6 +811,14 @@ public enum SessionErrorCode: String, CaseIterable, Codable, Sendable {
     case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
     case regenerateFailed = "REGENERATE_FAILED"
     case unknown = "UNKNOWN"
+
+    /// Fall back to `.unknown` for unrecognized codes so that version skew
+    /// between daemon and client never silently drops a session_error message.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = SessionErrorCode(rawValue: rawValue) ?? .unknown
+    }
 }
 
 /// Structured session-level error from the daemon.


### PR DESCRIPTION
## Summary

- Add custom `init(from:)` on `SessionErrorCode` Swift enum that falls back to `.unknown` for unrecognized raw values
- Prevents version-skew failures where a newer daemon sending a new error code would cause the entire `session_error` message to be silently dropped by the Swift client

Addresses review feedback from Codex and Devin on PR #2086.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
