### PR TITLE
Update docs to include ipc:check-swift-drift in enforcement checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -617,8 +617,8 @@ graph LR
     end
 
     subgraph "Enforcement"
-        CI["CI (GitHub Actions)<br/>bun run check:ipc-generated<br/>bun run ipc:inventory"]
-        HOOK["Pre-commit hook<br/>same checks on staged<br/>IPC files"]
+        CI["CI (GitHub Actions)<br/>bun run check:ipc-generated<br/>bun run ipc:inventory<br/>bun run ipc:check-swift-drift"]
+        HOOK["Pre-commit hook<br/>same 3 checks on staged<br/>IPC files"]
     end
 
     CONTRACT --> TJS

--- a/assistant/docs/ipc-contract.md
+++ b/assistant/docs/ipc-contract.md
@@ -115,10 +115,11 @@ Adding an optional field is backward-compatible. Removing a field or making an o
 
 ### CI (GitHub Actions)
 
-The `ci-assistant.yml` workflow runs on every PR that touches `assistant/` or `clients/shared/IPC/Generated/`:
+The `ci-assistant.yml` workflow runs on every PR that touches `assistant/`, `clients/shared/IPC/`, or `.githooks/`:
 
 1. `bun run check:ipc-generated` -- fails if the generated Swift file doesn't match what the generator would produce
 2. `bun run ipc:inventory` -- fails if the contract inventory snapshot has drifted
+3. `bun run ipc:check-swift-drift` -- fails if the Swift `ServerMessage` decoder is out of sync with the contract (stale or missing decode cases)
 
 ### Pre-commit hook
 
@@ -126,8 +127,9 @@ The `.githooks/pre-commit` hook runs automatically when any IPC-related file is 
 
 - Checks the generated Swift file is up to date (`bun run check:ipc-generated`)
 - Checks the inventory snapshot is up to date (`bun run ipc:inventory`)
+- Checks the Swift decoder is in sync with the contract (`bun run ipc:check-swift-drift`)
 
-If either check fails, the commit is blocked with instructions on how to fix it.
+If any check fails, the commit is blocked with instructions on how to fix it.
 
 ## Manual exception allowlist
 


### PR DESCRIPTION
## Summary
- Added `ipc:check-swift-drift` as the third enforcement check in `ipc-contract.md` (CI and pre-commit sections)
- Updated CI path filter description to match actual `ci-assistant.yml` (`clients/shared/IPC/` and `.githooks/`)
- Updated `ARCHITECTURE.md` Mermaid diagram to show all 3 checks in the Enforcement subgraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
