### PR TITLE
feat(workspace): auto-route dynamic pages to workspace

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -3,6 +3,7 @@ import Security
 
 extension Notification.Name {
     static let apiKeyManagerDidChange = Notification.Name("APIKeyManager.didChange")
+    static let openDynamicWorkspace = Notification.Name("MainWindow.openDynamicWorkspace")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -279,6 +279,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         daemonClient.onAppDataResponse = { [weak self] msg in
             self?.surfaceManager.resolveDataResponse(surfaceId: msg.surfaceId, response: msg)
         }
+
+        // Route dynamic pages to workspace
+        surfaceManager.onDynamicPageShow = { [weak self] msg in
+            guard let self else { return }
+            self.showMainWindow()
+            NotificationCenter.default.post(
+                name: .openDynamicWorkspace,
+                object: nil,
+                userInfo: ["surfaceMessage": msg]
+            )
+        }
     }
 
     private func setupToolConfirmationManager() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -155,6 +155,13 @@ struct MainWindowView: View {
             // Sync activeThreadId changes back to selectedThreadId to keep sidebar selection in sync
             selectedThreadId = newId
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
+            if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
+                activeDynamicSurface = msg
+                activePanel = .generated
+                isDynamicExpanded = true
+            }
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -78,11 +78,23 @@ final class SurfaceManager: ObservableObject {
     /// Parameters: surfaceId, callId, method, appId, recordId, data.
     var onDataRequest: ((String, String, String, String, String?, [String: Any]?) -> Void)?
 
+    /// When set, dynamic pages with `display != "inline"` route to the full-window
+    /// workspace instead of opening as floating NSPanels.
+    var onDynamicPageShow: ((UiSurfaceShowMessage) -> Void)?
+
     // MARK: - Show
 
     func showSurface(_ message: UiSurfaceShowMessage) {
         guard let surface = Surface.from(message) else {
             log.error("Failed to parse surface from message: surfaceId=\(message.surfaceId), type=\(message.surfaceType)")
+            return
+        }
+
+        // Route dynamic pages to workspace if callback is set
+        if case .dynamicPage = surface.data,
+           message.display != "inline",
+           let onDynamicPageShow {
+            onDynamicPageShow(message)
             return
         }
 


### PR DESCRIPTION
## Summary
- Add `onDynamicPageShow` callback to SurfaceManager — intercepts dynamic pages with `display != "inline"` before NSPanel creation
- Wire callback in AppDelegate to show main window and post `.openDynamicWorkspace` notification
- MainWindowView listens for notification and sets `activeDynamicSurface` + expands to workspace mode
- Non-dynamic surfaces and inline surfaces continue to render as before (floating NSPanels / chat embeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
