### PR TITLE
fix(trace): debounce bottom-anchor to prevent auto-scroll race

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -7,10 +7,13 @@ struct TraceTimelineView: View {
     @ObservedObject var traceStore: TraceStore
     let sessionId: String
 
-    /// Tracks whether the bottom anchor is visible — when true, new events
-    /// auto-scroll to the bottom. When the user scrolls up and the anchor
-    /// leaves the viewport, auto-scroll pauses until they return to the bottom.
+    /// Tracks whether auto-scroll is active. Uses a debounced approach to avoid
+    /// a race condition where new content pushes the bottom anchor out of the
+    /// viewport (firing onDisappear) before onChange can auto-scroll.
     @State private var isNearBottom = true
+    /// Pending task that will set isNearBottom to false after a short delay.
+    /// Cancelled if onAppear fires again (e.g. after auto-scroll completes).
+    @State private var disappearTask: Task<Void, Never>?
     @State private var expandedEventIds: Set<String> = []
 
     private var groupedEvents: [(key: String, events: [TraceStore.StoredEvent])] {
@@ -31,12 +34,25 @@ struct TraceTimelineView: View {
                         requestGroup(group.key, events: group.events)
                     }
 
-                    // Invisible anchor for auto-scroll and bottom detection
+                    // Invisible anchor for auto-scroll and bottom detection.
+                    // Uses debounced onDisappear to avoid a race where new content
+                    // pushes the anchor out of view before onChange can auto-scroll.
                     Color.clear
                         .frame(height: 1)
                         .id("trace-bottom")
-                        .onAppear { isNearBottom = true }
-                        .onDisappear { isNearBottom = false }
+                        .onAppear {
+                            disappearTask?.cancel()
+                            disappearTask = nil
+                            isNearBottom = true
+                        }
+                        .onDisappear {
+                            disappearTask?.cancel()
+                            disappearTask = Task { @MainActor in
+                                try? await Task.sleep(for: .milliseconds(150))
+                                guard !Task.isCancelled else { return }
+                                isNearBottom = false
+                            }
+                        }
                 }
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)


### PR DESCRIPTION
## Summary
- Fixes race condition in `TraceTimelineView` where auto-scroll silently stops working
- When new events arrive, the bottom anchor gets pushed out of the viewport, firing `onDisappear` and setting `isNearBottom = false` before the `onChange` handler can auto-scroll
- Debounce `onDisappear` with 150ms delay; cancelled if `onAppear` fires again (as it does after auto-scroll completes)
- Only genuine user scroll-up (staying away from bottom for >150ms) pauses auto-scroll

## Test plan
- [x] `swift build --target VellumAssistantLib` compiles
- [ ] Manual: scroll up in trace timeline, verify "Jump to bottom" button appears and auto-scroll pauses
- [ ] Manual: stay at bottom while new events arrive, verify auto-scroll continues reliably

Addresses feedback from #2256

## Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
