### PR TITLE
fix(errors): use specific PATH_NOT_ABSOLUTE / PATH_OUT_OF_BOUNDS codes instead of generic INVALID_PATH

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -87,14 +87,14 @@ describe('FileSystemOps.readFileSafe', () => {
     expect(result.error.code).toBe('SIZE_LIMIT_EXCEEDED');
   });
 
-  test('returns INVALID_PATH for path outside sandbox', () => {
+  test('returns PATH_OUT_OF_BOUNDS for path outside sandbox', () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = ops.readFileSafe({ path: '../../../etc/passwd' });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('INVALID_PATH');
+    expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
   });
 
   test('respects offset and limit', () => {
@@ -154,14 +154,14 @@ describe('FileSystemOps.writeFileSafe', () => {
     expect(existsSync(join(dir, 'a/b/c/deep.txt'))).toBe(true);
   });
 
-  test('returns INVALID_PATH for path outside sandbox', () => {
+  test('returns PATH_OUT_OF_BOUNDS for path outside sandbox', () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
     const result = ops.writeFileSafe({ path: '../../../tmp/evil.txt', content: 'bad' });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('INVALID_PATH');
+    expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
   });
 
   test('returns SIZE_LIMIT_EXCEEDED for oversized content', () => {
@@ -313,7 +313,7 @@ describe('FileSystemOps.editFileSafe', () => {
     expect(result.error.code).toBe('SIZE_LIMIT_EXCEEDED');
   });
 
-  test('returns INVALID_PATH for path outside sandbox', () => {
+  test('returns PATH_OUT_OF_BOUNDS for path outside sandbox', () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
@@ -325,6 +325,6 @@ describe('FileSystemOps.editFileSafe', () => {
     });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('INVALID_PATH');
+    expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
   });
 });

--- a/assistant/src/__tests__/host-file-edit-tool.test.ts
+++ b/assistant/src/__tests__/host-file-edit-tool.test.ts
@@ -30,7 +30,7 @@ describe('host_file_edit tool', () => {
       new_string: 'b',
     }, makeContext());
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('path must be absolute');
+    expect(result.content).toContain('must be absolute');
   });
 
   test('edits unique match', async () => {

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -28,6 +28,7 @@ describe('sandboxPolicy', () => {
     const result = sandboxPolicy('../../etc/passwd', boundary);
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('out_of_bounds');
       expect(result.error).toContain('outside the working directory');
     }
   });
@@ -38,6 +39,7 @@ describe('sandboxPolicy', () => {
     const result = sandboxPolicy('a/b/../../../../etc/shadow', boundary);
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('out_of_bounds');
       expect(result.error).toContain('outside the working directory');
     }
   });
@@ -52,6 +54,7 @@ describe('sandboxPolicy', () => {
     const result = sandboxPolicy('escape-link', boundary);
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('out_of_bounds');
       expect(result.error).toContain('outside the working directory');
     }
   });
@@ -67,6 +70,7 @@ describe('sandboxPolicy', () => {
     const result = sandboxPolicy('link-dir/new-file.txt', boundary, { mustExist: false });
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('out_of_bounds');
       expect(result.error).toContain('outside the working directory');
     }
   });
@@ -114,6 +118,7 @@ describe('hostPolicy', () => {
     const result = hostPolicy('relative/path.txt');
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('not_absolute');
       expect(result.error).toContain('must be absolute');
       expect(result.error).toContain('relative/path.txt');
     }
@@ -123,6 +128,7 @@ describe('hostPolicy', () => {
     const result = hostPolicy('file.txt');
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.reason).toBe('not_absolute');
       expect(result.error).toContain('must be absolute');
     }
   });

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import type { PathResult } from './path-policy.js';
+import type { PathResult, PathFailureReason } from './path-policy.js';
 import { checkFileSizeOnDisk, checkContentSize } from './size-guard.js';
 import { applyEdit } from './edit-engine.js';
 import type {
@@ -28,6 +28,13 @@ export type PathPolicy = (
 // Service
 // ---------------------------------------------------------------------------
 
+function pathError(path: string, reason: PathFailureReason, detail: string): Err.FsError {
+  switch (reason) {
+    case 'not_absolute': return Err.pathNotAbsolute(path);
+    case 'out_of_bounds': return { code: 'PATH_OUT_OF_BOUNDS', message: detail, path };
+  }
+}
+
 export class FileSystemOps {
   private policy: PathPolicy;
   private sizeLimit: number | undefined;
@@ -44,7 +51,7 @@ export class FileSystemOps {
   readFileSafe(input: ReadInput): ReadResult {
     const pathCheck = this.policy(input.path, { mustExist: true });
     if (!pathCheck.ok) {
-      return { ok: false, error: Err.invalidPath(input.path, pathCheck.error) };
+      return { ok: false, error: pathError(input.path, pathCheck.reason, pathCheck.error) };
     }
     const filePath = pathCheck.resolved;
 
@@ -91,7 +98,7 @@ export class FileSystemOps {
   writeFileSafe(input: WriteInput): WriteResult {
     const pathCheck = this.policy(input.path, { mustExist: false });
     if (!pathCheck.ok) {
-      return { ok: false, error: Err.invalidPath(input.path, pathCheck.error) };
+      return { ok: false, error: pathError(input.path, pathCheck.reason, pathCheck.error) };
     }
     const filePath = pathCheck.resolved;
 
@@ -140,7 +147,7 @@ export class FileSystemOps {
   editFileSafe(input: EditInput): EditResult {
     const pathCheck = this.policy(input.path, { mustExist: true });
     if (!pathCheck.ok) {
-      return { ok: false, error: Err.invalidPath(input.path, pathCheck.error) };
+      return { ok: false, error: pathError(input.path, pathCheck.reason, pathCheck.error) };
     }
     const filePath = pathCheck.resolved;
 

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -4,9 +4,11 @@ import { realpathSync } from 'node:fs';
 /**
  * Result type shared by both sandbox and host path policies.
  */
+export type PathFailureReason = 'not_absolute' | 'out_of_bounds';
+
 export type PathResult =
   | { ok: true; resolved: string }
-  | { ok: false; error: string };
+  | { ok: false; reason: PathFailureReason; error: string };
 
 // ---------------------------------------------------------------------------
 // Sandbox policy
@@ -68,6 +70,7 @@ export function sandboxPolicy(
   if (rel.startsWith('..') || resolve(realBoundary, rel) !== realResolved) {
     return {
       ok: false,
+      reason: 'out_of_bounds',
       error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realBoundary}"`,
     };
   }
@@ -87,6 +90,7 @@ export function hostPolicy(rawPath: string): PathResult {
   if (!isAbsolute(rawPath)) {
     return {
       ok: false,
+      reason: 'not_absolute',
       error: `path must be absolute for host file access: ${rawPath}`,
     };
   }


### PR DESCRIPTION
## Summary
- Add typed `reason` field (`'not_absolute' | 'out_of_bounds'`) to `PathResult` failures in `path-policy.ts`
- Map reasons in `file-ops-service.ts` to specific `Err.pathNotAbsolute(...)` / `PATH_OUT_OF_BOUNDS` errors instead of collapsing all path failures into `INVALID_PATH`
- Update tests to assert the specific error codes

## Test plan
- [x] `path-policy.test.ts` — reason assertions for all sandbox/host failures
- [x] `file-ops-service.test.ts` — PATH_OUT_OF_BOUNDS for sandbox escapes
- [x] `shared-filesystem-errors.test.ts` — unchanged, passes
- [x] `host-file-edit-tool.test.ts` — updated assertion for new message format
- [x] `file-edit-tool.test.ts`, `file-read-tool.test.ts`, `file-write-tool.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
