### PR TITLE
fix(pr-2360): gate share UI on daemon HTTP server availability via IPC

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -527,6 +527,13 @@ exports[`IPC message snapshots ServerMessage types pong serializes to expected J
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types daemon_status serializes to expected JSON 1`] = `
+{
+  "httpPort": 7821,
+  "type": "daemon_status",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types generation_cancelled serializes to expected JSON 1`] = `
 {
   "type": "generation_cancelled",

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -339,6 +339,10 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   pong: {
     type: 'pong',
   },
+  daemon_status: {
+    type: 'daemon_status',
+    httpPort: 7821,
+  },
   generation_cancelled: {
     type: 'generation_cancelled',
   },

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -542,6 +542,11 @@ export interface PongMessage {
   type: 'pong';
 }
 
+export interface DaemonStatusMessage {
+  type: 'daemon_status';
+  httpPort?: number;
+}
+
 export interface GenerationCancelled {
   type: 'generation_cancelled';
 }
@@ -1021,6 +1026,7 @@ export type ServerMessage =
   | SessionsClearResponse
   | ErrorMessage
   | PongMessage
+  | DaemonStatusMessage
   | GenerationCancelled
   | GenerationHandoff
   | ModelInfo

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -227,6 +227,7 @@ export async function runDaemon(): Promise<void> {
       });
       try {
         await runtimeHttp.start();
+        server.setHttpPort(port);
       } catch (err) {
         log.warn({ err, port }, 'Failed to start runtime HTTP server, continuing without it');
         runtimeHttp = null;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -44,6 +44,7 @@ export class DaemonServer {
   // Shared across all sessions so maxRequestsPerMinute is enforced globally.
   private sharedRequestTimestamps: number[] = [];
   private socketPath: string;
+  private httpPort: number | undefined;
   private watchers: FSWatcher[] = [];
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private suppressConfigReload = false;
@@ -211,6 +212,14 @@ export class DaemonServer {
       contextWindow: config.contextWindow,
       apiKeys: config.apiKeys,
     });
+  }
+
+  /**
+   * Record the runtime HTTP server port so it can be communicated
+   * to newly connected clients via the `daemon_status` message.
+   */
+  setHttpPort(port: number): void {
+    this.httpPort = port;
   }
 
   /**
@@ -452,6 +461,11 @@ export class DaemonServer {
       type: 'session_info',
       sessionId: conversation.id,
       title: conversation.title ?? 'New Conversation',
+    });
+
+    this.send(socket, {
+      type: 'daemon_status',
+      httpPort: this.httpPort,
     });
   }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -42,12 +42,9 @@ struct MainWindowView: View {
     /// but requires complex window geometry inspection.
     private let trafficLightPadding: CGFloat = 78
 
-    private static var runtimeHttpPort: String {
-        ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-    }
-
-    private static func pageURL(for appId: String) -> URL? {
-        URL(string: "http://localhost:\(runtimeHttpPort)/pages/\(appId)")
+    private func pageURL(for appId: String) -> URL? {
+        guard let port = daemonClient.httpPort else { return nil }
+        return URL(string: "http://localhost:\(port)/pages/\(appId)")
     }
 
     var body: some View {
@@ -450,7 +447,7 @@ struct MainWindowView: View {
                 Spacer()
 
                 // Share button — only shown when the runtime page server is active
-                if let appId = data.appId, let shareURL = Self.pageURL(for: appId) {
+                if let appId = data.appId, let shareURL = pageURL(for: appId) {
                     Menu {
                         Button {
                             NSPasteboard.general.clearContents()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -48,6 +48,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published public var isConnected: Bool = false
 
+    /// The runtime HTTP server port, populated via `daemon_status` on connect.
+    /// `nil` means the HTTP server is not running.
+    @Published public var httpPort: Int?
+
     /// Whether a TrustRulesView sheet is currently open from any settings surface.
     /// Used to prevent multiple trust rules sheets from racing on the shared callback.
     @Published public var isTrustRulesSheetOpen: Bool = false
@@ -623,6 +627,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         receiveBuffer = Data()
         isConnected = false
+        httpPort = nil
 
         // Finish all subscriber streams so `for await` loops terminate
         // instead of hanging forever on disconnect.
@@ -703,6 +708,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             awaitingPong = false
             pongTimeoutTask?.cancel()
             pongTimeoutTask = nil
+        }
+
+        // Handle daemon status internally.
+        if case .daemonStatus(let status) = message {
+            httpPort = status.httpPort.flatMap { Int(exactly: $0) }
         }
 
         // Forward surface messages to registered callbacks.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -240,11 +240,30 @@ public struct IPCCuSessionCreate: Codable, Sendable {
     public let interactionType: String?
 }
 
+public struct IPCDaemonStatusMessage: Codable, Sendable {
+    public let type: String
+    public let httpPort: Double?
+}
+
+public struct IPCDynamicPagePreview: Codable, Sendable {
+    public let title: String
+    public let subtitle: String?
+    public let description: String?
+    public let icon: String?
+    public let metrics: [IPCDynamicPagePreviewMetric]?
+}
+
+public struct IPCDynamicPagePreviewMetric: Codable, Sendable {
+    public let label: String
+    public let value: String
+}
+
 public struct IPCDynamicPageSurfaceData: Codable, Sendable {
     public let html: String
     public let width: Int?
     public let height: Int?
     public let appId: String?
+    public let preview: IPCDynamicPagePreview?
 }
 
 public struct IPCErrorMessage: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -539,6 +539,9 @@ public typealias TaskRoutedMessage = IPCTaskRouted
 /// Result from ambient observation analysis.
 public typealias AmbientResultMessage = IPCAmbientResult
 
+/// Daemon status sent on connect — includes runtime HTTP port when available.
+public typealias DaemonStatusMessage = IPCDaemonStatusMessage
+
 /// Surface show command from daemon.
 /// Wire type: `"ui_surface_show"`
 public struct UiSurfaceShowMessage: Decodable, Sendable {
@@ -1077,6 +1080,7 @@ public enum ServerMessage: Decodable, Sendable {
     case bundleAppResponse(BundleAppResponseMessage)
     case openBundleResponse(OpenBundleResponseMessage)
     case signBundlePayload(SignBundlePayloadMessage)
+    case daemonStatus(DaemonStatusMessage)
     case getSigningIdentity
     case pong
     case unknown(String)
@@ -1218,6 +1222,9 @@ public enum ServerMessage: Decodable, Sendable {
             self = .signBundlePayload(message)
         case "get_signing_identity":
             self = .getSigningIdentity
+        case "daemon_status":
+            let message = try DaemonStatusMessage(from: decoder)
+            self = .daemonStatus(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add `daemon_status` IPC message type with optional `httpPort` field
- Daemon sends `daemon_status` on client connect, including `httpPort` only when the runtime HTTP server successfully started
- DaemonClient stores `httpPort` as a `@Published` property, cleared on disconnect
- MainWindowView gates the share button on `daemonClient.httpPort` instead of using a hardcoded fallback port

Addresses Codex review feedback on #2360, which pointed out that defaulting to port 7821 would show share links even when the runtime HTTP server isn't running.

## Test plan
- [ ] Share button hidden when `RUNTIME_HTTP_PORT` is not set (HTTP server not started)
- [ ] Share button appears when `RUNTIME_HTTP_PORT` is set and server starts successfully
- [ ] Share URL uses the correct port from the daemon
- [ ] Share button disappears on daemon disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
