### PR TITLE
feat(storage): persist assistant attachments and link to assistant message rows

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -10,6 +10,7 @@ import type { CheckpointDecision } from '../agent/loop.js';
 import type { Provider } from '../providers/types.js';
 import { createUserMessage, createAssistantMessage } from '../agent/message-types.js';
 import * as conversationStore from '../memory/conversation-store.js';
+import { uploadAttachment, linkAttachmentToMessage } from '../memory/attachments-store.js';
 import { getApp } from '../memory/app-store.js';
 import { PermissionPrompter } from '../permissions/prompter.js';
 import { SecretPrompter } from '../permissions/secret-prompter.js';
@@ -557,6 +558,7 @@ export class Session {
       const accumulatedDirectives: DirectiveRequest[] = [];
       const accumulatedToolContentBlocks: ContentBlock[] = [];
       const directiveWarnings: string[] = [];
+      let lastAssistantMessageId: string | undefined;
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
@@ -709,11 +711,12 @@ export class Session {
             directiveWarnings.push(...msgWarnings);
 
             // Save assistant message with cleaned content (tags stripped)
-            conversationStore.addMessage(
+            const assistantMsg = conversationStore.addMessage(
               this.conversationId,
               'assistant',
               JSON.stringify(cleanedContent),
             );
+            lastAssistantMessageId = assistantMsg.id;
 
             // Emit assistant_message trace with content metrics.
             // Char count only includes text blocks; thinking blocks are
@@ -882,7 +885,23 @@ export class Session {
         assistantAttachments = validated.accepted;
       }
 
-      // Store resolved attachments on the session for PR 6 (persistence)
+      // Persist resolved attachments and link to the last assistant message
+      if (assistantAttachments.length > 0 && lastAssistantMessageId) {
+        const assistantId = getApp()?.id;
+        if (assistantId) {
+          for (let i = 0; i < assistantAttachments.length; i++) {
+            const draft = assistantAttachments[i];
+            const stored = uploadAttachment(
+              assistantId,
+              draft.filename,
+              draft.mimeType,
+              draft.dataBase64,
+            );
+            linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
+          }
+        }
+      }
+
       this.lastAssistantAttachments = assistantAttachments;
       this.lastAttachmentWarnings = directiveWarnings;
 

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -133,3 +133,35 @@ export function linkAttachmentToMessage(
     })
     .run();
 }
+
+/**
+ * Return all attachments linked to a message, ordered by position.
+ */
+export function getAttachmentsForMessage(
+  messageId: string,
+  assistantId: string,
+): Array<StoredAttachment & { dataBase64: string }> {
+  const db = getDb();
+  const links = db
+    .select({ attachmentId: messageAttachments.attachmentId, position: messageAttachments.position })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.messageId, messageId))
+    .orderBy(messageAttachments.position)
+    .all();
+
+  if (links.length === 0) return [];
+
+  const ids = links.map((l) => l.attachmentId).filter((id): id is string => id !== null);
+  return getAttachmentsByIds(assistantId, ids);
+}
+
+/**
+ * Retrieve a single attachment by ID, scoped to an assistant.
+ */
+export function getAttachmentById(
+  assistantId: string,
+  attachmentId: string,
+): (StoredAttachment & { dataBase64: string }) | null {
+  const results = getAttachmentsByIds(assistantId, [attachmentId]);
+  return results[0] ?? null;
+}


### PR DESCRIPTION
## Summary
- Upload accepted attachment drafts to the attachment store after agent loop completion
- Link each stored attachment to the last assistant message with deterministic position ordering
- Add `getAttachmentsForMessage(messageId, assistantId)` for position-ordered retrieval
- Add `getAttachmentById(assistantId, attachmentId)` for single-attachment lookup

## Test plan
- [x] Existing attachment store tests continue to pass
- [x] All 59 attachment unit tests pass
- [x] New store methods follow existing query patterns (assistant ID scoping, drizzle ORM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
