### PR TITLE
fix(usage): propagate requestId into usage ledger events

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -116,6 +116,25 @@ mock.module('../context/window-manager.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Usage event capture for request-ID correlation tests.
+// ---------------------------------------------------------------------------
+
+interface CapturedUsageEvent {
+  requestId: string | null;
+  actor: string;
+}
+
+let capturedUsageEvents: CapturedUsageEvent[] = [];
+
+mock.module('../memory/llm-usage-store.js', () => ({
+  recordUsageEvent: (input: { requestId: string | null; actor: string }) => {
+    capturedUsageEvents.push({ requestId: input.requestId, actor: input.actor });
+    return { id: 'mock-id', createdAt: Date.now(), ...input };
+  },
+  listUsageEvents: () => [],
+}));
+
+// ---------------------------------------------------------------------------
 // Controllable AgentLoop mock.
 //
 // Each `run()` call returns a promise that does NOT resolve until the test
@@ -910,5 +929,33 @@ describe('Session checkpoint handoff', () => {
     // Complete retry cleanly
     resolveRun(1);
     await p1;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Usage requestId correlation
+// ---------------------------------------------------------------------------
+
+describe('Session usage requestId correlation', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+    capturedUsageEvents = [];
+  });
+
+  test('usage events recorded during a request carry that request ID', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const p1 = session.processMessage('msg-1', [], () => {}, 'req-42');
+    await waitForPendingRun(1);
+
+    // Complete the run — this triggers recordUsage with the request's ID
+    resolveRun(0);
+    await p1;
+
+    // The usage event should carry the request ID, not null
+    const mainAgentUsage = capturedUsageEvents.find((e) => e.actor === 'main_agent');
+    expect(mainAgentUsage).toBeDefined();
+    expect(mainAgentUsage!.requestId).toBe('req-42');
   });
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -530,6 +530,7 @@ export class Session {
           compacted.summaryModel,
           onEvent,
           'context_compactor',
+          reqId,
         );
       }
 
@@ -825,7 +826,7 @@ export class Session {
       const restoredHistory = [...preRepairMessages, ...newMessages];
       this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, runtimeConfig.memory.retrieval.injectionStrategy);
 
-      this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent');
+      this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
 
       void getHookManager().trigger('post-message', {
         sessionId: this.conversationId,
@@ -1522,6 +1523,7 @@ export class Session {
     model: string,
     onEvent: (msg: ServerMessage) => void,
     actor: UsageActor,
+    requestId: string | null = null,
   ): void {
     if (inputTokens <= 0 && outputTokens <= 0) return;
 
@@ -1562,7 +1564,7 @@ export class Session {
           assistantId: null,
           conversationId: this.conversationId,
           runId: null,
-          requestId: null,
+          requestId,
         },
         pricing,
       );


### PR DESCRIPTION
## Summary
- Propagate `requestId` into `recordUsage()` so usage events written during a request carry that request's ID instead of null
- Both `main_agent` and `context_compactor` usage events now include the active `reqId`
- Added test verifying requestId correlation on in-flight requests

## Test plan
- [x] `bun test session-queue.test.ts` — all 23 tests pass (22 existing + 1 new)
- [x] `bun test llm-usage-store.test.ts` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
