### PR TITLE
fix(docs): restore correct Docker image and cpus defaults

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -857,7 +857,7 @@ graph TB
 
 - **Backend selection**: The `sandbox.backend` config option (`"native"` or `"docker"`) determines how `bash` commands are sandboxed. The default is `"docker"`.
 - **Native backend**: Uses OS-level sandboxing — `sandbox-exec` with SBPL profiles on macOS, `bwrap` (bubblewrap) on Linux. Denies network access and restricts filesystem writes to the sandbox root, `/tmp`, `/private/tmp`, and `/var/folders` (macOS) or the sandbox root and `/tmp` (Linux).
-- **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is `ubuntu:22.04`.
+- **Docker backend**: Wraps each command in an ephemeral `docker run --rm` container. The sandbox filesystem root is bind-mounted to `/workspace`. Containers run with all capabilities dropped, a read-only root filesystem, no network access, and host UID:GID forwarding. The default image is `node:20-slim` (pinned with a `sha256` digest).
 - **Fail-closed**: Both backends refuse to execute unsandboxed if their prerequisites are unavailable. The Docker backend runs preflight checks (CLI, daemon, image, mount probe) and throws `ToolError` with actionable messages on failure. Positive preflight results are cached; negative results are rechecked on every call.
 - **Host tools unchanged**: `host_bash`, `host_file_read`, `host_file_write`, and `host_file_edit` always execute directly on the host regardless of which sandbox backend is active.
 - Sandbox defaults: `file_*` and `bash` execute within `~/.vellum/data/sandbox/fs`.

--- a/README.md
+++ b/README.md
@@ -91,18 +91,18 @@ When `sandbox.backend` is set to `"docker"`, the daemon wraps every sandbox `bas
 
 - Docker installed and the `docker` CLI available in `PATH`.
 - Docker daemon running (Docker Desktop on macOS/Windows, or `systemd` service on Linux).
-- The configured image pulled locally. The default image is `ubuntu:22.04`:
+- The configured image pulled locally. The default image is pinned with a `sha256` digest for reproducibility:
   ```
-  docker pull ubuntu:22.04
+  node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9
   ```
-- The `ubuntu:22.04` image must also be available locally — the preflight mount probe uses it regardless of `sandbox.docker.image`. In air-gapped or offline environments, ensure both `ubuntu:22.04` and your configured image (if different) are pulled.
+  Pull it with: `docker pull node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9`
 
 **Docker configuration options** (all under `sandbox.docker`):
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `image` | `ubuntu:22.04` | Container image |
-| `cpus` | `2` | CPU limit per container |
+| `image` | `node:20-slim@sha256:...` | Container image (pinned with sha256 digest) |
+| `cpus` | `1` | CPU limit per container |
 | `memoryMb` | `512` | Memory limit in MB |
 | `pidsLimit` | `256` | Maximum number of processes |
 | `network` | `"none"` | Network mode (`"none"` or `"bridge"`) |


### PR DESCRIPTION
## Context

Addresses review feedback on #2168 — both Devin and Codex flagged that the docs were updated to match `DockerBackend` internal `DEFAULTS` (`ubuntu:22.04`, `cpus: 2`) instead of the actual Zod config schema defaults (`node:20-slim@sha256:...`, `cpus: 1`). The internal DEFAULTS are shadowed by schema defaults in normal operation and never reached.

## Changes

- **README.md**: Restore default image to `node:20-slim@sha256:...` (pinned) and `cpus` to `1`; remove incorrect `ubuntu:22.04` mount-probe note (the mount probe uses the configured image, not a hardcoded one)
- **ARCHITECTURE.md**: Restore default image description to `node:20-slim` (pinned with sha256 digest)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
