### PR TITLE
fix(sandbox-diag): use configured image and mount probe in doctor check

### DIFF
--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -315,6 +315,20 @@ describe('runSandboxDiagnostics — Docker container execution check', () => {
     expect(runCheck!.ok).toBe(true);
   });
 
+  test('uses configured image and sandbox mount for container probe', () => {
+    mockSandboxConfig.docker.image = 'alpine:3.19';
+    runSandboxDiagnostics();
+    const runCall = execFileSyncMock.mock.calls.find(
+      (call: unknown[]) => call[0] === 'docker' && Array.isArray(call[1]) && call[1].includes('run'),
+    );
+    expect(runCall).toBeDefined();
+    const args = runCall![1] as string[];
+    expect(args).toContain('alpine:3.19');
+    expect(args).not.toContain('ubuntu:22.04');
+    const mountArg = args.find((a: string) => a.startsWith('type=bind'));
+    expect(mountArg).toContain('/tmp/vellum-test/sandbox');
+  });
+
   test('fails when container execution errors', () => {
     execFileSyncMock.mockImplementation(
       (file: string, args?: readonly string[]) => {

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -1,5 +1,5 @@
 import { execSync, execFileSync } from 'node:child_process';
-import { isMacOS, isLinux } from '../../util/platform.js';
+import { isMacOS, isLinux, getSandboxRootDir } from '../../util/platform.js';
 import { getConfig } from '../../config/loader.js';
 import type { SandboxConfig } from '../../config/schema.js';
 
@@ -47,11 +47,16 @@ function checkDockerImage(image: string): SandboxCheckResult {
   }
 }
 
-function checkDockerRun(): SandboxCheckResult {
+function checkDockerRun(image: string): SandboxCheckResult {
+  const sandboxRoot = getSandboxRootDir();
   try {
     const out = execFileSync(
       'docker',
-      ['run', '--rm', 'ubuntu:22.04', 'echo', 'ok'],
+      [
+        'run', '--rm',
+        '--mount', `type=bind,src=${sandboxRoot},dst=/workspace`,
+        image, 'echo', 'ok',
+      ],
       { stdio: 'pipe', timeout: 15000, encoding: 'utf-8' },
     ).trim();
     if (out === 'ok') {
@@ -117,7 +122,7 @@ export function runSandboxDiagnostics(): SandboxDiagnostics {
 
     if (daemonResult.ok) {
       checks.push(checkDockerImage(sandboxConfig.docker.image));
-      checks.push(checkDockerRun());
+      checks.push(checkDockerRun(sandboxConfig.docker.image));
     }
   }
 


### PR DESCRIPTION
## Summary
- **Fixes hardcoded image**: `checkDockerRun()` now accepts the configured Docker image instead of using hardcoded `ubuntu:22.04`, matching the image verified by `checkDockerImage()`.
- **Adds mount probe**: The container execution check now bind-mounts the sandbox root directory (`--mount type=bind,src=<sandboxRoot>,dst=/workspace`), mirroring the real Docker backend's `checkMountProbe()`. This catches file-sharing misconfigurations (e.g., Docker Desktop not sharing the sandbox path) that would cause actual sandboxed commands to fail.
- **New test**: Verifies that the configured image and sandbox mount arguments are passed to the Docker run command.

Addresses review feedback on #2126.

## Test plan
- [x] All 30 sandbox diagnostics tests pass (29 existing + 1 new)
- [x] Type-check passes (pre-existing errors in other files only)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
