### PR TITLE
feat(workspace): route inline dynamic pages to workspace

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -897,6 +897,18 @@ public final class ChatViewModel: ObservableObject {
             guard belongsToSession(msg.sessionId) else { return }
             guard msg.display == nil || msg.display == "inline" else { break }
             guard let surface = Surface.from(msg) else { break }
+
+            // Route dynamic pages to workspace instead of inline chat
+            if case .dynamicPage = surface.data {
+                isThinking = false
+                NotificationCenter.default.post(
+                    name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                    object: nil,
+                    userInfo: ["surfaceMessage": msg]
+                )
+                break
+            }
+
             isThinking = false
             let inlineSurface = InlineSurfaceData(
                 id: surface.id,


### PR DESCRIPTION
## Summary
- Dynamic pages with `display=nil` were rendering inline in chat because ChatViewModel processed them before SurfaceManager
- Now ChatViewModel detects dynamic page surfaces and posts `.openDynamicWorkspace` notification to route them to the full-window workspace
- Non-dynamic inline surfaces (cards, tables, lists) continue rendering inline as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
