### PR TITLE
fix(pr-2334): remove descriptive what-comments from InlineDynamicPagePreview

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -13,7 +13,6 @@ public struct InlineDynamicPagePreview: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Icon + Title + Subtitle
             HStack(alignment: .top, spacing: VSpacing.sm) {
                 if let icon = preview.icon {
                     Text(icon)
@@ -35,7 +34,6 @@ public struct InlineDynamicPagePreview: View {
                 }
             }
 
-            // Description
             if let description = preview.description, !description.isEmpty {
                 Text(description)
                     .font(VFont.body)
@@ -43,7 +41,6 @@ public struct InlineDynamicPagePreview: View {
                     .lineLimit(3)
             }
 
-            // Metric pills (max 3)
             if let metrics = preview.metrics, !metrics.isEmpty {
                 HStack(spacing: VSpacing.sm) {
                     ForEach(Array(metrics.prefix(3).enumerated()), id: \.offset) { _, metric in
@@ -52,7 +49,6 @@ public struct InlineDynamicPagePreview: View {
                 }
             }
 
-            // View Output button
             HStack {
                 Spacer()
                 Button {


### PR DESCRIPTION
Remove section-header comments that restate the code (e.g. `// Icon + Title + Subtitle`, `// Description`, `// Metric pills (max 3)`, `// View Output button`) per Codex review feedback on #2334. These violate the project convention that comments should explain *why*, not *what*.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
