### PR TITLE
feat(commands): add contextual review assessment to check-reviews

### DIFF
--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -40,22 +40,70 @@ When a reviewer is skipped:
 - The skipped reviewer's status should display as "Skipped" in the output table.
 - Apply the normal actions logic using the one real review plus the implicit approval from the skip.
 
+## Contextual review assessment
+
+When a reviewer requests changes, don't blindly add the feedback to TODO. First assess whether the feedback actually makes sense:
+
+### 1. Understand the PR's intent
+
+Read the PR diff to understand what the PR is trying to accomplish:
+`gh pr diff <number>`
+
+### 2. Trace the feedback chain
+
+Check if this PR is itself addressing feedback from an earlier PR. Look at:
+- **Branch name:** branches named `fix/pr-<N>-*` are feedback PRs for PR #N
+- **PR title/body:** may reference the original PR directly
+
+If the PR is a feedback-addressing PR, fetch the original PR it references and read its diff too. Keep following the chain (the original may itself be a feedback PR) until you reach the **base PR** — the one that introduced the feature or fix. Read each PR's diff along the way so you understand the full context.
+
+### 3. Evaluate the feedback
+
+For each piece of reviewer feedback, assess:
+- Does this feedback make sense given what the PR (and the chain of PRs leading to it) is trying to do?
+- Would addressing this feedback **undo or regress** the functionality that the base PR introduced?
+
+Examples of feedback that would cause a regression:
+- Suggesting removal of code that was the whole point of the base PR
+- Recommending a pattern that contradicts a deliberate design choice from the original implementation
+- Flagging as "unused" something that was intentionally added and is used elsewhere
+
+### 4. Classify the feedback
+
+- **Valid feedback:** The suggestion improves the code without regressing the intended behavior. → Add to TODO as normal.
+- **Regression risk:** Addressing the feedback would undo or break the desired functionality from the base PR. → Flag to user (see below).
+- **Nonsensical feedback:** The reviewer misunderstood the code or the suggestion doesn't apply. → Discard silently and treat as an implicit approval for that reviewer.
+
 ## Actions
 
 - If either reviewer hasn't reviewed yet **and** the PR is less than 30 minutes old, keep the PR in UNREVIEWED_PRS.md for next time.
 - If the PR is 30+ minutes old and at least one reviewer has responded, treat any missing reviewer as skipped (implicit approval) and proceed as fully reviewed.
-- If both have reviewed (or one reviewed + one skipped) and either **real** review requested changes, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
+- If both have reviewed (or one reviewed + one skipped) and either **real** review requested changes with **valid feedback**, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
+- If all feedback on a PR was classified as nonsensical, treat that reviewer as having approved.
+- If any feedback is classified as **regression risk**, do NOT add it to TODO. Instead, flag it to the user (see output section) and **stop processing further PRs**. Wait for the user to decide what to do.
 - If fully reviewed (both reviewed, or one reviewed + one skipped), remove the PR from .private/UNREVIEWED_PRS.md.
 
 ## Output
 
 Display a table with these columns:
 
-| PR  | Age | Codex | Devin | Fully Reviewed | Added to TODO | Removed from Unreviewed |
-| --- | --- | ----- | ----- | -------------- | ------------- | ----------------------- |
+| PR  | Age | Codex | Devin | Verdict | Added to TODO | Removed from Unreviewed |
+| --- | --- | ----- | ----- | ------- | ------------- | ----------------------- |
 
 - **Age**: How long ago the PR was created (e.g., "2h 15m", "45m"). Include a ⏰ marker if the 30-minute timeout triggered a skip.
-- **Codex/Devin columns**: Show "Approved", "Changes requested", "Pending", or "Skipped" (when the 30-min timeout applied).
+- **Codex/Devin columns**: Show "Approved", "Changes requested", "Pending", "Skipped", or "Nonsensical" (feedback didn't apply).
+- **Verdict**: The overall assessment — "Approved", "Valid feedback", "Regression risk ⚠️", or "Pending".
+
+### Regression risk flagging
+
+When feedback is classified as regression risk, stop and present the following to the user:
+
+1. **The feedback chain**: List each PR in the chain from base PR → current PR, with one-line summaries of what each did.
+2. **The problematic feedback**: Quote the specific reviewer comment(s).
+3. **Why it's a regression risk**: Explain what functionality would be lost or broken if the feedback were addressed.
+4. **Ask the user**: "Should I add this to TODO anyway, discard the feedback, or do something else?"
+
+Do NOT continue processing remaining PRs until the user responds.
 
 </instructions>
 


### PR DESCRIPTION
## Summary
- Adds a "Contextual review assessment" section to `/check-reviews` that evaluates whether reviewer feedback makes sense before blindly adding it to TODO
- Traces feedback PR chains (via `fix/pr-<N>-*` branch names and PR references) back to the base PR to understand original intent
- Classifies feedback as valid (add to TODO), regression risk (halt and flag to user), or nonsensical (discard as implicit approval)
- When regression risk is detected, stops processing and presents the full PR chain, problematic feedback, and risk explanation for user decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
