### PR TITLE
feat(storage): garbage collect orphan attachments during message/conversation cleanup

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -30,7 +30,14 @@ import {
   getMessages,
   deleteLastExchange,
   isLastUserMessageToolResult,
+  clearAll,
 } from '../memory/conversation-store.js';
+import {
+  uploadAttachment,
+  linkAttachmentToMessage,
+  getAttachmentsForMessageUnscoped,
+  deleteOrphanAttachments,
+} from '../memory/attachments-store.js';
 
 // Initialize db once before all tests
 initializeDb();
@@ -208,5 +215,69 @@ describe('deleteLastExchange with tool_result messages', () => {
 
     const remaining = getMessages(conv.id);
     expect(remaining).toHaveLength(0);
+  });
+});
+
+describe('attachment orphan cleanup', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_attachments');
+    db.run('DELETE FROM attachments');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('deleteLastExchange cleans up orphaned attachments', () => {
+    const conv = createConversation('test');
+    addMessage(conv.id, 'user', 'hello');
+    const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
+
+    const stored = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
+
+    // Verify attachment is linked
+    expect(getAttachmentsForMessageUnscoped(assistantMsg.id)).toHaveLength(1);
+
+    // Delete the exchange — should also clean up orphaned attachments
+    deleteLastExchange(conv.id);
+
+    // Attachment row should be gone
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const remaining = raw.query('SELECT COUNT(*) AS c FROM attachments').get() as { c: number };
+    expect(remaining.c).toBe(0);
+  });
+
+  test('deleteLastExchange preserves attachments still linked to other messages', () => {
+    const conv = createConversation('test');
+    const msg1 = addMessage(conv.id, 'assistant', 'first');
+    addMessage(conv.id, 'user', 'question');
+    const msg2 = addMessage(conv.id, 'assistant', 'second');
+
+    const shared = uploadAttachment('ast-1', 'shared.png', 'image/png', 'AAAA');
+    linkAttachmentToMessage(msg1.id, shared.id, 0);
+    linkAttachmentToMessage(msg2.id, shared.id, 0);
+
+    // Delete last exchange (removes msg2 + user question)
+    deleteLastExchange(conv.id);
+
+    // Attachment should survive because msg1 still links to it
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const remaining = raw.query('SELECT COUNT(*) AS c FROM attachments').get() as { c: number };
+    expect(remaining.c).toBe(1);
+  });
+
+  test('clearAll removes all attachments', () => {
+    const conv = createConversation('test');
+    const msg = addMessage(conv.id, 'assistant', 'file');
+    const stored = uploadAttachment('ast-1', 'doc.pdf', 'application/pdf', 'JVBER');
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    clearAll();
+
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const attachmentCount = raw.query('SELECT COUNT(*) AS c FROM attachments').get() as { c: number };
+    const linkCount = raw.query('SELECT COUNT(*) AS c FROM message_attachments').get() as { c: number };
+    expect(attachmentCount.c).toBe(0);
+    expect(linkCount.c).toBe(0);
   });
 });

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -206,3 +206,16 @@ export function getAttachmentById(
   const results = getAttachmentsByIds(assistantId, [attachmentId]);
   return results[0] ?? null;
 }
+
+/**
+ * Delete attachments that have no remaining links in message_attachments.
+ * Returns the number of orphaned attachments removed.
+ */
+export function deleteOrphanAttachments(): number {
+  const db = getDb();
+  const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
+  const result = raw.run(
+    'DELETE FROM attachments WHERE id NOT IN (SELECT attachment_id FROM message_attachments)',
+  );
+  return result.changes;
+}

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -5,6 +5,7 @@ import { conversations, messages, messageRuns, channelInboundEvents, memoryItemS
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
+import { deleteOrphanAttachments } from './attachments-store.js';
 
 const log = getLogger('conversation-store');
 
@@ -171,6 +172,8 @@ export function clearAll(): { conversations: number; messages: number } {
   raw.exec('DELETE FROM memory_jobs');
   raw.exec('DELETE FROM memory_checkpoints');
   raw.exec('DELETE FROM llm_usage_events');
+  raw.exec('DELETE FROM message_attachments');
+  raw.exec('DELETE FROM attachments');
   raw.exec('DELETE FROM tool_invocations');
   raw.exec('DELETE FROM messages');
   raw.exec('DELETE FROM conversations');
@@ -239,6 +242,8 @@ export function deleteLastExchange(conversationId: string): number {
       .where(eq(conversations.id, conversationId))
       .run();
   });
+
+  deleteOrphanAttachments();
 
   return deleted;
 }
@@ -345,6 +350,8 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
       }
     }
   });
+
+  deleteOrphanAttachments();
 
   return result;
 }


### PR DESCRIPTION
## Summary
- Add `deleteOrphanAttachments()` helper to `attachments-store.ts` — deletes attachments with no remaining links in `message_attachments`
- Call it after `deleteLastExchange` and `deleteMessageById` to prevent unlinked attachment growth
- `clearAll` now explicitly clears `message_attachments` and `attachments` tables

## Test plan
- [x] `deleteLastExchange` cleans up orphaned attachments (1 test)
- [x] `deleteLastExchange` preserves attachments still linked to other messages (1 test)
- [x] `clearAll` removes all attachments and links (1 test)
- [x] All 13 conversation store tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
