### PR TITLE
fix(docs): correct error classifier default and remove Copy Debug from ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -728,7 +728,6 @@ The daemon emits two distinct error message types over IPC:
 | `SESSION_ABORTED` | Non-user abort interrupted the request | Yes |
 | `SESSION_PROCESSING_FAILED` | Catch-all for unexpected processing failures | No |
 | `REGENERATE_FAILED` | Failed to regenerate a previous response | Yes |
-| `UNKNOWN` | Unclassified error | No |
 
 ### Error Classification
 


### PR DESCRIPTION
Fixes documentation inaccuracies found in PR #2145 review:

- **Remove `UNKNOWN` error code**: The daemon classifier (`session-error.ts` `classifyByMessage()`) maps unmatched errors to `SESSION_PROCESSING_FAILED` (already in the table), not `UNKNOWN`. There are no emit sites assigning `UNKNOWN` in the session error path.
- **Remove `Copy Debug` from toast sequence**: `ChatView` only exposes Retry and Dismiss controls — there is no `copySessionErrorDebugDetails()` callback or button wired in the UI.

Addresses review feedback from codex on #2145.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
