### PR TITLE
fix(ui): reset sending state before retry to prevent stuck UI

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1170,6 +1170,15 @@ public final class ChatViewModel: ObservableObject {
     /// Retry the last message after a session error, if the error is retryable.
     public func retryAfterSessionError() {
         guard let error = sessionError, error.isRetryable else { return }
+        guard sessionId != nil else { return }
+        // Reset sending state that may still be set if the session error arrived
+        // while queued messages were pending (pendingQueuedCount > 0).
+        // Without this, regenerateLastMessage() silently bails at its
+        // `!isSending` guard, leaving the UI stuck with no error and no retry.
+        isSending = false
+        pendingQueuedCount = 0
+        pendingMessageIds = []
+        requestIdToMessageId = [:]
         dismissSessionError()
         regenerateLastMessage()
     }


### PR DESCRIPTION
Addresses review feedback from PR #2130.

## Problem

`retryAfterSessionError()` dismissed the error toast before calling `regenerateLastMessage()`. If the session error arrived while queued messages were pending (`pendingQueuedCount > 0` and not cancelling), `isSending` remained `true` and `regenerateLastMessage()` silently bailed at its `guard !isSending` check. The user was left with no error toast and no way to retry — the UI appeared stuck.

## Fix

Reset `isSending`, `pendingQueuedCount`, `pendingMessageIds`, and `requestIdToMessageId` before dismissing and retrying. This matches the cleanup already done in the session error handler's cancellation path. Also added a `sessionId != nil` guard to bail early if there's no session context.

## Files changed
- `clients/shared/Features/Chat/ChatViewModel.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
