### PR TITLE
feat(memory): add checkpointed entity-relation backfill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -502,6 +502,7 @@ graph TB
         EMBED_SUM["embed_summary<br/>→ memory_embeddings"]
         EXTRACT["extract_items<br/>→ memory_items +<br/>memory_item_sources"]
         EXTRACT_ENTITIES["extract_entities<br/>→ memory_entities +<br/>memory_item_entities +<br/>memory_entity_relations"]
+        BACKFILL_REL["backfill_entity_relations<br/>checkpointed message scan<br/>→ enqueue extract_entities"]
         BUILD_SUM["build_conversation_summary<br/>→ memory_summaries"]
         WEEKLY["refresh_weekly_summary<br/>→ memory_summaries"]
     end
@@ -543,6 +544,7 @@ graph TB
     WORKER --> EMBED_SUM
     WORKER --> EXTRACT
     WORKER --> EXTRACT_ENTITIES
+    WORKER --> BACKFILL_REL
     WORKER --> BUILD_SUM
     WORKER --> WEEKLY
     EXTRACT --> EXTRACT_ENTITIES

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -46,12 +46,13 @@ mock.module('../config/loader.js', () => ({
 }));
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { requestMemoryBackfill } from '../memory/admin.js';
+import { getMemoryCheckpoint } from '../memory/checkpoints.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
 import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
-import { claimMemoryJobs, enqueueMemoryJob } from '../memory/jobs-store.js';
+import { claimMemoryJobs, enqueueBackfillEntityRelationsJob, enqueueMemoryJob } from '../memory/jobs-store.js';
 import { currentWeekWindow, resetStaleSweepThrottle, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
@@ -1098,6 +1099,97 @@ describe('Memory V2 regressions', () => {
     expect(forceRow).not.toBeNull();
     expect(JSON.parse(resumeRow?.payload ?? '{}')).toMatchObject({ force: false });
     expect(JSON.parse(forceRow?.payload ?? '{}')).toMatchObject({ force: true });
+  });
+
+  test('relation backfill enqueue is deduped and force upgrades payload', () => {
+    const db = getDb();
+
+    const firstId = enqueueBackfillEntityRelationsJob();
+    const secondId = enqueueBackfillEntityRelationsJob();
+    expect(secondId).toBe(firstId);
+
+    const upgradedId = enqueueBackfillEntityRelationsJob(true);
+    expect(upgradedId).toBe(firstId);
+
+    const row = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, firstId))
+      .get();
+    expect(row).not.toBeUndefined();
+    expect(JSON.parse(row?.payload ?? '{}')).toMatchObject({ force: true });
+  });
+
+  test('relation backfill advances checkpoints in deterministic batches', async () => {
+    const db = getDb();
+    const now = 1_700_001_000_000;
+    const originalEnabled = TEST_CONFIG.memory.entity.extractRelations.enabled;
+    const originalBatchSize = TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize;
+    TEST_CONFIG.memory.entity.extractRelations.enabled = true;
+    TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize = 2;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-rel-backfill',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values([
+        {
+          id: 'msg-rel-backfill-1',
+          conversationId: 'conv-rel-backfill',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'Project Atlas uses Qdrant for memory search.' }]),
+          createdAt: now + 1,
+        },
+        {
+          id: 'msg-rel-backfill-2',
+          conversationId: 'conv-rel-backfill',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'Atlas collaborates with Orion.' }]),
+          createdAt: now + 2,
+        },
+        {
+          id: 'msg-rel-backfill-3',
+          conversationId: 'conv-rel-backfill',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'Orion depends on Redis caching.' }]),
+          createdAt: now + 3,
+        },
+      ]).run();
+
+      enqueueBackfillEntityRelationsJob(true);
+
+      const firstProcessed = await runMemoryJobsOnce();
+      expect(firstProcessed).toBe(1);
+      expect(getMemoryCheckpoint('memory:relation_backfill:last_created_at')).toBe(String(now + 2));
+      expect(getMemoryCheckpoint('memory:relation_backfill:last_message_id')).toBe('msg-rel-backfill-2');
+
+      db.run(`DELETE FROM memory_jobs WHERE type = 'extract_entities' AND status = 'pending'`);
+
+      const secondProcessed = await runMemoryJobsOnce();
+      expect(secondProcessed).toBe(1);
+      expect(getMemoryCheckpoint('memory:relation_backfill:last_created_at')).toBe(String(now + 3));
+      expect(getMemoryCheckpoint('memory:relation_backfill:last_message_id')).toBe('msg-rel-backfill-3');
+
+      const pendingBackfill = db
+        .select()
+        .from(memoryJobs)
+        .where(and(eq(memoryJobs.type, 'backfill_entity_relations'), eq(memoryJobs.status, 'pending')))
+        .all();
+      expect(pendingBackfill).toHaveLength(0);
+    } finally {
+      TEST_CONFIG.memory.entity.extractRelations.enabled = originalEnabled;
+      TEST_CONFIG.memory.entity.extractRelations.backfillBatchSize = originalBatchSize;
+    }
   });
 
   test('memory recall token budgeting includes recall marker overhead', async () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -85,6 +85,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       model: 'claude-haiku-4-5-20251001',
       extractRelations: {
         enabled: false,
+        backfillBatchSize: 200,
       },
     },
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -392,8 +392,14 @@ export const MemoryEntityConfigSchema = z.object({
     enabled: z
       .boolean({ error: 'memory.entity.extractRelations.enabled must be a boolean' })
       .default(false),
+    backfillBatchSize: z
+      .number({ error: 'memory.entity.extractRelations.backfillBatchSize must be a number' })
+      .int('memory.entity.extractRelations.backfillBatchSize must be an integer')
+      .positive('memory.entity.extractRelations.backfillBatchSize must be a positive integer')
+      .default(200),
   }).default({
     enabled: false,
+    backfillBatchSize: 200,
   }),
 });
 
