### PR TITLE
feat(memory): persist entity relations from extraction jobs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,6 +78,9 @@ graph TB
             DB_FTS["memory_segment_fts (FTS5)"]
             DB_ITEMS["memory_items"]
             DB_SRC["memory_item_sources"]
+            DB_ENT["memory_entities"]
+            DB_REL["memory_entity_relations"]
+            DB_ITEM_ENT["memory_item_entities"]
             DB_SUM["memory_summaries"]
             DB_EMB["memory_embeddings"]
             DB_JOBS["memory_jobs"]
@@ -197,6 +200,9 @@ graph TB
     INDEXER --> DB_JOBS
     JOBS_WORKER --> DB_JOBS
     JOBS_WORKER --> DB_EMB
+    JOBS_WORKER --> DB_ENT
+    JOBS_WORKER --> DB_REL
+    JOBS_WORKER --> DB_ITEM_ENT
     JOBS_WORKER --> DB_SUM
     RECALL --> DB_FTS
     RECALL --> DB_EMB
@@ -276,6 +282,9 @@ graph LR
         SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
         FTS["memory_segment_fts<br/>───────────────<br/>FTS5 virtual table<br/>Auto-synced via triggers<br/>Powers lexical search"]
         ITEMS["memory_items<br/>───────────────<br/>Extracted facts/entities<br/>kind, subject, statement<br/>confidence, fingerprint (dedup)<br/>verification_state, scope_id<br/>first/last seen timestamps"]
+        ENTITIES["memory_entities<br/>───────────────<br/>Canonical entities + aliases<br/>mention_count, first/last seen<br/>Resolved across messages"]
+        RELS["memory_entity_relations<br/>───────────────<br/>Directional entity edges<br/>Unique by source/target/relation<br/>first/last seen + evidence"]
+        ITEM_ENTS["memory_item_entities<br/>───────────────<br/>Join table linking extracted<br/>memory_items to entities"]
         SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill<br/>Status: pending → running →<br/>completed | failed"]
@@ -492,6 +501,7 @@ graph TB
         EMBED_ITEM["embed_item<br/>→ memory_embeddings"]
         EMBED_SUM["embed_summary<br/>→ memory_embeddings"]
         EXTRACT["extract_items<br/>→ memory_items +<br/>memory_item_sources"]
+        EXTRACT_ENTITIES["extract_entities<br/>→ memory_entities +<br/>memory_item_entities +<br/>memory_entity_relations"]
         BUILD_SUM["build_conversation_summary<br/>→ memory_summaries"]
         WEEKLY["refresh_weekly_summary<br/>→ memory_summaries"]
     end
@@ -532,8 +542,10 @@ graph TB
     WORKER --> EMBED_ITEM
     WORKER --> EMBED_SUM
     WORKER --> EXTRACT
+    WORKER --> EXTRACT_ENTITIES
     WORKER --> BUILD_SUM
     WORKER --> WEEKLY
+    EXTRACT --> EXTRACT_ENTITIES
 
     EMBED_SEG --> OAI_EMB
     EMBED_SEG --> GEM_EMB
@@ -1138,6 +1150,7 @@ graph LR
 | Conversations & messages | `~/.vellum/data/db/assistant.db` | SQLite + WAL | Drizzle ORM (Bun) | Permanent |
 | Memory segments & FTS | `~/.vellum/data/db/assistant.db` | SQLite FTS5 | Drizzle ORM | Permanent |
 | Extracted facts | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent, deduped |
+| Entity graph (entities/relations/item links) | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent, deduped by unique relation edge |
 | Embeddings | `~/.vellum/data/db/assistant.db` | JSON float arrays | Drizzle ORM | Permanent |
 | Async job queue | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Completed jobs persist |
 | Attachments | `~/.vellum/data/db/assistant.db` | Base64 in SQLite | Drizzle ORM | Permanent |

