### PR TITLE
fix(attachments): trim whitespace in estimateBase64Bytes

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -41,6 +41,18 @@ describe('estimateBase64Bytes', () => {
     // 12 base64 chars, no padding → 9 bytes
     expect(estimateBase64Bytes('SGVsbG8gV29y')).toBe(9);
   });
+
+  test('trims trailing whitespace and newlines before estimating', () => {
+    // "a" → base64 "YQ==" → 1 byte; trailing newline should not affect result
+    expect(estimateBase64Bytes('YQ==\n')).toBe(1);
+    expect(estimateBase64Bytes('YQ==\r\n')).toBe(1);
+    expect(estimateBase64Bytes('  YQ==  ')).toBe(1);
+  });
+
+  test('handles embedded line breaks in base64 (e.g. PEM-style)', () => {
+    // "YWJj" split across lines should still yield 3 bytes
+    expect(estimateBase64Bytes('YW\nJj')).toBe(3);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -43,8 +43,9 @@ export interface AssistantAttachmentDraft {
  * Accounts for trailing `=` padding characters.
  */
 export function estimateBase64Bytes(base64: string): number {
-  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
-  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+  const trimmed = base64.replace(/\s/g, '');
+  const padding = trimmed.endsWith('==') ? 2 : trimmed.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Trim whitespace/newlines from base64 input in `estimateBase64Bytes` before computing decoded size
- Trailing whitespace (common from shell/file outputs) inflated length calculations and hid `=` padding, potentially causing false rejections near the 20 MB size cap
- Addresses review feedback from PR #2246

## Test plan
- [x] Added test for trailing newlines (`YQ==\n`, `YQ==\r\n`)
- [x] Added test for surrounding spaces (`  YQ==  `)
- [x] Added test for embedded line breaks (PEM-style `YW\nJj`)
- [x] All 34 existing tests still pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
