### PR TITLE
Add resizable side panels and make drawer mode default

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -11,7 +11,8 @@ struct MainWindowView: View {
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var selectedThreadId: UUID?
-    @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
+    @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
+    @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     let daemonClient: DaemonClient
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
@@ -89,10 +90,6 @@ struct MainWindowView: View {
 
                             // Center: Chat + right panel
                             chatContentView(geometry: geometry)
-                                .background(VColor.backgroundSubtle)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                                .padding(.bottom, VSpacing.sm)
-                                .padding(.horizontal, VSpacing.sm)
                         }
                         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: columnVisibility)
                     }
@@ -219,6 +216,32 @@ struct MainWindowView: View {
                 }
                 .padding(.horizontal, VSpacing.sm)
             }
+
+            // Switch to tabs button
+            Button(action: {
+                useThreadDrawer = false
+            }) {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "rectangle.3.group")
+                        .font(.system(size: 11))
+                    Text("Switch to tabs")
+                        .font(VFont.caption)
+                }
+                .foregroundColor(VColor.textSecondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, VSpacing.sm)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.set()
+                } else {
+                    NSCursor.arrow.set()
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.bottom, VSpacing.md)
         }
         .frame(width: 240)
         .background(VColor.backgroundSubtle)
@@ -236,7 +259,7 @@ struct MainWindowView: View {
                 daemonClient: daemonClient
             )
         } else {
-            VSplitView(panelWidth: geometry.size.width / zoomManager.zoomLevel * 0.5, showPanel: activePanel != nil, main: {
+            VSplitView(panelWidth: $sidePanelWidth, showPanel: activePanel != nil, main: {
                 if let viewModel = threadManager.activeViewModel {
                     ChatView(
                         messages: viewModel.messages,

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -3,37 +3,66 @@ import SwiftUI
 public struct VSplitView<Main: View, Panel: View>: View {
     public let main: Main
     public let panel: Panel?
-    public var panelWidth: CGFloat = 320
+    @Binding public var panelWidth: Double
     public var showPanel: Bool = false
 
     public var body: some View {
         HStack(spacing: 0) {
-            // Main content - shrinks when panel appears
+            // Main content - styled as panel
             main
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.backgroundSubtle)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .padding([.bottom, .leading], VSpacing.sm)
+                .padding(.trailing, showPanel && panel != nil ? 0 : VSpacing.sm)
 
             // Panel slides in from right, pushing content
             if showPanel, let panel = panel {
+                // Drag divider (transparent but draggable)
+                dragDivider
+
                 panel
                     .frame(width: panelWidth)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding([.bottom, .leading, .trailing], VSpacing.sm)
+                    .padding([.bottom, .trailing], VSpacing.sm)
                     .transition(.move(edge: .trailing))
             }
         }
         .animation(VAnimation.standard, value: showPanel)
     }
 
+    private var dragDivider: some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: VSpacing.sm)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.set()
+                } else {
+                    NSCursor.arrow.set()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        // Dragging left (negative) increases width, dragging right (positive) decreases width
+                        let newWidth = panelWidth - value.translation.width
+                        panelWidth = min(max(newWidth, 300), 800)
+                    }
+            )
+    }
+
     public init(
-        panelWidth: CGFloat = 320,
+        panelWidth: Binding<Double>,
         showPanel: Bool = false,
         @ViewBuilder main: () -> Main,
         @ViewBuilder panel: () -> Panel
     ) {
         self.main = main()
         self.panel = panel()
-        self.panelWidth = panelWidth
+        self._panelWidth = panelWidth
         self.showPanel = showPanel
     }
 }
@@ -44,29 +73,37 @@ public extension VSplitView where Panel == EmptyView {
     ) {
         self.main = main()
         self.panel = nil
-        self.panelWidth = 320
+        self._panelWidth = .constant(320)
         self.showPanel = false
     }
 }
 
 #Preview("VSplitView") {
-    ZStack {
-        VColor.background.ignoresSafeArea()
-        VSplitView(panelWidth: 200, showPanel: true) {
-            VStack {
-                Text("Main Content")
-                    .font(VFont.title)
-                    .foregroundColor(VColor.textPrimary)
+    struct PreviewWrapper: View {
+        @State private var panelWidth: Double = 200
+
+        var body: some View {
+            ZStack {
+                VColor.background.ignoresSafeArea()
+                VSplitView(panelWidth: $panelWidth, showPanel: true) {
+                    VStack {
+                        Text("Main Content")
+                            .font(VFont.title)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(VColor.surface)
+                } panel: {
+                    VSidePanel(title: "Panel") {
+                        Text("Side panel")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.surface)
-        } panel: {
-            VSidePanel(title: "Panel") {
-                Text("Side panel")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-            }
+            .frame(width: 600, height: 300)
         }
     }
-    .frame(width: 600, height: 300)
+
+    return PreviewWrapper()
 }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -5,6 +5,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
     public let panel: Panel?
     @Binding public var panelWidth: Double
     public var showPanel: Bool = false
+    @GestureState private var dragStartWidth: Double? = nil
 
     public var body: some View {
         HStack(spacing: 0) {
@@ -46,9 +47,17 @@ public struct VSplitView<Main: View, Panel: View>: View {
             }
             .gesture(
                 DragGesture(minimumDistance: 0)
+                    .updating($dragStartWidth) { _, state, _ in
+                        // Capture initial width on first call
+                        if state == nil {
+                            state = panelWidth
+                        }
+                    }
                     .onChanged { value in
+                        // Use initial width from gesture state, not current panelWidth
+                        let initialWidth = dragStartWidth ?? panelWidth
                         // Dragging left (negative) increases width, dragging right (positive) decreases width
-                        let newWidth = panelWidth - value.translation.width
+                        let newWidth = initialWidth - value.translation.width
                         panelWidth = min(max(newWidth, 300), 800)
                     }
             )

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -11,32 +11,34 @@ public struct VSplitView<Main: View, Panel: View>: View {
     @GestureState private var dragStartWidth: Double? = nil
 
     public var body: some View {
-        HStack(spacing: 0) {
-            // Main content - styled as panel
-            main
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(VColor.backgroundSubtle)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                .padding([.bottom, .leading], VSpacing.sm)
-                .padding(.trailing, showPanel && panel != nil ? 0 : VSpacing.sm)
-
-            // Panel slides in from right, pushing content
-            if showPanel, let panel = panel {
-                // Drag divider (transparent but draggable)
-                dragDivider
-
-                panel
-                    .frame(width: panelWidth)
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                // Main content - styled as panel
+                main
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(VColor.backgroundSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    .padding([.bottom, .trailing], VSpacing.sm)
-                    .transition(.move(edge: .trailing))
+                    .padding([.bottom, .leading], VSpacing.sm)
+                    .padding(.trailing, showPanel && panel != nil ? 0 : VSpacing.sm)
+
+                // Panel slides in from right, pushing content
+                if showPanel, let panel = panel {
+                    // Drag divider (transparent but draggable)
+                    dragDivider(availableWidth: geometry.size.width)
+
+                    panel
+                        .frame(width: panelWidth)
+                        .background(VColor.backgroundSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        .padding([.bottom, .trailing], VSpacing.sm)
+                        .transition(.move(edge: .trailing))
+                }
             }
+            .animation(VAnimation.standard, value: showPanel)
         }
-        .animation(VAnimation.standard, value: showPanel)
     }
 
-    private var dragDivider: some View {
+    private func dragDivider(availableWidth: CGFloat) -> some View {
         Rectangle()
             .fill(Color.clear)
             .frame(width: VSpacing.sm)
@@ -63,7 +65,12 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         let initialWidth = dragStartWidth ?? panelWidth
                         // Dragging left (negative) increases width, dragging right (positive) decreases width
                         let newWidth = initialWidth - value.translation.width
-                        panelWidth = min(max(newWidth, 300), 800)
+
+                        // Compute max panel width: available width minus minimum main content (300pt), divider (8pt), and padding (16pt total)
+                        let minMainContent: CGFloat = 300
+                        let maxAllowed = availableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
+
+                        panelWidth = min(max(newWidth, 300), maxAllowed)
                     }
             )
     }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 public struct VSplitView<Main: View, Panel: View>: View {
     public let main: Main
@@ -38,6 +41,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
             .fill(Color.clear)
             .frame(width: VSpacing.sm)
             .contentShape(Rectangle())
+            #if os(macOS)
             .onHover { hovering in
                 if hovering {
                     NSCursor.resizeLeftRight.set()
@@ -45,6 +49,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     NSCursor.arrow.set()
                 }
             }
+            #endif
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .updating($dragStartWidth) { _, state, _ in

--- a/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct LayoutGallerySection: View {
     @State private var showPanel = true
-    @State private var panelWidth: CGFloat = 280
+    @State private var panelWidth: Double = 280
     @State private var pinnedTabSelection: Int = 0
 
     var body: some View {
@@ -98,7 +98,7 @@ struct LayoutGallerySection: View {
                     Divider().background(VColor.surfaceBorder)
 
                     VSplitView(
-                        panelWidth: panelWidth,
+                        panelWidth: $panelWidth,
                         showPanel: showPanel
                     ) {
                         VStack {


### PR DESCRIPTION
## Summary

- Implements drag-to-resize for chat and side panels (Settings, Dynamic, Skills, etc.)
- Makes drawer mode the default layout for new users
- Adds "Switch to tabs" button for discoverability
- Styles chat area as its own panel with rounded corners

## Implementation

### Resizable Side Panels

- Users can drag between the chat panel and right side panels to adjust width
- Transparent 8pt drag area shows resize cursor on hover (macOS only, with platform guards)
- Width persists across app launches via `@AppStorage`
- Dynamic constraints: min 300pt, max computed as availableWidth - 300pt (min main content) - 8pt (divider) - 16pt (padding)
- Uses `@GestureState` to capture initial width and prevent exponential drift from cumulative DragGesture translation
- Max width is relative to available space, preventing panel from hiding chat on smaller windows

### Visual Changes

- Chat area styled as its own panel with rounded corners
- All three panels (thread drawer, chat, side panel) have consistent visual treatment
- 8pt spacing between all panels for balanced layout
- Transparent drag divider (no visible line, just functional resize area)

### UX Improvements

- Drawer mode is now the default (`useThreadDrawer = true`)
- Added "Switch to tabs" button at bottom of thread list
- Existing users keep their preference via `@AppStorage`

## Files Changed

- `MainWindowView.swift` - Added panel width state, default drawer mode, "Switch to tabs" button
- `VSplitView.swift` - Added drag-to-resize with transparent divider, panel styling for main content, platform guards for NSCursor, relative width constraints
- `LayoutGallerySection.swift` - Updated to use Binding for panel width

## Technical Details

### Fixed Issues from Review

1. **Drag gesture exponential drift** - Used `@GestureState` to capture initial width and calculate relative to that, not the already-modified `panelWidth`
2. **iOS build compatibility** - Added `#if os(macOS)` guards around NSCursor usage since VSplitView is in shared module
3. **Panel can hide chat** - Made max width relative to available space instead of fixed 800pt

## Testing

- ✅ Drag to resize between chat and side panels works smoothly
- ✅ Width persists across app launches
- ✅ Resize cursor appears on hover (macOS)
- ✅ New users see drawer mode by default
- ✅ "Switch to tabs" button switches to tab layout
- ✅ All panel spacing is consistent
- ✅ Panel cannot grow large enough to hide chat content
- ✅ iOS build compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)