### PR TITLE
fix(attachments): preserve whitespace when no directives are parsed

### DIFF
--- a/assistant/src/__tests__/assistant-attachment-directive.test.ts
+++ b/assistant/src/__tests__/assistant-attachment-directive.test.ts
@@ -116,6 +116,14 @@ describe('parseDirectives', () => {
     expect(result.parseWarnings).toHaveLength(0);
   });
 
+  test('preserves whitespace when no directives are present', () => {
+    const text = '\n  Leading space\n\n\n\nTrailing space  \n';
+    const result = parseDirectives(text);
+
+    expect(result.cleanText).toBe(text);
+    expect(result.directiveRequests).toHaveLength(0);
+  });
+
   test('preserves non-self-closing tags as plain text', () => {
     const text = '<vellum-attachment path="file.txt">content</vellum-attachment>';
     const result = parseDirectives(text);

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -229,7 +229,9 @@ export function parseDirectives(text: string): DirectiveParseResult {
   });
 
   return {
-    cleanText: cleanText.replace(/\n{3,}/g, '\n\n').trim(),
+    cleanText: directiveRequests.length > 0
+      ? cleanText.replace(/\n{3,}/g, '\n\n').trim()
+      : cleanText,
     directiveRequests,
     parseWarnings,
   };


### PR DESCRIPTION
## Summary
- `parseDirectives()` was unconditionally normalizing whitespace (collapsing triple newlines and trimming) even when no `<vellum-attachment />` directives were found
- This mutated assistant text that contained intentional formatting (leading/trailing whitespace, markdown hard breaks, intentional blank-line separation)
- Now the normalization only applies when at least one directive was successfully parsed and stripped
- Added a test verifying whitespace-heavy text is returned unchanged when no directives are present

Addresses feedback from PR #2249.

## Test plan
- [x] Existing tests pass (31/31)
- [x] New test: whitespace-heavy text without directives is preserved exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
