### PR TITLE
Route dynamic pages to InlineDynamicPagePreview and wire View Output

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -146,17 +146,20 @@ public struct InlineSurfaceData: Identifiable, Equatable {
     public let title: String?
     public let data: SurfaceData
     public let actions: [SurfaceActionButton]
+    /// Original IPC message for dynamic pages, used to re-open the workspace.
+    public let surfaceMessage: UiSurfaceShowMessage?
 
     public static func == (lhs: InlineSurfaceData, rhs: InlineSurfaceData) -> Bool {
         lhs.id == rhs.id
     }
 
-    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton]) {
+    public init(id: String, surfaceType: SurfaceType, title: String?, data: SurfaceData, actions: [SurfaceActionButton], surfaceMessage: UiSurfaceShowMessage? = nil) {
         self.id = id
         self.surfaceType = surfaceType
         self.title = title
         self.data = data
         self.actions = actions
+        self.surfaceMessage = surfaceMessage
     }
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -899,13 +899,14 @@ public final class ChatViewModel: ObservableObject {
             guard let surface = Surface.from(msg) else { break }
 
             // On macOS, dynamic pages with no explicit display mode are routed
-            // to the workspace by SurfaceManager (which posts the notification).
-            // Suppress inline rendering here to avoid a duplicate widget.
+            // to the workspace by SurfaceManager. If the dynamic page has a
+            // preview, also render a compact preview card inline in chat.
             // On iOS there is no workspace, so dynamic pages always render inline.
             #if os(macOS)
-            if case .dynamicPage = surface.data, msg.display == nil {
+            if case .dynamicPage(let dpData) = surface.data, msg.display == nil {
                 isThinking = false
-                break
+                // Only render inline preview if the dynamic page has preview metadata
+                guard dpData.preview != nil else { break }
             }
             #endif
 
@@ -915,7 +916,8 @@ public final class ChatViewModel: ObservableObject {
                 surfaceType: surface.type,
                 title: surface.title,
                 data: surface.data,
-                actions: surface.actions
+                actions: surface.actions,
+                surfaceMessage: msg
             )
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -52,6 +52,21 @@ public struct InlineSurfaceRouter: View {
         switch surface.data {
         case .card(let data):
             InlineCardWidget(data: data)
+        case .dynamicPage(let data):
+            if let preview = data.preview {
+                InlineDynamicPagePreview(preview: preview) {
+                    // Post notification to open (or re-open) the workspace
+                    if let msg = surface.surfaceMessage {
+                        NotificationCenter.default.post(
+                            name: Notification.Name("MainWindow.openDynamicWorkspace"),
+                            object: nil,
+                            userInfo: ["surfaceMessage": msg]
+                        )
+                    }
+                }
+            } else {
+                InlineFallbackChip(surfaceType: surface.surfaceType)
+            }
         case .table(let data):
             InlineTableWidget(data: data) { actionId, payload in
                 if actionId == "selection_changed" {


### PR DESCRIPTION
## Summary
- Add optional `surfaceMessage` field to `InlineSurfaceData` to enable re-opening workspace from inline preview
- Modify ChatViewModel to render inline preview card for dynamic pages that have preview metadata (instead of fully suppressing inline rendering on macOS)
- Add `.dynamicPage` routing in `InlineSurfaceRouter` to render `InlineDynamicPagePreview` when preview data exists
- Wire "View Output" button to post `openDynamicWorkspace` notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
