### PR TITLE
fix(sandbox): add shell availability check with sh fallback

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -605,7 +605,8 @@ describe('DockerBackend — preflight: mount probe', () => {
       (args) =>
         args[0] === 'docker' &&
         Array.isArray(args[1]) &&
-        (args[1] as string[]).includes('run'),
+        (args[1] as string[]).includes('run') &&
+        (args[1] as string[]).includes('test'),
     );
     expect(mountCalls.length).toBe(1);
     // Verify mount arg is passed as a single argv element
@@ -627,7 +628,8 @@ describe('DockerBackend — preflight: mount probe', () => {
       (args) =>
         args[0] === 'docker' &&
         Array.isArray(args[1]) &&
-        (args[1] as string[]).includes('run'),
+        (args[1] as string[]).includes('run') &&
+        (args[1] as string[]).includes('test'),
     );
     expect(mountCalls.length).toBe(1);
     const argv = mountCalls[0]![1] as string[];
@@ -644,9 +646,73 @@ describe('DockerBackend — preflight: mount probe', () => {
       (args) =>
         args[0] === 'docker' &&
         Array.isArray(args[1]) &&
-        (args[1] as string[]).includes('run'),
+        (args[1] as string[]).includes('run') &&
+        (args[1] as string[]).includes('test'),
     );
     expect(mountCalls.length).toBe(1);
+  });
+});
+
+describe('DockerBackend — preflight: shell resolution', () => {
+  test('falls back to sh when configured shell is not available in image', () => {
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (
+          file === 'docker' &&
+          Array.isArray(args) &&
+          args.includes('run') &&
+          args.includes('bash')
+        ) {
+          throw new Error('executable file not found');
+        }
+        return undefined;
+      },
+    );
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    const result = backend.wrap('echo hi', sandboxRoot);
+    // Should fall back to 'sh' instead of 'bash'
+    const imageIdx = result.args.indexOf(defaultImage);
+    expect(result.args[imageIdx + 1]).toBe('sh');
+    expect(result.args[imageIdx + 2]).toBe('-c');
+  });
+
+  test('throws when neither configured shell nor sh is available', () => {
+    execFileSyncMock.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        if (
+          file === 'docker' &&
+          Array.isArray(args) &&
+          args.includes('run') &&
+          (args.includes('bash') || args.includes('sh'))
+        ) {
+          throw new Error('executable file not found');
+        }
+        return undefined;
+      },
+    );
+
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
+    expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
+      'Neither "bash" nor "sh" is available',
+    );
+  });
+
+  test('caches resolved shell per image', () => {
+    const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
+    backend.wrap('ls', sandboxRoot);
+    backend.wrap('ls', sandboxRoot);
+
+    // Shell resolution docker run (with '-c' and 'true') should only happen once
+    const shellCalls = execFileSyncMock.mock.calls.filter(
+      (args) =>
+        args[0] === 'docker' &&
+        Array.isArray(args[1]) &&
+        (args[1] as string[]).includes('run') &&
+        (args[1] as string[]).includes('true'),
+    );
+    expect(shellCalls.length).toBe(1);
   });
 });
 

--- a/assistant/src/tools/terminal/backends/docker.ts
+++ b/assistant/src/tools/terminal/backends/docker.ts
@@ -38,6 +38,8 @@ let dockerCliAvailable = false;
 let dockerDaemonReachable = false;
 const imageAvailableCache = new Set<string>();
 const mountProbeCache = new Set<string>();
