### PR TITLE
fix(test): require syscall to distinguish ErrnoException from TypeError

### DIFF
--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -582,7 +582,7 @@ describe('SandboxResult shape consistency across backends', () => {
       // throw system errors (ErrnoException). Both are legitimate — but
       // programming errors like TypeError/ReferenceError should still fail.
       const isToolError = err instanceof ToolError;
-      const isSystemError = err instanceof Error && 'code' in err && typeof (err as NodeJS.ErrnoException).code === 'string';
+      const isSystemError = err instanceof Error && 'syscall' in err && typeof (err as NodeJS.ErrnoException).code === 'string';
       expect(isToolError || isSystemError).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

Addresses review feedback on #2315 from Codex and Devin.

The `isSystemError` predicate in the sandbox parity test checked for `'code' in err`, but Node.js `TypeError`s also carry string `code` properties (e.g. `ERR_INVALID_ARG_TYPE`). This defeated the purpose of the original PR since programming errors that trigger `TypeError`s in `writeFileSync`/`mkdirSync` would still pass the check.

**Fix:** Replace `'code' in err` with `'syscall' in err`. Real `ErrnoException`s from filesystem calls always include a `syscall` property (e.g. `'open'`, `'mkdir'`), which `TypeError`s do not.

## Changed files
- `assistant/src/__tests__/sandbox-host-parity.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
