### PR TITLE
fix(pr-2338): preserve surfaceMessage on update and guard iOS View Output

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -946,7 +946,8 @@ public final class ChatViewModel: ObservableObject {
                             surfaceType: updated.type,
                             title: updated.title,
                             data: updated.data,
-                            actions: updated.actions
+                            actions: updated.actions,
+                            surfaceMessage: existing.surfaceMessage
                         )
                     }
                     return

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -49,6 +49,7 @@ public struct InlineDynamicPagePreview: View {
                 }
             }
 
+            #if os(macOS)
             HStack {
                 Spacer()
                 Button {
@@ -71,6 +72,7 @@ public struct InlineDynamicPagePreview: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("View Output")
             }
+            #endif
         }
         .frame(maxWidth: 350)
     }


### PR DESCRIPTION
Two fixes from review feedback on #2338:

1. **Preserve surfaceMessage during uiSurfaceUpdate:** The `uiSurfaceUpdate` handler was rebuilding `InlineSurfaceData` without forwarding the existing `surfaceMessage` field, causing it to default to `nil`. After any dynamic page surface update, the "View Output" button would silently stop working because it checks `if let msg = surface.surfaceMessage`. Now preserves `existing.surfaceMessage` through updates.

2. **Guard View Output button on iOS:** The "View Output" button posts an `openDynamicWorkspace` notification that only macOS handles. On iOS, tapping it did nothing. Wrapped the button in `#if os(macOS)` to hide it on iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
