### PR TITLE
fix(test): narrow parity test catch to ToolError and system errors

### DIFF
--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -51,6 +51,7 @@ import { formatShellOutput, MAX_OUTPUT_LENGTH } from '../tools/shared/shell-outp
 const { NativeBackend } = await import('../tools/terminal/backends/native.js');
 const { DockerBackend, _resetDockerChecks } = await import('../tools/terminal/backends/docker.js');
 const { wrapCommand } = await import('../tools/terminal/sandbox.js');
+const { ToolError } = await import('../util/errors.js');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -576,12 +577,13 @@ describe('SandboxResult shape consistency across backends', () => {
         expect(typeof arg).toBe('string');
       }
     } catch (err) {
-      // NativeBackend throws ToolError on unsupported platforms, but may also
-      // throw plain Errors from infra calls (e.g. writeFileSync in
-      // getProfilePath, execSync in isBwrapAvailable) depending on the
-      // environment. Both are legitimate — the key invariant is that wrap()
-      // never silently returns a non-sandboxed result.
-      expect(err).toBeInstanceOf(Error);
+      // NativeBackend explicitly throws ToolError on unsupported platforms or
+      // unsafe paths. Infrastructure calls (writeFileSync, mkdirSync) can
+      // throw system errors (ErrnoException). Both are legitimate — but
+      // programming errors like TypeError/ReferenceError should still fail.
+      const isToolError = err instanceof ToolError;
+      const isSystemError = err instanceof Error && 'code' in err && typeof (err as NodeJS.ErrnoException).code === 'string';
+      expect(isToolError || isSystemError).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary
- Addresses Codex feedback on PR #2253: the `expect(err).toBeInstanceOf(Error)` assertion was too broad and would mask programming errors (TypeError, ReferenceError) in `NativeBackend.wrap()`
- Now checks specifically for `ToolError` (explicit throws on unsupported platforms/unsafe paths) or `ErrnoException` (system errors with a `code` property from writeFileSync/mkdirSync)
- Programming errors will properly fail the test instead of being silently swallowed

## Test plan
- [x] `bun test sandbox-host-parity` — 49 pass, 0 fail
- [x] Type-check passes for the changed file (pre-existing TS errors in other files are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
