### PR TITLE
fix(ui): resolve nested ScrollView and auto-scroll cap in trace timeline

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -7,10 +7,20 @@ struct DebugPanel: View {
     var onClose: () -> Void
 
     var body: some View {
+        // TraceTimelineView owns its own ScrollView + ScrollViewReader for
+        // auto-scroll. To avoid nesting it inside VSidePanel's built-in
+        // ScrollView (which breaks scroll and auto-scroll on macOS), the
+        // timeline is placed in the pinnedContent area (not scroll-wrapped)
+        // and the scrollable content slot gets only the empty states.
         VSidePanel(title: "Debug", onClose: onClose, pinnedContent: {
             if let sessionId = activeSessionId {
                 metricsStrip(sessionId: sessionId)
                 Divider().background(VColor.surfaceBorder)
+
+                let events = traceStore.eventsBySession[sessionId] ?? []
+                if !events.isEmpty {
+                    TraceTimelineView(traceStore: traceStore, sessionId: sessionId)
+                }
             }
         }) {
             if let sessionId = activeSessionId {
@@ -21,8 +31,6 @@ struct DebugPanel: View {
                         subtitle: "Events will appear as the session runs",
                         icon: "waveform.path"
                     )
-                } else {
-                    TraceTimelineView(traceStore: traceStore, sessionId: sessionId)
                 }
             } else {
                 VEmptyState(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -36,7 +36,7 @@ struct TraceTimelineView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
-            .onChange(of: traceStore.eventsBySession[sessionId]?.count) {
+            .onChange(of: traceStore.eventsBySession[sessionId]?.last?.sequence) {
                 if !autoScrollPaused {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("trace-bottom", anchor: .bottom)


### PR DESCRIPTION
## Summary
- Fixes nested ScrollView issue where TraceTimelineView's ScrollView was inside VSidePanel's ScrollView, breaking scroll interactions and auto-scroll on macOS
- Fixes auto-scroll stopping at retention cap (5000 events) by observing the last event's sequence number instead of event count
- Addresses review feedback from both Codex and Devin on PR #2105

## Changes
1. **DebugPanel.swift**: Moved `TraceTimelineView` from VSidePanel's scrollable content area into the `pinnedContent` area (which is not scroll-wrapped). Empty states remain in the scrollable content slot.
2. **TraceTimelineView.swift**: Changed `.onChange(of: count)` to `.onChange(of: last?.sequence)` so auto-scroll continues working even when TraceStore evicts old events at the retention cap.

## Test plan
- [x] `swift build --product vellum-assistant` — clean build
- [ ] Open Debug panel and verify trace events scroll correctly (single ScrollView, no nesting)
- [ ] Verify auto-scroll follows new events to the bottom
- [ ] Verify pause/resume auto-scroll button still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
