### PR TITLE
fix(ui): disable scroll on empty chat state and composer when content fits

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -251,6 +251,7 @@ struct ChatView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
+            .scrollDisabled(messages.isEmpty && !isThinking)
             .onChange(of: messages.count) {
                 withAnimation(VAnimation.standard) {
                     if let lastMessage = messages.last {
@@ -547,6 +548,7 @@ struct ChatView: View {
             composerScrollIndicator
         }
         .scrollBounceBehavior(.basedOnSize)
+        .scrollDisabled(editorContentHeight <= 200)
         .onChange(of: inputText) {
             if editorContentHeight > 200 {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)


### PR DESCRIPTION
## Summary
- Disable scrolling on the message list when there are no messages (empty state)
- Disable scrolling on the composer text field when content fits within the 200pt max height, preventing placeholder text from moving on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
