### PR TITLE
feat(attachments): parse vellum-attachment xml directives from assistant text

### DIFF
--- a/assistant/src/__tests__/assistant-attachment-directive.test.ts
+++ b/assistant/src/__tests__/assistant-attachment-directive.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from 'bun:test';
+import { parseDirectives } from '../daemon/assistant-attachments.js';
+
+// ---------------------------------------------------------------------------
+// parseDirectives
+// ---------------------------------------------------------------------------
+
+describe('parseDirectives', () => {
+  test('parses a single sandbox directive with all attributes', () => {
+    const text = 'Here is the report:\n<vellum-attachment source="sandbox" path="output/report.pdf" filename="report.pdf" mime_type="application/pdf" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(1);
+    expect(result.directiveRequests[0]).toEqual({
+      source: 'sandbox',
+      path: 'output/report.pdf',
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+    });
+    expect(result.cleanText).toBe('Here is the report:');
+    expect(result.parseWarnings).toHaveLength(0);
+  });
+
+  test('defaults source to sandbox when omitted', () => {
+    const text = '<vellum-attachment path="chart.png" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(1);
+    expect(result.directiveRequests[0].source).toBe('sandbox');
+  });
+
+  test('parses host source', () => {
+    const text = '<vellum-attachment source="host" path="/Users/me/doc.pdf" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(1);
+    expect(result.directiveRequests[0].source).toBe('host');
+    expect(result.directiveRequests[0].path).toBe('/Users/me/doc.pdf');
+  });
+
+  test('leaves optional filename and mime_type undefined when absent', () => {
+    const text = '<vellum-attachment path="file.txt" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests[0].filename).toBeUndefined();
+    expect(result.directiveRequests[0].mimeType).toBeUndefined();
+  });
+
+  test('parses multiple directives preserving order', () => {
+    const text = [
+      'Results:',
+      '<vellum-attachment path="a.png" />',
+      'And also:',
+      '<vellum-attachment path="b.pdf" />',
+    ].join('\n');
+
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(2);
+    expect(result.directiveRequests[0].path).toBe('a.png');
+    expect(result.directiveRequests[1].path).toBe('b.pdf');
+    expect(result.cleanText).toBe('Results:\n\nAnd also:');
+  });
+
+  test('rejects directive without path attribute', () => {
+    const text = '<vellum-attachment source="sandbox" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(0);
+    expect(result.parseWarnings).toHaveLength(1);
+    expect(result.parseWarnings[0]).toContain('missing required "path"');
+    // Malformed tag preserved in text
+    expect(result.cleanText).toContain('<vellum-attachment');
+  });
+
+  test('rejects directive with invalid source value', () => {
+    const text = '<vellum-attachment source="cloud" path="x.txt" />';
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(0);
+    expect(result.parseWarnings).toHaveLength(1);
+    expect(result.parseWarnings[0]).toContain('invalid source="cloud"');
+    expect(result.cleanText).toContain('<vellum-attachment');
+  });
+
+  test('handles mixed valid and invalid directives', () => {
+    const text = [
+      '<vellum-attachment path="good.png" />',
+      '<vellum-attachment source="nope" path="bad.txt" />',
+      '<vellum-attachment path="also-good.pdf" />',
+    ].join('\n');
+
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(2);
+    expect(result.directiveRequests[0].path).toBe('good.png');
+    expect(result.directiveRequests[1].path).toBe('also-good.pdf');
+    expect(result.parseWarnings).toHaveLength(1);
+  });
+
+  test('returns original text when no directives present', () => {
+    const text = 'Hello world, no attachments here.';
+    const result = parseDirectives(text);
+
+    expect(result.cleanText).toBe(text);
+    expect(result.directiveRequests).toHaveLength(0);
+    expect(result.parseWarnings).toHaveLength(0);
+  });
+
+  test('preserves non-self-closing tags as plain text', () => {
+    const text = '<vellum-attachment path="file.txt">content</vellum-attachment>';
+    const result = parseDirectives(text);
+
+    // The regex only matches self-closing tags, so non-self-closing is not matched
+    expect(result.directiveRequests).toHaveLength(0);
+    expect(result.cleanText).toContain('content</vellum-attachment>');
+  });
+
+  test('handles single-quoted attributes', () => {
+    const text = "<vellum-attachment path='report.pdf' filename='my report.pdf' />";
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(1);
+    expect(result.directiveRequests[0].path).toBe('report.pdf');
+    expect(result.directiveRequests[0].filename).toBe('my report.pdf');
+  });
+
+  test('collapses excess blank lines after tag removal', () => {
+    const text = 'Before\n\n<vellum-attachment path="x.png" />\n\n\nAfter';
+    const result = parseDirectives(text);
+
+    // Should not have triple+ newlines
+    expect(result.cleanText).not.toMatch(/\n{3,}/);
+    expect(result.cleanText).toBe('Before\n\nAfter');
+  });
+
+  test('handles directive with multiline attributes', () => {
+    const text = [
+      '<vellum-attachment',
+      '  source="host"',
+      '  path="/tmp/data.csv"',
+      '  mime_type="text/csv"',
+      '/>',
+    ].join('\n');
+    const result = parseDirectives(text);
+
+    expect(result.directiveRequests).toHaveLength(1);
+    expect(result.directiveRequests[0].source).toBe('host');
+    expect(result.directiveRequests[0].path).toBe('/tmp/data.csv');
+    expect(result.directiveRequests[0].mimeType).toBe('text/csv');
+  });
+});

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -138,6 +138,94 @@ export function validateDrafts(drafts: AssistantAttachmentDraft[]): ValidatedDra
 }
 
 // ---------------------------------------------------------------------------
