### PR TITLE
PR 5: Add compaction stability guards and cooldown logic

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -245,4 +245,55 @@ describe('ContextWindowManager', () => {
     };
     expect(getSummaryFromContextMessage(userMessage)).toBeNull();
   });
+
+  test('skips compaction during cooldown when projected gain is too low', async () => {
+    const provider = createProvider(() => {
+      throw new Error('summarizer should not be called while cooldown skip is active');
+    });
+    const manager = new ContextWindowManager(
+      provider,
+      'system prompt',
+      makeConfig({ maxInputTokens: 260, targetInputTokens: 180, preserveRecentUserTurns: 1 }),
+    );
+    const long = 'c'.repeat(220);
+    const history: Message[] = [
+      message('user', `u1 ${long}`),
+      message('assistant', `a1 ${long}`),
+      message('user', `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      lastCompactedAt: Date.now() - 30_000,
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('compaction cooldown active with low projected gain');
+  });
+
+  test('ignores cooldown and compacts under severe token pressure', async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: 'text', text: '## Goals\n- compacted under pressure' }],
+      model: 'mock-model',
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: 'end_turn',
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      'system prompt',
+      makeConfig({ maxInputTokens: 320, targetInputTokens: 180, preserveRecentUserTurns: 1 }),
+    );
+    const long = 'p'.repeat(340);
+    const history: Message[] = [
+      message('user', `u1 ${long}`),
+      message('assistant', `a1 ${long}`),
+      message('user', `u2 ${long}`),
+      message('assistant', `a2 ${long}`),
+      message('user', `u3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      lastCompactedAt: Date.now() - 30_000,
+    });
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -11,6 +11,10 @@ const CHUNK_MIN_TOKENS = 1000;
 const MAX_BLOCK_PREVIEW_CHARS = 3000;
 const MAX_FALLBACK_SUMMARY_CHARS = 12000;
 const MAX_CONTEXT_SUMMARY_CHARS = 16000;
+const COMPACTION_COOLDOWN_MS = 2 * 60 * 1000;
+const MIN_GAIN_TOKENS_DURING_COOLDOWN = 1200;
+const SEVERE_PRESSURE_RATIO = 0.95;
+const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 const SUMMARY_SYSTEM_PROMPT = [
@@ -44,6 +48,10 @@ export interface ContextWindowResult {
   reason?: string;
 }
 
+export interface ContextWindowCompactOptions {
+  lastCompactedAt?: number;
+}
+
 export class ContextWindowManager {
   constructor(
     private readonly provider: Provider,
@@ -51,7 +59,11 @@ export class ContextWindowManager {
     private readonly config: ContextWindowConfig,
   ) {}
 
-  async maybeCompact(messages: Message[], signal?: AbortSignal): Promise<ContextWindowResult> {
+  async maybeCompact(
+    messages: Message[],
+    signal?: AbortSignal,
+    options?: ContextWindowCompactOptions,
+  ): Promise<ContextWindowResult> {
     const previousEstimatedInputTokens = estimatePromptTokens(
       messages,
       this.systemPrompt,
@@ -160,6 +172,63 @@ export class ContextWindowManager {
     }
 
     const compactedPersistedMessages = countPersistedMessages(compactableMessages);
+    const projectedMessages = [
+      createContextSummaryMessage(existingSummary ?? 'Projected summary'),
+      ...messages.slice(keepPlan.keepFromIndex),
+    ];
+    const projectedInputTokens = estimatePromptTokens(
+      projectedMessages,
+      this.systemPrompt,
+      { providerName: this.provider.name },
+    );
+    const projectedGainTokens = Math.max(0, previousEstimatedInputTokens - projectedInputTokens);
+    const severePressure = previousEstimatedInputTokens >= Math.floor(this.config.maxInputTokens * SEVERE_PRESSURE_RATIO);
+    const lastCompactedAt = options?.lastCompactedAt;
+    const withinCooldown = typeof lastCompactedAt === 'number'
+      && Date.now() - lastCompactedAt < COMPACTION_COOLDOWN_MS;
+
+    if (
+      withinCooldown
+      && projectedGainTokens < MIN_GAIN_TOKENS_DURING_COOLDOWN
+      && !severePressure
+    ) {
+      return {
+        messages,
+        compacted: false,
+        previousEstimatedInputTokens,
+        estimatedInputTokens: previousEstimatedInputTokens,
+        maxInputTokens: this.config.maxInputTokens,
+        thresholdTokens,
+        compactedMessages: 0,
+        compactedPersistedMessages: 0,
+        summaryCalls: 0,
+        summaryInputTokens: 0,
+        summaryOutputTokens: 0,
+        summaryModel: '',
+        summaryText: existingSummary ?? '',
+        reason: 'compaction cooldown active with low projected gain',
+      };
+    }
+
+    if (compactedPersistedMessages < MIN_COMPACTABLE_PERSISTED_MESSAGES && !severePressure) {
+      return {
+        messages,
+        compacted: false,
+        previousEstimatedInputTokens,
+        estimatedInputTokens: previousEstimatedInputTokens,
+        maxInputTokens: this.config.maxInputTokens,
+        thresholdTokens,
+        compactedMessages: 0,
+        compactedPersistedMessages: 0,
+        summaryCalls: 0,
+        summaryInputTokens: 0,
+        summaryOutputTokens: 0,
+        summaryModel: '',
+        summaryText: existingSummary ?? '',
+        reason: 'insufficient compactable persisted messages',
+      };
+    }
+
     const chunks = chunkMessages(compactableMessages, Math.max(this.config.chunkTokens, CHUNK_MIN_TOKENS));
     let summary = existingSummary ?? 'No previous summary.';
     let summaryInputTokens = 0;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -117,6 +117,7 @@ export class Session {
   private readonly systemPrompt: string;
   private contextWindowManager: ContextWindowManager;
   private contextCompactedMessageCount = 0;
+  private contextCompactedAt: number | null = null;
   private currentRequestId?: string;
   private assistantId: string | null = null;
   private hasNoClient = false;
@@ -262,6 +263,7 @@ export class Session {
       0,
       Math.min(conv?.contextCompactedMessageCount ?? 0, dbMessages.length),
     );
+    this.contextCompactedAt = conv?.contextCompactedAt ?? null;
 
     const parsedMessages: Message[] = dbMessages
       .slice(this.contextCompactedMessageCount)
@@ -583,10 +585,12 @@ export class Session {
       const compacted = await this.contextWindowManager.maybeCompact(
         this.messages,
         abortController.signal,
+        { lastCompactedAt: this.contextCompactedAt ?? undefined },
       );
       if (compacted.compacted) {
         this.messages = compacted.messages;
         this.contextCompactedMessageCount += compacted.compactedPersistedMessages;
+        this.contextCompactedAt = Date.now();
         conversationStore.updateConversationContextWindow(
           this.conversationId,
           compacted.summaryText,


### PR DESCRIPTION
## Summary
- add compaction cooldown guard to avoid repeated low-gain summarization
- add early-exit guard when compactable persisted message count is too small
- add severe-pressure override so compaction still runs near max input pressure
- thread persisted `contextCompactedAt` through session compaction decisions
- extend context-window-manager tests for cooldown skip + severe-pressure bypass

## Validation
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/context-window-manager.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/memory-context-benchmark.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
