### PR TITLE
feat(chat): hydrate assistant attachments from history_response

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1609,4 +1609,54 @@ final class ChatViewModelTests: XCTestCase {
         // Should just have the greeting — no extra empty assistant message
         XCTAssertEqual(viewModel.messages.count, 1)
     }
+
+    // MARK: - History Attachment Hydration
+
+    func testPopulateFromHistoryHydratesAssistantAttachments() {
+        let attachment = IPCUserMessageAttachment(
+            id: "hist-att-1", filename: "chart.png", mimeType: "image/png",
+            data: "iVBORw0KGgo=", extractedText: nil
+        )
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, attachments: nil),
+            IPCHistoryResponseMessage(role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, attachments: [attachment]),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].role, .assistant)
+        XCTAssertEqual(viewModel.messages[1].attachments.count, 1)
+        XCTAssertEqual(viewModel.messages[1].attachments[0].filename, "chart.png")
+        XCTAssertEqual(viewModel.messages[1].attachments[0].id, "hist-att-1")
+    }
+
+    func testPopulateFromHistoryIncludesAttachmentOnlyMessages() {
+        let attachment = IPCUserMessageAttachment(
+            id: "hist-att-2", filename: "report.pdf", mimeType: "application/pdf",
+            data: "JVBER", extractedText: nil
+        )
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, attachments: [attachment]),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        // Attachment-only message (empty text, no tool calls) should NOT be skipped
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].role, .assistant)
+        XCTAssertEqual(viewModel.messages[0].attachments.count, 1)
+        XCTAssertEqual(viewModel.messages[0].attachments[0].filename, "report.pdf")
+    }
+
+    func testPopulateFromHistorySkipsEmptyMessagesWithNoAttachments() {
+        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+            IPCHistoryResponseMessage(role: "assistant", text: "", timestamp: 1000, toolCalls: nil, attachments: nil),
+        ]
+
+        viewModel.populateFromHistory(historyItems)
+
+        // Empty message with no text, no tool calls, no attachments should be skipped
+        XCTAssertEqual(viewModel.messages.count, 0)
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1371,13 +1371,15 @@ public final class ChatViewModel: ObservableObject {
                     )
                 }
             }
+            let attachments: [ChatAttachment] = mapIPCAttachments(item.attachments ?? [])
             // Skip empty messages (internal tool-result-only turns already filtered by daemon)
-            if item.text.isEmpty && toolCalls.isEmpty { continue }
+            if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
             let chatMsg = ChatMessage(
                 role: role,
                 text: item.text,
                 timestamp: timestamp,
+                attachments: attachments,
                 toolCalls: toolCalls
             )
             chatMessages.append(chatMsg)


### PR DESCRIPTION
## Summary
- Update `populateFromHistory` to map `IPCHistoryResponseMessage.attachments` into `ChatAttachment` values using the existing `mapIPCAttachments` helper
- Attachment-only messages (empty text, no tool calls, but has attachments) are now preserved instead of being skipped
- Add 3 tests covering: history with attachments, attachment-only history messages, empty messages still skipped

## Test plan
- [ ] Verify historical assistant attachments render in macOS chat bubbles
- [ ] Run ChatViewModelTests to confirm new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
