### PR TITLE
docs(app-builder): add preview metadata to dynamic page tool and skill prompt

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -658,6 +658,38 @@ Call `app_create` with:
 
 Since `auto_open` defaults to `true`, the app will be displayed to the user as soon as it is created. You do **not** need to call `app_open` separately after `app_create` unless `auto_open` was explicitly set to `false`.
 
+#### Preview metadata
+
+When calling `ui_show` with `surface_type: "dynamic_page"`, include a `preview` object in the `data` so that a compact preview card appears inline in chat. This lets the user see a summary of the app without switching to the workspace. The preview card includes a "View Output" button that opens the full page.
+
+```json
+{
+  "surface_type": "dynamic_page",
+  "data": {
+    "html": "...",
+    "preview": {
+      "title": "Expense Tracker",
+      "subtitle": "Personal Finance App",
+      "description": "Track your daily expenses with category breakdowns and monthly summaries.",
+      "icon": "💰",
+      "metrics": [
+        { "label": "Records", "value": "24" },
+        { "label": "Categories", "value": "8" }
+      ]
+    }
+  }
+}
+```
+
+Preview fields:
+- `title` (required): Short app name
+- `subtitle` (optional): Category or tagline
+- `description` (optional): One-sentence summary of what the app does
+- `icon` (optional): Single emoji representing the app
+- `metrics` (optional): Up to 3 key-value pills shown below the description (e.g., record counts, totals, status summaries). Only include metrics when the app has meaningful data to surface.
+
+Always include `preview` when creating or opening a dynamic page. Choose an icon and title that clearly communicate what the app is at a glance.
+
 ### 5. Handle Iteration
 
 If the user wants changes after seeing the app:

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -44,7 +44,8 @@ export const uiShowTool: Tool = {
     '- confirmation: Yes/no confirmation dialog. ' +
     'data shape: { message: string, detail?: string, confirmLabel?: string, cancelLabel?: string, destructive?: boolean }\n' +
     '- dynamic_page: Custom HTML page rendered in a sandboxed container. ' +
-    'data shape: { html: string, width?: number, height?: number }\n' +
+    'data shape: { html: string, width?: number, height?: number, preview?: { title: string, subtitle?: string, description?: string, icon?: string (emoji), metrics?: Array<{ label: string, value: string }> } }. ' +
+    'When preview is provided, a compact preview card is shown inline in chat with the title, subtitle, description, metric pills, and a "View Output" button that opens the full page.\n' +
     '- file_upload: File upload dialog where the user can drag-and-drop or browse for files. ' +
     'data shape: { prompt: string, acceptedTypes?: string[], maxFiles?: number }\n\n' +
     'Action payload conventions:\n' +


### PR DESCRIPTION
## Summary
- Add `preview` field documentation to the `dynamic_page` surface type in `ui_show` tool description
- Add preview metadata section to app-builder skill prompt teaching the model to include title, subtitle, description, icon, and metrics when creating dynamic pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
