### PR TITLE
feat(runtime): add GET attachment-by-id endpoint for channel delivery

### DIFF
--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -137,4 +137,52 @@ describe('Runtime attachment metadata', () => {
 
     await server.stop();
   });
+
+  test('GET /attachments/:id returns attachment with payload', async () => {
+    const assistantId = 'ast-test-3';
+    const stored = uploadAttachment(assistantId, 'report.pdf', 'application/pdf', 'JVBER');
+
+    const res = await fetch(
+      `http://localhost:${port}/v1/assistants/${assistantId}/attachments/${stored.id}`,
+    );
+    const body = await res.json() as {
+      id: string; filename: string; mimeType: string; sizeBytes: number; kind: string; data: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.id).toBe(stored.id);
+    expect(body.filename).toBe('report.pdf');
+    expect(body.mimeType).toBe('application/pdf');
+    expect(body.kind).toBe('document');
+    expect(body.data).toBe('JVBER');
+    expect(body.sizeBytes).toBeGreaterThan(0);
+
+    await server.stop();
+  });
+
+  test('GET /attachments/:id returns 404 for wrong assistant', async () => {
+    const stored = uploadAttachment('ast-owner', 'secret.txt', 'text/plain', 'c2VjcmV0');
+
+    const res = await fetch(
+      `http://localhost:${port}/v1/assistants/ast-other/attachments/${stored.id}`,
+    );
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Attachment not found');
+
+    await server.stop();
+  });
+
+  test('GET /attachments/:id returns 404 for nonexistent attachment', async () => {
+    const res = await fetch(
+      `http://localhost:${port}/v1/assistants/ast-test-4/attachments/nonexistent-id`,
+    );
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Attachment not found');
+
+    await server.stop();
+  });
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -141,6 +141,12 @@ export class RuntimeHttpServer {
         return await this.handleDeleteAttachment(assistantId, req);
       }
 
+      // Match attachments/:attachmentId
+      const attachmentMatch = endpoint.match(/^attachments\/([^/]+)$/);
+      if (attachmentMatch && req.method === 'GET') {
+        return this.handleGetAttachment(assistantId, attachmentMatch[1]);
+      }
+
       if (endpoint === 'suggestion' && req.method === 'GET') {
         return await this.handleGetSuggestion(assistantId, url);
       }
@@ -871,5 +877,23 @@ export class RuntimeHttpServer {
     }
 
     return new Response(null, { status: 204 });
+  }
+
+  // ── Attachment fetch endpoint ──────────────────────────────────────
+
+  private handleGetAttachment(assistantId: string, attachmentId: string): Response {
+    const attachment = attachmentsStore.getAttachmentById(assistantId, attachmentId);
+    if (!attachment) {
+      return Response.json({ error: 'Attachment not found' }, { status: 404 });
+    }
+
+    return Response.json({
+      id: attachment.id,
+      filename: attachment.originalFilename,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      kind: attachment.kind,
+      data: attachment.dataBase64,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Add `GET /v1/assistants/:assistantId/attachments/:attachmentId` route returning metadata + base64 payload
- Enforce assistant ownership — returns 404 for wrong assistant or missing attachment
- Used by gateway/Telegram for on-demand attachment payload fetch

## Test plan
- [x] Fetch existing attachment returns full payload (id, filename, mimeType, sizeBytes, kind, data)
- [x] Wrong assistantId returns 404
- [x] Nonexistent attachmentId returns 404
- [x] All 5 runtime attachment tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
