### PR TITLE
fix(ui): auto-scroll composer when content height crosses 200pt threshold

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -592,6 +592,11 @@ struct ChatView: View {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)
             }
         }
+        .onChange(of: editorContentHeight) {
+            if editorContentHeight > 200 {
+                proxy.scrollTo("composer-bottom", anchor: .bottom)
+            }
+        }
         .onKeyPress(.tab, phases: .down) { keyPress in
             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
                 onAcceptSuggestion()


### PR DESCRIPTION
## Summary
- Adds an `onChange(of: editorContentHeight)` handler to the composer ScrollView that auto-scrolls to `"composer-bottom"` when `editorContentHeight` exceeds 200pt
- Fixes a race condition where `onChange(of: inputText)` fires before `GeometryReader` updates `editorContentHeight`, causing auto-scroll to be missed when content first crosses the 200pt threshold

## Context
Addresses feedback from Devin on PR #2203: "Composer scroll disabled prevents auto-scroll when content first exceeds 200pt"

The root cause: when a keystroke pushes content past 200pt, `onChange(of: inputText)` fires before `GeometryReader` updates `editorContentHeight`. At that moment, `editorContentHeight` is still <=200 (stale), so the auto-scroll guard fails. The new `onChange(of: editorContentHeight)` handler catches the geometry update and triggers auto-scroll at the right time.

## Test plan
- [ ] Type enough text in the composer to exceed 200pt height
- [ ] Verify the composer auto-scrolls to keep the cursor visible when crossing the threshold
- [ ] Verify normal scrolling behavior still works when content is already >200pt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
