### PR TITLE
feat(attachments): resolve sandbox vellum-attachment directives to payload drafts

### DIFF
--- a/assistant/src/__tests__/assistant-attachment-directive.test.ts
+++ b/assistant/src/__tests__/assistant-attachment-directive.test.ts
@@ -1,5 +1,14 @@
-import { describe, test, expect } from 'bun:test';
-import { parseDirectives } from '../daemon/assistant-attachments.js';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { parseDirectives, resolveSandboxDirective, type DirectiveRequest } from '../daemon/assistant-attachments.js';
+
+import { tmpdir } from 'node:os';
+
+// Use realpath to avoid macOS /tmp → /private/tmp symlink mismatches
+const RAW_TEST_DIR = join(tmpdir(), `vellum-sandbox-test-${Date.now()}`);
+mkdirSync(RAW_TEST_DIR, { recursive: true });
+const TEST_DIR = realpathSync(RAW_TEST_DIR);
 
 // ---------------------------------------------------------------------------
 // parseDirectives
@@ -148,5 +157,117 @@ describe('parseDirectives', () => {
     expect(result.directiveRequests[0].source).toBe('host');
     expect(result.directiveRequests[0].path).toBe('/tmp/data.csv');
     expect(result.directiveRequests[0].mimeType).toBe('text/csv');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSandboxDirective
+// ---------------------------------------------------------------------------
+
+describe('resolveSandboxDirective', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'sub'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  function makeDirective(overrides: Partial<DirectiveRequest> = {}): DirectiveRequest {
+    return {
+      source: 'sandbox',
+      path: 'hello.txt',
+      filename: undefined,
+      mimeType: undefined,
+      ...overrides,
+    };
+  }
+
+  test('resolves a valid sandbox file to a draft', () => {
+    const filePath = join(TEST_DIR, 'hello.txt');
+    writeFileSync(filePath, 'hello world');
+
+    const result = resolveSandboxDirective(makeDirective({ path: 'hello.txt' }), TEST_DIR);
+
+    expect(result.draft).not.toBeNull();
+    expect(result.warning).toBeNull();
+    expect(result.draft!.sourceType).toBe('sandbox_file');
+    expect(result.draft!.filename).toBe('hello.txt');
+    expect(result.draft!.mimeType).toBe('text/plain');
+    expect(result.draft!.sizeBytes).toBe(11);
+    expect(result.draft!.kind).toBe('document');
+  });
+
+  test('uses directive filename override when provided', () => {
+    writeFileSync(join(TEST_DIR, 'data.txt'), 'content');
+
+    const result = resolveSandboxDirective(
+      makeDirective({ path: 'data.txt', filename: 'custom-name.txt' }),
+      TEST_DIR,
+    );
+
+    expect(result.draft!.filename).toBe('custom-name.txt');
+  });
+
+  test('uses directive mimeType override when provided', () => {
+    writeFileSync(join(TEST_DIR, 'data.bin'), Buffer.from([1, 2, 3]));
+
+    const result = resolveSandboxDirective(
+      makeDirective({ path: 'data.bin', mimeType: 'application/x-custom' }),
+      TEST_DIR,
+    );
+
+    expect(result.draft!.mimeType).toBe('application/x-custom');
+  });
+
+  test('infers MIME type from extension', () => {
+    writeFileSync(join(TEST_DIR, 'image.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const result = resolveSandboxDirective(makeDirective({ path: 'image.png' }), TEST_DIR);
+
+    expect(result.draft!.mimeType).toBe('image/png');
+    expect(result.draft!.kind).toBe('image');
+  });
+
+  test('rejects paths that escape sandbox boundary', () => {
+    const result = resolveSandboxDirective(makeDirective({ path: '../../etc/passwd' }), TEST_DIR);
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('outside the working directory');
+  });
+
+  test('warns when file does not exist', () => {
+    const result = resolveSandboxDirective(makeDirective({ path: 'nonexistent.txt' }), TEST_DIR);
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('file not found');
+  });
+
+  test('warns when path is a directory', () => {
+    const result = resolveSandboxDirective(makeDirective({ path: 'sub' }), TEST_DIR);
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('not a regular file');
+  });
+
+  test('resolves relative subdirectory paths', () => {
+    writeFileSync(join(TEST_DIR, 'sub', 'nested.json'), '{"key":"value"}');
+
+    const result = resolveSandboxDirective(makeDirective({ path: 'sub/nested.json' }), TEST_DIR);
+
+    expect(result.draft).not.toBeNull();
+    expect(result.draft!.filename).toBe('nested.json');
+    expect(result.draft!.mimeType).toBe('application/json');
+  });
+
+  test('base64 encodes file content correctly', () => {
+    const content = 'test content';
+    writeFileSync(join(TEST_DIR, 'test.txt'), content);
+
+    const result = resolveSandboxDirective(makeDirective({ path: 'test.txt' }), TEST_DIR);
+
+    expect(result.draft).not.toBeNull();
+    const decoded = Buffer.from(result.draft!.dataBase64, 'base64').toString('utf-8');
+    expect(decoded).toBe(content);
   });
 });

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -5,6 +5,10 @@
  * directives, tool content blocks, and file reads.
  */
 
+import { basename } from 'node:path';
+import { readFileSync, statSync } from 'node:fs';
+import { sandboxPolicy } from '../tools/shared/filesystem/path-policy.js';
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -222,6 +226,86 @@ export function parseDirectives(text: string): DirectiveParseResult {
     cleanText: cleanText.replace(/\n{3,}/g, '\n\n').trim(),
     directiveRequests,
     parseWarnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox file resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolveResult {
+  draft: AssistantAttachmentDraft | null;
+  warning: string | null;
+}
+
+/**
+ * Resolve a sandbox directive to a draft attachment.
+ *
+ * Validates the path stays within the sandbox boundary, reads the file,
+ * base64-encodes it, and enforces the per-attachment size cap.
+ */
+export function resolveSandboxDirective(
+  directive: DirectiveRequest,
+  workingDir: string,
+): ResolveResult {
+  const pathResult = sandboxPolicy(directive.path, workingDir);
+  if (!pathResult.ok) {
+    return {
+      draft: null,
+      warning: `Skipped sandbox attachment "${directive.path}": ${pathResult.error}`,
+    };
+  }
+
+  const resolved = pathResult.resolved;
+
+  let stat;
+  try {
+    stat = statSync(resolved);
+  } catch {
+    return {
+      draft: null,
+      warning: `Skipped sandbox attachment "${directive.path}": file not found.`,
+    };
+  }
+
+  if (!stat.isFile()) {
+    return {
+      draft: null,
+      warning: `Skipped sandbox attachment "${directive.path}": not a regular file.`,
+    };
+  }
+
+  if (stat.size > MAX_ASSISTANT_ATTACHMENT_BYTES) {
+    return {
+      draft: null,
+      warning: `Skipped sandbox attachment "${directive.path}": size ${formatBytes(stat.size)} exceeds ${formatBytes(MAX_ASSISTANT_ATTACHMENT_BYTES)} limit.`,
+    };
+  }
+
+  let data: Buffer;
+  try {
+    data = readFileSync(resolved);
+  } catch (err) {
+    return {
+      draft: null,
+      warning: `Skipped sandbox attachment "${directive.path}": read error: ${(err as Error).message}`,
+    };
+  }
+
+  const filename = directive.filename ?? basename(resolved);
+  const mimeType = directive.mimeType ?? inferMimeType(filename);
+  const dataBase64 = data.toString('base64');
+
+  return {
+    draft: {
+      sourceType: 'sandbox_file',
+      filename,
+      mimeType,
+      dataBase64,
+      sizeBytes: data.length,
+      kind: classifyKind(mimeType),
+    },
+    warning: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `resolveSandboxDirective()` to convert sandbox directives into `AssistantAttachmentDraft` payloads
- Validates sandbox boundary via `sandboxPolicy`, reads/base64-encodes file, enforces 20 MB size cap
- Produces stable warning strings for missing files, directories, path escapes, and read errors

## Test plan
- [x] Valid sandbox file resolves to draft with correct fields
- [x] Filename/mimeType override from directive attributes
- [x] MIME inference from extension
- [x] Path traversal rejection (../../etc/passwd)
- [x] Missing file warning
- [x] Directory path warning
- [x] Nested subdirectory resolution
- [x] Base64 content round-trip verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
