### PR TITLE
fix(chat): replace what-style comments with ordering rationale

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -664,9 +664,8 @@ public final class ChatViewModel: ObservableObject {
             if pendingQueuedCount == 0 {
                 isSending = false
             }
-            // Ingest assistant attachments before finalizing the message
+            // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(complete.attachments)
-            // Mark the current assistant message as complete
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false
@@ -758,7 +757,7 @@ public final class ChatViewModel: ObservableObject {
         case .generationHandoff(let handoff):
             guard belongsToSession(handoff.sessionId) else { return }
             isThinking = false
-            // Ingest assistant attachments before finalizing the message
+            // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,


### PR DESCRIPTION
## Summary
- Replace what-style `// Ingest assistant attachments before finalizing the message` comments with rationale explaining *why* the call order matters: `ingestAssistantAttachments` reads `currentAssistantMessageId` to attach files to the correct message, so it must run before that property is cleared
- Remove redundant `// Mark the current assistant message as complete` comment whose intent is obvious from the code
- Applies to both `message_complete` and `generation_handoff` branches

Addresses review feedback from #2270.

## Test plan
- [x] No behavioral changes — comment-only edit
- [x] Verified both call sites retain identical logic

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
