### PR TITLE
fix(ui): insert shift+enter newline at cursor position

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -561,7 +561,9 @@ struct ChatView: View {
         }
         .onKeyPress(.return, phases: .down) { keyPress in
             if keyPress.modifiers == .shift {
-                inputText += "\n"
+                if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
+                    textView.insertNewlineIgnoringFieldEditor(nil)
+                }
                 return .handled
             }
             guard keyPress.modifiers.isEmpty else { return .ignored }


### PR DESCRIPTION
Uses `textView.insertNewlineIgnoringFieldEditor(nil)` to insert the newline at the current cursor position instead of `inputText += "\n"` which always appended to the end. This restores correct multiline editing behavior when the cursor is positioned in the middle of text.

Addresses review feedback from PR #2156.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
