### PR TITLE
fix(ui): preserve original filename for dropped image attachments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -99,7 +99,7 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
-        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
         }
     }
@@ -154,56 +154,16 @@ struct ChatView: View {
         }
     }
 
-    /// Handle dropped items — supports both file URLs and raw image data.
+    /// Handle dropped items — loads file URLs to preserve original filenames.
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        var urls: [URL] = []
-        var imageDataItems: [NSItemProvider] = []
-        let group = DispatchGroup()
-
         for provider in providers {
-            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-                // File URL drop (e.g. dragging a saved file)
-                group.enter()
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    DispatchQueue.main.async {
-                        if let url { urls.append(url) }
-                        group.leave()
-                    }
-                }
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                // Raw image data drop (e.g. dragging a screenshot thumbnail)
-                imageDataItems.append(provider)
-            }
-        }
-
-        // Load image data items
-        for provider in imageDataItems {
-            // Try PNG first, then TIFF, then generic image
-            let typeIdentifier: String
-            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
-                typeIdentifier = UTType.png.identifier
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                typeIdentifier = UTType.tiff.identifier
-            } else {
-                typeIdentifier = UTType.image.identifier
-            }
-
-            let suggestedName = provider.suggestedName
-            group.enter()
-            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
                 DispatchQueue.main.async {
-                    if let data {
-                        onDropImageData(data, suggestedName)
+                    if let url {
+                        onDropFiles([url])
                     }
-                    group.leave()
                 }
             }
-        }
-
-        group.notify(queue: .main) {
-            if !urls.isEmpty { onDropFiles(urls) }
         }
         return true
     }


### PR DESCRIPTION
## Summary
- Accept only `.fileURL` in `.onDrop` so macOS doesn't negotiate image files into raw PNG data (which strips the filename to generic "Dropped Image.png")
- All file drops now go through the URL path, preserving the real filename for images and non-images alike
- Simplifies `handleDrop` by removing the separate raw image data loading path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
