### PR TITLE
fix(error): restore generic error emission in runAgentLoop catch

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -405,7 +405,7 @@ describe('Session message queue', () => {
     expect(sessionErr3).toBeUndefined();
   });
 
-  test('session-scoped errors emit session_error only, not generic error', async () => {
+  test('session-scoped errors emit both generic error and session_error', async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -424,9 +424,10 @@ describe('Session message queue', () => {
     const sessionErr = events.find((e) => e.type === 'session_error');
     expect(sessionErr).toBeDefined();
 
-    // Should NOT emit generic error — session failures use session_error only
+    // Should also emit generic error so consumers like RunOrchestrator
+    // (which keys on msg.type === 'error') can detect the failure.
     const genericErr = events.find((e) => e.type === 'error');
-    expect(genericErr).toBeUndefined();
+    expect(genericErr).toBeDefined();
   });
 
   test('queue depth is reported correctly as messages are added and drained', async () => {
@@ -1338,7 +1339,7 @@ describe('Regression: cancel semantics and error channel split', () => {
     expect(sessionErr).toBeUndefined();
   });
 
-  test('provider failure during processing emits session_error only', async () => {
+  test('provider failure during processing emits both error and session_error', async () => {
     const allEvents: ServerMessage[] = [];
     const session = makeSession();
     await session.loadFromDb();
@@ -1354,9 +1355,9 @@ describe('Regression: cancel semantics and error channel split', () => {
     const sessionErr = allEvents.find((e) => e.type === 'session_error');
     expect(sessionErr).toBeDefined();
 
-    // Must not get generic error — session failures are session_error only
+    // Should also get generic error for backward-compatible consumers
     const genericErr = allEvents.find((e) => e.type === 'error');
-    expect(genericErr).toBeUndefined();
+    expect(genericErr).toBeDefined();
   });
 
   test('cancel after queued messages produces no session_error for any queued entry', async () => {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1051,8 +1051,10 @@ export class Session {
           status: 'error',
           attributes: { errorClass, message: message.slice(0, 500) },
         });
-        // Session-scoped failure: emit only session_error (not generic error)
-        // so the client routes it through the typed session-error channel.
+        // Emit generic error so consumers like RunOrchestrator (which keys
+        // on msg.type === 'error') can detect the failure.
+        onEvent({ type: 'error', message: `Failed to process message: ${message}` });
+        // Also emit the typed session_error for session-aware clients.
         const classified = classifySessionError(err, errorCtx);
         onEvent(buildSessionErrorMessage(this.conversationId, classified));
         void getHookManager().trigger('on-error', {


### PR DESCRIPTION
## Summary
- Restores the generic `error` event emission in the `runAgentLoop` catch block alongside `session_error`
- PR #2242 removed the `{ type: 'error' }` emission, which broke `RunOrchestrator` (it keys failure detection on `msg.type === 'error'`), causing failed runs to be silently marked as completed
- Now emits both `error` (for backward-compatible consumers like RunOrchestrator) and `session_error` (for session-aware clients)

Addresses review feedback from PR #2242.

## Test plan
- [x] All 33 session-queue tests pass
- [x] Updated test to verify both error and session_error are emitted on provider failure

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
