### PR TITLE
Add preview field to IPC contract and Swift types for dynamic page preview cards

### DIFF
--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -346,11 +346,20 @@ export interface ConfirmationSurfaceData {
   destructive?: boolean;
 }
 
+export interface DynamicPagePreview {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  icon?: string;
+  metrics?: Array<{ label: string; value: string }>;
+}
+
 export interface DynamicPageSurfaceData {
   html: string;
   width?: number;
   height?: number;
   appId?: string;
+  preview?: DynamicPagePreview;
 }
 
 export interface FileUploadSurfaceData {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -599,7 +599,27 @@ public extension Surface {
             html: html,
             width: dict["width"] as? Int,
             height: dict["height"] as? Int,
-            appId: dict["appId"] as? String
+            appId: dict["appId"] as? String,
+            preview: parseDynamicPagePreview(dict["preview"] as? [String: Any?])
+        )
+    }
+
+    private static func parseDynamicPagePreview(_ dict: [String: Any?]?) -> DynamicPagePreview? {
+        guard let dict = dict, let title = dict["title"] as? String else { return nil }
+        var metrics: [(label: String, value: String)]?
+        if let metricsArray = dict["metrics"] as? [[String: Any?]] {
+            metrics = metricsArray.compactMap { item in
+                guard let label = item["label"] as? String,
+                      let value = item["value"] as? String else { return nil }
+                return (label: label, value: value)
+            }
+        }
+        return DynamicPagePreview(
+            title: title,
+            subtitle: dict["subtitle"] as? String,
+            description: dict["description"] as? String,
+            icon: dict["icon"] as? String,
+            metrics: metrics
         )
     }
 


### PR DESCRIPTION
## Summary
- Add `DynamicPagePreview` interface to IPC contract (title, subtitle, description, icon, metrics)
- Add optional `preview` field to `DynamicPageSurfaceData` in both TypeScript and Swift
- Wire up parsing and partial-merge support for the new preview field in `SurfaceTypes.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
