### PR TITLE
fix(trace): exclude missing latencyMs from average LLM latency

### DIFF
--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -210,11 +210,11 @@ public final class TraceStore: ObservableObject {
         return 0
     }
 
-    private func doubleAttribute(_ event: StoredEvent, key: String) -> Double {
-        guard let attrs = event.attributes, let val = attrs[key] else { return 0 }
+    private func doubleAttribute(_ event: StoredEvent, key: String) -> Double? {
+        guard let attrs = event.attributes, let val = attrs[key] else { return nil }
         if let d = val.value as? Double { return d }
         if let i = val.value as? Int { return Double(i) }
-        return 0
+        return nil
     }
 }
 

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -170,6 +170,29 @@ struct TraceStoreTests {
     }
 
     @Test @MainActor
+    func averageLlmLatencyExcludesMissingAttribute() {
+        let store = TraceStore()
+        store.ingest(makeEvent(
+            eventId: "a", sequence: 1, kind: "llm_call_finished",
+            attributes: ["latencyMs": 100.0]
+        ))
+        store.ingest(makeEvent(
+            eventId: "b", sequence: 2, kind: "llm_call_finished",
+            attributes: ["latencyMs": 200.0]
+        ))
+        // Event without latencyMs should be excluded, not counted as 0.
+        store.ingest(makeEvent(
+            eventId: "c", sequence: 3, kind: "llm_call_finished",
+            attributes: ["inputTokens": 50]
+        ))
+        store.ingest(makeEvent(
+            eventId: "d", sequence: 4, kind: "llm_call_finished"
+        ))
+
+        #expect(store.averageLlmLatencyMs(sessionId: "s1") == 150.0)
+    }
+
+    @Test @MainActor
     func averageLlmLatencyEmpty() {
         let store = TraceStore()
         #expect(store.averageLlmLatencyMs(sessionId: "s1") == 0)


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #2088.

`doubleAttribute` returned a non-optional `Double` (defaulting to `0.0` for missing attributes), so `compactMap` in `averageLlmLatencyMs` could never filter out `llm_call_finished` events lacking a `latencyMs` attribute. Those events contributed `0.0` to the average, systematically under-reporting latency.

**Fix:** Changed `doubleAttribute` to return `Double?` so events without the attribute are properly excluded from the average.

**Test:** Added `averageLlmLatencyExcludesMissingAttribute` test that verifies events without `latencyMs` (or with unrelated attributes) are excluded from the average calculation.

## Test plan
- [x] Swift build passes
- [x] New test covers the missing-attribute edge case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
