### PR TITLE
fix(composer): prevent bottom fade gradient from clipping visible text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -48,7 +48,7 @@ struct ComposerView: View {
                     composerTextField
                         .frame(height: min(max(editorContentHeight, 28), 200))
 
-                    if editorContentHeight > 60 {
+                    if editorContentHeight > 200, !isScrolledToBottom {
                         LinearGradient(
                             colors: [VColor.surface.opacity(0), VColor.surface],
                             startPoint: .top,
@@ -92,6 +92,11 @@ struct ComposerView: View {
 
     private var isComposerExpanded: Bool {
         editorContentHeight > 28
+    }
+
+    private var isScrolledToBottom: Bool {
+        let maxOffset = editorContentHeight - 200
+        return maxOffset <= 0 || composerScrollOffset >= maxOffset - 5
     }
 
     private var composerTextField: some View {
@@ -141,9 +146,10 @@ struct ComposerView: View {
             .frame(minHeight: min(max(editorContentHeight, 28), 200), maxHeight: .infinity, alignment: .center)
             .background(ScrollOffsetReader(offset: $composerScrollOffset))
 
-            // Invisible anchor for auto-scroll
+            // Invisible anchor for auto-scroll; extra height provides breathing room
+            // so the last line isn't clipped by the fade gradient.
             Color.clear
-                .frame(height: 1)
+                .frame(height: editorContentHeight > 200 ? 20 : 1)
                 .id("composer-bottom")
         }
         .overlay(alignment: .topTrailing) {


### PR DESCRIPTION
## Summary
- The composer's bottom fade gradient appeared too early (at 60pt content height), hiding the last line of text when pressing Shift+Enter to add newlines — scrolling doesn't enable until 200pt
- Now the gradient only shows when content is actually scrollable and the user hasn't scrolled to the bottom
- Added breathing room in the scroll anchor so text is never clipped behind the fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
