### PR TITLE
fix(error): stop cancel-toasts and harden cancel cleanup

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -347,7 +347,7 @@ describe('Session message queue', () => {
     // Queue should be empty
     expect(session.getQueueDepth()).toBe(0);
 
-    // Both queued messages should have received error events
+    // Both queued messages should have received generic error events
     const err2 = events2.find((e) => e.type === 'error');
     expect(err2).toBeDefined();
     expect(err2!.type === 'error' && err2!.message).toContain('queued message discarded');
@@ -355,6 +355,14 @@ describe('Session message queue', () => {
     const err3 = events3.find((e) => e.type === 'error');
     expect(err3).toBeDefined();
     expect(err3!.type === 'error' && err3!.message).toContain('queued message discarded');
+
+    // abort() must NOT emit session_error — cancel should only show
+    // generation_cancelled behavior, never a session-error toast.
+    const sessionErr2 = events2.find((e) => e.type === 'session_error');
+    expect(sessionErr2).toBeUndefined();
+
+    const sessionErr3 = events3.find((e) => e.type === 'session_error');
+    expect(sessionErr3).toBeUndefined();
   });
 
   test('queue depth is reported correctly as messages are added and drained', async () => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -322,15 +322,12 @@ export class Session {
       unregisterTimerCompletionNotifier(this.conversationId);
       pruneSessionTimers(this.conversationId);
 
-      // Clear queued messages and notify each caller
+      // Clear queued messages and notify each caller.
+      // Only emit a generic `error` — NOT `session_error` — so the client's
+      // cancel-path suppression (wasCancelling) handles cleanup without
+      // surfacing a session-error toast to the user.
       for (const queued of this.messageQueue) {
         queued.onEvent({ type: 'error', message: 'Session aborted — queued message discarded' });
-        queued.onEvent(buildSessionErrorMessage(this.conversationId, {
-          code: 'SESSION_ABORTED',
-          userMessage: 'The request was interrupted. You can try sending your message again.',
-          retryable: true,
-          debugDetails: 'Session aborted — queued message discarded',
-        }));
       }
       this.messageQueue = [];
     }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1379,9 +1379,12 @@ final class ChatViewModelTests: XCTestCase {
         )
         viewModel.handleServerMessage(.sessionError(errorMsg))
 
-        // errorText should be suppressed during cancellation (user-initiated)
+        // Both errorText and sessionError should be suppressed during cancellation
+        // (user-initiated cancel should only show generation_cancelled, never a toast)
         XCTAssertNil(viewModel.errorText,
                       "Session error during cancellation should not display errorText")
+        XCTAssertNil(viewModel.sessionError,
+                      "Session error during cancellation should not set typed sessionError")
     }
 
     func testSessionErrorNonRetryableFlag() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -936,9 +936,7 @@ public final class ChatViewModel: ObservableObject {
 
         case .sessionError(let msg):
             guard sessionId != nil, belongsToSession(msg.sessionId) else { return }
-            let typedError = SessionError(from: msg)
             log.error("Session error [\(msg.code.rawValue)]: \(msg.userMessage)")
-            sessionError = typedError
             // Mirror the same UI reset as the generic .error handler so the
             // chat doesn't get stuck in a sending/thinking state.
             isThinking = false
@@ -949,8 +947,11 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
-            // Also set errorText so existing UI that reads errorText still works.
+            // When the user intentionally cancelled, suppress both the typed
+            // session error and the errorText so no toast appears.
             if !wasCancelling {
+                let typedError = SessionError(from: msg)
+                sessionError = typedError
                 errorText = msg.userMessage
             }
             for i in messages.indices {


### PR DESCRIPTION
## Summary
- Remove `session_error` emission from `abort()` queue-discard cleanup — cancel should only show `generation_cancelled` behavior, never a session-error toast
- Suppress both `sessionError` and `errorText` in ChatViewModel when `wasCancelling` is true
- Add daemon test assertions that abort() emits no `session_error`
- Extend Swift cancel-suppression test to verify `sessionError` is nil

## Test plan
- [x] Daemon session-queue tests pass (22/22)
- [x] Swift test target compiles (ChatViewModelTests)
- [x] Cancel during active session no longer surfaces error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
