### PR TITLE
fix(trace): align terminal event kinds with daemon IPC contract

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -46,8 +46,12 @@ struct TraceRowView: View {
             return "tray.and.arrow.down"
         case "request_started":
             return "play.circle"
-        case "request_finished":
+        case "message_complete":
             return "checkmark.circle"
+        case "generation_cancelled":
+            return "xmark.circle"
+        case "request_error":
+            return "exclamationmark.circle"
         case "session_started":
             return "bolt.circle"
         case "session_ended":

--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -101,8 +101,8 @@ public final class TraceStore: ObservableObject {
 
     /// Determines the terminal status of a request group by inspecting its events.
     ///
-    /// A request is considered terminal when it contains a `request_finished`,
-    /// `request_cancelled`, or `request_failed` event. If none of those are present
+    /// A request is considered terminal when it contains a `message_complete`,
+    /// `generation_cancelled`, or `request_error` event. If none of those are present
     /// but any event has `status == "error"`, the group is marked as error.
     public func requestGroupStatus(sessionId: String, requestId: String) -> RequestGroupStatus {
         let key = requestId.isEmpty ? "" : requestId
@@ -111,11 +111,11 @@ public final class TraceStore: ObservableObject {
 
         for event in events {
             switch event.kind {
-            case "request_cancelled":
+            case "generation_cancelled":
                 return .cancelled
-            case "request_failed":
+            case "request_error":
                 return .error
-            case "request_finished":
+            case "message_complete":
                 return .completed
             default:
                 break

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -308,7 +308,7 @@ struct TraceStoreTests {
         #expect(grouped2["r1"] == nil)
 
         // Adding more events to one session does not affect the other.
-        store.ingest(makeEvent(eventId: "e5", sessionId: "s1", requestId: "r1", sequence: 3, kind: "request_finished"))
+        store.ingest(makeEvent(eventId: "e5", sessionId: "s1", requestId: "r1", sequence: 3, kind: "message_complete"))
         #expect(store.eventsBySession["s1"]?.count == 3)
         #expect(store.eventsBySession["s2"]?.count == 2)
     }
@@ -321,7 +321,7 @@ struct TraceStoreTests {
 
         store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
         store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
-        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "request_cancelled", summary: "Cancelled by user"))
+        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "generation_cancelled", summary: "Cancelled by user"))
 
         let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
         #expect(status == .cancelled)
@@ -335,7 +335,7 @@ struct TraceStoreTests {
 
         store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
         store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
-        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "request_failed", status: "error", summary: "API error"))
+        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "request_error", status: "error", summary: "API error"))
 
         let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
         #expect(status == .error)
@@ -348,7 +348,7 @@ struct TraceStoreTests {
         let store = TraceStore()
 
         store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_started"))
-        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "request_finished"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "message_complete"))
 
         let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
         #expect(status == .completed)


### PR DESCRIPTION
## Summary
- Fix `requestGroupStatus()` in TraceStore to check for the correct daemon event kinds: `generation_cancelled`, `request_error`, and `message_complete` (instead of the non-existent `request_cancelled`, `request_failed`, `request_finished`)
- Update TraceRowView icon mappings to use the correct terminal kind strings
- Add icon cases for `generation_cancelled` (xmark.circle) and `request_error` (exclamationmark.circle)
- Update all TraceStore tests to use the correct event kind strings

Addresses feedback from PR #2113.

## Test plan
- [x] `swift build --target VellumAssistantLib` passes
- [x] `swift build --target vellum-assistantTests` compiles
- [x] `bunx tsc --noEmit` passes (pre-existing sandbox test errors only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
