### PR TITLE
docs(ui-surface): add multi-select action payload conventions

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -520,6 +520,38 @@ Combine widget primitives to build complex UIs efficiently:
 
 **Comparison view:** card grid + stat rows + status badges
 
+**Multi-select table:** checkboxes + sticky action toolbar + bulk actions
+```html
+<table class="v-data-table" id="my-table">
+  <thead><tr>
+    <th><input type="checkbox"></th>
+    <th data-sortable>Name</th>
+    <th data-sortable>Status</th>
+  </tr></thead>
+  <tbody>
+    <tr data-id="1"><td><input type="checkbox"></td><td>Item 1</td><td>Active</td></tr>
+    <tr data-id="2"><td><input type="checkbox"></td><td>Item 2</td><td>Pending</td></tr>
+  </tbody>
+</table>
+<div id="bulk-toolbar" hidden style="position:sticky;bottom:0;">
+  <button onclick="handleBulk('archive')">Archive Selected</button>
+  <button onclick="handleBulk('delete')">Delete Selected</button>
+</div>
+<script>
+  vellum.widgets.multiSelect('my-table');
+  function handleBulk(action) {
+    const selected = document.querySelectorAll('#my-table tbody input:checked');
+    const ids = Array.from(selected).map(cb => cb.closest('tr').dataset.id);
+    vellum.sendAction(action, { selectedIds: ids });
+  }
+</script>
+```
+
+For table-driven workflows (inbox cleanup, flight selection, batch operations):
+1. Add checkboxes per row with a "select all" header checkbox
+2. Show a sticky action toolbar when rows are selected
+3. Fire `vellum.sendAction('action_name', { selectedIds: ['id1', 'id2'] })` on bulk action click
+
 #### When to use widgets vs custom HTML
 
 - **Use widgets** for standard data patterns — tables, metrics, timelines, status displays, notifications. They ensure visual consistency and save time.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -46,7 +46,10 @@ export const uiShowTool: Tool = {
     '- dynamic_page: Custom HTML page rendered in a sandboxed container. ' +
     'data shape: { html: string, width?: number, height?: number }\n' +
     '- file_upload: File upload dialog where the user can drag-and-drop or browse for files. ' +
-    'data shape: { prompt: string, acceptedTypes?: string[], maxFiles?: number }',
+    'data shape: { prompt: string, acceptedTypes?: string[], maxFiles?: number }\n\n' +
+    'Action payload conventions:\n' +
+    '- Multi-select tables: use `window.vellum.sendAction(actionId, { selectedIds: [...] })` to send selected row IDs\n' +
+    '- Bulk actions: include `selectedRows` array with full row data for context',
   category: 'ui-surface',
   defaultRiskLevel: RiskLevel.Low,
   executionMode: 'proxy',


### PR DESCRIPTION
## Summary
- Add action payload conventions to `ui_show` tool description documenting the `sendAction` pattern for multi-select tables
- Add multi-select table composition pattern to app-builder SKILL.md with a full HTML/JS example showing checkboxes, sticky toolbar, and bulk action handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
