### PR TITLE
feat(workspace): wire GeneratedPanel app open to workspace

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -260,11 +260,14 @@ struct MainWindowView: View {
                 // Workspace mode: full-window dynamic page
                 dynamicWorkspaceView(surface: surface, data: dpData)
             } else {
-                // Gallery mode: existing behavior
+                // Gallery mode: existing behavior, with workspace routing
                 GeneratedPanel(
                     onClose: { activePanel = nil; isDynamicExpanded = false },
                     isExpanded: $isDynamicExpanded,
-                    daemonClient: daemonClient
+                    daemonClient: daemonClient,
+                    onOpenApp: { surfaceMsg in
+                        activeDynamicSurface = surfaceMsg
+                    }
                 )
             }
         } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -22,6 +22,8 @@ struct GeneratedPanel: View {
     var onClose: () -> Void
     @Binding var isExpanded: Bool
     let daemonClient: DaemonClient
+    /// When set, app opens route to the workspace instead of a floating NSPanel.
+    var onOpenApp: ((UiSurfaceShowMessage) -> Void)?
 
     @State private var displayItems: [DisplayAppItem] = []
     @State private var isLoading = false
@@ -35,10 +37,11 @@ struct GeneratedPanel: View {
     // Track how many list responses we're waiting for
     @State private var pendingResponses = 0
 
-    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient) {
+    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil) {
         self.onClose = onClose
         self._isExpanded = isExpanded
         self.daemonClient = daemonClient
+        self.onOpenApp = onOpenApp
     }
 
     var body: some View {
@@ -389,7 +392,9 @@ struct GeneratedPanel: View {
 
     private func openApp(_ item: DisplayAppItem) {
         if let localId = item.localAppId {
-            // Local apps: ask the daemon to open via ui_surface_show
+            // Local apps: ask the daemon to open via ui_surface_show.
+            // When onOpenApp is set, the daemon's response will be intercepted
+            // by SurfaceManager and routed to the workspace (see PR 5).
             try? daemonClient.sendAppOpen(appId: localId)
         } else if let uuid = item.sharedUUID {
             // Shared apps: construct surface from unpacked files on disk
@@ -415,7 +420,11 @@ struct GeneratedPanel: View {
                 actions: nil,
                 display: "panel"
             )
-            daemonClient.onSurfaceShow?(surfaceMsg)
+            if let onOpenApp {
+                onOpenApp(surfaceMsg)
+            } else {
+                daemonClient.onSurfaceShow?(surfaceMsg)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `onOpenApp` callback to GeneratedPanel for routing app opens to workspace
- Shared apps in expanded mode route through callback instead of floating NSPanel
- Side-panel GeneratedPanel retains default floating NSPanel behavior (callback is nil)
- Local apps still use `sendAppOpen` — daemon response interception comes in next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
