### PR TITLE
chore: API/docs cleanup and regression lock-in

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -731,7 +731,13 @@ The daemon emits two distinct error message types over IPC:
 
 ### Error Classification
 
-The daemon classifies errors via `classifySessionError()` in `session-error.ts`. Before classification, `isUserCancellation()` checks whether the error is a user-initiated abort (active abort signal or `AbortError`); if so, the daemon emits `generation_cancelled` instead of `session_error`. Classification uses regex pattern matching against the error message to detect network failures, rate limits, and provider API errors, with phase-specific overrides for queue and regeneration contexts.
+The daemon classifies errors via `classifySessionError()` in `session-error.ts`. Before classification, `isUserCancellation()` checks whether the error is a user-initiated abort (active abort signal or `AbortError`); if so, the daemon emits `generation_cancelled` instead of `session_error` — cancel never surfaces a session-error toast.
+
+Classification uses a two-tier strategy:
+1. **Structured provider errors**: If the error is a `ProviderError` with a `statusCode`, the status code determines the category deterministically — `429` maps to `PROVIDER_RATE_LIMIT` (retryable), `5xx` to `PROVIDER_API` (retryable), other `4xx` to `PROVIDER_API` (not retryable).
+2. **Regex fallback**: For non-provider errors or `ProviderError` without a status code, regex pattern matching against the error message detects network failures, rate limits, and API errors. Phase-specific overrides handle queue and regeneration contexts.
+
+Debug details are capped at 4,000 characters to prevent oversized IPC payloads.
 
 ### Error → Toast → Recovery Flow
 
@@ -745,11 +751,12 @@ sequenceDiagram
     Note over Daemon: LLM call fails or<br/>processing error occurs
     Daemon->>Daemon: classifySessionError(error, ctx)
     Daemon->>DC: session_error {sessionId, code,<br/>userMessage, retryable, debugDetails?}
-    DC->>VM: onSessionError callback
+    DC->>DC: broadcast to all subscribers
+    DC->>VM: subscribe() stream delivers message
     VM->>VM: set sessionError property<br/>clear isThinking / isCancelling
     VM-->>UI: @Published sessionError observed
 
-    UI->>UI: show sessionErrorToast<br/>[Retry] [Dismiss]
+    UI->>UI: show sessionErrorToast<br/>[Retry] [Dismiss] [Copy Debug Info?]
 
     alt User taps Retry (retryable == true)
         UI->>VM: retryAfterSessionError()
