### PR TITLE
fix(pr-2363): broadcast daemon_status when HTTP server starts

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -215,11 +215,18 @@ export class DaemonServer {
   }
 
   /**
-   * Record the runtime HTTP server port so it can be communicated
-   * to newly connected clients via the `daemon_status` message.
+   * Record the runtime HTTP server port and broadcast it to all
+   * connected clients so they can enable the share UI immediately.
    */
   setHttpPort(port: number): void {
     this.httpPort = port;
+    // Clients that connected before the HTTP server started received
+    // daemon_status with no httpPort. Broadcast the updated port so
+    // they can enable the share UI without reconnecting.
+    this.broadcast({
+      type: 'daemon_status',
+      httpPort: port,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Broadcast `daemon_status` to all connected clients when `setHttpPort()` is called
- Fixes race condition where clients connect before the HTTP server starts and never receive the port update

Addresses Codex review feedback on #2363.

## Test plan
- [ ] Start daemon, connect client, verify share button appears after HTTP server starts
- [ ] Verify clients connecting after HTTP server is up still receive port in initial `daemon_status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
