### PR TITLE
feat(workspace): add share button with copy link and native share sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -16,6 +16,7 @@ struct MainWindowView: View {
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var selectedThreadId: UUID?
     @State private var workspaceEditorContentHeight: CGFloat = 20
+    @State private var showSharePicker = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
     let daemonClient: DaemonClient
@@ -427,6 +428,38 @@ struct MainWindowView: View {
                     .foregroundColor(VColor.textPrimary)
 
                 Spacer()
+
+                // Share button — only shown for persisted apps with a shareable link
+                if let appId = data.appId {
+                    Menu {
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString("http://localhost:7821/pages/\(appId)", forType: .string)
+                        } label: {
+                            Label("Copy Link", systemImage: "doc.on.doc")
+                        }
+                        Button {
+                            showSharePicker = true
+                        } label: {
+                            Label("Share\u{2026}", systemImage: "square.and.arrow.up")
+                        }
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(VColor.textMuted)
+                            .frame(width: 28, height: 28)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .frame(width: 28)
+                    .accessibilityLabel("Share")
+                    .background(
+                        ShareSheetButton(
+                            items: [URL(string: "http://localhost:7821/pages/\(appId)")!],
+                            isPresented: $showSharePicker
+                        )
+                        .frame(width: 1, height: 1)
+                    )
+                }
 
                 Button(action: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
                     Image(systemName: "xmark")


### PR DESCRIPTION
## Summary
- Add share button to the dynamic workspace toolbar (visible when page has an appId)
- Menu with "Copy Link" (copies `http://localhost:7821/pages/<appId>` to clipboard) and "Share…" (native NSSharingServicePicker via existing ShareSheetButton helper)
- Button appears between the title and close button in the workspace toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
