### PR TITLE
feat(computer-use): resolve element_id targets before native actions

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ActionTypes.swift
@@ -16,6 +16,13 @@ enum ActionType: String, Codable {
     case respond
 }
 
+enum ActionTargetMode: String, Codable {
+    case ax
+    case vision
+    case mixed
+    case unknown
+}
+
 struct AgentAction: Codable {
     let type: ActionType
     var x: CGFloat?
@@ -32,6 +39,7 @@ struct AgentAction: Codable {
     var script: String?
     var reasoning: String
     var resolvedFromElementId: Int?
+    var resolvedToElementId: Int?
     var elementDescription: String?
 
     init(
@@ -50,6 +58,7 @@ struct AgentAction: Codable {
         appName: String? = nil,
         script: String? = nil,
         resolvedFromElementId: Int? = nil,
+        resolvedToElementId: Int? = nil,
         elementDescription: String? = nil
     ) {
         self.type = type
@@ -67,33 +76,43 @@ struct AgentAction: Codable {
         self.appName = appName
         self.script = script
         self.resolvedFromElementId = resolvedFromElementId
+        self.resolvedToElementId = resolvedToElementId
         self.elementDescription = elementDescription
+    }
+
+    var targetMode: ActionTargetMode {
+        let hasIdTargets = resolvedFromElementId != nil || resolvedToElementId != nil
+        let hasPointTargets = (x != nil && y != nil) || (toX != nil && toY != nil)
+        if hasIdTargets && hasPointTargets { return .mixed }
+        if hasIdTargets { return .ax }
+        if hasPointTargets { return .vision }
+        return .unknown
     }
 
     var displayDescription: String {
         switch type {
         case .click:
             if let id = resolvedFromElementId, let desc = elementDescription {
-                return "Click [\(id)] \(desc)"
+                return "Click [\(id)] \(desc) (\(targetMode.rawValue))"
             }
             if let x = x, let y = y {
-                return "Click at (\(Int(x)), \(Int(y)))"
+                return "Click at (\(Int(x)), \(Int(y))) (\(targetMode.rawValue))"
             }
             return "Click"
         case .doubleClick:
             if let id = resolvedFromElementId, let desc = elementDescription {
-                return "Double-click [\(id)] \(desc)"
+                return "Double-click [\(id)] \(desc) (\(targetMode.rawValue))"
             }
             if let x = x, let y = y {
-                return "Double-click at (\(Int(x)), \(Int(y)))"
+                return "Double-click at (\(Int(x)), \(Int(y))) (\(targetMode.rawValue))"
             }
             return "Double-click"
         case .rightClick:
             if let id = resolvedFromElementId, let desc = elementDescription {
-                return "Right-click [\(id)] \(desc)"
+                return "Right-click [\(id)] \(desc) (\(targetMode.rawValue))"
             }
             if let x = x, let y = y {
-                return "Right-click at (\(Int(x)), \(Int(y)))"
+                return "Right-click at (\(Int(x)), \(Int(y))) (\(targetMode.rawValue))"
             }
             return "Right-click"
         case .type:
@@ -110,15 +129,18 @@ struct AgentAction: Codable {
         case .scroll:
             let dir = scrollDirection ?? "down"
             let amt = scrollAmount ?? 3
-            return "Scroll \(dir) \(amt)x"
+            return "Scroll \(dir) \(amt)x (\(targetMode.rawValue))"
         case .wait:
             if let ms = waitDuration {
                 return "Wait \(ms)ms"
             }
             return "Wait"
         case .drag:
+            if let fromId = resolvedFromElementId, let toId = resolvedToElementId {
+                return "Drag [\(fromId)] to [\(toId)] (\(targetMode.rawValue))"
+            }
             if let x = x, let y = y, let tx = toX, let ty = toY {
-                return "Drag from (\(Int(x)),\(Int(y))) to (\(Int(tx)),\(Int(ty)))"
+                return "Drag from (\(Int(x)),\(Int(y))) to (\(Int(tx)),\(Int(ty))) (\(targetMode.rawValue))"
             }
             return "Drag"
         case .openApp:

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -210,8 +210,13 @@ final class ComputerUseSession: ObservableObject {
     // MARK: - Action Handler
 
     private func handleAction(_ action: CuActionMessage) async {
-        let agentAction = mapToAgentAction(action)
+        var agentAction = mapToAgentAction(action)
         currentStepNumber = action.stepNumber
+
+        guard let resolved = await resolveCoordinatesIfNeeded(for: agentAction, stepNumber: action.stepNumber) else {
+            return
+        }
+        agentAction = resolved
 
         // Update state for UI
         state = .running(
@@ -498,6 +503,8 @@ final class ComputerUseSession: ObservableObject {
         let script = msg.input["script"]?.value as? String
         let elementId = extractInt(from: msg.input, key: "element_id")
             ?? extractInt(from: msg.input, key: "elementId")
+        let toElementId = extractInt(from: msg.input, key: "to_element_id")
+            ?? extractInt(from: msg.input, key: "toElementId")
         let elementDescription = msg.input["element_description"]?.value as? String
             ?? msg.input["elementDescription"]?.value as? String
 
@@ -517,8 +524,112 @@ final class ComputerUseSession: ObservableObject {
             appName: appName,
             script: script,
             resolvedFromElementId: elementId,
+            resolvedToElementId: toElementId,
             elementDescription: elementDescription
         )
+    }
+
+    private func resolveCoordinatesIfNeeded(for action: AgentAction, stepNumber: Int) async -> AgentAction? {
+        var resolved = action
+
+        switch resolved.type {
+        case .click, .doubleClick, .rightClick:
+            if resolved.x == nil || resolved.y == nil {
+                guard let sourceId = resolved.resolvedFromElementId else {
+                    await sendRecoverableExecutionError(
+                        "Action requires either x/y coordinates or element_id.",
+                        stepNumber: stepNumber
+                    )
+                    return nil
+                }
+                guard let center = elementCenter(for: sourceId) else {
+                    await sendRecoverableExecutionError(
+                        "Could not resolve element_id [\(sourceId)] in the focused window. Use an ID from CURRENT SCREEN STATE or provide x/y coordinates.",
+                        stepNumber: stepNumber
+                    )
+                    return nil
+                }
+                resolved.x = center.x
+                resolved.y = center.y
+            }
+
+        case .scroll:
+            if (resolved.x == nil || resolved.y == nil), let sourceId = resolved.resolvedFromElementId {
+                guard let center = elementCenter(for: sourceId) else {
+                    await sendRecoverableExecutionError(
+                        "Could not resolve element_id [\(sourceId)] in the focused window. Use an ID from CURRENT SCREEN STATE or provide x/y coordinates.",
+                        stepNumber: stepNumber
+                    )
+                    return nil
+                }
+                resolved.x = center.x
+                resolved.y = center.y
+            }
+
+        case .drag:
+            if resolved.x == nil || resolved.y == nil {
+                if let sourceId = resolved.resolvedFromElementId {
+                    guard let center = elementCenter(for: sourceId) else {
+                        await sendRecoverableExecutionError(
+                            "Could not resolve source element_id [\(sourceId)] in the focused window. Use an ID from CURRENT SCREEN STATE or provide source x/y coordinates.",
+                            stepNumber: stepNumber
+                        )
+                        return nil
+                    }
+                    resolved.x = center.x
+                    resolved.y = center.y
+                } else {
+                    await sendRecoverableExecutionError(
+                        "Drag action requires source coordinates (x/y) or element_id.",
+                        stepNumber: stepNumber
+                    )
+                    return nil
+                }
+            }
+
+            if resolved.toX == nil || resolved.toY == nil {
+                if let destinationId = resolved.resolvedToElementId {
+                    guard let center = elementCenter(for: destinationId) else {
+                        await sendRecoverableExecutionError(
+                            "Could not resolve destination to_element_id [\(destinationId)] in the focused window. Use an ID from CURRENT SCREEN STATE or provide to_x/to_y coordinates.",
+                            stepNumber: stepNumber
+                        )
+                        return nil
+                    }
+                    resolved.toX = center.x
+                    resolved.toY = center.y
+                } else {
+                    await sendRecoverableExecutionError(
+                        "Drag action requires destination coordinates (to_x/to_y) or to_element_id.",
+                        stepNumber: stepNumber
+                    )
+                    return nil
+                }
+            }
+
+        default:
+            break
+        }
+
+        return resolved
+    }
+
+    private func elementCenter(for elementId: Int) -> CGPoint? {
+        guard let flatElements = previousFlatElements,
+              let element = flatElements.first(where: { $0.id == elementId }),
+              !element.frame.isEmpty else {
+            return nil
+        }
+        return CGPoint(x: element.frame.midX, y: element.frame.midY)
+    }
+
+    private func sendRecoverableExecutionError(_ message: String, stepNumber: Int) async {
+        log.warning("[\(stepNumber)] Coordinate resolution failed: \(message, privacy: .public)")
+        let obs = await buildObservation(executionResult: nil, executionError: message)
+        if let obs {
+            try? daemonClient.send(obs)
+        }
+        state = .thinking(step: stepNumber + 1, maxSteps: maxSteps)
     }
 
     private func extractCGFloat(from input: [String: AnyCodable], key: String) -> CGFloat? {

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -636,6 +636,166 @@ final class SessionTests: XCTestCase {
         await runTask.value
     }
 
+    // MARK: - Element ID Resolution
+
+    @MainActor
+    func testClickWithElementId_resolvesCoordinates() async {
+        let daemonClient = MockDaemonClient()
+        let continuation = daemonClient.setupTestStream()
+        let executor = MockActionExecutor()
+        let session = makeSession(daemonClient: daemonClient, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_click",
+            input: ["element_id": AnyCodable(1)],
+            reasoning: "Click the submit button by ID",
+            stepNumber: 1
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuComplete(makeCompleteMessage(
+            sessionId: session.id,
+            summary: "Clicked by ID",
+            stepCount: 1
+        )))
+
+        await runTask.value
+
+        XCTAssertEqual(executor.executedActions.count, 1)
+        let executed = executor.executedActions[0]
+        XCTAssertEqual(executed.type, .click)
+        XCTAssertEqual(executed.resolvedFromElementId, 1)
+        XCTAssertEqual(executed.x ?? -1, 140, accuracy: 0.001)
+        XCTAssertEqual(executed.y ?? -1, 215, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testDragWithElementIds_resolvesBothEndpoints() async {
+        let daemonClient = MockDaemonClient()
+        let continuation = daemonClient.setupTestStream()
+        let executor = MockActionExecutor()
+        let session = makeSession(daemonClient: daemonClient, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_drag",
+            input: [
+                "element_id": AnyCodable(1),
+                "to_element_id": AnyCodable(2),
+            ],
+            reasoning: "Drag from source ID to destination ID",
+            stepNumber: 1
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuComplete(makeCompleteMessage(
+            sessionId: session.id,
+            summary: "Dragged by IDs",
+            stepCount: 1
+        )))
+
+        await runTask.value
+
+        XCTAssertEqual(executor.executedActions.count, 1)
+        let executed = executor.executedActions[0]
+        XCTAssertEqual(executed.type, .drag)
+        XCTAssertEqual(executed.resolvedFromElementId, 1)
+        XCTAssertEqual(executed.resolvedToElementId, 2)
+        XCTAssertEqual(executed.x ?? -1, 140, accuracy: 0.001)
+        XCTAssertEqual(executed.y ?? -1, 215, accuracy: 0.001)
+        XCTAssertEqual(executed.toX ?? -1, 200, accuracy: 0.001)
+        XCTAssertEqual(executed.toY ?? -1, 165, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testUnresolvableElementId_sendsRecoverableErrorObservation() async {
+        let daemonClient = MockDaemonClient()
+        let continuation = daemonClient.setupTestStream()
+        let executor = MockActionExecutor()
+        let session = makeSession(daemonClient: daemonClient, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        let initialObsCount = daemonClient.sentMessages.compactMap({ $0 as? CuObservationMessage }).count
+
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_click",
+            input: ["element_id": AnyCodable(999)],
+            reasoning: "Try stale element ID",
+            stepNumber: 1
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        let obsMessages = daemonClient.sentMessages.compactMap { $0 as? CuObservationMessage }
+        XCTAssertGreaterThan(obsMessages.count, initialObsCount)
+        XCTAssertTrue(obsMessages.last?.executionError?.contains("Could not resolve element_id [999]") == true)
+        XCTAssertEqual(executor.executedActions.count, 0)
+
+        continuation.yield(.cuComplete(makeCompleteMessage(
+            sessionId: session.id,
+            summary: "Recovered from stale id",
+            stepCount: 1
+        )))
+        await runTask.value
+    }
+
+    @MainActor
+    func testDragDestinationElementId_acceptsCamelCaseKey() async {
+        let daemonClient = MockDaemonClient()
+        let continuation = daemonClient.setupTestStream()
+        let executor = MockActionExecutor()
+        let session = makeSession(daemonClient: daemonClient, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_drag",
+            input: [
+                "element_id": AnyCodable(1),
+                "toElementId": AnyCodable(2),
+            ],
+            reasoning: "Use camelCase destination element key",
+            stepNumber: 1
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        continuation.yield(.cuComplete(makeCompleteMessage(
+            sessionId: session.id,
+            summary: "Dragged by camelCase IDs",
+            stepCount: 1
+        )))
+
+        await runTask.value
+
+        XCTAssertEqual(executor.executedActions.count, 1)
+        XCTAssertEqual(executor.executedActions[0].resolvedToElementId, 2)
+        XCTAssertEqual(executor.executedActions[0].toX ?? -1, 200, accuracy: 0.001)
+        XCTAssertEqual(executor.executedActions[0].toY ?? -1, 165, accuracy: 0.001)
+    }
+
     // MARK: - Undo
 
     @MainActor


### PR DESCRIPTION
## Summary
- resolve `element_id` / `to_element_id` to concrete coordinates in `ComputerUseSession` before verification and execution
- add recoverable observation errors for unresolved IDs or missing drag endpoints instead of falling through to generic executor failures
- add SessionTests coverage for ID-only click/drag resolution, stale-ID recoverable errors, and camelCase `toElementId` parsing

## Verification
- `cd clients && swift build --target VellumAssistantLib`
- `cd clients && swift build --target vellum-assistantTests` *(fails in existing unrelated `ChatViewModelTests.swift` initializers on `main`; SessionTests compiles before that failure)*

Part of plan: VLM.md (PR 1 of 7)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
