### PR TITLE
feat(threads): drawer starts closed with clearer icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -7,7 +7,7 @@ struct MainWindowView: View {
     var zoomManager: ZoomManager
     @ObservedObject var traceStore: TraceStore
     @ObservedObject var windowState: MainWindowState
-    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
+    @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
     @State private var selectedThreadId: UUID?
     @State private var workspaceEditorContentHeight: CGFloat = 20
     @State private var showSharePicker = false
@@ -54,7 +54,7 @@ struct MainWindowView: View {
                         VStack(spacing: 0) {
                             HStack(spacing: 0) {
                                 // Thread drawer toggle
-                                VIconButton(label: "Threads", icon: "list.bullet", isActive: columnVisibility != .detailOnly, iconOnly: true) {
+                                VIconButton(label: "Threads", icon: "sidebar.left", isActive: columnVisibility != .detailOnly, iconOnly: true) {
                                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                                         columnVisibility = (columnVisibility == .detailOnly) ? .all : .detailOnly
                                     }


### PR DESCRIPTION
## Summary

Makes the threads drawer start closed by default and improves icon visibility for the drawer toggle button.

## Changes

1. **Drawer starts closed** — Changed default `columnVisibility` from `.automatic` to `.detailOnly` so the drawer is hidden on first launch
2. **Clearer icon** — Changed drawer toggle icon from `list.bullet` to `sidebar.left`, which better represents a sidebar/drawer action

## Rationale

The drawer opening by default takes up screen space when users first open the app. Starting closed gives users the full chat interface immediately, and they can open the drawer when needed using the more noticeable sidebar icon.

## Testing

Launch the app — the threads drawer should be closed by default, with a clear sidebar icon to toggle it open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
