### PR TITLE
fix(sandbox): harden Docker mount root wiring

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -12,6 +12,7 @@ const execSyncMock = mock((_command: string): unknown => {
 mock.module('../util/platform.js', () => ({
   isMacOS: () => platform === 'darwin',
   isLinux: () => platform === 'linux',
+  getSandboxWorkingDir: () => '/tmp/sandbox/fs',
 }));
 
 mock.module('../util/logger.js', () => ({

--- a/assistant/src/tools/terminal/sandbox.ts
+++ b/assistant/src/tools/terminal/sandbox.ts
@@ -2,6 +2,7 @@ import { NativeBackend } from './backends/native.js';
 import { DockerBackend } from './backends/docker.js';
 import type { SandboxResult } from './backends/types.js';
 import type { SandboxConfig } from '../../config/schema.js';
+import { getSandboxWorkingDir } from '../../util/platform.js';
 
 export type { SandboxResult, SandboxBackend } from './backends/types.js';
 
@@ -28,7 +29,11 @@ export function wrapCommand(
   }
 
   if (config.backend === 'docker') {
-    const backend = new DockerBackend(workingDir, config.docker);
+    // Always mount the canonical sandbox fs root, not whatever workingDir
+    // happens to be. workingDir may be a subdirectory; the mount source
+    // must be the fixed root so the entire sandbox filesystem is available.
+    const sandboxRoot = getSandboxWorkingDir();
+    const backend = new DockerBackend(sandboxRoot, config.docker);
     return backend.wrap(command, workingDir);
   }
 


### PR DESCRIPTION
## Summary
- Fix `wrapCommand` to always mount the canonical sandbox filesystem root (`getSandboxWorkingDir()`) instead of whatever `workingDir` happens to be
- Previously, if `workingDir` was a subdirectory of the sandbox root, only that subdirectory would be bind-mounted — the rest of the sandbox filesystem would be inaccessible inside the container
- Updated platform mock in `terminal-sandbox.test.ts` to include `getSandboxWorkingDir`

## Test plan
- [x] All terminal-sandbox tests pass (13/13)
- [x] All terminal-sandbox-docker tests pass (55/55)
- [x] All sandbox-host-parity tests pass (49/49)
- [x] No behavior drift for normal sessions (workingDir == sandbox root still works identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
