### PR TITLE
fix(trace): correlate regenerate traces and close slash short-circuit lifecycles

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -794,12 +794,14 @@ async function handleRegenerate(
   }
 
   const sendEvent = (event: ServerMessage) => ctx.send(socket, event);
+  const requestId = uuid();
   session.traceEmitter.emit('request_received', 'Regenerate requested', {
+    requestId,
     status: 'info',
     attributes: { source: 'regenerate' },
   });
   try {
-    await session.regenerate(sendEvent);
+    await session.regenerate(sendEvent, requestId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -955,6 +955,10 @@ export class Session {
         this.messages.push(assistantMsg);
 
         next.onEvent({ type: 'assistant_text_delta', text: slashResult.message });
+        this.traceEmitter.emit('message_complete', 'Unknown slash command handled', {
+          requestId: next.requestId,
+          status: 'success',
+        });
         next.onEvent({ type: 'message_complete', sessionId: this.conversationId });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -1028,6 +1032,10 @@ export class Session {
       this.messages.push(assistantMsg);
 
       onEvent({ type: 'assistant_text_delta', text: slashResult.message });
+      this.traceEmitter.emit('message_complete', 'Unknown slash command handled', {
+        requestId,
+        status: 'success',
+      });
       onEvent({ type: 'message_complete', sessionId: this.conversationId });
       return persisted.id;
     }
@@ -1191,7 +1199,7 @@ export class Session {
    * (and any intermediate tool_result messages) from memory, DB, and
    * Qdrant, then re-run the agent loop with the same user message.
    */
-  async regenerate(onEvent: (msg: ServerMessage) => void): Promise<void> {
+  async regenerate(onEvent: (msg: ServerMessage) => void, requestId?: string): Promise<void> {
     if (this.processing) {
       onEvent({ type: 'error', message: 'Cannot regenerate while processing' });
       return;
@@ -1277,7 +1285,7 @@ export class Session {
     // in both this.messages and the DB.
     this.processing = true;
     this.abortController = new AbortController();
-    this.currentRequestId = uuid();
+    this.currentRequestId = requestId ?? uuid();
 
     await this.runAgentLoop(content, existingUserMessageId, onEvent, { skipPreMessageRollback: true });
   }


### PR DESCRIPTION
## Summary
- Pass `requestId` from `handleRegenerate` into `Session.regenerate()` so the `request_received` trace shares the same ID as all downstream trace events (fixes broken trace correlation for regenerate requests)
- Emit `message_complete` trace events in `processMessage()` and `drainQueue()` when unknown slash commands short-circuit, ensuring every `request_received` has a matching terminal trace

Addresses review feedback on PR #2107.

## Test plan
- [x] All 22 session-queue tests pass
- [x] All 14 trace-emitter tests pass
- [x] TypeScript type-check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
