### PR TITLE
fix(workspace): scope dynamic workspace handlers to active surface

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -173,7 +173,8 @@ struct MainWindowView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
-            if let updated = notification.userInfo?["surface"] as? Surface {
+            if let updated = notification.userInfo?["surface"] as? Surface,
+               updated.id == activeDynamicSurface?.surfaceId {
                 activeDynamicParsedSurface = updated
             }
         }
@@ -181,11 +182,15 @@ struct MainWindowView: View {
             // If a specific surfaceId was dismissed, only clear if it matches.
             if let surfaceId = notification.userInfo?["surfaceId"] as? String {
                 if activeDynamicSurface?.surfaceId == surfaceId {
+                    activePanel = nil
+                    isDynamicExpanded = false
                     activeDynamicSurface = nil
                     activeDynamicParsedSurface = nil
                 }
             } else {
                 // Bulk dismiss (dismissAll)
+                activePanel = nil
+                isDynamicExpanded = false
                 activeDynamicSurface = nil
                 activeDynamicParsedSurface = nil
             }


### PR DESCRIPTION
## Summary
- **updateDynamicWorkspace handler**: Added surfaceId check (`updated.id == activeDynamicSurface?.surfaceId`) so updates from non-active surfaces are ignored, preventing stale data from overwriting the current workspace view.
- **dismissDynamicWorkspace handler**: Added `activePanel = nil` and `isDynamicExpanded = false` resets in both the targeted and bulk dismiss branches, matching the existing "close workspace" button behavior and preventing the workspace from appearing stuck open after a dismiss notification.

Addresses review feedback from Codex and Devin on #2323.

## Test plan
- [ ] Open a dynamic workspace surface, then trigger an update notification for a *different* surface ID — verify the workspace does not re-render with the wrong data.
- [ ] Dismiss a workspace-routed surface via daemon IPC — verify `isDynamicExpanded` resets and the view returns to the normal chat layout.
- [ ] Dismiss all surfaces (bulk dismiss) — verify the same full cleanup occurs.
- [ ] Verify the close (xmark) button still works as before (unchanged code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
