### PR TITLE
feat(ipc): add daemon blob store with validation and cleanup

### DIFF
--- a/assistant/src/__tests__/ipc-blob-store.test.ts
+++ b/assistant/src/__tests__/ipc-blob-store.test.ts
@@ -1,0 +1,323 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+
+const testDir = mkdtempSync(join(tmpdir(), 'ipc-blob-store-test-'));
+const blobDir = join(testDir, 'ipc-blobs');
+
+// Mock platform module so blob store writes to temp dir
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => blobDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+// Mock logger to suppress output during tests
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import {
+  ensureBlobDir,
+  isValidBlobId,
+  resolveBlobPath,
+  readBlob,
+  deleteBlob,
+  sweepStaleBlobs,
+} from '../daemon/ipc-blob-store.js';
+import type { IpcBlobRef } from '../daemon/ipc-contract.js';
+
+/** Write a blob file to the test blob directory and return its path. */
+function writeBlobFile(id: string, content: Buffer): string {
+  const filePath = join(blobDir, `${id}.blob`);
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe('ipc-blob-store', () => {
+  beforeEach(() => {
+    // Reset blob dir before each test
+    if (existsSync(blobDir)) {
+      rmSync(blobDir, { recursive: true });
+    }
+    mkdirSync(blobDir, { recursive: true });
+  });
+
+  // -- ensureBlobDir --
+
+  describe('ensureBlobDir', () => {
+    test('creates blob directory if missing', () => {
+      rmSync(blobDir, { recursive: true });
+      expect(existsSync(blobDir)).toBe(false);
+      ensureBlobDir();
+      expect(existsSync(blobDir)).toBe(true);
+    });
+
+    test('succeeds if blob directory already exists', () => {
+      ensureBlobDir();
+      expect(existsSync(blobDir)).toBe(true);
+    });
+  });
+
+  // -- isValidBlobId --
+
+  describe('isValidBlobId', () => {
+    test('accepts valid UUID v4', () => {
+      expect(isValidBlobId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+      expect(isValidBlobId(randomUUID())).toBe(true);
+    });
+
+    test('accepts uppercase hex', () => {
+      expect(isValidBlobId('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
+    });
+
+    test('rejects empty string', () => {
+      expect(isValidBlobId('')).toBe(false);
+    });
+
+    test('rejects too-short string', () => {
+      expect(isValidBlobId('550e8400')).toBe(false);
+    });
+
+    test('rejects path traversal characters', () => {
+      expect(isValidBlobId('../../etc/passwd/aaaaaaaaaaaaaaaa')).toBe(false);
+    });
+
+    test('rejects strings with non-hex characters', () => {
+      expect(isValidBlobId('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')).toBe(false);
+    });
+  });
+
+  // -- resolveBlobPath --
+
+  describe('resolveBlobPath', () => {
+    test('returns correct path for valid ID', () => {
+      const id = '550e8400-e29b-41d4-a716-446655440000';
+      const result = resolveBlobPath(id);
+      expect(result).toBe(join(blobDir, `${id}.blob`));
+    });
+
+    test('throws for invalid ID', () => {
+      expect(() => resolveBlobPath('not-a-valid-uuid')).toThrow('Invalid blob ID');
+    });
+
+    test('throws for path traversal attempt', () => {
+      // This should fail at the regex check before even reaching the path check
+      expect(() => resolveBlobPath('../../etc/passwd/aaaaaaaaaaaaaaaa')).toThrow('Invalid blob ID');
+    });
+  });
+
+  // -- readBlob --
+
+  describe('readBlob', () => {
+    test('reads a valid blob successfully', async () => {
+      const id = randomUUID();
+      const content = Buffer.from('hello world');
+      const sha256 = createHash('sha256').update(content).digest('hex');
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'ax_tree',
+        encoding: 'utf8',
+        byteLength: content.byteLength,
+        sha256,
+      };
+
+      const result = await readBlob(ref);
+      expect(result.toString()).toBe('hello world');
+    });
+
+    test('reads blob without sha256 check', async () => {
+      const id = randomUUID();
+      const content = Buffer.from('some data');
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'ax_tree',
+        encoding: 'utf8',
+        byteLength: content.byteLength,
+      };
+
+      const result = await readBlob(ref);
+      expect(result.byteLength).toBe(content.byteLength);
+    });
+
+    test('rejects when byteLength does not match', async () => {
+      const id = randomUUID();
+      const content = Buffer.from('hello');
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'ax_tree',
+        encoding: 'utf8',
+        byteLength: 999,
+      };
+
+      await expect(readBlob(ref)).rejects.toThrow('Blob size mismatch');
+    });
+
+    test('rejects when sha256 does not match', async () => {
+      const id = randomUUID();
+      const content = Buffer.from('hello');
+
+      writeBlobFile(id, content);
+
+      // Compute a definitely-wrong hash by hashing different content
+      const wrongHash = createHash('sha256').update('not-hello').digest('hex');
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'ax_tree',
+        encoding: 'utf8',
+        byteLength: content.byteLength,
+        sha256: wrongHash,
+      };
+
+      await expect(readBlob(ref)).rejects.toThrow('Blob SHA-256 mismatch');
+    });
+
+    test('rejects oversized ax_tree blob', async () => {
+      const id = randomUUID();
+      // 2 MB + 1 byte
+      const content = Buffer.alloc(2 * 1024 * 1024 + 1);
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'ax_tree',
+        encoding: 'utf8',
+        byteLength: content.byteLength,
+      };
+
+      await expect(readBlob(ref)).rejects.toThrow('exceeds size limit');
+    });
+
+    test('rejects oversized screenshot_jpeg blob', async () => {
+      const id = randomUUID();
+      // 10 MB + 1 byte
+      const content = Buffer.alloc(10 * 1024 * 1024 + 1);
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'screenshot_jpeg',
+        encoding: 'binary',
+        byteLength: content.byteLength,
+      };
+
+      await expect(readBlob(ref)).rejects.toThrow('exceeds size limit');
+    });
+
+    test('accepts screenshot_jpeg blob at exactly 10 MB', async () => {
+      const id = randomUUID();
+      const content = Buffer.alloc(10 * 1024 * 1024);
+
+      writeBlobFile(id, content);
+
+      const ref: IpcBlobRef = {
+        id,
+        kind: 'screenshot_jpeg',
+        encoding: 'binary',
+        byteLength: content.byteLength,
+      };
+
+      const result = await readBlob(ref);
+      expect(result.byteLength).toBe(10 * 1024 * 1024);
+    });
+  });
+
+  // -- deleteBlob --
+
+  describe('deleteBlob', () => {
+    test('removes existing file', () => {
+      const id = randomUUID();
+      const filePath = writeBlobFile(id, Buffer.from('data'));
+      expect(existsSync(filePath)).toBe(true);
+
+      deleteBlob(id);
+      expect(existsSync(filePath)).toBe(false);
+    });
+
+    test('does not throw for missing file', () => {
+      const id = randomUUID();
+      expect(() => deleteBlob(id)).not.toThrow();
+    });
+  });
+
+  // -- sweepStaleBlobs --
+
+  describe('sweepStaleBlobs', () => {
+    test('removes old files and keeps recent ones', async () => {
+      const oldId = randomUUID();
+      const recentId = randomUUID();
+
+      const oldPath = writeBlobFile(oldId, Buffer.from('old'));
+      const recentPath = writeBlobFile(recentId, Buffer.from('recent'));
+
+      // Set old file's mtime to 1 hour ago
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      utimesSync(oldPath, oneHourAgo, oneHourAgo);
+
+      // Sweep files older than 30 minutes
+      const deleted = await sweepStaleBlobs(30 * 60 * 1000);
+
+      expect(deleted).toBe(1);
+      expect(existsSync(oldPath)).toBe(false);
+      expect(existsSync(recentPath)).toBe(true);
+    });
+
+    test('returns 0 when no files to sweep', async () => {
+      const deleted = await sweepStaleBlobs(30 * 60 * 1000);
+      expect(deleted).toBe(0);
+    });
+
+    test('returns 0 when blob directory does not exist', async () => {
+      rmSync(blobDir, { recursive: true });
+      const deleted = await sweepStaleBlobs(30 * 60 * 1000);
+      expect(deleted).toBe(0);
+    });
+
+    test('ignores non-blob files', async () => {
+      const nonBlobPath = join(blobDir, 'readme.txt');
+      writeFileSync(nonBlobPath, 'not a blob');
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      utimesSync(nonBlobPath, oneHourAgo, oneHourAgo);
+
+      const deleted = await sweepStaleBlobs(30 * 60 * 1000);
+      expect(deleted).toBe(0);
+      expect(existsSync(nonBlobPath)).toBe(true);
+    });
+  });
+});

