### PR TITLE
fix(ui): center ghost suggestion text in compact composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -508,6 +508,21 @@ struct ChatView: View {
                 .disabled(!hasAPIKey)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityLabel("Message")
+                .overlay(alignment: .topLeading) {
+                    if let ghostSuffix {
+                        (Text(inputText)
+                            .font(VFont.body)
+                            .foregroundColor(.clear)
+                        + Text(ghostSuffix)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textMuted.opacity(0.5)))
+                            .lineSpacing(4)
+                            .lineLimit(1...)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+                }
                 .background(
                     GeometryReader { geo in
                         Color.clear
@@ -519,22 +534,6 @@ struct ChatView: View {
                             }
                     }
                 )
-
-                if let ghostSuffix {
-                    (Text(inputText)
-                        .font(VFont.body)
-                        .foregroundColor(.clear)
-                    + Text(ghostSuffix)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textMuted.opacity(0.5)))
-                        .lineSpacing(4)
-                        .lineLimit(1...)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxHeight: min(max(editorContentHeight, 28), 200), alignment: .topLeading)
-                        .clipped()
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
             }
             .frame(minHeight: min(max(editorContentHeight, 28), 200), maxHeight: .infinity, alignment: .center)
             .background(ScrollOffsetReader(offset: $composerScrollOffset))


### PR DESCRIPTION
## Summary
- Move ghost suggestion text from a ZStack sibling to a `.overlay` on the TextField, so it inherits the same vertical position as the cursor/placeholder
- Fixes regression where suggestion text (e.g. "what does that mean?") sat at the top of the input bar instead of being vertically centered in subsequent messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
