### PR TITLE
fix(pr-2357): fall back to default port for share URL

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -42,13 +42,12 @@ struct MainWindowView: View {
     /// but requires complex window geometry inspection.
     private let trafficLightPadding: CGFloat = 78
 
-    private static var runtimeHttpPort: String? {
-        ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+    private static var runtimeHttpPort: String {
+        ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
     }
 
     private static func pageURL(for appId: String) -> URL? {
-        guard let port = runtimeHttpPort else { return nil }
-        return URL(string: "http://localhost:\(port)/pages/\(appId)")
+        URL(string: "http://localhost:\(runtimeHttpPort)/pages/\(appId)")
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Fall back to default port 7821 when RUNTIME_HTTP_PORT env var is not set
- Fixes share button being hidden in production since the env var is only set on the daemon process, not the macOS app

Addresses Devin review feedback on #2357.

## Test plan
- [ ] Verify share button appears in production (without RUNTIME_HTTP_PORT set)
- [ ] Verify share URL uses port 7821 by default
- [ ] Verify custom port is used when RUNTIME_HTTP_PORT is explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
