### PR TITLE
fix(error-handling): require AbortError type for user cancellation

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -7,9 +7,14 @@ import {
 import type { ErrorContext } from '../daemon/session-error.js';
 
 describe('isUserCancellation', () => {
-  it('returns true when abort flag is set', () => {
+  it('returns false for non-AbortError even when abort flag is set', () => {
     const ctx: ErrorContext = { phase: 'agent_loop', aborted: true };
-    expect(isUserCancellation(new Error('something'), ctx)).toBe(true);
+    expect(isUserCancellation(new Error('something'), ctx)).toBe(false);
+  });
+
+  it('returns false for non-AbortError network failure during abort', () => {
+    const ctx: ErrorContext = { phase: 'agent_loop', aborted: true };
+    expect(isUserCancellation(new Error('ECONNREFUSED'), ctx)).toBe(false);
   });
 
   it('returns true for AbortError (DOMException-style) when aborted', () => {
@@ -173,11 +178,13 @@ describe('classifySessionError', () => {
   });
 
   describe('cancel/abort should NOT produce false-positive session errors', () => {
-    it('user-initiated cancel should be caught by isUserCancellation, not classifySessionError', () => {
-      // If aborted flag is set, isUserCancellation returns true and
-      // classifySessionError should not be called. Verify the guard works.
+    it('user-initiated cancel requires both AbortError and active abort signal', () => {
+      const abortErr = new DOMException('The operation was aborted', 'AbortError');
       const abortCtx: ErrorContext = { phase: 'agent_loop', aborted: true };
-      expect(isUserCancellation(new Error('The operation was aborted'), abortCtx)).toBe(true);
+      expect(isUserCancellation(abortErr, abortCtx)).toBe(true);
+
+      // Non-AbortError during abort should NOT be treated as user cancellation
+      expect(isUserCancellation(new Error('ECONNRESET'), abortCtx)).toBe(false);
     });
 
     it('DOMException AbortError is only caught when abort signal is active', () => {

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -64,9 +64,9 @@ export interface ErrorContext {
  * instead of `session_error`.
  */
 export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
-  if (ctx.aborted) return true;
-  if (error instanceof DOMException && error.name === 'AbortError' && ctx.aborted) return true;
-  if (error instanceof Error && error.name === 'AbortError' && ctx.aborted) return true;
+  if (!ctx.aborted) return false;
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  if (error instanceof Error && error.name === 'AbortError') return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Restructure `isUserCancellation()` to require both `ctx.aborted` AND an actual `AbortError` — not just the abort signal alone
- Previously, the unconditional `if (ctx.aborted) return true` on line 67 made the subsequent AbortError checks dead code, and silently swallowed real errors (e.g. network failures) that happened to be in-flight when the user cancelled
- Now non-AbortError errors during abort are properly classified as `session_error` instead of being hidden as "user cancellation"
- Updated tests to verify non-AbortError errors return `false` even when `ctx.aborted` is true

Addresses review feedback on #2191.

## Files modified
- `assistant/src/daemon/session-error.ts` — restructure guard logic
- `assistant/src/__tests__/session-error.test.ts` — update and add tests for corrected behavior

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All 40 session-error tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
