### PR TITLE
fix: dismissError clears sessionError + gate session_error on claimed session

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -223,6 +223,25 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testDismissErrorAlsoClearsSessionError() {
+        viewModel.sessionId = "sess-1"
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "API error",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+        XCTAssertNotNil(viewModel.sessionError)
+        XCTAssertNotNil(viewModel.errorText)
+
+        viewModel.dismissError()
+
+        XCTAssertNil(viewModel.sessionError,
+                      "dismissError() should also clear sessionError")
+        XCTAssertNil(viewModel.errorText)
+    }
+
     func testErrorFinalizesStreamingAssistantMessage() {
         viewModel.isSending = true
         viewModel.isThinking = true
@@ -1233,6 +1252,23 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertNil(viewModel.sessionError,
                       "session_error from a different session should be ignored")
+        XCTAssertNil(viewModel.errorText)
+    }
+
+    func testSessionErrorIgnoredBeforeSessionClaimed() {
+        // sessionId is nil — no session claimed yet
+        XCTAssertNil(viewModel.sessionId)
+
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-other",
+            code: .providerNetwork,
+            userMessage: "Connection failed",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNil(viewModel.sessionError,
+                      "session_error should be ignored before session is claimed")
         XCTAssertNil(viewModel.errorText)
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -933,7 +933,7 @@ public final class ChatViewModel: ObservableObject {
             }
 
         case .sessionError(let msg):
-            guard belongsToSession(msg.sessionId) else { return }
+            guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
             let typedError = SessionError(from: msg)
             log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
             sessionError = typedError
@@ -1140,6 +1140,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func dismissError() {
+        sessionError = nil
         errorText = nil
     }
 


### PR DESCRIPTION
## Summary
- `dismissError()` now also clears `sessionError` so the UI-wired dismiss button doesn't leave stale typed error state (fixes Devin review on #2115)
- `session_error` handler now requires `sessionId != nil` before processing, preventing cross-session contamination during bootstrap when the view model hasn't claimed a session yet (fixes Codex review on #2115)

## Test plan
- [x] `swift build --target VellumAssistantLib` compiles without errors
- [x] `swift build --target vellum-assistantTests` compiles without errors
- [x] Added `testDismissErrorAlsoClearsSessionError` — verifies dismissError() clears both errorText and sessionError
- [x] Added `testSessionErrorIgnoredBeforeSessionClaimed` — verifies session_error is ignored when sessionId is nil
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
