### PR TITLE
fix(ui): clear sessionError on regenerate

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -463,6 +463,27 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText, "Regenerate while sending should silently do nothing")
     }
 
+    func testRegenerateClearsStaleSessionError() {
+        viewModel.sessionId = "sess-1"
+        daemonClient.isConnected = true
+
+        // Simulate a stale session error from a previous failure
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "Stale error",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+        XCTAssertNotNil(viewModel.sessionError)
+        XCTAssertNotNil(viewModel.errorText)
+
+        viewModel.regenerateLastMessage()
+
+        XCTAssertNil(viewModel.sessionError, "Regenerate should clear stale session error")
+        XCTAssertNil(viewModel.errorText, "Regenerate should clear stale error text")
+    }
+
     func testStopGeneratingWhenDisconnectedResetsAllState() {
         // Set up state directly to establish meaningful queue state, since
         // DaemonClient.send() throws when connection is nil.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1119,6 +1119,8 @@ public final class ChatViewModel: ObservableObject {
             return
         }
 
+        errorText = nil
+        sessionError = nil
         isSending = true
         isThinking = true
         suggestion = nil


### PR DESCRIPTION
## Summary
- `regenerateLastMessage()` now clears `sessionError` and `errorText` before starting, matching `sendMessage()` behavior
- Prevents stale error toast from persisting during/after successful regeneration
- Adds test `testRegenerateClearsStaleSessionError` verifying the fix

Addresses review feedback from PR #2124.

## Test plan
- [x] `swift build --target vellum-assistant` passes
- [x] `swift build --target vellum-assistantTests` compiles
- [ ] Verify error toast disappears when user clicks regenerate while a session error is visible

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
