### PR TITLE
fix(trace): emit request_error on surface-action queue-full rejection

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1225,6 +1225,11 @@ export class Session {
 
     if (result.rejected) {
       log.error({ surfaceId, actionId }, 'Surface action rejected — queue full');
+      this.traceEmitter.emit('request_error', 'Surface action rejected — queue full', {
+        requestId,
+        status: 'error',
+        attributes: { reason: 'queue_full', source: 'surface_action' },
+      });
       onEvent({ type: 'error', message: 'Surface action rejected — session queue is full' });
       return;
     }


### PR DESCRIPTION
## Summary
- Emit `request_error` trace event when a surface action is rejected due to a full queue
- The `request_received` trace was already emitted but had no terminal counterpart, leaving the request permanently "active" in the trace timeline
- Includes `reason: queue_full` and `source: surface_action` attributes for diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
