### PR TITLE
fix(memory): prioritize exact name matches in resolveEntityName

### DIFF
--- a/assistant/src/__tests__/entity-extractor.test.ts
+++ b/assistant/src/__tests__/entity-extractor.test.ts
@@ -131,6 +131,30 @@ describe('entity extractor helpers', () => {
     expect(relationRows[0].evidence).toBe('Atlas still depends on Qdrant');
   });
 
+  test('resolveEntityName prefers exact canonical name over alias match', () => {
+    // Entity A has "React" as an alias
+    const aliasEntityId = upsertEntity({
+      name: 'React Native',
+      type: 'tool',
+      aliases: ['React', 'RN'],
+    });
+
+    // Entity B has "React" as its canonical name
+    const canonicalEntityId = upsertEntity({
+      name: 'React',
+      type: 'tool',
+      aliases: ['ReactJS'],
+    });
+
+    // resolveEntityName("React") should return the entity whose canonical
+    // name is "React", not the one that merely lists it as an alias.
+    expect(resolveEntityName('React')).toBe(canonicalEntityId);
+    expect(resolveEntityName('react')).toBe(canonicalEntityId);
+    // Alias-only lookups still work
+    expect(resolveEntityName('RN')).toBe(aliasEntityId);
+    expect(resolveEntityName('ReactJS')).toBe(canonicalEntityId);
+  });
+
   test('upsertEntityRelation drops self-edges', () => {
     const db = getDb();
     const entityId = upsertEntity({

--- a/assistant/src/memory/entity-extractor.ts
+++ b/assistant/src/memory/entity-extractor.ts
@@ -195,10 +195,15 @@ export function resolveEntity(entity: ExtractedEntity): string | null {
 
 /**
  * Resolve an entity by canonical name or alias.
+ * Prefers exact canonical name matches over alias-only matches so that
+ * relations are attached to the correct node.
  */
 export function resolveEntityName(entityName: string): string | null {
   const candidates = findEntityCandidates(entityName);
-  return candidates.length > 0 ? candidates[0].id : null;
+  if (candidates.length === 0) return null;
+  const nameLower = entityName.trim().toLowerCase();
+  const exactNameMatch = candidates.find((c) => c.name.toLowerCase() === nameLower);
+  return exactNameMatch?.id ?? candidates[0].id;
 }
 
 /**


### PR DESCRIPTION
## Summary

`resolveEntityName` returned `candidates[0]` from `findEntityCandidates`, but the underlying SQL `UNION` query mixes exact canonical-name matches with alias matches in arbitrary order. When a search string (e.g. "React") matches both an entity's canonical name **and** another entity's alias, relations could be attached to the wrong node, corrupting persisted graph edges.

**Fix:** Before returning `candidates[0]`, check if any candidate has an exact canonical name match and prefer it.

**Test:** Added a test where "React" exists as both a canonical name (entity B) and an alias of "React Native" (entity A), verifying that `resolveEntityName("React")` returns entity B.

Addresses feedback from #2361.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
