### PR TITLE
PR 4: Add dynamic per-turn memory recall budgeting

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-budget.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-budget.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { computeRecallBudget } from '../memory/retrieval-budget.js';
+
+describe('memory retrieval budget', () => {
+  test('clamps to maxInjectTokens when headroom is large', () => {
+    const budget = computeRecallBudget({
+      estimatedPromptTokens: 20_000,
+      maxInputTokens: 180_000,
+      targetHeadroomTokens: 8_000,
+      minInjectTokens: 1_200,
+      maxInjectTokens: 10_000,
+    });
+    expect(budget).toBe(10_000);
+  });
+
+  test('clamps to minInjectTokens when headroom is tight', () => {
+    const budget = computeRecallBudget({
+      estimatedPromptTokens: 172_000,
+      maxInputTokens: 180_000,
+      targetHeadroomTokens: 8_000,
+      minInjectTokens: 1_200,
+      maxInjectTokens: 10_000,
+    });
+    expect(budget).toBe(1_200);
+  });
+
+  test('returns computed value when between min and max', () => {
+    const budget = computeRecallBudget({
+      estimatedPromptTokens: 165_000,
+      maxInputTokens: 180_000,
+      targetHeadroomTokens: 8_000,
+      minInjectTokens: 1_200,
+      maxInjectTokens: 10_000,
+    });
+    expect(budget).toBe(7_000);
+  });
+
+  test('normalizes invalid min/max ordering safely', () => {
+    const budget = computeRecallBudget({
+      estimatedPromptTokens: 150_000,
+      maxInputTokens: 180_000,
+      targetHeadroomTokens: 8_000,
+      minInjectTokens: 12_000,
+      maxInjectTokens: 1_200,
+    });
+    expect(budget).toBe(12_000);
+  });
+});
+

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1153,6 +1153,69 @@ describe('Memory V2 regressions', () => {
     expect(recall.injectedTokens).toBe(0);
   });
 
