### PR TITLE
test(trace): add regression test for surface-action queue-full request_error

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1037,6 +1037,60 @@ describe('Terminal trace events on rejection/failure', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Surface-action queue-full trace emission
+// ---------------------------------------------------------------------------
+
+describe('Surface-action queue-full trace', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('surface-action queue-full rejection emits request_error trace', async () => {
+    const traceEvents: ServerMessage[] = [];
+    const session = makeSession((msg) => {
+      if ('type' in msg && msg.type === 'trace_event') traceEvents.push(msg);
+    });
+    await session.loadFromDb();
+
+    // Start processing to make the session busy
+    session.processMessage('msg-1', [], () => {}, 'req-1');
+    await waitForPendingRun(1);
+
+    // Fill the queue to MAX_QUEUE_DEPTH
+    for (let i = 0; i < MAX_QUEUE_DEPTH; i++) {
+      const result = session.enqueueMessage(`queued-${i}`, [], () => {}, `req-q-${i}`);
+      expect(result.queued).toBe(true);
+    }
+    expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
+
+    // Register a pending surface action so handleSurfaceAction doesn't bail early
+    (session as any).pendingSurfaceActions.set('surf-1', { surfaceType: 'confirmation' });
+
+    // Trigger the surface action — queue is full, should be rejected
+    session.handleSurfaceAction('surf-1', 'confirm');
+
+    // Should have a request_received trace followed by a request_error trace
+    const receivedTrace = traceEvents.find(
+      (e) => 'kind' in e && e.kind === 'request_received',
+    );
+    expect(receivedTrace).toBeDefined();
+
+    const errorTrace = traceEvents.find(
+      (e) => 'kind' in e && e.kind === 'request_error',
+    );
+    expect(errorTrace).toBeDefined();
+    if (errorTrace && 'attributes' in errorTrace) {
+      const attrs = (errorTrace as any).attributes;
+      expect(attrs.reason).toBe('queue_full');
+      expect(attrs.source).toBe('surface_action');
+    }
+
+    // Queue depth should not have increased
+    expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: cancel semantics + session/global error channel split
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds an explicit regression test for the surface-action queue-full `request_error` trace emission path
- Verifies that when a surface action is rejected due to a full queue, both `request_received` and `request_error` trace events are emitted with correct attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
