### PR TITLE
fix(sandbox): restore portable Docker default shell to sh

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -85,7 +85,7 @@ describe('AssistantConfigSchema', () => {
       backend: 'docker',
       docker: {
         image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
-        shell: 'bash',
+        shell: 'sh',
         cpus: 1,
         memoryMb: 512,
         pidsLimit: 256,

--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -586,7 +586,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled returns bash with sandboxed=false', () => {
-    const result = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'bash', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+    const result = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     expect(result.command).toBe('bash');
     expect(result.args).toEqual(['-c', '--', 'echo hi']);
@@ -594,7 +594,7 @@ describe('SandboxResult shape consistency across backends', () => {
   });
 
   test('wrapCommand disabled result has same shape as enabled result', () => {
-    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'bash', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+    const disabled = wrapCommand('echo hi', '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
 
     // Both must have: command (string), args (string[]), sandboxed (boolean)
     expect(typeof disabled.command).toBe('string');
@@ -875,7 +875,7 @@ describe('DockerBackend vs NativeBackend: SandboxResult shape parity', () => {
     // Various commands should all be wrapped consistently when disabled
     const commands = ['echo hello', 'ls -la', 'cat /etc/hosts', 'true && false'];
     for (const cmd of commands) {
-      const result = wrapCommand(cmd, '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'bash', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
+      const result = wrapCommand(cmd, '/tmp', { enabled: false, backend: 'native', docker: { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' } });
       expect(result.command).toBe('bash');
       expect(result.args[0]).toBe('-c');
       expect(result.args[1]).toBe('--');

--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -111,13 +111,13 @@ describe('DockerBackend — argument construction', () => {
     expect(result.args).toContain(defaultImage);
   });
 
-  test('wraps command with bash -c by default', () => {
+  test('wraps command with sh -c by default', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     const cmd = 'cat /etc/passwd | wc -l';
     const result = backend.wrap(cmd, sandboxRoot);
-    const bashIdx = result.args.indexOf('bash');
-    expect(bashIdx).toBeGreaterThan(0);
-    expect(result.args.slice(bashIdx)).toEqual(['bash', '-c', cmd]);
+    const shIdx = result.args.indexOf('sh');
+    expect(shIdx).toBeGreaterThan(0);
+    expect(result.args.slice(shIdx)).toEqual(['sh', '-c', cmd]);
   });
 });
 

--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -43,7 +43,7 @@ mock.module('node:fs', () => ({
 const { wrapCommand } = await import('../tools/terminal/sandbox.js');
 const { ToolError } = await import('../util/errors.js');
 
-const defaultDocker = { image: 'node:20-slim', shell: 'bash', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const };
+const defaultDocker = { image: 'node:20-slim', shell: 'sh', cpus: 1, memoryMb: 512, pidsLimit: 256, network: 'none' as const };
 
 function disabledConfig(): SandboxConfig {
   return { enabled: false, backend: 'native', docker: defaultDocker };

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -94,7 +94,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
-      shell: 'bash',
+      shell: 'sh',
       cpus: 1,
       memoryMb: 512,
       pidsLimit: 256,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -31,7 +31,7 @@ export const DockerConfigSchema = z.object({
     .default('node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687'),
   shell: z
     .string({ error: 'sandbox.docker.shell must be a string' })
-    .default('bash'),
+    .default('sh'),
   cpus: z
     .number({ error: 'sandbox.docker.cpus must be a number' })
     .finite('sandbox.docker.cpus must be finite')
@@ -65,7 +65,7 @@ export const SandboxConfigSchema = z.object({
     .default('docker'),
   docker: DockerConfigSchema.default({
     image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
-    shell: 'bash',
+    shell: 'sh',
     cpus: 1,
     memoryMb: 512,
     pidsLimit: 256,
@@ -575,7 +575,7 @@ export const AssistantConfigSchema = z.object({
     backend: 'docker',
     docker: {
       image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
-      shell: 'bash',
+      shell: 'sh',
       cpus: 1,
       memoryMb: 512,
       pidsLimit: 256,

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -14,7 +14,7 @@ const log = getLogger('docker-sandbox');
  */
 const DEFAULTS: Required<DockerConfig> = {
   image: 'node:20-slim@sha256:c6585df72c34172bebd8d36abed961e231d7d3b5cee2e01294c4495e8a03f687',
-  shell: 'bash',
+  shell: 'sh',
   cpus: 1,
   memoryMb: 512,
   pidsLimit: 256,


### PR DESCRIPTION
## Summary
- Restore the Docker sandbox default shell from `bash` back to `sh` (reverting the change from #2240)
- `sh` is universally available in all Docker images, whereas `bash` is absent from minimal images like `alpine:*`
- Users who need bash can still set `sandbox.docker.shell = "bash"` explicitly

## Test plan
- [x] config-schema tests pass (48/48)
- [x] terminal-sandbox-docker tests pass (55/55)
- [x] terminal-sandbox tests pass (13/13)
- [x] sandbox-host-parity tests pass (49/49)

Addresses feedback from #2240.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
