### PR TITLE
refactor(attachments): add assistant attachment dto + conversion helpers

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  estimateBase64Bytes,
+  inferMimeType,
+  classifyKind,
+  validateDrafts,
+  MAX_ASSISTANT_ATTACHMENTS,
+  MAX_ASSISTANT_ATTACHMENT_BYTES,
+  type AssistantAttachmentDraft,
+} from '../daemon/assistant-attachments.js';
+
+// ---------------------------------------------------------------------------
+// estimateBase64Bytes
+// ---------------------------------------------------------------------------
+
+describe('estimateBase64Bytes', () => {
+  test('returns 0 for empty string', () => {
+    expect(estimateBase64Bytes('')).toBe(0);
+  });
+
+  test('handles no-padding base64', () => {
+    // "abc" → base64 "YWJj" (4 chars, 0 padding → 3 bytes)
+    expect(estimateBase64Bytes('YWJj')).toBe(3);
+  });
+
+  test('handles single-pad base64', () => {
+    // "ab" → base64 "YWI=" (4 chars, 1 padding → 2 bytes)
+    expect(estimateBase64Bytes('YWI=')).toBe(2);
+  });
+
+  test('handles double-pad base64', () => {
+    // "a" → base64 "YQ==" (4 chars, 2 padding → 1 byte)
+    expect(estimateBase64Bytes('YQ==')).toBe(1);
+  });
+
+  test('estimates correctly for longer strings', () => {
+    // 12 base64 chars, no padding → 9 bytes
+    expect(estimateBase64Bytes('SGVsbG8gV29y')).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMimeType
+// ---------------------------------------------------------------------------
+
+describe('inferMimeType', () => {
+  test('infers image types', () => {
+    expect(inferMimeType('photo.png')).toBe('image/png');
+    expect(inferMimeType('photo.jpg')).toBe('image/jpeg');
+    expect(inferMimeType('photo.jpeg')).toBe('image/jpeg');
+    expect(inferMimeType('sticker.webp')).toBe('image/webp');
+    expect(inferMimeType('icon.gif')).toBe('image/gif');
+    expect(inferMimeType('diagram.svg')).toBe('image/svg+xml');
+  });
+
+  test('infers document types', () => {
+    expect(inferMimeType('report.pdf')).toBe('application/pdf');
+    expect(inferMimeType('data.json')).toBe('application/json');
+    expect(inferMimeType('notes.txt')).toBe('text/plain');
+    expect(inferMimeType('readme.md')).toBe('text/markdown');
+    expect(inferMimeType('table.csv')).toBe('text/csv');
+  });
+
+  test('is case-insensitive on extension', () => {
+    expect(inferMimeType('PHOTO.PNG')).toBe('image/png');
+    expect(inferMimeType('Report.PDF')).toBe('application/pdf');
+  });
+
+  test('returns octet-stream for unknown extension', () => {
+    expect(inferMimeType('file.xyz')).toBe('application/octet-stream');
+  });
+
+  test('returns octet-stream for no extension', () => {
+    expect(inferMimeType('Makefile')).toBe('application/octet-stream');
+  });
+
+  test('uses last extension for double-dotted names', () => {
+    expect(inferMimeType('archive.tar.gz')).toBe('application/gzip');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyKind
+// ---------------------------------------------------------------------------
+
+describe('classifyKind', () => {
+  test('classifies image mime types as image', () => {
+    expect(classifyKind('image/png')).toBe('image');
+    expect(classifyKind('image/jpeg')).toBe('image');
+    expect(classifyKind('image/webp')).toBe('image');
+  });
+
+  test('classifies non-image mime types as document', () => {
+    expect(classifyKind('application/pdf')).toBe('document');
+    expect(classifyKind('text/plain')).toBe('document');
+    expect(classifyKind('application/octet-stream')).toBe('document');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDrafts
+// ---------------------------------------------------------------------------
+
+function makeDraft(overrides: Partial<AssistantAttachmentDraft> = {}): AssistantAttachmentDraft {
+  return {
+    sourceType: 'sandbox_file',
+    filename: 'test.txt',
+    mimeType: 'text/plain',
+    dataBase64: 'dGVzdA==',
+    sizeBytes: 4,
+    kind: 'document',
+    ...overrides,
+  };
+}
+
+describe('validateDrafts', () => {
+  test('accepts drafts within limits', () => {
+    const drafts = [makeDraft({ filename: 'a.txt' }), makeDraft({ filename: 'b.txt' })];
+    const result = validateDrafts(drafts);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test('rejects oversized attachments', () => {
+    const drafts = [makeDraft({ filename: 'big.bin', sizeBytes: MAX_ASSISTANT_ATTACHMENT_BYTES + 1 })];
+    const result = validateDrafts(drafts);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('big.bin');
+    expect(result.warnings[0]).toContain('exceeds');
+  });
+
+  test('truncates beyond max count', () => {
+    const drafts = Array.from({ length: MAX_ASSISTANT_ATTACHMENTS + 2 }, (_, i) =>
+      makeDraft({ filename: `file-${i}.txt` }),
+    );
+    const result = validateDrafts(drafts);
+    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toContain(`file-${MAX_ASSISTANT_ATTACHMENTS}.txt`);
+    expect(result.warnings[0]).toContain('exceeded maximum');
+  });
+
+  test('rejects oversized before applying count cap', () => {
+    const drafts = [
+      makeDraft({ filename: 'big.bin', sizeBytes: MAX_ASSISTANT_ATTACHMENT_BYTES + 1 }),
+      ...Array.from({ length: MAX_ASSISTANT_ATTACHMENTS }, (_, i) =>
+        makeDraft({ filename: `ok-${i}.txt` }),
+      ),
+    ];
+    const result = validateDrafts(drafts);
+    // big.bin rejected for size; all MAX_ASSISTANT_ATTACHMENTS ok files accepted
+    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('big.bin');
+  });
+
+  test('returns empty accepted for empty input', () => {
+    const result = validateDrafts([]);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -1,0 +1,148 @@
+/**
+ * Assistant outbound attachment types and helpers.
+ *
+ * Shared DTOs and utilities for building attachment candidates from
+ * directives, tool content blocks, and file reads.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of attachments the assistant may emit per turn. */
+export const MAX_ASSISTANT_ATTACHMENTS = 5;
+
+/** Maximum size in bytes for a single assistant attachment (20 MB). */
+export const MAX_ASSISTANT_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AttachmentSourceType = 'sandbox_file' | 'host_file' | 'tool_block';
+
+export interface AssistantAttachmentDraft {
+  sourceType: AttachmentSourceType;
+  filename: string;
+  mimeType: string;
+  dataBase64: string;
+  sizeBytes: number;
+  kind: 'image' | 'document';
+}
+
+// ---------------------------------------------------------------------------
+// Base64 size estimation
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the decoded byte length of a base64-encoded string.
+ * Accounts for trailing `=` padding characters.
+ */
+export function estimateBase64Bytes(base64: string): number {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+// ---------------------------------------------------------------------------
+// MIME inference
+// ---------------------------------------------------------------------------
+
+const EXTENSION_MIME_MAP: Record<string, string> = {
+  // Images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+
+  // Documents
+  pdf: 'application/pdf',
+  json: 'application/json',
+  xml: 'application/xml',
+  csv: 'text/csv',
+  txt: 'text/plain',
+  md: 'text/markdown',
+  html: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  ts: 'text/typescript',
+
+  // Archives
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+};
+
+/**
+ * Infer a MIME type from a filename extension.
+ * Returns `application/octet-stream` when the extension is unrecognised.
+ */
+export function inferMimeType(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  if (dot === -1) return 'application/octet-stream';
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return EXTENSION_MIME_MAP[ext] ?? 'application/octet-stream';
+}
+
+// ---------------------------------------------------------------------------
+// Kind classification
+// ---------------------------------------------------------------------------
+
+export function classifyKind(mimeType: string): 'image' | 'document' {
+  return mimeType.startsWith('image/') ? 'image' : 'document';
+}
+
+// ---------------------------------------------------------------------------
+// Validation / cap enforcement
+// ---------------------------------------------------------------------------
+
+export interface ValidatedDrafts {
+  accepted: AssistantAttachmentDraft[];
+  warnings: string[];
+}
+
+/**
+ * Enforce per-turn attachment caps.
+ *
+ * - Rejects individual drafts that exceed `MAX_ASSISTANT_ATTACHMENT_BYTES`.
+ * - Truncates the list at `MAX_ASSISTANT_ATTACHMENTS`.
+ */
+export function validateDrafts(drafts: AssistantAttachmentDraft[]): ValidatedDrafts {
+  const accepted: AssistantAttachmentDraft[] = [];
+  const warnings: string[] = [];
+
+  for (const draft of drafts) {
+    if (draft.sizeBytes > MAX_ASSISTANT_ATTACHMENT_BYTES) {
+      warnings.push(
+        `Skipped attachment "${draft.filename}": ` +
+        `size ${formatBytes(draft.sizeBytes)} exceeds ${formatBytes(MAX_ASSISTANT_ATTACHMENT_BYTES)} limit.`,
+      );
+      continue;
+    }
+
+    if (accepted.length >= MAX_ASSISTANT_ATTACHMENTS) {
+      warnings.push(
+        `Skipped attachment "${draft.filename}": ` +
+        `exceeded maximum of ${MAX_ASSISTANT_ATTACHMENTS} attachments per turn.`,
+      );
+      continue;
+    }
+
+    accepted.push(draft);
+  }
+
+  return { accepted, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## Summary
- Add `AssistantAttachmentDraft` type and shared helpers for assistant outbound attachments
- Includes base64 size estimation, MIME inference by extension, kind classification, and per-turn cap validation
- Foundational layer for directive parsing and session integration (no behavior change yet)

## Test plan
- [x] Unit tests for `estimateBase64Bytes` (empty, no-pad, single-pad, double-pad)
- [x] Unit tests for `inferMimeType` (images, documents, case-insensitive, unknown, no extension)
- [x] Unit tests for `classifyKind` (image vs document)
- [x] Unit tests for `validateDrafts` (within limits, oversized, count overflow, empty input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