@@ -762,10 +769,11 @@ sequenceDiagram
     end
 ```
 
-1. **Daemon** encounters a session-scoped failure, classifies it via `classifySessionError()`, and sends a `session_error` IPC message with the session ID, typed error code, user-facing message, retryable flag, and optional debug details.
-2. **ChatViewModel** receives the error via the `onSessionError` callback, sets the `sessionError` property, and transitions out of the streaming/loading state so the UI is interactive.
+1. **Daemon** encounters a session-scoped failure, classifies it via `classifySessionError()`, and sends a `session_error` IPC message with the session ID, typed error code, user-facing message, retryable flag, and optional debug details. Session-scoped failures emit *only* `session_error` (never the generic `error` type) to prevent cross-session bleed.
+2. **ChatViewModel** receives the error via DaemonClient's `subscribe()` stream (each view model gets an independent stream), sets the `sessionError` property, and transitions out of the streaming/loading state so the UI is interactive. If the error arrives during an active cancel (`wasCancelling == true`), it is suppressed — cancel only shows `generation_cancelled` behavior.
 3. **ChatView** observes the published `sessionError` and displays an actionable toast with a category-specific icon and accent color:
    - **Retry** (shown when `retryable` is true): calls `retryAfterSessionError()`, which clears the error and sends a `regenerate` message to the daemon.
+   - **Copy Debug Info** (shown when `debugDetails` is non-nil): copies structured debug information to the clipboard for bug reports.
    - **Dismiss (X)**: calls `dismissSessionError()` to clear the error without retrying.
 4. If the error is not retryable, the Retry button is hidden and the user can only dismiss.
 

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1033,3 +1033,80 @@ describe('Terminal trace events on rejection/failure', () => {
     await new Promise((r) => setTimeout(r, 50));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: cancel semantics + session/global error channel split
+// ---------------------------------------------------------------------------
+
+describe('Regression: cancel semantics and error channel split', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('user cancellation emits generation_cancelled, never session_error', async () => {
+    const msgEvents: ServerMessage[] = [];
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // Start processing a message — collect events from the per-message callback
+    const p1 = session.processMessage('msg-1', [], (e) => msgEvents.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // User cancels — sets the abort signal
+    session.abort();
+
+    // Resolve the pending run so the abort-check path fires
+    resolveRun(0);
+    await p1;
+
+    // generation_cancelled should be emitted via the per-message callback
+    const cancelEvent = msgEvents.find((e) => e.type === 'generation_cancelled');
+    expect(cancelEvent).toBeDefined();
+
+    // session_error must never appear on cancel
+    const sessionErr = msgEvents.find((e) => e.type === 'session_error');
+    expect(sessionErr).toBeUndefined();
+  });
+
+  test('provider failure during processing emits session_error only', async () => {
+    const allEvents: ServerMessage[] = [];
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const p1 = session.processMessage('msg-1', [], (e) => allEvents.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Simulate a provider failure
+    pendingRuns[0].reject(new Error('Connection refused'));
+    await p1;
+
+    // Should get session_error (structured)
+    const sessionErr = allEvents.find((e) => e.type === 'session_error');
+    expect(sessionErr).toBeDefined();
+
+    // Must not get generic error — session failures are session_error only
+    const genericErr = allEvents.find((e) => e.type === 'error');
+    expect(genericErr).toBeUndefined();
+  });
+
+  test('cancel after queued messages produces no session_error for any queued entry', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const eventsPerMsg: ServerMessage[][] = [[], [], []];
+
+    session.processMessage('msg-1', [], (e) => eventsPerMsg[0].push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    session.enqueueMessage('msg-2', [], (e) => eventsPerMsg[1].push(e), 'req-2');
+    session.enqueueMessage('msg-3', [], (e) => eventsPerMsg[2].push(e), 'req-3');
+
+    session.abort();
+
+    // No queued message should have received session_error
+    for (const events of eventsPerMsg) {
+      const sessionErr = events.find((e) => e.type === 'session_error');
+      expect(sessionErr).toBeUndefined();
+    }
+  });
+});

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1457,4 +1457,65 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.sessionError?.debugDetails,
                       "debugDetails should be nil when not provided in IPC message")
     }
+
+    // MARK: - Regression: Cancel semantics and error channel split
+
+    func testCancelSuppressesAllSessionErrorFields() {
+        // Regression: cancel must suppress both errorText AND typed sessionError
+        viewModel.sessionId = "sess-1"
+        viewModel.isCancelling = true
+
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerApi,
+            userMessage: "Server error",
+            retryable: true,
+            debugDetails: "stack trace here"
+        )
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNil(viewModel.sessionError,
+                      "Typed sessionError must be nil during cancel")
+        XCTAssertNil(viewModel.errorText,
+                      "errorText must be nil during cancel")
+    }
+
+    func testSessionErrorDeliveredViaStreamNotCallback() {
+        // Regression: session errors arrive through handleServerMessage (stream),
+        // not through a singleton callback on DaemonClient.
+        viewModel.sessionId = "sess-1"
+
+        let errorMsg = SessionErrorMessage(
+            sessionId: "sess-1",
+            code: .providerRateLimit,
+            userMessage: "Rate limited",
+            retryable: true
+        )
+
+        // Deliver via the same path the subscribe() stream uses
+        viewModel.handleServerMessage(.sessionError(errorMsg))
+
+        XCTAssertNotNil(viewModel.sessionError,
+                         "sessionError should be set via handleServerMessage")
+        XCTAssertEqual(viewModel.sessionError?.category, .rateLimit)
+        XCTAssertEqual(viewModel.sessionError?.isRetryable, true)
+    }
+
+    func testGenerationCancelledClearsThinkingState() {
+        // Regression: generation_cancelled should clear thinking/sending state
+        viewModel.sessionId = "sess-1"
+        viewModel.isThinking = true
+        viewModel.isSending = true
+
+        viewModel.handleServerMessage(.generationCancelled(
+            GenerationCancelledMessage(sessionId: "sess-1")
+        ))
+
+        XCTAssertFalse(viewModel.isThinking,
+                        "generation_cancelled should clear isThinking")
+        XCTAssertFalse(viewModel.isSending,
+                        "generation_cancelled should clear isSending")
+        XCTAssertNil(viewModel.sessionError,
+                      "generation_cancelled should not set sessionError")
+    }
 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -124,9 +124,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `history_response` message.
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
-    /// Called when the daemon sends a `session_error` message with typed error information.
-    public var onSessionError: ((SessionErrorMessage) -> Void)?
-
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
@@ -759,8 +756,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             onHistoryResponse?(msg)
         case .traceEvent(let msg):
             onTraceEvent?(msg)
-        case .sessionError(let msg):
-            onSessionError?(msg)
         case .error(let msg):
             onError?(msg)
         #if os(macOS)


### PR DESCRIPTION
## Summary
- Remove unused `onSessionError` singleton callback from `DaemonClient.swift` — stream subscribers (`subscribe()`) are the actual delivery mechanism
- Update `ARCHITECTURE.md` to reflect the final error channel split (session-only `session_error`, no generic `error` for session failures), cancel semantics (cancel never surfaces a toast), ProviderError-first classification, Copy Debug Info UX, and stream-based message delivery
- Add TS regression tests: cancel emits `generation_cancelled` never `session_error`, provider failure emits `session_error` only, cancel with queued messages produces no `session_error`
- Add Swift regression tests: cancel suppresses all error fields, errors delivered via stream not callback, `generation_cancelled` clears thinking state

## Test plan
- [x] 28/28 TS session-queue tests pass (3 new regression tests)
- [x] Swift test target compiles (221/221 objects, 3 new regression tests)
- [x] Verified `onSessionError` has no external consumers before removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
