### PR TITLE
feat(memory): add relation-aware entity recall expansion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,7 +66,7 @@ graph TB
         subgraph "Memory System"
             CONV_STORE["ConversationStore<br/>Drizzle ORM CRUD"]
             INDEXER["Memory Indexer<br/>segment + extract"]
-            RECALL["Memory Recall<br/>FTS5 + Qdrant + Entity + RRF<br/>Trust + Freshness + Scope"]
+            RECALL["Memory Recall<br/>FTS5 + Qdrant + Entity Graph + RRF<br/>Trust + Freshness + Scope"]
             JOBS_WORKER["MemoryJobsWorker<br/>poll every 1.5s"]
         end
 
@@ -518,7 +518,8 @@ graph TB
         QUERY["Recall Query"]
         LEX["Lexical Search<br/>FTS5 on memory_segment_fts"]
         SEM["Semantic Search<br/>Qdrant cosine similarity"]
-        ENTITY_SEARCH["Entity Search<br/>Name/alias matching"]
+        ENTITY_SEARCH["Entity Search<br/>Seed name/alias matching"]
+        REL_EXPAND["Relation Expansion<br/>1-hop via memory_entity_relations<br/>→ neighbor item links"]
         DIRECT["Direct Item Search<br/>LIKE on subject/statement"]
         SCOPE["Scope Filter<br/>scope_id filtering<br/>(strict | global_fallback)"]
         MERGE["RRF Merge<br/>+ Trust Weighting<br/>+ Freshness Decay"]
@@ -559,7 +560,8 @@ graph TB
     QUERY --> DIRECT
     LEX --> SCOPE
     SEM --> SCOPE
