### PR TITLE
fix(pr-2364): skip daemon_status in sendOneMessage()

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -72,7 +72,10 @@ function sendOneMessage(
     socket.on('data', (data) => {
       const messages = parser.feed(data.toString()) as ServerMessage[];
       for (const m of messages) {
-        // Skip the initial session_info that the server sends on connect
+        // Skip push messages that aren't responses to our request
+        if (m.type === 'daemon_status') {
+          continue;
+        }
         if (m.type === 'session_info' && msg.type !== 'session_create') {
           continue;
         }


### PR DESCRIPTION
sendOneMessage() resolves on the first non-session_info frame. When the daemon broadcasts daemon_status (e.g. on HTTP server start), one-shot CLI commands could receive it as a false response. Skip daemon_status messages the same way session_info is skipped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
