### PR TITLE
fix: convert remaining generic error emissions to session_error

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -466,7 +466,6 @@ async function handleUserMessage(
         status: 'error',
         attributes: { reason: 'queue_full', queueDepth: session.getQueueDepth() },
       });
-      ctx.send(socket, { type: 'error', message: 'Message rejected — session queue is full. Please wait and try again.' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, {
         code: 'QUEUE_FULL',
         userMessage: 'The message queue is full. Please wait and try again.',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -678,7 +678,8 @@ export class Session {
               // Defer the error event — only forward if retry also fails
               deferredOrderingError = event.error.message;
             } else {
-              onEvent({ type: 'error', message: event.error.message });
+              const classified = classifySessionError(event.error, { phase: 'agent_loop' });
+              onEvent(buildSessionErrorMessage(this.conversationId, classified));
             }
             break;
           case 'message_complete': {
@@ -810,7 +811,8 @@ export class Session {
 
       // Forward the deferred ordering error to the client if retry failed or was not attempted
       if (deferredOrderingError) {
-        onEvent({ type: 'error', message: deferredOrderingError });
+        const classified = classifySessionError(new Error(deferredOrderingError), { phase: 'agent_loop' });
+        onEvent(buildSessionErrorMessage(this.conversationId, classified));
       }
 
       // Reconcile synthesized cancellation tool_results from history tail.


### PR DESCRIPTION
## Summary
- Convert streaming provider error path in `session.ts` to emit classified `session_error` instead of generic `error`
- Convert deferred ordering error path in `session.ts` to emit classified `session_error` instead of generic `error`
- Remove redundant generic `error` emission for queue-full in `handlers.ts` (the typed `session_error` was already being sent alongside it)

## Test plan
- [x] 28/28 session-queue tests pass
- [x] 50/50 session-error tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
