### PR TITLE
PR 2: Add recall quality fixtures for conflict states and entity aliases

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -70,6 +70,8 @@ import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { buildMemoryRecall } from '../memory/retriever.js';
 import {
   conversations,
+  memoryEntities,
+  memoryItemEntities,
   memoryItems,
   memoryItemSources,
   messages,
@@ -188,6 +190,9 @@ describe('Memory Recall Quality', () => {
   beforeEach(() => {
     const db = getDb();
     db.run('DELETE FROM memory_item_sources');
+    db.run('DELETE FROM memory_item_entities');
+    db.run('DELETE FROM memory_entity_relations');
+    db.run('DELETE FROM memory_entities');
     db.run('DELETE FROM memory_embeddings');
     db.run('DELETE FROM memory_summaries');
     db.run('DELETE FROM memory_items');
@@ -359,6 +364,59 @@ describe('Memory Recall Quality', () => {
 
       expect(recall.injectedText).toContain('PostgreSQL');
     });
+
+    test('pending clarification and invalidated items are excluded from direct item recall', async () => {
+      const db = getDb();
+      const now = 1_700_000_275_000;
+      insertConversation(db, 'conv-conflict-status', now);
+      insertMessage(
+        db,
+        'msg-conflict-status',
+        'conv-conflict-status',
+        'user',
+        'Framework preference is React for this codebase.',
+        now,
+      );
+
+      insertItem(db, {
+        id: 'item-framework-active',
+        kind: 'preference',
+        subject: 'framework preference',
+        statement: 'Framework preference is React for this codebase',
+        status: 'active',
+        importance: 0.9,
+        firstSeenAt: now,
+      });
+      insertItemSource(db, 'item-framework-active', 'msg-conflict-status', now);
+
+      insertItem(db, {
+        id: 'item-framework-pending',
+        kind: 'preference',
+        subject: 'framework preference',
+        statement: 'Framework preference is Vue for this codebase',
+        status: 'pending_clarification',
+        importance: 0.9,
+        firstSeenAt: now + 1,
+      });
+      insertItemSource(db, 'item-framework-pending', 'msg-conflict-status', now + 1);
+
+      insertItem(db, {
+        id: 'item-framework-invalid',
+        kind: 'preference',
+        subject: 'framework preference',
+        statement: 'Framework preference is Angular for this codebase',
+        status: 'active',
+        importance: 0.9,
+        firstSeenAt: now + 2,
+      });
+      db.run(`UPDATE memory_items SET invalid_at = ${now + 3} WHERE id = 'item-framework-invalid'`);
+      insertItemSource(db, 'item-framework-invalid', 'msg-conflict-status', now + 2);
+
+      const recall = await buildMemoryRecall('framework preference', 'conv-conflict-status', TEST_CONFIG);
+      expect(recall.injectedText).toContain('React');
+      expect(recall.injectedText).not.toContain('Vue');
+      expect(recall.injectedText).not.toContain('Angular');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -468,6 +526,49 @@ describe('Memory Recall Quality', () => {
 
       expect(recall.injectedText).toBe('');
       expect(recall.injectedTokens).toBe(0);
+    });
+
+    test('entity alias matching recalls linked items on indirect query terms', async () => {
+      const db = getDb();
+      const now = 1_700_000_650_000;
+      insertConversation(db, 'conv-entity-alias', now);
+      insertMessage(
+        db,
+        'msg-entity-alias',
+        'conv-entity-alias',
+        'user',
+        'Our team standard editor is Visual Studio Code.',
+        now,
+      );
+
+      insertItem(db, {
+        id: 'item-editor-vscode',
+        kind: 'preference',
+        subject: 'editor preference',
+        statement: 'Team standard editor is Visual Studio Code',
+        importance: 0.8,
+        firstSeenAt: now,
+      });
+      insertItemSource(db, 'item-editor-vscode', 'msg-entity-alias', now);
+
+      db.insert(memoryEntities).values({
+        id: 'entity-vscode',
+        name: 'Visual Studio Code',
+        type: 'tool',
+        aliases: JSON.stringify(['vscode']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        mentionCount: 1,
+      }).run();
+      db.insert(memoryItemEntities).values({
+        memoryItemId: 'item-editor-vscode',
+        entityId: 'entity-vscode',
+      }).run();
+
+      const recall = await buildMemoryRecall('vscode debug setup', 'conv-entity-alias', TEST_CONFIG);
+      expect(recall.entityHits).toBeGreaterThan(0);
+      expect(recall.injectedText).toContain('Visual Studio Code');
     });
   });
 


### PR DESCRIPTION
## Summary
- extend memory recall quality fixtures with conflict-state suppression coverage
- add fixture ensuring `pending_clarification` and invalidated items are excluded from recall
- add fixture verifying entity alias lookup (`vscode` -> `Visual Studio Code`) returns linked memory items
- clear entity graph tables in test setup for isolation

## Validation
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-recall-quality.test.ts
  - all test assertions pass (13/13)
  - Bun panics post-run (runtime issue observed outside this change)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
