### PR TITLE
CI/hook hardening for IPC guardrails

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -129,8 +129,10 @@ IPC_CONTRACT_FILES=(
     "assistant/src/daemon/ipc-contract-inventory.ts"
     "assistant/scripts/ipc/generate-swift.ts"
     "assistant/scripts/ipc/check-contract-inventory.ts"
+    "assistant/scripts/ipc/check-swift-decoder-drift.ts"
     "assistant/src/daemon/ipc-contract-inventory.json"
     "clients/shared/IPC/Generated/IPCContractGenerated.swift"
+    "clients/shared/IPC/IPCMessages.swift"
 )
 
 IPC_CHANGED=0
@@ -173,6 +175,16 @@ if [ $IPC_CHANGED -eq 1 ]; then
             exit 1
         fi
         echo "✅ IPC contract inventory is up to date"
+
+        if ! (cd assistant && "$BUN" run ipc:check-swift-drift) 2>/dev/null; then
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}Swift decoder is out of sync with the IPC contract!${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
+            echo "Update IPCMessages.swift decode cases or the drift checker allowlist."
+            exit 1
+        fi
+        echo "✅ Swift decoder is in sync with the contract"
 
         # Verify generated output files are staged (not just regenerated on disk).
         # The checks above compare against the working tree, so if a developer

--- a/.github/workflows/ci-assistant.yml
+++ b/.github/workflows/ci-assistant.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - 'assistant/**'
-      - 'clients/shared/IPC/Generated/**'
+      - 'clients/shared/IPC/**'
+      - '.githooks/**'
       - '.github/workflows/ci-assistant.yml'
 
 jobs:
@@ -32,6 +33,9 @@ jobs:
 
       - name: Verify IPC contract inventory is up to date
         run: bun run ipc:inventory
+
+      - name: Verify Swift decoder is in sync with contract
+        run: bun run ipc:check-swift-drift
 
       - name: Type check
         run: bunx tsc --noEmit


### PR DESCRIPTION
## Summary
- Added `ipc:check-swift-drift` step to CI workflow (`ci-assistant.yml`) alongside existing IPC checks
- Added Swift drift check to pre-commit hook, triggered when any IPC-related file is staged
- Expanded CI path filters: `clients/shared/IPC/**` (was `clients/shared/IPC/Generated/**` only) and added `.githooks/**`
- Added `IPCMessages.swift` and `check-swift-decoder-drift.ts` to the pre-commit IPC file watch list

## Test plan
- [x] CI workflow runs drift check on IPC file changes
- [x] Pre-commit hook triggers drift check when IPC files are staged
- [x] Path filters now cover all relevant IPC files and hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
