### PR TITLE
fix(workspace): reset share state, derive URL from runtime port

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -42,6 +42,15 @@ struct MainWindowView: View {
     /// but requires complex window geometry inspection.
     private let trafficLightPadding: CGFloat = 78
 
+    private static var runtimeHttpPort: String? {
+        ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+    }
+
+    private static func pageURL(for appId: String) -> URL? {
+        guard let port = runtimeHttpPort else { return nil }
+        return URL(string: "http://localhost:\(port)/pages/\(appId)")
+    }
+
     var body: some View {
         GeometryReader { geometry in
             Group {
@@ -150,6 +159,7 @@ struct MainWindowView: View {
             // Reset expanded state and active surface when navigating away from the
             // Dynamic panel via toolbar or tab bar buttons, which only modify activePanel.
             if newPanel != .generated {
+                showSharePicker = false
                 isDynamicExpanded = false
                 activeDynamicSurface = nil
                 activeDynamicParsedSurface = nil
@@ -182,6 +192,7 @@ struct MainWindowView: View {
             // If a specific surfaceId was dismissed, only clear if it matches.
             if let surfaceId = notification.userInfo?["surfaceId"] as? String {
                 if activeDynamicSurface?.surfaceId == surfaceId {
+                    showSharePicker = false
                     activePanel = nil
                     isDynamicExpanded = false
                     activeDynamicSurface = nil
@@ -189,6 +200,7 @@ struct MainWindowView: View {
                 }
             } else {
                 // Bulk dismiss (dismissAll)
+                showSharePicker = false
                 activePanel = nil
                 isDynamicExpanded = false
                 activeDynamicSurface = nil
@@ -419,7 +431,7 @@ struct MainWindowView: View {
         VStack(spacing: 0) {
             // Toolbar
             HStack {
-                Button(action: { activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
+                Button(action: { showSharePicker = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textMuted)
@@ -434,12 +446,12 @@ struct MainWindowView: View {
 
                 Spacer()
 
-                // Share button — only shown for persisted apps with a shareable link
-                if let appId = data.appId {
+                // Share button — only shown when the runtime page server is active
+                if let appId = data.appId, let shareURL = Self.pageURL(for: appId) {
                     Menu {
                         Button {
                             NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString("http://localhost:7821/pages/\(appId)", forType: .string)
+                            NSPasteboard.general.setString(shareURL.absoluteString, forType: .string)
                         } label: {
                             Label("Copy Link", systemImage: "doc.on.doc")
                         }
@@ -459,14 +471,14 @@ struct MainWindowView: View {
                     .accessibilityLabel("Share")
                     .background(
                         ShareSheetButton(
-                            items: [URL(string: "http://localhost:7821/pages/\(appId)")!],
+                            items: [shareURL],
                             isPresented: $showSharePicker
                         )
                         .frame(width: 1, height: 1)
                     )
                 }
 
-                Button(action: { activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
+                Button(action: { showSharePicker = false; activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(VColor.textMuted)


### PR DESCRIPTION
## Summary
- Reset `showSharePicker` in all workspace exit paths (back button, close button, onChange, dismiss handler) to prevent spurious share sheet on re-entry
- Derive share URL from `RUNTIME_HTTP_PORT` env var instead of hardcoding port 7821
- Gate share UI on page server availability — hidden when `RUNTIME_HTTP_PORT` is not set

Addresses Devin and Codex review feedback on #2341.

## Test plan
- [ ] Open workspace, trigger Share, close workspace, reopen — verify no spurious share sheet
- [ ] Verify share button hidden when `RUNTIME_HTTP_PORT` env var is not set
- [ ] Set `RUNTIME_HTTP_PORT` and verify Copy Link uses the correct port

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
