### PR TITLE
fix(codegen): add sequence to INT_PATTERNS for Int generation

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -162,6 +162,7 @@ const INT_PATTERNS = [
   /^maxResponseTokens$/,
   /Messages$/,
   /Calls$/,
+  /^sequence$/,
 ];
 
 function shouldBeInt(propName: string): boolean {


### PR DESCRIPTION
## Context

Addresses review feedback from PR #2120.

## Changes

Adds `^sequence$` to the `INT_PATTERNS` list in `generate-swift.ts`. The `sequence` field in `TraceEvent` represents a monotonic integer counter for ordering trace events. Without this pattern, the Swift code generator would produce `Double` instead of `Int` when `TraceEvent` is migrated to generated types, causing a type mismatch with `TraceStore.StoredEvent.sequence` and the hand-maintained `TraceEventMessage`.

## Files modified

- `assistant/scripts/ipc/generate-swift.ts` — added `/^sequence$/` to `INT_PATTERNS`

## Test plan

- [x] `bun run generate:ipc -- --check` passes (generated file unchanged since TraceEvent is still in SKIP_TYPES)
- [x] TypeScript type-check passes (pre-existing errors in unrelated test files only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
