### PR TITLE
fix(attachments): deduplicate estimateBase64Bytes in handlers.ts

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -61,6 +61,7 @@ import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, claw
 import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
+import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
 import { getAttachmentsForMessageUnscoped } from '../memory/attachments-store.js';
 import type { UserMessageAttachment } from './ipc-contract.js';
@@ -160,12 +161,6 @@ function wireEscalationHandler(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
-}
-
-function estimateBase64Bytes(base64: string): number {
-  const sanitized = base64.trim();
-  const padding = sanitized.endsWith('==') ? 2 : (sanitized.endsWith('=') ? 1 : 0);
-  return Math.max(0, Math.floor((sanitized.length * 3) / 4) - padding);
 }
 
 function formatBytes(sizeBytes: number): string {


### PR DESCRIPTION
Remove the duplicate `estimateBase64Bytes` function from `handlers.ts` that still used `.trim()` (missing embedded whitespace handling like PEM-style line breaks) and import the fixed version from `assistant-attachments.ts` which uses `.replace(/\s/g, '')`.

Addresses review feedback from PR #2296 (Devin, thread PRRT_kwDORLCYic5urPa1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