--- a/assistant/src/daemon/ipc-blob-store.ts
+++ b/assistant/src/daemon/ipc-blob-store.ts
@@ -1,0 +1,146 @@
+import { getIpcBlobDir } from '../util/platform.js';
+import { getLogger } from '../util/logger.js';
+import type { IpcBlobRef } from './ipc-contract.js';
+import {
+  mkdirSync,
+  existsSync,
+  unlinkSync,
+} from 'node:fs';
+import { readFile, readdir, stat, unlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const log = getLogger('ipc-blob-store');
+
+const BLOB_ID_REGEX = /^[0-9a-fA-F-]{36}$/;
+const MAX_SCREENSHOT_BLOB_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_AX_BLOB_SIZE = 2 * 1024 * 1024; // 2 MB
+const BLOB_EXTENSION = '.blob';
+
+/** Ensure the blob directory exists. Call at daemon startup. */
+export function ensureBlobDir(): void {
+  const dir = getIpcBlobDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/** Validate a blob ID matches UUID format. */
+export function isValidBlobId(id: string): boolean {
+  return BLOB_ID_REGEX.test(id);
+}
+
+/**
+ * Resolve a blob ID to its absolute file path.
+ * Throws if the ID is invalid or the resolved path escapes the blob directory.
+ */
+export function resolveBlobPath(id: string): string {
+  if (!isValidBlobId(id)) {
+    throw new Error(`Invalid blob ID: ${id}`);
+  }
+  const blobDir = getIpcBlobDir();
+  const candidate = resolve(join(blobDir, `${id}${BLOB_EXTENSION}`));
+
+  // Symlink protection: verify the resolved path stays within the blob dir.
+  // Use resolve() on the blob dir itself to normalize it consistently.
+  const normalizedBlobDir = resolve(blobDir);
+  if (!candidate.startsWith(normalizedBlobDir + '/') && candidate !== normalizedBlobDir) {
+    throw new Error(`Blob path escapes blob directory: ${id}`);
+  }
+
+  return candidate;
+}
+
+/**
+ * Read a blob file and validate it against the ref metadata.
+ * Returns the raw bytes.
+ */
+export async function readBlob(ref: IpcBlobRef): Promise<Buffer> {
+  const filePath = resolveBlobPath(ref.id);
+
+  const buf = await readFile(filePath);
+
+  // Validate size matches declared byteLength
+  if (buf.byteLength !== ref.byteLength) {
+    throw new Error(
+      `Blob size mismatch for ${ref.id}: expected ${ref.byteLength} bytes, got ${buf.byteLength}`,
+    );
+  }
+
+  // Enforce hard size limits by kind
+  const maxSize = ref.kind === 'screenshot_jpeg' ? MAX_SCREENSHOT_BLOB_SIZE : MAX_AX_BLOB_SIZE;
+  if (buf.byteLength > maxSize) {
+    throw new Error(
+      `Blob ${ref.id} exceeds size limit for kind "${ref.kind}": ${buf.byteLength} > ${maxSize}`,
+    );
+  }
+
+  // Verify SHA-256 if provided
+  if (ref.sha256) {
+    const hash = createHash('sha256').update(buf).digest('hex');
+    if (hash !== ref.sha256) {
+      throw new Error(
+        `Blob SHA-256 mismatch for ${ref.id}: expected ${ref.sha256}, got ${hash}`,
+      );
+    }
+  }
+
+  return buf;
+}
+
+/** Delete a blob file by ID. Best-effort, logs warning on failure. */
+export function deleteBlob(id: string): void {
+  try {
+    const filePath = resolveBlobPath(id);
+    unlinkSync(filePath);
+  } catch (err) {
+    // ENOENT is expected when the blob was already cleaned up
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log.warn({ err, blobId: id }, 'Failed to delete blob');
+    }
+  }
+}
+
+/** Sweep stale blob files older than maxAgeMs. Returns count of deleted files. */
+export async function sweepStaleBlobs(maxAgeMs: number): Promise<number> {
+  const blobDir = getIpcBlobDir();
+  let entries: string[];
+  try {
+    entries = await readdir(blobDir);
+  } catch (err) {
+    // Directory may not exist yet if no blobs have been written
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return 0;
+    }
+    log.warn({ err }, 'Failed to read blob directory for sweep');
+    return 0;
+  }
+
+  const now = Date.now();
+  let deleted = 0;
+
+  for (const entry of entries) {
+    if (!entry.endsWith(BLOB_EXTENSION)) continue;
+
+    const filePath = join(blobDir, entry);
+    try {
+      const fileStat = await stat(filePath);
+      const ageMs = now - fileStat.mtimeMs;
+      if (ageMs > maxAgeMs) {
+        await unlink(filePath);
+        deleted++;
+      }
+    } catch (err) {
+      // File may have been deleted between readdir and stat/unlink
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        log.warn({ err, filePath }, 'Failed to stat/delete blob during sweep');
+      }
+    }
+  }
+
+  if (deleted > 0) {
+    log.info({ deleted, total: entries.length }, 'Swept stale blobs');
+  }
+
+  return deleted;
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -23,6 +23,7 @@ import {
 import { validateClientMessage } from './ipc-validate.js';
 import { handleMessage, type HandlerContext, type SessionCreateOptions } from './handlers.js';
 import { RunOrchestrator } from '../runtime/run-orchestrator.js';
+import { ensureBlobDir, sweepStaleBlobs } from './ipc-blob-store.js';
 
 const log = getLogger('server');
 
@@ -51,6 +52,7 @@ export class DaemonServer {
   private suppressConfigReload = false;
   private lastConfigFingerprint = '';
   private lastConfigRefreshTime = 0;
+  private blobSweepTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly CONFIG_REFRESH_INTERVAL_MS = 30_000;
 
   constructor() {
@@ -67,6 +69,13 @@ export class DaemonServer {
     const config = getConfig();
     initializeProviders(config);
     this.lastConfigFingerprint = this.configFingerprint(config);
+
+    ensureBlobDir();
+    this.blobSweepTimer = setInterval(() => {
+      sweepStaleBlobs(30 * 60 * 1000).catch((err) => {
+        log.warn({ err }, 'Blob sweep failed');
+      });
+    }, 5 * 60 * 1000);
 
     this.startFileWatchers();
 
@@ -98,6 +107,10 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
+    if (this.blobSweepTimer) {
+      clearInterval(this.blobSweepTimer);
+      this.blobSweepTimer = null;
+    }
     this.stopFileWatchers();
 
     // 1. Stop accepting new connections first. server.close() prevents new

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -53,6 +53,14 @@ export function getDataDir(): string {
 }
 
 /**
+ * Returns the IPC blob directory (~/.vellum/data/ipc-blobs).
+ * Temporary blob files for zero-copy IPC payloads live here.
+ */
+export function getIpcBlobDir(): string {
+  return join(getDataDir(), 'ipc-blobs');
+}
+
+/**
  * Returns the sandbox root directory (~/.vellum/data/sandbox).
  * Global sandbox state lives under this directory.
  */


### PR DESCRIPTION
## Summary
- Add `getIpcBlobDir()` platform helper for `~/.vellum/data/ipc-blobs/`
- Implement `ipc-blob-store.ts` with `ensureBlobDir`, `resolveBlobPath` (UUID validation + symlink protection), `readBlob` (byteLength/SHA-256/size-limit validation), `deleteBlob`, and `sweepStaleBlobs`
- Integrate blob dir creation and periodic sweep (5min interval, 30min TTL) into daemon server startup/shutdown lifecycle
- Add comprehensive test suite covering all blob store operations (24 tests)

## Test plan
- [x] All 24 blob store unit tests pass (`bun test src/__tests__/ipc-blob-store.test.ts`)
- [x] No new lint errors introduced
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
