### PR TITLE
fix(trace): emit request_error traces on rejection/failure paths

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -177,7 +177,7 @@ mock.module('../agent/loop.js', () => ({
 import { Session, MAX_QUEUE_DEPTH } from '../daemon/session.js';
 import type { QueueDrainReason, QueuePolicy } from '../daemon/session.js';
 
-function makeSession(): Session {
+function makeSession(sendToClient?: (msg: ServerMessage) => void): Session {
   const provider = {
     name: 'mock',
     async sendMessage(): Promise<ProviderResponse> {
@@ -189,7 +189,7 @@ function makeSession(): Session {
       };
     },
   };
-  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+  return new Session('conv-1', provider, 'system prompt', 4096, sendToClient ?? (() => {}), '/tmp');
 }
 
 /**
@@ -957,5 +957,47 @@ describe('Session usage requestId correlation', () => {
     const mainAgentUsage = capturedUsageEvents.find((e) => e.actor === 'main_agent');
     expect(mainAgentUsage).toBeDefined();
     expect(mainAgentUsage!.requestId).toBe('req-42');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Terminal trace events on rejection/failure paths
+// ---------------------------------------------------------------------------
+
+describe('Terminal trace events on rejection/failure', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('queued persist failure emits request_error trace', async () => {
+    const traceEvents: ServerMessage[] = [];
+    const session = makeSession((msg) => {
+      if ('type' in msg && msg.type === 'trace_event') traceEvents.push(msg);
+    });
+    await session.loadFromDb();
+
+    // Start first message
+    const p1 = session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Enqueue empty content (will fail persistUserMessage)
+    session.enqueueMessage('', [], () => {}, 'req-bad');
+    // Enqueue valid message so drain continues
+    session.enqueueMessage('msg-3', [], () => {}, 'req-3');
+
+    // Complete first — triggers drain, empty msg fails persist
+    resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    // Should have a request_error trace for the failed persist
+    const errorTrace = traceEvents.find(
+      (e) => 'kind' in e && e.kind === 'request_error' && 'requestId' in e && e.requestId === 'req-bad',
+    );
+    expect(errorTrace).toBeDefined();
+
+    // Cleanup
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
   });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -461,6 +461,11 @@ async function handleUserMessage(
     const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
+      session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
+        requestId,
+        status: 'error',
+        attributes: { reason: 'queue_full', queueDepth: session.getQueueDepth() },
+      });
       ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
         code: 'QUEUE_FULL',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -965,6 +965,11 @@ export class Session {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist unknown-slash exchange');
+        this.traceEmitter.emit('request_error', `Unknown-slash persist failed: ${message}`, {
+          requestId: next.requestId,
+          status: 'error',
+          attributes: { reason: 'persist_failure' },
+        });
         next.onEvent({ type: 'error', message });
       }
       // Continue draining regardless of success/failure
@@ -984,6 +989,11 @@ export class Session {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, conversationId: this.conversationId, requestId: next.requestId }, 'Failed to persist queued message');
+      this.traceEmitter.emit('request_error', `Queued message persist failed: ${message}`, {
+        requestId: next.requestId,
+        status: 'error',
+        attributes: { reason: 'persist_failure' },
+      });
       next.onEvent({ type: 'error', message });
       // Continue draining — don't strand remaining messages
       this.drainQueue();


### PR DESCRIPTION
## Summary
- Queue-full rejection now emits `request_error` trace with `reason: queue_full` and `queueDepth`
- Queued-persist-failure now emits `request_error` trace with `reason: persist_failure`
- Unknown-slash persist failure now emits `request_error` trace
- Every `request_received` now gets a guaranteed terminal trace event

## Test plan
- [x] `bun test session-queue.test.ts` — all 24 tests pass (23 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
