### PR TITLE
fix(workspace): wire up action and data bridge callbacks for workspace dynamic pages

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -4,6 +4,8 @@ import Security
 extension Notification.Name {
     static let apiKeyManagerDidChange = Notification.Name("APIKeyManager.didChange")
     static let openDynamicWorkspace = Notification.Name("MainWindow.openDynamicWorkspace")
+    static let updateDynamicWorkspace = Notification.Name("MainWindow.updateDynamicWorkspace")
+    static let dismissDynamicWorkspace = Notification.Name("MainWindow.dismissDynamicWorkspace")
 }
 
 /// Manages API keys in the macOS login keychain.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -888,7 +888,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.show()
             return
         }
-        let main = MainWindow(daemonClient: daemonClient, ambientAgent: ambientAgent, zoomManager: zoomManager)
+        let main = MainWindow(daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, zoomManager: zoomManager)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -6,6 +6,7 @@ import SwiftUI
 @MainActor
 final class MainWindow {
     private let daemonClient: DaemonClient
+    private let surfaceManager: SurfaceManager
     private let ambientAgent: AmbientAgent
     private let zoomManager: ZoomManager
     private var window: NSWindow?
@@ -29,8 +30,9 @@ final class MainWindow {
         threadManager.activeViewModel
     }
 
-    init(daemonClient: DaemonClient, ambientAgent: AmbientAgent, zoomManager: ZoomManager) {
+    init(daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, zoomManager: ZoomManager) {
         self.daemonClient = daemonClient
+        self.surfaceManager = surfaceManager
         self.ambientAgent = ambientAgent
         self.zoomManager = zoomManager
         self.threadManager = ThreadManager(daemonClient: daemonClient)
@@ -75,7 +77,7 @@ final class MainWindow {
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let windowWidth = min(1100.0, screenFrame.width * 0.75)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -9,20 +9,25 @@ struct MainWindowView: View {
     @State private var activePanel: SidePanelType?
     @State private var isDynamicExpanded = false
     @State private var activeDynamicSurface: UiSurfaceShowMessage?
+    /// Parsed surface for the active workspace dynamic page, kept in sync with
+    /// SurfaceManager via notifications so updates from the daemon are reflected.
+    @State private var activeDynamicParsedSurface: Surface?
     @State private var hasAPIKey = APIKeyManager.hasAnyKey()
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var selectedThreadId: UUID?
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     let daemonClient: DaemonClient
+    let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
     let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.zoomManager = zoomManager
         self.traceStore = traceStore
         self.daemonClient = daemonClient
+        self.surfaceManager = surfaceManager
         self.ambientAgent = ambientAgent
         self.onMicrophoneToggle = onMicrophoneToggle
     }
@@ -145,6 +150,7 @@ struct MainWindowView: View {
             if newPanel != .generated {
                 isDynamicExpanded = false
                 activeDynamicSurface = nil
+                activeDynamicParsedSurface = nil
             }
         }
         .onChange(of: selectedThreadId) { _, newId in
@@ -159,8 +165,27 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
                 activeDynamicSurface = msg
+                activeDynamicParsedSurface = Surface.from(msg)
                 activePanel = .generated
                 isDynamicExpanded = true
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
+            if let updated = notification.userInfo?["surface"] as? Surface {
+                activeDynamicParsedSurface = updated
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dismissDynamicWorkspace)) { notification in
+            // If a specific surfaceId was dismissed, only clear if it matches.
+            if let surfaceId = notification.userInfo?["surfaceId"] as? String {
+                if activeDynamicSurface?.surfaceId == surfaceId {
+                    activeDynamicSurface = nil
+                    activeDynamicParsedSurface = nil
+                }
+            } else {
+                // Bulk dismiss (dismissAll)
+                activeDynamicSurface = nil
+                activeDynamicParsedSurface = nil
             }
         }
     }
@@ -262,19 +287,19 @@ struct MainWindowView: View {
     @ViewBuilder
     private func chatContentView(geometry: GeometryProxy) -> some View {
         if isDynamicExpanded && activePanel == .generated {
-            if let surfaceMsg = activeDynamicSurface,
-               let surface = Surface.from(surfaceMsg),
+            if let surface = activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
                 // Workspace mode: full-window dynamic page
                 dynamicWorkspaceView(surface: surface, data: dpData)
             } else {
                 // Gallery mode: existing behavior, with workspace routing
                 GeneratedPanel(
-                    onClose: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil },
+                    onClose: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil },
                     isExpanded: $isDynamicExpanded,
                     daemonClient: daemonClient,
                     onOpenApp: { surfaceMsg in
                         activeDynamicSurface = surfaceMsg
+                        activeDynamicParsedSurface = Surface.from(surfaceMsg)
                     }
                 )
             }
@@ -387,7 +412,7 @@ struct MainWindowView: View {
         VStack(spacing: 0) {
             // Toolbar
             HStack {
-                Button(action: { activeDynamicSurface = nil }) {
+                Button(action: { activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textMuted)
@@ -402,7 +427,7 @@ struct MainWindowView: View {
 
                 Spacer()
 
-                Button(action: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil }) {
+                Button(action: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textMuted)
@@ -419,8 +444,17 @@ struct MainWindowView: View {
             // Dynamic page WebView fills remaining space
             DynamicPageSurfaceView(
                 data: data,
-                onAction: { _, _ in },
-                appId: data.appId
+                onAction: { actionId, actionData in
+                    surfaceManager.onAction?(surface.sessionId, surface.id, actionId, actionData as? [String: Any])
+                },
+                appId: data.appId,
+                onDataRequest: data.appId != nil ? { callId, method, recordId, requestData in
+                    guard let appId = surfaceManager.surfaceAppIds[surface.id] else { return }
+                    surfaceManager.onDataRequest?(surface.id, callId, method, appId, recordId, requestData)
+                } : nil,
+                onCoordinatorReady: data.appId != nil ? { coordinator in
+                    surfaceManager.surfaceCoordinators[surface.id] = coordinator
+                } : nil
             )
 
             // Chatbar pinned at bottom
@@ -454,7 +488,7 @@ struct MainWindowView: View {
         if let panel = activePanel {
             switch panel {
             case .generated:
-                GeneratedPanel(onClose: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil }, isExpanded: $isDynamicExpanded, daemonClient: daemonClient)
+                GeneratedPanel(onClose: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }, isExpanded: $isDynamicExpanded, daemonClient: daemonClient)
             case .agent:
                 AgentPanel(onClose: { activePanel = nil }, onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
@@ -509,7 +543,7 @@ private struct ZoomIndicatorView: View {
 
 #Preview {
     let dc = DaemonClient()
-    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, ambientAgent: AmbientAgent())
+    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent())
         .frame(width: 900, height: 600)
         .padding(.top, 36)
 }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -62,6 +62,10 @@ final class SurfaceManager: ObservableObject {
     /// Prevents duplicate actions (e.g. submit followed by dismiss) from racing.
     private var respondedSurfaces: Set<String> = []
 
+    /// Surfaces routed to the workspace instead of floating NSPanels.
+    /// Tracked so that update/dismiss messages can be forwarded via notifications.
+    private var workspaceRoutedSurfaces: Set<String> = []
+
     private var closeObservers: [String: Any] = [:]
 
     private let panelWidth: CGFloat = 380
@@ -90,16 +94,8 @@ final class SurfaceManager: ObservableObject {
             return
         }
 
-        // Route dynamic pages to workspace if callback is set
-        if case .dynamicPage = surface.data,
-           message.display != "inline",
-           let onDynamicPageShow {
-            onDynamicPageShow(message)
-            return
-        }
-
         // Dismiss any existing surface with the same ID first.
-        if panels[surface.id] != nil {
+        if panels[surface.id] != nil || workspaceRoutedSurfaces.contains(surface.id) {
             dismissSurfaceById(surface.id)
         }
 
@@ -114,6 +110,17 @@ final class SurfaceManager: ObservableObject {
         } else if message.surfaceType == "dynamic_page" {
             let keys = dict.keys.joined(separator: ", ")
             log.warning("dynamic_page surface has no appId — data bridge will not be injected. Keys in data: [\(keys)]")
+        }
+
+        // Route dynamic pages to workspace if callback is set.
+        // Registration above ensures update/dismiss messages still work.
+        if case .dynamicPage = surface.data,
+           message.display != "inline",
+           let onDynamicPageShow {
+            workspaceRoutedSurfaces.insert(surface.id)
+            onDynamicPageShow(message)
+            log.info("Routed surface to workspace: id=\(surface.id, privacy: .public)")
+            return
         }
 
         let appId = surfaceAppIds[surface.id]
@@ -260,8 +267,17 @@ final class SurfaceManager: ObservableObject {
 
         activeSurfaces[message.surfaceId] = updated
 
-        // Update the existing view model so child views preserve their @State.
-        viewModels[message.surfaceId]?.surface = updated
+        if workspaceRoutedSurfaces.contains(message.surfaceId) {
+            // Notify the workspace view so it can re-render with updated data.
+            NotificationCenter.default.post(
+                name: .updateDynamicWorkspace,
+                object: nil,
+                userInfo: ["surface": updated]
+            )
+        } else {
+            // Update the existing view model so child views preserve their @State.
+            viewModels[message.surfaceId]?.surface = updated
+        }
 
         log.info("Updated surface: id=\(message.surfaceId)")
     }
@@ -277,6 +293,9 @@ final class SurfaceManager: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
         closeObservers.removeAll()
+
+        let hadWorkspaceRouted = !workspaceRoutedSurfaces.isEmpty
+
         let ids = Array(panels.keys)
         for id in ids {
             panels[id]?.close()
@@ -285,13 +304,31 @@ final class SurfaceManager: ObservableObject {
             activeSurfaces.removeValue(forKey: id)
             log.info("Dismissed surface: id=\(id)")
         }
+
+        // Also clean up workspace-routed surfaces (no NSPanel to close).
+        for id in workspaceRoutedSurfaces {
+            activeSurfaces.removeValue(forKey: id)
+            log.info("Dismissed workspace-routed surface: id=\(id)")
+        }
+        workspaceRoutedSurfaces.removeAll()
+
         surfaceOrder.removeAll()
         surfaceAppIds.removeAll()
         surfaceCoordinators.removeAll()
         respondedSurfaces.removeAll()
+
+        if hadWorkspaceRouted {
+            NotificationCenter.default.post(
+                name: .dismissDynamicWorkspace,
+                object: nil,
+                userInfo: nil
+            )
+        }
     }
 
     private func dismissSurfaceById(_ surfaceId: String) {
+        let wasWorkspaceRouted = workspaceRoutedSurfaces.remove(surfaceId) != nil
+
         if let observer = closeObservers.removeValue(forKey: surfaceId) {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -304,6 +341,15 @@ final class SurfaceManager: ObservableObject {
         respondedSurfaces.remove(surfaceId)
         surfaceOrder.removeAll { $0 == surfaceId }
         repositionAllPanels()
+
+        if wasWorkspaceRouted {
+            NotificationCenter.default.post(
+                name: .dismissDynamicWorkspace,
+                object: nil,
+                userInfo: ["surfaceId": surfaceId]
+            )
+        }
+
         log.info("Dismissed surface: id=\(surfaceId)")
     }
 


### PR DESCRIPTION
## Summary
- Wire up proper `onAction`, `onDataRequest`, and `onCoordinatorReady` callbacks in the workspace `DynamicPageSurfaceView`, routing through SurfaceManager's existing callback infrastructure instead of using no-op handlers
- Track workspace-routed surfaces in `SurfaceManager.activeSurfaces` and `surfaceAppIds` so that subsequent `ui_surface_update` and `ui_surface_dismiss` IPC messages are properly handled instead of being silently dropped
- Add `.updateDynamicWorkspace` and `.dismissDynamicWorkspace` notifications so `MainWindowView` can react to lifecycle events for workspace-routed surfaces

Addresses feedback from PR #2292 where both Codex and Devin flagged that:
1. The early return in surface routing bypassed appId/surfaceAppIds/surfaceCoordinators registration
2. Rerouted surfaces weren't added to activeSurfaces, causing update/dismiss messages to be dropped
3. The workspace DynamicPageSurfaceView used no-op action handlers and omitted data bridge callbacks

## Test plan
- [ ] Open a dynamic page app in the workspace view and verify that actions (button clicks etc.) are forwarded to the daemon
- [ ] Verify that data bridge calls (query/create/update/delete) work correctly for apps with an appId
- [ ] Send a `ui_surface_update` message for a workspace-routed surface and verify the content updates
- [ ] Send a `ui_surface_dismiss` message and verify the workspace view closes
- [ ] Verify that the existing NSPanel path for inline surfaces still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
