### PR TITLE
feat(dynamic-page): add openExternal and confirm JS bridge functions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -107,6 +107,24 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             window.vellum = {
                 sendAction: function(actionId, data) {
                     window.webkit.messageHandlers.vellumBridge.postMessage({actionId: actionId, data: data});
+                },
+                openExternal: function(url) {
+                    window.webkit.messageHandlers.vellumBridge.postMessage({type: 'open_external', url: String(url)});
+                },
+                _confirmPending: {},
+                _confirmNextId: 1,
+                confirm: function(title, message) {
+                    return new Promise(function(resolve) {
+                        var confirmId = 'confirm_' + (window.vellum._confirmNextId++);
+                        window.vellum._confirmPending[confirmId] = resolve;
+                        window.webkit.messageHandlers.vellumBridge.postMessage({
+                            type: 'confirm', confirmId: confirmId, title: String(title || ''), message: String(message || '')
+                        });
+                    });
+                },
+                _resolveConfirm: function(confirmId, result) {
+                    var p = window.vellum._confirmPending[confirmId];
+                    if (p) { delete window.vellum._confirmPending[confirmId]; p(result); }
                 }
             };
             """
@@ -316,6 +334,47 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     log.error("data_request received but onDataRequest callback is nil — appId was likely not set")
                 }
                 onDataRequest?(callId, method, recordId, data)
+                return
+            }
+
+            // Handle openExternal requests from the JS bridge.
+            if let type = body["type"] as? String, type == "open_external" {
+                guard let urlString = body["url"] as? String,
+                      let url = URL(string: urlString),
+                      let scheme = url.scheme?.lowercased(),
+                      ["http", "https", "mailto"].contains(scheme) else {
+                    log.warning("open_external: blocked invalid or disallowed URL: \(body["url"] as? String ?? "nil", privacy: .public)")
+                    return
+                }
+                NSWorkspace.shared.open(url)
+                return
+            }
+
+            // Handle confirm dialog requests from the JS bridge.
+            if let type = body["type"] as? String, type == "confirm" {
+                guard let confirmId = body["confirmId"] as? String else {
+                    log.error("confirm: missing confirmId")
+                    return
+                }
+                let title = body["title"] as? String ?? ""
+                let msg = body["message"] as? String ?? ""
+                let alert = NSAlert()
+                alert.messageText = title
+                alert.informativeText = msg
+                alert.alertStyle = .informational
+                alert.addButton(withTitle: "OK")
+                alert.addButton(withTitle: "Cancel")
+                let response = alert.runModal()
+                let confirmed = response == .alertFirstButtonReturn
+                let safeId = confirmId
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "'", with: "\\'")
+                let js = "window.vellum._resolveConfirm('\(safeId)', \(confirmed))"
+                webView?.evaluateJavaScript(js) { _, error in
+                    if let error {
+                        log.error("confirm: JS eval error: \(error.localizedDescription, privacy: .public)")
+                    }
+                }
                 return
             }
 


### PR DESCRIPTION
## Summary
- Add `window.vellum.openExternal(url)` JS function that opens http/https/mailto URLs in the system default browser via the native bridge
- Add `window.vellum.confirm(title, message)` that returns a `Promise<boolean>` resolved via a native NSAlert dialog
- Both new message types handled in the Coordinator's `userContentController` with scheme validation for security

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
