### PR TITLE
fix(ui): fix nested ScrollView and auto-scroll in trace timeline

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -11,6 +11,13 @@ struct DebugPanel: View {
             if let sessionId = activeSessionId {
                 metricsStrip(sessionId: sessionId)
                 Divider().background(VColor.surfaceBorder)
+
+                // Render timeline in pinned area so it owns its own ScrollView
+                // without nesting inside VSidePanel's scrollable content slot.
+                let events = traceStore.eventsBySession[sessionId] ?? []
+                if !events.isEmpty {
+                    TraceTimelineView(traceStore: traceStore, sessionId: sessionId)
+                }
             }
         }) {
             if let sessionId = activeSessionId {
@@ -21,8 +28,6 @@ struct DebugPanel: View {
                         subtitle: "Events will appear as the session runs",
                         icon: "waveform.path"
                     )
-                } else {
-                    TraceTimelineView(traceStore: traceStore, sessionId: sessionId)
                 }
             } else {
                 VEmptyState(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -36,7 +36,7 @@ struct TraceTimelineView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
-            .onChange(of: traceStore.eventsBySession[sessionId]?.count) {
+            .onChange(of: traceStore.latestEventIdBySession[sessionId]) {
                 if !autoScrollPaused {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("trace-bottom", anchor: .bottom)

--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -30,6 +30,10 @@ public final class TraceStore: ObservableObject {
     /// All events per session, in stable order.
     @Published public private(set) var eventsBySession: [String: [StoredEvent]] = [:]
 
+    /// The ID of the most recently ingested event per session. Unlike `eventsBySession[sid]?.count`,
+    /// this always changes on ingestion even when the retention cap holds count constant.
+    @Published public private(set) var latestEventIdBySession: [String: String] = [:]
+
     /// Set of seen eventIds per session for dedup.
     private var seenIds: [String: Set<String>] = [:]
 
@@ -79,6 +83,7 @@ public final class TraceStore: ObservableObject {
         }
 
         eventsBySession[sid] = events
+        latestEventIdBySession[sid] = event.id
     }
 
     // MARK: - Queries
@@ -183,12 +188,14 @@ public final class TraceStore: ObservableObject {
     /// Remove all events for a given session.
     public func resetSession(sessionId: String) {
         eventsBySession.removeValue(forKey: sessionId)
+        latestEventIdBySession.removeValue(forKey: sessionId)
         seenIds.removeValue(forKey: sessionId)
     }
 
     /// Remove all events for all sessions.
     public func resetAll() {
         eventsBySession.removeAll()
+        latestEventIdBySession.removeAll()
         seenIds.removeAll()
         nextInsertionIndex = 0
     }


### PR DESCRIPTION
## Summary
- Move `TraceTimelineView` into `VSidePanel`'s `pinnedContent` area so it owns its own `ScrollView` without nesting inside the panel's scrollable content slot — fixes broken scroll interactions and auto-scroll behavior on macOS
- Add `latestEventIdBySession` published property to `TraceStore` and observe it instead of event count, so auto-scroll continues to fire when the retention cap (5000 events) holds count constant
- Empty states remain in the scrollable content area since they don't need their own ScrollView

Addresses review feedback on #2105

## Test plan
- [ ] Open Debug panel with active session — trace events scroll correctly (no nested scroll fighting)
- [ ] Auto-scroll follows new events when not paused
- [ ] Pause/resume auto-scroll button works
- [ ] With 5000+ events, auto-scroll still follows newest events (retention cap scenario)
- [ ] Empty states ("No trace events yet", "No session selected") display correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
