### PR TITLE
feat(skills): add managed skill filesystem service

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import {
+  validateManagedSkillId,
+  getManagedSkillsDir,
+  getManagedSkillDir,
+  buildSkillMarkdown,
+  upsertSkillsIndexEntry,
+  removeSkillsIndexEntry,
+  createManagedSkill,
+  deleteManagedSkill,
+} from '../skills/managed-store.js';
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'managed-store-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('validateManagedSkillId', () => {
+  test('accepts valid slug IDs', () => {
+    expect(validateManagedSkillId('my-skill')).toBeNull();
+    expect(validateManagedSkillId('skill123')).toBeNull();
+    expect(validateManagedSkillId('my.skill')).toBeNull();
+    expect(validateManagedSkillId('my_skill')).toBeNull();
+  });
+
+  test('rejects empty string', () => {
+    expect(validateManagedSkillId('')).not.toBeNull();
+  });
+
+  test('rejects traversal patterns', () => {
+    expect(validateManagedSkillId('../escape')).not.toBeNull();
+    expect(validateManagedSkillId('foo/bar')).not.toBeNull();
+    expect(validateManagedSkillId('foo\\bar')).not.toBeNull();
+  });
+
+  test('rejects uppercase', () => {
+    expect(validateManagedSkillId('MySkill')).not.toBeNull();
+  });
+
+  test('rejects IDs starting with special chars', () => {
+    expect(validateManagedSkillId('.hidden')).not.toBeNull();
+    expect(validateManagedSkillId('-dash')).not.toBeNull();
+  });
+});
+
+describe('buildSkillMarkdown', () => {
+  test('generates valid frontmatter and body', () => {
+    const result = buildSkillMarkdown({
+      name: 'Test Skill',
+      description: 'A test skill',
+      bodyMarkdown: 'Do the thing.',
+    });
+    expect(result).toContain('---\n');
+    expect(result).toContain('name: "Test Skill"');
+    expect(result).toContain('description: "A test skill"');
+    expect(result).toContain('Do the thing.');
+    expect(result.endsWith('\n')).toBe(true);
+  });
+
+  test('includes optional emoji', () => {
+    const result = buildSkillMarkdown({
+      name: 'Emoji Skill',
+      description: 'Has an emoji',
+      bodyMarkdown: 'Body.',
+      emoji: '🧪',
+    });
+    expect(result).toContain('emoji: "🧪"');
+  });
+
+  test('includes user-invocable=false when specified', () => {
+    const result = buildSkillMarkdown({
+      name: 'Internal',
+      description: 'Not user invocable',
+      bodyMarkdown: 'Body.',
+      userInvocable: false,
+    });
+    expect(result).toContain('user-invocable: false');
+  });
+
+  test('includes disable-model-invocation when true', () => {
+    const result = buildSkillMarkdown({
+      name: 'Manual',
+      description: 'Manual only',
+      bodyMarkdown: 'Body.',
+      disableModelInvocation: true,
+    });
+    expect(result).toContain('disable-model-invocation: true');
+  });
+});
+
+describe('SKILLS.md index management', () => {
+  test('SKILLS.md is created when absent', () => {
+    upsertSkillsIndexEntry('my-skill');
+    const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+    expect(existsSync(indexPath)).toBe(true);
+    const content = readFileSync(indexPath, 'utf-8');
+    expect(content).toContain('- my-skill');
+  });
+
+  test('index add is idempotent', () => {
+    upsertSkillsIndexEntry('my-skill');
+    upsertSkillsIndexEntry('my-skill');
+    const content = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    const matches = content.match(/- my-skill/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  test('delete removes directory and index entry', () => {
+    // Set up a skill
+    const skillDir = join(TEST_DIR, 'skills', 'doomed');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), 'test');
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- doomed\n- survivor\n',
+    );
+
+    const result = deleteManagedSkill('doomed');
+    expect(result.deleted).toBe(true);
+    expect(result.indexUpdated).toBe(true);
+    expect(existsSync(skillDir)).toBe(false);
+
+    const content = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(content).not.toContain('doomed');
+    expect(content).toContain('survivor');
+  });
+
+  test('remove from index handles missing entry gracefully', () => {
+    writeFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'),
+      '- other-skill\n',
+    );
+    removeSkillsIndexEntry('nonexistent');
+    const content = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(content).toContain('other-skill');
+  });
+});
+
+describe('createManagedSkill', () => {
+  test('creates skill and writes to expected path', () => {
+    const result = createManagedSkill({
+      id: 'test-skill',
+      name: 'Test Skill',
+      description: 'A test skill',
+      bodyMarkdown: 'Instructions here.',
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(existsSync(result.path)).toBe(true);
+
+    const content = readFileSync(result.path, 'utf-8');
+    expect(content).toContain('name: "Test Skill"');
+    expect(content).toContain('Instructions here.');
+  });
+
+  test('rejects duplicate unless overwrite=true', () => {
+    createManagedSkill({
+      id: 'dupe',
+      name: 'Original',
+      description: 'First version',
+      bodyMarkdown: 'V1.',
+    });
+
+    const result2 = createManagedSkill({
+      id: 'dupe',
+      name: 'Duplicate',
+      description: 'Second version',
+      bodyMarkdown: 'V2.',
+    });
+    expect(result2.created).toBe(false);
+    expect(result2.error).toContain('already exists');
+
+    const result3 = createManagedSkill({
+      id: 'dupe',
+      name: 'Overwritten',
+      description: 'Third version',
+      bodyMarkdown: 'V3.',
+      overwrite: true,
+    });
+    expect(result3.created).toBe(true);
+    const content = readFileSync(result3.path, 'utf-8');
+    expect(content).toContain('Overwritten');
+  });
+
+  test('rejects invalid IDs', () => {
+    const result = createManagedSkill({
+      id: '../escape',
+      name: 'Bad',
+      description: 'Bad',
+      bodyMarkdown: 'Bad.',
+    });
+    expect(result.created).toBe(false);
+    expect(result.error).toContain('traversal');
+  });
+
+  test('updates SKILLS.md index', () => {
+    createManagedSkill({
+      id: 'indexed-skill',
+      name: 'Indexed',
+      description: 'Gets indexed',
+      bodyMarkdown: 'Body.',
+    });
+
+    const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(indexContent).toContain('- indexed-skill');
+  });
+
+  test('skips index when addToIndex=false', () => {
+    createManagedSkill({
+      id: 'no-index',
+      name: 'No Index',
+      description: 'Not indexed',
+      bodyMarkdown: 'Body.',
+      addToIndex: false,
+    });
+
+    const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+    if (existsSync(indexPath)) {
+      const content = readFileSync(indexPath, 'utf-8');
+      expect(content).not.toContain('no-index');
+    }
+  });
+});
+
+describe('deleteManagedSkill', () => {
+  test('deletes existing skill', () => {
+    createManagedSkill({
+      id: 'to-delete',
+      name: 'Delete Me',
+      description: 'Will be deleted',
+      bodyMarkdown: 'Gone soon.',
+    });
+
+    const result = deleteManagedSkill('to-delete');
+    expect(result.deleted).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'skills', 'to-delete'))).toBe(false);
+  });
+
+  test('returns error for non-existent skill', () => {
+    const result = deleteManagedSkill('ghost');
+    expect(result.deleted).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  test('rejects invalid IDs', () => {
+    const result = deleteManagedSkill('../bad');
+    expect(result.deleted).toBe(false);
+    expect(result.error).toContain('traversal');
+  });
+
+  test('skips index removal when removeFromIndex=false', () => {
+    createManagedSkill({
+      id: 'keep-index',
+      name: 'Keep Index',
+      description: 'Index stays',
+      bodyMarkdown: 'Body.',
+    });
+
+    const result = deleteManagedSkill('keep-index', false);
+    expect(result.deleted).toBe(true);
+    expect(result.indexUpdated).toBe(false);
+
+    const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(indexContent).toContain('- keep-index');
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -59,6 +59,7 @@ import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, lis
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { parseSlashCandidate } from '../skills/slash-commands.js';
+import { removeSkillsIndexEntry } from '../skills/managed-store.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
@@ -1105,6 +1106,9 @@ async function handleSkillsUninstall(
   }
   try {
     rmSync(skillDir, { recursive: true });
+
+    // Clean SKILLS.md index entry (idempotent, safe for non-managed skills)
+    try { removeSkillsIndexEntry(msg.name); } catch { /* best effort */ }
 
     // Clean config entry
     const raw = loadRawConfig();

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -1,0 +1,212 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, renameSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { getRootDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+
+const log = getLogger('managed-store');
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+const VALID_SKILL_ID = /^[a-z0-9][a-z0-9._-]*$/;
+
+export function validateManagedSkillId(id: string): string | null {
+  if (!id || typeof id !== 'string') return 'skill_id is required';
+  if (id.includes('..') || id.includes('/') || id.includes('\\')) {
+    return 'skill_id must not contain path traversal characters';
+  }
+  if (!VALID_SKILL_ID.test(id)) {
+    return 'skill_id must start with a lowercase letter or digit and contain only lowercase letters, digits, dots, hyphens, and underscores';
+  }
+  return null;
+}
+
+// ─── Path helpers ────────────────────────────────────────────────────────────
+
+export function getManagedSkillsDir(): string {
+  return join(getRootDir(), 'skills');
+}
+
+export function getManagedSkillDir(id: string): string {
+  return join(getManagedSkillsDir(), id);
+}
+
+function getSkillsIndexPath(): string {
+  return join(getManagedSkillsDir(), 'SKILLS.md');
+}
+
+// ─── SKILL.md generation ─────────────────────────────────────────────────────
+
+export interface BuildSkillMarkdownInput {
+  name: string;
+  description: string;
+  bodyMarkdown: string;
+  emoji?: string;
+  userInvocable?: boolean;
+  disableModelInvocation?: boolean;
+}
+
+export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
+  const lines: string[] = ['---'];
+  lines.push(`name: "${input.name}"`);
+  lines.push(`description: "${input.description}"`);
+  if (input.emoji) {
+    lines.push(`emoji: "${input.emoji}"`);
+  }
+  if (input.userInvocable === false) {
+    lines.push('user-invocable: false');
+  }
+  if (input.disableModelInvocation === true) {
+    lines.push('disable-model-invocation: true');
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push(input.bodyMarkdown);
+  // Ensure trailing newline
+  const content = lines.join('\n');
+  return content.endsWith('\n') ? content : content + '\n';
+}
+
+// ─── Atomic write ────────────────────────────────────────────────────────────
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const dir = dirname(filePath);
+  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+  writeFileSync(tmpPath, content, 'utf-8');
+  renameSync(tmpPath, filePath);
+}
+
+// ─── SKILLS.md index management ──────────────────────────────────────────────
+
+function readIndexLines(): string[] {
+  const indexPath = getSkillsIndexPath();
+  if (!existsSync(indexPath)) return [];
+  return readFileSync(indexPath, 'utf-8').split('\n');
+}
+
+function writeIndexLines(lines: string[]): void {
+  const content = lines.join('\n');
+  atomicWriteFile(getSkillsIndexPath(), content.endsWith('\n') ? content : content + '\n');
+}
+
+function indexEntryRegex(id: string): RegExp {
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^-\\s+(?:\\[.*?\\]\\()?${escaped}(?:\\))?(?:/SKILL\\.md)?\\s*$`);
+}
+
+export function upsertSkillsIndexEntry(id: string): void {
+  const lines = readIndexLines();
+  const pattern = indexEntryRegex(id);
+  if (lines.some((line) => pattern.test(line))) {
+    return; // already present
+  }
+  // Append new entry
+  const nonEmpty = lines.filter((l) => l.trim());
+  nonEmpty.push(`- ${id}`);
+  writeIndexLines(nonEmpty);
+  log.info({ id }, 'Added managed skill to SKILLS.md index');
+}
+
+export function removeSkillsIndexEntry(id: string): void {
+  const lines = readIndexLines();
+  const pattern = indexEntryRegex(id);
+  const filtered = lines.filter((line) => !pattern.test(line));
+  if (filtered.length === lines.length) {
+    return; // not found
+  }
+  writeIndexLines(filtered.filter((l) => l.trim()));
+  log.info({ id }, 'Removed managed skill from SKILLS.md index');
+}
+
+// ─── Create / Delete ─────────────────────────────────────────────────────────
+
+export interface CreateManagedSkillParams {
+  id: string;
+  name: string;
+  description: string;
+  bodyMarkdown: string;
+  emoji?: string;
+  userInvocable?: boolean;
+  disableModelInvocation?: boolean;
+  overwrite?: boolean;
+  addToIndex?: boolean;
+}
+
+export interface CreateManagedSkillResult {
+  created: boolean;
+  path: string;
+  indexUpdated: boolean;
+  error?: string;
+}
+
+export function createManagedSkill(params: CreateManagedSkillParams): CreateManagedSkillResult {
+  const validationError = validateManagedSkillId(params.id);
+  if (validationError) {
+    return { created: false, path: '', indexUpdated: false, error: validationError };
+  }
+
+  const skillDir = getManagedSkillDir(params.id);
+  const skillFilePath = join(skillDir, 'SKILL.md');
+
+  if (existsSync(skillFilePath) && !params.overwrite) {
+    return {
+      created: false,
+      path: skillFilePath,
+      indexUpdated: false,
+      error: `Managed skill "${params.id}" already exists. Set overwrite=true to replace it.`,
+    };
+  }
+
+  const content = buildSkillMarkdown({
+    name: params.name,
+    description: params.description,
+    bodyMarkdown: params.bodyMarkdown,
+    emoji: params.emoji,
+    userInvocable: params.userInvocable,
+    disableModelInvocation: params.disableModelInvocation,
+  });
+
+  mkdirSync(skillDir, { recursive: true });
+  atomicWriteFile(skillFilePath, content);
+  log.info({ id: params.id, path: skillFilePath }, 'Created managed skill');
+
+  let indexUpdated = false;
+  if (params.addToIndex !== false) {
+    upsertSkillsIndexEntry(params.id);
+    indexUpdated = true;
+  }
+
+  return { created: true, path: skillFilePath, indexUpdated };
+}
+
+export interface DeleteManagedSkillResult {
+  deleted: boolean;
+  indexUpdated: boolean;
+  error?: string;
+}
+
+export function deleteManagedSkill(
+  id: string,
+  removeFromIndex = true,
+): DeleteManagedSkillResult {
+  const validationError = validateManagedSkillId(id);
+  if (validationError) {
+    return { deleted: false, indexUpdated: false, error: validationError };
+  }
+
+  const skillDir = getManagedSkillDir(id);
+  if (!existsSync(skillDir)) {
+    return { deleted: false, indexUpdated: false, error: `Managed skill "${id}" not found` };
+  }
+
+  rmSync(skillDir, { recursive: true });
+  log.info({ id, path: skillDir }, 'Deleted managed skill');
+
+  let indexUpdated = false;
+  if (removeFromIndex) {
+    removeSkillsIndexEntry(id);
+    indexUpdated = true;
+  }
+
+  return { deleted: true, indexUpdated };
+}


### PR DESCRIPTION
## Summary
- Create `managed-store.ts` with centralized validation, create, delete, and SKILLS.md index management for managed skills
- Add SKILLS.md index cleanup to daemon uninstall handler (idempotent, safe for all skill types)
- Atomic writes for SKILL.md and SKILLS.md to prevent partial files on failure

**PR 2 of 6 in the DYNAMIC_TOOLS plan.**

## Test plan
- [x] `bun test src/__tests__/managed-store.test.ts` — 22 tests pass
- [x] `bun test src/__tests__/skills.test.ts` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
