### PR TITLE
fix(error-handling): restrict AbortError cancellation check to active abort signal

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -12,17 +12,30 @@ describe('isUserCancellation', () => {
     expect(isUserCancellation(new Error('something'), ctx)).toBe(true);
   });
 
-  it('returns true for AbortError (DOMException-style)', () => {
+  it('returns true for AbortError (DOMException-style) when aborted', () => {
     const err = new DOMException('The operation was aborted', 'AbortError');
-    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: true };
     expect(isUserCancellation(err, ctx)).toBe(true);
   });
 
-  it('returns true for AbortError (Error with name set)', () => {
+  it('returns true for AbortError (Error with name set) when aborted', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: true };
+    expect(isUserCancellation(err, ctx)).toBe(true);
+  });
+
+  it('returns false for AbortError (DOMException-style) when NOT aborted', () => {
+    const err = new DOMException('The operation was aborted', 'AbortError');
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
+    expect(isUserCancellation(err, ctx)).toBe(false);
+  });
+
+  it('returns false for AbortError (Error with name set) when NOT aborted', () => {
     const err = new Error('aborted');
     err.name = 'AbortError';
     const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
-    expect(isUserCancellation(err, ctx)).toBe(true);
+    expect(isUserCancellation(err, ctx)).toBe(false);
   });
 
   it('returns false for non-abort errors without abort flag', () => {
@@ -167,10 +180,13 @@ describe('classifySessionError', () => {
       expect(isUserCancellation(new Error('The operation was aborted'), abortCtx)).toBe(true);
     });
 
-    it('DOMException AbortError is caught by isUserCancellation', () => {
+    it('DOMException AbortError is only caught when abort signal is active', () => {
       const err = new DOMException('The operation was aborted', 'AbortError');
-      const ctx: ErrorContext = { phase: 'agent_loop', aborted: false };
-      expect(isUserCancellation(err, ctx)).toBe(true);
+      const notAborted: ErrorContext = { phase: 'agent_loop', aborted: false };
+      expect(isUserCancellation(err, notAborted)).toBe(false);
+
+      const aborted: ErrorContext = { phase: 'agent_loop', aborted: true };
+      expect(isUserCancellation(err, aborted)).toBe(true);
     });
   });
 });

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -65,8 +65,8 @@ export interface ErrorContext {
  */
 export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   if (ctx.aborted) return true;
-  if (error instanceof DOMException && error.name === 'AbortError') return true;
-  if (error instanceof Error && error.name === 'AbortError') return true;
+  if (error instanceof DOMException && error.name === 'AbortError' && ctx.aborted) return true;
+  if (error instanceof Error && error.name === 'AbortError' && ctx.aborted) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Fix `isUserCancellation()` to only treat `AbortError` as user-initiated when `ctx.aborted` is `true`
- Previously, any `AbortError` (including provider timeouts, internal fetch aborts) was treated as user cancellation, silently swallowing real errors
- Updated tests to verify the corrected behavior: AbortError without active abort signal is no longer classified as user cancellation

Addresses review feedback on #2100.

## Files modified
- `assistant/src/daemon/session-error.ts` — add `&& ctx.aborted` guard to AbortError checks
- `assistant/src/__tests__/session-error.test.ts` — update and add tests for the corrected behavior

## Test plan
- [x] `bunx tsc --noEmit` passes (no new type errors)
- [x] All 39 session-error tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
