### PR TITLE
fix(ui): prevent traffic light drift and clean up notification observers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1327,6 +1327,10 @@ private struct ScrollOffsetReader: NSViewRepresentable {
             self.offset = offset
         }
 
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+
         @objc func boundsDidChange(_ notification: Notification) {
             guard let clipView = notification.object as? NSClipView else { return }
             offset.wrappedValue = clipView.bounds.origin.y

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -16,6 +16,7 @@ final class MainWindow {
     /// Tracks daemon reconnects so trace state can be reset on stream restart.
     private var connectionCancellable: AnyCancellable?
     private var layoutObserver: NSObjectProtocol?
+    private var defaultTrafficLightOrigin: NSPoint?
     private var hasConnectedOnce = false
 
     /// Whether the main window is currently visible on screen.
@@ -126,13 +127,22 @@ final class MainWindow {
     private func repositionTrafficLights(_ window: NSWindow) {
         guard let closeButton = window.standardWindowButton(.closeButton),
               let containerView = closeButton.superview else { return }
+        if defaultTrafficLightOrigin == nil {
+            defaultTrafficLightOrigin = containerView.frame.origin
+        }
+        guard let origin = defaultTrafficLightOrigin else { return }
         containerView.setFrameOrigin(NSPoint(
-            x: containerView.frame.origin.x + 2,
-            y: containerView.frame.origin.y - 2.5
+            x: origin.x + 2,
+            y: origin.y - 2.5
         ))
     }
 
     func close() {
+        if let observer = layoutObserver {
+            NotificationCenter.default.removeObserver(observer)
+            layoutObserver = nil
+        }
+        defaultTrafficLightOrigin = nil
         window?.close()
         window = nil
     }


### PR DESCRIPTION
- Store baseline origin for traffic light positioning to prevent cumulative drift on window resize
- Add deinit to ScrollOffsetReader.Coordinator to remove notification observer
- Clean up layoutObserver in MainWindow.close() to prevent retain cycles

Addresses review feedback from PR #2157.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
