### PR TITLE
fix(trace): debounce onDisappear to prevent auto-scroll race

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -13,6 +13,11 @@ struct TraceTimelineView: View {
     @State private var isNearBottom = true
     @State private var expandedEventIds: Set<String> = []
 
+    /// Debounces onDisappear so that new content pushing the anchor out of
+    /// view during an update cycle doesn't immediately disable auto-scroll.
+    /// onAppear cancels any pending disappear, preventing the race.
+    @State private var disappearWork: DispatchWorkItem?
+
     private var groupedEvents: [(key: String, events: [TraceStore.StoredEvent])] {
         let byRequest = traceStore.eventsByRequest(sessionId: sessionId)
         return byRequest.map { (key: $0.key, events: $0.value) }
@@ -35,8 +40,17 @@ struct TraceTimelineView: View {
                     Color.clear
                         .frame(height: 1)
                         .id("trace-bottom")
-                        .onAppear { isNearBottom = true }
-                        .onDisappear { isNearBottom = false }
+                        .onAppear {
+                            disappearWork?.cancel()
+                            disappearWork = nil
+                            isNearBottom = true
+                        }
+                        .onDisappear {
+                            disappearWork?.cancel()
+                            let work = DispatchWorkItem { isNearBottom = false }
+                            disappearWork = work
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
+                        }
                 }
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)


### PR DESCRIPTION
## Summary
- Debounce the `onDisappear` callback on the trace timeline bottom anchor by 150ms
- `onAppear` cancels any pending disappear, so auto-scroll continues working when new content pushes the anchor temporarily out of view
- Fixes the race condition identified in PR #2256 review where new events added to the `LazyVStack` could push the bottom anchor out of the viewport, firing `onDisappear` and setting `isNearBottom = false` before `onChange` could trigger auto-scroll

## Context
Addresses feedback from Devin review on #2256: the `onAppear`/`onDisappear` approach for detecting scroll position has a race condition during SwiftUI update cycles. When `TraceStore.ingest()` adds a new event, the layout pass inserts rows above the anchor, pushing it below the viewport. `onDisappear` fires and disables auto-scroll before `onChange` can scroll to bottom.

The debounce ensures only sustained user-initiated scrolls away from the bottom disable auto-scroll.

## Test plan
- [x] `swift build --target VellumAssistantLib` compiles
- [ ] Manual: scroll up in trace timeline -> button appears, new events don't auto-scroll; scroll to bottom or tap button -> auto-scroll resumes; stay at bottom -> new events auto-scroll reliably

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
