### PR TITLE
fix(ui): resolve panel resize jitter and improve code quality

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -119,7 +119,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
         registerBundledFonts()
-        runMigrations()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
@@ -1153,22 +1152,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? "unknown")")
             }
         }
-    }
-
-    // MARK: - Migrations
-
-    /// Run one-time data migrations on app launch
-    private func runMigrations() {
-        migrateToListViewDefault()
-    }
-
-    /// Migration: Reset all users to list view (thread drawer) - v0.1.15
-    private func migrateToListViewDefault() {
-        let migrationKey = "didMigrateToListViewDefault"
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
-
-        UserDefaults.standard.set(true, forKey: "useThreadDrawer")
-        UserDefaults.standard.set(true, forKey: migrationKey)
     }
 
     // MARK: - File Open Handler

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -120,6 +120,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.appearance = NSAppearance(named: .darkAqua)
         registerBundledFonts()
 
+        // One-time migration: reset all users to list view (thread drawer)
+        if !UserDefaults.standard.bool(forKey: "didMigrateToListViewDefault") {
+            UserDefaults.standard.set(true, forKey: "useThreadDrawer")
+            UserDefaults.standard.set(true, forKey: "didMigrateToListViewDefault")
+        }
+
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
         #else

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -119,12 +119,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.appearance = NSAppearance(named: .darkAqua)
         registerBundledFonts()
-
-        // One-time migration: reset all users to list view (thread drawer)
-        if !UserDefaults.standard.bool(forKey: "didMigrateToListViewDefault") {
-            UserDefaults.standard.set(true, forKey: "useThreadDrawer")
-            UserDefaults.standard.set(true, forKey: "didMigrateToListViewDefault")
-        }
+        runMigrations()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
@@ -1158,6 +1153,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? "unknown")")
             }
         }
+    }
+
+    // MARK: - Migrations
+
+    /// Run one-time data migrations on app launch
+    private func runMigrations() {
+        migrateToListViewDefault()
+    }
+
+    /// Migration: Reset all users to list view (thread drawer) - v0.1.15
+    private func migrateToListViewDefault() {
+        let migrationKey = "didMigrateToListViewDefault"
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
+
+        UserDefaults.standard.set(true, forKey: "useThreadDrawer")
+        UserDefaults.standard.set(true, forKey: migrationKey)
     }
 
     // MARK: - File Open Handler

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -4,6 +4,8 @@ import AppKit
 #endif
 
 public struct VSplitView<Main: View, Panel: View>: View {
+    // MARK: - Properties
+
     public let main: Main
     public let panel: Panel?
     @Binding public var panelWidth: Double
@@ -11,6 +13,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
     @State private var isDragging: Bool = false
+
+    // MARK: - Body
 
     public var body: some View {
         GeometryReader { geometry in
@@ -58,46 +62,56 @@ public struct VSplitView<Main: View, Panel: View>: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        // Capture initial state on first drag event
-                        if dragStartWidth == nil {
-                            dragStartWidth = panelWidth
-                            dragStartAvailableWidth = availableWidth
-                            isDragging = true
-                        }
-
-                        guard let initialWidth = dragStartWidth,
-                              let initialAvailableWidth = dragStartAvailableWidth else {
-                            return
-                        }
-
-                        // Dragging left (negative) increases width, dragging right (positive) decreases width
-                        let newWidth = initialWidth - value.translation.width
-
-                        // Compute max panel width: available width minus minimum main content (300pt), divider (8pt), and padding (16pt total)
-                        let minMainContent: CGFloat = 300
-                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
-
-                        // Disable all animations during drag to prevent jitter
-                        var transaction = Transaction()
-                        transaction.disablesAnimations = true
-                        withTransaction(transaction) {
-                            panelWidth = min(max(newWidth, 300), maxAllowed)
-                        }
+                        self.handleDragChanged(value, availableWidth: availableWidth)
                     }
                     .onEnded { _ in
-                        // Reset drag state
-                        isDragging = false
-                        dragStartWidth = nil
-                        dragStartAvailableWidth = nil
+                        self.resetDragState()
                     }
             )
             .onDisappear {
-                // Reset drag state if view is removed mid-drag (e.g., panel closed)
-                isDragging = false
-                dragStartWidth = nil
-                dragStartAvailableWidth = nil
+                self.resetDragState()
             }
     }
+
+    // MARK: - Drag Helpers
+
+    private func handleDragChanged(_ value: DragGesture.Value, availableWidth: CGFloat) {
+        // Capture initial state on first drag event
+        if dragStartWidth == nil {
+            dragStartWidth = panelWidth
+            dragStartAvailableWidth = availableWidth
+            isDragging = true
+        }
+
+        guard let initialWidth = dragStartWidth,
+              let initialAvailableWidth = dragStartAvailableWidth else {
+            return
+        }
+
+        // Calculate new width (dragging left increases, right decreases)
+        let newWidth = initialWidth - value.translation.width
+
+        // Calculate constraints
+        let minPanelWidth: CGFloat = 300
+        let minMainContentWidth: CGFloat = 300
+        let dividerAndPadding = VSpacing.sm + (VSpacing.sm * 2)
+        let maxAllowed = initialAvailableWidth - minMainContentWidth - dividerAndPadding
+
+        // Update width without animation to prevent jitter
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            panelWidth = min(max(newWidth, minPanelWidth), maxAllowed)
+        }
+    }
+
+    private func resetDragState() {
+        isDragging = false
+        dragStartWidth = nil
+        dragStartAvailableWidth = nil
+    }
+
+    // MARK: - Initialization
 
     public init(
         panelWidth: Binding<Double>,

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -8,7 +8,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
     public let panel: Panel?
     @Binding public var panelWidth: Double
     public var showPanel: Bool = false
-    @GestureState private var dragStartWidth: Double? = nil
+    @State private var dragStartWidth: Double?
+    @State private var dragStartAvailableWidth: CGFloat?
 
     public var body: some View {
         GeometryReader { geometry in
@@ -35,7 +36,6 @@ public struct VSplitView<Main: View, Panel: View>: View {
                 }
             }
             .animation(VAnimation.standard, value: showPanel)
-            .animation(nil, value: panelWidth)
         }
     }
 
