### PR TITLE
fix(storage): scope orphan attachment GC to deleted message candidates

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -294,10 +294,10 @@ describe('getAttachmentsForMessageUnscoped', () => {
 describe('deleteOrphanAttachments', () => {
   beforeEach(resetTables);
 
-  test('removes attachments with no message links', () => {
-    uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'ZGF0YQ==');
+  test('removes candidate attachments with no message links', () => {
+    const stored = uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'ZGF0YQ==');
 
-    const removed = deleteOrphanAttachments();
+    const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(1);
   });
 
@@ -307,29 +307,41 @@ describe('deleteOrphanAttachments', () => {
     const stored = uploadAttachment('ast-1', 'linked.txt', 'text/plain', 'ZGF0YQ==');
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const removed = deleteOrphanAttachments();
+    const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(0);
 
     const fetched = getAttachmentById('ast-1', stored.id);
     expect(fetched).not.toBeNull();
   });
 
-  test('removes only orphans when mixed', () => {
+  test('removes only orphans when mixed candidates provided', () => {
     const conv = createConversation();
     const msg = addMessage(conv.id, 'assistant', 'Mixed');
     const linked = uploadAttachment('ast-1', 'linked.txt', 'text/plain', 'AAAA');
-    uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'BBBB');
+    const orphan = uploadAttachment('ast-1', 'orphan.txt', 'text/plain', 'BBBB');
     linkAttachmentToMessage(msg.id, linked.id, 0);
 
-    const removed = deleteOrphanAttachments();
+    const removed = deleteOrphanAttachments([linked.id, orphan.id]);
     expect(removed).toBe(1);
 
     const remaining = getAttachmentById('ast-1', linked.id);
     expect(remaining).not.toBeNull();
   });
 
-  test('returns 0 when no orphans exist', () => {
-    const removed = deleteOrphanAttachments();
+  test('returns 0 when no candidates provided', () => {
+    const removed = deleteOrphanAttachments([]);
     expect(removed).toBe(0);
+  });
+
+  test('does not delete attachments outside the candidate set', () => {
+    const unrelated = uploadAttachment('ast-1', 'unrelated.txt', 'text/plain', 'AAAA');
+    const candidate = uploadAttachment('ast-1', 'candidate.txt', 'text/plain', 'BBBB');
+
+    const removed = deleteOrphanAttachments([candidate.id]);
+    expect(removed).toBe(1);
+
+    // The unrelated attachment should still exist
+    const fetched = getAttachmentById('ast-1', unrelated.id);
+    expect(fetched).not.toBeNull();
   });
 });

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -280,4 +280,23 @@ describe('attachment orphan cleanup', () => {
     expect(attachmentCount.c).toBe(0);
     expect(linkCount.c).toBe(0);
   });
+
+  test('deleteLastExchange does not delete unlinked user uploads', () => {
+    const conv = createConversation('test');
+    addMessage(conv.id, 'user', 'hello');
+    const assistantMsg = addMessage(conv.id, 'assistant', 'Here is a file');
+
+    // An attachment linked to the assistant message (should be cleaned up)
+    const linked = uploadAttachment('ast-1', 'chart.png', 'image/png', 'iVBOR');
+    linkAttachmentToMessage(assistantMsg.id, linked.id, 0);
+
+    // A freshly uploaded attachment not linked to any message (should survive)
+    uploadAttachment('ast-1', 'pending.png', 'image/png', 'AAAA');
+
+    deleteLastExchange(conv.id);
+
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const remaining = raw.query('SELECT COUNT(*) AS c FROM attachments').get() as { c: number };
+    expect(remaining.c).toBe(1); // only the unlinked upload survives
+  });
 });

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -254,14 +254,21 @@ export function getAttachmentById(
 }
 
 /**
- * Delete attachments that have no remaining links in message_attachments.
+ * Delete attachments from a specific candidate set that have no remaining
+ * links in message_attachments. Only the given IDs are considered — this
+ * prevents freshly uploaded (but not yet linked) attachments from being
+ * mistakenly garbage-collected.
+ *
  * Returns the number of orphaned attachments removed.
  */
-export function deleteOrphanAttachments(): number {
+export function deleteOrphanAttachments(candidateIds: string[]): number {
+  if (candidateIds.length === 0) return 0;
   const db = getDb();
   const raw = (db as unknown as { $client: import('bun:sqlite').Database }).$client;
-  const result = raw.run(
-    'DELETE FROM attachments WHERE id NOT IN (SELECT attachment_id FROM message_attachments)',
+  const placeholders = candidateIds.map(() => '?').join(', ');
+  const stmt = raw.prepare(
+    `DELETE FROM attachments WHERE id IN (${placeholders}) AND id NOT IN (SELECT attachment_id FROM message_attachments)`,
   );
+  const result = stmt.run(...candidateIds);
   return result.changes;
 }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, count, sql, inArray } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments } from './schema.js';
+import { conversations, messages, messageRuns, channelInboundEvents, memoryItemSources, memoryItems, memoryEmbeddings, memoryItemEntities, memorySegments, messageAttachments } from './schema.js';
 import { getConfig } from '../config/loader.js';
 import { indexMessageNow } from './indexer.js';
 import { getLogger } from '../util/logger.js';
@@ -235,6 +235,18 @@ export function deleteLastExchange(conversationId: string): number {
   const [{ deleted }] = db.select({ deleted: count() }).from(messages).where(condition).all();
   if (deleted === 0) return 0;
 
+  // Collect attachment IDs linked to the messages being deleted so we can
+  // scope orphan cleanup to only those candidates (not freshly uploaded ones).
+  const messageIds = db.select({ id: messages.id }).from(messages).where(condition).all().map((r) => r.id);
+  const candidateAttachmentIds = messageIds.length > 0
+    ? db.select({ attachmentId: messageAttachments.attachmentId })
+      .from(messageAttachments)
+      .where(inArray(messageAttachments.messageId, messageIds))
+      .all()
+      .map((r) => r.attachmentId)
+      .filter((id): id is string => id !== null)
+    : [];
+
   db.transaction((tx) => {
     tx.delete(messages).where(condition).run();
     tx.update(conversations)
@@ -243,7 +255,7 @@ export function deleteLastExchange(conversationId: string): number {
       .run();
   });
 
-  deleteOrphanAttachments();
+  deleteOrphanAttachments(candidateAttachmentIds);
 
   return deleted;
 }
@@ -277,6 +289,16 @@ export interface DeletedMemoryIds {
 export function deleteMessageById(messageId: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+
+  // Collect attachment IDs linked to this message before cascade-delete
+  // so we can scope orphan cleanup to only those candidates.
+  const candidateAttachmentIds = db
+    .select({ attachmentId: messageAttachments.attachmentId })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.messageId, messageId))
+    .all()
+    .map((r) => r.attachmentId)
+    .filter((id): id is string => id !== null);
 
   db.transaction((tx) => {
     // Collect memory segment IDs linked to this message before cascade.
@@ -351,7 +373,7 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     }
   });
 
-  deleteOrphanAttachments();
+  deleteOrphanAttachments(candidateAttachmentIds);
 
   return result;
 }


### PR DESCRIPTION
## Summary
- `deleteOrphanAttachments()` now accepts a list of candidate attachment IDs instead of blanket-deleting all unlinked attachments
- Both `deleteLastExchange` and `deleteMessageById` collect linked attachment IDs before cascade-deleting messages, then pass only those candidates to GC
- Prevents freshly uploaded (but not yet linked) user attachments from being mistakenly garbage-collected

Addresses review feedback from #2268.

## Test plan
- [x] Existing orphan cleanup tests updated for scoped API
- [x] New test: `deleteLastExchange does not delete unlinked user uploads`
- [x] New test: `does not delete attachments outside the candidate set`
- [x] All 14 conversation-store tests pass
- [x] All 26 attachments-store tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
