### PR TITLE
fix(dynamic-page): block openExternal in sandbox mode and complete confirmId escaping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -339,6 +339,10 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
             // Handle openExternal requests from the JS bridge.
             if let type = body["type"] as? String, type == "open_external" {
+                if sandboxMode {
+                    log.warning("open_external: blocked in sandbox mode")
+                    return
+                }
                 guard let urlString = body["url"] as? String,
                       let url = URL(string: urlString),
                       let scheme = url.scheme?.lowercased(),
@@ -369,6 +373,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 let safeId = confirmId
                     .replacingOccurrences(of: "\\", with: "\\\\")
                     .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                    .replacingOccurrences(of: "\r", with: "\\r")
                 let js = "window.vellum._resolveConfirm('\(safeId)', \(confirmed))"
                 webView?.evaluateJavaScript(js) { _, error in
                     if let error {


### PR DESCRIPTION
## Summary
- Blocks `openExternal` calls when `sandboxMode` is enabled, preventing sandboxed pages from bypassing navigation restrictions.
- Adds `\n` and `\r` escaping to `confirmId` string sanitization, matching the existing `safeCallId` pattern in `resolveDataResponse` and preventing JS string literal breakage.

Addresses review feedback from PRs #2325 and #2327.

## Test plan
- [ ] Verify sandboxed pages cannot call `window.vellum.openExternal()` to open URLs
- [ ] Verify non-sandboxed pages can still use `openExternal` normally
- [ ] Verify confirm dialogs work with edge-case confirmId strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
