### PR TITLE
fix(workspace): use mutable state for workspace composer height

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -12,6 +12,7 @@ struct MainWindowView: View {
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var selectedThreadId: UUID?
+    @State private var workspaceEditorContentHeight: CGFloat = 20
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     let daemonClient: DaemonClient
@@ -442,7 +443,7 @@ struct MainWindowView: View {
                     onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                     onPaste: { viewModel.addAttachmentFromPasteboard() },
                     onMicrophoneToggle: onMicrophoneToggle,
-                    editorContentHeight: .constant(20)
+                    editorContentHeight: $workspaceEditorContentHeight
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Replace `.constant(20)` with a `@State` variable for `editorContentHeight` in the workspace `ComposerView`
- This allows the composer to properly track content height and expand for multi-line input

Addresses feedback from PR #2290 where both Codex and Devin flagged that `.constant()` discards writes, preventing the composer from growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
