### PR TITLE
fix(test): correct SIZE_LIMIT_EXCEEDED assertions and add edit coverage

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -80,9 +80,11 @@ describe('FileSystemOps.readFileSafe', () => {
     const filePath = join(dir, 'big.txt');
     writeFileSync(filePath, 'x'.repeat(200));
 
-    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
     const result = ops.readFileSafe({ path: 'big.txt' });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SIZE_LIMIT_EXCEEDED');
   });
 
   test('returns INVALID_PATH for path outside sandbox', () => {
@@ -162,12 +164,14 @@ describe('FileSystemOps.writeFileSafe', () => {
     expect(result.error.code).toBe('INVALID_PATH');
   });
 
-  test('returns SIZE_LIMIT_EXCEEDED for oversized content (indirectly)', () => {
+  test('returns SIZE_LIMIT_EXCEEDED for oversized content', () => {
     const dir = makeTempDir();
-    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 10 });
 
-    const result = ops.writeFileSafe({ path: 'small.txt', content: 'small' });
-    expect(result.ok).toBe(true);
+    const result = ops.writeFileSafe({ path: 'big.txt', content: 'x'.repeat(50) });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SIZE_LIMIT_EXCEEDED');
   });
 });
 
@@ -291,6 +295,22 @@ describe('FileSystemOps.editFileSafe', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('MATCH_NOT_FOUND');
+  });
+
+  test('returns SIZE_LIMIT_EXCEEDED for oversized file on edit', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'big.txt'), 'x'.repeat(200));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
+
+    const result = ops.editFileSafe({
+      path: 'big.txt',
+      oldString: 'x',
+      newString: 'y',
+      replaceAll: false,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SIZE_LIMIT_EXCEEDED');
   });
 
   test('returns INVALID_PATH for path outside sandbox', () => {

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -30,9 +30,11 @@ export type PathPolicy = (
 
 export class FileSystemOps {
   private policy: PathPolicy;
+  private sizeLimit: number | undefined;
 
-  constructor(policy: PathPolicy) {
+  constructor(policy: PathPolicy, options?: { sizeLimit?: number }) {
     this.policy = policy;
+    this.sizeLimit = options?.sizeLimit;
   }
 
   // -------------------------------------------------------------------------
@@ -55,7 +57,7 @@ export class FileSystemOps {
       return { ok: false, error: Err.notAFile(filePath) };
     }
 
-    const sizeErr = checkFileSizeOnDisk(filePath);
+    const sizeErr = checkFileSizeOnDisk(filePath, this.sizeLimit);
     if (sizeErr) {
       return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
@@ -93,7 +95,7 @@ export class FileSystemOps {
     }
     const filePath = pathCheck.resolved;
 
-    const sizeErr = checkContentSize(input.content, filePath);
+    const sizeErr = checkContentSize(input.content, filePath, this.sizeLimit);
     if (sizeErr) {
       return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
@@ -144,7 +146,7 @@ export class FileSystemOps {
 
     // Size-check the file on disk (swallow ENOENT — readFileSync gives a clearer error)
     try {
-      const sizeErr = checkFileSizeOnDisk(filePath);
+      const sizeErr = checkFileSizeOnDisk(filePath, this.sizeLimit);
       if (sizeErr) {
         return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
       }


### PR DESCRIPTION
## Summary
- Fix false-positive SIZE_LIMIT_EXCEEDED tests in `file-ops-service.test.ts` that were asserting success instead of verifying error paths
- Add configurable `sizeLimit` option to `FileSystemOps` constructor so tests can use tiny limits instead of huge fixtures
- Add missing "oversized file on edit" test coverage for `editFileSafe`

## Test plan
- [x] `size-guard.test.ts` — all 10 tests pass
- [x] `file-ops-service.test.ts` — all 20 tests pass (3 fixed/new assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