+/** Maps image → resolved shell path (e.g. 'bash' → 'bash', or fell back to 'sh'). */
+const shellResolvedCache = new Map<string, string>();
 
 /** Exported for tests to reset cached state between runs. */
 export function _resetDockerChecks(): void {
@@ -45,6 +47,7 @@ export function _resetDockerChecks(): void {
   dockerDaemonReachable = false;
   imageAvailableCache.clear();
   mountProbeCache.clear();
+  shellResolvedCache.clear();
 }
 
 function checkDockerCli(): void {
@@ -111,6 +114,52 @@ function checkMountProbe(sandboxRoot: string, image: string): void {
 }
 
 /**
+ * Verify the configured shell exists in the image.  If the requested shell
+ * (e.g. 'bash') is missing, fall back to 'sh' which is available on virtually
+ * every Linux image.  If neither exists the image is too minimal to use.
+ */
+function resolveShell(image: string, shell: string): string {
+  const cacheKey = `${image}\0${shell}`;
+  const cached = shellResolvedCache.get(cacheKey);
+  if (cached) return cached;
+
+  // Try the configured shell first.
+  try {
+    execFileSync('docker', ['run', '--rm', image, shell, '-c', 'true'], {
+      stdio: 'ignore',
+      timeout: 15000,
+    });
+    shellResolvedCache.set(cacheKey, shell);
+    return shell;
+  } catch {
+    // configured shell not available — try sh fallback
+  }
+
+  if (shell === 'sh') {
+    throw new ToolError(
+      `Shell "sh" is not available in Docker image "${image}". The image may be too minimal for sandbox use.`,
+      'bash',
+    );
+  }
+
+  try {
+    execFileSync('docker', ['run', '--rm', image, 'sh', '-c', 'true'], {
+      stdio: 'ignore',
+      timeout: 15000,
+    });
+    log.warn(`Shell "${shell}" not found in image "${image}", falling back to "sh"`);
+    shellResolvedCache.set(cacheKey, 'sh');
+    return 'sh';
+  } catch {
+    throw new ToolError(
+      `Neither "${shell}" nor "sh" is available in Docker image "${image}". ` +
+      'Choose a different image or set sandbox.docker.shell to a shell that exists in the image.',
+      'bash',
+    );
+  }
+}
+
+/**
  * Validate that a path is safe to use in Docker mount arguments.
  * Rejects paths containing null bytes, newlines, or carriage returns which
  * could cause argument injection or parsing issues.
@@ -168,18 +217,20 @@ export class DockerBackend implements SandboxBackend {
 
   /**
    * Run preflight checks in dependency order. Each check is cached
-   * on success; failures re-check on every call.
+   * on success; failures re-check on every call.  Returns the resolved
+   * shell (may differ from config if the configured shell is missing).
    */
-  preflight(): void {
+  preflight(): string {
     checkDockerCli();
     checkDockerDaemon();
     checkImageAvailable(this.config.image);
     checkMountProbe(this.sandboxRoot, this.config.image);
+    return resolveShell(this.config.image, this.config.shell);
   }
 
   wrap(command: string, workingDir: string): SandboxResult {
     // Preflight: fail closed if Docker is not usable.
-    this.preflight();
+    const shell = this.preflight();
 
     // Resolve + follow symlinks for the working directory.
     const resolved = resolve(workingDir);
@@ -205,7 +256,7 @@ export class DockerBackend implements SandboxBackend {
     const containerWorkDir =
       relPath === '' ? '/workspace' : posix.join('/workspace', relPath);
 
-    const { image, shell, cpus, memoryMb, pidsLimit, network } = this.config;
+    const { image, cpus, memoryMb, pidsLimit, network } = this.config;
 
     // Every flag is a separate argv segment — no shell interpolation occurs.
     const args: string[] = [


### PR DESCRIPTION
## Summary
- Adds a `resolveShell` preflight check that verifies the configured shell exists in the Docker image
- If the configured shell (default: `bash`) is missing, automatically falls back to `sh`
- If neither shell exists, throws a clear error with guidance
- Prevents silent runtime failures when users override `sandbox.docker.image` to minimal images (e.g. `alpine:*`) that don't ship bash
- Shell resolution is cached per image+shell combination (same positive-only caching pattern as other preflight checks)

## Test plan
- [x] All 58 terminal-sandbox-docker tests pass (3 new tests for shell resolution)
- [x] TypeScript compiles cleanly (pre-existing errors unrelated)

Addresses feedback from #2240

## Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
