### PR TITLE
fix(ui): transition queued messages to sent on retry reset

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1182,6 +1182,11 @@ public final class ChatViewModel: ObservableObject {
         pendingQueuedCount = 0
         pendingMessageIds = []
         requestIdToMessageId = [:]
+        for i in messages.indices {
+            if case .queued = messages[i].status, messages[i].role == .user {
+                messages[i].status = .sent
+            }
+        }
         dismissSessionError()
         regenerateLastMessage()
     }


### PR DESCRIPTION
Addresses review feedback from PR #2175.

## Problem

`retryAfterSessionError()` reset `pendingQueuedCount = 0` but did not transition messages still in `.queued` status back to `.sent`. This left those user messages permanently showing "Queued" with 0.7 opacity in the UI, since the queue-processing machinery had been torn down and nothing would ever advance their status.

## Fix

Added the same `queued -> sent` transition loop used in every other reset path in the codebase (cancel timeout, session error cancel, `stopGenerating` disconnected/failure paths). This ensures no messages are left stranded in `.queued` status after a retry reset.

## Files changed
- `clients/shared/Features/Chat/ChatViewModel.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
