### PR TITLE
fix(workspace): scope activePanel reset to .generated in dismiss handlers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -193,7 +193,9 @@ struct MainWindowView: View {
             if let surfaceId = notification.userInfo?["surfaceId"] as? String {
                 if activeDynamicSurface?.surfaceId == surfaceId {
                     showSharePicker = false
-                    activePanel = nil
+                    if activePanel == .generated {
+                        activePanel = nil
+                    }
                     isDynamicExpanded = false
                     activeDynamicSurface = nil
                     activeDynamicParsedSurface = nil
@@ -201,7 +203,9 @@ struct MainWindowView: View {
             } else {
                 // Bulk dismiss (dismissAll)
                 showSharePicker = false
-                activePanel = nil
+                if activePanel == .generated {
+                    activePanel = nil
+                }
                 isDynamicExpanded = false
                 activeDynamicSurface = nil
                 activeDynamicParsedSurface = nil


### PR DESCRIPTION
## Summary
- Scope `activePanel = nil` reset in dismiss handlers to only fire when `activePanel == .generated`
- Prevents Settings, Debug, Doctor, and other panels from being unexpectedly closed when the daemon bulk-dismisses surfaces or dismisses a specific surface

Addresses Codex and Devin review feedback on #2342.

## Test plan
- [ ] Open Settings panel, trigger a surface dismiss notification — verify Settings stays open
- [ ] Open Generated workspace, dismiss the surface — verify workspace closes properly
- [ ] Bulk dismiss (dismissAll) while Settings is open — verify Settings panel remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
