### PR TITLE
fix(context): count mixed tool_result+text user messages as persisted

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -230,6 +230,44 @@ describe('ContextWindowManager', () => {
     expect(result.compactedPersistedMessages).toBe(3);
   });
 
+  test('counts mixed tool_result+text user messages as persisted', async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: 'text', text: '## Goals\n- mixed summary' }],
+      model: 'mock-model',
+      usage: { inputTokens: 75, outputTokens: 20 },
+      stopReason: 'end_turn',
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      'system prompt',
+      makeConfig({ maxInputTokens: 320, targetInputTokens: 170, preserveRecentUserTurns: 1 }),
+    );
+    const long = 'k'.repeat(220);
+    // Simulates a merged user message (repairHistory merges consecutive same-role
+    // messages), resulting in a user turn with both tool_result and text blocks.
+    const history: Message[] = [
+      message('user', `u1 ${long}`),
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'read_file', input: { path: '/tmp/a' } }],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'contents' },
+          { type: 'text', text: `follow-up question ${long}` },
+        ],
+      },
+      message('assistant', `a1 ${long}`),
+      message('user', `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+    expect(result.compacted).toBe(true);
+    // The mixed user message should be counted as persisted (4 = u1 + mixed + a_tooluse + a1)
+    expect(result.compactedPersistedMessages).toBe(4);
+  });
+
   test('parses legacy assistant-role context summary messages', () => {
     const legacySummary: Message = {
       role: 'assistant',

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -354,7 +354,7 @@ function collectUserTurnStartIndexes(messages: Message[]): number[] {
     const message = messages[i];
     if (message.role !== 'user') continue;
     if (getSummaryFromContextMessage(message) !== null) continue;
-    if (message.content.some((block) => block.type === 'tool_result')) continue;
+    if (isToolResultOnly(message)) continue;
     starts.push(i);
   }
   return starts;
@@ -364,8 +364,14 @@ function countPersistedMessages(messages: Message[]): number {
   return messages.filter((message) => {
     if (message.role === 'assistant') return true;
     if (getSummaryFromContextMessage(message) !== null) return false;
-    return !message.content.some((block) => block.type === 'tool_result');
+    return !isToolResultOnly(message);
   }).length;
+}
+
+/** A user message that contains ONLY tool_result blocks (no text or other content). */
+function isToolResultOnly(message: Message): boolean {
+  return message.content.length > 0
+    && message.content.every((block) => block.type === 'tool_result');
 }
 
 export function getSummaryFromContextMessage(message: Message | undefined): string | null {


### PR DESCRIPTION
## Summary

`countPersistedMessages` and `collectUserTurnStartIndexes` in `window-manager.ts` previously dropped any user message containing a `tool_result` block — even when the message also had text content (e.g. after `repairHistory` merges consecutive same-role messages). This caused the `MIN_COMPACTABLE_PERSISTED_MESSAGES` guard to incorrectly block compaction for valid histories with mixed user turns, delaying summarization and increasing prompt growth risk.

### Changes

- Extracted `isToolResultOnly()` helper that returns `true` only when a message consists solely of `tool_result` blocks (no text or other content)
- Updated `countPersistedMessages` and `collectUserTurnStartIndexes` to use `isToolResultOnly()` instead of `message.content.some(b => b.type === 'tool_result')`
- Added test case verifying mixed `tool_result` + text user messages are counted as persisted

Addresses feedback from [PR #2353](https://github.com/vellum-ai/vellum-assistant/pull/2353).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
