### PR TITLE
perf(attachments): use metadata-only query for runtime endpoints

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -156,6 +156,52 @@ export function getAttachmentsForMessage(
 }
 
 /**
+ * Return metadata (no dataBase64) for all attachments linked to a message.
+ * Use this instead of getAttachmentsForMessage when you only need the
+ * id/filename/mimeType/sizeBytes/kind fields — avoids deserializing
+ * potentially large base64 blobs from the database.
+ */
+export function getAttachmentMetadataForMessage(
+  messageId: string,
+  assistantId: string,
+): StoredAttachment[] {
+  const db = getDb();
+  const links = db
+    .select({ attachmentId: messageAttachments.attachmentId })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.messageId, messageId))
+    .orderBy(messageAttachments.position)
+    .all();
+
+  if (links.length === 0) return [];
+
+  const results: StoredAttachment[] = [];
+  for (const link of links) {
+    if (!link.attachmentId) continue;
+    const row = db
+      .select({
+        id: attachments.id,
+        assistantId: attachments.assistantId,
+        originalFilename: attachments.originalFilename,
+        mimeType: attachments.mimeType,
+        sizeBytes: attachments.sizeBytes,
+        kind: attachments.kind,
+        createdAt: attachments.createdAt,
+      })
+      .from(attachments)
+      .where(
+        and(
+          eq(attachments.id, link.attachmentId),
+          eq(attachments.assistantId, assistantId),
+        ),
+      )
+      .get();
+    if (row) results.push(row);
+  }
+  return results;
+}
+
+/**
  * Return all attachments linked to a message without assistant scoping.
  * Used by the desktop IPC history handler where tenant isolation is not needed.
  */

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -240,7 +240,7 @@ export class RuntimeHttpServer {
     const messages: RuntimeMessagePayload[] = merged.map((m) => {
       let msgAttachments: RuntimeAttachmentMetadata[] = [];
       if (m.role === 'assistant' && m.id) {
-        const linked = attachmentsStore.getAttachmentsForMessage(m.id, assistantId);
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id, assistantId);
         if (linked.length > 0) {
           msgAttachments = linked.map((a) => ({
             id: a.id,
@@ -814,7 +814,7 @@ export class RuntimeHttpServer {
           try { parsed = JSON.parse(msgs[i].content); } catch { parsed = msgs[i].content; }
           const rendered = renderHistoryContent(parsed);
 
-          const linked = attachmentsStore.getAttachmentsForMessage(msgs[i].id, assistantId);
+          const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id, assistantId);
           const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
             id: a.id,
             filename: a.originalFilename,


### PR DESCRIPTION
## Summary
- Add `getAttachmentMetadataForMessage` to `attachments-store.ts` that selects only metadata columns (id, filename, mimeType, sizeBytes, kind, createdAt) without reading `dataBase64`
- Update `handleListMessages` and `handleChannelInbound` in `http-server.ts` to use the new metadata-only query instead of `getAttachmentsForMessage`
- Addresses review feedback on #2265: the runtime polling endpoint was deserializing potentially large base64 blobs (up to 20MB each) just to return metadata fields

## Test plan
- [x] All 5 runtime attachment metadata tests pass
- [x] All 25 attachments-store tests pass
- [x] All 20 server-history-render tests pass
- [x] Type-check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
