### PR TITLE
fix(dynamic-page): block openExternal in sandbox mode and fix confirmId escaping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -339,6 +339,10 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
             // Handle openExternal requests from the JS bridge.
             if let type = body["type"] as? String, type == "open_external" {
+                if sandboxMode {
+                    log.warning("open_external: blocked in sandbox mode")
+                    return
+                }
                 guard let urlString = body["url"] as? String,
                       let url = URL(string: urlString),
                       let scheme = url.scheme?.lowercased(),
@@ -369,6 +373,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 let safeId = confirmId
                     .replacingOccurrences(of: "\\", with: "\\\\")
                     .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                    .replacingOccurrences(of: "\r", with: "\\r")
                 let js = "window.vellum._resolveConfirm('\(safeId)', \(confirmed))"
                 webView?.evaluateJavaScript(js) { _, error in
                     if let error {


### PR DESCRIPTION
## Summary
- Block `openExternal` calls when `sandboxMode` is enabled to maintain sandbox security boundary
- Add missing `\n` and `\r` escaping to `confirmId` to match the pattern used in `resolveDataResponse`

Addresses feedback from #2325 and #2327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
