### PR TITLE
fix(test): disable LLM reranking in memory context benchmark

### DIFF
--- a/assistant/src/__tests__/memory-context-benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.test.ts
@@ -190,6 +190,7 @@ describe('Memory context benchmark', () => {
           lexicalTopK: 50,
           semanticTopK: 20,
           maxInjectTokens: 750,
+          reranking: { ...DEFAULT_CONFIG.memory.retrieval.reranking, enabled: false },
         },
       },
     };


### PR DESCRIPTION
Addresses feedback from Codex reviewer on PR #2326.

The memory context benchmark fixture inherits `reranking.enabled=true` from `DEFAULT_CONFIG`, which can invoke `rerankWithLLM` with real Anthropic credentials when enough candidates exist. This introduces external network/model variability into assertions, making the benchmark flaky and non-reproducible.

**Fix:** Explicitly set `reranking: { ...DEFAULT_CONFIG.memory.retrieval.reranking, enabled: false }` in the benchmark's `recallConfig` to ensure deterministic behavior.

**Files modified:**
- `assistant/src/__tests__/memory-context-benchmark.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
