### PR TITLE
feat(tools): add scaffold_managed_skill and delete_managed_skill tools

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { DeleteManagedSkillTool } from '../tools/skills/delete-managed.js';
+import type { ToolContext } from '../tools/types.js';
+
+const tool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+function createSkill(id: string): void {
+  const skillDir = join(TEST_DIR, 'skills', id);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: "Test"\ndescription: "Test"\n---\n\nBody.\n');
+  // Update SKILLS.md
+  const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+  const existing = existsSync(indexPath) ? readFileSync(indexPath, 'utf-8') : '';
+  writeFileSync(indexPath, existing + `- ${id}\n`);
+}
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'delete-tool-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('delete_managed_skill tool', () => {
+  test('deletes existing skill and updates index', async () => {
+    createSkill('doomed');
+    createSkill('survivor');
+
+    const result = await tool.execute({
+      skill_id: 'doomed',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.deleted).toBe(true);
+    expect(parsed.skill_id).toBe('doomed');
+    expect(parsed.index_updated).toBe(true);
+
+    expect(existsSync(join(TEST_DIR, 'skills', 'doomed'))).toBe(false);
+
+    const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(indexContent).not.toContain('doomed');
+    expect(indexContent).toContain('survivor');
+  });
+
+  test('returns error for non-existent skill', async () => {
+    const result = await tool.execute({
+      skill_id: 'ghost',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('not found');
+  });
+
+  test('rejects missing skill_id', async () => {
+    const result = await tool.execute({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('skill_id is required');
+  });
+
+  test('rejects invalid skill_id', async () => {
+    const result = await tool.execute({
+      skill_id: '../escape',
+    }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('traversal');
+  });
+});

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { ScaffoldManagedSkillTool } from '../tools/skills/scaffold-managed.js';
+import type { ToolContext } from '../tools/types.js';
+
+// Use internal class directly to avoid registry side effects
+const tool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'scaffold-tool-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('scaffold_managed_skill tool', () => {
+  test('creates a valid skill and index entry', async () => {
+    const result = await tool.execute({
+      skill_id: 'test-skill',
+      name: 'Test Skill',
+      description: 'A test skill',
+      body_markdown: 'Do the thing.',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.created).toBe(true);
+    expect(parsed.skill_id).toBe('test-skill');
+    expect(parsed.index_updated).toBe(true);
+
+    // Verify file was created
+    const skillFile = join(TEST_DIR, 'skills', 'test-skill', 'SKILL.md');
+    expect(existsSync(skillFile)).toBe(true);
+    const content = readFileSync(skillFile, 'utf-8');
+    expect(content).toContain('name: "Test Skill"');
+
+    // Verify index was updated
+    const indexContent = readFileSync(join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8');
+    expect(indexContent).toContain('- test-skill');
+  });
+
+  test('rejects duplicate unless overwrite=true', async () => {
+    await tool.execute({
+      skill_id: 'dupe',
+      name: 'Original',
+      description: 'First',
+      body_markdown: 'V1.',
+    }, makeContext());
+
+    const result2 = await tool.execute({
+      skill_id: 'dupe',
+      name: 'Duplicate',
+      description: 'Second',
+      body_markdown: 'V2.',
+    }, makeContext());
+    expect(result2.isError).toBe(true);
+    expect(result2.content).toContain('already exists');
+
+    const result3 = await tool.execute({
+      skill_id: 'dupe',
+      name: 'Overwritten',
+      description: 'Third',
+      body_markdown: 'V3.',
+      overwrite: true,
+    }, makeContext());
+    expect(result3.isError).toBe(false);
+  });
+
+  test('rejects missing required fields', async () => {
+    const cases = [
+      { name: 'N', description: 'D', body_markdown: 'B' }, // missing skill_id
+      { skill_id: 's', description: 'D', body_markdown: 'B' }, // missing name
+      { skill_id: 's', name: 'N', body_markdown: 'B' }, // missing description
+      { skill_id: 's', name: 'N', description: 'D' }, // missing body_markdown
+    ];
+
+    for (const input of cases) {
+      const result = await tool.execute(input, makeContext());
+      expect(result.isError).toBe(true);
+    }
+  });
+
+  test('rejects invalid skill_id', async () => {
+    const result = await tool.execute({
+      skill_id: '../escape',
+      name: 'Bad',
+      description: 'Bad',
+      body_markdown: 'Bad.',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('traversal');
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -143,6 +143,11 @@ function buildCommandCandidates(toolName: string, input: Record<string, unknown>
     return [...new Set(targets)].map((target) => `${toolName}:${target}`);
   }
 
+  if (toolName === 'scaffold_managed_skill' || toolName === 'delete_managed_skill') {
+    const skillId = getStringField(input, 'skill_id').trim();
+    return [`${toolName}:${skillId}`];
+  }
+
   if (toolName === 'web_fetch' || toolName === 'browser_navigate') {
     const rawUrl = getStringField(input, 'url').trim();
     const candidates: string[] = [];
@@ -415,6 +420,25 @@ export function generateAllowlistOptions(toolName: string, input: Record<string,
       seen.add(o.pattern);
       return true;
     });
+  }
+
+  if (toolName === 'scaffold_managed_skill' || toolName === 'delete_managed_skill') {
+    const skillId = getStringField(input, 'skill_id').trim();
+    const toolLabel = toolName === 'scaffold_managed_skill' ? 'scaffold' : 'delete';
+    const options: AllowlistOption[] = [];
+    if (skillId) {
+      options.push({
+        label: skillId,
+        description: `This skill only`,
+        pattern: `${toolName}:${skillId}`,
+      });
+    }
+    options.push({
+      label: `${toolName}:*`,
+      description: `All managed skill ${toolLabel}s`,
+      pattern: `${toolName}:*`,
+    });
+    return options;
   }
 
   return [{ label: '*', description: 'Everything', pattern: '*' }];

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -108,6 +108,8 @@ export async function initializeTools(): Promise<void> {
   await import('./network/web-search.js');
   await import('./network/web-fetch.js');
   await import('./skills/load.js');
+  await import('./skills/scaffold-managed.js');
+  await import('./skills/delete-managed.js');
   await import('./browser/headless-browser.js');
   await import('./weather/get-weather.js');
   await import('./memory/register.js');

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -1,0 +1,60 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { deleteManagedSkill } from '../../skills/managed-store.js';
+
+export class DeleteManagedSkillTool implements Tool {
+  name = 'delete_managed_skill';
+  description = 'Delete a managed skill from ~/.vellum/skills and remove it from the SKILLS.md index.';
+  category = 'skills';
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          skill_id: {
+            type: 'string',
+            description: 'The ID of the managed skill to delete.',
+          },
+          remove_from_index: {
+            type: 'boolean',
+            description: 'Whether to remove the skill from SKILLS.md index (default: true).',
+          },
+        },
+        required: ['skill_id'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const skillId = input.skill_id;
+    if (typeof skillId !== 'string' || !skillId.trim()) {
+      return { content: 'Error: skill_id is required and must be a non-empty string', isError: true };
+    }
+
+    const removeFromIndex = input.remove_from_index !== false;
+
+    const result = deleteManagedSkill(skillId.trim(), removeFromIndex);
+
+    if (!result.deleted) {
+      return { content: `Error: ${result.error}`, isError: true };
+    }
+
+    return {
+      content: JSON.stringify({
+        deleted: true,
+        skill_id: skillId.trim(),
+        index_updated: result.indexUpdated,
+      }),
+      isError: false,
+    };
+  }
+}
+
+export const deleteManagedSkillTool: Tool = new DeleteManagedSkillTool();
+registerTool(deleteManagedSkillTool);

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -1,0 +1,112 @@
+import { RiskLevel } from '../../permissions/types.js';
+import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { ToolDefinition } from '../../providers/types.js';
+import { registerTool } from '../registry.js';
+import { createManagedSkill } from '../../skills/managed-store.js';
+
+export class ScaffoldManagedSkillTool implements Tool {
+  name = 'scaffold_managed_skill';
+  description = 'Create or update a managed skill in ~/.vellum/skills. The skill becomes available for skill_load immediately.';
+  category = 'skills';
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: 'object',
+        properties: {
+          skill_id: {
+            type: 'string',
+            description: 'Unique identifier for the skill (lowercase slug, e.g. "my-skill").',
+          },
+          name: {
+            type: 'string',
+            description: 'Human-readable name for the skill.',
+          },
+          description: {
+            type: 'string',
+            description: 'Short description of what the skill does.',
+          },
+          body_markdown: {
+            type: 'string',
+            description: 'The full skill body in markdown — instructions, prompts, templates, etc.',
+          },
+          emoji: {
+            type: 'string',
+            description: 'Optional emoji icon for the skill.',
+          },
+          user_invocable: {
+            type: 'boolean',
+            description: 'Whether users can invoke this skill directly (default: true).',
+          },
+          disable_model_invocation: {
+            type: 'boolean',
+            description: 'Whether to prevent the model from auto-invoking this skill (default: false).',
+          },
+          overwrite: {
+            type: 'boolean',
+            description: 'Whether to overwrite an existing skill with the same ID (default: false).',
+          },
+          add_to_index: {
+            type: 'boolean',
+            description: 'Whether to add the skill to SKILLS.md index (default: true).',
+          },
+        },
+        required: ['skill_id', 'name', 'description', 'body_markdown'],
+      },
+    };
+  }
+
+  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
+    const skillId = input.skill_id;
+    if (typeof skillId !== 'string' || !skillId.trim()) {
+      return { content: 'Error: skill_id is required and must be a non-empty string', isError: true };
+    }
+
+    const name = input.name;
+    if (typeof name !== 'string' || !name.trim()) {
+      return { content: 'Error: name is required and must be a non-empty string', isError: true };
+    }
+
+    const description = input.description;
+    if (typeof description !== 'string' || !description.trim()) {
+      return { content: 'Error: description is required and must be a non-empty string', isError: true };
+    }
+
+    const bodyMarkdown = input.body_markdown;
+    if (typeof bodyMarkdown !== 'string' || !bodyMarkdown.trim()) {
+      return { content: 'Error: body_markdown is required and must be a non-empty string', isError: true };
+    }
+
+    const result = createManagedSkill({
+      id: skillId.trim(),
+      name: name.trim(),
+      description: description.trim(),
+      bodyMarkdown: bodyMarkdown,
+      emoji: typeof input.emoji === 'string' ? input.emoji : undefined,
+      userInvocable: typeof input.user_invocable === 'boolean' ? input.user_invocable : undefined,
+      disableModelInvocation: typeof input.disable_model_invocation === 'boolean' ? input.disable_model_invocation : undefined,
+      overwrite: input.overwrite === true,
+      addToIndex: input.add_to_index !== false,
+    });
+
+    if (!result.created) {
+      return { content: `Error: ${result.error}`, isError: true };
+    }
+
+    return {
+      content: JSON.stringify({
+        created: true,
+        skill_id: skillId.trim(),
+        path: result.path,
+        index_updated: result.indexUpdated,
+      }),
+      isError: false,
+    };
+  }
+}
+
+export const scaffoldManagedSkillTool: Tool = new ScaffoldManagedSkillTool();
+registerTool(scaffoldManagedSkillTool);


### PR DESCRIPTION
## Summary
- Add `scaffold_managed_skill` tool for creating/updating managed skills with strict validation
- Add `delete_managed_skill` tool for removing managed skills and cleaning the SKILLS.md index
- Update permissions checker with skill-id-scoped trust rule candidate matching
- Add scoped allowlist options (`scaffold_managed_skill:<id>`, `delete_managed_skill:<id>`)
- Both tools set `defaultRiskLevel = High` (always requires user approval)

**PR 3 of 6 in the DYNAMIC_TOOLS plan.**

## Test plan
- [x] `bun test src/__tests__/scaffold-managed-skill-tool.test.ts` — all pass
- [x] `bun test src/__tests__/delete-managed-skill-tool.test.ts` — all pass
- [x] `bun test src/__tests__/checker.test.ts` — 119 total tests, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
