### PR TITLE
feat(ipc): add zero-copy baseline instrumentation metrics

### DIFF
--- a/.private/reports/zero-copy/BASELINE.md
+++ b/.private/reports/zero-copy/BASELINE.md
@@ -1,0 +1,91 @@
+# ZERO_COPY Baseline (PR 1)
+
+Status: scaffolded. Run the scenario below and fill the metrics tables before PR 9.
+
+## Scope
+
+This baseline captures the current inline IPC behavior for `cu_observation` before any blob transport changes.
+
+## Fixed Scenario
+
+Run this exact task in local macOS daemon mode (no socket forwarding) and let it execute at least 20 perceive/action steps.
+
+Prompt:
+
+```text
+Open Safari, go to https://news.ycombinator.com, open the first story in a new tab, summarize the headline in one sentence, switch back to Hacker News, scroll down one page, and then respond with done.
+```
+
+## Capture Setup
+
+1. Truncate daemon log:
+
+```bash
+: > ~/.vellum/data/logs/vellum.log
+```
+
+2. Start Swift-side IPC metric capture in a separate terminal:
+
+```bash
+log stream \
+  --style compact \
+  --predicate 'subsystem == "com.vellum.vellum-assistant" AND (category == "Session" OR category == "DaemonClient") AND eventMessage CONTAINS "IPC_METRIC"' \
+  > /tmp/zero-copy-swift.log
+```
+
+3. Run the fixed CU scenario once.
+
+4. Stop the `log stream` command after completion.
+
+## Metric Extraction
+
+### Observation JSON line size (daemon parse view)
+
+```bash
+jq -r 'select(.msg == "IPC_METRIC cu_observation_parse") | .payloadJsonBytes' ~/.vellum/data/logs/vellum.log > /tmp/zero-copy-line-bytes.txt
+```
+
+### Swift screenshot sizes (raw + base64)
+
+```bash
+rg 'IPC_METRIC cu_observation_build' /tmp/zero-copy-swift.log > /tmp/zero-copy-build-lines.txt
+```
+
+### Send -> daemon receive latency (same-machine clock)
+
+```bash
+rg 'IPC_METRIC cu_observation_send|IPC_METRIC cu_observation_daemon_receive' /tmp/zero-copy-swift.log ~/.vellum/data/logs/vellum.log
+```
+
+Use `sessionId` + `sequence` to pair rows.
+
+## Baseline Results
+
+Fill these values from the collected run.
+
+### Observation IPC JSON bytes
+
+| Metric | Value |
+|---|---|
+| p50 | TODO |
+| p95 | TODO |
+| samples | TODO |
+
+### Screenshot payload size
+
+| Metric | Raw bytes (p50/p95) | Base64 bytes (p50/p95) |
+|---|---|---|
+| Screenshot | TODO / TODO | TODO / TODO |
+
+### Send -> daemon receive latency (ms)
+
+| Metric | Value |
+|---|---|
+| p50 | TODO |
+| p95 | TODO |
+| samples | TODO |
+
+## Notes
+
+- Keep this baseline file immutable after capture. Post-change numbers go in `AFTER.md` (PR 9).
+- If the run aborts before 20 steps, discard and rerun.

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -71,6 +71,7 @@ const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
 const FALLBACK_SCREEN = { width: 1920, height: 1080 };
 let cachedScreenDims: { width: number; height: number } | null = null;
