### PR TITLE
fix: use configured image in mount probe and eliminate shell injection in preflight

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -362,12 +362,18 @@ describe('DockerBackend — custom config', () => {
 
 describe('DockerBackend — preflight: Docker CLI check', () => {
   test('throws ToolError with install hint when docker CLI is missing', () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('docker')) {
-        throw new Error('command not found: docker');
-      }
-      return undefined;
-    });
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (
+          file === 'docker' &&
+          Array.isArray(args) &&
+          args.includes('--version')
+        ) {
+          throw new Error('command not found: docker');
+        }
+        return undefined;
+      },
+    );
 
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
@@ -382,8 +388,11 @@ describe('DockerBackend — preflight: Docker CLI check', () => {
     backend.wrap('ls', sandboxRoot);
 
     // docker --version should only be called once (cached after success).
-    const versionCalls = execSyncMock.mock.calls.filter(
-      (args) => typeof args[0] === 'string' && args[0] === 'docker --version',
+    const versionCalls = execFileSyncMock.mock.calls.filter(
+      (args) =>
+        args[0] === 'docker' &&
+        Array.isArray(args[1]) &&
+        (args[1] as string[]).includes('--version'),
     );
     expect(versionCalls.length).toBe(1);
   });
@@ -391,12 +400,18 @@ describe('DockerBackend — preflight: Docker CLI check', () => {
 
 describe('DockerBackend — preflight: Docker daemon check', () => {
   test('throws ToolError with start hint when daemon is unreachable', () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd === 'docker info') {
-        throw new Error('Cannot connect to the Docker daemon');
-      }
-      return undefined;
-    });
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (
+          file === 'docker' &&
+          Array.isArray(args) &&
+          args.includes('info')
+        ) {
+          throw new Error('Cannot connect to the Docker daemon');
+        }
+        return undefined;
+      },
+    );
 
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
@@ -410,8 +425,11 @@ describe('DockerBackend — preflight: Docker daemon check', () => {
     backend.wrap('ls', sandboxRoot);
     backend.wrap('ls', sandboxRoot);
 
-    const infoCalls = execSyncMock.mock.calls.filter(
-      (args) => typeof args[0] === 'string' && args[0] === 'docker info',
+    const infoCalls = execFileSyncMock.mock.calls.filter(
+      (args) =>
+        args[0] === 'docker' &&
+        Array.isArray(args[1]) &&
+        (args[1] as string[]).includes('info'),
     );
     expect(infoCalls.length).toBe(1);
   });
@@ -568,6 +586,27 @@ describe('DockerBackend — preflight: mount probe', () => {
     expect(argv).toContain('--mount');
   });
 
+  test('mount probe uses configured image, not hardcoded ubuntu:22.04', () => {
+    const backend = new DockerBackend(
+      sandboxRoot,
+      { image: 'alpine:3.19' },
+      1000,
+      1000,
+    );
+    backend.wrap('ls', sandboxRoot);
+
+    const mountCalls = execFileSyncMock.mock.calls.filter(
+      (args) =>
+        args[0] === 'docker' &&
+        Array.isArray(args[1]) &&
+        (args[1] as string[]).includes('run'),
+    );
+    expect(mountCalls.length).toBe(1);
+    const argv = mountCalls[0]![1] as string[];
+    expect(argv).toContain('alpine:3.19');
+    expect(argv).not.toContain('ubuntu:22.04');
+  });
+
   test('caches successful mount probe per sandbox root', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     backend.wrap('ls', sandboxRoot);
@@ -585,13 +624,15 @@ describe('DockerBackend — preflight: mount probe', () => {
 
 describe('DockerBackend — preflight check order', () => {
   test('checks CLI before daemon', () => {
-    // All docker commands fail, but we expect the CLI error first.
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('docker')) {
-        throw new Error('docker not available');
-      }
-      return undefined;
-    });
+    // All docker execFileSync calls fail, but we expect the CLI error first.
+    execFileSyncMock.mockImplementation(
+      (file: string) => {
+        if (file === 'docker') {
+          throw new Error('docker not available');
+        }
+        return undefined;
+      },
+    );
 
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     try {
@@ -609,12 +650,6 @@ describe('DockerBackend — preflight check order', () => {
     backend.wrap('ls', sandboxRoot);
 
     // Now make all docker commands fail.
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('docker')) {
-        throw new Error('docker unavailable');
-      }
-      return undefined;
-    });
     execFileSyncMock.mockImplementation(
       (file: string) => {
         if (file === 'docker') {
@@ -632,12 +667,18 @@ describe('DockerBackend — preflight check order', () => {
 
   test('re-checks negative results on subsequent calls', () => {
     // Start with CLI failing.
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd === 'docker --version') {
-        throw new Error('not found');
-      }
-      return undefined;
-    });
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (
+          file === 'docker' &&
+          Array.isArray(args) &&
+          args.includes('--version')
+        ) {
+          throw new Error('not found');
+        }
+        return undefined;
+      },
+    );
 
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
@@ -645,7 +686,7 @@ describe('DockerBackend — preflight check order', () => {
     );
 
     // Now make it succeed.
-    execSyncMock.mockImplementation(() => undefined);
+    execFileSyncMock.mockImplementation(() => undefined);
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.command).toBe('docker');
   });
@@ -659,12 +700,14 @@ describe('DockerBackend — no unsandboxed fallback', () => {
   });
 
   test('preflight failure always throws, never returns unsandboxed result', () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (typeof cmd === 'string' && cmd.includes('docker')) {
-        throw new Error('not available');
-      }
-      return undefined;
-    });
+    execFileSyncMock.mockImplementation(
+      (file: string) => {
+        if (file === 'docker') {
+          throw new Error('not available');
+        }
+        return undefined;
+      },
+    );
 
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     let threw = false;

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { resolve, relative, posix } from 'node:path';
 import { ToolError } from '../../../util/errors.js';
@@ -55,7 +55,7 @@ export function _resetDockerChecks(): void {
 function checkDockerCli(): void {
   if (dockerCliAvailable) return;
   try {
-    execSync('docker --version', { stdio: 'ignore', timeout: 5000 });
+    execFileSync('docker', ['--version'], { stdio: 'ignore', timeout: 5000 });
     dockerCliAvailable = true;
   } catch {
     throw new ToolError(
@@ -68,7 +68,7 @@ function checkDockerCli(): void {
 function checkDockerDaemon(): void {
   if (dockerDaemonReachable) return;
   try {
-    execSync('docker info', { stdio: 'ignore', timeout: 10000 });
+    execFileSync('docker', ['info'], { stdio: 'ignore', timeout: 10000 });
     dockerDaemonReachable = true;
   } catch {
     throw new ToolError(
@@ -92,21 +92,20 @@ function checkImageAvailable(image: string): void {
   }
 }
 
-function checkMountProbe(sandboxRoot: string): void {
-  if (mountProbeCache.has(sandboxRoot)) return;
+function checkMountProbe(sandboxRoot: string, image: string): void {
+  const cacheKey = `${sandboxRoot}\0${image}`;
+  if (mountProbeCache.has(cacheKey)) return;
   try {
-    // Use execFileSync with argv segments to prevent shell interpolation
-    // of the sandbox root path (which may contain spaces or special chars).
     execFileSync(
       'docker',
       [
         'run', '--rm',
         '--mount', `type=bind,src=${sandboxRoot},dst=/workspace`,
-        'ubuntu:22.04', 'test', '-w', '/workspace',
+        image, 'test', '-w', '/workspace',
       ],
       { stdio: 'ignore', timeout: 15000 },
     );
-    mountProbeCache.add(sandboxRoot);
+    mountProbeCache.add(cacheKey);
   } catch {
     throw new ToolError(
       'Cannot bind-mount the sandbox root into a Docker container or /workspace is not writable. ' +
@@ -171,7 +170,7 @@ export class DockerBackend implements SandboxBackend {
     checkDockerCli();
     checkDockerDaemon();
     checkImageAvailable(this.config.image);
-    checkMountProbe(this.sandboxRoot);
+    checkMountProbe(this.sandboxRoot, this.config.image);
   }
 
   wrap(command: string, workingDir: string): SandboxResult {


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #2089.

- **Mount probe uses configured image**: `checkMountProbe` now accepts the configured image instead of hardcoding `ubuntu:22.04`. This prevents misleading "File Sharing" errors when a custom image is configured but `ubuntu:22.04` isn't available locally. Cache key includes both sandboxRoot and image.
- **Eliminate shell injection surface**: Converted `checkDockerCli` and `checkDockerDaemon` from `execSync` (shell string) to `execFileSync` (argv array), matching the pattern already used by `checkImageAvailable` and `checkMountProbe`. All four preflight checks now use `execFileSync` exclusively.
- **Tests updated**: All preflight tests updated to use `execFileSyncMock` instead of `execSyncMock`. Added new test verifying mount probe uses the configured image.

## Test plan
- [x] `bun test src/__tests__/terminal-sandbox-docker.test.ts` — 53 pass
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 13 pass (no regressions)
- [x] `bunx tsc --noEmit` — clean (pre-existing errors in unrelated test files only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
