### PR TITLE
fix(attachments): strip directives from streamed text deltas

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -5,6 +5,7 @@ import {
   classifyKind,
   validateDrafts,
   cleanAssistantContent,
+  drainDirectiveDisplayBuffer,
   contentBlocksToDrafts,
   deduplicateDrafts,
   MAX_ASSISTANT_ATTACHMENTS,
@@ -212,6 +213,36 @@ describe('cleanAssistantContent', () => {
     expect(result.directives).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
     expect(result.cleanedContent).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drainDirectiveDisplayBuffer
+// ---------------------------------------------------------------------------
+
+describe('drainDirectiveDisplayBuffer', () => {
+  test('strips complete valid directives from streamed text', () => {
+    const input = 'Before <vellum-attachment path="out.png" /> After';
+    const result = drainDirectiveDisplayBuffer(input);
+    expect(result.emitText).toBe('Before  After');
+    expect(result.bufferedRemainder).toBe('');
+  });
+
+  test('preserves invalid directives as plain text', () => {
+    const input = 'Bad <vellum-attachment source="bad" path="x.txt" /> tag';
+    const result = drainDirectiveDisplayBuffer(input);
+    expect(result.emitText).toBe(input);
+    expect(result.bufferedRemainder).toBe('');
+  });
+
+  test('buffers incomplete directives until completion', () => {
+    const first = drainDirectiveDisplayBuffer('Start <vellum-attachment path="file');
+    expect(first.emitText).toBe('Start ');
+    expect(first.bufferedRemainder).toContain('<vellum-attachment');
+
+    const second = drainDirectiveDisplayBuffer(first.bufferedRemainder + '.png" /> done');
+    expect(second.emitText).toBe(' done');
+    expect(second.bufferedRemainder).toBe('');
   });
 });
 

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -160,6 +160,11 @@ export interface DirectiveParseResult {
   parseWarnings: string[];
 }
 
+export interface DirectiveDisplayDrainResult {
+  emitText: string;
+  bufferedRemainder: string;
+}
+
 /**
  * Match self-closing `<vellum-attachment ... />` tags.
  *
@@ -227,6 +232,53 @@ export function parseDirectives(text: string): DirectiveParseResult {
     directiveRequests,
     parseWarnings,
   };
+}
+
+/**
+ * Drain streamed assistant text while stripping only valid, complete
+ * self-closing `<vellum-attachment ... />` directives.
+ *
+ * - Valid complete directives are removed from emitted text.
+ * - Invalid directives are preserved as plain text.
+ * - Incomplete directives are retained in `bufferedRemainder` until more
+ *   text arrives.
+ */
+export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDrainResult {
+  let emitText = '';
+  let cursor = 0;
+
+  while (cursor < buffer.length) {
+    const start = buffer.indexOf('<vellum-attachment', cursor);
+    if (start === -1) {
+      emitText += buffer.slice(cursor);
+      return { emitText, bufferedRemainder: '' };
+    }
+
+    emitText += buffer.slice(cursor, start);
+
+    const end = buffer.indexOf('/>', start);
+    if (end === -1) {
+      return {
+        emitText,
+        bufferedRemainder: buffer.slice(start),
+      };
+    }
+
+    const tag = buffer.slice(start, end + 2);
+    const parsed = parseDirectives(tag);
+    const isValidDirective =
+      parsed.directiveRequests.length > 0 &&
+      parsed.parseWarnings.length === 0 &&
+      parsed.cleanText.length === 0;
+
+    if (!isValidDirective) {
+      emitText += tag;
+    }
+
+    cursor = end + 2;
+  }
+
+  return { emitText, bufferedRemainder: '' };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -58,6 +58,7 @@ import {
 } from '../skills/slash-commands.js';
 import {
   cleanAssistantContent,
+  drainDirectiveDisplayBuffer,
   resolveDirectives,
   contentBlocksToDrafts,
   deduplicateDrafts,
@@ -604,6 +605,7 @@ export class Session {
       const accumulatedDirectives: DirectiveRequest[] = [];
       const accumulatedToolContentBlocks: ContentBlock[] = [];
       const directiveWarnings: string[] = [];
+      let pendingDirectiveDisplayBuffer = '';
       let lastAssistantMessageId: string | undefined;
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
@@ -687,11 +689,17 @@ export class Session {
         };
 
         switch (event.type) {
-          case 'text_delta':
+          case 'text_delta': {
             emitLlmCallStartedIfNeeded();
-            onEvent({ type: 'assistant_text_delta', text: event.text, sessionId: this.conversationId });
-            if (isFirstMessage) firstAssistantText += event.text;
+            pendingDirectiveDisplayBuffer += event.text;
+            const drained = drainDirectiveDisplayBuffer(pendingDirectiveDisplayBuffer);
+            pendingDirectiveDisplayBuffer = drained.bufferedRemainder;
+            if (drained.emitText.length > 0) {
+              onEvent({ type: 'assistant_text_delta', text: drained.emitText, sessionId: this.conversationId });
+              if (isFirstMessage) firstAssistantText += drained.emitText;
+            }
             break;
+          }
           case 'thinking_delta':
             // Thinking content itself is NOT included in traces to avoid leaking
             // extended-thinking data.
@@ -729,6 +737,15 @@ export class Session {
             }
             break;
           case 'message_complete': {
+            if (pendingDirectiveDisplayBuffer.length > 0) {
+              onEvent({
+                type: 'assistant_text_delta',
+                text: pendingDirectiveDisplayBuffer,
+                sessionId: this.conversationId,
+              });
+              if (isFirstMessage) firstAssistantText += pendingDirectiveDisplayBuffer;
+              pendingDirectiveDisplayBuffer = '';
+            }
             // Save pending tool results as a user message before the next assistant message.
             // tool_result blocks belong in user messages per the Anthropic API spec.
             if (pendingToolResults.size > 0) {

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -114,7 +114,7 @@ When the assistant includes attachments in a reply, the gateway downloads each a
 
 - **Images** (`image/*` MIME types) are sent via `sendPhoto` (multipart form upload).
 - **Other files** are sent via `sendDocument` (multipart form upload).
-- **Oversized** attachments (exceeding `GATEWAY_MAX_ATTACHMENT_BYTES`, default 20 MB) are silently skipped.
+- **Oversized** attachments (exceeding `GATEWAY_MAX_ATTACHMENT_BYTES`, default 20 MB) are skipped and included in the partial-failure notice.
 - **Partial failures** are handled gracefully: each attachment is attempted independently. If any fail, a single summary notice is sent to the chat listing the undelivered filenames.
 - **Concurrency** is controlled by `GATEWAY_MAX_ATTACHMENT_CONCURRENCY` (default 3).
 


### PR DESCRIPTION
## Summary
- strip valid `<vellum-attachment ... />` directives from live streamed text deltas
- preserve malformed/invalid directives as plain text and buffer incomplete directives across chunks
- add unit tests for stream-drain directive behavior
- align gateway README wording with implemented oversized-attachment failure notice behavior

## Validation
- `bun test src/__tests__/assistant-attachments.test.ts src/__tests__/assistant-attachment-directive.test.ts src/__tests__/session-queue.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
