### PR TITLE
fix(config): point dynamic budget validation error at parent object

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -660,7 +660,7 @@ export const AssistantConfigSchema = z.object({
   if (config.memory.retrieval.dynamicBudget.minInjectTokens > config.memory.retrieval.dynamicBudget.maxInjectTokens) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      path: ['memory', 'retrieval', 'dynamicBudget', 'minInjectTokens'],
+      path: ['memory', 'retrieval', 'dynamicBudget'],
       message: 'memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens',
     });
   }


### PR DESCRIPTION
## Summary
- Fixes the `minInjectTokens > maxInjectTokens` validation error path from `['memory', 'retrieval', 'dynamicBudget', 'minInjectTokens']` to `['memory', 'retrieval', 'dynamicBudget']`
- This ensures `validateWithSchema` resets the entire `dynamicBudget` group to consistent defaults on retry, instead of deleting just `minInjectTokens` (which restores its default of 1200 and can still conflict with a user-set `maxInjectTokens` below 1200)

Addresses feedback from PR #2348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
