### PR TITLE
fix(error): restore generic error emission alongside session_error

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -405,7 +405,7 @@ describe('Session message queue', () => {
     expect(sessionErr3).toBeUndefined();
   });
 
-  test('session-scoped errors emit session_error only, not generic error', async () => {
+  test('session-scoped errors emit both session_error and generic error', async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -424,9 +424,10 @@ describe('Session message queue', () => {
     const sessionErr = events.find((e) => e.type === 'session_error');
     expect(sessionErr).toBeDefined();
 
-    // Should NOT emit generic error — session failures use session_error only
+    // Should also emit generic error for backward compatibility
+    // (RunOrchestrator relies on error events to detect failures)
     const genericErr = events.find((e) => e.type === 'error');
-    expect(genericErr).toBeUndefined();
+    expect(genericErr).toBeDefined();
   });
 
   test('queue depth is reported correctly as messages are added and drained', async () => {
@@ -1338,7 +1339,7 @@ describe('Regression: cancel semantics and error channel split', () => {
     expect(sessionErr).toBeUndefined();
   });
 
-  test('provider failure during processing emits session_error only', async () => {
+  test('provider failure during processing emits both session_error and generic error', async () => {
     const allEvents: ServerMessage[] = [];
     const session = makeSession();
     await session.loadFromDb();
@@ -1354,9 +1355,9 @@ describe('Regression: cancel semantics and error channel split', () => {
     const sessionErr = allEvents.find((e) => e.type === 'session_error');
     expect(sessionErr).toBeDefined();
 
-    // Must not get generic error — session failures are session_error only
+    // Should also get generic error for backward compatibility
     const genericErr = allEvents.find((e) => e.type === 'error');
-    expect(genericErr).toBeUndefined();
+    expect(genericErr).toBeDefined();
   });
 
   test('cancel after queued messages produces no session_error for any queued entry', async () => {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -498,15 +498,16 @@ async function handleUserMessage(
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
     session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
-      // Session-scoped failure: emit only session_error (not generic error)
-      // so the client routes it through the typed session-error channel.
+      ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
       const classified = classifySessionError(err, { phase: 'agent_loop' });
       ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
     });
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, 'Error setting up user message processing');
-    // Session-scoped failure: emit only session_error (not generic error).
+    ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
     const classified = classifySessionError(err, { phase: 'handler' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -830,7 +831,7 @@ async function handleRegenerate(
       status: 'error',
       attributes: { errorClass: err instanceof Error ? err.constructor.name : 'Error', message: message.slice(0, 500) },
     });
-    // Session-scoped failure: emit only session_error (not generic error).
+    ctx.send(socket, { type: 'error', message: `Failed to regenerate: ${message}` });
     const classified = classifySessionError(err, { phase: 'regenerate' });
     ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
   }
@@ -1397,8 +1398,9 @@ async function handleTaskSubmit(
       session.processMessage(msg.task, msg.attachments ?? [], (event) => {
         ctx.send(socket, event);
       }, requestId).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
         rlog.error({ err }, 'Error processing task_submit text QA');
-        // Session-scoped failure: emit only session_error (not generic error).
+        ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, { phase: 'agent_loop' });
         ctx.send(socket, buildSessionErrorMessage(conversation.id, classified));
       });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1051,8 +1051,7 @@ export class Session {
           status: 'error',
           attributes: { errorClass, message: message.slice(0, 500) },
         });
-        // Session-scoped failure: emit only session_error (not generic error)
-        // so the client routes it through the typed session-error channel.
+        onEvent({ type: 'error', message: `Failed to process message: ${message}` });
         const classified = classifySessionError(err, errorCtx);
         onEvent(buildSessionErrorMessage(this.conversationId, classified));
         void getHookManager().trigger('on-error', {


### PR DESCRIPTION
## Summary
- Restore generic `error` event emission alongside `session_error` in session catch blocks
- PR #2242 removed the dual emission, breaking `RunOrchestrator.startRun` which relies on `msg.type === 'error'` to detect failures and mark runs as failed
- Without the generic `error`, failed runs were being recorded as completed
- Updated tests to expect both `session_error` (structured) and `error` (backward-compatible)

## Files modified
- `assistant/src/daemon/session.ts` — restore `error` emission in `runAgentLoop` catch block
- `assistant/src/daemon/handlers.ts` — restore `error` emission in 4 catch blocks (user_message, setup, regenerate, task_submit)
- `assistant/src/__tests__/session-queue.test.ts` — update 2 tests to expect both event types

## Test plan
- [x] All 33 session-queue tests pass
- [x] Type-check passes (no new errors)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
