### PR TITLE
Remove stale skills_updates_available wiring

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -94,9 +94,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `skills_state_changed` push event.
     public var onSkillStateChanged: ((SkillStateChangedMessage) -> Void)?
 
-    /// Called when the daemon sends a `skills_updates_available` push event.
-    public var onSkillsUpdatesAvailable: ((SkillsUpdatesAvailableMessage) -> Void)?
-
     /// Called when the daemon sends a `skills_operation_response` message.
     public var onSkillsOperationResponse: ((SkillsOperationResponseMessage) -> Void)?
 
@@ -742,8 +739,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onTrustRulesListResponse?(msg.rules)
         case .skillStateChanged(let msg):
             onSkillStateChanged?(msg)
-        case .skillsUpdatesAvailable(let msg):
-            onSkillsUpdatesAvailable?(msg)
         case .skillsOperationResponse(let msg):
             onSkillsOperationResponse?(msg)
         case .skillsInspectResponse(let msg):

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -633,17 +633,6 @@ public typealias SkillDetailResponseMessage = IPCSkillDetailResponse
 /// Backed by generated `IPCSkillStateChanged`.
 public typealias SkillStateChangedMessage = IPCSkillStateChanged
 
-/// Push event: updates available. Wire type: "skills_updates_available"
-/// Kept hand-maintained — no generated equivalent in the TS contract.
-public struct SkillsUpdatesAvailableMessage: Decodable, Sendable {
-    public struct UpdateInfo: Decodable, Sendable {
-        public let name: String
-        public let installedVersion: String
-        public let latestVersion: String
-    }
-    public let skills: [UpdateInfo]
-}
-
 /// A ClaWHub skill returned from a search or explore query.
 /// Kept hand-maintained — this type is decoded from the `data` field of
 /// `skills_operation_response` (which is `AnyCodable` in the contract).
@@ -1038,7 +1027,6 @@ public enum ServerMessage: Decodable, Sendable {
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
     case skillStateChanged(SkillStateChangedMessage)
-    case skillsUpdatesAvailable(SkillsUpdatesAvailableMessage)
     case skillsOperationResponse(SkillsOperationResponseMessage)
     case skillsInspectResponse(SkillsInspectResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
@@ -1148,9 +1136,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "skills_state_changed":
             let message = try SkillStateChangedMessage(from: decoder)
             self = .skillStateChanged(message)
-        case "skills_updates_available":
-            let message = try SkillsUpdatesAvailableMessage(from: decoder)
-            self = .skillsUpdatesAvailable(message)
         case "skills_operation_response":
             let message = try SkillsOperationResponseMessage(from: decoder)
             self = .skillsOperationResponse(message)


### PR DESCRIPTION
## Summary
- Removed `SkillsUpdatesAvailableMessage` struct from IPCMessages.swift — this server message type was never part of the TS IPC contract and has no daemon-side sender
- Removed the corresponding `ServerMessage.skillsUpdatesAvailable` enum case and JSON decode path
- Removed the `onSkillsUpdatesAvailable` callback from DaemonClient.swift

## Test plan
- [x] Verified no remaining references to `skills_updates_available` in the codebase
- [x] No test files referenced this type (grep confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
