### PR TITLE
fix(permissions): remove default ask-rules for cu_done/cu_respond terminal tools

### DIFF
--- a/assistant/src/__tests__/computer-use-session-compaction.test.ts
+++ b/assistant/src/__tests__/computer-use-session-compaction.test.ts
@@ -61,7 +61,7 @@ describe('ComputerUseSession.compactHistory', () => {
     const firstToolResult = compacted[1].content[0];
     expect(firstToolResult.type).toBe('tool_result');
     if (firstToolResult.type === 'tool_result') {
-      expect(firstToolResult.content).toContain('[Previous screen state omitted for brevity]');
+      expect(firstToolResult.content).toContain('<ax_tree_omitted />');
       expect(firstToolResult.content).not.toContain('<ax-tree>');
     }
 
@@ -98,7 +98,7 @@ describe('ComputerUseSession.compactHistory', () => {
     const firstToolResult = compacted[1].content[0];
     if (firstToolResult.type === 'tool_result') {
       expect(firstToolResult.content).not.toContain('<ax-tree>');
-      expect(firstToolResult.content).toContain('[Previous screen state omitted for brevity]');
+      expect(firstToolResult.content).toContain('<ax_tree_omitted />');
     }
   });
 

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -24,9 +24,9 @@ const COMPUTER_USE_TOOLS = [
   'cu_wait',
   'cu_open_app',
   'cu_run_applescript',
-  'cu_done',
-  'cu_respond',
   'request_computer_control',
+  // cu_done and cu_respond are terminal signal tools (RiskLevel.Low) — they
+  // don't perform any computer action, so they should NOT get an 'ask' rule.
 ] as const;
 
 /**

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -59,6 +59,20 @@ function backfillDefaults(rules: TrustRule[]): boolean {
     }
   }
 
+  // Remove default rules that are no longer in the template set (e.g.
+  // cu_done/cu_respond were removed from the computer-use ask-rule list
+  // because they are terminal signal tools that don't need approval).
+  const templateIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i];
+    if (rule.id.startsWith('default:') && !templateIds.has(rule.id)) {
+      rules.splice(i, 1);
+      existingIds.delete(rule.id);
+      changed = true;
+      log.info({ ruleId: rule.id }, 'Removed stale default trust rule');
+    }
+  }
+
   // Migrate existing default rules whose priority or pattern has changed
   // in the template (e.g. host_bash pattern changed from '*' to '**',
   // host tool priorities changed from 1000 to 50).


### PR DESCRIPTION
## Summary
- Removed `cu_done` and `cu_respond` from the `COMPUTER_USE_TOOLS` default ask-rule list — these are terminal signal tools (`RiskLevel.Low`) that don't perform any computer action, so prompting for approval is unnecessary and caused test timeouts
- Added migration logic in `backfillDefaults` to remove stale default rules from the persisted trust file when they're no longer in the template set
- Fixed compaction test assertions to match the actual `<ax_tree_omitted />` placeholder string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
