### PR TITLE
PR 3: Extract deterministic memory query builder

### DIFF
--- a/assistant/src/__tests__/memory-query-builder.test.ts
+++ b/assistant/src/__tests__/memory-query-builder.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { createContextSummaryMessage } from '../context/window-manager.js';
+import { buildMemoryQuery } from '../memory/query-builder.js';
+import type { Message } from '../providers/types.js';
+
+function userMessage(text: string): Message {
+  return { role: 'user', content: [{ type: 'text', text }] };
+}
+
+describe('memory query builder', () => {
+  test('builds deterministic user-request section when no summary exists', () => {
+    const messages = [userMessage('hello')];
+    const query = buildMemoryQuery('Need a memory recall query.', messages);
+
+    expect(query).toContain('## User Request');
+    expect(query).toContain('Need a memory recall query.');
+    expect(query).not.toContain('## Session Context Summary');
+  });
+
+  test('includes session summary section when summary context message exists', () => {
+    const messages = [
+      createContextSummaryMessage('## Goals\n- Keep tests deterministic'),
+      userMessage('what did we decide?'),
+    ];
+    const query = buildMemoryQuery('Summarize decisions.', messages);
+
+    expect(query).toContain('## User Request');
+    expect(query).toContain('## Session Context Summary');
+    expect(query).toContain('Keep tests deterministic');
+  });
+
+  test('truncates oversized sections with deterministic marker', () => {
+    const oversizedRequest = 'r'.repeat(400);
+    const oversizedSummary = 's'.repeat(500);
+    const messages = [createContextSummaryMessage(oversizedSummary)];
+
+    const query = buildMemoryQuery(oversizedRequest, messages, {
+      maxUserRequestChars: 120,
+      maxSessionSummaryChars: 120,
+    });
+
+    expect(query).toContain('<truncated />');
+    expect(query).toContain('## User Request');
+    expect(query).toContain('## Session Context Summary');
+  });
+
+  test('returns stable output for identical inputs', () => {
+    const messages = [
+      createContextSummaryMessage('stable summary'),
+      userMessage('latest'),
+    ];
+    const a = buildMemoryQuery('stable request', messages);
+    const b = buildMemoryQuery('stable request', messages);
+    expect(a).toBe(b);
+  });
+});
+

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,6 +47,7 @@ import {
   injectMemoryRecallAsSeparateMessage,
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
+import { buildMemoryQuery } from '../memory/query-builder.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
@@ -1828,22 +1829,4 @@ const ORDERING_ERROR_PATTERNS = [
 
 function isProviderOrderingError(message: string): boolean {
   return ORDERING_ERROR_PATTERNS.some((pattern) => pattern.test(message));
-}
-
-function buildMemoryQuery(content: string, messages: Message[]): string {
-  const summaryText = messages
-    .map((message) => getSummaryFromContextMessage(message))
-    .find((summary): summary is string => summary !== null) ?? '';
-  const maxLen = 1200;
-  let compactSummary: string;
-  if (summaryText.length <= maxLen) {
-    compactSummary = summaryText;
-  } else {
-    const marker = '<truncated />';
-    const half = Math.floor((maxLen - marker.length) / 2);
-    compactSummary = summaryText.slice(0, half) + marker + summaryText.slice(-half);
-  }
-  return compactSummary.length > 0
-    ? `${content}\n\nContext summary:\n${compactSummary}`
-    : content;
 }

--- a/assistant/src/memory/query-builder.ts
+++ b/assistant/src/memory/query-builder.ts
@@ -1,0 +1,45 @@
+import { getSummaryFromContextMessage } from '../context/window-manager.js';
+import type { Message } from '../providers/types.js';
+
+const TRUNCATION_MARKER = '<truncated />';
+
+export interface MemoryQueryBuilderOptions {
+  maxUserRequestChars?: number;
+  maxSessionSummaryChars?: number;
+}
+
+/**
+ * Build a deterministic memory recall query string from the current user
+ * request plus any in-context session summary message.
+ */
+export function buildMemoryQuery(
+  userRequest: string,
+  messages: Message[],
+  options?: MemoryQueryBuilderOptions,
+): string {
+  const maxUserRequestChars = options?.maxUserRequestChars ?? 2000;
+  const maxSessionSummaryChars = options?.maxSessionSummaryChars ?? 1200;
+
+  const requestText = clampSection(userRequest.trim(), maxUserRequestChars);
+  const sessionSummary = messages
+    .map((message) => getSummaryFromContextMessage(message))
+    .find((summary): summary is string => summary !== null);
+
+  const sections: string[] = [
+    `## User Request\n${requestText.length > 0 ? requestText : '(empty)'}`,
+  ];
+  if (sessionSummary && sessionSummary.trim().length > 0) {
+    sections.push(`## Session Context Summary\n${clampSection(sessionSummary.trim(), maxSessionSummaryChars)}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+function clampSection(value: string, maxChars: number): string {
+  if (maxChars <= 0) return '';
+  if (value.length <= maxChars) return value;
+  const half = Math.floor((maxChars - TRUNCATION_MARKER.length) / 2);
+  if (half <= 0) return value.slice(0, maxChars);
+  return value.slice(0, half) + TRUNCATION_MARKER + value.slice(-half);
+}
+


### PR DESCRIPTION
## Summary
- extract memory query composition from session into a dedicated module: `assistant/src/memory/query-builder.ts`
- switch `assistant/src/daemon/session.ts` to use the shared query-builder
- add unit tests in `assistant/src/__tests__/memory-query-builder.test.ts` for determinism, summary inclusion, and truncation

## Validation
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-query-builder.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "memory recall injection remains user-role"

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
