### PR TITLE
fix(generated-panel): keep sharing row mounted while bundle is in flight

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -153,8 +153,11 @@ struct GeneratedPanel: View {
     private var filteredItems: [DisplayAppItem] {
         guard !searchText.isEmpty else { return displayItems }
         return displayItems.filter {
-            $0.name.localizedCaseInsensitiveContains(searchText) ||
-            ($0.description?.localizedCaseInsensitiveContains(searchText) ?? false)
+            // Always keep the row being shared so its ShareSheetButton stays
+            // in the view tree even if the search text changes mid-bundle.
+            if let sharingAppId, $0.id == sharingAppId { return true }
+            return $0.name.localizedCaseInsensitiveContains(searchText) ||
+                ($0.description?.localizedCaseInsensitiveContains(searchText) ?? false)
         }
     }
 
@@ -295,7 +298,10 @@ struct GeneratedPanel: View {
                     items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
                     isPresented: Binding(
                         get: { showShareSheet && sharingAppId == item.id },
-                        set: { showShareSheet = $0 }
+                        set: { newValue in
+                            showShareSheet = newValue
+                            if !newValue { sharingAppId = nil }
+                        }
                     )
                 )
                 .frame(width: 0, height: 0)
@@ -311,7 +317,10 @@ struct GeneratedPanel: View {
                     items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
                     isPresented: Binding(
                         get: { showShareSheet && sharingAppId == item.id },
-                        set: { showShareSheet = $0 }
+                        set: { newValue in
+                            showShareSheet = newValue
+                            if !newValue { sharingAppId = nil }
+                        }
                     )
                 )
                 .frame(width: 0, height: 0)


### PR DESCRIPTION
## Summary
- Fixes a bug where changing the search text in the Generated panel after pressing Share could remove the row's `ShareSheetButton` from the view tree, causing the share sheet to silently fail when bundling completes.
- The `filteredItems` computed property now always includes the item identified by `sharingAppId`, ensuring its `ShareSheetButton` stays mounted during the entire sharing flow.
- `sharingAppId` is now cleared when the share sheet is dismissed, so the pinned-filter behavior doesn't persist after sharing is complete.

Addresses feedback from PR #2322.

## Test plan
- [ ] Open Generated panel with multiple items
- [ ] Start sharing an item, then change search text so the item is filtered out
- [ ] Verify the share sheet still appears when bundling completes
- [ ] Verify that after dismissing the share sheet, the item disappears from results if it doesn't match the current filter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
