### PR TITLE
feat(workspace): add ComposerView chatbar to workspace layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -411,6 +411,29 @@ struct MainWindowView: View {
                 onAction: { _, _ in },
                 appId: data.appId
             )
+
+            // Chatbar pinned at bottom
+            if let viewModel = threadManager.activeViewModel {
+                ComposerView(
+                    inputText: Binding(
+                        get: { viewModel.inputText },
+                        set: { viewModel.inputText = $0 }
+                    ),
+                    hasAPIKey: hasAPIKey,
+                    isSending: viewModel.isSending,
+                    isRecording: viewModel.isRecording,
+                    suggestion: viewModel.suggestion,
+                    pendingAttachments: viewModel.pendingAttachments,
+                    onSend: viewModel.sendMessage,
+                    onStop: viewModel.stopGenerating,
+                    onAcceptSuggestion: viewModel.acceptSuggestion,
+                    onAttach: { Self.openFilePicker(viewModel: viewModel) },
+                    onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+                    onPaste: { viewModel.addAttachmentFromPasteboard() },
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    editorContentHeight: .constant(20)
+                )
+            }
         }
         .background(VColor.backgroundSubtle)
     }


### PR DESCRIPTION
## Summary
- Add ComposerView below DynamicPageSurfaceView in the workspace, wired to the active ChatViewModel
- Messages typed in the workspace chatbar go to the current thread
- Uses constant editorContentHeight since workspace doesn't need ChatView's scroll-reserve calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
