### PR TITLE
fix(tracing): emit llm_call_started for tool-only provider turns

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -609,32 +609,29 @@ export class Session {
       let llmCallStartedEmitted = false;
 
       const buildEventHandler = () => (event: import('../agent/loop.js').AgentEvent) => {
+        // Emit llm_call_started once per provider call. Called on first streaming
+        // token (text or thinking) or, for tool-only turns, right before the
+        // usage event so every llm_call_finished has a matching start.
+        const emitLlmCallStartedIfNeeded = () => {
+          if (llmCallStartedEmitted) return;
+          llmCallStartedEmitted = true;
+          this.traceEmitter.emit('llm_call_started', `LLM call to ${this.provider.name}`, {
+            requestId: reqId,
+            status: 'info',
+            attributes: { provider: this.provider.name, model: model || 'unknown' },
+          });
+        };
+
         switch (event.type) {
           case 'text_delta':
-            // Emit llm_call_started on the first streaming token of each provider call
-            if (!llmCallStartedEmitted) {
-              llmCallStartedEmitted = true;
-              this.traceEmitter.emit('llm_call_started', `LLM call to ${this.provider.name}`, {
-                requestId: reqId,
-                status: 'info',
-                attributes: { provider: this.provider.name, model: model || 'unknown' },
-              });
-            }
+            emitLlmCallStartedIfNeeded();
             onEvent({ type: 'assistant_text_delta', text: event.text, sessionId: this.conversationId });
             if (isFirstMessage) firstAssistantText += event.text;
             break;
           case 'thinking_delta':
-            // Emit llm_call_started on first thinking token if not already emitted.
             // Thinking content itself is NOT included in traces to avoid leaking
             // extended-thinking data.
-            if (!llmCallStartedEmitted) {
-              llmCallStartedEmitted = true;
-              this.traceEmitter.emit('llm_call_started', `LLM call to ${this.provider.name}`, {
-                requestId: reqId,
-                status: 'info',
-                attributes: { provider: this.provider.name, model: model || 'unknown' },
-              });
-            }
+            emitLlmCallStartedIfNeeded();
             onEvent({ type: 'assistant_thinking_delta', thinking: event.thinking });
             break;
           case 'tool_use':
@@ -708,6 +705,10 @@ export class Session {
             exchangeInputTokens += event.inputTokens;
             exchangeOutputTokens += event.outputTokens;
             model = event.model;
+
+            // Ensure llm_call_started is emitted even for tool-only turns
+            // (where no text_delta or thinking_delta events fire)
+            emitLlmCallStartedIfNeeded();
 
             // Emit llm_call_finished trace with token and latency metrics
             this.traceEmitter.emit('llm_call_finished', `LLM call to ${this.provider.name} finished`, {


### PR DESCRIPTION
## Summary
- Fixes unpaired `llm_call_finished` trace events for provider turns that return only `tool_use` blocks (no text or thinking content)
- Extracts the `llm_call_started` emission into a shared `emitLlmCallStartedIfNeeded()` helper, called from `text_delta`, `thinking_delta`, and now `usage` handlers
- Addresses review feedback from both Codex and Devin on PR #2121

## Context
When the LLM responds with only tool_use blocks (common in multi-turn tool loops), no `text_delta` or `thinking_delta` streaming events fire, so `llm_call_started` was never emitted. However, the `usage` event always fires, which unconditionally emits `llm_call_finished`. This produced trace timelines with unmatched finished events.

## Test plan
- [x] `bun test session-slash-known.test.ts` — 2/2 pass
- [x] `bun test session-queue.test.ts` — 22/22 pass
- [x] `bun test agent-loop.test.ts` — 30/30 pass
- [x] `bun test session-slash-unknown.test.ts` — 5/5 pass
- [x] `bun test tool-trace-listener.test.ts` — 11/11 pass
- [x] `bunx tsc --noEmit` — clean (pre-existing sandbox test errors only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
