### PR TITLE
docs(attachments): add required conversationKey param to messages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Attachments are sent inline (base64) in `message_complete`, `generation_handoff`
 
 ### Runtime HTTP API
 
-The `GET /v1/assistants/:id/messages` endpoint returns attachment metadata on each message:
+The `GET /v1/assistants/:id/messages?conversationKey=<key>` endpoint returns attachment metadata on each message (the `conversationKey` query parameter is required):
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Add the required `conversationKey` query parameter to the `GET /v1/assistants/:id/messages` endpoint documentation in README.md
- The endpoint returns 400 without this parameter, but the docs omitted it — callers following the docs would fail

Addresses feedback from PR #2281 (codex review comment about missing conversationKey).

The other two codex review comments on #2281 were incorrect:
1. "Stop advertising host attachments" — claimed `approveHostRead` is hardcoded to `false`, but `approveHostAttachmentRead()` actually delegates to the permission checker and can return `true` when trusted.
2. "Correct IPC docs for completion and handoff attachments" — claimed `message_complete` and `generation_handoff` don't include attachments, but both events conditionally include the `attachments` field when `emittedAttachments.length > 0`.

## Test plan
- [x] Verified `handleListMessages` in `http-server.ts` requires `conversationKey` query parameter (returns 400 without it)
- [x] README docs now accurately reflect the endpoint signature

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
