### PR TITLE
Show newest threads at the top of thread list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -42,7 +42,7 @@ final class ThreadManager: ObservableObject {
     func createThread() {
         let thread = ThreadModel()
         let viewModel = makeViewModel()
-        threads.append(thread)
+        threads.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         activeThreadId = thread.id
         log.info("Created thread \(thread.id) with title \"\(thread.title)\"")


### PR DESCRIPTION
## Summary

New threads now appear at the top of the thread list instead of the bottom.

## Changes

- **ThreadManager.swift**: Changed `createThread()` to insert at index 0 instead of appending

## Before
When creating a new thread, it was appended to the end of the `threads` array, appearing at the bottom of the UI.

## After
New threads are inserted at the beginning of the array, appearing at the top of the list.

## Note
Restored sessions (from `handleSessionListResponse`) already appear at the top since they're prepended to the array. This change just makes manual thread creation consistent with that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
