### PR TITLE
fix(docker): remove -- separator for POSIX sh compat and expose shell in config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -85,6 +85,7 @@ describe('AssistantConfigSchema', () => {
       backend: 'docker',
       docker: {
         image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+        shell: 'sh',
         cpus: 1,
         memoryMb: 512,
         pidsLimit: 256,

--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -582,7 +582,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled returns bash with sandboxed=false', () => {
-    const result = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+    const result = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     expect(result.command).toBe('bash');
     expect(result.args).toEqual(['-c', '--', 'echo hi']);
@@ -590,7 +590,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled result has same shape as enabled result', () => {
-    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     // Both must have: command (string), args (string[]), sandboxed (boolean)
     expect(typeof disabled.command).toBe('string');
@@ -871,7 +871,7 @@ describe('DockerBackend vs NativeBackend: SandboxResult shape parity', () => {
     // Various commands should all be wrapped consistently when disabled
     const commands = ['echo hello', 'ls -la', 'cat /etc/hosts', 'true && false'];
     for (const cmd of commands) {
-      const result = wrapCommand(cmd, '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+      const result = wrapCommand(cmd, '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
       expect(result.command).toBe('bash');
       expect(result.args[0]).toBe('-c');
       expect(result.args[1]).toBe('--');

--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -111,13 +111,13 @@ describe('DockerBackend — argument construction', () => {
     expect(result.args).toContain(defaultImage);
   });
 
-  test('wraps command with sh -c -- by default', () => {
+  test('wraps command with sh -c by default', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const cmd = 'cat /etc/passwd | wc -l';
     const result = backend.wrap(cmd, sandboxRoot);
     const shIdx = result.args.indexOf('sh');
     expect(shIdx).toBeGreaterThan(0);
-    expect(result.args.slice(shIdx)).toEqual(['sh', '-c', '--', cmd]);
+    expect(result.args.slice(shIdx)).toEqual(['sh', '-c', cmd]);
   });
 });
 
@@ -281,10 +281,10 @@ describe('DockerBackend — argv segment safety', () => {
   test('all args are discrete strings — no shell metacharacters are interpreted', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const result = backend.wrap('echo $(whoami)', sandboxRoot);
-    // The command is passed as a single argv element after '--'
-    const dashDashIdx = result.args.indexOf('--');
-    expect(dashDashIdx).toBeGreaterThan(0);
-    expect(result.args[dashDashIdx + 1]).toBe('echo $(whoami)');
+    // The command is passed as a single argv element after 'sh -c'
+    const cIdx = result.args.indexOf('-c');
+    expect(cIdx).toBeGreaterThan(0);
+    expect(result.args[cIdx + 1]).toBe('echo $(whoami)');
     // The command itself is a single string, not split by the shell
     expect(result.args.filter((a: string) => a === '$(whoami)').length).toBe(0);
   });
@@ -373,7 +373,7 @@ describe('DockerBackend — custom config', () => {
     const result = backend.wrap('echo hi', sandboxRoot);
     const bashIdx = result.args.indexOf('bash');
     expect(bashIdx).toBeGreaterThan(0);
-    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', '--', 'echo hi']);
+    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', 'echo hi']);
   });
 
   test('accepts custom network mode', () => {

--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -42,7 +42,7 @@ mock.module('node:fs', () => ({
 const { wrapCommand } = await import('../tools/terminal/sandbox.js');
 const { ToolError } = await import('../util/errors.js');
 
-const defaultDocker = { image: 'node:20-slim', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const };
+const defaultDocker = { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const };
 
 function disabledConfig(): SandboxConfig {
   return { enabled: false, backend: 'native', docker: defaultDocker };

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -94,6 +94,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      shell: 'sh',
       cpus: 1,
       memoryMb: 512,
       pidsLimit: 256,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -29,6 +29,9 @@ export const DockerConfigSchema = z.object({
   image: z
     .string({ error: 'sandbox.docker.image must be a string' })
     .default('node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9'),
+  shell: z
+    .string({ error: 'sandbox.docker.shell must be a string' })
+    .default('sh'),
   cpus: z
     .number({ error: 'sandbox.docker.cpus must be a number' })
     .finite('sandbox.docker.cpus must be finite')
@@ -62,6 +65,7 @@ export const SandboxConfigSchema = z.object({
     .default('docker'),
   docker: DockerConfigSchema.default({
     image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+    shell: 'sh',
     cpus: 1,
     memoryMb: 512,
     pidsLimit: 256,
@@ -571,6 +575,7 @@ export const AssistantConfigSchema = z.object({
     backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      shell: 'sh',
       cpus: 1,
       memoryMb: 512,
       pidsLimit: 256,

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -8,23 +8,17 @@ import type { SandboxBackend, SandboxResult } from './types.js';
 
 const log = getLogger('docker-sandbox');
 
-/** DockerBackend-specific config extends the schema type with shell selection. */
-interface DockerBackendConfig extends DockerConfig {
-  /** Shell binary used to interpret commands (default: 'sh' for POSIX portability). */
-  shell: string;
-}
-
 /**
  * Fallback defaults when DockerBackend is constructed without explicit config.
  * Must stay in sync with DockerConfigSchema defaults in config/schema.ts.
  */
-const DEFAULTS: DockerBackendConfig = {
+const DEFAULTS: Required<DockerConfig> = {
   image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+  shell: 'sh',
   cpus: 1,
   memoryMb: 512,
   pidsLimit: 256,
   network: 'none',
-  shell: 'sh',
 };
 
 /**
@@ -143,13 +137,13 @@ function validatePathSafety(path: string, label: string): void {
  */
 export class DockerBackend implements SandboxBackend {
   private readonly sandboxRoot: string;
-  private readonly config: DockerBackendConfig;
+  private readonly config: Required<DockerConfig>;
   private readonly uid: number;
   private readonly gid: number;
 
   constructor(
     sandboxRoot: string,
-    config?: Partial<DockerBackendConfig>,
+    config?: Partial<Required<DockerConfig>>,
     uid?: number,
     gid?: number,
   ) {
@@ -236,7 +230,6 @@ export class DockerBackend implements SandboxBackend {
       image,
       shell,
       '-c',
-      '--',
       command,
     ];
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2162:

- **Remove `--` end-of-options separator** from `sh -c` invocation in Docker backend. POSIX `sh` (dash/ash) treats `--` as the command string itself, silently dropping the actual command — every Docker-sandboxed command would appear to succeed (exit 0) without executing.
- **Add `shell` field to `DockerConfigSchema`** so users can override it via the config file (`sandbox.docker.shell`). Previously the field only existed on an internal interface, so user-supplied values were silently dropped during Zod parsing.

## Test plan

- [x] `bun test src/__tests__/terminal-sandbox-docker.test.ts` — 55/55 pass
- [x] `bun test src/__tests__/config-schema.test.ts` — 48/48 pass
- [x] `bun test src/__tests__/terminal-sandbox.test.ts` — 13/13 pass
- [x] `bun test src/__tests__/sandbox-host-parity.test.ts` — 49/49 pass
- [x] `bunx tsc --noEmit` — no type errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
