### PR TITLE
fix(tests): resolve TypeScript errors in sandbox test files

### DIFF
--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -33,15 +33,19 @@ mock.module('../util/platform.js', () => ({
 }));
 
 // Mock config loader — return a config with sandbox settings
-let mockSandboxConfig = {
+let mockSandboxConfig: {
+  enabled: boolean;
+  backend: 'native' | 'docker';
+  docker: { image: string; cpus: number; memoryMb: number; pidsLimit: number; network: 'none' | 'bridge' };
+} = {
   enabled: true,
-  backend: 'native' as const,
+  backend: 'native',
   docker: {
     image: 'node:20-slim',
     cpus: 1,
     memoryMb: 512,
     pidsLimit: 256,
-    network: 'none' as const,
+    network: 'none',
   },
 };
 

--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -463,6 +463,7 @@ describe('applyEdit engine: deterministic across invocations', () => {
     expect(r1.ok).toBe(false);
     if (r1.ok) return;
     expect(r1.reason).toBe('ambiguous');
+    if (r1.reason !== 'ambiguous') return;
     expect(r1.matchCount).toBe(3);
   });
 
@@ -581,7 +582,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled returns bash with sandboxed=false', () => {
-    const result = wrapCommand('echo hi', '/tmp', { enabled: false });
+    const result = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     expect(result.command).toBe('bash');
     expect(result.args).toEqual(['-c', '--', 'echo hi']);
@@ -589,7 +590,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled result has same shape as enabled result', () => {
-    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false });
+    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     // Both must have: command (string), args (string[]), sandboxed (boolean)
     expect(typeof disabled.command).toBe('string');
@@ -869,7 +870,7 @@ describe('DockerBackend vs NativeBackend: SandboxResult shape parity', () => {
     // Various commands should all be wrapped consistently when disabled
     const commands = ['echo hello', 'ls -la', 'cat /etc/hosts', 'true && false'];
     for (const cmd of commands) {
-      const result = wrapCommand(cmd, '/tmp', { enabled: false });
+      const result = wrapCommand(cmd, '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
       expect(result.command).toBe('bash');
       expect(result.args[0]).toBe('-c');
       expect(result.args[1]).toBe('--');


### PR DESCRIPTION
## Summary
- Widen `mockSandboxConfig` type annotation to accept `'native' | 'docker'` backend instead of `'native' as const`
- Add `reason` narrowing guard before accessing `matchCount` on the `EditEngineResult` union type
- Provide full `SandboxConfig` objects (with `backend` and `docker` fields) to `wrapCommand` instead of partial `{ enabled: false }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