@@ -474,6 +480,7 @@ export const MemoryConfigSchema = z.object({
     model: 'claude-haiku-4-5-20251001',
     extractRelations: {
       enabled: false,
+      backfillBatchSize: 200,
     },
   }),
 });
@@ -611,6 +618,7 @@ export const AssistantConfigSchema = z.object({
       model: 'claude-haiku-4-5-20251001',
       extractRelations: {
         enabled: false,
+        backfillBatchSize: 200,
       },
     },
   }),

--- a/assistant/src/memory/checkpoints.ts
+++ b/assistant/src/memory/checkpoints.ts
@@ -2,6 +2,11 @@ import { eq } from 'drizzle-orm';
 import { getDb } from './db.js';
 import { memoryCheckpoints } from './schema.js';
 
+export interface MessageCursorCheckpoint {
+  createdAt: number;
+  messageId: string;
+}
+
 export function getMemoryCheckpoint(key: string): string | null {
   const db = getDb();
   const row = db
@@ -22,4 +27,26 @@ export function setMemoryCheckpoint(key: string, value: string): void {
       set: { value, updatedAt: now },
     })
     .run();
+}
+
+export function readMessageCursorCheckpoint(
+  createdAtKey: string,
+  messageIdKey: string,
+): MessageCursorCheckpoint {
+  const createdAt = Number.parseInt(getMemoryCheckpoint(createdAtKey) ?? '0', 10) || 0;
+  const messageId = getMemoryCheckpoint(messageIdKey) ?? '';
+  return { createdAt, messageId };
+}
+
+export function writeMessageCursorCheckpoint(
+  createdAtKey: string,
+  messageIdKey: string,
+  checkpoint: MessageCursorCheckpoint,
+): void {
+  setMemoryCheckpoint(createdAtKey, String(checkpoint.createdAt));
+  setMemoryCheckpoint(messageIdKey, checkpoint.messageId);
+}
+
+export function resetMessageCursorCheckpoint(createdAtKey: string, messageIdKey: string): void {
+  writeMessageCursorCheckpoint(createdAtKey, messageIdKey, { createdAt: 0, messageId: '' });
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -9,6 +9,7 @@ export type MemoryJobType =
   | 'embed_summary'
   | 'extract_items'
   | 'extract_entities'
+  | 'backfill_entity_relations'
   | 'check_contradictions'
   | 'refresh_weekly_summary'
   | 'refresh_monthly_summary'
@@ -52,6 +53,44 @@ export function enqueueMemoryJob(
     updatedAt: now,
   }).run();
   return id;
