### PR TITLE
fix(ui): restore non-file image drop support as fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -99,7 +99,7 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
-        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
         }
     }
@@ -154,16 +154,55 @@ struct ChatView: View {
         }
     }
 
-    /// Handle dropped items — loads file URLs to preserve original filenames.
+    /// Handle dropped items — supports both file URLs and raw image data.
+    /// File URLs are preferred (preserves original filenames); raw image data
+    /// is used as a fallback for providers without a backing file (e.g. screenshot
+    /// thumbnails or images dragged from certain apps).
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        var urls: [URL] = []
+        var imageDataItems: [NSItemProvider] = []
+        let group = DispatchGroup()
+
         for provider in providers {
-            _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                DispatchQueue.main.async {
-                    if let url {
-                        onDropFiles([url])
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                group.enter()
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    DispatchQueue.main.async {
+                        if let url { urls.append(url) }
+                        group.leave()
                     }
                 }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                imageDataItems.append(provider)
             }
+        }
+
+        for provider in imageDataItems {
+            let typeIdentifier: String
+            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
+                typeIdentifier = UTType.png.identifier
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                typeIdentifier = UTType.tiff.identifier
+            } else {
+                typeIdentifier = UTType.image.identifier
+            }
+
+            let suggestedName = provider.suggestedName
+            group.enter()
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                DispatchQueue.main.async {
+                    if let data {
+                        onDropImageData(data, suggestedName)
+                    }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .main) {
+            if !urls.isEmpty { onDropFiles(urls) }
         }
         return true
     }


### PR DESCRIPTION
## Summary

- Restores `.image`, `.png`, `.tiff` to the `.onDrop` modifier that was narrowed to only `.fileURL` in PR #2182
- Re-adds the raw image data loading fallback path in `handleDrop` for providers without a backing file URL (e.g. screenshot thumbnails, images from certain apps)
- Preserves the file URL priority path from #2182 so original filenames are kept when a file URL is available

Addresses feedback from Codex on #2182: restricting to `.fileURL` only rejected image drags that provide `public.image`/`public.png` without a backing file URL.

## Test plan

- [ ] Drop an image file from Finder — should attach with original filename preserved
- [ ] Drop a screenshot thumbnail (e.g. from Screenshot app or some browsers) — should attach as raw image data via the fallback path
- [ ] Drop a non-image file — should still work via file URL path
- [ ] Drop multiple items of mixed types — file URLs and raw images should both be handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
