### PR TITLE
feat(edit): expose fuzzy similarity percentage in edit success messages

### DIFF
--- a/assistant/src/__tests__/edit-engine.test.ts
+++ b/assistant/src/__tests__/edit-engine.test.ts
@@ -15,6 +15,7 @@ describe('edit engine', () => {
     expect(result.updatedContent).toBe('updated\n');
     expect(result.matchCount).toBe(1);
     expect(result.matchMethod).toBe('exact');
+    expect(result.similarity).toBe(1);
   });
 
   test('exact replacement in multi-line content', () => {
@@ -42,6 +43,7 @@ describe('edit engine', () => {
     if (!result.ok) return;
     expect(result.matchMethod).toBe('whitespace');
     expect(result.matchCount).toBe(1);
+    expect(result.similarity).toBe(1);
     // The indentation should be adjusted
     expect(result.updatedContent).toContain('function bar()');
   });
@@ -57,6 +59,8 @@ describe('edit engine', () => {
     if (!result.ok) return;
     expect(result.matchMethod).toBe('fuzzy');
     expect(result.matchCount).toBe(1);
+    expect(result.similarity).toBeGreaterThan(0.8);
+    expect(result.similarity).toBeLessThan(1);
   });
 
   // -----------------------------------------------------------------------
@@ -111,6 +115,7 @@ describe('edit engine', () => {
     expect(result.updatedContent).toBe('replaced\ny\nreplaced\nz\nreplaced\n');
     expect(result.matchCount).toBe(3);
     expect(result.matchMethod).toBe('exact');
+    expect(result.similarity).toBe(1);
   });
 
   test('replace_all: single occurrence reports count of 1', () => {

--- a/assistant/src/__tests__/file-edit-tool.test.ts
+++ b/assistant/src/__tests__/file-edit-tool.test.ts
@@ -79,6 +79,21 @@ describe('file_edit tool (sandbox)', () => {
     expect(result.content).toContain('appears multiple times');
   });
 
+  test('fuzzy match includes similarity percentage in message', async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, 'sample.txt');
+    writeFileSync(filePath, 'function fooo() {\n  return 1;\n}\n');
+
+    const result = await fileEditTool.execute(
+      { path: 'sample.txt', old_string: 'function foo() {\n  return 1;\n}', new_string: 'function bar() {\n  return 2;\n}' },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('fuzzy matched');
+    expect(result.content).toMatch(/\d+% similar/);
+  });
+
   test('returns error when old_string is not found', async () => {
     const dir = makeTempDir();
     const filePath = join(dir, 'sample.txt');

--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -68,6 +68,24 @@ describe('host_file_edit tool', () => {
     expect(result.content).toContain('Successfully replaced 2 occurrences');
   });
 
+  test('fuzzy match includes similarity percentage in message', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
+    testDirs.push(dir);
+    const filePath = join(dir, 'sample.txt');
+    // Content has a typo-level difference from oldString
+    writeFileSync(filePath, 'function fooo() {\n  return 1;\n}\n');
+
+    const result = await hostFileEditTool.execute({
+      path: filePath,
+      old_string: 'function foo() {\n  return 1;\n}',
+      new_string: 'function bar() {\n  return 2;\n}',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('fuzzy matched');
+    expect(result.content).toMatch(/\d+% similar/);
+  });
+
   test('returns ambiguity error when old_string appears multiple times', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'host-file-edit-test-'));
     testDirs.push(dir);

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -94,7 +94,7 @@ class FileEditTool implements Tool {
       }
     }
 
-    const { filePath, matchCount, oldContent, newContent, matchMethod } = result.value;
+    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
 
     if (replaceAll) {
       return {
@@ -108,7 +108,7 @@ class FileEditTool implements Tool {
       ? ''
       : matchMethod === 'whitespace'
         ? ' (matched with whitespace normalization)'
-        : ' (fuzzy matched)';
+        : ` (fuzzy matched, ${Math.round(similarity * 100)}% similar)`;
     return {
       content: `Successfully edited ${filePath}${methodNote}`,
       isError: false,

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -91,7 +91,7 @@ class HostFileEditTool implements Tool {
       }
     }
 
-    const { filePath, matchCount, oldContent, newContent, matchMethod } = result.value;
+    const { filePath, matchCount, oldContent, newContent, matchMethod, similarity } = result.value;
 
     if (replaceAll) {
       return {
@@ -105,7 +105,7 @@ class HostFileEditTool implements Tool {
       ? ''
       : matchMethod === 'whitespace'
         ? ' (matched with whitespace normalization)'
-        : ' (fuzzy matched)';
+        : ` (fuzzy matched, ${Math.round(similarity * 100)}% similar)`;
 
     return {
       content: `Successfully edited ${filePath}${methodNote}`,

--- a/assistant/src/tools/shared/filesystem/edit-engine.ts
+++ b/assistant/src/tools/shared/filesystem/edit-engine.ts
@@ -6,7 +6,7 @@ import type { MatchMethod } from '../../filesystem/fuzzy-match.js';
 // ---------------------------------------------------------------------------
 
 export type EditEngineResult =
-  | { ok: true; updatedContent: string; matchCount: number; matchMethod: MatchMethod }
+  | { ok: true; updatedContent: string; matchCount: number; matchMethod: MatchMethod; similarity: number }
   | { ok: false; reason: 'not_found' }
   | { ok: false; reason: 'ambiguous'; matchCount: number };
 
@@ -34,7 +34,7 @@ export function applyEdit(
     }
     const count = content.split(oldString).length - 1;
     const updatedContent = content.split(oldString).join(newString);
-    return { ok: true, updatedContent, matchCount: count, matchMethod: 'exact' };
+    return { ok: true, updatedContent, matchCount: count, matchMethod: 'exact', similarity: 1 };
   }
 
   // Single-match path: cascading exact -> whitespace -> fuzzy
@@ -52,5 +52,5 @@ export function applyEdit(
     : newString;
 
   const updatedContent = content.slice(0, match.start) + adjustedNewString + content.slice(match.end);
-  return { ok: true, updatedContent, matchCount: 1, matchMethod: match.method };
+  return { ok: true, updatedContent, matchCount: 1, matchMethod: match.method, similarity: match.similarity };
 }

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -199,6 +199,7 @@ export class FileSystemOps {
         oldContent: content,
         newContent: result.updatedContent,
         matchMethod: result.matchMethod,
+        similarity: result.similarity,
       },
     };
   }

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -67,6 +67,8 @@ export interface EditOutput {
   newContent: string;
   /** How the match was found (exact, whitespace-normalized, or fuzzy). */
   matchMethod: 'exact' | 'whitespace' | 'fuzzy';
+  /** Match similarity score (0–1). Always 1 for exact/whitespace, <1 for fuzzy. */
+  similarity: number;
 }
 
 export type EditResult =


### PR DESCRIPTION
## Summary
- Thread fuzzy `similarity` score from `MatchResult` through `EditEngineResult` → `EditOutput` → tool response
- Fuzzy matches now show "fuzzy matched, 93% similar" instead of just "fuzzy matched"
- Exact and whitespace matches carry `similarity: 1` for consistency

## Test plan
- [x] `edit-engine.test.ts` — similarity assertions for exact, whitespace, fuzzy, and replace_all
- [x] `file-edit-tool.test.ts` — new fuzzy match test validates `% similar` in message
- [x] `host-file-edit-tool.test.ts` — new fuzzy match test validates `% similar` in message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
