### PR TITLE
feat(gateway): type assistant attachments and add runtime attachment fetch helper

### DIFF
--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
-import { forwardToRuntime } from "../runtime/client.js";
+import { forwardToRuntime, downloadAttachment } from "../runtime/client.js";
+import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
 
 const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
@@ -33,6 +34,14 @@ const payload = {
   senderName: "Test User",
 };
 
+const testAttachment: RuntimeAttachmentMeta = {
+  id: "att-1",
+  filename: "chart.png",
+  mimeType: "image/png",
+  sizeBytes: 1024,
+  kind: "generated_image",
+};
+
 const successBody = {
   accepted: true,
   duplicate: false,
@@ -42,7 +51,7 @@ const successBody = {
     role: "assistant" as const,
     content: "Hi there!",
     timestamp: new Date().toISOString(),
-    attachments: [],
+    attachments: [testAttachment],
   },
 };
 
@@ -116,5 +125,70 @@ describe("forwardToRuntime", () => {
     await expect(
       forwardToRuntime(config, "assistant-a", payload),
     ).rejects.toThrow("Runtime returned 500");
+  });
+
+  test("response includes typed attachment metadata", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(successBody), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig();
+    const result = await forwardToRuntime(config, "assistant-a", payload);
+    const attachments = result.assistantMessage?.attachments ?? [];
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].id).toBe("att-1");
+    expect(attachments[0].filename).toBe("chart.png");
+    expect(attachments[0].mimeType).toBe("image/png");
+    expect(attachments[0].sizeBytes).toBe(1024);
+    expect(attachments[0].kind).toBe("generated_image");
+  });
+});
+
+describe("downloadAttachment", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("downloads attachment payload with base64 data", async () => {
+    const attachmentPayload = {
+      id: "att-1",
+      filename: "chart.png",
+      mimeType: "image/png",
+      sizeBytes: 1024,
+      kind: "generated_image",
+      data: "iVBORw0KGgo=",
+    };
+
+    const fetchMock = mockFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(attachmentPayload), { status: 200 }),
+      ),
+    );
+
+    const config = makeConfig();
+    const result = await downloadAttachment(config, "assistant-a", "att-1");
+    expect(result.id).toBe("att-1");
+    expect(result.filename).toBe("chart.png");
+    expect(result.data).toBe("iVBORw0KGgo=");
+
+    const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
+    expect(calledUrl).toContain("/attachments/att-1");
+  });
+
+  test("throws on 404 not found", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response('{"error":"Attachment not found"}', { status: 404 }),
+      ),
+    );
+
+    const config = makeConfig();
+    await expect(
+      downloadAttachment(config, "assistant-a", "nonexistent"),
+    ).rejects.toThrow("Attachment download failed (404)");
   });
 });

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -15,6 +15,18 @@ export type RuntimeInboundPayload = {
   attachmentIds?: string[];
 };
 
+export type RuntimeAttachmentMeta = {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+};
+
+export type RuntimeAttachmentPayload = RuntimeAttachmentMeta & {
+  data: string; // base64-encoded
+};
+
 export type RuntimeInboundResponse = {
   accepted: boolean;
   duplicate: boolean;
@@ -24,7 +36,7 @@ export type RuntimeInboundResponse = {
     role: "assistant";
     content: string;
     timestamp: string;
-    attachments: unknown[];
+    attachments: RuntimeAttachmentMeta[];
   };
 };
 
@@ -125,6 +137,26 @@ export type UploadAttachmentInput = {
 export type UploadAttachmentResponse = {
   id: string;
 };
+
+export async function downloadAttachment(
+  config: GatewayConfig,
+  assistantId: string,
+  attachmentId: string,
+): Promise<RuntimeAttachmentPayload> {
+  const url = `${config.assistantRuntimeBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/attachments/${encodeURIComponent(attachmentId)}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Attachment download failed (${response.status}): ${body}`);
+  }
+
+  return (await response.json()) as RuntimeAttachmentPayload;
+}
 
 export async function uploadAttachment(
   config: GatewayConfig,


### PR DESCRIPTION
## Summary
- Define `RuntimeAttachmentMeta` (id, filename, mimeType, sizeBytes, kind) and `RuntimeAttachmentPayload` (meta + base64 data) types
- Replace `attachments: unknown[]` with `RuntimeAttachmentMeta[]` in `RuntimeInboundResponse`
- Add `downloadAttachment()` helper that GETs attachment data from the runtime fetch endpoint

## Test plan
- [x] All 7 runtime client tests pass (3 new: typed metadata decoding, download success, download 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
