### PR TITLE
test(sandbox): align host-parity path-policy expectations

### DIFF
--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -512,14 +512,14 @@ describe('Path policy divergence: sandbox blocks escapes, host requires absolute
     const sandboxResult = sandboxOps.readFileSafe({ path: '../../../etc/hostname' });
     expect(sandboxResult.ok).toBe(false);
     if (!sandboxResult.ok) {
-      expect(sandboxResult.error.code).toBe('INVALID_PATH');
+      expect(sandboxResult.error.code).toBe('PATH_OUT_OF_BOUNDS');
     }
 
     // Host: relative paths are rejected (requires absolute)
     const hostResult = hostOps.readFileSafe({ path: 'relative.txt' });
     expect(hostResult.ok).toBe(false);
     if (!hostResult.ok) {
-      expect(hostResult.error.code).toBe('INVALID_PATH');
+      expect(hostResult.error.code).toBe('PATH_NOT_ABSOLUTE');
     }
   });
 
@@ -539,7 +539,7 @@ describe('Path policy divergence: sandbox blocks escapes, host requires absolute
     const result = hostOps.readFileSafe({ path: 'just-a-name.txt' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.code).toBe('INVALID_PATH');
+      expect(result.error.code).toBe('PATH_NOT_ABSOLUTE');
     }
   });
 
@@ -550,7 +550,7 @@ describe('Path policy divergence: sandbox blocks escapes, host requires absolute
     const result = sandboxOps.writeFileSafe({ path: '/tmp/somewhere-else.txt', content: 'bad' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.code).toBe('INVALID_PATH');
+      expect(result.error.code).toBe('PATH_OUT_OF_BOUNDS');
     }
   });
 });


### PR DESCRIPTION
## Summary
- replace stale `INVALID_PATH` expectations in sandbox host-parity tests with current canonical FsError codes
- assert `PATH_OUT_OF_BOUNDS` for sandbox boundary violations and `PATH_NOT_ABSOLUTE` for host relative paths
- restore green status for the path-policy divergence coverage block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