+// Directive parser
+// ---------------------------------------------------------------------------
+
+export type DirectiveSource = 'sandbox' | 'host';
+
+export interface DirectiveRequest {
+  source: DirectiveSource;
+  path: string;
+  filename: string | undefined;
+  mimeType: string | undefined;
+}
+
+export interface DirectiveParseResult {
+  cleanText: string;
+  directiveRequests: DirectiveRequest[];
+  parseWarnings: string[];
+}
+
+/**
+ * Match self-closing `<vellum-attachment ... />` tags.
+ *
+ * Captures the attribute string between the tag name and the `/>` close.
+ * Non-greedy so multiple tags on separate lines are matched individually.
+ */
+const DIRECTIVE_RE = /<vellum-attachment\s+([\s\S]*?)\/>/g;
+
+/**
+ * Parse individual attribute key="value" pairs.
+ * Supports both double and single quotes.
+ */
+const ATTR_RE = /(\w+)\s*=\s*"([^"]*)"|(\w+)\s*=\s*'([^']*)'/g;
+
+function parseAttributes(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(raw)) !== null) {
+    const key = m[1] ?? m[3];
+    const value = m[2] ?? m[4];
+    attrs[key] = value;
+  }
+  return attrs;
+}
+
+/**
+ * Scan assistant text for `<vellum-attachment ... />` directives.
+ *
+ * Returns the text with successfully parsed directives stripped,
+ * along with the parsed directive requests and any warnings for
+ * malformed tags.
+ */
+export function parseDirectives(text: string): DirectiveParseResult {
+  const directiveRequests: DirectiveRequest[] = [];
+  const parseWarnings: string[] = [];
+
+  const cleanText = text.replace(DIRECTIVE_RE, (fullMatch, attrStr: string) => {
+    const attrs = parseAttributes(attrStr);
+
+    if (!attrs['path']) {
+      parseWarnings.push('Ignored <vellum-attachment />: missing required "path" attribute.');
+      return fullMatch;
+    }
+
+    const sourceRaw = attrs['source'] ?? 'sandbox';
+    if (sourceRaw !== 'sandbox' && sourceRaw !== 'host') {
+      parseWarnings.push(
+        `Ignored <vellum-attachment />: invalid source="${sourceRaw}". Must be "sandbox" or "host".`,
+      );
+      return fullMatch;
+    }
+
+    directiveRequests.push({
+      source: sourceRaw,
+      path: attrs['path'],
+      filename: attrs['filename'] || undefined,
+      mimeType: attrs['mime_type'] || undefined,
+    });
+
+    return '';
+  });
+
+  return {
+    cleanText: cleanText.replace(/\n{3,}/g, '\n\n').trim(),
+    directiveRequests,
+    parseWarnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Formatting helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `parseDirectives()` to scan assistant text for `<vellum-attachment />` self-closing XML tags
- Extracts source, path, filename, mime_type attributes; defaults source to sandbox
- Strips parsed tags from text; preserves malformed tags as plain text with warnings

## Test plan
- [x] Single directive with all attributes
- [x] Default source to sandbox
- [x] Host source parsing
- [x] Optional attribute handling
- [x] Multiple directives in order
- [x] Missing path rejection
- [x] Invalid source rejection
- [x] Mixed valid/invalid
- [x] No directives (passthrough)
- [x] Non-self-closing tag preservation
- [x] Single-quoted attributes
- [x] Blank line collapse
- [x] Multiline attribute spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
