### PR TITLE
fix(runs): allow host attachment confirmation for run sessions

### DIFF
--- a/assistant/src/runtime/run-orchestrator.ts
+++ b/assistant/src/runtime/run-orchestrator.ts
@@ -87,8 +87,8 @@ export class RunOrchestrator {
     // Hook into session to intercept confirmation_request events.
     // When the prompter sends a confirmation_request, we record it in the
     // run store so the web UI can poll and submit a decision.
-    // Pass hasNoClient=true so interactive-only prompts (e.g. host
-    // attachment reads) fail fast instead of waiting for a timeout.
+    // Do NOT set hasNoClient — run sessions have a client (the HTTP caller)
+    // and confirmations are handled via the /runs/:id/decision endpoint.
     let lastError: string | null = null;
     session.updateClient((msg: ServerMessage) => {
       if (msg.type === 'confirmation_request') {
@@ -106,13 +106,15 @@ export class RunOrchestrator {
           session,
         });
       }
-    }, true);
+    });
 
     // Fire-and-forget the agent loop
     const cleanup = () => {
       this.pending.delete(run.id);
       // Reset the session's client callback to a no-op so the stale
       // closure doesn't intercept events from future runs on the same session.
+      // Set hasNoClient=true here since the run is done and no HTTP caller
+      // is actively listening — truly no client at this point.
       session.updateClient(() => {}, true);
     };
 


### PR DESCRIPTION
## Summary

Run sessions created via the HTTP API DO have a client (the HTTP caller), they just don't have a WebSocket/IPC client. The `hasNoClient` flag was incorrectly set to `true` for run sessions, causing `approveHostAttachmentRead` to deny immediately — host attachment directives could never enter `needs_confirmation` state and were always skipped.

**The fix:** Remove `hasNoClient=true` from the `updateClient` call during active run processing in `RunOrchestrator.startRun()`. The run orchestrator already intercepts `confirmation_request` events and stores them via `runsStore.setRunConfirmation`, so the `/runs/:id/decision` endpoint can handle approvals. The `hasNoClient=true` flag is still set in the cleanup callback after the run completes, since there truly is no client at that point.

## Changes

- `assistant/src/runtime/run-orchestrator.ts`: Remove `hasNoClient=true` from `updateClient()` during active run, keeping it only in the post-run cleanup.

Addresses feedback from PR #2306.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
