### PR TITLE
fix(attachments): differentiate ENOENT from other stat errors

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -314,10 +314,17 @@ export function resolveSandboxDirective(
   let stat;
   try {
     stat = statSync(resolved);
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return {
+        draft: null,
+        warning: `Skipped sandbox attachment "${directive.path}": file not found.`,
+      };
+    }
     return {
       draft: null,
-      warning: `Skipped sandbox attachment "${directive.path}": file not found.`,
+      warning: `Skipped sandbox attachment "${directive.path}": stat error: ${(err as Error).message}`,
     };
   }
 
@@ -413,10 +420,17 @@ export async function resolveHostDirective(
   let stat;
   try {
     stat = statSync(resolved);
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return {
+        draft: null,
+        warning: `Skipped host attachment "${directive.path}": file not found.`,
+      };
+    }
     return {
       draft: null,
-      warning: `Skipped host attachment "${directive.path}": file not found.`,
+      warning: `Skipped host attachment "${directive.path}": stat error: ${(err as Error).message}`,
     };
   }
 


### PR DESCRIPTION
## Summary
- `resolveSandboxDirective` and `resolveHostDirective` now check for `ENOENT` specifically in the `statSync` catch block
- `ENOENT` continues to produce "file not found" warnings
- Other errors (e.g. `EACCES`, `EPERM`, `ENOTDIR`) now surface the actual error message as "stat error: ..." instead of being misreported as "file not found"

Addresses review feedback from PR #2252.

## Test plan
- [x] All 30 existing directive tests pass
- [x] All 34 existing attachment tests pass
- [x] "file not found" test still passes (ENOENT path unchanged)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
