### PR TITLE
fix(sandbox): update default docker image pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ When `sandbox.backend` is set to `"docker"`, the daemon wraps every sandbox `bas
 - Docker daemon running (Docker Desktop on macOS/Windows, or `systemd` service on Linux).
 - The configured image pulled locally. The default image is pinned with a `sha256` digest for reproducibility:
   ```
-  node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9
+  node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687
   ```
-  Pull it with: `docker pull node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9`
+  Pull it with: `docker pull node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687`
 
 **Docker configuration options** (all under `sandbox.docker`):
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -84,7 +84,7 @@ describe('AssistantConfigSchema', () => {
       enabled: true,
       backend: 'docker',
       docker: {
-        image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+        image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
         shell: 'bash',
         cpus: 1,
         memoryMb: 512,

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -93,7 +93,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     // opt into the native backend via `sandbox.backend = "native"`.
     backend: 'docker',
     docker: {
-      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
       shell: 'bash',
       cpus: 1,
       memoryMb: 512,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -28,7 +28,7 @@ export const TimeoutConfigSchema = z.object({
 export const DockerConfigSchema = z.object({
   image: z
     .string({ error: 'sandbox.docker.image must be a string' })
-    .default('node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9'),
+    .default('node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687'),
   shell: z
     .string({ error: 'sandbox.docker.shell must be a string' })
     .default('bash'),
@@ -64,7 +64,7 @@ export const SandboxConfigSchema = z.object({
     })
     .default('docker'),
   docker: DockerConfigSchema.default({
-    image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+    image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
     shell: 'bash',
     cpus: 1,
     memoryMb: 512,
@@ -574,7 +574,7 @@ export const AssistantConfigSchema = z.object({
     enabled: true,
     backend: 'docker',
     docker: {
-      image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+      image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
       shell: 'bash',
       cpus: 1,
       memoryMb: 512,

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -13,7 +13,7 @@ const log = getLogger('docker-sandbox');
  * Must stay in sync with DockerConfigSchema defaults in config/schema.ts.
  */
 const DEFAULTS: Required<DockerConfig> = {
-  image: 'node:20-slim@sha256:a22f79e64de59efd3533828aecc9817bfdc97d3b4a58f0fc1b7b33a5e2b4d5f9',
+  image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
   shell: 'bash',
   cpus: 1,
   memoryMb: 512,


### PR DESCRIPTION
## Summary
- replace the stale `node:20-slim` digest used by sandbox defaults with a pullable pinned digest
- update runtime defaults, schema defaults, tests, and README examples to keep config/docs aligned
- restore expected Docker backend operability for default sandbox configuration

## Verification
- export PATH=\"$HOME/.bun/bin:$PATH\"; cd assistant && bun test src/__tests__/config-schema.test.ts
- export PATH=\"$HOME/.bun/bin:$PATH\"; cd assistant && bun test src/__tests__/terminal-sandbox-docker.test.ts
- export PATH=\"$HOME/.bun/bin:$PATH\"; cd assistant && bun test src/__tests__/sandbox-diagnostics.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
