### PR TITLE
fix(ui): give VSidePanel content ScrollView lower layout priority

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -42,11 +42,13 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             // Pinned content (not scrollable)
             pinnedContent()
 
-            // Scrollable content
+            // Scrollable content — lower priority so pinnedContent's
+            // own ScrollView (e.g. TraceTimelineView) isn't starved.
             ScrollView {
                 content()
                     .padding(VSpacing.xl)
             }
+            .layoutPriority(-1)
         }
         .background(VColor.backgroundSubtle)
     }


### PR DESCRIPTION
## Summary
- Adds `.layoutPriority(-1)` to VSidePanel's content `ScrollView` so that `pinnedContent`'s own `ScrollView` (e.g. `TraceTimelineView`) gets full vertical space instead of splitting ~50/50 with the empty content `ScrollView`
- Addresses review feedback on #2195 where Devin identified that `TraceTimelineView` loses ~50% vertical space to the empty content `ScrollView`

## Test plan
- [ ] Open Debug panel with active session — trace timeline uses full available height
- [ ] Empty states still display correctly (content `ScrollView` gets space when pinned content has no `ScrollView`)
- [ ] Side panels with both pinned and scrollable content (e.g. with segmented control) still layout correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
