### PR TITLE
feat(system-prompt): add dynamic skill authoring workflow guidance

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TEST_DIR = join(tmpdir(), `vellum-dyn-skill-test-${crypto.randomUUID()}`);
+
+import { mock } from 'bun:test';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getPlatformName: () => process.platform,
+  getClipboardCommand: () => null,
+  removeSocketFile: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+const { buildSystemPrompt } = await import('../config/system-prompt.js');
+
+describe('Dynamic Skill Authoring Workflow prompt section', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  test('buildSystemPrompt includes dynamic skill workflow section', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Dynamic Skill Authoring Workflow');
+  });
+
+  test('workflow section mentions all three new tools', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('evaluate_typescript_code');
+    expect(result).toContain('scaffold_managed_skill');
+    expect(result).toContain('delete_managed_skill');
+  });
+
+  test('workflow section includes user confirmation warning', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('explicit user confirmation');
+  });
+
+  test('workflow section includes retry limit guidance', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('3 attempts');
+  });
+
+  test('workflow section includes session eviction note', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('recreated session');
+  });
+
+  test('prompt still includes available skills catalog when skills exist', () => {
+    const skillsDir = join(TEST_DIR, 'skills');
+    mkdirSync(join(skillsDir, 'test-skill'), { recursive: true });
+    writeFileSync(
+      join(skillsDir, 'test-skill', 'SKILL.md'),
+      '---\nname: "Test Skill"\ndescription: "For testing."\n---\n\nDo testing.\n',
+    );
+    writeFileSync(join(skillsDir, 'SKILLS.md'), '- test-skill\n');
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('id="test-skill"');
+    expect(result).toContain('## Dynamic Skill Authoring Workflow');
+  });
+
+  test('prompt is additive with IDENTITY/SOUL/USER files', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'Identity here');
+    writeFileSync(join(TEST_DIR, 'SOUL.md'), 'Soul here');
+    writeFileSync(join(TEST_DIR, 'USER.md'), 'User here');
+
+    const result = buildSystemPrompt();
+    expect(result).toContain('Identity here');
+    expect(result).toContain('Soul here');
+    expect(result).toContain('User here');
+    expect(result).toContain('## Dynamic Skill Authoring Workflow');
+  });
+
+  test('workflow section includes skill_load instruction', () => {
+    writeFileSync(join(TEST_DIR, 'IDENTITY.md'), 'I am Vellum.');
+    const result = buildSystemPrompt();
+    expect(result).toContain('skill_load');
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -139,11 +139,35 @@ function readPromptFile(path: string): string | null {
 
 function appendSkillsCatalog(basePrompt: string): string {
   const skills = loadSkillCatalog();
-  if (skills.length === 0) return basePrompt;
+
+  const sections: string[] = [basePrompt];
 
   const catalog = formatSkillsCatalog(skills);
-  if (!catalog) return basePrompt;
-  return `${basePrompt}\n\n${catalog}`;
+  if (catalog) sections.push(catalog);
+
+  sections.push(buildDynamicSkillWorkflowSection());
+
+  return sections.join('\n\n');
+}
+
+function buildDynamicSkillWorkflowSection(): string {
+  return [
+    '## Dynamic Skill Authoring Workflow',
+    '',
+    'When the user requests a capability that no existing tool or skill can satisfy, follow this exact procedure:',
+    '',
+    '1. **Validate the gap.** Confirm no existing tool or installed skill covers the need.',
+    '2. **Draft a TypeScript snippet.** Write a self-contained snippet that exports a `default` or `run` function with signature `(input: unknown) => unknown | Promise<unknown>`.',
+    '3. **Test with `evaluate_typescript_code`.** Call the tool to run the snippet in a sandbox. Iterate until it passes.',
+    '4. **Persist with `scaffold_managed_skill`.** Only after successful evaluation and explicit user consent, call `scaffold_managed_skill` to write the skill to `~/.vellum/skills/<id>/`.',
+    '5. **Load and use.** Call `skill_load` with the new skill ID before invoking the skill-driven flow.',
+    '',
+    'Important constraints:',
+    '- **Never persist or delete skills without explicit user confirmation.** Both operations require user approval.',
+    '- If evaluation fails after 3 attempts, summarize the failure and ask the user for guidance instead of continuing to retry.',
+    '- After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.',
+    '- To remove a managed skill, use `delete_managed_skill`.',
+  ].join('\n');
 }
 
 function escapeXml(str: string): string {


### PR DESCRIPTION
## Summary
- Adds a `## Dynamic Skill Authoring Workflow` section to the system prompt that guides the model through the end-to-end flow: validate gap → draft snippet → test with `evaluate_typescript_code` → persist with `scaffold_managed_skill` → load via `skill_load`
- Includes guardrails: explicit user confirmation required, 3-attempt retry limit, session eviction awareness
- Section is always appended (after skills catalog if present), ensuring the model always knows how to author new skills

## Test plan
- [x] 8 new tests in `dynamic-skill-workflow-prompt.test.ts` covering section presence, tool mentions, constraints, coexistence with skills catalog, and additivity with IDENTITY/SOUL/USER files
- [x] All 40 existing `system-prompt.test.ts` tests continue to pass
- [x] Full regression suite verified (pre-existing failures only)

Part 4 of the DYNAMIC_TOOLS.md plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
