### PR TITLE
fix(workspace): gate dynamic page reroute to macOS and remove duplicate notification

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -898,16 +898,16 @@ public final class ChatViewModel: ObservableObject {
             guard msg.display == nil || msg.display == "inline" else { break }
             guard let surface = Surface.from(msg) else { break }
 
-            // Route dynamic pages to workspace instead of inline chat
-            if case .dynamicPage = surface.data {
+            // On macOS, dynamic pages with no explicit display mode are routed
+            // to the workspace by SurfaceManager (which posts the notification).
+            // Suppress inline rendering here to avoid a duplicate widget.
+            // On iOS there is no workspace, so dynamic pages always render inline.
+            #if os(macOS)
+            if case .dynamicPage = surface.data, msg.display == nil {
                 isThinking = false
-                NotificationCenter.default.post(
-                    name: Notification.Name("MainWindow.openDynamicWorkspace"),
-                    object: nil,
-                    userInfo: ["surfaceMessage": msg]
-                )
                 break
             }
+            #endif
 
             isThinking = false
             let inlineSurface = InlineSurfaceData(


### PR DESCRIPTION
## Summary
- Gate the workspace dynamic page reroute in ChatViewModel to macOS only (`#if os(macOS)`) so iOS inline rendering isn't broken
- Remove duplicate `.openDynamicWorkspace` notification from ChatViewModel — SurfaceManager already handles this

Addresses feedback from PR #2310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
