### PR TITLE
fix(composer): eliminate height flicker on Shift+Enter newlines

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -88,6 +88,7 @@ struct ComposerView: View {
         .padding(.bottom, 18)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
+        .animation(VAnimation.fast, value: editorContentHeight)
     }
 
     private var isComposerExpanded: Bool {
@@ -136,9 +137,7 @@ struct ComposerView: View {
                         Color.clear
                             .onAppear { editorContentHeight = geo.size.height }
                             .onChange(of: geo.size.height) { _, h in
-                                withAnimation(VAnimation.spring) {
-                                    editorContentHeight = h
-                                }
+                                editorContentHeight = h
                             }
                     }
                 )


### PR DESCRIPTION
## Summary
- Removed `withAnimation(VAnimation.spring)` from the `editorContentHeight` GeometryReader update — spring overshoot caused competing animations and layout thrashing when pressing Shift+Enter rapidly
- Added `VAnimation.fast` at the container level so height transitions are still smooth but don't bounce or cause the compact/expanded layout to flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
