### PR TITLE
fix(doctor): make Docker checks match runtime preflight

### DIFF
--- a/assistant/src/__tests__/sandbox-diagnostics.test.ts
+++ b/assistant/src/__tests__/sandbox-diagnostics.test.ts
@@ -311,15 +311,15 @@ describe('runSandboxDiagnostics — Docker image check', () => {
   });
 });
 
-describe('runSandboxDiagnostics — Docker container execution check', () => {
-  test('passes when container runs successfully', () => {
+describe('runSandboxDiagnostics — Docker mount writable check', () => {
+  test('passes when mount probe succeeds', () => {
     const result = runSandboxDiagnostics();
-    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
-    expect(runCheck).toBeDefined();
-    expect(runCheck!.ok).toBe(true);
+    const mountCheck = result.checks.find((c) => c.label === 'Docker mount writable');
+    expect(mountCheck).toBeDefined();
+    expect(mountCheck!.ok).toBe(true);
   });
 
-  test('uses configured image and sandbox mount for container probe', () => {
+  test('uses configured image and sandbox working dir for mount probe', () => {
     mockSandboxConfig.docker.image = 'alpine:3.19';
     runSandboxDiagnostics();
     const runCall = execFileSyncMock.mock.calls.find(
@@ -328,40 +328,29 @@ describe('runSandboxDiagnostics — Docker container execution check', () => {
     expect(runCall).toBeDefined();
     const args = runCall![1] as string[];
     expect(args).toContain('alpine:3.19');
-    expect(args).not.toContain('ubuntu:22.04');
+    // Mount source should be the sandbox working dir (getSandboxWorkingDir)
     const mountArg = args.find((a: string) => a.startsWith('type=bind'));
-    expect(mountArg).toContain('/tmp/vellum-test/sandbox');
+    expect(mountArg).toContain('/tmp/vellum-test/sandbox/workspace');
+    // Probe command should be 'test -w /workspace' matching runtime preflight
+    expect(args).toContain('test');
+    expect(args).toContain('-w');
+    expect(args).toContain('/workspace');
   });
 
-  test('fails when container execution errors', () => {
+  test('fails when mount probe errors', () => {
     execFileSyncMock.mockImplementation(
       (file: string, args?: readonly string[]) => {
         if (file === 'docker' && Array.isArray(args) && args.includes('run')) {
-          throw new Error('container failed');
+          throw new Error('mount failed');
         }
-        return 'ok\n';
+        return undefined;
       },
     );
     const result = runSandboxDiagnostics();
-    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
-    expect(runCheck).toBeDefined();
-    expect(runCheck!.ok).toBe(false);
-  });
-
-  test('fails when container output is unexpected', () => {
-    execFileSyncMock.mockImplementation(
-      (file: string, args?: readonly string[]) => {
-        if (file === 'docker' && Array.isArray(args) && args.includes('run')) {
-          return 'unexpected\n';
-        }
-        return 'ok\n';
-      },
-    );
-    const result = runSandboxDiagnostics();
-    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
-    expect(runCheck).toBeDefined();
-    expect(runCheck!.ok).toBe(false);
-    expect(runCheck!.detail).toContain('unexpected');
+    const mountCheck = result.checks.find((c) => c.label === 'Docker mount writable');
+    expect(mountCheck).toBeDefined();
+    expect(mountCheck!.ok).toBe(false);
+    expect(mountCheck!.detail).toContain('File Sharing');
   });
 
   test('skipped when daemon is not running', () => {
@@ -372,8 +361,8 @@ describe('runSandboxDiagnostics — Docker container execution check', () => {
       return 'Docker version 24.0.7';
     });
     const result = runSandboxDiagnostics();
-    const runCheck = result.checks.find((c) => c.label === 'Docker container execution');
-    expect(runCheck).toBeUndefined();
+    const mountCheck = result.checks.find((c) => c.label === 'Docker mount writable');
+    expect(mountCheck).toBeUndefined();
   });
 });
 
@@ -390,7 +379,7 @@ describe('runSandboxDiagnostics — check cascade', () => {
     expect(labels).toContain('Docker CLI installed');
     expect(labels).not.toContain('Docker daemon running');
     expect(labels.find((l) => l.includes('Docker image'))).toBeUndefined();
-    expect(labels).not.toContain('Docker container execution');
+    expect(labels).not.toContain('Docker mount writable');
   });
 
   test('image and run checks are skipped when daemon is down', () => {
@@ -405,7 +394,7 @@ describe('runSandboxDiagnostics — check cascade', () => {
     expect(labels).toContain('Docker CLI installed');
     expect(labels).toContain('Docker daemon running');
     expect(labels.find((l) => l.includes('Docker image'))).toBeUndefined();
-    expect(labels).not.toContain('Docker container execution');
+    expect(labels).not.toContain('Docker mount writable');
   });
 
   test('all Docker checks run when everything works', () => {
@@ -414,6 +403,6 @@ describe('runSandboxDiagnostics — check cascade', () => {
     expect(labels).toContain('Docker CLI installed');
     expect(labels).toContain('Docker daemon running');
     expect(labels.find((l) => l.includes('Docker image'))).toBeDefined();
-    expect(labels).toContain('Docker container execution');
+    expect(labels).toContain('Docker mount writable');
   });
 });

--- a/assistant/src/tools/terminal/sandbox-diagnostics.ts
+++ b/assistant/src/tools/terminal/sandbox-diagnostics.ts
@@ -1,5 +1,5 @@
 import { execSync, execFileSync } from 'node:child_process';
-import { isMacOS, isLinux, getSandboxRootDir } from '../../util/platform.js';
+import { isMacOS, isLinux, getSandboxWorkingDir } from '../../util/platform.js';
 import { getConfig } from '../../config/loader.js';
 import type { SandboxConfig } from '../../config/schema.js';
 
@@ -47,25 +47,31 @@ function checkDockerImage(image: string): SandboxCheckResult {
   }
 }
 
-function checkDockerRun(image: string): SandboxCheckResult {
-  const sandboxRoot = getSandboxRootDir();
+function checkDockerMountProbe(image: string): SandboxCheckResult {
+  // Use the same sandbox path and writable-mount probe that the runtime
+  // preflight uses (checkMountProbe in docker.ts) so doctor validates
+  // exactly what runtime enforces.
+  const sandboxRoot = getSandboxWorkingDir();
   try {
-    const out = execFileSync(
+    execFileSync(
       'docker',
       [
         'run', '--rm',
         '--mount', `type=bind,src=${sandboxRoot},dst=/workspace`,
-        image, 'echo', 'ok',
+        image, 'test', '-w', '/workspace',
       ],
-      { stdio: 'pipe', timeout: 15000, encoding: 'utf-8' },
-    ).trim();
-    if (out === 'ok') {
-      return { label: 'Docker container execution', ok: true };
-    }
-    return { label: 'Docker container execution', ok: false, detail: `unexpected output: ${out}` };
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    return { label: 'Docker mount writable', ok: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown error';
-    return { label: 'Docker container execution', ok: false, detail: msg };
+    return {
+      label: 'Docker mount writable',
+      ok: false,
+      detail: 'Cannot bind-mount sandbox root or /workspace is not writable. ' +
+        'If using Docker Desktop, enable file sharing for this path in Settings > Resources > File Sharing. ' +
+        `(${msg})`,
+    };
   }
 }
 
@@ -122,7 +128,7 @@ export function runSandboxDiagnostics(): SandboxDiagnostics {
 
     if (daemonResult.ok) {
       checks.push(checkDockerImage(sandboxConfig.docker.image));
-      checks.push(checkDockerRun(sandboxConfig.docker.image));
+      checks.push(checkDockerMountProbe(sandboxConfig.docker.image));
     }
   }
 


### PR DESCRIPTION
## Summary
- Doctor now uses `test -w /workspace` mount probe (same as runtime `checkMountProbe` in docker.ts) instead of `echo ok`
- Uses `getSandboxWorkingDir()` (the canonical sandbox fs root) instead of `getSandboxRootDir()` to match PR #2234
- Label changed from "Docker container execution" to "Docker mount writable" for clarity
- Failure message includes actionable Docker Desktop File Sharing remediation

## Test plan
- [x] All sandbox-diagnostics tests pass (29/29)
- [x] Doctor validates exactly what runtime enforces — same path, same probe command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
