### PR TITLE
fix(run-orchestrator): detect session_error events for run failure tracking

### DIFF
--- a/assistant/src/__tests__/run-orchestrator.test.ts
+++ b/assistant/src/__tests__/run-orchestrator.test.ts
@@ -40,6 +40,7 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     // Return undefined so createRun stores messageId as null and avoids
     // a foreign-key dependency on the conversation-store message table.
     persistUserMessage: () => undefined as unknown as string,
+    setAssistantId: () => {},
     updateClient: (handler: (msg: ServerMessage) => void) => {
       clientHandler = handler;
     },
@@ -50,6 +51,78 @@ function makeSessionWithConfirmation(message: ServerMessage): Session {
     handleConfirmationResponse: () => {},
   } as unknown as Session;
 }
+
+/**
+ * Build a session whose runAgentLoop emits the given message via the onEvent
+ * callback and then resolves (simulating a completed agent loop).
+ */
+function makeSessionWithEvent(message: ServerMessage): Session {
+  return {
+    isProcessing: () => false,
+    persistUserMessage: () => undefined as unknown as string,
+    setAssistantId: () => {},
+    updateClient: () => {},
+    runAgentLoop: async (_content: string, _messageId: string, onEvent: (msg: ServerMessage) => void) => {
+      onEvent(message);
+    },
+    handleConfirmationResponse: () => {},
+  } as unknown as Session;
+}
+
+describe('run failure detection', () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM message_runs');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+  });
+
+  test('session_error event marks the run as failed', async () => {
+    const conversation = createConversation('session error test');
+    const session = makeSessionWithEvent({
+      type: 'session_error',
+      sessionId: conversation.id,
+      code: 'PROVIDER_NETWORK',
+      userMessage: 'Unable to reach the AI provider.',
+      retryable: true,
+    });
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Hello');
+
+    // The agent loop fires asynchronously; give it a tick to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stored = orchestrator.getRun(run.id);
+    expect(stored?.status).toBe('failed');
+    expect(stored?.error).toBe('Unable to reach the AI provider.');
+  });
+
+  test('generic error event still marks the run as failed', async () => {
+    const conversation = createConversation('generic error test');
+    const session = makeSessionWithEvent({
+      type: 'error',
+      message: 'Something went wrong',
+    });
+
+    const orchestrator = new RunOrchestrator({
+      getOrCreateSession: async () => session,
+      resolveAttachments: () => [],
+    });
+
+    const run = await orchestrator.startRun('assistant-1', conversation.id, 'Hello');
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stored = orchestrator.getRun(run.id);
+    expect(stored?.status).toBe('failed');
+    expect(stored?.error).toBe('Something went wrong');
+  });
+});
 
 describe('run approval state executionTarget', () => {
   beforeEach(() => {

--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -119,6 +119,8 @@ export class RunOrchestrator {
     session.runAgentLoop(content, messageId, (msg: ServerMessage) => {
       if (msg.type === 'error') {
         lastError = msg.message;
+      } else if (msg.type === 'session_error') {
+        lastError = msg.userMessage;
       }
     }).then(() => {
       if (lastError) {


### PR DESCRIPTION
## Summary
- RunOrchestrator only checked for `msg.type === 'error'` to record run failures
- After PR #2263 converted agent-loop errors to `session_error`, provider/network failures no longer set `lastError`, causing runs to be marked `completed` instead of `failed`
- Now also checks for `session_error` messages and uses their `userMessage` field
- Adds tests for both `session_error` and generic `error` detection paths

Addresses feedback from [PR #2263](https://github.com/vellum-ai/vellum-assistant/pull/2263#discussion_r2808555808).

## Test plan
- [x] 5/5 run-orchestrator tests pass (2 new + 3 existing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
