### PR TITLE
fix(ui): add fallback for shift+enter when NSTextView cast fails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -564,6 +564,8 @@ struct ChatView: View {
             if keyPress.modifiers == .shift {
                 if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
                     textView.insertNewlineIgnoringFieldEditor(nil)
+                } else {
+                    inputText += "\n"
                 }
                 return .handled
             }


### PR DESCRIPTION
## Summary
- Adds an `else` fallback to the Shift+Return handler in `ChatView.swift` so that if the `NSTextView` cast fails, it falls back to appending `"\n"` to `inputText` instead of silently consuming the keypress
- Addresses review feedback from Devin on PR #2190

## Context
PR #2190 changed `inputText += "\n"` to use `textView.insertNewlineIgnoringFieldEditor(nil)` for cursor-position-correct newline insertion. However, if `NSApp.keyWindow?.firstResponder as? NSTextView` evaluates to `nil`, no newline was inserted but the keypress was still consumed (returned `.handled`). This adds the safe fallback.

## Test plan
- [ ] Open the chat composer, type some text, press Shift+Enter — newline should be inserted at cursor position
- [ ] Verify the fallback path works if the NSTextView cast were to fail (newline appended to end of text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
