### PR TITLE
docs(attachments): add conversationKey to messages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Attachments are sent inline (base64) in `message_complete`, `generation_handoff`
 
 ### Runtime HTTP API
 
-The `GET /v1/assistants/:id/messages` endpoint returns attachment metadata on each message:
+The `GET /v1/assistants/:id/messages?conversationKey=<key>` endpoint returns attachment metadata on each message:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Add the required `conversationKey` query parameter to the `GET /v1/assistants/:id/messages` endpoint in the README
- The endpoint returns 400 without this parameter (enforced in `handleListMessages` in `http-server.ts`), so the docs were incomplete

Addresses review feedback from Codex on #2281 (comment #3 - missing conversationKey).

The other two Codex comments on #2281 are stale:
- Comment #1 (host attachments always denied): `approveHostAttachmentRead` now delegates to the permission checker via `check()`, not hardcoded false
- Comment #2 (attachments not on message_complete/generation_handoff): Both events now include `attachments` payload when present (lines 999 and 1015 in session.ts)

## Test plan
- [x] README accurately reflects the required query parameter

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
