### PR TITLE
feat(chat): ingest assistant attachments from message_complete and generation_handoff

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1518,4 +1518,95 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.sessionError,
                       "generation_cancelled should not set sessionError")
     }
+
+    // MARK: - Assistant Attachment Ingestion
+
+    func testMessageCompleteWithAttachmentsAddsToExistingMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Stream some text first
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Here is an image")))
+        XCTAssertEqual(viewModel.messages.count, 2) // greeting + assistant
+
+        // Complete with attachments
+        let attachment = IPCUserMessageAttachment(
+            id: "att-1", filename: "photo.png", mimeType: "image/png",
+            data: "iVBORw0KGgo=", extractedText: nil
+        )
+        viewModel.handleServerMessage(.messageComplete(
+            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 2, "Should add attachments to existing message, not create new")
+        XCTAssertEqual(viewModel.messages[1].attachments.count, 1)
+        XCTAssertEqual(viewModel.messages[1].attachments[0].filename, "photo.png")
+        XCTAssertEqual(viewModel.messages[1].attachments[0].id, "att-1")
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+
+    func testMessageCompleteWithAttachmentsCreatesNewMessageWhenNoStreaming() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Complete with attachments but no prior text deltas (attachment-only turn)
+        let attachment = IPCUserMessageAttachment(
+            id: "att-1", filename: "report.pdf", mimeType: "application/pdf",
+            data: "JVBER", extractedText: nil
+        )
+        viewModel.handleServerMessage(.messageComplete(
+            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
+        ))
+
+        XCTAssertEqual(viewModel.messages.count, 2, "Should create new assistant message for attachment-only turn")
+        XCTAssertEqual(viewModel.messages[1].role, .assistant)
+        XCTAssertEqual(viewModel.messages[1].attachments.count, 1)
+        XCTAssertEqual(viewModel.messages[1].attachments[0].filename, "report.pdf")
+    }
+
+    func testGenerationHandoffWithAttachmentsAddsToExistingMessage() {
+        viewModel.sessionId = "sess-1"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Stream some text
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Generated file")))
+
+        // Handoff with attachments
+        let attachment = IPCUserMessageAttachment(
+            id: "att-2", filename: "output.csv", mimeType: "text/csv",
+            data: "Y29sQQ==", extractedText: nil
+        )
+        viewModel.handleServerMessage(.generationHandoff(
+            GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1, attachments: [attachment])
+        ))
+
+        XCTAssertEqual(viewModel.messages[1].attachments.count, 1)
+        XCTAssertEqual(viewModel.messages[1].attachments[0].filename, "output.csv")
+        XCTAssertFalse(viewModel.messages[1].isStreaming)
+    }
+
+    func testMessageCompleteWithNilAttachmentsDoesNotCreateMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Complete without attachments (nil)
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        // Should just have the greeting — no extra empty assistant message
+        XCTAssertEqual(viewModel.messages.count, 1)
+    }
+
+    func testMessageCompleteWithEmptyAttachmentsDoesNotCreateMessage() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        // Complete with empty attachments array
+        viewModel.handleServerMessage(.messageComplete(
+            MessageCompleteMessage(sessionId: nil, attachments: [])
+        ))
+
+        // Should just have the greeting — no extra empty assistant message
+        XCTAssertEqual(viewModel.messages.count, 1)
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -664,6 +664,8 @@ public final class ChatViewModel: ObservableObject {
             if pendingQueuedCount == 0 {
                 isSending = false
             }
+            // Ingest assistant attachments before finalizing the message
+            ingestAssistantAttachments(complete.attachments)
             // Mark the current assistant message as complete
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -745,6 +747,8 @@ public final class ChatViewModel: ObservableObject {
         case .generationHandoff(let handoff):
             guard belongsToSession(handoff.sessionId) else { return }
             isThinking = false
+            // Ingest assistant attachments before finalizing the message
+            ingestAssistantAttachments(handoff.attachments)
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -1261,6 +1265,59 @@ public final class ChatViewModel: ObservableObject {
         } catch {
             log.error("Failed to send add_trust_rule: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    /// Map IPC attachment DTOs to ChatAttachment values, generating thumbnails for images.
+    private func mapIPCAttachments(_ ipcAttachments: [IPCUserMessageAttachment]) -> [ChatAttachment] {
+        ipcAttachments.compactMap { ipc in
+            let id = ipc.id ?? UUID().uuidString
+            let base64 = ipc.data
+            let dataLength = base64.count
+
+            var thumbnailData: Data?
+            #if os(macOS)
+            var thumbnailImage: NSImage?
+            #elseif os(iOS)
+            var thumbnailImage: UIImage?
+            #else
+            #error("Unsupported platform")
+            #endif
+
+            if ipc.mimeType.hasPrefix("image/"), let rawData = Data(base64Encoded: base64) {
+                thumbnailData = Self.generateThumbnail(from: rawData, maxDimension: 120)
+                #if os(macOS)
+                thumbnailImage = thumbnailData.flatMap { NSImage(data: $0) }
+                #elseif os(iOS)
+                thumbnailImage = thumbnailData.flatMap { UIImage(data: $0) }
+                #endif
+            }
+
+            return ChatAttachment(
+                id: id,
+                filename: ipc.filename,
+                mimeType: ipc.mimeType,
+                data: base64,
+                thumbnailData: thumbnailData,
+                dataLength: dataLength,
+                thumbnailImage: thumbnailImage
+            )
+        }
+    }
+
+    /// Ingest attachments from a completion/handoff event into the current or new assistant message.
+    private func ingestAssistantAttachments(_ ipcAttachments: [IPCUserMessageAttachment]?) {
+        guard let ipcAttachments, !ipcAttachments.isEmpty else { return }
+        let chatAttachments = mapIPCAttachments(ipcAttachments)
+        guard !chatAttachments.isEmpty else { return }
+
+        if let existingId = currentAssistantMessageId,
+           let index = messages.firstIndex(where: { $0.id == existingId }) {
+            messages[index].attachments.append(contentsOf: chatAttachments)
+        } else {
+            let msg = ChatMessage(role: .assistant, text: "", attachments: chatAttachments)
+            currentAssistantMessageId = msg.id
+            messages.append(msg)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `mapIPCAttachments` and `ingestAssistantAttachments` helpers to `ChatViewModel` that convert incoming `IPCUserMessageAttachment` DTOs into `ChatAttachment` values with image thumbnail generation
- On `message_complete` and `generation_handoff` events, any attached files are appended to the current assistant message or a new assistant message is created for attachment-only turns
- Add 5 tests covering: attachments on existing message, attachment-only turn, handoff attachments, nil attachments no-op, empty attachments no-op

## Test plan
- [ ] Verify assistant attachments appear in live chat during streaming without breaking text
- [ ] Verify attachment-only turns create a new assistant message
- [ ] Run ChatViewModelTests to confirm all new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