+  test('memory recall respects maxInjectTokensOverride when provided', async () => {
+    const db = getDb();
+    const createdAt = 1_700_000_301_000;
+    db.insert(conversations).values({
+      id: 'conv-budget-override',
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+
+    for (let i = 0; i < 4; i++) {
+      const msgId = `msg-budget-override-${i}`;
+      const segId = `seg-budget-override-${i}`;
+      const text = `budget override sentinel item ${i} with enough text to exceed tiny limits`;
+      db.insert(messages).values({
+        id: msgId,
+        conversationId: 'conv-budget-override',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text }]),
+        createdAt: createdAt + i,
+      }).run();
+      db.run(`
+        INSERT INTO memory_segments (
+          id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at
+        ) VALUES (
+          '${segId}', '${msgId}', 'conv-budget-override', 'user', 0, '${text}', 20, ${createdAt + i}, ${createdAt + i}
+        )
+      `);
+    }
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        embeddings: {
+          ...DEFAULT_CONFIG.memory.embeddings,
+          provider: 'openai' as const,
+          required: false,
+        },
+        retrieval: {
+          ...DEFAULT_CONFIG.memory.retrieval,
+          maxInjectTokens: 5000,
+          lexicalTopK: 10,
+        },
+      },
+    };
+
+    const override = 120;
+    const recall = await buildMemoryRecall(
+      'budget override sentinel',
+      'conv-budget-override',
+      config,
+      { maxInjectTokensOverride: override },
+    );
+    expect(recall.injectedTokens).toBeLessThanOrEqual(override);
+  });
+
   test('claimMemoryJobs only returns rows it actually claimed', () => {
     const db = getDb();
     const jobId = enqueueMemoryJob('build_conversation_summary', { conversationId: 'conv-lock' });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -54,6 +54,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         reinforcementShieldDays: 7,
       },
       scopePolicy: 'allow_global_fallback' as const,
+      dynamicBudget: {
+        enabled: false,
+        minInjectTokens: 1200,
+        maxInjectTokens: 10000,
+        targetHeadroomTokens: 10000,
+      },
     },
     segmentation: {
       targetTokens: 450,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -219,6 +219,27 @@ export const MemoryRerankingConfigSchema = z.object({
     .default(20),
 });
 
+export const MemoryDynamicBudgetConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.retrieval.dynamicBudget.enabled must be a boolean' })
+    .default(false),
+  minInjectTokens: z
+    .number({ error: 'memory.retrieval.dynamicBudget.minInjectTokens must be a number' })
+    .int('memory.retrieval.dynamicBudget.minInjectTokens must be an integer')
+    .positive('memory.retrieval.dynamicBudget.minInjectTokens must be a positive integer')
+    .default(1200),
+  maxInjectTokens: z
+    .number({ error: 'memory.retrieval.dynamicBudget.maxInjectTokens must be a number' })
+    .int('memory.retrieval.dynamicBudget.maxInjectTokens must be an integer')
+    .positive('memory.retrieval.dynamicBudget.maxInjectTokens must be a positive integer')
+    .default(10000),
+  targetHeadroomTokens: z
+    .number({ error: 'memory.retrieval.dynamicBudget.targetHeadroomTokens must be a number' })
+    .int('memory.retrieval.dynamicBudget.targetHeadroomTokens must be an integer')
+    .positive('memory.retrieval.dynamicBudget.targetHeadroomTokens must be a positive integer')
+    .default(10000),
+});
+
 /**
  * Per-kind freshness windows (in days). Items older than their window
  * (based on lastSeenAt) are down-ranked unless recently reinforced.
@@ -313,6 +334,12 @@ export const MemoryRetrievalConfigSchema = z.object({
       error: 'memory.retrieval.scopePolicy must be "allow_global_fallback" or "strict"',
     })
     .default('allow_global_fallback'),
+  dynamicBudget: MemoryDynamicBudgetConfigSchema.default({
+    enabled: false,
+    minInjectTokens: 1200,
+    maxInjectTokens: 10000,
+    targetHeadroomTokens: 10000,
+  }),
 });
 
 export const MemorySegmentationConfigSchema = z.object({
@@ -409,6 +436,12 @@ export const MemoryConfigSchema = z.object({
       reinforcementShieldDays: 7,
     },
     scopePolicy: 'allow_global_fallback',
+    dynamicBudget: {
+      enabled: false,
+      minInjectTokens: 1200,
+      maxInjectTokens: 10000,
+      targetHeadroomTokens: 10000,
+    },
   }),
   segmentation: MemorySegmentationConfigSchema.default({
     targetTokens: 450,
@@ -537,6 +570,12 @@ export const AssistantConfigSchema = z.object({
         reinforcementShieldDays: 7,
       },
       scopePolicy: 'allow_global_fallback',
+      dynamicBudget: {
+        enabled: false,
+        minInjectTokens: 1200,
+        maxInjectTokens: 10000,
+        targetHeadroomTokens: 10000,
+      },
     },
     segmentation: {
       targetTokens: 450,
@@ -616,6 +655,13 @@ export const AssistantConfigSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ['memory', 'segmentation', 'overlapTokens'],
       message: 'memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens',
+    });
+  }
+  if (config.memory.retrieval.dynamicBudget.minInjectTokens > config.memory.retrieval.dynamicBudget.maxInjectTokens) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['memory', 'retrieval', 'dynamicBudget', 'minInjectTokens'],
+      message: 'memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens',
     });
   }
 });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -40,6 +40,7 @@ import {
   createContextSummaryMessage,
   getSummaryFromContextMessage,
 } from '../context/window-manager.js';
+import { estimatePromptTokens } from '../context/token-estimator.js';
 import { getHookManager } from '../hooks/manager.js';
 import {
   buildMemoryRecall,
@@ -48,6 +49,7 @@ import {
   stripMemoryRecallMessages,
 } from '../memory/retriever.js';
 import { buildMemoryQuery } from '../memory/query-builder.js';
+import { computeRecallBudget } from '../memory/retrieval-budget.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
@@ -112,6 +114,7 @@ export class Session {
   private workingDir: string;
   private sandboxOverride?: boolean;
   private usageStats: UsageStats = { inputTokens: 0, outputTokens: 0, estimatedCost: 0 };
+  private readonly systemPrompt: string;
   private contextWindowManager: ContextWindowManager;
   private contextCompactedMessageCount = 0;
   private currentRequestId?: string;
@@ -139,6 +142,7 @@ export class Session {
     workingDir: string,
   ) {
     this.conversationId = conversationId;
+    this.systemPrompt = systemPrompt;
     this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
@@ -625,9 +629,23 @@ export class Session {
       let lastAssistantMessageId: string | undefined;
       const runtimeConfig = getConfig();
       const recallQuery = buildMemoryQuery(content, this.messages);
+      const recallBudget = runtimeConfig.memory.retrieval.dynamicBudget.enabled
+        ? computeRecallBudget({
+            estimatedPromptTokens: estimatePromptTokens(
+              this.messages,
+              this.systemPrompt,
+              { providerName: this.provider.name },
+            ),
+            maxInputTokens: runtimeConfig.contextWindow.maxInputTokens,
+            targetHeadroomTokens: runtimeConfig.memory.retrieval.dynamicBudget.targetHeadroomTokens,
+            minInjectTokens: runtimeConfig.memory.retrieval.dynamicBudget.minInjectTokens,
+            maxInjectTokens: runtimeConfig.memory.retrieval.dynamicBudget.maxInjectTokens,
+          })
+        : undefined;
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
         excludeMessageIds: [userMessageId],
         signal: abortController.signal,
+        maxInjectTokensOverride: recallBudget,
       });
 
       onEvent({

--- a/assistant/src/memory/retrieval-budget.ts
+++ b/assistant/src/memory/retrieval-budget.ts
@@ -1,0 +1,30 @@
+export interface RecallBudgetInput {
+  estimatedPromptTokens: number;
+  maxInputTokens: number;
+  targetHeadroomTokens: number;
+  minInjectTokens: number;
+  maxInjectTokens: number;
+}
+
+/**
+ * Compute per-turn memory recall injection budget from context headroom.
+ *
+ * The result is always clamped into [minInjectTokens, maxInjectTokens].
+ */
+export function computeRecallBudget(input: RecallBudgetInput): number {
+  const maxInput = Math.max(0, Math.floor(input.maxInputTokens));
+  const estimatedPrompt = Math.max(0, Math.floor(input.estimatedPromptTokens));
+  const headroomTarget = Math.max(0, Math.floor(input.targetHeadroomTokens));
+  const minInject = Math.max(1, Math.floor(input.minInjectTokens));
+  const maxInject = Math.max(minInject, Math.floor(input.maxInjectTokens));
+
+  const available = maxInput - estimatedPrompt - headroomTarget;
+  return clamp(Math.floor(available), minInject, maxInject);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -67,6 +67,7 @@ interface MemoryRecallOptions {
   excludeMessageIds?: string[];
   signal?: AbortSignal;
   scopeId?: string;
+  maxInjectTokensOverride?: number;
 }
 
 interface CollectedCandidates {
@@ -301,7 +302,11 @@ export async function buildMemoryRecall(
   }
 
   const mergedCount = merged.length;
-  const selected = trimToTokenBudget(merged, config.memory.retrieval.maxInjectTokens, config.memory.retrieval.injectionFormat);
+  const maxInjectTokens = Math.max(
+    1,
+    Math.floor(options?.maxInjectTokensOverride ?? config.memory.retrieval.maxInjectTokens),
+  );
+  const selected = trimToTokenBudget(merged, maxInjectTokens, config.memory.retrieval.injectionFormat);
   markItemUsage(selected);
 
   const injectedText = buildInjectedText(selected, config.memory.retrieval.injectionFormat);
@@ -324,6 +329,7 @@ export async function buildMemoryRecall(
     entityHits: entityCandidates.length,
     mergedCount,
     selected: selected.length,
+    maxInjectTokens,
     rerankApplied,
     injectedTokens: estimateTextTokens(injectedText),
     latencyMs,


### PR DESCRIPTION
## Summary
- add `memory.retrieval.dynamicBudget` config with defaults and validation
- add pure budget calculator: `assistant/src/memory/retrieval-budget.ts`
- wire `Session` to compute per-turn recall budget from prompt headroom
- add `maxInjectTokensOverride` support in `buildMemoryRecall` options
- add tests for budget computation and override enforcement

## Validation
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-retrieval-budget.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "token budgeting|maxInjectTokensOverride"
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/config-schema.test.ts

Note: Bun currently panics after some successful test runs; assertions pass before panic.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
