### PR TITLE
fix(attachments): buffer partial directive tag prefixes across stream chunks

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -268,6 +268,49 @@ describe('drainDirectiveDisplayBuffer', () => {
     expect(second.emitText).toBe(' done');
     expect(second.bufferedRemainder).toBe('');
   });
+
+  test('buffers trailing partial prefix "<" split across chunks', () => {
+    const result = drainDirectiveDisplayBuffer('Hello world<');
+    expect(result.emitText).toBe('Hello world');
+    expect(result.bufferedRemainder).toBe('<');
+  });
+
+  test('buffers trailing partial prefix "<vel" split across chunks', () => {
+    const result = drainDirectiveDisplayBuffer('Some text<vel');
+    expect(result.emitText).toBe('Some text');
+    expect(result.bufferedRemainder).toBe('<vel');
+  });
+
+  test('buffers trailing partial prefix "<vellum-attachmen" (one char short)', () => {
+    const result = drainDirectiveDisplayBuffer('Data <vellum-attachmen');
+    expect(result.emitText).toBe('Data ');
+    expect(result.bufferedRemainder).toBe('<vellum-attachmen');
+  });
+
+  test('does not buffer trailing "<" that is not a prefix of the tag', () => {
+    // "<x" does not match any prefix of "<vellum-attachment"
+    const result = drainDirectiveDisplayBuffer('Hello<x');
+    expect(result.emitText).toBe('Hello<x');
+    expect(result.bufferedRemainder).toBe('');
+  });
+
+  test('partial prefix reassembles into a complete directive across chunks', () => {
+    const first = drainDirectiveDisplayBuffer('Before <vellum-at');
+    expect(first.emitText).toBe('Before ');
+    expect(first.bufferedRemainder).toBe('<vellum-at');
+
+    const second = drainDirectiveDisplayBuffer(
+      first.bufferedRemainder + 'tachment path="out.png" /> After',
+    );
+    expect(second.emitText).toBe(' After');
+    expect(second.bufferedRemainder).toBe('');
+  });
+
+  test('emits everything when text has no partial prefix', () => {
+    const result = drainDirectiveDisplayBuffer('No special chars here');
+    expect(result.emitText).toBe('No special chars here');
+    expect(result.bufferedRemainder).toBe('');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -246,15 +246,44 @@ export function parseDirectives(text: string): DirectiveParseResult {
  * - Incomplete directives are retained in `bufferedRemainder` until more
  *   text arrives.
  */
+const DIRECTIVE_TAG_PREFIX = '<vellum-attachment';
+
+/**
+ * Check whether `text` ends with a prefix of `tag` (e.g. "<", "<v", "<ve", …).
+ * Returns the safe-to-emit portion and any trailing partial prefix to buffer.
+ */
+function splitTrailingPrefix(
+  text: string,
+  tag: string,
+): { safe: string; trailing: string } {
+  // Scan backwards from the end for a '<' that could start a partial tag.
+  // We only need to check the last `tag.length - 1` characters — a full
+  // match would have been caught by indexOf above.
+  const searchStart = Math.max(0, text.length - tag.length + 1);
+  for (let i = text.length - 1; i >= searchStart; i--) {
+    if (text[i] === '<') {
+      const candidate = text.slice(i);
+      if (tag.startsWith(candidate)) {
+        return { safe: text.slice(0, i), trailing: candidate };
+      }
+    }
+  }
+  return { safe: text, trailing: '' };
+}
+
 export function drainDirectiveDisplayBuffer(buffer: string): DirectiveDisplayDrainResult {
   let emitText = '';
   let cursor = 0;
 
   while (cursor < buffer.length) {
-    const start = buffer.indexOf('<vellum-attachment', cursor);
+    const start = buffer.indexOf(DIRECTIVE_TAG_PREFIX, cursor);
     if (start === -1) {
-      emitText += buffer.slice(cursor);
-      return { emitText, bufferedRemainder: '' };
+      // No full tag-prefix match — but the remaining text might end with a
+      // partial prefix of "<vellum-attachment" split across streaming chunks.
+      const remaining = buffer.slice(cursor);
+      const split = splitTrailingPrefix(remaining, DIRECTIVE_TAG_PREFIX);
+      emitText += split.safe;
+      return { emitText, bufferedRemainder: split.trailing };
     }
 
     emitText += buffer.slice(cursor, start);


### PR DESCRIPTION
Follows up on PR #2288 feedback from Codex and Devin.

## Problem

`drainDirectiveDisplayBuffer` did not handle partial `<vellum-attachment` tag prefixes split across streaming chunks. If a chunk ended with e.g. `<vel` or `<vellum-at`, that partial prefix was emitted as visible text instead of being buffered. When the next chunk completed the tag, the prefix had already been shown to the user.

## Fix

After the main loop's `indexOf('<vellum-attachment', cursor)` returns -1, scan backwards from the end of the remaining text for any `<` character that starts a valid prefix of `<vellum-attachment`. If found, split the remaining text: emit everything before the prefix, and return the prefix as `bufferedRemainder`.

## Tests added

- Buffers trailing `<` split across chunks
- Buffers trailing `<vel` split across chunks  
- Buffers trailing `<vellum-attachmen` (one char short)
- Does NOT buffer `<x` (not a valid prefix)
- Partial prefix reassembles into a complete directive across chunks
- Emits everything when text has no partial prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
