### PR TITLE
fix(tests): resolve eslint errors across test files

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -11,7 +11,7 @@ const originalSpawn = realChildProcess.spawn;
 const spawnCalls: { command: string; args: string[] }[] = [];
 const spawnSpy = mock((...args: Parameters<typeof realChildProcess.spawn>) => {
   spawnCalls.push({ command: args[0] as string, args: args[1] as string[] });
-  return (originalSpawn as Function)(...args);
+  return (originalSpawn as (...a: unknown[]) => unknown)(...args);
 });
 
 mock.module('node:child_process', () => ({

--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -835,6 +835,7 @@ describe('Regression: edge cases in shared FileSystemOps', () => {
 
     const linkPath = join(dir, 'link.txt');
     try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('node:fs').symlinkSync(targetFile, linkPath);
     } catch {
       // Symlink creation may fail on some systems — skip gracefully

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -116,7 +116,7 @@ mock.module('../config/skills.js', () => ({
 }));
 
 mock.module('../config/skill-state.js', () => ({
-  resolveSkillStates: (catalog: any[]) => catalog.map((s: any) => ({
+  resolveSkillStates: (catalog: Record<string, unknown>[]) => catalog.map((s) => ({
     summary: s,
     state: 'enabled',
     degraded: false,
@@ -217,8 +217,8 @@ describe('Session slash command — known', () => {
     const lastUserMsg = pendingRuns[0].messages[pendingRuns[0].messages.length - 1];
     expect(lastUserMsg.role).toBe('user');
     const text = lastUserMsg.content
-      .filter((b: any) => b.type === 'text')
-      .map((b: any) => b.text)
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text)
       .join('');
     expect(text).toContain('slash command');
     expect(text).toContain('start-the-day');
@@ -241,8 +241,8 @@ describe('Session slash command — known', () => {
     const lastUserMsg = pendingRuns[0].messages[pendingRuns[0].messages.length - 1];
     expect(lastUserMsg.role).toBe('user');
     const text = lastUserMsg.content
-      .filter((b: any) => b.type === 'text')
-      .map((b: any) => b.text)
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text)
       .join('');
     expect(text).toContain('hello world');
 

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -116,7 +116,7 @@ mock.module('../config/skills.js', () => ({
 }));
 
 mock.module('../config/skill-state.js', () => ({
-  resolveSkillStates: (catalog: any[]) => catalog.map((s: any) => ({
+  resolveSkillStates: (catalog: Record<string, unknown>[]) => catalog.map((s) => ({
     summary: s,
     state: 'enabled',
     degraded: false,
@@ -233,7 +233,7 @@ describe('Session queue slash handling', () => {
     expect(eventsUnknown.some((e) => e.type === 'message_dequeued')).toBe(true);
     const textDeltas = eventsUnknown.filter((e) => e.type === 'assistant_text_delta');
     expect(textDeltas.length).toBe(1);
-    expect((textDeltas[0] as any).text).toContain('Unknown command');
+    expect((textDeltas[0] as { text: string }).text).toContain('Unknown command');
     expect(eventsUnknown.some((e) => e.type === 'message_complete')).toBe(true);
 
     // msg-3 events: dequeued (agent loop started)
@@ -269,8 +269,8 @@ describe('Session queue slash handling', () => {
     const lastUserMsg = pendingRuns[1].messages[pendingRuns[1].messages.length - 1];
     expect(lastUserMsg.role).toBe('user');
     const text = lastUserMsg.content
-      .filter((b: any) => b.type === 'text')
-      .map((b: any) => b.text)
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text)
       .join('');
     expect(text).toContain('start-the-day');
     expect(text).toContain('Start the Day');

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -119,7 +119,7 @@ mock.module('../config/skills.js', () => ({
 }));
 
 mock.module('../config/skill-state.js', () => ({
-  resolveSkillStates: (catalog: any[]) => catalog.map((s: any) => ({
+  resolveSkillStates: (catalog: Record<string, unknown>[]) => catalog.map((s) => ({
     summary: s,
     state: 'enabled',
     degraded: false,
@@ -195,7 +195,7 @@ describe('Session slash command — unknown', () => {
     // Should have emitted assistant_text_delta with the unknown message
     const textDeltas = events.filter((e) => e.type === 'assistant_text_delta');
     expect(textDeltas.length).toBe(1);
-    const delta = textDeltas[0] as any;
+    const delta = textDeltas[0] as { text: string };
     expect(delta.text).toContain('Unknown command `/not-a-skill`');
     expect(delta.text).toContain('/start-the-day');
 

--- a/assistant/src/__tests__/slash-commands-resolver.test.ts
+++ b/assistant/src/__tests__/slash-commands-resolver.test.ts
@@ -3,6 +3,7 @@ import {
   buildInvocableSlashCatalog,
   formatUnknownSlashSkillMessage,
   resolveSlashSkillCommand,
+  type InvocableSlashSkill,
 } from '../skills/slash-commands.js';
 import type { SkillSummary } from '../config/skills.js';
 import type { ResolvedSkill } from '../config/skill-state.js';
@@ -28,7 +29,7 @@ function makeResolved(skill: SkillSummary, state: ResolvedSkill['state']): Resol
   };
 }
 
-function buildCatalog(skills: SkillSummary[]): Map<string, any> {
+function buildCatalog(skills: SkillSummary[]): Map<string, InvocableSlashSkill> {
   const resolved = skills.map((s) => makeResolved(s, 'enabled'));
   return buildInvocableSlashCatalog(skills, resolved);
 }


### PR DESCRIPTION
## Summary
- Replace `Function` type with explicit `(...a: unknown[]) => unknown` in host-shell-tool test
- Add `eslint-disable` for unavoidable `require()` call in sandbox-host-parity symlink test
- Replace all `any` annotations with proper types (`Record<string, unknown>`, `{ text: string }`, `InvocableSlashSkill`) across session slash and slash-commands-resolver tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
