### PR TITLE
fix(tests): update trust-store test to match cu_done/cu_respond removal from defaults

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -598,12 +598,10 @@ describe('Trust Store', () => {
         .sort();
       expect(defaultTools).toEqual([
         'cu_click',
-        'cu_done',
         'cu_double_click',
         'cu_drag',
         'cu_key',
         'cu_open_app',
-        'cu_respond',
         'cu_right_click',
         'cu_run_applescript',
         'cu_scroll',


### PR DESCRIPTION
## Summary
- Removed `cu_done` and `cu_respond` from the expected default tools list in `trust-store.test.ts` to match the intentional removal in #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
