### PR TITLE
feat(gateway): send assistant attachments to telegram with partial-failure notices

### DIFF
--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { sendTelegramAttachments } from "../telegram/send.js";
+import type { RuntimeAttachmentMeta } from "../runtime/client.js";
+import type { GatewayConfig } from "../config.js";
+
+const makeConfig = (overrides: Partial<GatewayConfig> = {}): GatewayConfig => ({
+  telegramBotToken: "tok",
+  telegramWebhookSecret: "wh-ver",
+  telegramApiBaseUrl: "https://api.telegram.org",
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  routingEntries: [],
+  defaultAssistantId: undefined,
+  unmappedPolicy: "reject",
+  port: 7830,
+  runtimeProxyEnabled: false,
+  runtimeProxyRequireAuth: true,
+  runtimeProxyBearerToken: undefined,
+  shutdownDrainMs: 5000,
+  runtimeTimeoutMs: 30000,
+  runtimeMaxRetries: 2,
+  runtimeInitialBackoffMs: 500,
+  telegramTimeoutMs: 15000,
+  maxWebhookPayloadBytes: 1048576,
+  maxAttachmentBytes: 20971520,
+  maxAttachmentConcurrency: 3,
+  ...overrides,
+});
+
+const telegramOk = { ok: true, result: { message_id: 1 } };
+
+function mockFetch(fn: (url: string, init?: RequestInit) => Promise<Response>) {
+  const m = mock(fn);
+  Object.assign(m, { preconnect: () => {} });
+  globalThis.fetch = m as unknown as typeof fetch;
+  return m;
+}
+
+describe("sendTelegramAttachments", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends image attachment via sendPhoto", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      // Runtime download endpoint
+      if (url.includes("/attachments/att-1")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-1",
+            filename: "photo.png",
+            mimeType: "image/png",
+            sizeBytes: 100,
+            kind: "generated_image",
+            data: "iVBORw0KGgo=",
+          }),
+        );
+      }
+      // Telegram sendPhoto
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = {
+      id: "att-1",
+      filename: "photo.png",
+      mimeType: "image/png",
+      sizeBytes: 100,
+      kind: "generated_image",
+    };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    // Should have called: 1) runtime download, 2) telegram sendPhoto
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("/attachments/att-1");
+    expect(calls[1]).toContain("sendPhoto");
+  });
+
+  test("sends non-image attachment via sendDocument", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      if (url.includes("/attachments/att-2")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-2",
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 200,
+            kind: "filesystem",
+            data: "JVBER",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const meta: RuntimeAttachmentMeta = {
+      id: "att-2",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 200,
+      kind: "filesystem",
+    };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("/attachments/att-2");
+    expect(calls[1]).toContain("sendDocument");
+  });
+
+  test("skips oversized attachments and sends failure notice", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig({ maxAttachmentBytes: 50 });
+    const meta: RuntimeAttachmentMeta = {
+      id: "att-3",
+      filename: "huge.zip",
+      mimeType: "application/zip",
+      sizeBytes: 100, // exceeds 50 byte limit
+      kind: "filesystem",
+    };
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", [meta]);
+
+    // Should have sent only the failure notice via sendMessage
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("sendMessage");
+  });
+
+  test("continues sending remaining attachments on individual failure", async () => {
+    const calls: string[] = [];
+
+    mockFetch(async (url: string) => {
+      calls.push(url);
+      // First attachment download fails
+      if (url.includes("/attachments/att-fail")) {
+        return new Response('{"error":"not found"}', { status: 404 });
+      }
+      // Second attachment succeeds
+      if (url.includes("/attachments/att-ok")) {
+        return new Response(
+          JSON.stringify({
+            id: "att-ok",
+            filename: "good.png",
+            mimeType: "image/png",
+            sizeBytes: 50,
+            kind: "generated_image",
+            data: "iVBORw0KGgo=",
+          }),
+        );
+      }
+      return new Response(JSON.stringify(telegramOk));
+    });
+
+    const config = makeConfig();
+    const attachments: RuntimeAttachmentMeta[] = [
+      { id: "att-fail", filename: "bad.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },
+      { id: "att-ok", filename: "good.png", mimeType: "image/png", sizeBytes: 50, kind: "generated_image" },
+    ];
+
+    await sendTelegramAttachments(config, "chat-1", "assistant-a", attachments);
+
+    // Should have: download att-fail (fail), download att-ok, sendPhoto for att-ok, sendMessage for notice
+    expect(calls.filter((u) => u.includes("sendPhoto"))).toHaveLength(1);
+    expect(calls.filter((u) => u.includes("sendMessage"))).toHaveLength(1);
+  });
+});

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -16,6 +16,7 @@ const MAX_TYPING_DURATION_MS = 60_000;
 export type OnReply = (
   chatId: string,
   result: InboundResult,
+  assistantId: string,
 ) => Promise<void>;
 
 export function createTelegramWebhookHandler(
@@ -176,8 +177,8 @@ export function createTelegramWebhookHandler(
     }
 
     // Fire reply asynchronously so webhook ack is not blocked by outbound send
-    if (onReply && !result.rejected && result.runtimeResponse?.assistantMessage) {
-      onReply(normalized.message.externalChatId, result).catch((err) => {
+    if (onReply && !isRejection(routing) && !result.rejected && result.runtimeResponse?.assistantMessage) {
+      onReply(normalized.message.externalChatId, result, routing.assistantId).catch((err) => {
         log.error({ err, updateId: payload.update_id }, "Failed to send reply");
       });
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,7 +2,7 @@ import pino from "pino";
 import { loadConfig } from "./config.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
-import { sendTelegramReply } from "./telegram/send.js";
+import { sendTelegramReply, sendTelegramAttachments } from "./telegram/send.js";
 import { callTelegramApi } from "./telegram/api.js";
 
 const log = pino({ name: "gateway" });
@@ -19,16 +19,29 @@ function main() {
   const handleTelegramWebhook = telegramConfigured
     ? createTelegramWebhookHandler(
         config,
-        async (chatId, result) => {
-          const content = result.runtimeResponse?.assistantMessage?.content;
-          if (!content) {
+        async (chatId, result, assistantId) => {
+          const msg = result.runtimeResponse?.assistantMessage;
+          const content = msg?.content;
+          const attachments = msg?.attachments ?? [];
+
+          if (!content && attachments.length === 0) {
             return;
           }
 
           try {
-            await sendTelegramReply(config, chatId, content);
+            if (content) {
+              await sendTelegramReply(config, chatId, content);
+            }
           } catch (err) {
             log.error({ err, chatId }, "Failed to send Telegram reply");
+          }
+
+          if (attachments.length > 0) {
+            try {
+              await sendTelegramAttachments(config, chatId, assistantId, attachments);
+            } catch (err) {
+              log.error({ err, chatId }, "Failed to send Telegram attachments");
+            }
           }
         },
       )

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -30,3 +30,27 @@ export async function callTelegramApi<T>(
 
   return data.result;
 }
+
+export async function callTelegramApiMultipart<T>(
+  config: GatewayConfig,
+  method: string,
+  form: FormData,
+): Promise<T> {
+  const url = `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`;
+  const response = await fetch(url, {
+    method: "POST",
+    body: form,
+    signal: AbortSignal.timeout(config.telegramTimeoutMs),
+  });
+
+  const data = (await response.json().catch(() => ({}))) as TelegramApiResponse<T>;
+  if (!response.ok || !data.ok || data.result === undefined) {
+    throw new Error(
+      data.description
+        ? `Telegram ${method} failed: ${data.description}`
+        : `Telegram ${method} failed with status ${response.status}`,
+    );
+  }
+
+  return data.result;
+}

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,10 +1,13 @@
 import pino from "pino";
 import type { GatewayConfig } from "../config.js";
-import { callTelegramApi } from "./api.js";
+import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
+import { downloadAttachment, type RuntimeAttachmentMeta } from "../runtime/client.js";
 
 const log = pino({ name: "gateway:telegram-send" });
 
 const TELEGRAM_MAX_MESSAGE_LEN = 4000;
+
+const IMAGE_MIME_PREFIXES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 function splitText(text: string): string[] {
   if (text.length <= TELEGRAM_MAX_MESSAGE_LEN) {
@@ -40,6 +43,55 @@ export async function sendTelegramReply(
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
+}
+
+export async function sendTelegramAttachments(
+  config: GatewayConfig,
+  chatId: string,
+  assistantId: string,
+  attachments: RuntimeAttachmentMeta[],
+): Promise<void> {
+  const failures: string[] = [];
+
+  for (const meta of attachments) {
+    if (meta.sizeBytes > config.maxAttachmentBytes) {
+      log.warn({ attachmentId: meta.id, sizeBytes: meta.sizeBytes }, "Skipping oversized outbound attachment");
+      failures.push(meta.filename);
+      continue;
+    }
+
+    try {
+      const payload = await downloadAttachment(config, assistantId, meta.id);
+      const buffer = Buffer.from(payload.data, "base64");
+      const blob = new Blob([buffer], { type: meta.mimeType });
+
+      const form = new FormData();
+      form.set("chat_id", chatId);
+
+      const isImage = IMAGE_MIME_PREFIXES.some((p) => meta.mimeType.startsWith(p));
+      if (isImage) {
+        form.set("photo", blob, meta.filename);
+        await callTelegramApiMultipart(config, "sendPhoto", form);
+      } else {
+        form.set("document", blob, meta.filename);
+        await callTelegramApiMultipart(config, "sendDocument", form);
+      }
+
+      log.debug({ chatId, attachmentId: meta.id, filename: meta.filename }, "Attachment sent to Telegram");
+    } catch (err) {
+      log.error({ err, attachmentId: meta.id, filename: meta.filename }, "Failed to send attachment to Telegram");
+      failures.push(meta.filename);
+    }
+  }
+
+  if (failures.length > 0) {
+    const notice = `⚠️ ${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
+    try {
+      await sendTelegramReply(config, chatId, notice);
+    } catch (err) {
+      log.error({ err, chatId }, "Failed to send attachment failure notice");
+    }
+  }
 }
 
 export async function sendTypingIndicator(config: GatewayConfig, chatId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `callTelegramApiMultipart` to `api.ts` for multipart form data uploads (sendPhoto/sendDocument)
- Add `sendTelegramAttachments` to `send.ts` — downloads each attachment from runtime, sends images via `sendPhoto` and files via `sendDocument`, with partial-failure resilience
- Update `OnReply` callback to include `assistantId` for attachment fetching
- Update `index.ts` to send both text reply and attachments

## Test plan
- [x] All 78 gateway tests pass (4 new: sendPhoto for images, sendDocument for files, oversized skip with notice, partial failure continues)
- [ ] Manual test: assistant generates an image attachment and it appears in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
