### PR TITLE
fix(memory): remove static heading tokens from recall query prefix

### DIFF
--- a/assistant/src/__tests__/memory-query-builder.test.ts
+++ b/assistant/src/__tests__/memory-query-builder.test.ts
@@ -12,9 +12,8 @@ describe('memory query builder', () => {
     const messages = [userMessage('hello')];
     const query = buildMemoryQuery('Need a memory recall query.', messages);
 
-    expect(query).toContain('## User Request');
-    expect(query).toContain('Need a memory recall query.');
-    expect(query).not.toContain('## Session Context Summary');
+    expect(query).toBe('Need a memory recall query.');
+    expect(query).not.toContain('Context summary:');
   });
 
   test('includes session summary section when summary context message exists', () => {
@@ -24,9 +23,11 @@ describe('memory query builder', () => {
     ];
     const query = buildMemoryQuery('Summarize decisions.', messages);
 
-    expect(query).toContain('## User Request');
-    expect(query).toContain('## Session Context Summary');
+    expect(query).toContain('Summarize decisions.');
+    expect(query).toContain('Context summary:');
     expect(query).toContain('Keep tests deterministic');
+    expect(query).not.toContain('## User Request');
+    expect(query).not.toContain('## Session Context Summary');
   });
 
   test('truncates oversized sections with deterministic marker', () => {
@@ -40,8 +41,9 @@ describe('memory query builder', () => {
     });
 
     expect(query).toContain('<truncated />');
-    expect(query).toContain('## User Request');
-    expect(query).toContain('## Session Context Summary');
+    expect(query).toContain('Context summary:');
+    expect(query).not.toContain('## User Request');
+    expect(query).not.toContain('## Session Context Summary');
   });
 
   test('returns stable output for identical inputs', () => {

--- a/assistant/src/memory/query-builder.ts
+++ b/assistant/src/memory/query-builder.ts
@@ -25,14 +25,14 @@ export function buildMemoryQuery(
     .map((message) => getSummaryFromContextMessage(message))
     .find((summary): summary is string => summary !== null);
 
-  const sections: string[] = [
-    `## User Request\n${requestText.length > 0 ? requestText : '(empty)'}`,
-  ];
+  const content = requestText.length > 0 ? requestText : '(empty)';
+
   if (sessionSummary && sessionSummary.trim().length > 0) {
-    sections.push(`## Session Context Summary\n${clampSection(sessionSummary.trim(), maxSessionSummaryChars)}`);
+    const compactSummary = clampSection(sessionSummary.trim(), maxSessionSummaryChars);
+    return `${content}\n\nContext summary:\n${compactSummary}`;
   }
 
-  return sections.join('\n\n');
+  return content;
 }
 
 function clampSection(value: string, maxChars: number): string {


### PR DESCRIPTION
## Summary

Addresses feedback from Codex reviewer on #2340.

The `## User Request` and `## Session Context Summary` markdown headings injected generic terms ("user", "request", "session", "context", "summary") into every recall query. Because `buildFtsMatchQuery` keeps only the first 24 unique tokens and `directItemSearch` OR-matches every token, these headings displaced meaningful user terms and introduced noisy matches.

Restores the original plain format: raw user content first, followed by an optional `Context summary:` section — no markdown headings that pollute the token budget.

## Changes

- `assistant/src/memory/query-builder.ts` — Replaced `## User Request` / `## Session Context Summary` heading format with plain `${content}\n\nContext summary:\n${summary}` format
- `assistant/src/__tests__/memory-query-builder.test.ts` — Updated assertions to match the new heading-free format
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
