### PR TITLE
feat(tools): add evaluate_typescript_code sandbox tool

### DIFF
--- a/assistant/src/__tests__/evaluate-typescript-tool.test.ts
+++ b/assistant/src/__tests__/evaluate-typescript-tool.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: true, action: 'warn' as const, entropyThreshold: 4.0 },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Mock wrapCommand to pass through without actual sandboxing (tests run bun directly)
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (command: string, _workingDir: string, _config: unknown) => ({
+    command: 'bash',
+    args: ['-c', '--', command],
+    sandboxed: false,
+  }),
+}));
+
+import { EvaluateTypescriptTool } from '../tools/terminal/evaluate-typescript.js';
+import type { ToolContext } from '../tools/types.js';
+
+const tool = new EvaluateTypescriptTool();
+const testDirs: string[] = [];
+
+function makeContext(workingDir?: string): ToolContext {
+  const dir = workingDir ?? mkdtempSync(join(tmpdir(), 'eval-ts-test-'));
+  if (!workingDir) testDirs.push(dir);
+  return {
+    workingDir: dir,
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('evaluate_typescript_code tool', () => {
+  test('successful execution returns exitCode=0 and expected output', async () => {
+    const result = await tool.execute({
+      code: 'export default function(input: unknown) { return { greeting: "hello" }; }',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exitCode).toBe(0);
+    expect(parsed.timeout).toBe(false);
+    expect(parsed.result).toEqual({ greeting: 'hello' });
+    expect(typeof parsed.durationMs).toBe('number');
+  });
+
+  test('passes mock_input_json to snippet', async () => {
+    const result = await tool.execute({
+      code: 'export default function(input: any) { return { received: input }; }',
+      mock_input_json: '{"name":"test"}',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toEqual({ received: { name: 'test' } });
+  });
+
+  test('syntax error returns non-zero and stderr', async () => {
+    const result = await tool.execute({
+      code: 'export default function( { return }',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.exitCode).not.toBe(0);
+    expect(parsed.stderr.length).toBeGreaterThan(0);
+  });
+
+  test('runtime throw returns non-zero and stack fragment in stderr', async () => {
+    const result = await tool.execute({
+      code: 'export default function() { throw new Error("boom"); }',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.exitCode).not.toBe(0);
+    expect(parsed.stderr).toContain('boom');
+  });
+
+  test('timeout kills process and returns timeout marker', async () => {
+    const result = await tool.execute({
+      code: 'export default async function() { await new Promise(r => setTimeout(r, 60000)); }',
+      timeout_seconds: 1,
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.timeout).toBe(true);
+  }, 10_000);
+
+  test('invalid JSON in mock_input_json returns deterministic validation error', async () => {
+    const result = await tool.execute({
+      code: 'export default function() { return 1; }',
+      mock_input_json: 'not-json{',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe('Error: mock_input_json must be valid JSON');
+  });
+
+  test('missing export returns deterministic contract error', async () => {
+    const result = await tool.execute({
+      code: 'const x = 42;',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.stderr).toContain('must export a function');
+  });
+
+  test('entrypoint=run calls the run export', async () => {
+    const result = await tool.execute({
+      code: 'export function run(input: any) { return "ran"; }',
+      entrypoint: 'run',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toBe('ran');
+  });
+
+  test('oversized code is rejected before execution', async () => {
+    const result = await tool.execute({
+      code: 'x'.repeat(200_000),
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exceeds maximum size');
+  });
+
+  test('oversized mock_input_json is rejected before execution', async () => {
+    const result = await tool.execute({
+      code: 'export default function() { return 1; }',
+      mock_input_json: JSON.stringify({ data: 'x'.repeat(200_000) }),
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('exceeds maximum size');
+  });
+
+  test('temp directory is removed after completion', async () => {
+    const ctx = makeContext();
+
+    await tool.execute({
+      code: 'export default function() { return 1; }',
+    }, ctx);
+
+    const evalDir = join(ctx.workingDir, '.vellum-eval');
+    // The parent .vellum-eval dir may exist but should have no children
+    if (existsSync(evalDir)) {
+      expect(readdirSync(evalDir).length).toBe(0);
+    }
+  });
+
+  test('empty code is rejected', async () => {
+    const result = await tool.execute({
+      code: '',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('code is required');
+  });
+
+  test('missing code is rejected', async () => {
+    const result = await tool.execute({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('code is required');
+  });
+
+  test('async snippet works', async () => {
+    const result = await tool.execute({
+      code: 'export default async function(input: any) { return { async: true, got: input }; }',
+      mock_input_json: '42',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toEqual({ async: true, got: 42 });
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -134,6 +134,54 @@ export async function initializeTools(): Promise<void> {
   registerUiSurfaceTools();
   registerAppTools();
 
+  // evaluate_typescript_code — sandboxed TypeScript snippet runner.
+  // Lazy because it imports the sandbox module (same WASM dependency as bash).
+  registerLazyTool({
+    name: 'evaluate_typescript_code',
+    description: 'Evaluate a TypeScript snippet in an isolated sandbox. Use this to test code before persisting it as a managed skill.',
+    category: 'terminal',
+    defaultRiskLevel: RiskLevel.High,
+    definition: {
+      name: 'evaluate_typescript_code',
+      description: 'Evaluate a TypeScript snippet in an isolated sandbox. Use this to test code before persisting it as a managed skill.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description: 'The TypeScript source code to evaluate. Must export a `default` or `run` function.',
+          },
+          mock_input_json: {
+            type: 'string',
+            description: 'Optional JSON string to pass as input. Defaults to "{}".',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description: 'Optional timeout in seconds (1-20). Defaults to 10.',
+          },
+          filename: {
+            type: 'string',
+            description: 'Optional filename for the snippet (default: "snippet.ts").',
+          },
+          entrypoint: {
+            type: 'string',
+            enum: ['default', 'run'],
+            description: 'Which export to call: "default" or "run". Defaults to "default".',
+          },
+          max_output_chars: {
+            type: 'number',
+            description: 'Optional max output characters (1-25000). Defaults to 25000.',
+          },
+        },
+        required: ['code'],
+      },
+    },
+    loader: async () => {
+      const mod = await import('./terminal/evaluate-typescript.js');
+      return mod.evaluateTypescriptTool;
+    },
+  });
+
   // The bash tool loads web-tree-sitter WASM for command parsing, which is
   // expensive.  Register it lazily so the WASM is only loaded on first use.
   registerLazyTool({

--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -1,0 +1,265 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { getConfig } from '../../config/loader.js';
+import { getLogger } from '../../util/logger.js';
+import { wrapCommand } from './sandbox.js';
+import { buildSanitizedEnv } from './safe-env.js';
+
+const log = getLogger('evaluate-typescript');
+
+const MAX_CODE_BYTES = 100_000;
+const MAX_MOCK_INPUT_BYTES = 100_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 25_000;
+const DEFAULT_TIMEOUT_SEC = 10;
+const MIN_TIMEOUT_SEC = 1;
+const MAX_TIMEOUT_SEC = 20;
+
+interface EvalResult {
+  ok: boolean;
+  exitCode: number | null;
+  durationMs: number;
+  result?: unknown;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+  timeout: boolean;
+}
+
+function sanitizeFilename(raw: string): string {
+  const base = basename(raw).replace(/[^a-zA-Z0-9._-]/g, '_');
+  if (!base || base.startsWith('.')) return 'snippet.ts';
+  if (!base.endsWith('.ts')) return base + '.ts';
+  return base;
+}
+
+function buildWrapperSource(snippetFilename: string, entrypoint: string): string {
+  const exportName = entrypoint === 'run' ? 'run' : 'default';
+  return `
+import * as mod from './${snippetFilename}';
+
+const fn = (mod as any)['${exportName}'];
+if (typeof fn !== 'function') {
+  console.error(JSON.stringify({ __eval_error: 'Snippet must export a function named "${exportName}"' }));
+  process.exit(1);
+}
+
+const inputJson = process.env.__EVAL_INPUT_JSON ?? '{}';
+let input: unknown;
+try {
+  input = JSON.parse(inputJson);
+} catch {
+  console.error(JSON.stringify({ __eval_error: 'Invalid JSON in __EVAL_INPUT_JSON' }));
+  process.exit(1);
+}
+
+try {
+  const result = await fn(input);
+  console.log(JSON.stringify({ __eval_result: result }));
+} catch (err: any) {
+  console.error(err?.stack ?? String(err));
+  process.exit(1);
+}
+`;
+}
+
+export class EvaluateTypescriptTool implements Tool {
+  name = 'evaluate_typescript_code';
+  description = 'Evaluate a TypeScript snippet in an isolated sandbox. Use this to test code before persisting it as a managed skill.';
+  category = 'terminal';
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description: 'The TypeScript source code to evaluate. Must export a `default` or `run` function with signature `(input: unknown) => unknown | Promise<unknown>`.',
+          },
+          mock_input_json: {
+            type: 'string',
+            description: 'Optional JSON string to pass as the input argument to the exported function. Defaults to "{}".',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description: `Optional timeout in seconds (${MIN_TIMEOUT_SEC}-${MAX_TIMEOUT_SEC}). Defaults to ${DEFAULT_TIMEOUT_SEC}.`,
+          },
+          filename: {
+            type: 'string',
+            description: 'Optional filename for the snippet (default: "snippet.ts"). Sanitized to basename only.',
+          },
+          entrypoint: {
+            type: 'string',
+            enum: ['default', 'run'],
+            description: 'Which export to call: "default" or "run". Defaults to "default".',
+          },
+          max_output_chars: {
+            type: 'number',
+            description: `Optional max output characters (1-${DEFAULT_MAX_OUTPUT_CHARS}). Defaults to ${DEFAULT_MAX_OUTPUT_CHARS}.`,
+          },
+        },
+        required: ['code'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    const code = input.code;
+    if (typeof code !== 'string' || !code.trim()) {
+      return { content: 'Error: code is required and must be a non-empty string', isError: true };
+    }
+    if (Buffer.byteLength(code) > MAX_CODE_BYTES) {
+      return { content: `Error: code exceeds maximum size of ${MAX_CODE_BYTES} bytes`, isError: true };
+    }
+
+    const mockInputJson = typeof input.mock_input_json === 'string' ? input.mock_input_json : '{}';
+    if (Buffer.byteLength(mockInputJson) > MAX_MOCK_INPUT_BYTES) {
+      return { content: `Error: mock_input_json exceeds maximum size of ${MAX_MOCK_INPUT_BYTES} bytes`, isError: true };
+    }
+    try {
+      JSON.parse(mockInputJson);
+    } catch {
+      return { content: 'Error: mock_input_json must be valid JSON', isError: true };
+    }
+
+    const rawTimeout = typeof input.timeout_seconds === 'number' ? input.timeout_seconds : DEFAULT_TIMEOUT_SEC;
+    const timeoutSec = Math.max(MIN_TIMEOUT_SEC, Math.min(MAX_TIMEOUT_SEC, Math.round(rawTimeout)));
+    const timeoutMs = timeoutSec * 1000;
+
+    const filename = sanitizeFilename(typeof input.filename === 'string' ? input.filename : 'snippet.ts');
+    const entrypoint = input.entrypoint === 'run' ? 'run' : 'default';
+    const maxOutputChars = typeof input.max_output_chars === 'number'
+      ? Math.max(1, Math.min(DEFAULT_MAX_OUTPUT_CHARS, Math.round(input.max_output_chars)))
+      : DEFAULT_MAX_OUTPUT_CHARS;
+
+    const evalDir = join(context.workingDir, '.vellum-eval', randomUUID());
+
+    try {
+      mkdirSync(evalDir, { recursive: true });
+      writeFileSync(join(evalDir, filename), code, 'utf-8');
+      writeFileSync(join(evalDir, '__runner.ts'), buildWrapperSource(filename, entrypoint), 'utf-8');
+
+      const result = await this.runSnippet(evalDir, mockInputJson, timeoutSec, timeoutMs, maxOutputChars, context);
+      return { content: JSON.stringify(result), isError: !result.ok };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err }, 'evaluate_typescript_code failed');
+      return { content: `Error: ${msg}`, isError: true };
+    } finally {
+      try {
+        rmSync(evalDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  private runSnippet(
+    evalDir: string,
+    mockInputJson: string,
+    timeoutSec: number,
+    timeoutMs: number,
+    maxOutputChars: number,
+    context: ToolContext,
+  ): Promise<EvalResult> {
+    return new Promise<EvalResult>((resolve) => {
+      const startTime = Date.now();
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+
+      const config = getConfig();
+      // Force sandbox on regardless of global config
+      const sandboxConfig = { ...config.sandbox, enabled: true };
+      const bunRunCmd = `bun run __runner.ts`;
+      const wrapped = wrapCommand(bunRunCmd, evalDir, sandboxConfig);
+
+      const env = buildSanitizedEnv();
+      env.__EVAL_INPUT_JSON = mockInputJson;
+
+      const child = spawn(wrapped.command, wrapped.args, {
+        cwd: evalDir,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, timeoutMs);
+
+      child.stdout.on('data', (data: Buffer) => stdoutChunks.push(data));
+      child.stderr.on('data', (data: Buffer) => stderrChunks.push(data));
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        const durationMs = Date.now() - startTime;
+
+        let stdout = Buffer.concat(stdoutChunks).toString();
+        let stderr = Buffer.concat(stderrChunks).toString();
+        let truncated = false;
+
+        if (stdout.length + stderr.length > maxOutputChars) {
+          truncated = true;
+          const halfMax = Math.floor(maxOutputChars / 2);
+          if (stdout.length > halfMax) stdout = stdout.slice(0, halfMax) + '\n[stdout truncated]';
+          if (stderr.length > halfMax) stderr = stderr.slice(0, halfMax) + '\n[stderr truncated]';
+        }
+
+        // Extract structured result from stdout
+        let result: unknown = undefined;
+        if (code === 0) {
+          const lines = stdout.split('\n');
+          for (const line of lines) {
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed && typeof parsed === 'object' && '__eval_result' in parsed) {
+                result = parsed.__eval_result;
+                break;
+              }
+            } catch {
+              // not the result line
+            }
+          }
+        }
+
+        resolve({
+          ok: code === 0 && !timedOut,
+          exitCode: code,
+          durationMs,
+          result,
+          stdout,
+          stderr,
+          truncated,
+          timeout: timedOut,
+        });
+      });
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        const durationMs = Date.now() - startTime;
+        resolve({
+          ok: false,
+          exitCode: null,
+          durationMs,
+          stdout: '',
+          stderr: `Error spawning process: ${err.message}`,
+          truncated: false,
+          timeout: false,
+        });
+      });
+    });
+  }
+}
+
+export const evaluateTypescriptTool: Tool = new EvaluateTypescriptTool();
+registerTool(evaluateTypescriptTool);

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -1,0 +1,37 @@
+/**
+ * Environment variables that are safe to pass through to child processes.
+ * Everything else (API keys, tokens, credentials) is stripped to prevent
+ * accidental leakage via agent-spawned commands.
+ *
+ * Shared by the sandbox bash tool and the evaluate_typescript_code tool.
+ */
+const SAFE_ENV_VARS = [
+  'PATH',
+  'HOME',
+  'TERM',
+  'LANG',
+  'EDITOR',
+  'SHELL',
+  'USER',
+  'TMPDIR',
+  'LC_ALL',
+  'LC_CTYPE',
+  'XDG_RUNTIME_DIR',
+  'DISPLAY',
+  'COLORTERM',
+  'TERM_PROGRAM',
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'GPG_TTY',
+  'GNUPGHOME',
+] as const;
+
+export function buildSanitizedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of SAFE_ENV_VARS) {
+    if (process.env[key] != null) {
+      env[key] = process.env[key]!;
+    }
+  }
+  return env;
+}

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -7,44 +7,9 @@ import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
 import { wrapCommand } from './sandbox.js';
 import { formatShellOutput } from '../shared/shell-output.js';
+import { buildSanitizedEnv } from './safe-env.js';
 
 const log = getLogger('shell-tool');
-
-/**
- * Environment variables that are safe to pass through to child processes.
- * Everything else (API keys, tokens, credentials) is stripped to prevent
- * accidental leakage via agent-spawned commands.
- */
-const SAFE_ENV_VARS = [
-  'PATH',
-  'HOME',
-  'TERM',
-  'LANG',
-  'EDITOR',
-  'SHELL',
-  'USER',
-  'TMPDIR',
-  'LC_ALL',
-  'LC_CTYPE',
-  'XDG_RUNTIME_DIR',
-  'DISPLAY',
-  'COLORTERM',
-  'TERM_PROGRAM',
-  'SSH_AUTH_SOCK',
-  'SSH_AGENT_PID',
-  'GPG_TTY',
-  'GNUPGHOME',
-] as const;
-
-function buildSanitizedEnv(): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const key of SAFE_ENV_VARS) {
-    if (process.env[key] != null) {
-      env[key] = process.env[key]!;
-    }
-  }
-  return env;
-}
 
 class ShellTool implements Tool {
   name = 'bash';


### PR DESCRIPTION
## Summary
- Add `evaluate_typescript_code` tool: a sandboxed TypeScript snippet evaluator for testing code before persisting as managed skills
- Extract shared sanitized-env logic from `shell.ts` into `safe-env.ts` for reuse across terminal tools
- Register new tool lazily in the tool registry (High risk level, always requires approval)
- Add 14 test cases covering success, errors, timeouts, validation, and cleanup

**PR 1 of 6 in the DYNAMIC_TOOLS plan.**

## Test plan
- [x] `bun test src/__tests__/evaluate-typescript-tool.test.ts` — 14 tests pass
- [x] `bun test src/__tests__/host-shell-tool.test.ts` — no regressions
- [x] `bun test src/__tests__/registry.test.ts` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
