### PR TITLE
Add explicit manual exception allowlist for Swift IPC types

### DIFF
--- a/assistant/docs/ipc-contract.md
+++ b/assistant/docs/ipc-contract.md
@@ -129,6 +129,20 @@ The `.githooks/pre-commit` hook runs automatically when any IPC-related file is 
 
 If either check fails, the commit is blocked with instructions on how to fix it.
 
+## Manual exception allowlist
+
+Most IPC message types in `IPCMessages.swift` are typealiases to auto-generated structs from `IPCContractGenerated.swift`. A small set of types are **intentionally hand-maintained** because the code generator cannot express their requirements. These are documented in a table at the top of `IPCMessages.swift`.
+
+Common reasons a type stays manual:
+
+- **AnyCodable fields**: The contract uses opaque `SurfaceData` or embedded JSON blobs that need `AnyCodable` on the Swift side.
+- **Hand-maintained enums**: `SessionErrorCode` and `TraceEventKind` are Swift string enums with fallback decoding; the generator only produces structs.
+- **Skipped contract types**: Some contract types are in `SKIP_TYPES` in the generator because they reference the above enums.
+- **Extra fields**: The Swift type includes fields (e.g. `sessionId` on `GenerationCancelledMessage`) not present in the contract.
+- **Nested decode types**: Types like `ClawhubSkillItem` are decoded from an `AnyCodable` field of another message, not direct wire types.
+
+**Rule**: Do not add new manual structs without documenting the reason in the allowlist table in `IPCMessages.swift`. If the generator gains support for a case, migrate the type to a typealias and remove it from the list.
+
 ## Contract inventory
 
 The inventory system tracks which interfaces are members of the `ClientMessage` and `ServerMessage` unions. It consists of:

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1,5 +1,44 @@
 import Foundation
 
+// MARK: - Manual IPC Type Allowlist
+//
+// Most IPC message types are auto-generated from the TS contract into
+// IPCContractGenerated.swift and referenced here via typealiases.
+// The following structs are **intentionally** hand-maintained because
+// the code generator cannot express their requirements:
+//
+// ┌─────────────────────────────────┬──────────────────────────────────────────┐
+// │ Type                            │ Reason                                   │
+// ├─────────────────────────────────┼──────────────────────────────────────────┤
+// │ AnyCodable                      │ Infrastructure — not an IPC message type │
+// │ UiSurfaceShowMessage            │ Uses AnyCodable for `data` field and     │
+// │                                 │ custom SurfaceActionData array; the      │
+// │                                 │ contract type is skipped (SKIP_TYPES)    │
+// │ UiSurfaceUpdateMessage          │ Uses AnyCodable for `data` field;        │
+// │                                 │ contract type is skipped (SKIP_TYPES)    │
+// │ GenerationCancelledMessage      │ Swift adds `sessionId` for session       │
+// │                                 │ filtering not present in the contract    │
+// │ ClawhubSkillItem                │ Decoded from nested `data` field of      │
+// │                                 │ skills_operation_response, not a direct  │
+// │                                 │ wire message                             │
+// │ ClawhubSearchData               │ Wrapper for ClawhubSkillItem array,      │
+// │                                 │ not a direct wire message                │
+// │ SkillsOperationResponseMessage  │ Uses typed ClawhubSearchData? for `data` │
+// │                                 │ instead of generated AnyCodable?         │
+// │ TraceEventMessage               │ References hand-maintained TraceEventKind│
+// │                                 │ via string `kind`; contract type skipped │
+// │ SessionErrorMessage             │ References hand-maintained               │
+// │                                 │ SessionErrorCode enum                    │
+// │ SessionErrorCode (enum)         │ String enum with fallback decoding;      │
+// │                                 │ code generator cannot emit Swift enums   │
+// │ ServerMessage (enum)            │ Discriminated union with custom          │
+// │                                 │ Decodable init; always hand-maintained   │
+// └─────────────────────────────────┴──────────────────────────────────────────┘
+//
+// **Do not add new manual structs** without documenting the reason here.
+// If the code generator gains support for a case above, migrate the type
+// to a typealias and remove it from this list.
+
 // MARK: - AnyCodable
 
 /// Lightweight wrapper for arbitrary JSON values in tool input dictionaries.


### PR DESCRIPTION
## Summary
- Added a documented allowlist table at the top of `IPCMessages.swift` listing every intentionally hand-maintained IPC struct and the reason it can't be auto-generated
- Added a "Manual exception allowlist" section to `ipc-contract.md` explaining the policy and common reasons types stay manual
- Establishes the rule: no new manual structs without updating the allowlist

## Test plan
- [x] Documentation-only change — no behavioral changes
- [x] All listed types verified as legitimately requiring manual maintenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
