### PR TITLE
fix(config): guard against null config.skills in resolveSkillStates

### DIFF
--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -17,7 +17,7 @@ export function resolveSkillStates(
   config: AssistantConfig,
 ): ResolvedSkill[] {
   const results: ResolvedSkill[] = [];
-  const { entries, allowBundled } = config.skills;
+  const { entries, allowBundled } = config.skills ?? { entries: {}, allowBundled: null };
 
   for (const skill of catalog) {
     // Filter bundled skills by allowlist


### PR DESCRIPTION
## Summary
- Added null guard to `resolveSkillStates` so it handles missing `config.skills` gracefully (falls back to `{ entries: {}, allowBundled: null }`)
- Fixes `session-abort-tool-results.test.ts` which crashed with `TypeError: Cannot destructure property 'entries' from null or undefined value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
