### PR TITLE
feat(session): assemble assistant attachment candidates from directives and tool blocks

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -4,6 +4,9 @@ import {
   inferMimeType,
   classifyKind,
   validateDrafts,
+  cleanAssistantContent,
+  contentBlocksToDrafts,
+  deduplicateDrafts,
   MAX_ASSISTANT_ATTACHMENTS,
   MAX_ASSISTANT_ATTACHMENT_BYTES,
   type AssistantAttachmentDraft,
@@ -159,5 +162,134 @@ describe('validateDrafts', () => {
     const result = validateDrafts([]);
     expect(result.accepted).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanAssistantContent
+// ---------------------------------------------------------------------------
+
+describe('cleanAssistantContent', () => {
+  test('strips directives from text blocks and returns them', () => {
+    const content = [
+      { type: 'text', text: 'Here is the file:\n<vellum-attachment path="out.png" />' },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.directives).toHaveLength(1);
+    expect(result.directives[0].path).toBe('out.png');
+    expect((result.cleanedContent[0] as { text: string }).text).toBe('Here is the file:');
+  });
+
+  test('leaves non-text blocks unchanged', () => {
+    const content = [
+      { type: 'tool_use', id: 't1', name: 'read', input: {} },
+      { type: 'text', text: '<vellum-attachment path="x.pdf" />' },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.cleanedContent[0]).toEqual(content[0]);
+    expect(result.directives).toHaveLength(1);
+  });
+
+  test('accumulates warnings for malformed tags', () => {
+    const content = [
+      { type: 'text', text: '<vellum-attachment source="bad" path="x.txt" />' },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('invalid source');
+  });
+
+  test('handles content with no text blocks', () => {
+    const content = [
+      { type: 'thinking', thinking: 'hmm', signature: 'sig' },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.cleanedContent).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contentBlocksToDrafts
+// ---------------------------------------------------------------------------
+
+describe('contentBlocksToDrafts', () => {
+  test('converts image content block to draft', () => {
+    const blocks = [
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' },
+      },
+    ];
+    const drafts = contentBlocksToDrafts(blocks);
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].sourceType).toBe('tool_block');
+    expect(drafts[0].filename).toBe('tool-output.png');
+    expect(drafts[0].mimeType).toBe('image/png');
+    expect(drafts[0].kind).toBe('image');
+  });
+
+  test('converts file content block to draft', () => {
+    const blocks = [
+      {
+        type: 'file',
+        source: { type: 'base64', media_type: 'application/pdf', data: 'JVBER', filename: 'report.pdf' },
+      },
+    ];
+    const drafts = contentBlocksToDrafts(blocks);
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].sourceType).toBe('tool_block');
+    expect(drafts[0].filename).toBe('report.pdf');
+    expect(drafts[0].kind).toBe('document');
+  });
+
+  test('skips non-image/file blocks', () => {
+    const blocks = [
+      { type: 'text', text: 'hello' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: '/9j/' } },
+    ];
+    const drafts = contentBlocksToDrafts(blocks);
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].mimeType).toBe('image/jpeg');
+  });
+
+  test('returns empty for empty input', () => {
+    expect(contentBlocksToDrafts([])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateDrafts
+// ---------------------------------------------------------------------------
+
+describe('deduplicateDrafts', () => {
+  test('removes duplicates by filename + content prefix', () => {
+    const d = makeDraft({ filename: 'same.txt', dataBase64: 'AAAA'.repeat(20) });
+    const result = deduplicateDrafts([d, { ...d }, makeDraft({ filename: 'other.txt' })]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].filename).toBe('same.txt');
+    expect(result[1].filename).toBe('other.txt');
+  });
+
+  test('keeps drafts with same filename but different content', () => {
+    const d1 = makeDraft({ filename: 'file.txt', dataBase64: 'AAAA'.repeat(20) });
+    const d2 = makeDraft({ filename: 'file.txt', dataBase64: 'BBBB'.repeat(20) });
+    const result = deduplicateDrafts([d1, d2]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns empty for empty input', () => {
+    expect(deduplicateDrafts([])).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -409,6 +409,141 @@ export async function resolveHostDirective(
 }
 
 // ---------------------------------------------------------------------------
+// Batch directive resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an array of parsed directives to attachment drafts.
+ *
+ * Sandbox directives are resolved synchronously; host directives go through
+ * the async approval callback.
+ */
+export async function resolveDirectives(
+  directives: DirectiveRequest[],
+  workingDir: string,
+  approveHostRead: ApproveHostRead,
+): Promise<{ drafts: AssistantAttachmentDraft[]; warnings: string[] }> {
+  const drafts: AssistantAttachmentDraft[] = [];
+  const warnings: string[] = [];
+
+  for (const d of directives) {
+    const result = d.source === 'sandbox'
+      ? resolveSandboxDirective(d, workingDir)
+      : await resolveHostDirective(d, approveHostRead);
+    if (result.draft) drafts.push(result.draft);
+    if (result.warning) warnings.push(result.warning);
+  }
+
+  return { drafts, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Tool content block → draft conversion
+// ---------------------------------------------------------------------------
+
+interface ImageBlock {
+  type: 'image';
+  source: { type: 'base64'; media_type: string; data: string };
+}
+
+interface FileBlock {
+  type: 'file';
+  source: { type: 'base64'; media_type: string; data: string; filename: string };
+}
+
+/**
+ * Convert tool content blocks (images/files from tool results) into
+ * attachment drafts. Blocks that aren't image or file types are skipped.
+ */
+export function contentBlocksToDrafts(
+  blocks: readonly unknown[],
+): AssistantAttachmentDraft[] {
+  const drafts: AssistantAttachmentDraft[] = [];
+
+  for (const block of blocks) {
+    const b = block as Record<string, unknown>;
+    if (b.type === 'image') {
+      const src = b.source as ImageBlock['source'];
+      const data = src.data;
+      const mimeType = src.media_type;
+      const ext = mimeType.split('/')[1] ?? 'png';
+      drafts.push({
+        sourceType: 'tool_block',
+        filename: `tool-output.${ext}`,
+        mimeType,
+        dataBase64: data,
+        sizeBytes: estimateBase64Bytes(data),
+        kind: 'image',
+      });
+    } else if (b.type === 'file') {
+      const src = b.source as FileBlock['source'];
+      const data = src.data;
+      const mimeType = src.media_type;
+      const filename = src.filename;
+      drafts.push({
+        sourceType: 'tool_block',
+        filename,
+        mimeType,
+        dataBase64: data,
+        sizeBytes: estimateBase64Bytes(data),
+        kind: classifyKind(mimeType),
+      });
+    }
+  }
+
+  return drafts;
+}
+
+// ---------------------------------------------------------------------------
+// Content cleaning: strip directives from assistant text blocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse directives from assistant content blocks, returning cleaned content
+ * (tags stripped) and all accumulated directive requests + warnings.
+ */
+export function cleanAssistantContent(
+  content: readonly unknown[],
+): {
+  cleanedContent: unknown[];
+  directives: DirectiveRequest[];
+  warnings: string[];
+} {
+  const directives: DirectiveRequest[] = [];
+  const warnings: string[] = [];
+
+  const cleanedContent = content.map((block) => {
+    const b = block as Record<string, unknown>;
+    if (b.type !== 'text') return block;
+    const text = b.text as string;
+    const result = parseDirectives(text);
+    directives.push(...result.directiveRequests);
+    warnings.push(...result.parseWarnings);
+    return { ...b, text: result.cleanText };
+  });
+
+  return { cleanedContent, directives, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// De-duplication
+// ---------------------------------------------------------------------------
+
+/**
+ * De-duplicate drafts by filename + content hash (first 64 chars of base64
+ * as a cheap proxy for content identity).
+ */
+export function deduplicateDrafts(drafts: AssistantAttachmentDraft[]): AssistantAttachmentDraft[] {
+  const seen = new Set<string>();
+  return drafts.filter((d) => {
+    const key = `${d.filename}:${d.dataBase64.slice(0, 64)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Formatting helpers
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -56,6 +56,16 @@ import {
   resolveSlashSkillCommand,
   rewriteKnownSlashCommandPrompt,
 } from '../skills/slash-commands.js';
+import {
+  cleanAssistantContent,
+  resolveDirectives,
+  contentBlocksToDrafts,
+  deduplicateDrafts,
+  validateDrafts,
+  type DirectiveRequest,
+  type AssistantAttachmentDraft,
+  type ApproveHostRead,
+} from './assistant-attachments.js';
 
 const log = getLogger('session');
 
@@ -110,6 +120,11 @@ export class Session {
   private surfaceState = new Map<string, { surfaceType: SurfaceType; data: SurfaceData }>();
   private onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
   public readonly traceEmitter: TraceEmitter;
+
+  /** Resolved assistant attachment drafts from the most recent exchange. */
+  public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
+  /** Warnings from directive parsing/resolution for the most recent exchange. */
+  public lastAttachmentWarnings: string[] = [];
 
   constructor(
     conversationId: string,
@@ -539,6 +554,9 @@ export class Session {
       let runMessages = this.messages;
       const pendingToolResults = new Map<string, { content: string; isError: boolean; contentBlocks?: ContentBlock[] }>();
       const persistedToolUseIds = new Set<string>();
+      const accumulatedDirectives: DirectiveRequest[] = [];
+      const accumulatedToolContentBlocks: ContentBlock[] = [];
+      const directiveWarnings: string[] = [];
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
@@ -642,6 +660,14 @@ export class Session {
             const imageBlock = event.contentBlocks?.find((b): b is ImageContent => b.type === 'image');
             onEvent({ type: 'tool_result', toolName: '', result: event.content, isError: event.isError, diff: event.diff, status: event.status, sessionId: this.conversationId, imageData: imageBlock?.source.data });
             pendingToolResults.set(event.toolUseId, { content: event.content, isError: event.isError, contentBlocks: event.contentBlocks });
+            // Collect image/file content blocks for assistant attachment conversion
+            if (event.contentBlocks) {
+              for (const cb of event.contentBlocks) {
+                if (cb.type === 'image' || cb.type === 'file') {
+                  accumulatedToolContentBlocks.push(cb);
+                }
+              }
+            }
             break;
           }
           case 'error':
@@ -676,19 +702,25 @@ export class Session {
               }
               pendingToolResults.clear();
             }
-            // Save assistant message to DB
+            // Parse and strip attachment directives from assistant text
+            const { cleanedContent, directives: msgDirectives, warnings: msgWarnings } =
+              cleanAssistantContent(event.message.content);
+            accumulatedDirectives.push(...msgDirectives);
+            directiveWarnings.push(...msgWarnings);
+
+            // Save assistant message with cleaned content (tags stripped)
             conversationStore.addMessage(
               this.conversationId,
               'assistant',
-              JSON.stringify(event.message.content),
+              JSON.stringify(cleanedContent),
             );
 
             // Emit assistant_message trace with content metrics.
             // Char count only includes text blocks; thinking blocks are
             // explicitly excluded from traces.
-            const charCount = event.message.content
-              .filter((b) => b.type === 'text')
-              .reduce((sum, b) => sum + ((b as { type: 'text'; text: string }).text?.length ?? 0), 0);
+            const charCount = cleanedContent
+              .filter((b) => (b as Record<string, unknown>).type === 'text')
+              .reduce((sum: number, b) => sum + ((b as { text?: string }).text?.length ?? 0), 0);
             const toolUseCount = event.message.content
               .filter((b) => b.type === 'tool_use')
               .length;
@@ -828,6 +860,31 @@ export class Session {
       void getHookManager().trigger('post-message', {
         sessionId: this.conversationId,
       });
+
+      // Resolve accumulated attachment directives and tool content blocks
+      let assistantAttachments: AssistantAttachmentDraft[] = [];
+      if (accumulatedDirectives.length > 0 || accumulatedToolContentBlocks.length > 0) {
+        const approveHostRead: ApproveHostRead = async (_filePath) => {
+          // TODO(PR-6+): Wire to permission prompter for interactive approval
+          return false;
+        };
+
+        const directiveDrafts = accumulatedDirectives.length > 0
+          ? await resolveDirectives(accumulatedDirectives, this.workingDir, approveHostRead)
+          : { drafts: [], warnings: [] };
+        directiveWarnings.push(...directiveDrafts.warnings);
+
+        const toolDrafts = contentBlocksToDrafts(accumulatedToolContentBlocks);
+
+        const merged = deduplicateDrafts([...directiveDrafts.drafts, ...toolDrafts]);
+        const validated = validateDrafts(merged);
+        directiveWarnings.push(...validated.warnings);
+        assistantAttachments = validated.accepted;
+      }
+
+      // Store resolved attachments on the session for PR 6 (persistence)
+      this.lastAssistantAttachments = assistantAttachments;
+      this.lastAttachmentWarnings = directiveWarnings;
 
       if (yieldedForHandoff) {
         this.traceEmitter.emit('generation_handoff', 'Handing off to next queued message', {


### PR DESCRIPTION
## Summary
- Parse `<vellum-attachment />` directives from assistant text and strip them before persistence
- Accumulate directive requests and tool content blocks (images/files) during the agent loop
- After loop completion: resolve directives, convert tool blocks, de-duplicate, validate caps
- Store resolved drafts as `session.lastAssistantAttachments` for persistence in PR 6

## Test plan
- [x] `cleanAssistantContent`: strips directives, preserves non-text blocks, accumulates warnings
- [x] `contentBlocksToDrafts`: image blocks, file blocks, skip non-image/file, empty input
- [x] `deduplicateDrafts`: same name+content removed, different content kept, empty input
- [x] All 59 attachment tests pass across both test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
