### PR TITLE
test(sandbox): add runtime-gated Docker integration tests

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.integration.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Runtime-gated Docker integration tests.
+ *
+ * These tests run real Docker containers — they are skipped automatically
+ * when Docker is not available or the sandbox image is not pulled locally.
+ * To run them locally:
+ *   1. Install Docker Desktop / Docker Engine
+ *   2. docker pull node:20-slim
+ *   3. bun test src/__tests__/terminal-sandbox.integration.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Runtime gate: skip entire file if Docker is not usable
+// ---------------------------------------------------------------------------
+
+function dockerAvailable(): boolean {
+  try {
+    execFileSync('docker', ['info'], { stdio: 'ignore', timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const IMAGE = 'node:20-slim';
+
+function imageAvailable(): boolean {
+  try {
+    execFileSync('docker', ['image', 'inspect', IMAGE], {
+      stdio: 'ignore',
+      timeout: 10000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const DOCKER_OK = dockerAvailable() && imageAvailable();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let sandboxRoot: string;
+
+beforeAll(() => {
+  if (!DOCKER_OK) return;
+  sandboxRoot = realpathSync(mkdtempSync(join(tmpdir(), 'docker-integ-')));
+});
+
+afterAll(() => {
+  if (sandboxRoot && existsSync(sandboxRoot)) {
+    rmSync(sandboxRoot, { recursive: true, force: true });
+  }
+});
+
+/** Run a command inside a Docker container with the sandbox root mounted. */
+function dockerRun(cmd: string): { stdout: string; exitCode: number } {
+  const uid = process.getuid?.() ?? 1000;
+  const gid = process.getgid?.() ?? 1000;
+  const result = spawnSync('docker', [
+    'run', '--rm',
+    '--network=none',
+    '--cap-drop=ALL',
+    '--security-opt=no-new-privileges',
+    '--read-only',
+    '--tmpfs', '/tmp:rw,nosuid,nodev,noexec',
+    '--mount', `type=bind,src=${sandboxRoot},dst=/workspace`,
+    '--workdir', '/workspace',
+    '--user', `${uid}:${gid}`,
+    IMAGE,
+    'bash', '-c', cmd,
+  ], { timeout: 30000, encoding: 'utf-8' });
+  return {
+    stdout: (result.stdout ?? '').trim(),
+    exitCode: result.status ?? -1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!DOCKER_OK)('Docker integration: write inside sandbox', () => {
+  test('writing a file inside /workspace succeeds', () => {
+    const { exitCode } = dockerRun('echo "hello" > /workspace/test-write.txt && cat /workspace/test-write.txt');
+    expect(exitCode).toBe(0);
+    // Verify the file appeared on the host
+    const hostPath = join(sandboxRoot, 'test-write.txt');
+    expect(existsSync(hostPath)).toBe(true);
+    expect(readFileSync(hostPath, 'utf-8').trim()).toBe('hello');
+  });
+
+  test('creating nested directories inside /workspace succeeds', () => {
+    const { exitCode, stdout } = dockerRun('mkdir -p /workspace/a/b/c && echo ok');
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('ok');
+    expect(existsSync(join(sandboxRoot, 'a/b/c'))).toBe(true);
+  });
+});
+
+describe.skipIf(!DOCKER_OK)('Docker integration: write outside workspace fails', () => {
+  test('writing to /etc inside container fails (read-only root)', () => {
+    const { exitCode } = dockerRun('touch /etc/evil 2>/dev/null');
+    expect(exitCode).not.toBe(0);
+  });
+
+  test('writing to /home inside container fails (read-only root)', () => {
+    const { exitCode } = dockerRun('touch /home/evil 2>/dev/null');
+    expect(exitCode).not.toBe(0);
+  });
+
+  test('writing to /tmp succeeds (tmpfs mount)', () => {
+    // /tmp is an explicit tmpfs mount so writes should work
+    const { exitCode, stdout } = dockerRun('echo ok > /tmp/test.txt && cat /tmp/test.txt');
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('ok');
+  });
+});
+
+describe.skipIf(!DOCKER_OK)('Docker integration: host-writable files', () => {
+  test('files created in container are owned by host UID:GID', () => {
+    const filename = 'host-owner-test.txt';
+    dockerRun(`echo "owned" > /workspace/${filename}`);
+    const hostPath = join(sandboxRoot, filename);
+    expect(existsSync(hostPath)).toBe(true);
+    const stat = statSync(hostPath);
+    const expectedUid = process.getuid?.() ?? 1000;
+    const expectedGid = process.getgid?.() ?? 1000;
+    expect(stat.uid).toBe(expectedUid);
+    expect(stat.gid).toBe(expectedGid);
+  });
+
+  test('host can read files created by container', () => {
+    const filename = 'host-readable-test.txt';
+    const content = 'container-created-content';
+    dockerRun(`echo "${content}" > /workspace/${filename}`);
+    const hostPath = join(sandboxRoot, filename);
+    expect(readFileSync(hostPath, 'utf-8').trim()).toBe(content);
+  });
+
+  test('container can read files created by host', () => {
+    const filename = 'host-created.txt';
+    writeFileSync(join(sandboxRoot, filename), 'from-host');
+    const { stdout, exitCode } = dockerRun(`cat /workspace/${filename}`);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('from-host');
+  });
+});


### PR DESCRIPTION
## Summary
- New `terminal-sandbox.integration.test.ts` with 8 real Docker container tests
- Runtime-gated: auto-skips when Docker daemon or `node:20-slim` image is unavailable
- Tests verify sandbox write isolation, read-only root enforcement, host UID:GID ownership, and bidirectional file visibility

## Test plan
- [x] Tests skip gracefully when Docker image is not available (8 skip, 0 fail)
- [x] Tests exercise real containers when Docker + image are present
- [x] No interference with existing unit test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
