### PR TITLE
feat(history): include linked assistant attachments in history_response

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -1,5 +1,46 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), 'history-render-test-')));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
 import { renderHistoryContent, mergeToolResults } from '../daemon/handlers.js';
+import {
+  uploadAttachment,
+  linkAttachmentToMessage,
+  getAttachmentsForMessageUnscoped,
+} from '../memory/attachments-store.js';
+import {
+  createConversation,
+  addMessage,
+} from '../memory/conversation-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
 
 describe('renderHistoryContent', () => {
   test('renders text-only content unchanged', () => {
@@ -225,5 +266,64 @@ describe('mergeToolResults', () => {
     mergeToolResults(original);
     // Original assistant toolCalls should not have result attached
     expect((original[0].toolCalls[0] as Record<string, unknown>).result).toBeUndefined();
+  });
+});
+
+describe('getAttachmentsForMessageUnscoped', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_attachments');
+    db.run('DELETE FROM attachments');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  function createMessage(role: string, content: string): string {
+    const conv = createConversation('test');
+    const msg = addMessage(conv.id, role, content);
+    return msg.id;
+  }
+
+  test('returns attachments linked to a message', () => {
+    const msgId = createMessage('assistant', 'Here is a chart');
+    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    linkAttachmentToMessage(msgId, stored.id, 0);
+
+    const result = getAttachmentsForMessageUnscoped(msgId);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(stored.id);
+    expect(result[0].originalFilename).toBe('chart.png');
+    expect(result[0].mimeType).toBe('image/png');
+    expect(result[0].dataBase64).toBe('iVBOR');
+  });
+
+  test('returns empty array when no attachments are linked', () => {
+    expect(getAttachmentsForMessageUnscoped('msg-nonexistent')).toEqual([]);
+  });
+
+  test('returns multiple attachments in position order', () => {
+    const msgId = createMessage('assistant', 'Two files');
+    const a1 = uploadAttachment('ast-1', 'first.txt', 'text/plain', 'AAAA');
+    const a2 = uploadAttachment('ast-1', 'second.txt', 'text/plain', 'BBBB');
+
+    linkAttachmentToMessage(msgId, a2.id, 1);
+    linkAttachmentToMessage(msgId, a1.id, 0);
+
+    const result = getAttachmentsForMessageUnscoped(msgId);
+    expect(result).toHaveLength(2);
+    expect(result[0].originalFilename).toBe('first.txt');
+    expect(result[1].originalFilename).toBe('second.txt');
+  });
+
+  test('works across different assistantIds', () => {
+    const msgId = createMessage('assistant', 'Mixed');
+    const a1 = uploadAttachment('ast-A', 'a.png', 'image/png', 'AAAA');
+    const a2 = uploadAttachment('ast-B', 'b.png', 'image/png', 'BBBB');
+
+    linkAttachmentToMessage(msgId, a1.id, 0);
+    linkAttachmentToMessage(msgId, a2.id, 1);
+
+    const result = getAttachmentsForMessageUnscoped(msgId);
+    expect(result).toHaveLength(2);
   });
 });

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -62,6 +62,8 @@ import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
+import { getAttachmentsForMessageUnscoped } from '../memory/attachments-store.js';
+import type { UserMessageAttachment } from './ipc-contract.js';
 
 const log = getLogger('handlers');
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
@@ -721,7 +723,7 @@ function handleHistoryRequest(
       log.debug({ err, messageId: m.id }, 'Failed to parse message content as JSON, using raw text');
       text = m.content;
     }
-    return { role: m.role, text, timestamp: m.createdAt, toolCalls };
+    return { id: m.id, role: m.role, text, timestamp: m.createdAt, toolCalls };
   });
 
   // Merge tool_result data from user messages into the preceding assistant
@@ -729,12 +731,27 @@ function handleHistoryRequest(
   // tool_result blocks (internal agent-loop turns).
   const merged = mergeToolResults(parsed);
 
-  const historyMessages = merged.map((m) => ({
-    role: m.role,
-    text: m.text,
-    timestamp: m.timestamp,
-    ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
-  }));
+  const historyMessages = merged.map((m) => {
+    let attachments: UserMessageAttachment[] | undefined;
+    if (m.role === 'assistant' && m.id) {
+      const linked = getAttachmentsForMessageUnscoped(m.id);
+      if (linked.length > 0) {
+        attachments = linked.map((a) => ({
+          id: a.id,
+          filename: a.originalFilename,
+          mimeType: a.mimeType,
+          data: a.dataBase64,
+        }));
+      }
+    }
+    return {
+      role: m.role,
+      text: m.text,
+      timestamp: m.timestamp,
+      ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
+      ...(attachments ? { attachments } : {}),
+    };
+  });
   ctx.send(socket, { type: 'history_response', sessionId: msg.sessionId, messages: historyMessages });
 }
 

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -156,6 +156,47 @@ export function getAttachmentsForMessage(
 }
 
 /**
+ * Return all attachments linked to a message without assistant scoping.
+ * Used by the desktop IPC history handler where tenant isolation is not needed.
+ */
+export function getAttachmentsForMessageUnscoped(
+  messageId: string,
+): Array<StoredAttachment & { dataBase64: string }> {
+  const db = getDb();
+  const links = db
+    .select({ attachmentId: messageAttachments.attachmentId, position: messageAttachments.position })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.messageId, messageId))
+    .orderBy(messageAttachments.position)
+    .all();
+
+  if (links.length === 0) return [];
+
+  const results: Array<StoredAttachment & { dataBase64: string }> = [];
+  for (const link of links) {
+    if (!link.attachmentId) continue;
+    const row = db
+      .select()
+      .from(attachments)
+      .where(eq(attachments.id, link.attachmentId))
+      .get();
+    if (row) {
+      results.push({
+        id: row.id,
+        assistantId: row.assistantId,
+        originalFilename: row.originalFilename,
+        mimeType: row.mimeType,
+        sizeBytes: row.sizeBytes,
+        kind: row.kind,
+        dataBase64: row.dataBase64,
+        createdAt: row.createdAt,
+      });
+    }
+  }
+  return results;
+}
+
+/**
  * Retrieve a single attachment by ID, scoped to an assistant.
  */
 export function getAttachmentById(


### PR DESCRIPTION
## Summary
- Populate `history_response.messages[].attachments` for assistant turns by looking up linked attachments via `message_attachments` junction table
- Add `getAttachmentsForMessageUnscoped()` to attachments-store for the desktop IPC history path (no tenant isolation needed)
- Add integration tests for the new store function with real DB setup

## Test plan
- [x] Existing `renderHistoryContent` and `mergeToolResults` tests remain green (17 pass)
- [x] New `getAttachmentsForMessageUnscoped` tests pass (4 tests covering single, multiple, empty, cross-assistant)
- [x] IPC snapshot tests pass (106 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