--- a/assistant/src/__tests__/entity-extractor.test.ts
+++ b/assistant/src/__tests__/entity-extractor.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { and, eq } from 'drizzle-orm';
+
+const testDir = mkdtempSync(join(tmpdir(), 'entity-extractor-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { resolveEntityName, upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
+import { memoryEntities, memoryEntityRelations } from '../memory/schema.js';
+
+describe('entity extractor helpers', () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM memory_item_entities');
+    db.run('DELETE FROM memory_entity_relations');
+    db.run('DELETE FROM memory_entities');
+    db.run('DELETE FROM memory_checkpoints');
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+  });
+
+  test('upsertEntity reuses existing row via alias matching', () => {
+    const db = getDb();
+
+    const firstId = upsertEntity({
+      name: 'VS Code',
+      type: 'tool',
+      aliases: ['vscode'],
+    });
+    const secondId = upsertEntity({
+      name: 'Visual Studio Code',
+      type: 'tool',
+      aliases: ['VS Code', 'vscode'],
+    });
+
+    expect(secondId).toBe(firstId);
+    expect(resolveEntityName('vscode')).toBe(firstId);
+    expect(resolveEntityName('VS Code')).toBe(firstId);
+
+    const stored = db
+      .select()
+      .from(memoryEntities)
+      .where(eq(memoryEntities.id, firstId))
+      .get();
+
+    expect(stored).toBeDefined();
+    expect(stored!.mentionCount).toBe(2);
+    const aliases = stored!.aliases ? JSON.parse(stored!.aliases) as string[] : [];
+    expect(aliases).toContain('vscode');
+  });
+
+  test('upsertEntityRelation merges duplicate edges by uniqueness key', () => {
+    const db = getDb();
+    const sourceEntityId = upsertEntity({
+      name: 'Project Atlas',
+      type: 'project',
+      aliases: ['atlas'],
+    });
+    const targetEntityId = upsertEntity({
+      name: 'Qdrant',
+      type: 'tool',
+      aliases: [],
+    });
+
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: 'Project Atlas uses Qdrant for memory search',
+      seenAt: 1_700_000_000_000,
+    });
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: null,
+      seenAt: 1_700_000_100_000,
+    });
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: 'Atlas still depends on Qdrant',
+      seenAt: 1_700_000_200_000,
+    });
+
+    const relationRows = db
+      .select()
+      .from(memoryEntityRelations)
+      .where(and(
+        eq(memoryEntityRelations.sourceEntityId, sourceEntityId),
+        eq(memoryEntityRelations.targetEntityId, targetEntityId),
+        eq(memoryEntityRelations.relation, 'uses'),
+      ))
+      .all();
+
+    expect(relationRows.length).toBe(1);
+    expect(relationRows[0].firstSeenAt).toBe(1_700_000_000_000);
+    expect(relationRows[0].lastSeenAt).toBe(1_700_000_200_000);
+    expect(relationRows[0].evidence).toBe('Atlas still depends on Qdrant');
+  });
+
+  test('upsertEntityRelation drops self-edges', () => {
+    const db = getDb();
+    const entityId = upsertEntity({
+      name: 'Sidd',
+      type: 'person',
+      aliases: [],
+    });
+
+    upsertEntityRelation({
+      sourceEntityId: entityId,
+      targetEntityId: entityId,
+      relation: 'collaborates_with',
+      evidence: 'self edge should not be stored',
+    });
+
+    const relationRows = db.select().from(memoryEntityRelations).all();
+    expect(relationRows.length).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -48,6 +48,7 @@ import { estimateTextTokens } from '../context/token-estimator.js';
 import { requestMemoryBackfill } from '../memory/admin.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
+import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
 import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
 import { claimMemoryJobs, enqueueMemoryJob } from '../memory/jobs-store.js';
@@ -64,6 +65,7 @@ import {
 import {
   conversations,
   memoryEmbeddings,
+  memoryEntityRelations,
   memoryItems,
   memoryItemSources,
   memoryJobs,
@@ -79,6 +81,9 @@ describe('Memory V2 regressions', () => {
 
   beforeEach(() => {
     const db = getDb();
+    db.run('DELETE FROM memory_item_entities');
+    db.run('DELETE FROM memory_entity_relations');
+    db.run('DELETE FROM memory_entities');
     db.run('DELETE FROM memory_item_sources');
     db.run('DELETE FROM memory_embeddings');
     db.run('DELETE FROM memory_summaries');
@@ -1978,5 +1983,56 @@ describe('Memory V2 regressions', () => {
     const summary = db.select().from(memorySummaries).where(eq(memorySummaries.id, 'summary-scope-test')).get();
     expect(summary).toBeDefined();
     expect(summary!.scopeId).toBe('default');
+  });
+
+  test('entity relations upsert is idempotent under repeated processing', () => {
+    const db = getDb();
+    const sourceEntityId = upsertEntity({
+      name: 'Project Atlas',
+      type: 'project',
+      aliases: ['atlas'],
+    });
+    const targetEntityId = upsertEntity({
+      name: 'Qdrant',
+      type: 'tool',
+      aliases: [],
+    });
+
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: 'Project Atlas uses Qdrant for vector search',
+      seenAt: 1_700_000_000_000,
+    });
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: null,
+      seenAt: 1_700_000_100_000,
+    });
+    upsertEntityRelation({
+      sourceEntityId,
+      targetEntityId,
+      relation: 'uses',
+      evidence: 'Atlas currently depends on Qdrant',
+      seenAt: 1_700_000_200_000,
+    });
+
+    const rows = db
+      .select()
+      .from(memoryEntityRelations)
+      .where(and(
+        eq(memoryEntityRelations.sourceEntityId, sourceEntityId),
+        eq(memoryEntityRelations.targetEntityId, targetEntityId),
+        eq(memoryEntityRelations.relation, 'uses'),
+      ))
+      .all();
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].firstSeenAt).toBe(1_700_000_000_000);
+    expect(rows[0].lastSeenAt).toBe(1_700_000_200_000);
+    expect(rows[0].evidence).toBe('Atlas currently depends on Qdrant');
   });
 });

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -83,6 +83,9 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     entity: {
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
+      extractRelations: {
+        enabled: false,
+      },
     },
   },
   dataDir: getDataDir(),

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -388,6 +388,13 @@ export const MemoryEntityConfigSchema = z.object({
   model: z
     .string({ error: 'memory.entity.model must be a string' })
     .default('claude-haiku-4-5-20251001'),
+  extractRelations: z.object({
+    enabled: z
+      .boolean({ error: 'memory.entity.extractRelations.enabled must be a boolean' })
+      .default(false),
+  }).default({
+    enabled: false,
+  }),
 });
 
 export const MemorySummarizationConfigSchema = z.object({
@@ -465,6 +472,9 @@ export const MemoryConfigSchema = z.object({
   entity: MemoryEntityConfigSchema.default({
     enabled: true,
     model: 'claude-haiku-4-5-20251001',
+    extractRelations: {
+      enabled: false,
+    },
   }),
 });
 
@@ -599,6 +609,9 @@ export const AssistantConfigSchema = z.object({
     entity: {
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
+      extractRelations: {
+        enabled: false,
+      },
     },
   }),
   dataDir: z

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -380,6 +380,7 @@ export function initializeDb(): void {
 
   migrateJobDeferrals(database);
   migrateToolInvocationsFk(database);
+  migrateMemoryEntityRelationDedup(database);
 
   // Indexes for query performance on large datasets
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)`);
@@ -420,6 +421,7 @@ export function initializeDb(): void {
 
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_name ON memory_entities(name)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entities_type ON memory_entities(type)`);
+  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_entity_relations_unique_edge ON memory_entity_relations(source_entity_id, target_entity_id, relation)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entity_relations_source ON memory_entity_relations(source_entity_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_entity_relations_target ON memory_entity_relations(target_entity_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_entities_memory_item ON memory_item_entities(memory_item_id)`);
@@ -528,4 +530,82 @@ function migrateMemoryFtsBackfill(database: ReturnType<typeof drizzle<typeof sch
     INSERT INTO memory_segment_fts(segment_id, text)
     SELECT id, text FROM memory_segments
   `);
+}
+
+/**
+ * One-shot migration: merge duplicate relation edges so uniqueness can be
+ * enforced on (source_entity_id, target_entity_id, relation).
+ */
+function migrateMemoryEntityRelationDedup(database: ReturnType<typeof drizzle<typeof schema>>): void {
+  const raw = (database as unknown as { $client: Database }).$client;
+  const checkpointKey = 'migration_memory_entity_relations_dedup_v1';
+  const checkpoint = raw.query(
+    `SELECT 1 FROM memory_checkpoints WHERE key = ?`,
+  ).get(checkpointKey);
+  if (checkpoint) return;
+
+  try {
+    raw.exec('BEGIN');
+
+    raw.exec(/*sql*/ `
+      CREATE TEMP TABLE memory_entity_relation_merge AS
+      WITH ranked AS (
+        SELECT
+          source_entity_id,
+          target_entity_id,
+          relation,
+          first_seen_at,
+          last_seen_at,
+          evidence,
+          ROW_NUMBER() OVER (
+            PARTITION BY source_entity_id, target_entity_id, relation
+            ORDER BY last_seen_at DESC, first_seen_at DESC, id DESC
+          ) AS rank_latest
+        FROM memory_entity_relations
+      )
+      SELECT
+        source_entity_id,
+        target_entity_id,
+        relation,
+        MIN(first_seen_at) AS merged_first_seen_at,
+        MAX(last_seen_at) AS merged_last_seen_at,
+        MAX(CASE WHEN rank_latest = 1 THEN evidence ELSE NULL END) AS merged_evidence
+      FROM ranked
+      GROUP BY source_entity_id, target_entity_id, relation
+    `);
+
+    raw.exec(/*sql*/ `DELETE FROM memory_entity_relations`);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_entity_relations (
+        id,
+        source_entity_id,
+        target_entity_id,
+        relation,
+        evidence,
+        first_seen_at,
+        last_seen_at
+      )
+      SELECT
+        lower(hex(randomblob(16))),
+        source_entity_id,
+        target_entity_id,
+        relation,
+        merged_evidence,
+        merged_first_seen_at,
+        merged_last_seen_at
+      FROM memory_entity_relation_merge
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_entity_relation_merge`);
+
+    raw.query(
+      `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
+    ).run(checkpointKey, Date.now());
+
+    raw.exec('COMMIT');
+  } catch (e) {
+    try { raw.exec('ROLLBACK'); } catch { /* no active transaction */ }
+    throw e;
+  }
 }

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../config/loader.js';
 import type { MemoryEntityConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { getDb } from './db.js';
-import { memoryEntities, memoryItemEntities } from './schema.js';
+import { memoryEntities, memoryEntityRelations, memoryItemEntities } from './schema.js';
 
 const log = getLogger('memory-entity-extractor');
 
@@ -17,8 +17,31 @@ export type EntityType =
   | 'location'
   | 'organization';
 
+export type EntityRelationType =
+  | 'works_on'
+  | 'uses'
+  | 'owns'
+  | 'member_of'
+  | 'located_in'
+  | 'depends_on'
+  | 'collaborates_with'
+  | 'reports_to'
+  | 'related_to';
+
 const VALID_ENTITY_TYPES = new Set<string>([
   'person', 'project', 'tool', 'company', 'concept', 'location', 'organization',
+]);
+
+const VALID_RELATION_TYPES = new Set<string>([
+  'works_on',
+  'uses',
+  'owns',
+  'member_of',
+  'located_in',
+  'depends_on',
+  'collaborates_with',
+  'reports_to',
+  'related_to',
 ]);
 
 export interface ExtractedEntity {
@@ -27,10 +50,37 @@ export interface ExtractedEntity {
   aliases: string[];
 }
 
+export interface ExtractedEntityRelation {
+  sourceEntityName: string;
+  targetEntityName: string;
+  relation: EntityRelationType;
+  evidence: string | null;
+}
+
+export interface ExtractedEntityGraph {
+  entities: ExtractedEntity[];
+  relations: ExtractedEntityRelation[];
+}
+
+export interface UpsertEntityRelationInput {
+  sourceEntityId: string;
+  targetEntityId: string;
+  relation: EntityRelationType;
+  evidence?: string | null;
+  seenAt?: number;
+}
+
 interface LLMExtractedEntity {
   name: string;
   type: string;
   aliases: string[];
+}
+
+interface LLMExtractedRelation {
+  sourceEntityName: string;
+  targetEntityName: string;
+  relation: string;
+  evidence?: string;
 }
 
 const ENTITY_EXTRACTION_SYSTEM_PROMPT = `You are an entity extraction system. Given text from a conversation, extract named entities that are worth tracking across conversations.
@@ -44,28 +94,40 @@ Extract entities in these categories:
 - location: Cities, offices, regions relevant to the user
 - organization: Non-commercial orgs, teams, groups, communities
 
+If relation extraction is enabled, also extract directional entity relations using:
+- works_on, uses, owns, member_of, located_in, depends_on, collaborates_with, reports_to, related_to
+
 For each entity, provide:
 - name: The canonical name (proper casing, full name preferred)
 - type: One of the categories above
 - aliases: Array of alternate names, abbreviations, or nicknames (empty array if none)
+
+If relation extraction is enabled, for each relation provide:
+- sourceEntityName: canonical source entity name
+- targetEntityName: canonical target entity name
+- relation: one of the allowed relation types
+- evidence: short evidence phrase from the text (optional)
 
 Rules:
 - Only extract concrete, named entities. Skip generic terms like "the project" or "that tool".
 - Prefer the most specific and complete name as the canonical name.
 - Include common abbreviations and nicknames as aliases.
 - Do NOT extract the assistant itself or generic conversation participants.
-- If there are no extractable entities, return an empty array.`;
+- If there are no extractable entities, return an empty entities array.
+- Only emit relations that are explicitly or strongly implied by the text.`;
 
 export async function extractEntitiesWithLLM(
   text: string,
   entityConfig: MemoryEntityConfig,
-): Promise<ExtractedEntity[]> {
+): Promise<ExtractedEntityGraph> {
   const config = getConfig();
   const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     log.debug('No Anthropic API key available for entity extraction');
-    return [];
+    return { entities: [], relations: [] };
   }
+
+  const extractRelations = entityConfig.extractRelations?.enabled ?? false;
 
   try {
     const client = new Anthropic({ apiKey });
@@ -77,76 +139,36 @@ export async function extractEntitiesWithLLM(
         tools: [{
           name: 'store_entities',
           description: 'Store extracted entities from the text',
-          input_schema: {
-            type: 'object' as const,
-            properties: {
-              entities: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    name: {
-                      type: 'string',
-                      description: 'Canonical name of the entity',
-                    },
-                    type: {
-                      type: 'string',
-                      enum: [...VALID_ENTITY_TYPES],
-                      description: 'Category of the entity',
-                    },
-                    aliases: {
-                      type: 'array',
-                      items: { type: 'string' },
-                      description: 'Alternate names or abbreviations',
-                    },
-                  },
-                  required: ['name', 'type', 'aliases'],
-                },
-              },
-            },
-            required: ['entities'],
-          },
+          input_schema: buildToolInputSchema(extractRelations),
         }],
         tool_choice: { type: 'tool' as const, name: 'store_entities' },
         messages: [{ role: 'user' as const, content: text }],
-      }),
+      }) as Promise<Anthropic.Message>,
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Entity extraction LLM timeout')), 15000),
       ),
-    ]);
+    ]) as Anthropic.Message;
 
-    const toolBlock = response.content.find((b) => b.type === 'tool_use');
+    const toolBlock = response.content.find((block) => block.type === 'tool_use');
     if (!toolBlock || toolBlock.type !== 'tool_use') {
       log.warn('No tool_use block in entity extraction response');
-      return [];
+      return { entities: [], relations: [] };
     }
 
-    const input = toolBlock.input as { entities?: LLMExtractedEntity[] };
+    const input = toolBlock.input as { entities?: LLMExtractedEntity[]; relations?: LLMExtractedRelation[] };
     if (!Array.isArray(input.entities)) {
       log.warn('Invalid entities in entity extraction response');
-      return [];
+      return { entities: [], relations: [] };
     }
 
-    const entities: ExtractedEntity[] = [];
-    for (const raw of input.entities) {
-      if (!VALID_ENTITY_TYPES.has(raw.type)) continue;
-      if (!raw.name || raw.name.trim().length === 0) continue;
-      const name = String(raw.name).trim().slice(0, 200);
-      const aliases = Array.isArray(raw.aliases)
-        ? raw.aliases.map((a) => String(a).trim().slice(0, 200)).filter((a) => a.length > 0)
-        : [];
-      entities.push({
-        name,
-        type: raw.type as EntityType,
-        aliases,
-      });
-    }
+    const entities = parseExtractedEntities(input.entities);
+    const relations = extractRelations ? parseExtractedRelations(input.relations) : [];
 
-    return entities;
+    return { entities, relations };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err: message }, 'Entity extraction LLM call failed');
-    return [];
+    return { entities: [], relations: [] };
   }
 }
 
@@ -155,42 +177,28 @@ export async function extractEntitiesWithLLM(
  * Returns the existing entity ID if a match is found, or null if no match.
  */
 export function resolveEntity(entity: ExtractedEntity): string | null {
-  const db = getDb();
-  const nameLower = entity.name.toLowerCase();
-
-  // Search by exact name match or exact alias match using json_each()
-  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
-  const candidates = raw.query(`
-    SELECT DISTINCT me.* FROM memory_entities me
-    WHERE LOWER(me.name) = ?
-    UNION
-    SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
-    WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
-  `).all(nameLower, nameLower) as Array<typeof memoryEntities.$inferSelect>;
-
-  if (candidates.length === 0) {
-    // Also check if any of the extracted aliases match an existing entity name
-    for (const alias of entity.aliases) {
-      const aliasLower = alias.toLowerCase();
-      const aliasCandidates = raw.query(`
-        SELECT DISTINCT me.* FROM memory_entities me
-        WHERE LOWER(me.name) = ?
-        UNION
-        SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
-        WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
-      `).all(aliasLower, aliasLower) as Array<typeof memoryEntities.$inferSelect>;
-      if (aliasCandidates.length > 0) {
-        // Return the first match — same type preferred
-        const sameType = aliasCandidates.find((c) => c.type === entity.type);
-        return sameType?.id ?? aliasCandidates[0].id;
-      }
-    }
-    return null;
+  const candidates = findEntityCandidates(entity.name);
+  if (candidates.length > 0) {
+    const sameType = candidates.find((candidate) => candidate.type === entity.type);
+    return sameType?.id ?? candidates[0].id;
   }
 
-  // Prefer same-type matches
-  const sameType = candidates.find((c) => c.type === entity.type);
-  return sameType?.id ?? candidates[0].id;
+  for (const alias of entity.aliases) {
+    const aliasCandidates = findEntityCandidates(alias);
+    if (aliasCandidates.length > 0) {
+      const sameType = aliasCandidates.find((candidate) => candidate.type === entity.type);
+      return sameType?.id ?? aliasCandidates[0].id;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve an entity by canonical name or alias.
+ */
+export function resolveEntityName(entityName: string): string | null {
+  const candidates = findEntityCandidates(entityName);
+  return candidates.length > 0 ? candidates[0].id : null;
 }
 
 /**
@@ -204,7 +212,6 @@ export function upsertEntity(entity: ExtractedEntity): string {
   const existingId = resolveEntity(entity);
 
   if (existingId) {
-    // Update existing entity: bump mention count, update lastSeenAt, merge aliases
     const existing = db
       .select()
       .from(memoryEntities)
@@ -221,7 +228,7 @@ export function upsertEntity(entity: ExtractedEntity): string {
         .set({
           lastSeenAt: now,
           mentionCount: sql`${memoryEntities.mentionCount} + 1`,
-          aliases: JSON.stringify(mergedAliases),
+          aliases: mergedAliases.length > 0 ? JSON.stringify(mergedAliases) : null,
         })
         .where(eq(memoryEntities.id, existingId))
         .run();
@@ -230,7 +237,6 @@ export function upsertEntity(entity: ExtractedEntity): string {
     return existingId;
   }
 
-  // Insert new entity
   const id = crypto.randomUUID();
   db.insert(memoryEntities).values({
     id,
@@ -247,6 +253,43 @@ export function upsertEntity(entity: ExtractedEntity): string {
 }
 
 /**
+ * Upsert an entity relation edge using (source, target, relation) as a stable uniqueness key.
+ */
+export function upsertEntityRelation(input: UpsertEntityRelationInput): void {
+  if (input.sourceEntityId === input.targetEntityId) return;
+
+  const db = getDb();
+  const seenAt = input.seenAt ?? Date.now();
+  const normalizedEvidence = normalizeEvidence(input.evidence);
+
+  db.insert(memoryEntityRelations).values({
+    id: crypto.randomUUID(),
+    sourceEntityId: input.sourceEntityId,
+    targetEntityId: input.targetEntityId,
+    relation: input.relation,
+    evidence: normalizedEvidence,
+    firstSeenAt: seenAt,
+    lastSeenAt: seenAt,
+  }).onConflictDoUpdate({
+    target: [
+      memoryEntityRelations.sourceEntityId,
+      memoryEntityRelations.targetEntityId,
+      memoryEntityRelations.relation,
+    ],
+    set: normalizedEvidence === null
+      ? {
+        firstSeenAt: sql`MIN(${memoryEntityRelations.firstSeenAt}, ${seenAt})`,
+        lastSeenAt: sql`MAX(${memoryEntityRelations.lastSeenAt}, ${seenAt})`,
+      }
+      : {
+        firstSeenAt: sql`MIN(${memoryEntityRelations.firstSeenAt}, ${seenAt})`,
+        lastSeenAt: sql`MAX(${memoryEntityRelations.lastSeenAt}, ${seenAt})`,
+        evidence: normalizedEvidence,
+      },
+  }).run();
+}
+
+/**
  * Link a memory item to an entity via the join table.
  */
 export function linkMemoryItemToEntity(memoryItemId: string, entityId: string): void {
@@ -257,6 +300,136 @@ export function linkMemoryItemToEntity(memoryItemId: string, entityId: string): 
   }).onConflictDoNothing().run();
 }
 
+type ToolInputSchema = Record<string, unknown> & {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required: string[];
+};
+
+function buildToolInputSchema(includeRelations: boolean): ToolInputSchema {
+  const properties: Record<string, unknown> = {
+    entities: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Canonical name of the entity',
+          },
+          type: {
+            type: 'string',
+            enum: [...VALID_ENTITY_TYPES],
+            description: 'Category of the entity',
+          },
+          aliases: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Alternate names or abbreviations',
+          },
+        },
+        required: ['name', 'type', 'aliases'],
+      },
+    },
+  };
+
+  const required: string[] = ['entities'];
+
+  if (includeRelations) {
+    properties.relations = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          sourceEntityName: { type: 'string' },
+          targetEntityName: { type: 'string' },
+          relation: {
+            type: 'string',
+            enum: [...VALID_RELATION_TYPES],
+          },
+          evidence: { type: 'string' },
+        },
+        required: ['sourceEntityName', 'targetEntityName', 'relation'],
+      },
+    };
+    required.push('relations');
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required,
+  };
+}
+
+function parseExtractedEntities(rawEntities: LLMExtractedEntity[]): ExtractedEntity[] {
+  const entities: ExtractedEntity[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawEntities) {
+    if (!VALID_ENTITY_TYPES.has(raw.type)) continue;
+    const name = normalizeEntityName(raw.name);
+    if (!name) continue;
+
+    const aliases = Array.isArray(raw.aliases)
+      ? dedupeAliasList(raw.aliases, name)
+      : [];
+    const dedupeKey = `${name.toLowerCase()}|${raw.type}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    entities.push({
+      name,
+      type: raw.type as EntityType,
+      aliases,
+    });
+  }
+  return entities;
+}
+
+function parseExtractedRelations(
+  rawRelations: LLMExtractedRelation[] | undefined,
+): ExtractedEntityRelation[] {
+  if (!Array.isArray(rawRelations)) return [];
+  const relations: ExtractedEntityRelation[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawRelations) {
+    if (!VALID_RELATION_TYPES.has(raw.relation)) continue;
+    const sourceEntityName = normalizeEntityName(raw.sourceEntityName);
+    const targetEntityName = normalizeEntityName(raw.targetEntityName);
+    if (!sourceEntityName || !targetEntityName) continue;
+    if (sourceEntityName.toLowerCase() === targetEntityName.toLowerCase()) continue;
+    const relation = raw.relation as EntityRelationType;
+    const dedupeKey = `${sourceEntityName.toLowerCase()}|${targetEntityName.toLowerCase()}|${relation}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    relations.push({
+      sourceEntityName,
+      targetEntityName,
+      relation,
+      evidence: normalizeEvidence(raw.evidence),
+    });
+  }
+  return relations;
+}
+
+function findEntityCandidates(nameOrAlias: string): Array<typeof memoryEntities.$inferSelect> {
+  const normalized = normalizeEntityName(nameOrAlias);
+  if (!normalized) return [];
+  const db = getDb();
+  const nameLower = normalized.toLowerCase();
+
+  const raw = (db as unknown as {
+    $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } };
+  }).$client;
+
+  return raw.query(`
+    SELECT DISTINCT me.* FROM memory_entities me
+    WHERE LOWER(me.name) = ?
+    UNION
+    SELECT DISTINCT me.* FROM memory_entities me, json_each(me.aliases) je
+    WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
+  `).all(nameLower, nameLower) as Array<typeof memoryEntities.$inferSelect>;
+}
+
 /**
  * Merge alias lists, deduplicating and excluding the canonical name.
  */
@@ -265,11 +438,29 @@ function mergeAliases(existing: string[], incoming: string[], canonicalName: str
   const canonicalLower = canonicalName.toLowerCase();
   const merged: string[] = [];
   for (const alias of [...existing, ...incoming]) {
-    const lower = alias.toLowerCase();
+    const normalizedAlias = normalizeEntityName(alias);
+    if (!normalizedAlias) continue;
+    const lower = normalizedAlias.toLowerCase();
     if (lower === canonicalLower) continue;
     if (seen.has(lower)) continue;
     seen.add(lower);
-    merged.push(alias);
+    merged.push(normalizedAlias);
   }
   return merged;
+}
+
+function dedupeAliasList(rawAliases: string[], canonicalName: string): string[] {
+  return mergeAliases([], rawAliases, canonicalName);
+}
+
+function normalizeEntityName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = String(value).trim().slice(0, 200);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeEvidence(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = String(value).trim().slice(0, 500);
+  return normalized.length > 0 ? normalized : null;
 }

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -17,7 +17,13 @@ import {
   type MemoryJob,
   resetRunningJobsToPending,
 } from './jobs-store.js';
-import { extractEntitiesWithLLM, upsertEntity, linkMemoryItemToEntity } from './entity-extractor.js';
+import {
+  extractEntitiesWithLLM,
+  linkMemoryItemToEntity,
+  resolveEntityName,
+  upsertEntity,
+  upsertEntityRelation,
+} from './entity-extractor.js';
 import { indexMessageNow } from './indexer.js';
 import { checkContradictions } from './contradiction-checker.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
@@ -273,8 +279,10 @@ async function extractEntitiesJob(job: MemoryJob, config: AssistantConfig): Prom
   const text = extractTextFromStoredMessageContent(message.content);
   if (text.trim().length < 15) return;
 
-  const entities = await extractEntitiesWithLLM(text, config.memory.entity);
-  if (entities.length === 0) return;
+  const extracted = await extractEntitiesWithLLM(text, config.memory.entity);
+  const entities = extracted.entities;
+  const relations = extracted.relations;
+  if (entities.length === 0 && relations.length === 0) return;
 
   // Find all memory items linked to this message via memory_item_sources
   const linkedItems = db
@@ -283,16 +291,63 @@ async function extractEntitiesJob(job: MemoryJob, config: AssistantConfig): Prom
     .where(eq(memoryItemSources.messageId, messageId))
     .all();
   const itemIds = linkedItems.map((row) => row.memoryItemId);
+  const entityNameToId = new Map<string, string>();
 
   for (const entity of entities) {
     const entityId = upsertEntity(entity);
+    entityNameToId.set(entity.name.toLowerCase(), entityId);
+    for (const alias of entity.aliases) {
+      entityNameToId.set(alias.toLowerCase(), entityId);
+    }
     // Link all memory items from this message to the entity
     for (const itemId of itemIds) {
       linkMemoryItemToEntity(itemId, entityId);
     }
   }
 
-  log.debug({ messageId, entityCount: entities.length, linkedItems: itemIds.length }, 'Extracted entities from message');
+  const relationTelemetry = {
+    attempted: 0,
+    parsed: relations.length,
+    persisted: 0,
+    dropped: 0,
+  };
+
+  if (config.memory.entity.extractRelations.enabled && relations.length > 0) {
+    const seenRelationKeys = new Set<string>();
+    for (const relation of relations) {
+      relationTelemetry.attempted += 1;
+      const sourceLookup = relation.sourceEntityName.toLowerCase();
+      const targetLookup = relation.targetEntityName.toLowerCase();
+      const sourceEntityId = entityNameToId.get(sourceLookup) ?? resolveEntityName(relation.sourceEntityName);
+      const targetEntityId = entityNameToId.get(targetLookup) ?? resolveEntityName(relation.targetEntityName);
+      if (!sourceEntityId || !targetEntityId || sourceEntityId === targetEntityId) {
+        relationTelemetry.dropped += 1;
+        continue;
+      }
+
+      const dedupeKey = `${sourceEntityId}|${targetEntityId}|${relation.relation}`;
+      if (seenRelationKeys.has(dedupeKey)) continue;
+      seenRelationKeys.add(dedupeKey);
+
+      upsertEntityRelation({
+        sourceEntityId,
+        targetEntityId,
+        relation: relation.relation,
+        evidence: relation.evidence,
+      });
+      relationTelemetry.persisted += 1;
+    }
+  }
+
+  log.debug({
+    messageId,
+    entityCount: entities.length,
+    linkedItems: itemIds.length,
+    relationAttempts: relationTelemetry.attempted,
+    relationParsed: relationTelemetry.parsed,
+    relationPersisted: relationTelemetry.persisted,
+    relationDropped: relationTelemetry.dropped,
+  }, 'Extracted entity graph from message');
 }
 
 async function checkContradictionsJob(job: MemoryJob): Promise<void> {


### PR DESCRIPTION
## Summary
- add relation extraction config gate at `memory.entity.extractRelations.enabled` (default off)
- extend entity extraction to parse entity relation edges and upsert them via a unique `(source_entity_id, target_entity_id, relation)` key
- update `extract_entities` worker flow to persist entities, link items, and persist relation edges with telemetry counters
- add DB migration to dedupe existing relation rows before enforcing the unique edge index
- add tests for entity relation upsert idempotency and update architecture docs for the relation write path

## Validation
- `cd assistant && bun test src/__tests__/entity-extractor.test.ts`
- `cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "entity relations upsert is idempotent"`
- `cd assistant && bun test src/__tests__/config-schema.test.ts -t "parses empty object with full defaults"`
- `cd assistant && bun test src/__tests__/memory-context-benchmark.test.ts`

## Notes
- full-suite runs still include pre-existing `[experimental]` failures in `memory-v2-regressions` unrelated to this change