### PR TITLE
fix(commands): keep regression-risk PRs tracked in check-reviews

### DIFF
--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -72,8 +72,8 @@ Examples of feedback that would cause a regression:
 - If either reviewer hasn't reviewed yet, keep the PR in UNREVIEWED_PRS.md for next time.
 - If both have reviewed and either review requested changes with **valid feedback**, add `- Address the feedback on <link to PR>` to the **top** of .private/TODO.md (ordered by PR number, lowest first).
 - If all feedback on a PR was classified as nonsensical, treat that reviewer as having approved.
-- If any feedback is classified as **regression risk**, do NOT add it to TODO. Instead, flag it to the user (see output section) and **stop processing further PRs**. Wait for the user to decide what to do.
-- If fully reviewed (both have reviewed) and Codex is not rate-limited, remove the PR from .private/UNREVIEWED_PRS.md.
+- If any feedback is classified as **regression risk**, do NOT add it to TODO. Instead, flag it to the user (see output section) and **stop processing further PRs**. Keep the PR in .private/UNREVIEWED_PRS.md so it is revisited on the next run. Wait for the user to decide what to do.
+- If fully reviewed (both have reviewed), Codex is not rate-limited, and no feedback was classified as regression risk, remove the PR from .private/UNREVIEWED_PRS.md.
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 
 | Command | Purpose |
 |---------|---------|
-| `/check-reviews` | Checks for review feedback on unreviewed PRs and creates follow-up tasks. |
+| `/check-reviews` | Checks for review feedback on unreviewed PRs, assesses feedback contextually (valid, nonsensical, or regression risk), creates follow-up tasks for valid feedback, and halts for user decision on regression risks. |
 
 ### Typical flow
 


### PR DESCRIPTION
## Summary
- Addresses feedback from PR #2184 (chatgpt-codex-connector)
- **Regression-risk PRs now stay in UNREVIEWED_PRS.md** so they are revisited on the next `/check-reviews` run, preventing feedback from being silently lost when no TODO item is created
- Only removes PRs from UNREVIEWED_PRS.md when fully reviewed with no regression-risk classification and no Codex rate-limit
- **Updates README** `/check-reviews` description to reflect the contextual assessment behavior added in #2184

## Files changed
- `.claude/commands/check-reviews.md` — added condition to keep regression-risk PRs in tracking file
- `README.md` — updated `/check-reviews` command description
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
