### PR TITLE
fix(error): enforce session-vs-global error channels

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -384,6 +384,30 @@ describe('Session message queue', () => {
     expect(sessionErr3).toBeUndefined();
   });
 
+  test('session-scoped errors emit session_error only, not generic error', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: ServerMessage[] = [];
+
+    // Start a message — blocks on AgentLoop.run
+    const p1 = session.processMessage('msg-1', [], (e) => events.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Reject the AgentLoop.run() with a provider error to trigger the
+    // runAgentLoop catch block
+    pendingRuns[0].reject(new Error('Provider returned 500'));
+    await p1;
+
+    // Should emit session_error (typed, structured)
+    const sessionErr = events.find((e) => e.type === 'session_error');
+    expect(sessionErr).toBeDefined();
+
+    // Should NOT emit generic error — session failures use session_error only
+    const genericErr = events.find((e) => e.type === 'error');
+    expect(genericErr).toBeUndefined();
+  });
+
   test('queue depth is reported correctly as messages are added and drained', async () => {
     const session = makeSession();
     await session.loadFromDb();

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -497,16 +497,15 @@ async function handleUserMessage(
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
     session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
-      const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
-      ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+      // Session-scoped failure: emit only session_error (not generic error)
+      // so the client routes it through the typed session-error channel.
       const classified = classifySessionError(err, { phase: 'agent_loop' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');
-    ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+    // Session-scoped failure: emit only session_error (not generic error).
     const classified = classifySessionError(err, { phase: 'handler' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -815,7 +814,7 @@ async function handleRegenerate(
       status: 'error',
       attributes: { errorClass: err instanceof Error ? err.constructor.name : 'Error', message: message.slice(0, 500) },
     });
-    ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
+    // Session-scoped failure: emit only session_error (not generic error).
     const classified = classifySessionError(err, { phase: 'regenerate' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -1382,9 +1381,8 @@ async function handleTaskSubmit(
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
       }, requestId).catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
-        ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
+        // Session-scoped failure: emit only session_error (not generic error).
         const classified = classifySessionError(err, { phase: 'agent_loop' });
         ctx.send(socket, buildSessionErrorMessage(conversation.id, classified));
       });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -880,7 +880,8 @@ export class Session {
           status: 'error',
           attributes: { errorClass, message: message.slice(0, 500) },
         });
-        onEvent({ type: 'error', message: `Failed to process message: ${message}` });
+        // Session-scoped failure: emit only session_error (not generic error)
+        // so the client routes it through the typed session-error channel.
         const classified = classifySessionError(err, errorCtx);
         onEvent(buildSessionErrorMessage(this.conversationId, classified));
         void getHookManager().trigger('on-error', {


### PR DESCRIPTION
## Summary
- Remove dual emission (generic `error` + `session_error`) for session-scoped runtime failures
- When `sessionId` is known, emit only `session_error` — client routes through typed channel
- Generic `error` preserved for non-session/global handlers (task routing, etc.)
- Clean up unused `message` variables in catch blocks

## Test plan
- [x] Session-queue tests pass (25/25, including new channel-separation test)
- [x] Session-scoped errors emit only `session_error`, no generic `error`
- [x] Global/non-session handlers still emit generic `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
