### PR TITLE
fix(http-server): wrap /pages/:appId route in try/catch

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -122,7 +122,12 @@ export class RuntimeHttpServer {
     // Serve shareable app pages
     const pagesMatch = path.match(/^\/pages\/([^/]+)$/);
     if (pagesMatch && req.method === 'GET') {
-      return this.handleServePage(pagesMatch[1]);
+      try {
+        return this.handleServePage(pagesMatch[1]);
+      } catch (err) {
+        log.error({ err, appId: pagesMatch[1] }, 'Runtime HTTP handler error serving page');
+        return Response.json({ error: 'Internal server error' }, { status: 500 });
+      }
     }
 
     // Match /v1/assistants/:assistantId/<endpoint>


### PR DESCRIPTION
Wrap the shareable page route handler in try/catch to gracefully handle getApp()/validateId() exceptions instead of letting them bubble as unhandled 500 errors.

The `/pages/:appId` route was outside the try/catch block that wraps other routes, so malformed IDs (e.g. `..`) would trigger `validateId()` exceptions and produce unhandled server errors.

Per review feedback from Codex and Devin on #2337.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
