### PR TITLE
Finish generated-model adoption for suggestion_response

### DIFF
--- a/assistant/scripts/ipc/generate-swift.ts
+++ b/assistant/scripts/ipc/generate-swift.ts
@@ -215,6 +215,17 @@ function schemaToSwiftType(
     return `IPC${refName}`;
   }
 
+  // Array type syntax: e.g. "type": ["null", "string"] → String?
+  if (Array.isArray(prop.type)) {
+    const nonNull = prop.type.filter((t: string) => t !== 'null');
+    const hasNull = prop.type.includes('null');
+    if (nonNull.length === 1) {
+      const inner = schemaToSwiftType({ type: nonNull[0] }, parentName, propName, allDefs);
+      return hasNull ? `${inner}?` : inner;
+    }
+    return 'AnyCodable';
+  }
+
   // anyOf — union. Check nullable pattern: [T, {type: "null"}]
   if (prop.anyOf) {
     const nonNull = prop.anyOf.filter((v) => v.type !== 'null');

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -636,11 +636,11 @@ public struct IPCSkillsInspectResponseData: Codable, Sendable {
     public let skill: IPCSkillsInspectResponseDataSkill
     public let owner: IPCSkillsInspectResponseDataOwner?
     public let stats: IPCSkillsInspectResponseDataStats?
-    public let createdAt: AnyCodable?
-    public let updatedAt: AnyCodable?
+    public let createdAt: Int?
+    public let updatedAt: Int?
     public let latestVersion: IPCSkillsInspectResponseDataLatestVersion?
     public let files: [IPCSkillsInspectResponseDataFile]?
-    public let skillMdContent: AnyCodable?
+    public let skillMdContent: String?
 }
 
 public struct IPCSkillsInspectResponseDataFile: Codable, Sendable {
@@ -757,7 +757,7 @@ public struct IPCSuggestionRequest: Codable, Sendable {
 public struct IPCSuggestionResponse: Codable, Sendable {
     public let type: String
     public let requestId: String
-    public let suggestion: AnyCodable
+    public let suggestion: String?
     public let source: String
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -722,13 +722,13 @@ public typealias ClawhubInspectFile = IPCSkillsInspectResponseDataFile
 /// Backed by generated `IPCSkillsInspectResponseData`.
 public typealias ClawhubInspectData = IPCSkillsInspectResponseData
 
-// The generated `IPCSkillsInspectResponseData` uses `AnyCodable?` for
-// `createdAt`, `updatedAt`, and `skillMdContent`. Provide typed accessors
-// for backward compatibility with call sites that expect concrete types.
+// Backward-compatible typed accessors. The generated struct now uses
+// concrete types (Int?, String?) instead of AnyCodable?, so these are
+// simple pass-throughs for existing call sites.
 extension IPCSkillsInspectResponseData {
-    public var createdAtInt: Int? { createdAt?.value as? Int }
-    public var updatedAtInt: Int? { updatedAt?.value as? Int }
-    public var skillMdContentString: String? { skillMdContent?.value as? String }
+    public var createdAtInt: Int? { createdAt }
+    public var updatedAtInt: Int? { updatedAt }
+    public var skillMdContentString: String? { skillMdContent }
 }
 
 /// Response from inspecting a ClaWHub skill.
@@ -863,12 +863,8 @@ public typealias ToolOutputChunkMessage = IPCToolOutputChunk
 public typealias ToolResultMessage = IPCToolResult
 
 /// Follow-up suggestion response from daemon.
-/// Wire type: `"suggestion_response"`
-public struct SuggestionResponseMessage: Decodable, Sendable {
-    public let requestId: String
-    public let suggestion: String?
-    public let source: String
-}
+/// Backed by generated `IPCSuggestionResponse`.
+public typealias SuggestionResponseMessage = IPCSuggestionResponse
 
 /// Secret input request from daemon.
 /// Backed by generated `IPCSecretRequest`.


### PR DESCRIPTION
## Summary
- Fixed Swift code generator to handle JSON Schema array type syntax (`"type": ["null", "string"]` → `String?`) which was falling through to `AnyCodable`
- Replaced hand-maintained `SuggestionResponseMessage` struct with typealias to generated `IPCSuggestionResponse`
- Also corrected `IPCSkillsInspectResponseData` fields (`createdAt`, `updatedAt`, `skillMdContent`) from `AnyCodable?` to proper concrete types (`Int?`, `String?`)
- Updated backward-compatible accessors to simple pass-throughs

## Test plan
- [x] `bun run check:ipc-generated` passes — generated file matches
- [x] `bun run ipc:inventory` passes — inventory is in sync
- [x] No manual `SuggestionResponseMessage` struct remains
- [x] Existing call sites (`ChatViewModel.swift`) continue to work since field types match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
