### PR TITLE
fix(attachments): address PR #2285 feedback — ordering, fast-deny, run scoping

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -519,6 +519,12 @@ export class DaemonServer {
           rebindClient ? sendToClient : () => {},
           workingDir,
         );
+        // When created without a socket (HTTP path), mark the session
+        // so interactive prompts (e.g. host attachment reads) can fail
+        // fast instead of waiting for a timeout with no client to respond.
+        if (!socket) {
+          newSession.updateClient(sendToClient, true);
+        }
         await newSession.loadFromDb();
         if (rebindClient && socket) {
           newSession.setSandboxOverride(this.socketSandboxOverride.get(socket));
@@ -591,13 +597,16 @@ export class DaemonServer {
     attachmentIds?: string[],
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
-    session.setAssistantId(assistantId);
 
     // Reject concurrent requests upfront. The HTTP path should never use
     // the message queue — it returns 409 to the caller instead.
     if (session.isProcessing()) {
       throw new Error('Session is already processing a message');
     }
+
+    // Set assistantId AFTER the isProcessing check so a rejected request
+    // doesn't mutate the session state visible to an in-flight request.
+    session.setAssistantId(assistantId);
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds
@@ -634,11 +643,14 @@ export class DaemonServer {
     attachmentIds?: string[],
   ): Promise<{ messageId: string }> {
     const session = await this.getOrCreateSession(conversationId);
-    session.setAssistantId(assistantId);
 
     if (session.isProcessing()) {
       throw new Error('Session is already processing a message');
     }
+
+    // Set assistantId AFTER the isProcessing check so a rejected request
+    // doesn't mutate the session state visible to an in-flight request.
+    session.setAssistantId(assistantId);
 
     // Resolve attachment IDs to full attachment data for the session
     const attachments = attachmentIds

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -115,6 +115,7 @@ export class Session {
   private contextCompactedMessageCount = 0;
   private currentRequestId?: string;
   private assistantId: string | null = null;
+  private hasNoClient = false;
   private messageQueue: QueuedMessage[] = [];
   private pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
@@ -293,8 +294,9 @@ export class Session {
     log.info({ conversationId: this.conversationId, count: this.messages.length }, 'Loaded messages from DB');
   }
 
-  updateClient(sendToClient: (msg: ServerMessage) => void): void {
+  updateClient(sendToClient: (msg: ServerMessage) => void, hasNoClient = false): void {
     this.sendToClient = sendToClient;
+    this.hasNoClient = hasNoClient;
     this.prompter.updateSender(sendToClient);
     this.secretPrompter.updateSender(sendToClient);
     this.traceEmitter.updateSender(sendToClient);
@@ -432,6 +434,14 @@ export class Session {
       return true;
     }
     if (decision.decision === 'deny') {
+      return false;
+    }
+
+    // HTTP-created sessions use a no-op sendToClient — prompting would
+    // block for the full permission timeout before auto-denying. Fail
+    // fast instead.
+    if (this.hasNoClient) {
+      log.info({ filePath }, 'Denying host attachment read: no interactive client connected');
       return false;
     }
 

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -81,9 +81,14 @@ export class RunOrchestrator {
     const messageId = session.persistUserMessage(content, attachments, requestId);
     const run = runsStore.createRun(assistantId, conversationId, messageId);
 
+    // Set the assistant ID so attachments are scoped correctly.
+    session.setAssistantId(assistantId);
+
     // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the
     // run store so the web UI can poll and submit a decision.
+    // Pass hasNoClient=true so interactive-only prompts (e.g. host
+    // attachment reads) fail fast instead of waiting for a timeout.
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
@@ -101,14 +106,14 @@ export class RunOrchestrator {
           session,
         });
       }
-    });
+    }, true);
 
     // Fire-and-forget the agent loop
     const cleanup = () => {
       this.pending.delete(run.id);
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.
-      session.updateClient(() => {});
+      session.updateClient(() => {}, true);
     };
 
     session.runAgentLoop(content, messageId, (msg: ServerMessage) => {


### PR DESCRIPTION
## Summary

Addresses three review comments from PR #2285:

- **Race condition (Devin)**: Move `setAssistantId()` after `isProcessing()` check in `persistAndProcessMessage` and `processMessage` so a rejected concurrent request doesn't mutate the assistantId visible to an in-flight request.
- **Timeout blocking (Codex P1)**: Add `hasNoClient` flag to Session so `approveHostAttachmentRead` can deny immediately for HTTP-created sessions instead of blocking for the full permission timeout (300s) with no client to respond.
- **Run attachment scoping (Codex P2)**: Call `session.setAssistantId(assistantId)` in `RunOrchestrator.startRun` so run-generated attachments are stored under the correct assistant ID instead of falling back to `'local-assistant'`.

## Test plan

- [ ] Verify type-check passes (pre-existing errors only)
- [ ] Confirm attachments created via `/runs` endpoint are scoped to the correct assistant
- [ ] Verify concurrent HTTP requests to the same session don't corrupt assistantId
- [ ] Verify host attachment reads deny immediately in HTTP sessions without IPC client
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
