### PR TITLE
fix(docker): guard UID/GID APIs for non-POSIX platforms

### DIFF
--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -159,8 +159,17 @@ export class DockerBackend implements SandboxBackend {
     this.sandboxRoot = realpathSync(resolved);
     validatePathSafety(this.sandboxRoot, 'Sandbox root');
     this.config = { ...DEFAULTS, ...config };
-    this.uid = uid ?? process.getuid!();
-    this.gid = gid ?? process.getgid!();
+    if (uid != null) {
+      this.uid = uid;
+    } else if (process.getuid) {
+      this.uid = process.getuid();
+    } else {
+      throw new ToolError(
+        'Docker sandbox requires POSIX UID/GID APIs (process.getuid/getgid) which are not available on this platform.',
+        'bash',
+      );
+    }
+    this.gid = gid ?? (process.getgid ? process.getgid() : this.uid);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Guards `process.getuid()` / `process.getgid()` calls in `DockerBackend` constructor against platforms where these APIs are undefined (e.g. Windows)
- Throws a controlled `ToolError` with an actionable message instead of crashing with a `TypeError`
- Falls back to UID for GID if `process.getgid` is unavailable but `process.getuid` exists

Addresses review feedback from Codex on PR #2101.

## Test plan
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 13 pass
- [x] `bunx tsc --noEmit` — no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
