### PR TITLE
feat(test): add dedicated filesystem-tools regression runner

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -14,7 +14,8 @@
     "generate:ipc": "bun run scripts/ipc/generate-swift.ts",
     "check:ipc-generated": "bun run scripts/ipc/generate-swift.ts --check",
     "lint": "eslint",
-    "test": "bash scripts/test.sh"
+    "test": "bash scripts/test.sh",
+    "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",

--- a/assistant/scripts/test-filesystem-tools.sh
+++ b/assistant/scripts/test-filesystem-tools.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Focused regression runner for filesystem-related tests.
+#
+# Runs each test file in its own Bun process (same isolation as test.sh)
+# to avoid mock.module cross-contamination.
+# ---------------------------------------------------------------------------
+
+FILESYSTEM_TESTS=(
+  "src/__tests__/size-guard.test.ts"
+  "src/__tests__/edit-engine.test.ts"
+  "src/__tests__/fuzzy-match.test.ts"
+  "src/__tests__/fuzzy-match-property.test.ts"
+  "src/__tests__/shared-filesystem-errors.test.ts"
+  "src/__tests__/path-policy.test.ts"
+  "src/__tests__/file-ops-service.test.ts"
+  "src/__tests__/file-read-tool.test.ts"
+  "src/__tests__/file-write-tool.test.ts"
+  "src/__tests__/file-edit-tool.test.ts"
+  "src/__tests__/host-file-read-tool.test.ts"
+  "src/__tests__/host-file-write-tool.test.ts"
+  "src/__tests__/host-file-edit-tool.test.ts"
+)
+
+passed=0
+failed=0
+
+for test_file in "${FILESYSTEM_TESTS[@]}"; do
+  if [[ ! -f "${test_file}" ]]; then
+    echo "SKIP ${test_file} (not found)"
+    continue
+  fi
+  echo "==> Running ${test_file}"
+  if bun test "${test_file}"; then
+    ((passed++))
+  else
+    ((failed++))
+  fi
+done
+
+echo ""
+echo "=== Filesystem tools: ${passed} files passed, ${failed} files failed ==="
+
+if [[ ${failed} -gt 0 ]]; then
+  exit 1
+fi

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -26,7 +26,7 @@ describe('host_file_read tool', () => {
   test('rejects relative paths', async () => {
     const result = await hostFileReadTool.execute({ path: 'relative.txt' }, makeContext());
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('path must be absolute');
+    expect(result.content).toContain('must be absolute');
   });
 
   test('reads file with line numbers', async () => {

--- a/assistant/src/__tests__/host-file-write-tool.test.ts
+++ b/assistant/src/__tests__/host-file-write-tool.test.ts
@@ -26,7 +26,7 @@ describe('host_file_write tool', () => {
   test('rejects relative paths', async () => {
     const result = await hostFileWriteTool.execute({ path: 'relative.txt', content: 'hi' }, makeContext());
     expect(result.isError).toBe(true);
-    expect(result.content).toContain('path must be absolute');
+    expect(result.content).toContain('must be absolute');
   });
 
   test('rejects non-string content', async () => {


### PR DESCRIPTION
## Summary
- Add `scripts/test-filesystem-tools.sh` — isolated per-file execution for all 13 filesystem test files
- Add `test:filesystem-tools` npm script for easy `bun run test:filesystem-tools` invocation
- Fix `host-file-read-tool.test.ts` and `host-file-write-tool.test.ts` assertions to match the `PATH_NOT_ABSOLUTE` message format from #2238

## Test plan
- [x] `bun run test:filesystem-tools` — all 13 files pass (118 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
