### PR TITLE
fix: dismissError clears sessionError, gate session_error to claimed sessions

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -217,10 +217,24 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
-    func testDismissErrorClearsErrorText() {
+    func testDismissErrorClearsErrorTextAndSessionError() {
+        viewModel.sessionId = "sess-1"
         viewModel.errorText = "Some error"
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "API error",
+            retryable: false
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+        XCTAssertNotNil(viewModel.sessionError)
+        XCTAssertNotNil(viewModel.errorText)
+
         viewModel.dismissError()
+
         XCTAssertNil(viewModel.errorText)
+        XCTAssertNil(viewModel.sessionError,
+                      "dismissError() should also clear sessionError")
     }
 
     func testErrorFinalizesStreamingAssistantMessage() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -933,7 +933,9 @@ public final class ChatViewModel: ObservableObject {
             }
 
         case .sessionError(let msg):
-            guard belongsToSession(msg.sessionId) else { return }
+            // Require a claimed session — sessionError always carries a sessionId,
+            // and accepting it before claiming would contaminate uncorrelated tabs.
+            guard let sessionId, msg.sessionId == sessionId else { return }
             let typedError = SessionError(from: msg)
             log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
             sessionError = typedError
@@ -1140,6 +1142,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func dismissError() {
+        sessionError = nil
         errorText = nil
     }
 


### PR DESCRIPTION
## Summary
- Make `dismissError()` also clear `sessionError` so the UI-wired dismiss action (MainWindowView:69) doesn't leave stale typed error state after the user dismisses the error banner
- Require a claimed `sessionId` before accepting `.sessionError` messages to prevent cross-session contamination when the view model hasn't yet established its session (before `sessionInfo` is received)
- Update test to verify `dismissError()` clears both `errorText` and `sessionError`

Addresses review feedback on #2115

## Test plan
- [ ] Trigger a session error, dismiss via error banner — both `errorText` and `sessionError` should be nil
- [ ] Open two chat tabs, trigger error in one — other tab should not show the error
- [ ] Existing session error tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
