### PR TITLE
fix(test): make queue-full trace attribute assertions unconditional

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1098,11 +1098,10 @@ describe('Surface-action queue-full trace', () => {
       (e) => 'kind' in e && e.kind === 'request_error',
     );
     expect(errorTrace).toBeDefined();
-    if (errorTrace && 'attributes' in errorTrace) {
-      const attrs = (errorTrace as any).attributes;
-      expect(attrs.reason).toBe('queue_full');
-      expect(attrs.source).toBe('surface_action');
-    }
+    expect(errorTrace).toHaveProperty('attributes');
+    const attrs = (errorTrace as any).attributes;
+    expect(attrs.reason).toBe('queue_full');
+    expect(attrs.source).toBe('surface_action');
 
     // Queue depth should not have increased
     expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);


### PR DESCRIPTION
## Summary
- Removes the conditional guard `if (errorTrace && 'attributes' in errorTrace)` from the surface-action queue-full regression test
- Replaces it with unconditional `toHaveProperty('attributes')` + direct attribute assertions, so the test will now fail if `request_error` is emitted without the expected `reason` and `source` attributes

Addresses review feedback on #2275.

## Test plan
- [x] `bun test session-queue.test.ts --test-name-pattern "surface-action queue-full"` passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
