### PR TITLE
feat(attachments): host vellum-attachment directives require approval

### DIFF
--- a/assistant/src/__tests__/assistant-attachment-directive.test.ts
+++ b/assistant/src/__tests__/assistant-attachment-directive.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
-import { parseDirectives, resolveSandboxDirective, type DirectiveRequest } from '../daemon/assistant-attachments.js';
+import { parseDirectives, resolveSandboxDirective, resolveHostDirective, type DirectiveRequest } from '../daemon/assistant-attachments.js';
 
 import { tmpdir } from 'node:os';
 
@@ -269,5 +269,125 @@ describe('resolveSandboxDirective', () => {
     expect(result.draft).not.toBeNull();
     const decoded = Buffer.from(result.draft!.dataBase64, 'base64').toString('utf-8');
     expect(decoded).toBe(content);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveHostDirective
+// ---------------------------------------------------------------------------
+
+describe('resolveHostDirective', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, 'host-sub'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  function makeHostDirective(overrides: Partial<DirectiveRequest> = {}): DirectiveRequest {
+    return {
+      source: 'host',
+      path: join(TEST_DIR, 'doc.txt'),
+      filename: undefined,
+      mimeType: undefined,
+      ...overrides,
+    };
+  }
+
+  const alwaysApprove = async () => true;
+  const alwaysDeny = async () => false;
+
+  test('resolves an approved host file to a draft', async () => {
+    const filePath = join(TEST_DIR, 'doc.txt');
+    writeFileSync(filePath, 'host content');
+
+    const result = await resolveHostDirective(makeHostDirective(), alwaysApprove);
+
+    expect(result.draft).not.toBeNull();
+    expect(result.warning).toBeNull();
+    expect(result.draft!.sourceType).toBe('host_file');
+    expect(result.draft!.filename).toBe('doc.txt');
+    expect(result.draft!.mimeType).toBe('text/plain');
+    expect(result.draft!.sizeBytes).toBe(12);
+  });
+
+  test('skips when user denies', async () => {
+    writeFileSync(join(TEST_DIR, 'secret.txt'), 'private');
+
+    const result = await resolveHostDirective(
+      makeHostDirective({ path: join(TEST_DIR, 'secret.txt') }),
+      alwaysDeny,
+    );
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('access denied by user');
+  });
+
+  test('rejects relative paths', async () => {
+    const result = await resolveHostDirective(
+      makeHostDirective({ path: 'relative/path.txt' }),
+      alwaysApprove,
+    );
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('must be absolute');
+  });
+
+  test('warns when file does not exist', async () => {
+    const result = await resolveHostDirective(
+      makeHostDirective({ path: join(TEST_DIR, 'nonexistent.txt') }),
+      alwaysApprove,
+    );
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('file not found');
+  });
+
+  test('warns when path is a directory', async () => {
+    const result = await resolveHostDirective(
+      makeHostDirective({ path: join(TEST_DIR, 'host-sub') }),
+      alwaysApprove,
+    );
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('not a regular file');
+  });
+
+  test('uses directive filename and mimeType overrides', async () => {
+    writeFileSync(join(TEST_DIR, 'data.bin'), Buffer.from([1, 2, 3]));
+
+    const result = await resolveHostDirective(
+      makeHostDirective({
+        path: join(TEST_DIR, 'data.bin'),
+        filename: 'custom.dat',
+        mimeType: 'application/x-custom',
+      }),
+      alwaysApprove,
+    );
+
+    expect(result.draft!.filename).toBe('custom.dat');
+    expect(result.draft!.mimeType).toBe('application/x-custom');
+  });
+
+  test('handles approval callback error gracefully', async () => {
+    writeFileSync(join(TEST_DIR, 'doc.txt'), 'content');
+
+    const failApprove = async () => { throw new Error('IPC disconnected'); };
+    const result = await resolveHostDirective(makeHostDirective(), failApprove);
+
+    expect(result.draft).toBeNull();
+    expect(result.warning).toContain('approval request failed');
+  });
+
+  test('calls approve with the resolved absolute path', async () => {
+    writeFileSync(join(TEST_DIR, 'doc.txt'), 'content');
+
+    let approvedPath = '';
+    const captureApprove = async (p: string) => { approvedPath = p; return true; };
+
+    await resolveHostDirective(makeHostDirective(), captureApprove);
+
+    expect(approvedPath).toBe(join(TEST_DIR, 'doc.txt'));
   });
 });

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -7,7 +7,7 @@
 
 import { basename } from 'node:path';
 import { readFileSync, statSync } from 'node:fs';
-import { sandboxPolicy } from '../tools/shared/filesystem/path-policy.js';
+import { sandboxPolicy, hostPolicy } from '../tools/shared/filesystem/path-policy.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -299,6 +299,105 @@ export function resolveSandboxDirective(
   return {
     draft: {
       sourceType: 'sandbox_file',
+      filename,
+      mimeType,
+      dataBase64,
+      sizeBytes: data.length,
+      kind: classifyKind(mimeType),
+    },
+    warning: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Host file resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Callback the caller provides to approve host file reads.
+ * Returns `true` to allow, `false` to deny/skip.
+ */
+export type ApproveHostRead = (filePath: string) => Promise<boolean>;
+
+/**
+ * Resolve a host directive to a draft attachment.
+ *
+ * Requires an absolute path. Before reading, calls the `approve` callback
+ * so the session layer can gate access via the user-facing permission prompt.
+ */
+export async function resolveHostDirective(
+  directive: DirectiveRequest,
+  approve: ApproveHostRead,
+): Promise<ResolveResult> {
+  const pathResult = hostPolicy(directive.path);
+  if (!pathResult.ok) {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": ${pathResult.error}`,
+    };
+  }
+
+  const resolved = pathResult.resolved;
+
+  // Gate on user approval before touching the filesystem
+  let approved: boolean;
+  try {
+    approved = await approve(resolved);
+  } catch {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": approval request failed.`,
+    };
+  }
+
+  if (!approved) {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": access denied by user.`,
+    };
+  }
+
+  let stat;
+  try {
+    stat = statSync(resolved);
+  } catch {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": file not found.`,
+    };
+  }
+
+  if (!stat.isFile()) {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": not a regular file.`,
+    };
+  }
+
+  if (stat.size > MAX_ASSISTANT_ATTACHMENT_BYTES) {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": size ${formatBytes(stat.size)} exceeds ${formatBytes(MAX_ASSISTANT_ATTACHMENT_BYTES)} limit.`,
+    };
+  }
+
+  let data: Buffer;
+  try {
+    data = readFileSync(resolved);
+  } catch (err) {
+    return {
+      draft: null,
+      warning: `Skipped host attachment "${directive.path}": read error: ${(err as Error).message}`,
+    };
+  }
+
+  const filename = directive.filename ?? basename(resolved);
+  const mimeType = directive.mimeType ?? inferMimeType(filename);
+  const dataBase64 = data.toString('base64');
+
+  return {
+    draft: {
+      sourceType: 'host_file',
       filename,
       mimeType,
       dataBase64,


### PR DESCRIPTION
## Summary
- Add `resolveHostDirective()` with async approval callback for gated host file access
- Validates absolute path via `hostPolicy`, calls `approve(filePath)` before any filesystem read
- Deny/timeout/callback-error paths produce user-visible warnings; no silent failures
- Callback pattern keeps module decoupled from the IPC/permission layer

## Test plan
- [x] Approved host file resolves to draft with correct fields
- [x] Denied host file produces warning
- [x] Relative path rejection
- [x] Missing file warning
- [x] Directory path warning
- [x] Filename/mimeType overrides
- [x] Approval callback error handling
- [x] Approve callback receives the resolved absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
