### PR TITLE
fix(sandbox): align DockerBackend defaults with config schema

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -26,6 +26,9 @@ const { DockerBackend, _resetDockerChecks } = await import(
   '../tools/terminal/backends/docker.js'
 );
 const { ToolError } = await import('../util/errors.js');
+const { DEFAULT_CONFIG } = await import('../config/defaults.js');
+
+const defaultImage = DEFAULT_CONFIG.sandbox.docker.image;
 
 // Use a real temp dir so realpathSync resolves correctly.
 const sandboxRoot = realpathSync('/tmp');
@@ -79,7 +82,7 @@ describe('DockerBackend — argument construction', () => {
   test('applies default resource limits', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
-    expect(result.args).toContain('--cpus=2');
+    expect(result.args).toContain('--cpus=1');
     expect(result.args).toContain('--memory=512m');
     expect(result.args).toContain('--pids-limit=256');
   });
@@ -102,10 +105,10 @@ describe('DockerBackend — argument construction', () => {
     );
   });
 
-  test('uses default image ubuntu:22.04', () => {
+  test('uses default image from config', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
-    expect(result.args).toContain('ubuntu:22.04');
+    expect(result.args).toContain(defaultImage);
   });
 
   test('wraps command with sh -c -- by default', () => {
@@ -137,7 +140,7 @@ describe('DockerBackend — read-only root and tmpfs', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     const readOnlyIdx = result.args.indexOf('--read-only');
-    const imageIdx = result.args.indexOf('ubuntu:22.04');
+    const imageIdx = result.args.indexOf(defaultImage);
     expect(readOnlyIdx).toBeLessThan(imageIdx);
   });
 
@@ -145,7 +148,7 @@ describe('DockerBackend — read-only root and tmpfs', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     const tmpfsIdx = result.args.indexOf('--tmpfs');
-    const imageIdx = result.args.indexOf('ubuntu:22.04');
+    const imageIdx = result.args.indexOf(defaultImage);
     expect(tmpfsIdx).toBeLessThan(imageIdx);
   });
 });
@@ -273,7 +276,7 @@ describe('DockerBackend — argv segment safety', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
     // None of the docker flag args (before the image) should contain ; | && etc.
-    const imageIdx = result.args.indexOf('ubuntu:22.04');
+    const imageIdx = result.args.indexOf(defaultImage);
     const flagArgs = result.args.slice(0, imageIdx);
     for (const arg of flagArgs) {
       expect(arg).not.toContain(';');
@@ -319,7 +322,7 @@ describe('DockerBackend — custom config', () => {
     );
     const result = backend.wrap('ls', sandboxRoot);
     expect(result.args).toContain('alpine:3.19');
-    expect(result.args).not.toContain('ubuntu:22.04');
+    expect(result.args).not.toContain(defaultImage);
   });
 
   test('accepts custom resource limits', () => {
@@ -454,7 +457,7 @@ describe('DockerBackend — preflight: image availability check', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
-      'docker pull ubuntu:22.04',
+      `docker pull ${defaultImage}`,
     );
   });
 
@@ -503,7 +506,7 @@ describe('DockerBackend — preflight: image availability check', () => {
     const argv = imageCalls[0]![1] as string[];
     expect(argv).toContain('image');
     expect(argv).toContain('inspect');
-    expect(argv).toContain('ubuntu:22.04');
+    expect(argv).toContain(defaultImage);
   });
 
   test('caches successful image check per image', () => {
@@ -725,7 +728,7 @@ describe('DockerBackend — complete hardening profile verification', () => {
   test('all security flags are present in correct order before image', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('ls', sandboxRoot);
-    const imageIdx = result.args.indexOf('ubuntu:22.04');
+    const imageIdx = result.args.indexOf(defaultImage);
 
     // All of these must appear before the image name
     const securityFlags = [

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -3,27 +3,28 @@ import { realpathSync } from 'node:fs';
 import { resolve, relative, posix } from 'node:path';
 import { ToolError } from '../../../util/errors.js';
 import { getLogger } from '../../../util/logger.js';
+import type { DockerConfig } from '../../../config/types.js';
 import type { SandboxBackend, SandboxResult } from './types.js';
 
 const log = getLogger('docker-sandbox');
 
-export interface DockerConfig {
-  image?: string;
+/** DockerBackend-specific config extends the schema type with shell selection. */
+interface DockerBackendConfig extends DockerConfig {
   /** Shell binary used to interpret commands (default: 'sh' for POSIX portability). */
-  shell?: string;
-  cpus?: number;
-  memoryMb?: number;
-  pidsLimit?: number;
-  network?: string;
+  shell: string;
 }
 
-const DEFAULTS: Required<DockerConfig> = {
-  image: 'ubuntu:22.04',
-  shell: 'sh',
-  cpus: 2,
+/**
+ * Fallback defaults when DockerBackend is constructed without explicit config.
+ * Must stay in sync with DockerConfigSchema defaults in config/schema.ts.
+ */
+const DEFAULTS: DockerBackendConfig = {
+  image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+  cpus: 1,
   memoryMb: 512,
   pidsLimit: 256,
   network: 'none',
+  shell: 'sh',
 };
 
 /**
@@ -142,13 +143,13 @@ function validatePathSafety(path: string, label: string): void {
  */
 export class DockerBackend implements SandboxBackend {
   private readonly sandboxRoot: string;
-  private readonly config: Required<DockerConfig>;
+  private readonly config: DockerBackendConfig;
   private readonly uid: number;
   private readonly gid: number;
 
   constructor(
     sandboxRoot: string,
-    config?: DockerConfig,
+    config?: Partial<DockerBackendConfig>,
     uid?: number,
     gid?: number,
   ) {


### PR DESCRIPTION
## Summary
- Replace the local `DockerConfig` interface in `DockerBackend` with the canonical type from `config/types.ts`, eliminating type duplication
- Update `DEFAULTS` in `docker.ts` to match the Zod schema values (`node:20-slim` image, 1 CPU) instead of the divergent values (`ubuntu:22.04`, 2 CPUs)
- Update Docker sandbox tests to reference defaults dynamically via `DEFAULT_CONFIG`

Addresses review feedback on #2096 (Codex P1: divergent Docker config defaults).

## Test plan
- [x] `bun test src/__tests__/terminal-sandbox-docker.test.ts` — 51 tests pass
- [x] `bun test src/__tests__/config-schema.test.ts` — 48 tests pass
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 13 tests pass
- [x] `bun test src/__tests__/sandbox-host-parity.test.ts` — 48 tests pass
- [x] `bunx tsc --noEmit` — no new type errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
