### PR TITLE
fix(ui): use exact shift modifier match for newline handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -600,7 +600,7 @@ struct ChatView: View {
             return .ignored
         }
         .onKeyPress(.return, phases: .down) { keyPress in
-            if keyPress.modifiers.contains(.shift) {
+            if keyPress.modifiers == .shift {
                 inputText += "\n"
                 return .handled
             }


### PR DESCRIPTION
Changes `.contains(.shift)` to `== .shift` so only pure Shift+Return inserts a newline, not Shift+Cmd+Return or other modifier combos.

Addresses review feedback from PR #2155.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
