### PR TITLE
fix(attachments): address PR #2260 review feedback

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -216,6 +216,18 @@ describe('cleanAssistantContent', () => {
     expect(result.warnings[0]).toContain('invalid source');
   });
 
+  test('preserves whitespace in plain text blocks without directives', () => {
+    const content = [
+      { type: 'text', text: '  Hello\n\n\n\nWorld  ' },
+    ];
+    const result = cleanAssistantContent(content);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    // Text should be returned exactly as-is — no trimming or blank-line collapsing
+    expect((result.cleanedContent[0] as { text: string }).text).toBe('  Hello\n\n\n\nWorld  ');
+  });
+
   test('handles content with no text blocks', () => {
     const content = [
       { type: 'thinking', thinking: 'hmm', signature: 'sig' },
@@ -315,7 +327,7 @@ describe('contentBlocksToDrafts', () => {
 // ---------------------------------------------------------------------------
 
 describe('deduplicateDrafts', () => {
-  test('removes duplicates by filename + content prefix', () => {
+  test('removes duplicates by filename + content hash', () => {
     const d = makeDraft({ filename: 'same.txt', dataBase64: 'AAAA'.repeat(20) });
     const result = deduplicateDrafts([d, { ...d }, makeDraft({ filename: 'other.txt' })]);
 
@@ -327,6 +339,17 @@ describe('deduplicateDrafts', () => {
   test('keeps drafts with same filename but different content', () => {
     const d1 = makeDraft({ filename: 'file.txt', dataBase64: 'AAAA'.repeat(20) });
     const d2 = makeDraft({ filename: 'file.txt', dataBase64: 'BBBB'.repeat(20) });
+    const result = deduplicateDrafts([d1, d2]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test('keeps drafts with same filename and same prefix but different content', () => {
+    // Shared 64-char prefix but different suffix — old prefix-based dedup
+    // would incorrectly drop the second draft.
+    const sharedPrefix = 'A'.repeat(64);
+    const d1 = makeDraft({ filename: 'tool-output.png', dataBase64: sharedPrefix + 'XXXX' });
+    const d2 = makeDraft({ filename: 'tool-output.png', dataBase64: sharedPrefix + 'YYYY' });
     const result = deduplicateDrafts([d1, d2]);
 
     expect(result).toHaveLength(2);

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -569,6 +569,10 @@ export function cleanAssistantContent(
     const b = block as Record<string, unknown>;
     if (b.type !== 'text') return block;
     const text = b.text as string;
+    // Only run the directive parser when the text actually contains a
+    // potential tag. This avoids unintentional whitespace normalisation
+    // (parseDirectives trims and collapses blank lines) on plain messages.
+    if (!text.includes('<vellum-attachment')) return block;
     const result = parseDirectives(text);
     directives.push(...result.directiveRequests);
     warnings.push(...result.parseWarnings);
@@ -583,13 +587,17 @@ export function cleanAssistantContent(
 // ---------------------------------------------------------------------------
 
 /**
- * De-duplicate drafts by filename + content hash (first 64 chars of base64
- * as a cheap proxy for content identity).
+ * De-duplicate drafts by filename + full content hash.
+ *
+ * Uses a fast hash of the entire base64 payload so that files with shared
+ * prefixes (common for image formats, tool screenshots named identically)
+ * are not incorrectly treated as duplicates.
  */
 export function deduplicateDrafts(drafts: AssistantAttachmentDraft[]): AssistantAttachmentDraft[] {
   const seen = new Set<string>();
   return drafts.filter((d) => {
-    const key = `${d.filename}:${d.dataBase64.slice(0, 64)}`;
+    const hash = Bun.hash(d.dataBase64).toString(36);
+    const key = `${d.filename}:${hash}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -549,6 +549,11 @@ export class Session {
     const rlog = log.child({ conversationId: this.conversationId, requestId: reqId });
     let yieldedForHandoff = false;
 
+    // Reset attachment state so a failed exchange never retains stale data
+    // from a prior successful run.
+    this.lastAssistantAttachments = [];
+    this.lastAttachmentWarnings = [];
+
     try {
       const preMessageResult = await getHookManager().trigger('pre-message', {
         sessionId: this.conversationId,
@@ -929,7 +934,16 @@ export class Session {
       // synthetic tool_result blocks from pre-run repair don't leak into
       // this.messages.  Only the new messages appended by the agent loop
       // (beyond the repaired prefix) are carried forward.
-      const newMessages = updatedHistory.slice(preRunHistoryLength);
+      //
+      // Strip directive tags from assistant messages so in-memory history
+      // matches the cleaned content persisted to the DB. Without this,
+      // subsequent turns would send raw <vellum-attachment /> tags to the
+      // LLM, wasting tokens and encouraging hallucinated directives.
+      const newMessages = updatedHistory.slice(preRunHistoryLength).map((msg) => {
+        if (msg.role !== 'assistant') return msg;
+        const { cleanedContent } = cleanAssistantContent(msg.content);
+        return { ...msg, content: cleanedContent as ContentBlock[] };
+      });
       const restoredHistory = [...preRepairMessages, ...newMessages];
       this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, runtimeConfig.memory.retrieval.injectionStrategy);
 


### PR DESCRIPTION
## Summary
Addresses all 4 review comments from PR #2260:

- **In-memory/DB divergence** (Devin): Strip directive tags from assistant messages in the post-loop history reconstruction so `this.messages` matches the cleaned content persisted to DB. Prevents leaking raw `<vellum-attachment />` tags to subsequent LLM calls.
- **Stale attachment state on error** (Devin): Reset `lastAssistantAttachments` and `lastAttachmentWarnings` at the top of `runAgentLoop` so failed exchanges never retain data from a prior successful run.
- **Weak dedup key** (Codex): Replace 64-char base64 prefix with full `Bun.hash()` for `deduplicateDrafts`, preventing false collisions on same-named files with shared headers (e.g. multiple `tool-output.png` screenshots).
- **Unintentional whitespace normalization** (Codex): Guard `cleanAssistantContent` to skip `parseDirectives` on text blocks that don't contain `<vellum-attachment` tags, preserving original whitespace in plain messages.

## Test plan
- [x] All 36 assistant-attachments tests pass (including 2 new tests)
- [x] All 30 directive tests pass
- [x] New test: dedup correctly keeps drafts with shared 64-char prefix but different suffixes
- [x] New test: plain text blocks without directives preserve original whitespace
- [x] No new type errors introduced

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