+const cuObservationSequenceBySession = new Map<string, number>();
 
 /**
  * Query the main display dimensions via CoreGraphics.
@@ -1743,6 +1744,7 @@ function removeCuSessionReferences(
     return;
   }
   ctx.cuSessions.delete(sessionId);
+  cuObservationSequenceBySession.delete(sessionId);
   for (const [sock, ids] of ctx.socketToCuSession) {
     if (ids.delete(sessionId) && ids.size === 0) {
       ctx.socketToCuSession.delete(sock);
@@ -1826,6 +1828,28 @@ function handleCuObservation(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
+  const receiveTimestampMs = Date.now();
+  const previousSequence = cuObservationSequenceBySession.get(msg.sessionId) ?? 0;
+  const sequence = previousSequence + 1;
+  cuObservationSequenceBySession.set(msg.sessionId, sequence);
+  const axTreeBytes = msg.axTree ? Buffer.byteLength(msg.axTree, 'utf8') : 0;
+  const axDiffBytes = msg.axDiff ? Buffer.byteLength(msg.axDiff, 'utf8') : 0;
+  const secondaryWindowsBytes = msg.secondaryWindows ? Buffer.byteLength(msg.secondaryWindows, 'utf8') : 0;
+  const screenshotBase64Bytes = msg.screenshot ? Buffer.byteLength(msg.screenshot, 'utf8') : 0;
+  const screenshotApproxRawBytes = msg.screenshot
+    ? Math.floor((msg.screenshot.length / 4) * 3)
+    : 0;
+  log.info({
+    sessionId: msg.sessionId,
+    sequence,
+    receiveTimestampMs,
+    axTreeBytes,
+    axDiffBytes,
+    secondaryWindowsBytes,
+    screenshotBase64Bytes,
+    screenshotApproxRawBytes,
+  }, 'IPC_METRIC cu_observation_daemon_receive');
+
   const session = ctx.cuSessions.get(msg.sessionId);
   if (!session) {
     ctx.send(socket, {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -34,6 +34,7 @@ export class DaemonServer {
   private socketToCuSession = new Map<net.Socket, Set<string>>();
   private connectedSockets = new Set<net.Socket>();
   private socketSandboxOverride = new Map<net.Socket, boolean>();
+  private cuObservationParseSequence = new Map<string, number>();
   // Persisted session options (e.g. systemPromptOverride, maxResponseTokens)
   // so that evicted sessions can be recreated with the same overrides.
   private sessionOptions = new Map<string, SessionCreateOptions>();
@@ -137,6 +138,7 @@ export class DaemonServer {
     this.connectedSockets.clear();
     this.socketToSession.clear();
     this.socketSandboxOverride.clear();
+    this.cuObservationParseSequence.clear();
 
     await serverClosed;
     log.info('Daemon server stopped');
@@ -390,6 +392,8 @@ export class DaemonServer {
     });
 
     socket.on('data', (data) => {
+      const chunkReceivedAtMs = Date.now();
+      const parseStartNs = process.hrtime.bigint();
       let messages;
       try {
         messages = parser.feed(data.toString());
@@ -399,7 +403,24 @@ export class DaemonServer {
         socket.destroy();
         return;
       }
+      const parsedAtMs = Date.now();
+      const parseDurationMs = Number(process.hrtime.bigint() - parseStartNs) / 1_000_000;
       for (const msg of messages) {
+        if (typeof msg === 'object' && msg !== null && (msg as { type?: unknown }).type === 'cu_observation') {
+          const maybeSessionId = (msg as { sessionId?: unknown }).sessionId;
+          const sessionId = typeof maybeSessionId === 'string' ? maybeSessionId : 'unknown';
+          const previousSequence = this.cuObservationParseSequence.get(sessionId) ?? 0;
+          const sequence = previousSequence + 1;
+          this.cuObservationParseSequence.set(sessionId, sequence);
+          log.info({
+            sessionId,
+            sequence,
+            chunkReceivedAtMs,
+            parsedAtMs,
+            parseDurationMs,
+            payloadJsonBytes: Buffer.byteLength(JSON.stringify(msg), 'utf8'),
+          }, 'IPC_METRIC cu_observation_parse');
+        }
         const result = validateClientMessage(msg);
         if (!result.valid) {
           log.warn({ reason: result.reason }, 'Invalid IPC message, dropping client');
@@ -425,6 +446,7 @@ export class DaemonServer {
       const cuSessionIds = this.socketToCuSession.get(socket);
       if (cuSessionIds) {
         for (const cuSessionId of cuSessionIds) {
+          this.cuObservationParseSequence.delete(cuSessionId);
           const cuSession = this.cuSessions.get(cuSessionId);
           if (cuSession) {
             cuSession.abort();

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -449,7 +449,7 @@ final class ComputerUseSession: ObservableObject {
         // Encode screenshot as base64
         let screenshotBase64 = screenshot?.base64EncodedString()
 
-        return CuObservationMessage(
+        let observation = CuObservationMessage(
             sessionId: id,
             axTree: axTreeText,
             axDiff: axDiffText,
@@ -458,6 +458,19 @@ final class ComputerUseSession: ObservableObject {
             executionResult: executionResult,
             executionError: executionError
         )
+
+        let screenshotRawBytes = screenshot?.count ?? 0
+        let screenshotBase64Bytes = screenshotBase64?.utf8.count ?? 0
+        let axTreeBytes = axTreeText?.utf8.count ?? 0
+        let axDiffBytes = axDiffText?.utf8.count ?? 0
+        let secondaryWindowsBytes = secondaryWindowsText?.utf8.count ?? 0
+        let payloadJSONBytes = (try? JSONEncoder().encode(observation).count) ?? 0
+        let buildTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
+        log.info(
+            "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) axTreeBytes=\(axTreeBytes) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"
+        )
+
+        return observation
     }
 
     // MARK: - Tool Name Mapping

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -161,6 +161,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Maximum line size: 96 MB (for screenshots with base64).
     private let maxLineSize = 96 * 1024 * 1024
 
+    /// Monotonic per-session sequence for CU observation sends.
+    private var cuObservationSequenceBySession: [String: Int] = [:]
+
     /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
 
@@ -377,6 +380,19 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         var data = try encoder.encode(message)
         data.append(contentsOf: [0x0A]) // newline byte
+
+        if let observation = message as? CuObservationMessage {
+            let previousSequence = cuObservationSequenceBySession[observation.sessionId] ?? 0
+            let sequence = previousSequence + 1
+            cuObservationSequenceBySession[observation.sessionId] = sequence
+            let payloadJSONBytes = max(0, data.count - 1)
+            let screenshotBase64Bytes = observation.screenshot?.utf8.count ?? 0
+            let axTreeBytes = observation.axTree?.utf8.count ?? 0
+            let sendTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
+            log.info(
+                "IPC_METRIC cu_observation_send sessionId=\(observation.sessionId) sequence=\(sequence) sendTsMs=\(sendTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) axTreeBytes=\(axTreeBytes)"
+            )
+        }
 
         conn.send(content: data, completion: .contentProcessed { error in
             if let error {
@@ -626,6 +642,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         receiveBuffer = Data()
+        cuObservationSequenceBySession.removeAll()
         isConnected = false
         httpPort = nil
 


### PR DESCRIPTION
## Summary
- Add structured `IPC_METRIC` logs at three points in the CU observation pipeline: Swift build, Swift send, and daemon receive/parse
- Create baseline metrics report template with fixed scenario and extraction instructions
- Part 1 of the ZERO_COPY plan — captures before-state numbers for comparison after blob transport changes

## Test plan
- [x] Lint passes (no new errors)
- [x] No behavior change — metrics are log-only
- [ ] Manual: run a CU scenario and confirm IPC_METRIC log lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