-    ENTITY_SEARCH --> SCOPE
+    ENTITY_SEARCH --> REL_EXPAND
+    REL_EXPAND --> SCOPE
     DIRECT --> SCOPE
     SCOPE --> MERGE
     MERGE --> RERANK

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -71,6 +71,7 @@ import { buildMemoryRecall } from '../memory/retriever.js';
 import {
   conversations,
   memoryEntities,
+  memoryEntityRelations,
   memoryItemEntities,
   memoryItems,
   memoryItemSources,
@@ -569,6 +570,92 @@ describe('Memory Recall Quality', () => {
       const recall = await buildMemoryRecall('vscode debug setup', 'conv-entity-alias', TEST_CONFIG);
       expect(recall.entityHits).toBeGreaterThan(0);
       expect(recall.injectedText).toContain('Visual Studio Code');
+    });
+
+    test('relation expansion recalls neighbor-linked items when only seed entity is mentioned', async () => {
+      const db = getDb();
+      const now = 1_700_000_680_000;
+      insertConversation(db, 'conv-entity-rel', now);
+      insertMessage(
+        db,
+        'msg-entity-rel',
+        'conv-entity-rel',
+        'user',
+        'Project Atlas reliability playbook.',
+        now,
+      );
+
+      insertItem(db, {
+        id: 'item-k8s-hpa',
+        kind: 'fact',
+        subject: 'autoscaling strategy',
+        statement: 'Use Kubernetes horizontal pod autoscaling for sustained traffic spikes',
+        importance: 0.75,
+        firstSeenAt: now,
+      });
+      insertItemSource(db, 'item-k8s-hpa', 'msg-entity-rel', now);
+
+      db.insert(memoryEntities).values([
+        {
+          id: 'entity-atlas',
+          name: 'Project Atlas',
+          type: 'project',
+          aliases: JSON.stringify(['atlas']),
+          description: null,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          mentionCount: 1,
+        },
+        {
+          id: 'entity-kubernetes',
+          name: 'Kubernetes',
+          type: 'tool',
+          aliases: JSON.stringify(['k8s']),
+          description: null,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          mentionCount: 1,
+        },
+      ]).run();
+      db.insert(memoryEntityRelations).values({
+        id: 'rel-atlas-k8s',
+        sourceEntityId: 'entity-atlas',
+        targetEntityId: 'entity-kubernetes',
+        relation: 'uses',
+        evidence: 'Project Atlas runs on Kubernetes',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      }).run();
+      db.insert(memoryItemEntities).values({
+        memoryItemId: 'item-k8s-hpa',
+        entityId: 'entity-kubernetes',
+      }).run();
+
+      const relationConfig = {
+        ...TEST_CONFIG,
+        memory: {
+          ...TEST_CONFIG.memory,
+          entity: {
+            ...TEST_CONFIG.memory.entity,
+            relationRetrieval: {
+              ...TEST_CONFIG.memory.entity.relationRetrieval,
+              enabled: true,
+              maxSeedEntities: 4,
+              maxNeighborEntities: 4,
+              maxEdges: 6,
+              neighborScoreMultiplier: 0.6,
+            },
+          },
+        },
+      };
+
+      const recall = await buildMemoryRecall(
+        'atlas reliability guidance',
+        'conv-entity-rel',
+        relationConfig,
+      );
+      expect(recall.entityHits).toBeGreaterThan(0);
+      expect(recall.injectedText).toContain('Kubernetes horizontal pod autoscaling');
     });
   });
 

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -66,7 +66,9 @@ import {
 import {
   conversations,
   memoryEmbeddings,
+  memoryEntities,
   memoryEntityRelations,
+  memoryItemEntities,
   memoryItems,
   memoryItemSources,
   memoryJobs,
@@ -2054,6 +2056,224 @@ describe('Memory V2 regressions', () => {
     // Only strict-project scope segment should appear
     expect(keys).not.toContain('segment:seg-strict-default');
     expect(keys).toContain('segment:seg-strict-custom');
+  });
+
+  test('relation retrieval respects scope and active-item filters', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = 'conv-relation-scope';
+
+    db.insert(conversations).values({
+      id: convId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+    db.insert(messages).values({
+      id: 'msg-relation-scope',
+      conversationId: convId,
+      role: 'user',
+      content: JSON.stringify([{ type: 'text', text: 'atlas reliability memo' }]),
+      createdAt: now,
+    }).run();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'item-rel-a-active',
+        kind: 'fact',
+        subject: 'autoscaling policy',
+        statement: 'Use Kubernetes HPA for sustained traffic spikes',
+        status: 'active',
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: 'fp-rel-a-active',
+        verificationState: 'user_confirmed',
+        scopeId: 'project-a',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+      {
+        id: 'item-rel-b-active',
+        kind: 'fact',
+        subject: 'scheduler policy',
+        statement: 'Use Nomad system jobs for batch workloads',
+        status: 'active',
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: 'fp-rel-b-active',
+        verificationState: 'user_confirmed',
+        scopeId: 'project-b',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+      {
+        id: 'item-rel-a-invalid',
+        kind: 'fact',
+        subject: 'deprecated platform',
+        statement: 'Legacy Kubernetes cluster should still be used',
+        status: 'active',
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: 'fp-rel-a-invalid',
+        verificationState: 'user_confirmed',
+        scopeId: 'project-a',
+        firstSeenAt: now,
+        lastSeenAt: now,
+        invalidAt: now + 1,
+      },
+      {
+        id: 'item-rel-a-pending',
+        kind: 'fact',
+        subject: 'pending platform policy',
+        statement: 'Pending clarification platform statement',
+        status: 'pending_clarification',
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: 'fp-rel-a-pending',
+        verificationState: 'assistant_inferred',
+        scopeId: 'project-a',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+    ]).run();
+
+    db.insert(memoryItemSources).values([
+      {
+        memoryItemId: 'item-rel-a-active',
+        messageId: 'msg-relation-scope',
+        evidence: 'source a active',
+        createdAt: now,
+      },
+      {
+        memoryItemId: 'item-rel-b-active',
+        messageId: 'msg-relation-scope',
+        evidence: 'source b active',
+        createdAt: now,
+      },
+      {
+        memoryItemId: 'item-rel-a-invalid',
+        messageId: 'msg-relation-scope',
+        evidence: 'source a invalid',
+        createdAt: now,
+      },
+      {
+        memoryItemId: 'item-rel-a-pending',
+        messageId: 'msg-relation-scope',
+        evidence: 'source a pending',
+        createdAt: now,
+      },
+    ]).run();
+
+    db.insert(memoryEntities).values([
+      {
+        id: 'entity-atlas-test',
+        name: 'Project Atlas',
+        type: 'project',
+        aliases: JSON.stringify(['atlas']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        mentionCount: 1,
+      },
+      {
+        id: 'entity-k8s-test',
+        name: 'Kubernetes',
+        type: 'tool',
+        aliases: JSON.stringify(['k8s']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        mentionCount: 1,
+      },
+      {
+        id: 'entity-nomad-test',
+        name: 'Nomad',
+        type: 'tool',
+        aliases: JSON.stringify(['nomad']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        mentionCount: 1,
+      },
+    ]).run();
+
+    db.insert(memoryEntityRelations).values([
+      {
+        id: 'rel-atlas-k8s-test',
+        sourceEntityId: 'entity-atlas-test',
+        targetEntityId: 'entity-k8s-test',
+        relation: 'uses',
+        evidence: 'Atlas uses Kubernetes',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+      {
+        id: 'rel-atlas-nomad-test',
+        sourceEntityId: 'entity-atlas-test',
+        targetEntityId: 'entity-nomad-test',
+        relation: 'uses',
+        evidence: 'Atlas also uses Nomad in a different scope',
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+    ]).run();
+
+    db.insert(memoryItemEntities).values([
+      {
+        memoryItemId: 'item-rel-a-active',
+        entityId: 'entity-k8s-test',
+      },
+      {
+        memoryItemId: 'item-rel-a-invalid',
+        entityId: 'entity-k8s-test',
+      },
+      {
+        memoryItemId: 'item-rel-a-pending',
+        entityId: 'entity-k8s-test',
+      },
+      {
+        memoryItemId: 'item-rel-b-active',
+        entityId: 'entity-nomad-test',
+      },
+    ]).run();
+
+    const relationConfig = {
+      ...TEST_CONFIG,
+      memory: {
+        ...TEST_CONFIG.memory,
+        embeddings: { ...TEST_CONFIG.memory.embeddings, required: false },
+        entity: {
+          ...TEST_CONFIG.memory.entity,
+          relationRetrieval: {
+            ...TEST_CONFIG.memory.entity.relationRetrieval,
+            enabled: true,
+            maxSeedEntities: 6,
+            maxNeighborEntities: 6,
+            maxEdges: 10,
+            neighborScoreMultiplier: 0.7,
+          },
+        },
+      },
+    };
+
+    const result = await buildMemoryRecall(
+      'atlas reliability roadmap',
+      convId,
+      relationConfig,
+      { scopeId: 'project-a' },
+    );
+    const keys = result.topCandidates.map((candidate) => candidate.key);
+
+    expect(keys).toContain('item:item-rel-a-active');
+    expect(keys).not.toContain('item:item-rel-b-active');
+    expect(keys).not.toContain('item:item-rel-a-invalid');
+    expect(keys).not.toContain('item:item-rel-a-pending');
   });
 
   test('scope columns: summaries default to scope_id=default', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -87,6 +87,13 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         enabled: false,
         backfillBatchSize: 200,
       },
+      relationRetrieval: {
+        enabled: false,
+        maxSeedEntities: 8,
+        maxNeighborEntities: 20,
+        maxEdges: 40,
+        neighborScoreMultiplier: 0.7,
+      },
     },
   },
   dataDir: getDataDir(),

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -401,6 +401,37 @@ export const MemoryEntityConfigSchema = z.object({
     enabled: false,
     backfillBatchSize: 200,
   }),
+  relationRetrieval: z.object({
+    enabled: z
+      .boolean({ error: 'memory.entity.relationRetrieval.enabled must be a boolean' })
+      .default(false),
+    maxSeedEntities: z
+      .number({ error: 'memory.entity.relationRetrieval.maxSeedEntities must be a number' })
+      .int('memory.entity.relationRetrieval.maxSeedEntities must be an integer')
+      .positive('memory.entity.relationRetrieval.maxSeedEntities must be a positive integer')
+      .default(8),
+    maxNeighborEntities: z
+      .number({ error: 'memory.entity.relationRetrieval.maxNeighborEntities must be a number' })
+      .int('memory.entity.relationRetrieval.maxNeighborEntities must be an integer')
+      .positive('memory.entity.relationRetrieval.maxNeighborEntities must be a positive integer')
+      .default(20),
+    maxEdges: z
+      .number({ error: 'memory.entity.relationRetrieval.maxEdges must be a number' })
+      .int('memory.entity.relationRetrieval.maxEdges must be an integer')
+      .positive('memory.entity.relationRetrieval.maxEdges must be a positive integer')
+      .default(40),
+    neighborScoreMultiplier: z
+      .number({ error: 'memory.entity.relationRetrieval.neighborScoreMultiplier must be a number' })
+      .gt(0, 'memory.entity.relationRetrieval.neighborScoreMultiplier must be > 0')
+      .lte(1, 'memory.entity.relationRetrieval.neighborScoreMultiplier must be <= 1')
+      .default(0.7),
+  }).default({
+    enabled: false,
+    maxSeedEntities: 8,
+    maxNeighborEntities: 20,
+    maxEdges: 40,
+    neighborScoreMultiplier: 0.7,
+  }),
 });
 
 export const MemorySummarizationConfigSchema = z.object({
@@ -481,6 +512,13 @@ export const MemoryConfigSchema = z.object({
     extractRelations: {
       enabled: false,
       backfillBatchSize: 200,
+    },
+    relationRetrieval: {
+      enabled: false,
+      maxSeedEntities: 8,
+      maxNeighborEntities: 20,
+      maxEdges: 40,
+      neighborScoreMultiplier: 0.7,
     },
   }),
 });
@@ -619,6 +657,13 @@ export const AssistantConfigSchema = z.object({
       extractRelations: {
         enabled: false,
         backfillBatchSize: 200,
+      },
+      relationRetrieval: {
+        enabled: false,
+        maxSeedEntities: 8,
+        maxNeighborEntities: 20,
+        maxEdges: 40,
+        neighborScoreMultiplier: 0.7,
       },
     },
   }),

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,13 +1,20 @@
-import { and, desc, eq, inArray, isNull, notInArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, notInArray, or, sql } from 'drizzle-orm';
 import Anthropic from '@anthropic-ai/sdk';
-import type { AssistantConfig, MemoryRerankingConfig } from '../config/types.js';
+import type { AssistantConfig, MemoryEntityConfig, MemoryRerankingConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
 import { embedWithBackend, getMemoryBackendStatus, logMemoryEmbeddingWarning } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { getQdrantClient } from './qdrant-client.js';
-import { memoryItems, memoryItemSources, memorySegments, memorySummaries } from './schema.js';
+import {
+  memoryEntityRelations,
+  memoryItemEntities,
+  memoryItems,
+  memoryItemSources,
+  memorySegments,
+  memorySummaries,
+} from './schema.js';
 
 const log = getLogger('memory-retriever');
 const MEMORY_RECALL_OPEN_TAG = '<memory source="long_term_memory" confidence="approximate">';
@@ -75,7 +82,27 @@ interface CollectedCandidates {
   recency: Candidate[];
   semantic: Candidate[];
   entity: Candidate[];
+  relationSeedEntityCount: number;
+  relationTraversedEdgeCount: number;
+  relationNeighborEntityCount: number;
+  relationExpandedItemCount: number;
   merged: Candidate[];
+}
+
+interface EntitySearchResult {
+  candidates: Candidate[];
+  relationSeedEntityCount: number;
+  relationTraversedEdgeCount: number;
+  relationNeighborEntityCount: number;
+  relationExpandedItemCount: number;
+}
+
+interface MatchedEntityRow {
+  id: string;
+  name: string;
+  type: string;
+  aliases: string | null;
+  mention_count: number;
 }
 
 /**
@@ -124,8 +151,22 @@ async function collectAndMergeCandidates(
   }
 
   let entity: Candidate[] = [];
+  let relationSeedEntityCount = 0;
+  let relationTraversedEdgeCount = 0;
+  let relationNeighborEntityCount = 0;
+  let relationExpandedItemCount = 0;
   if (config.memory.entity.enabled) {
-    entity = entitySearch(query, scopeIds);
+    const entitySearchResult = entitySearch(
+      query,
+      config.memory.entity,
+      scopeIds,
+      excludeMessageIds,
+    );
+    entity = entitySearchResult.candidates;
+    relationSeedEntityCount = entitySearchResult.relationSeedEntityCount;
+    relationTraversedEdgeCount = entitySearchResult.relationTraversedEdgeCount;
+    relationNeighborEntityCount = entitySearchResult.relationNeighborEntityCount;
+    relationExpandedItemCount = entitySearchResult.relationExpandedItemCount;
   }
 
   // Direct item search supplements FTS with LIKE-based matching.
@@ -153,7 +194,17 @@ async function collectAndMergeCandidates(
 
   const merged = mergeCandidates(lexical, semantic, recency, [...entity, ...directItems], config.memory.retrieval.freshness);
 
-  return { lexical, recency, semantic, entity, merged };
+  return {
+    lexical,
+    recency,
+    semantic,
+    entity,
+    relationSeedEntityCount,
+    relationTraversedEdgeCount,
+    relationNeighborEntityCount,
+    relationExpandedItemCount,
+    merged,
+  };
 }
 
 /**
@@ -271,7 +322,16 @@ export async function buildMemoryRecall(
     });
   }
 
-  const { lexical: lexicalCandidates, recency: recencyCandidates, semantic: semanticCandidates, entity: entityCandidates } = collected;
+  const {
+    lexical: lexicalCandidates,
+    recency: recencyCandidates,
+    semantic: semanticCandidates,
+    entity: entityCandidates,
+    relationSeedEntityCount,
+    relationTraversedEdgeCount,
+    relationNeighborEntityCount,
+    relationExpandedItemCount,
+  } = collected;
   let merged = collected.merged;
 
   // LLM re-ranking: send top candidates to Haiku for relevance scoring
@@ -327,6 +387,10 @@ export async function buildMemoryRecall(
     semanticHits: semanticCandidates.length,
     recencyHits: recencyCandidates.length,
     entityHits: entityCandidates.length,
+    relationSeedEntityCount,
+    relationTraversedEdgeCount,
+    relationNeighborEntityCount,
+    relationExpandedItemCount,
     mergedCount,
     selected: selected.length,
     maxInjectTokens,
@@ -703,16 +767,87 @@ function recencySearch(conversationId: string, limit: number, excludedMessageIds
 }
 
 /**
- * Entity-based retrieval: extract entity names from the query,
- * fuzzy match against known entities (name + aliases), and return
- * all memory items linked to those entities.
+ * Entity-based retrieval: match seed entities from query text, fetch directly
+ * linked items, and optionally expand one hop across entity relations.
  */
-function entitySearch(query: string, scopeIds?: string[]): Candidate[] {
+function entitySearch(
+  query: string,
+  entityConfig: MemoryEntityConfig,
+  scopeIds?: string[],
+  excludedMessageIds: string[] = [],
+): EntitySearchResult {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return emptyEntitySearchResult();
+
+  const relationConfig = entityConfig.relationRetrieval;
+  const matchedEntities = findMatchedEntities(
+    trimmed,
+    relationConfig.enabled ? relationConfig.maxSeedEntities : 20,
+  );
+  if (matchedEntities.length === 0) return emptyEntitySearchResult();
+
+  const seedEntityIds = matchedEntities.map((row) => row.id);
+  const directCandidates = getEntityLinkedItemCandidates(seedEntityIds, {
+    scopeIds,
+    excludedMessageIds,
+    confidenceMultiplier: 1,
+  });
+
+  if (!relationConfig.enabled) {
+    return {
+      candidates: directCandidates,
+      relationSeedEntityCount: 0,
+      relationTraversedEdgeCount: 0,
+      relationNeighborEntityCount: 0,
+      relationExpandedItemCount: 0,
+    };
+  }
+
+  const relationSeedEntityCount = seedEntityIds.length;
+  const {
+    neighborEntityIds,
+    traversedEdgeCount: relationTraversedEdgeCount,
+  } = findNeighborEntities(
+    seedEntityIds,
+    relationConfig.maxEdges,
+    relationConfig.maxNeighborEntities,
+  );
+  const relationNeighborEntityCount = neighborEntityIds.length;
+  const directItemIds = new Set(directCandidates.map((candidate) => candidate.id));
+  const relationCandidates = getEntityLinkedItemCandidates(neighborEntityIds, {
+    scopeIds,
+    excludedMessageIds,
+    confidenceMultiplier: relationConfig.neighborScoreMultiplier,
+    excludeItemIds: directItemIds,
+  });
+  const relationExpandedItemCount = relationCandidates.length;
+
+  return {
+    candidates: [...directCandidates, ...relationCandidates],
+    relationSeedEntityCount,
+    relationTraversedEdgeCount,
+    relationNeighborEntityCount,
+    relationExpandedItemCount,
+  };
+}
+
+function emptyEntitySearchResult(): EntitySearchResult {
+  return {
+    candidates: [],
+    relationSeedEntityCount: 0,
+    relationTraversedEdgeCount: 0,
+    relationNeighborEntityCount: 0,
+    relationExpandedItemCount: 0,
+  };
+}
+
+function findMatchedEntities(query: string, maxMatches: number): MatchedEntityRow[] {
   const trimmed = query.trim();
   if (trimmed.length === 0) return [];
 
   const db = getDb();
   const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+  const safeLimit = Math.max(1, Math.floor(maxMatches));
 
   // Tokenize query into words for entity matching (min length 3 to reduce false positives)
   const tokens = trimmed
@@ -736,7 +871,7 @@ function entitySearch(query: string, scopeIds?: string[]): Candidate[] {
       SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
       FROM memory_entities me, json_each(me.aliases) je
       WHERE me.aliases IS NOT NULL AND (LOWER(je.value) IN (${namePlaceholders}) OR LOWER(je.value) = ?)
-      LIMIT 20
+      LIMIT ${safeLimit}
     `;
     queryParams = [...tokens, fullQuery, ...tokens, fullQuery];
   } else {
@@ -748,73 +883,132 @@ function entitySearch(query: string, scopeIds?: string[]): Candidate[] {
       SELECT DISTINCT me.id, me.name, me.type, me.aliases, me.mention_count
       FROM memory_entities me, json_each(me.aliases) je
       WHERE me.aliases IS NOT NULL AND LOWER(je.value) = ?
-      LIMIT 20
+      LIMIT ${safeLimit}
     `;
     queryParams = [fullQuery, fullQuery];
   }
 
-  let matchedEntities: Array<{
-    id: string;
-    name: string;
-    type: string;
-    aliases: string | null;
-    mention_count: number;
-  }> = [];
+  let matchedEntities: MatchedEntityRow[] = [];
   try {
-    matchedEntities = raw.query(entityQuery).all(...queryParams) as Array<{
-      id: string;
-      name: string;
-      type: string;
-      aliases: string | null;
-      mention_count: number;
-    }>;
+    matchedEntities = raw.query(entityQuery).all(...queryParams) as MatchedEntityRow[];
   } catch (err) {
     log.warn({ err }, 'Entity search query failed');
     return [];
   }
+  return matchedEntities;
+}
 
-  if (matchedEntities.length === 0) return [];
-
-  // Get all entity IDs
-  const entityIds = matchedEntities.map((e) => e.id);
-
-  // Find all memory items linked to these entities
-  const placeholders = entityIds.map(() => '?').join(',');
-  let linkedRows: Array<{
-    memory_item_id: string;
-    entity_id: string;
-  }> = [];
-  try {
-    linkedRows = raw.query(`
-      SELECT memory_item_id, entity_id
-      FROM memory_item_entities
-      WHERE entity_id IN (${placeholders})
-    `).all(...entityIds) as Array<{
-      memory_item_id: string;
-      entity_id: string;
-    }>;
-  } catch (err) {
-    log.warn({ err }, 'Entity item link query failed');
-    return [];
+function findNeighborEntities(
+  seedEntityIds: string[],
+  maxEdges: number,
+  maxNeighborEntities: number,
+): { neighborEntityIds: string[]; traversedEdgeCount: number } {
+  if (seedEntityIds.length === 0 || maxEdges <= 0 || maxNeighborEntities <= 0) {
+    return { neighborEntityIds: [], traversedEdgeCount: 0 };
   }
+
+  const db = getDb();
+  const rows = db
+    .select({
+      sourceEntityId: memoryEntityRelations.sourceEntityId,
+      targetEntityId: memoryEntityRelations.targetEntityId,
+    })
+    .from(memoryEntityRelations)
+    .where(or(
+      inArray(memoryEntityRelations.sourceEntityId, seedEntityIds),
+      inArray(memoryEntityRelations.targetEntityId, seedEntityIds),
+    ))
+    .orderBy(desc(memoryEntityRelations.lastSeenAt))
+    .limit(Math.max(1, maxEdges))
+    .all();
+
+  const seedSet = new Set(seedEntityIds);
+  const seen = new Set<string>();
+  const neighbors: string[] = [];
+  for (const row of rows) {
+    if (seedSet.has(row.sourceEntityId) && !seedSet.has(row.targetEntityId) && !seen.has(row.targetEntityId)) {
+      neighbors.push(row.targetEntityId);
+      seen.add(row.targetEntityId);
+    }
+    if (neighbors.length >= maxNeighborEntities) break;
+    if (seedSet.has(row.targetEntityId) && !seedSet.has(row.sourceEntityId) && !seen.has(row.sourceEntityId)) {
+      neighbors.push(row.sourceEntityId);
+      seen.add(row.sourceEntityId);
+    }
+    if (neighbors.length >= maxNeighborEntities) break;
+  }
+
+  return {
+    neighborEntityIds: neighbors.slice(0, maxNeighborEntities),
+    traversedEdgeCount: rows.length,
+  };
+}
+
+function getEntityLinkedItemCandidates(
+  entityIds: string[],
+  opts: {
+    scopeIds?: string[];
+    excludedMessageIds?: string[];
+    confidenceMultiplier: number;
+    excludeItemIds?: Set<string>;
+  },
+): Candidate[] {
+  if (entityIds.length === 0) return [];
+  const excludedMessageIds = opts.excludedMessageIds ?? [];
+
+  const db = getDb();
+  const linkedRows = db
+    .select({
+      memoryItemId: memoryItemEntities.memoryItemId,
+    })
+    .from(memoryItemEntities)
+    .where(inArray(memoryItemEntities.entityId, entityIds))
+    .all();
 
   if (linkedRows.length === 0) return [];
 
-  // Fetch the actual memory items
-  const itemIds = [...new Set(linkedRows.map((r) => r.memory_item_id))];
+  const itemIds = [...new Set(linkedRows.map((row) => row.memoryItemId))]
+    .filter((itemId) => !opts.excludeItemIds?.has(itemId));
+  if (itemIds.length === 0) return [];
+
   const itemConditions = [
     inArray(memoryItems.id, itemIds),
     eq(memoryItems.status, 'active'),
     isNull(memoryItems.invalidAt),
   ];
-  if (scopeIds && scopeIds.length > 0) {
-    itemConditions.push(inArray(memoryItems.scopeId, scopeIds));
+  if (opts.scopeIds && opts.scopeIds.length > 0) {
+    itemConditions.push(inArray(memoryItems.scopeId, opts.scopeIds));
   }
-  const items = db
+  let items = db
     .select()
     .from(memoryItems)
     .where(and(...itemConditions))
     .all();
+  if (items.length === 0) return [];
+
+  if (excludedMessageIds.length > 0) {
+    const excludedSet = new Set(excludedMessageIds);
+    const sources = db
+      .select({
+        memoryItemId: memoryItemSources.memoryItemId,
+        messageId: memoryItemSources.messageId,
+      })
+      .from(memoryItemSources)
+      .where(inArray(memoryItemSources.memoryItemId, items.map((item) => item.id)))
+      .all();
+    const hasAnySource = new Set<string>();
+    const hasNonExcludedSource = new Set<string>();
+    for (const source of sources) {
+      hasAnySource.add(source.memoryItemId);
+      if (!excludedSet.has(source.messageId)) {
+        hasNonExcludedSource.add(source.memoryItemId);
+      }
+    }
+    items = items.filter((item) => !hasAnySource.has(item.id) || hasNonExcludedSource.has(item.id));
+  }
+  if (items.length === 0) return [];
+
+  const confidenceMultiplier = Math.max(0, Math.min(1, opts.confidenceMultiplier));
 
   return items.map((item) => ({
     key: `item:${item.id}`,
@@ -822,7 +1016,7 @@ function entitySearch(query: string, scopeIds?: string[]): Candidate[] {
     id: item.id,
     text: `${item.subject}: ${item.statement}`,
     kind: item.kind,
-    confidence: item.confidence,
+    confidence: item.confidence * confidenceMultiplier,
     importance: item.importance ?? 0.5,
     createdAt: item.lastSeenAt,
     lexical: 0,


### PR DESCRIPTION
## Summary
- add relation-aware entity retrieval config under `memory.entity.relationRetrieval`
- expand entity recall one hop through `memory_entity_relations` with caps for seeds, edges, and neighbor entities
- keep scope/status/exclusion filtering for relation-expanded item candidates and log relation expansion counters
- add relation-focused recall quality/regression tests and update architecture read-path diagram

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/memory-recall-quality.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "relation"

Both suites passed all assertions; Bun then panicked after completion (runtime issue in this environment).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
