### PR TITLE
build(ipc): regenerate swift contract for assistant attachment fields

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -289,6 +289,7 @@ public struct IPCGenerationHandoff: Codable, Sendable {
     public let sessionId: String
     public let requestId: String?
     public let queuedCount: Int
+    public let attachments: [IPCUserMessageAttachment]?
 }
 
 public struct IPCGetSigningIdentityRequest: Codable, Sendable {
@@ -317,6 +318,7 @@ public struct IPCHistoryResponseMessage: Codable, Sendable {
     public let text: String
     public let timestamp: Double
     public let toolCalls: [IPCHistoryResponseToolCall]?
+    public let attachments: [IPCUserMessageAttachment]?
 }
 
 public struct IPCHistoryResponseToolCall: Codable, Sendable {
@@ -379,6 +381,7 @@ public struct IPCMemoryStatus: Codable, Sendable {
 public struct IPCMessageComplete: Codable, Sendable {
     public let type: String
     public let sessionId: String?
+    public let attachments: [IPCUserMessageAttachment]?
 }
 
 public struct IPCMessageDequeued: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -518,8 +518,8 @@ extension IPCAssistantThinkingDelta {
 public typealias MessageCompleteMessage = IPCMessageComplete
 
 extension IPCMessageComplete {
-    public init(sessionId: String? = nil) {
-        self.init(type: "message_complete", sessionId: sessionId)
+    public init(sessionId: String? = nil, attachments: [IPCUserMessageAttachment]? = nil) {
+        self.init(type: "message_complete", sessionId: sessionId, attachments: attachments)
     }
 }
 
@@ -597,8 +597,8 @@ public struct GenerationCancelledMessage: Decodable, Sendable {
 public typealias GenerationHandoffMessage = IPCGenerationHandoff
 
 extension IPCGenerationHandoff {
-    public init(sessionId: String, requestId: String?, queuedCount: Int) {
-        self.init(type: "generation_handoff", sessionId: sessionId, requestId: requestId, queuedCount: queuedCount)
+    public init(sessionId: String, requestId: String?, queuedCount: Int, attachments: [IPCUserMessageAttachment]? = nil) {
+        self.init(type: "generation_handoff", sessionId: sessionId, requestId: requestId, queuedCount: queuedCount, attachments: attachments)
     }
 }
 


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to pick up `attachments` fields added to `message_complete`, `generation_handoff`, and `history_response` messages
- Update convenience initializers in `IPCMessages.swift` for `IPCMessageComplete` and `IPCGenerationHandoff` to pass through the new optional `attachments` parameter

## Test plan
- [ ] Shared Swift target compiles with generated changes
- [ ] No manual wire-struct divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
