### PR TITLE
feat(ipc): add assistant attachment fields to message_complete generation_handoff history_response

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -468,6 +468,13 @@ exports[`IPC message snapshots ServerMessage types confirmation_request serializ
 
 exports[`IPC message snapshots ServerMessage types message_complete serializes to expected JSON 1`] = `
 {
+  "attachments": [
+    {
+      "data": "iVBORw0K",
+      "filename": "chart.png",
+      "mimeType": "image/png",
+    },
+  ],
   "sessionId": "sess-001",
   "type": "message_complete",
 }
@@ -528,6 +535,13 @@ exports[`IPC message snapshots ServerMessage types generation_cancelled serializ
 
 exports[`IPC message snapshots ServerMessage types generation_handoff serializes to expected JSON 1`] = `
 {
+  "attachments": [
+    {
+      "data": "JVBER",
+      "filename": "report.pdf",
+      "mimeType": "application/pdf",
+    },
+  ],
   "queuedCount": 2,
   "requestId": "req-handoff-001",
   "sessionId": "sess-001",
@@ -552,6 +566,13 @@ exports[`IPC message snapshots ServerMessage types history_response serializes t
       "timestamp": 1700000000,
     },
     {
+      "attachments": [
+        {
+          "data": "iVBORw0K",
+          "filename": "result.png",
+          "mimeType": "image/png",
+        },
+      ],
       "role": "assistant",
       "text": "Hi there!",
       "timestamp": 1700000001,

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -311,6 +311,9 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   message_complete: {
     type: 'message_complete',
     sessionId: 'sess-001',
+    attachments: [
+      { filename: 'chart.png', mimeType: 'image/png', data: 'iVBORw0K' },
+    ],
   },
   session_info: {
     type: 'session_info',
@@ -344,6 +347,9 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: 'sess-001',
     requestId: 'req-handoff-001',
     queuedCount: 2,
+    attachments: [
+      { filename: 'report.pdf', mimeType: 'application/pdf', data: 'JVBER' },
+    ],
   },
   model_info: {
     type: 'model_info',
@@ -355,7 +361,14 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: 'sess-history-001',
     messages: [
       { role: 'user', text: 'Hello', timestamp: 1700000000 },
-      { role: 'assistant', text: 'Hi there!', timestamp: 1700000001 },
+      {
+        role: 'assistant',
+        text: 'Hi there!',
+        timestamp: 1700000001,
+        attachments: [
+          { filename: 'result.png', mimeType: 'image/png', data: 'iVBORw0K' },
+        ],
+      },
     ],
   },
   undo_complete: {

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -504,6 +504,7 @@ export interface SecretRequest {
 export interface MessageComplete {
   type: 'message_complete';
   sessionId?: string;
+  attachments?: UserMessageAttachment[];
 }
 
 export interface SessionInfo {
@@ -541,6 +542,7 @@ export interface GenerationHandoff {
   sessionId: string;
   requestId?: string;
   queuedCount: number;
+  attachments?: UserMessageAttachment[];
 }
 
 export interface ModelInfo {
@@ -566,6 +568,7 @@ export interface HistoryResponse {
     text: string;
     timestamp: number;
     toolCalls?: HistoryResponseToolCall[];
+    attachments?: UserMessageAttachment[];
   }>;
 }
 


### PR DESCRIPTION
## Summary
- Add optional `attachments?: UserMessageAttachment[]` to `MessageComplete`, `GenerationHandoff`, and `HistoryResponse.messages[]`
- Reuses existing `UserMessageAttachment` shape for wire compatibility
- All fields optional — existing clients decode without changes
- IPC snapshot tests updated and green; contract inventory unchanged

## Test plan
- [x] IPC snapshot tests updated with attachment examples (106 tests pass)
- [x] Contract inventory check passes (types/wire strings unchanged)
- [x] Fields are optional — no breaking change for existing clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
