### PR TITLE
fix(test): prevent errexit abort in filesystem runner

### DIFF
--- a/assistant/scripts/test-filesystem-tools.sh
+++ b/assistant/scripts/test-filesystem-tools.sh
@@ -34,9 +34,9 @@ for test_file in "${FILESYSTEM_TESTS[@]}"; do
   fi
   echo "==> Running ${test_file}"
   if bun test "${test_file}"; then
-    ((passed++))
+    ((passed++)) || true
   else
-    ((failed++))
+    ((failed++)) || true
   fi
 done
 


### PR DESCRIPTION
## Summary
- Fix `((passed++))` and `((failed++))` in `test-filesystem-tools.sh` aborting under `set -e` when the counter is 0
- Bash `((expr))` returns exit code 1 when the expression evaluates to 0, so `((passed++))` fails on the first successful test (pre-increment value is 0)
- Append `|| true` to both counters to prevent errexit from killing the script

Addresses review feedback from Codex and Devin on #2241.

## Test plan
- [x] Script no longer aborts on first test file

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
