### PR TITLE
fix(trace): treat generation_handoff as terminal in macOS trace grouping

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -92,6 +92,10 @@ struct TraceTimelineView: View {
                     Text("Cancelled")
                         .font(VFont.small)
                         .foregroundColor(Amber._500)
+                } else if groupStatus == .handedOff {
+                    Text("Handed off")
+                        .font(VFont.small)
+                        .foregroundColor(Indigo._400)
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
@@ -114,6 +118,7 @@ struct TraceTimelineView: View {
         case .active: return "arrow.right.circle"
         case .completed: return "checkmark.circle.fill"
         case .cancelled: return "xmark.circle.fill"
+        case .handedOff: return "arrow.right.arrow.left.circle.fill"
         case .error: return "exclamationmark.triangle.fill"
         }
     }
@@ -123,6 +128,7 @@ struct TraceTimelineView: View {
         case .active: return Emerald._400
         case .completed: return Emerald._400
         case .cancelled: return Amber._500
+        case .handedOff: return Indigo._400
         case .error: return Rose._500
         }
     }

--- a/clients/macos/vellum-assistant/Logging/TraceStore.swift
+++ b/clients/macos/vellum-assistant/Logging/TraceStore.swift
@@ -101,15 +101,16 @@ public final class TraceStore: ObservableObject {
         case active
         case completed
         case cancelled
+        case handedOff
         case error
     }
 
     /// Determines the terminal status of a request group by inspecting its events.
     ///
     /// A request is considered terminal when it contains a `message_complete`,
-    /// `generation_cancelled`, or `request_error` event (matching the daemon's
-    /// `TraceEventKind` contract). If none of those are present but any event
-    /// has `status == "error"`, the group is marked as error.
+    /// `generation_cancelled`, `generation_handoff`, or `request_error` event
+    /// (matching the daemon's `TraceEventKind` contract). If none of those are
+    /// present but any event has `status == "error"`, the group is marked as error.
     public func requestGroupStatus(sessionId: String, requestId: String) -> RequestGroupStatus {
         let key = requestId.isEmpty ? "" : requestId
         let grouped = eventsByRequest(sessionId: sessionId)
@@ -119,6 +120,8 @@ public final class TraceStore: ObservableObject {
             switch event.kind {
             case "generation_cancelled":
                 return .cancelled
+            case "generation_handoff":
+                return .handedOff
             case "request_error":
                 return .error
             case "message_complete":

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -336,6 +336,20 @@ struct TraceStoreTests {
         #expect(store.eventsBySession["s2"]?.count == 2)
     }
 
+    // MARK: - Handoff Terminal Event
+
+    @Test @MainActor
+    func handoffTerminalEvent() {
+        let store = TraceStore()
+
+        store.ingest(makeEvent(eventId: "e1", requestId: "r1", sequence: 1, kind: "request_received"))
+        store.ingest(makeEvent(eventId: "e2", requestId: "r1", sequence: 2, kind: "llm_call_started"))
+        store.ingest(makeEvent(eventId: "e3", requestId: "r1", sequence: 3, kind: "generation_handoff", summary: "Handing off to next queued message"))
+
+        let status = store.requestGroupStatus(sessionId: "s1", requestId: "r1")
+        #expect(status == .handedOff)
+    }
+
     // MARK: - Cancellation Terminal Event
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- Add `.handedOff` case to `RequestGroupStatus` enum in `TraceStore.swift` and handle `generation_handoff` kind as terminal
- Render handed-off request groups with distinct icon (`arrow.right.arrow.left.circle.fill`), color (`Indigo._400`), and "Handed off" label in `TraceTimelineView.swift`
- Add `handoffTerminalEvent()` test verifying the new terminal status

## Test plan
- [x] `swift build --target vellum-assistantTests` compiles successfully (including new test)
- [x] `swift build --target VellumAssistantLib` compiles successfully
- [ ] `swift test` blocked by pre-existing iOS target UIKit issue (not related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