+}
+
+/**
+ * Ensure there is only one pending relation backfill orchestrator job.
+ * If `force=true` arrives while a pending job exists, its payload is upgraded.
+ */
+export function enqueueBackfillEntityRelationsJob(force = false): string {
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(eq(memoryJobs.type, 'backfill_entity_relations'), eq(memoryJobs.status, 'pending')))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+
+  if (existing) {
+    if (force) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.force !== true) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, force: true }),
+            updatedAt: now,
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+
+  return enqueueMemoryJob('backfill_entity_relations', { force });
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -5,13 +5,20 @@ import type { AssistantConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
-import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
+import {
+  getMemoryCheckpoint,
+  readMessageCursorCheckpoint,
+  resetMessageCursorCheckpoint,
+  setMemoryCheckpoint,
+  writeMessageCursorCheckpoint,
+} from './checkpoints.js';
 import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';
 import { getDb } from './db.js';
 import {
   claimMemoryJobs,
   completeMemoryJob,
   deferMemoryJob,
+  enqueueBackfillEntityRelationsJob,
   enqueueMemoryJob,
   failMemoryJob,
   type MemoryJob,
@@ -50,6 +57,8 @@ class BackendUnavailableError extends Error {
 
 const BACKFILL_CHECKPOINT_KEY = 'memory:backfill:last_created_at';
 const BACKFILL_CHECKPOINT_ID_KEY = 'memory:backfill:last_message_id';
+const RELATION_BACKFILL_CHECKPOINT_KEY = 'memory:relation_backfill:last_created_at';
+const RELATION_BACKFILL_CHECKPOINT_ID_KEY = 'memory:relation_backfill:last_message_id';
 
 const SUMMARY_LLM_TIMEOUT_MS = 20_000;
 const SUMMARY_MAX_TOKENS = 800;
@@ -186,6 +195,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
       return;
     case 'backfill':
       backfillJob(job, config);
+      return;
+    case 'backfill_entity_relations':
+      backfillEntityRelationsJob(job, config);
       return;
     case 'rebuild_index':
       rebuildIndexJob();
@@ -598,18 +610,16 @@ function backfillJob(job: MemoryJob, config: AssistantConfig): void {
   const db = getDb();
   const force = job.payload.force === true;
   if (force) {
-    setMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY, '0');
-    setMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY, '');
+    resetMessageCursorCheckpoint(BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_ID_KEY);
   }
 
-  const lastCreatedAt = Number.parseInt(getMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY) ?? '0', 10) || 0;
-  const lastMessageId = getMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY) ?? '';
+  const cursor = readMessageCursorCheckpoint(BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_ID_KEY);
   const batch = db
     .select()
     .from(messages)
     .where(or(
-      gt(messages.createdAt, lastCreatedAt),
-      and(eq(messages.createdAt, lastCreatedAt), gt(messages.id, lastMessageId)),
+      gt(messages.createdAt, cursor.createdAt),
+      and(eq(messages.createdAt, cursor.createdAt), gt(messages.id, cursor.messageId)),
     ))
     .orderBy(asc(messages.createdAt), asc(messages.id))
     .limit(200)
@@ -625,11 +635,67 @@ function backfillJob(job: MemoryJob, config: AssistantConfig): void {
     }, config.memory);
   }
   const lastMessage = batch[batch.length - 1];
