### PR TITLE
fix(docs): align session_error architecture docs with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -715,7 +715,7 @@ The daemon emits two distinct error message types over IPC:
 | `session_error` | Session-scoped | Typed, actionable failures during chat/session runtime (e.g., provider network error, rate limit, API failure) | `sessionId`, `code` (typed enum), `userMessage`, `retryable`, `debugDetails?` |
 | `error` | Global | Generic, non-session failures (e.g., daemon startup errors, unknown message types) | `message` (string) |
 
-**Design rationale:** `session_error` carries structured metadata (error code, retryable flag, debug details) so the client can present actionable UI — a toast with retry/copy-debug/dismiss buttons — rather than a generic error banner. The older `error` type is retained for backward compatibility with non-session contexts.
+**Design rationale:** `session_error` carries structured metadata (error code, retryable flag, debug details) so the client can present actionable UI — a toast with retry/dismiss buttons — rather than a generic error banner. The older `error` type is retained for backward compatibility with non-session contexts.
 
 ### Session Error Codes
 
@@ -750,16 +750,13 @@ sequenceDiagram
     VM->>VM: set sessionError property<br/>clear isThinking / isCancelling
     VM-->>UI: @Published sessionError observed
 
-    UI->>UI: show sessionErrorToast<br/>[Retry] [Copy Debug] [Dismiss]
+    UI->>UI: show sessionErrorToast<br/>[Retry] [Dismiss]
 
     alt User taps Retry (retryable == true)
         UI->>VM: retryAfterSessionError()
         VM->>VM: dismissSessionError()<br/>+ regenerateLastMessage()
         VM->>DC: regenerate {sessionId}
         DC->>Daemon: IPC
-    else User taps Copy Debug
-        UI->>VM: copySessionErrorDebugDetails()
-        Note over VM: Copies error details<br/>to system clipboard
     else User taps Dismiss
         UI->>VM: dismissSessionError()
         VM->>VM: clear sessionError + errorText
@@ -770,9 +767,8 @@ sequenceDiagram
 2. **ChatViewModel** receives the error via the `onSessionError` callback, sets the `sessionError` property, and transitions out of the streaming/loading state so the UI is interactive.
 3. **ChatView** observes the published `sessionError` and displays an actionable toast with a category-specific icon and accent color:
    - **Retry** (shown when `retryable` is true): calls `retryAfterSessionError()`, which clears the error and sends a `regenerate` message to the daemon.
-   - **Copy Debug**: calls `copySessionErrorDebugDetails()` to copy error details to the clipboard.
    - **Dismiss (X)**: calls `dismissSessionError()` to clear the error without retrying.
-4. If the error is not retryable, the Retry button is hidden and the user can only dismiss or copy debug info.
+4. If the error is not retryable, the Retry button is hidden and the user can only dismiss.
 
 ---
 


### PR DESCRIPTION
Fixes documentation inaccuracies found in PR #2141 review: removes nonexistent Copy Debug button references from the session error toast documentation in ARCHITECTURE.md.

## Changes
- Removed `[Copy Debug]` from the Mermaid sequence diagram toast label
- Removed the "User taps Copy Debug" flow branch and `copySessionErrorDebugDetails()` reference
- Removed "Copy Debug" from the numbered list describing toast buttons
- Updated design rationale text to say "retry/dismiss buttons" instead of "retry/copy-debug/dismiss buttons"
- Updated non-retryable error description to say "the user can only dismiss" instead of "dismiss or copy debug info"

## Verification
Confirmed against the actual implementation:
- `ChatView.swift:367-390` — toast only renders Retry and Dismiss (X) buttons
- `ChatViewModel.swift:1174` — method is `retryAfterSessionError()` (already correct in docs)
- `IPCMessages.swift:280` — regenerate type is `"regenerate"` (already correct in docs)
- `ipc-contract.ts:674-682` — error codes are UPPER_CASE (already correct in docs)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
