### PR TITLE
feat(attachments): emit assistant attachments on completion events

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1213,6 +1213,99 @@ describe('Session host attachment directives', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Attachment payload emission tests
+// ---------------------------------------------------------------------------
+
+describe('Session attachment event payloads', () => {
+  beforeEach(() => {
+    pendingRuns = [];
+  });
+
+  test('message_complete includes assistant attachments', async () => {
+    const events: ServerMessage[] = [];
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const p1 = session.processMessage('msg-1', [], (e) => events.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    const run = pendingRuns[0];
+    const assistantMsg: Message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Here is your chart.' }],
+    };
+    run.onEvent({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      content: 'ok',
+      isError: false,
+      contentBlocks: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
+      ],
+    });
+    run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
+    run.onEvent({ type: 'message_complete', message: assistantMsg });
+    run.resolve([...run.messages, assistantMsg]);
+
+    await p1;
+
+    const completion = events.find((e) => e.type === 'message_complete' && Array.isArray(e.attachments));
+    expect(completion).toBeDefined();
+    const attachments = (completion as { attachments: Array<{ mimeType: string; data: string; id?: string }> }).attachments;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].mimeType).toBe('image/png');
+    expect(attachments[0].data).toBe('iVBORw0K');
+    expect(attachments[0].id).toBeDefined();
+  });
+
+  test('generation_handoff includes assistant attachments', async () => {
+    const events1: ServerMessage[] = [];
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const p1 = session.processMessage('msg-1', [], (e) => events1.push(e), 'req-1');
+    await waitForPendingRun(1);
+
+    // Queue a second message so the first run yields via checkpoint handoff.
+    session.enqueueMessage('msg-2', [], () => {}, 'req-2');
+
+    const run = pendingRuns[0];
+    expect(run.onCheckpoint).toBeDefined();
+    expect(run.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true })).toBe('yield');
+
+    const assistantMsg: Message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Handing off with attachment.' }],
+    };
+    run.onEvent({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      content: 'ok',
+      isError: false,
+      contentBlocks: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
+      ],
+    });
+    run.onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 100 });
+    run.onEvent({ type: 'message_complete', message: assistantMsg });
+    run.resolve([...run.messages, assistantMsg]);
+
+    await p1;
+
+    const handoff = events1.find((e) => e.type === 'generation_handoff' && Array.isArray(e.attachments));
+    expect(handoff).toBeDefined();
+    const attachments = (handoff as { attachments: Array<{ mimeType: string; data: string; id?: string }> }).attachments;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].mimeType).toBe('image/png');
+    expect(attachments[0].data).toBe('iVBORw0K');
+
+    await waitForPendingRun(2);
+    resolveRun(1);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: cancel semantics + session/global error channel split
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -914,6 +914,7 @@ export class Session {
 
       // Resolve accumulated attachment directives and tool content blocks
       let assistantAttachments: AssistantAttachmentDraft[] = [];
+      const emittedAttachments: UserMessageAttachment[] = [];
       if (accumulatedDirectives.length > 0 || accumulatedToolContentBlocks.length > 0) {
         const approveHostRead: ApproveHostRead = async (filePath) => this.approveHostAttachmentRead(filePath);
 
@@ -942,6 +943,20 @@ export class Session {
             draft.dataBase64,
           );
           linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
+          emittedAttachments.push({
+            id: stored.id,
+            filename: draft.filename,
+            mimeType: draft.mimeType,
+            data: draft.dataBase64,
+          });
+        }
+      } else if (assistantAttachments.length > 0) {
+        for (const draft of assistantAttachments) {
+          emittedAttachments.push({
+            filename: draft.filename,
+            mimeType: draft.mimeType,
+            data: draft.dataBase64,
+          });
         }
       }
 
@@ -964,6 +979,7 @@ export class Session {
           sessionId: this.conversationId,
           requestId: reqId,
           queuedCount: this.getQueueDepth(),
+          ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
         });
       } else if (abortController.signal.aborted) {
         this.traceEmitter.emit('generation_cancelled', 'Generation cancelled by user', {
@@ -976,7 +992,11 @@ export class Session {
           requestId: reqId,
           status: 'success',
         });
-        onEvent({ type: 'message_complete', sessionId: this.conversationId });
+        onEvent({
+          type: 'message_complete',
+          sessionId: this.conversationId,
+          ...(emittedAttachments.length > 0 ? { attachments: emittedAttachments } : {}),
+        });
       }
 
       // Auto-generate conversation title after first exchange


### PR DESCRIPTION
## Summary
- include assistant attachment payloads on  when attachments are generated
- include assistant attachment payloads on  for queued handoff turns
- add session tests covering both completion paths

## Validation
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
