### PR TITLE
fix(trace): emit terminal trace events for regenerate early-return paths

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -805,6 +805,11 @@ async function handleRegenerate(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, sessionId: msg.sessionId }, 'Error regenerating message');
+    session.traceEmitter.emit('request_error', message.slice(0, 200), {
+      requestId,
+      status: 'error',
+      attributes: { errorClass: err instanceof Error ? err.constructor.name : 'Error', message: message.slice(0, 500) },
+    });
     ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
     const classified = classifySessionError(err, { phase: 'regenerate' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1203,6 +1203,13 @@ export class Session {
   async regenerate(onEvent: (msg: ServerMessage) => void, requestId?: string): Promise<void> {
     if (this.processing) {
       onEvent({ type: 'error', message: 'Cannot regenerate while processing' });
+      if (requestId) {
+        this.traceEmitter.emit('request_error', 'Cannot regenerate while processing', {
+          requestId,
+          status: 'error',
+          attributes: { reason: 'already_processing' },
+        });
+      }
       return;
     }
 
@@ -1211,12 +1218,26 @@ export class Session {
     const lastUserIdx = findLastUndoableUserMessageIndex(this.messages);
     if (lastUserIdx === -1) {
       onEvent({ type: 'error', message: 'No messages to regenerate' });
+      if (requestId) {
+        this.traceEmitter.emit('request_error', 'No messages to regenerate', {
+          requestId,
+          status: 'error',
+          attributes: { reason: 'no_messages' },
+        });
+      }
       return;
     }
 
     // There must be at least one message after the user message (the assistant reply).
     if (lastUserIdx >= this.messages.length - 1) {
       onEvent({ type: 'error', message: 'No assistant response to regenerate' });
+      if (requestId) {
+        this.traceEmitter.emit('request_error', 'No assistant response to regenerate', {
+          requestId,
+          status: 'error',
+          attributes: { reason: 'no_assistant_response' },
+        });
+      }
       return;
     }
 
@@ -1243,6 +1264,13 @@ export class Session {
 
     if (dbUserMsgIdx === -1) {
       onEvent({ type: 'error', message: 'No user message found in DB' });
+      if (requestId) {
+        this.traceEmitter.emit('request_error', 'No user message found in DB', {
+          requestId,
+          status: 'error',
+          attributes: { reason: 'no_db_user_message' },
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Emit `request_error` trace events at all four early-return paths in `Session.regenerate()` (already processing, no messages, no assistant response, no DB user message) so every `request_received` has a matching terminal trace
- Emit `request_error` in the `handleRegenerate` catch block for unexpected exceptions that bypass `runAgentLoop`'s internal error handling

Addresses review feedback on PR #2177.

## Test plan
- [x] All 22 session-queue tests pass
- [x] All 14 trace-emitter tests pass
- [x] All 5 session-undo tests pass
- [x] TypeScript type-check passes (no new errors)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
