### PR TITLE
feat(dynamic-page): open external links in default browser

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -400,6 +400,12 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             } else {
                 if navigationAction.navigationType == .other {
                     decisionHandler(.allow)
+                } else if navigationAction.navigationType == .linkActivated,
+                          let url = navigationAction.request.url,
+                          let scheme = url.scheme?.lowercased(),
+                          ["http", "https", "mailto"].contains(scheme) {
+                    NSWorkspace.shared.open(url)
+                    decisionHandler(.cancel)
                 } else {
                     decisionHandler(.cancel)
                 }


### PR DESCRIPTION
## Summary
- When a user clicks an http/https/mailto link inside a dynamic page, open it in the system default browser via `NSWorkspace.shared.open(url)` instead of blocking the navigation
- Keeps existing sandbox mode logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
