### PR TITLE
fix(surfaces): add Equatable conformance to DynamicPagePreview

### DIFF
--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -172,7 +172,7 @@ public struct ConfirmationSurfaceData: Sendable {
     }
 }
 
-public struct DynamicPagePreview: Sendable {
+public struct DynamicPagePreview: Sendable, Equatable {
     public let title: String
     public let subtitle: String?
     public let description: String?
@@ -185,6 +185,21 @@ public struct DynamicPagePreview: Sendable {
         self.description = description
         self.icon = icon
         self.metrics = metrics
+    }
+
+    public static func == (lhs: DynamicPagePreview, rhs: DynamicPagePreview) -> Bool {
+        guard lhs.title == rhs.title,
+              lhs.subtitle == rhs.subtitle,
+              lhs.description == rhs.description,
+              lhs.icon == rhs.icon else { return false }
+        switch (lhs.metrics, rhs.metrics) {
+        case (.none, .none):
+            return true
+        case let (.some(l), .some(r)):
+            return l.count == r.count && zip(l, r).allSatisfy { $0.label == $1.label && $0.value == $1.value }
+        default:
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `Equatable` conformance to `DynamicPagePreview` struct with a manual `==` implementation, since the tuple array `metrics` field prevents Swift from auto-synthesizing it.
- Required for SwiftUI view diffing when preview data changes.

Addresses review feedback from PR #2324.

## Test plan
- [ ] Verify SurfaceTypes.swift compiles without errors
- [ ] Verify DynamicPagePreview equality comparisons work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
