### PR TITLE
feat(memory): calibrate relation candidate ranking

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -657,6 +657,130 @@ describe('Memory Recall Quality', () => {
       expect(recall.entityHits).toBeGreaterThan(0);
       expect(recall.injectedText).toContain('Kubernetes horizontal pod autoscaling');
     });
+
+    test('direct preference evidence outranks weak relation-expanded noise', async () => {
+      const db = getDb();
+      const now = 1_700_000_690_000;
+      insertConversation(db, 'conv-rel-rank', now);
+      insertMessage(
+        db,
+        'msg-rel-rank',
+        'conv-rel-rank',
+        'user',
+        'For Project Atlas deployments, we prefer blue-green rollout strategy.',
+        now,
+      );
+      insertSegment(
+        db,
+        'seg-rel-rank',
+        'msg-rel-rank',
+        'conv-rel-rank',
+        'user',
+        'For Project Atlas deployments, we prefer blue-green rollout strategy.',
+        now,
+      );
+
+      insertItem(db, {
+        id: 'item-direct-pref',
+        kind: 'preference',
+        subject: 'deployment preference',
+        statement: 'Project Atlas deployment preference is blue-green rollouts',
+        importance: 0.95,
+        firstSeenAt: now,
+      });
+      insertItemSource(db, 'item-direct-pref', 'msg-rel-rank', now);
+
+      db.insert(memoryEntities).values({
+        id: 'entity-atlas-rank',
+        name: 'Project Atlas',
+        type: 'project',
+        aliases: JSON.stringify(['atlas']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        mentionCount: 1,
+      }).run();
+      db.insert(memoryItemEntities).values({
+        memoryItemId: 'item-direct-pref',
+        entityId: 'entity-atlas-rank',
+      }).run();
+
+      for (let index = 1; index <= 8; index++) {
+        const entityId = `entity-noise-${index}`;
+        const itemId = `item-rel-noise-${index}`;
+        db.insert(memoryEntities).values({
+          id: entityId,
+          name: `AtlasTool${index}`,
+          type: 'tool',
+          aliases: JSON.stringify([`atlas-tool-${index}`]),
+          description: null,
+          firstSeenAt: now + index,
+          lastSeenAt: now + index,
+          mentionCount: 1,
+        }).run();
+        db.insert(memoryEntityRelations).values({
+          id: `rel-atlas-noise-${index}`,
+          sourceEntityId: 'entity-atlas-rank',
+          targetEntityId: entityId,
+          relation: 'uses',
+          evidence: `Project Atlas uses AtlasTool${index}`,
+          firstSeenAt: now + index,
+          lastSeenAt: now + index,
+        }).run();
+        insertItem(db, {
+          id: itemId,
+          kind: 'fact',
+          subject: `atlas tool ${index}`,
+          statement: `AtlasTool${index} emits generic observability metrics`,
+          importance: 0.35,
+          firstSeenAt: now + index,
+        });
+        insertItemSource(db, itemId, 'msg-rel-rank', now + index);
+        db.insert(memoryItemEntities).values({
+          memoryItemId: itemId,
+          entityId,
+        }).run();
+      }
+
+      const relationConfig = {
+        ...TEST_CONFIG,
+        memory: {
+          ...TEST_CONFIG.memory,
+          retrieval: {
+            ...TEST_CONFIG.memory.retrieval,
+            semanticTopK: 10,
+          },
+          entity: {
+            ...TEST_CONFIG.memory.entity,
+            relationRetrieval: {
+              ...TEST_CONFIG.memory.entity.relationRetrieval,
+              enabled: true,
+              maxSeedEntities: 6,
+              maxNeighborEntities: 20,
+              maxEdges: 20,
+              neighborScoreMultiplier: 0.7,
+            },
+          },
+        },
+      };
+
+      const recall = await buildMemoryRecall(
+        'atlas deployment preference strategy',
+        'conv-rel-rank',
+        relationConfig,
+      );
+      const orderedKeys = recall.topCandidates.map((candidate) => candidate.key);
+      const directIndex = orderedKeys.indexOf('item:item-direct-pref');
+      const noiseIndices = orderedKeys
+        .map((key, index) => ({ key, index }))
+        .filter(({ key }) => key.startsWith('item:item-rel-noise-'))
+        .map(({ index }) => index);
+
+      expect(directIndex).toBeGreaterThanOrEqual(0);
+      expect(noiseIndices.length).toBeGreaterThan(0);
+      expect(noiseIndices.every((index) => index > directIndex)).toBe(true);
+      expect(noiseIndices.length).toBeLessThanOrEqual(4);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -25,11 +25,19 @@ const MEMORY_RECALL_DISCLAIMER =
   'incorrectly recalled.';
 
 type CandidateType = 'segment' | 'item' | 'summary';
+type CandidateSource =
+  | 'lexical'
+  | 'semantic'
+  | 'recency'
+  | 'entity_direct'
+  | 'entity_relation'
+  | 'item_direct';
 
 interface Candidate {
   key: string;
   type: CandidateType;
   id: string;
+  source: CandidateSource;
   text: string;
   kind: string;
   confidence: number;
@@ -336,7 +344,7 @@ export async function buildMemoryRecall(
     relationNeighborEntityCount,
     relationExpandedItemCount,
   } = collected;
-  let merged = collected.merged;
+  let merged = applySourceCaps(collected.merged, config);
 
   // LLM re-ranking: send top candidates to Haiku for relevance scoring
   const rerankingConfig = config.memory.retrieval.reranking;
@@ -629,6 +637,7 @@ function lexicalSearch(query: string, limit: number, excludedMessageIds: string[
       key: `segment:${row.segment_id}`,
       type: 'segment' as CandidateType,
       id: row.segment_id,
+      source: 'lexical',
       text: row.text,
       kind: 'segment',
       confidence: 0.55,
@@ -686,6 +695,7 @@ async function semanticSearch(
         key: `item:${payload.target_id}`,
         type: 'item',
         id: payload.target_id,
+        source: 'semantic',
         text: `${item.subject}: ${item.statement}`,
         kind: item.kind,
         confidence: item.confidence,
@@ -705,6 +715,7 @@ async function semanticSearch(
         key: `summary:${payload.target_id}`,
         type: 'summary',
         id: payload.target_id,
+        source: 'semantic',
         text: payload.text.replace(/^\[[^\]]+\]\s*/, ''),
         kind: payload.kind === 'global' ? 'global_summary' : 'conversation_summary',
         confidence: 0.6,
@@ -724,6 +735,7 @@ async function semanticSearch(
         key: `segment:${payload.target_id}`,
         type: 'segment',
         id: payload.target_id,
+        source: 'semantic',
         text: payload.text,
         kind: 'segment',
         confidence: 0.55,
@@ -762,6 +774,7 @@ function recencySearch(conversationId: string, limit: number, excludedMessageIds
     key: `segment:${row.id}`,
     type: 'segment' as CandidateType,
     id: row.id,
+    source: 'recency',
     text: row.text,
     kind: 'segment',
     confidence: 0.55,
@@ -799,6 +812,7 @@ function entitySearch(
     scopeIds,
     excludedMessageIds,
     confidenceMultiplier: 1,
+    source: 'entity_direct',
   });
 
   if (!relationConfig.enabled) {
@@ -826,6 +840,7 @@ function entitySearch(
     scopeIds,
     excludedMessageIds,
     confidenceMultiplier: relationConfig.neighborScoreMultiplier,
+    source: 'entity_relation',
     excludeItemIds: directItemIds,
   });
   const relationExpandedItemCount = relationCandidates.length;
@@ -958,6 +973,7 @@ function getEntityLinkedItemCandidates(
     scopeIds?: string[];
     excludedMessageIds?: string[];
     confidenceMultiplier: number;
+    source: CandidateSource;
     excludeItemIds?: Set<string>;
   },
 ): Candidate[] {
@@ -1022,6 +1038,7 @@ function getEntityLinkedItemCandidates(
     key: `item:${item.id}`,
     type: 'item' as CandidateType,
     id: item.id,
+    source: opts.source,
     text: `${item.subject}: ${item.statement}`,
     kind: item.kind,
     confidence: item.confidence * confidenceMultiplier,
@@ -1111,7 +1128,8 @@ function mergeCandidates(
     const lastUsedAt = meta?.lastUsedAt ?? null;
     const freshnessWeight = computeFreshnessWeight(row, accessCount, lastUsedAt, freshnessConfig);
 
-    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight * freshnessWeight;
+    const sourceWeight = SOURCE_WEIGHTS[row.source] ?? 1.0;
+    row.finalScore = rrfScore * (0.5 + 0.5 * effectiveImportance) * trustWeight * freshnessWeight * sourceWeight;
   }
 
   rows.sort((a, b) => {
@@ -1122,6 +1140,47 @@ function mergeCandidates(
     return a.key.localeCompare(b.key);
   });
   return rows;
+}
+
+function applySourceCaps(candidates: Candidate[], config: AssistantConfig): Candidate[] {
+  if (candidates.length === 0) return candidates;
+  const sourceCaps = buildSourceCaps(config);
+  const counts: Partial<Record<CandidateSource, number>> = {};
+  const capped: Candidate[] = [];
+
+  for (const candidate of candidates) {
+    const cap = sourceCaps[candidate.source];
+    const current = counts[candidate.source] ?? 0;
+    if (current >= cap) continue;
+    counts[candidate.source] = current + 1;
+    capped.push(candidate);
+  }
+
+  return capped;
+}
+
+function buildSourceCaps(config: AssistantConfig): Record<CandidateSource, number> {
+  const lexicalTopK = Math.max(1, config.memory.retrieval.lexicalTopK);
+  const semanticTopK = Math.max(1, config.memory.retrieval.semanticTopK);
+  const relationLimit = Math.max(
+    3,
+    Math.floor(
+      Math.min(
+        config.memory.entity.relationRetrieval.maxNeighborEntities,
+        config.memory.entity.relationRetrieval.maxEdges,
+        semanticTopK,
+      ) * 0.4,
+    ),
+  );
+
+  return {
+    lexical: Math.max(12, lexicalTopK),
+    semantic: Math.max(8, semanticTopK),
+    recency: Math.max(6, Math.floor(semanticTopK / 2)),
+    entity_direct: Math.max(6, Math.floor(semanticTopK / 2)),
+    item_direct: Math.max(8, Math.floor(lexicalTopK / 2)),
+    entity_relation: relationLimit,
+  };
 }
 
 /** Reciprocal Rank Fusion score: sum of 1/(k+rank) across all lists. */
@@ -1190,6 +1249,15 @@ const TRUST_WEIGHTS: Record<string, number> = {
   assistant_inferred: 0.7,
 };
 const DEFAULT_TRUST_WEIGHT = 0.85;
+
+const SOURCE_WEIGHTS: Record<CandidateSource, number> = {
+  lexical: 1.0,
+  semantic: 1.0,
+  recency: 1.0,
+  entity_direct: 1.0,
+  item_direct: 0.95,
+  entity_relation: 0.72,
+};
 
 const MS_PER_DAY = 86_400_000;
 
@@ -1735,6 +1803,7 @@ function directItemSearch(query: string, limit: number, scopeIds?: string[]): Ca
     key: `item:${row.id}`,
     type: 'item' as CandidateType,
     id: row.id,
+    source: 'item_direct',
     text: `${row.subject}: ${row.statement}`,
     kind: row.kind,
     confidence: row.confidence,


### PR DESCRIPTION
## Summary
- add explicit retrieval source labels for candidates and apply source-aware weighting in merge scoring
- cap candidates per source before reranking/trim to prevent relation-expanded flooding
- add a regression fixture that verifies direct preference evidence outranks weak relation-expanded noise while relation expansion remains active

## Verification
- export PATH="$HOME/.bun/bin:$PATH"; cd assistant && bun test src/__tests__/memory-recall-quality.test.ts

All assertions passed; Bun then panicked after completion (runtime issue in this environment).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
