### PR TITLE
fix(design-system): resolve duplicate empty-state, table border-radius, and avatar color

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -358,14 +358,6 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   outline-offset: -2px;
 }
 
-/* Empty state */
-.v-empty-state {
-  text-align: center;
-  color: var(--v-text-muted);
-  padding: var(--v-spacing-xxl) var(--v-spacing-lg);
-  font-size: var(--v-font-size-base);
-}
-
 /* Toggle switch */
 .v-toggle {
   position: relative;
@@ -514,7 +506,8 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 /* Data Table — sortable, hoverable, sticky header */
 .v-data-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   background: var(--v-surface);
   border: 1px solid var(--v-surface-border);
   border-radius: var(--v-radius-lg);
@@ -999,7 +992,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   height: 36px;
   border-radius: 50%;
   background: var(--v-accent);
-  color: white;
+  color: var(--v-slate-50);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Remove duplicate `.v-empty-state` definition (keep enhanced Layer 5 version, remove original at Layer 3)
- Fix `.v-data-table` to use `border-collapse: separate; border-spacing: 0` so `border-radius` works
- Replace hardcoded `color: white` on avatar with a design token

Addresses feedback from PR #2293 where both Codex and Devin flagged CSS issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
