### PR TITLE
Fix session-scoped cancellation and cancel queue cleanup

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -344,7 +344,7 @@ describe('Session message queue', () => {
     await new Promise((r) => setTimeout(r, 50));
   });
 
-  test('abort() clears the queue and sends errors for each queued message', async () => {
+  test('abort() clears the queue and sends generation_cancelled for each queued message', async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -366,17 +366,19 @@ describe('Session message queue', () => {
     // Queue should be empty
     expect(session.getQueueDepth()).toBe(0);
 
-    // Both queued messages should have received generic error events
+    // Both queued messages should receive session-scoped cancellation events.
+    const cancel2 = events2.find((e) => e.type === 'generation_cancelled');
+    expect(cancel2).toEqual({ type: 'generation_cancelled', sessionId: 'conv-1' });
+
+    const cancel3 = events3.find((e) => e.type === 'generation_cancelled');
+    expect(cancel3).toEqual({ type: 'generation_cancelled', sessionId: 'conv-1' });
+
+    // abort() must NOT emit session_error or generic error for queued discards.
     const err2 = events2.find((e) => e.type === 'error');
-    expect(err2).toBeDefined();
-    expect(err2!.type === 'error' && err2!.message).toContain('queued message discarded');
-
+    expect(err2).toBeUndefined();
     const err3 = events3.find((e) => e.type === 'error');
-    expect(err3).toBeDefined();
-    expect(err3!.type === 'error' && err3!.message).toContain('queued message discarded');
+    expect(err3).toBeUndefined();
 
-    // abort() must NOT emit session_error — cancel should only show
-    // generation_cancelled behavior, never a session-error toast.
     const sessionErr2 = events2.find((e) => e.type === 'session_error');
     expect(sessionErr2).toBeUndefined();
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -338,12 +338,10 @@ export class Session {
       unregisterTimerCompletionNotifier(this.conversationId);
       pruneSessionTimers(this.conversationId);
 
-      // Clear queued messages and notify each caller.
-      // Only emit a generic `error` — NOT `session_error` — so the client's
-      // cancel-path suppression (wasCancelling) handles cleanup without
-      // surfacing a session-error toast to the user.
+      // Clear queued messages and notify each caller with a session-scoped
+      // cancel event so other sessions do not receive cross-thread errors.
       for (const queued of this.messageQueue) {
-        queued.onEvent({ type: 'error', message: 'Session aborted — queued message discarded' });
+        queued.onEvent({ type: 'generation_cancelled', sessionId: this.conversationId });
       }
       this.messageQueue = [];
     }
@@ -924,7 +922,7 @@ export class Session {
           requestId: reqId,
           status: 'warning',
         });
-        onEvent({ type: 'generation_cancelled' });
+        onEvent({ type: 'generation_cancelled', sessionId: this.conversationId });
       } else {
         this.traceEmitter.emit('message_complete', 'Message processing complete', {
           requestId: reqId,
@@ -948,7 +946,7 @@ export class Session {
           requestId: reqId,
           status: 'warning',
         });
-        onEvent({ type: 'generation_cancelled' });
+        onEvent({ type: 'generation_cancelled', sessionId: this.conversationId });
       } else {
         const message = err instanceof Error ? err.message : String(err);
         const errorClass = err instanceof Error ? err.constructor.name : 'Error';

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -697,9 +697,20 @@ public final class ChatViewModel: ObservableObject {
             guard belongsToSession(cancelled.sessionId) else { return }
             cancelTimeoutTask?.cancel()
             cancelTimeoutTask = nil
+            let wasCancelling = isCancelling
             isCancelling = false
             isThinking = false
-            if pendingQueuedCount == 0 {
+            if wasCancelling {
+                isSending = false
+                pendingQueuedCount = 0
+                pendingMessageIds = []
+                requestIdToMessageId = [:]
+                for i in messages.indices {
+                    if case .queued = messages[i].status, messages[i].role == .user {
+                        messages[i].status = .sent
+                    }
+                }
+            } else if pendingQueuedCount == 0 {
                 isSending = false
             }
             if let existingId = currentAssistantMessageId,
@@ -782,12 +793,10 @@ public final class ChatViewModel: ObservableObject {
                     messages[i].status = .sent
                 }
             }
-            // When cancelling, the daemon's abort() emits error events for
-            // queued messages but drops the queue without sending
-            // message_dequeued events, so pendingQueuedCount never drains
-            // on its own. Force-clear all queue state to prevent isSending
-            // from staying true permanently. Also reset queued message
-            // statuses since the daemon will not process them.
+            // When a cancellation-related generic error arrives while we are
+            // in cancel mode, force-clear queue bookkeeping because queued
+            // messages will not be processed and no message_dequeued events
+            // are expected for them.
             if wasCancelling {
                 isSending = false
                 pendingQueuedCount = 0


### PR DESCRIPTION
## Summary
- Emit `generation_cancelled` with `sessionId` for queued abort cleanup and cancel branches in session processing
- Ensure chat cancel acknowledgment force-clears queued bookkeeping when cancel was user-initiated
- Update queue regression test expectations to enforce cancel event semantics and no generic/session errors for queued discards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