-  setMemoryCheckpoint(BACKFILL_CHECKPOINT_KEY, String(lastMessage.createdAt));
-  setMemoryCheckpoint(BACKFILL_CHECKPOINT_ID_KEY, lastMessage.id);
+  writeMessageCursorCheckpoint(BACKFILL_CHECKPOINT_KEY, BACKFILL_CHECKPOINT_ID_KEY, {
+    createdAt: lastMessage.createdAt,
+    messageId: lastMessage.id,
+  });
+
+  if (config.memory.entity.enabled && config.memory.entity.extractRelations.enabled) {
+    enqueueBackfillEntityRelationsJob(force);
+  }
+
   if (batch.length === 200) {
     enqueueMemoryJob('backfill', {});
   }
+}
+
+function backfillEntityRelationsJob(job: MemoryJob, config: AssistantConfig): void {
+  if (!config.memory.entity.enabled) return;
+  if (!config.memory.entity.extractRelations.enabled) return;
+
+  const force = job.payload.force === true;
+  if (force) {
+    resetMessageCursorCheckpoint(RELATION_BACKFILL_CHECKPOINT_KEY, RELATION_BACKFILL_CHECKPOINT_ID_KEY);
+  }
+
+  const db = getDb();
+  const cursor = readMessageCursorCheckpoint(
+    RELATION_BACKFILL_CHECKPOINT_KEY,
+    RELATION_BACKFILL_CHECKPOINT_ID_KEY,
+  );
+  const batchSize = Math.max(1, config.memory.entity.extractRelations.backfillBatchSize);
+  const batch = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(or(
+      gt(messages.createdAt, cursor.createdAt),
+      and(eq(messages.createdAt, cursor.createdAt), gt(messages.id, cursor.messageId)),
+    ))
+    .orderBy(asc(messages.createdAt), asc(messages.id))
+    .limit(batchSize)
+    .all();
+  if (batch.length === 0) return;
+
+  for (const message of batch) {
+    enqueueMemoryJob('extract_entities', { messageId: message.id });
+  }
+
+  const lastMessage = batch[batch.length - 1];
+  writeMessageCursorCheckpoint(RELATION_BACKFILL_CHECKPOINT_KEY, RELATION_BACKFILL_CHECKPOINT_ID_KEY, {
+    createdAt: lastMessage.createdAt,
+    messageId: lastMessage.id,
+  });
+
+  if (batch.length === batchSize) {
+    enqueueBackfillEntityRelationsJob();
+  }
+
+  log.debug({
+    queuedExtractEntityJobs: batch.length,
+    batchSize,
+    lastCreatedAt: lastMessage.createdAt,
+    lastMessageId: lastMessage.id,
+  }, 'Queued relation backfill batch');
 }
 
 function rebuildIndexJob(): void {


### PR DESCRIPTION
## Summary
- add a new `backfill_entity_relations` memory job type with deterministic cursor checkpoints (`created_at + id`)
- add relation-backfill queue dedupe via `enqueueBackfillEntityRelationsJob()` and force-payload upgrade support
- add cursor checkpoint helpers in `checkpoints.ts` and reuse them in existing backfill flow
- add `memory.entity.extractRelations.backfillBatchSize` config (default `200`) to bound per-batch relation backfill work
- wire normal `backfill` runs to enqueue relation-backfill orchestration when relation extraction is enabled
- add regression tests for enqueue dedupe + force upgrade and resumable checkpoint progression
- update architecture memory flow to include `backfill_entity_relations`

## Validation
- `cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "relation backfill"`
- `cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "memory backfill request resumes"`
- `cd assistant && bun test src/__tests__/entity-extractor.test.ts`
- `cd assistant && bun test src/__tests__/memory-context-benchmark.test.ts`
- `cd assistant && bun test src/__tests__/config-schema.test.ts -t "parses empty object with full defaults"`

## Notes
- full `tsc --noEmit` still reports pre-existing unrelated errors in `session-queue.test.ts`, `session.ts`, and `ipc-validate.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
