### PR TITLE
fix(ipc): restore defensive decoding defaults for ClawhubInspectStats

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -703,6 +703,24 @@ public typealias ClawhubInspectOwner = IPCSkillsInspectResponseDataOwner
 /// Backed by generated `IPCSkillsInspectResponseDataStats`.
 public typealias ClawhubInspectStats = IPCSkillsInspectResponseDataStats
 
+// The server may omit stats fields for newly created skills,
+// so we default missing values to 0 instead of crashing.
+extension IPCSkillsInspectResponseDataStats {
+    enum CodingKeys: String, CodingKey {
+        case stars, installs, downloads, versions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            stars: try container.decodeIfPresent(Int.self, forKey: .stars) ?? 0,
+            installs: try container.decodeIfPresent(Int.self, forKey: .installs) ?? 0,
+            downloads: try container.decodeIfPresent(Int.self, forKey: .downloads) ?? 0,
+            versions: try container.decodeIfPresent(Int.self, forKey: .versions) ?? 0
+        )
+    }
+}
+
 /// Version info from a ClaWHub inspect response.
 /// Backed by generated `IPCSkillsInspectResponseDataLatestVersion`.
 public typealias ClawhubInspectVersion = IPCSkillsInspectResponseDataLatestVersion


### PR DESCRIPTION
Fixes potential crash found in PR #2146 review: adds custom decoder extension on `IPCSkillsInspectResponseDataStats` to use `decodeIfPresent` with `?? 0` defaults, matching the old `ClawhubInspectStats` behavior.

Prevents `DecodingError.keyNotFound` when the ClaWHub API omits stats fields (e.g. for newly created skills with no stats).

**Changes:**
- Added `extension IPCSkillsInspectResponseDataStats` with custom `init(from:)` in `clients/shared/IPC/IPCMessages.swift`
- Does NOT modify the generated file
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
