### PR TITLE
docs(check-reviews): require fetching current time for PR age calculation

### DIFF
--- a/.claude/commands/check-reviews.md
+++ b/.claude/commands/check-reviews.md
@@ -8,6 +8,8 @@ Check each PR to see if **both** chatgpt-codex-connector and devin-ai-integratio
 
 ## How to fetch PR data
 
+Before fetching any PR data, run `date -u +%s` to get the current UTC epoch time. You will need this to accurately compute PR ages for the output table — do not guess the current time.
+
 For each PR, run these commands in parallel:
 
 1. **Reviews, comments, and creation time:** `gh pr view <number> --json comments,reviews,createdAt`


### PR DESCRIPTION
## Summary
- Adds an explicit step to run `date -u +%s` before fetching PR data, so PR ages in the output table are computed from the actual current time rather than guessed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