@@ -55,23 +55,36 @@ public struct VSplitView<Main: View, Panel: View>: View {
             #endif
             .gesture(
                 DragGesture(minimumDistance: 0)
-                    .updating($dragStartWidth) { _, state, _ in
-                        // Capture initial width on first call
-                        if state == nil {
-                            state = panelWidth
-                        }
-                    }
                     .onChanged { value in
-                        // Use initial width from gesture state, not current panelWidth
-                        let initialWidth = dragStartWidth ?? panelWidth
+                        // Capture initial state on first drag event
+                        if dragStartWidth == nil {
+                            dragStartWidth = panelWidth
+                            dragStartAvailableWidth = availableWidth
+                        }
+
+                        guard let initialWidth = dragStartWidth,
+                              let initialAvailableWidth = dragStartAvailableWidth else {
+                            return
+                        }
+
                         // Dragging left (negative) increases width, dragging right (positive) decreases width
                         let newWidth = initialWidth - value.translation.width
 
                         // Compute max panel width: available width minus minimum main content (300pt), divider (8pt), and padding (16pt total)
                         let minMainContent: CGFloat = 300
-                        let maxAllowed = availableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
+                        let maxAllowed = initialAvailableWidth - minMainContent - VSpacing.sm - (VSpacing.sm * 2)
 
-                        panelWidth = min(max(newWidth, 300), maxAllowed)
+                        // Disable all animations during drag to prevent jitter
+                        var transaction = Transaction()
+                        transaction.disablesAnimations = true
+                        withTransaction(transaction) {
+                            panelWidth = min(max(newWidth, 300), maxAllowed)
+                        }
+                    }
+                    .onEnded { _ in
+                        // Reset drag state
+                        dragStartWidth = nil
+                        dragStartAvailableWidth = nil
                     }
             )
     }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -87,6 +87,11 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         dragStartAvailableWidth = nil
                     }
             )
+            .onDisappear {
+                // Reset drag state if view is removed mid-drag (e.g., panel closed)
+                dragStartWidth = nil
+                dragStartAvailableWidth = nil
+            }
     }
 
     public init(

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -10,6 +10,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
     public var showPanel: Bool = false
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
+    @State private var isDragging: Bool = false
 
     public var body: some View {
         GeometryReader { geometry in
@@ -29,13 +30,14 @@ public struct VSplitView<Main: View, Panel: View>: View {
 
                     panel
                         .frame(width: panelWidth)
+                        .animation(nil, value: panelWidth)  // Disable animation on width changes
                         .background(VColor.backgroundSubtle)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                         .padding([.bottom, .trailing], VSpacing.sm)
                         .transition(.move(edge: .trailing))
                 }
             }
-            .animation(VAnimation.standard, value: showPanel)
+            .animation(isDragging ? nil : VAnimation.standard, value: showPanel)
         }
     }
 
@@ -60,6 +62,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                         if dragStartWidth == nil {
                             dragStartWidth = panelWidth
                             dragStartAvailableWidth = availableWidth
+                            isDragging = true
                         }
 
                         guard let initialWidth = dragStartWidth,
@@ -83,12 +86,14 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     }
                     .onEnded { _ in
                         // Reset drag state
+                        isDragging = false
                         dragStartWidth = nil
                         dragStartAvailableWidth = nil
                     }
             )
             .onDisappear {
                 // Reset drag state if view is removed mid-drag (e.g., panel closed)
+                isDragging = false
                 dragStartWidth = nil
                 dragStartAvailableWidth = nil
             }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -35,6 +35,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                 }
             }
             .animation(VAnimation.standard, value: showPanel)
+            .animation(nil, value: panelWidth)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes unstable panel widths and visual artifacts during resize, plus code quality improvements.

## Problem

When dragging the panel divider, the panels would:
- Jump and shake visually
- Have unstable widths that felt "jittery"
- Flash as layout recalculated

## Root Causes

1. SwiftUI animations were triggering during drag gestures
2. Using `@GestureState` which had unreliable state capture
3. Recalculating available width on every frame (geometry reader changes during resize)
4. Fallback logic (`dragStartWidth ?? panelWidth`) that could create feedback loops

## Solution

**VSplitView.swift** - Panel resize improvements:
- Changed from `@GestureState` to `@State` for reliable state tracking
- Capture both initial panel width AND available width at drag start
- Use captured values throughout the drag (no recalculation per frame)
- Reset state in `.onEnded()` handler
- Wrap `panelWidth` updates in `Transaction` with `disablesAnimations = true`

**Code quality improvements:**
- Extracted drag logic to `handleDragChanged()` helper method
- Extracted state reset to `resetDragState()` (eliminates duplication)
- Added clear MARK comments for organization
- Extracted constants for maintainability

This ensures stable, smooth resize with no jumping or flashing, while making the code more maintainable.

## Files Changed

- `clients/shared/DesignSystem/Components/Layout/VSplitView.swift` - Panel resize fix + refactoring

## Testing

✅ Panel show/hide animates smoothly
✅ Panel resize is stable with no jumping, shaking, or flashing
✅ Width stays consistent during drag (no feedback loops)
✅ Drag behavior works correctly with min/max constraints
✅ Code is more readable and maintainable (DRY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)