### PR TITLE
fix(sandbox): validate read-only root with root user in tests

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.integration.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.integration.test.ts
@@ -75,10 +75,16 @@ afterAll(() => {
   }
 });
 
+interface DockerRunOptions {
+  /** Run as root instead of the host UID:GID. Useful for testing filesystem-level protections. */
+  asRoot?: boolean;
+}
+
 /** Run a command inside a Docker container with the sandbox root mounted. */
-function dockerRun(cmd: string): { stdout: string; exitCode: number } {
+function dockerRun(cmd: string, opts?: DockerRunOptions): { stdout: string; exitCode: number } {
   const uid = process.getuid?.() ?? 1000;
   const gid = process.getgid?.() ?? 1000;
+  const userArgs = opts?.asRoot ? ['--user', '0:0'] : ['--user', `${uid}:${gid}`];
   const result = spawnSync('docker', [
     'run', '--rm',
     '--network=none',
@@ -88,7 +94,7 @@ function dockerRun(cmd: string): { stdout: string; exitCode: number } {
     '--tmpfs', '/tmp:rw,nosuid,nodev,noexec',
     '--mount', `type=bind,src=${sandboxRoot},dst=/workspace`,
     '--workdir', '/workspace',
-    '--user', `${uid}:${gid}`,
+    ...userArgs,
     IMAGE,
     'bash', '-c', cmd,
   ], { timeout: 30000, encoding: 'utf-8' });
@@ -121,13 +127,15 @@ describe.skipIf(!DOCKER_OK)('Docker integration: write inside sandbox', () => {
 });
 
 describe.skipIf(!DOCKER_OK)('Docker integration: write outside workspace fails', () => {
+  // Run as root so Unix permissions are not a factor — the read-only
+  // filesystem mount is the only thing preventing these writes.
   test('writing to /etc inside container fails (read-only root)', () => {
-    const { exitCode } = dockerRun('touch /etc/evil 2>/dev/null');
+    const { exitCode } = dockerRun('touch /etc/evil 2>/dev/null', { asRoot: true });
     expect(exitCode).not.toBe(0);
   });
 
   test('writing to /home inside container fails (read-only root)', () => {
-    const { exitCode } = dockerRun('touch /home/evil 2>/dev/null');
+    const { exitCode } = dockerRun('touch /home/evil 2>/dev/null', { asRoot: true });
     expect(exitCode).not.toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback on #2248: read-only root tests were not actually validating the `--read-only` filesystem mount because the container ran as a non-root user whose Unix permissions would already block writes to `/etc` and `/home`.
- Added an `asRoot` option to the `dockerRun` helper, and use it for the read-only root tests so the _only_ barrier to writing is the read-only filesystem mount.

## Test plan
- [x] Type-check passes (no new errors)
- [x] Read-only tests now run as root (`--user 0:0`), isolating the read-only filesystem invariant
- [x] Other tests continue to run as host UID:GID

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
