### PR TITLE
feat(ipc): add daemon blob probe handler

### DIFF
--- a/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
+++ b/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash, randomUUID, randomBytes } from 'node:crypto';
+import * as net from 'node:net';
+
+const testDir = mkdtempSync(join(tmpdir(), 'handlers-blob-probe-test-'));
+const blobDir = join(testDir, 'ipc-blobs');
+
+// Mock platform module so blob store writes to temp dir
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => blobDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+// Mock logger to suppress output during tests
+mock.module('../util/logger.js', () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { handleMessage, type HandlerContext } from '../daemon/handlers.js';
+import type { IpcBlobProbe, ServerMessage } from '../daemon/ipc-contract.js';
+
+/** Write a probe file to the test blob directory. */
+function writeProbeFile(probeId: string, content: Buffer): string {
+  const filePath = join(blobDir, `${probeId}.blob`);
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+/** Create a minimal HandlerContext that captures sent messages. */
+function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new Map(),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => { sent.push(msg); },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => { throw new Error('not implemented'); },
+  };
+  return { ctx, sent };
+}
+
+describe('handleIpcBlobProbe', () => {
+  beforeEach(() => {
+    if (existsSync(blobDir)) {
+      rmSync(blobDir, { recursive: true });
+    }
+    mkdirSync(blobDir, { recursive: true });
+  });
+
+  test('success: probe file exists and hash matches', () => {
+    const probeId = randomUUID();
+    const nonce = randomBytes(32);
+    const nonceSha256 = createHash('sha256').update(nonce).digest('hex');
+
+    writeProbeFile(probeId, nonce);
+
+    const msg: IpcBlobProbe = {
+      type: 'ipc_blob_probe',
+      probeId,
+      nonceSha256,
+    };
+
+    const { ctx, sent } = createTestContext();
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const result = sent[0] as { type: string; probeId: string; ok: boolean; observedNonceSha256?: string };
+    expect(result.type).toBe('ipc_blob_probe_result');
+    expect(result.probeId).toBe(probeId);
+    expect(result.ok).toBe(true);
+    expect(result.observedNonceSha256).toBe(nonceSha256);
+
+    // Probe file should be cleaned up
+    expect(existsSync(join(blobDir, `${probeId}.blob`))).toBe(false);
+  });
+
+  test('failure: missing probe file', () => {
+    const probeId = randomUUID();
+    const nonceSha256 = createHash('sha256').update('anything').digest('hex');
+
+    const msg: IpcBlobProbe = {
+      type: 'ipc_blob_probe',
+      probeId,
+      nonceSha256,
+    };
+
+    const { ctx, sent } = createTestContext();
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const result = sent[0] as { type: string; probeId: string; ok: boolean; reason?: string };
+    expect(result.type).toBe('ipc_blob_probe_result');
+    expect(result.probeId).toBe(probeId);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('missing_probe_file');
+  });
+
+  test('failure: hash mismatch', () => {
+    const probeId = randomUUID();
+    const nonce = randomBytes(32);
+    const correctHash = createHash('sha256').update(nonce).digest('hex');
+    // Compute a wrong hash by hashing different content
+    const wrongHash = createHash('sha256').update('wrong-nonce-data').digest('hex');
+
+    writeProbeFile(probeId, nonce);
+
+    const msg: IpcBlobProbe = {
+      type: 'ipc_blob_probe',
+      probeId,
+      nonceSha256: wrongHash,
+    };
+
+    const { ctx, sent } = createTestContext();
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const result = sent[0] as { type: string; probeId: string; ok: boolean; reason?: string; observedNonceSha256?: string };
+    expect(result.type).toBe('ipc_blob_probe_result');
+    expect(result.probeId).toBe(probeId);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('hash_mismatch');
+    expect(result.observedNonceSha256).toBe(correctHash);
+
+    // Probe file should still be cleaned up even on mismatch
+    expect(existsSync(join(blobDir, `${probeId}.blob`))).toBe(false);
+  });
+
+  test('failure: invalid probe id', () => {
+    const msg: IpcBlobProbe = {
+      type: 'ipc_blob_probe',
+      probeId: '../../../etc/passwd',
+      nonceSha256: createHash('sha256').update('x').digest('hex'),
+    };
+
+    const { ctx, sent } = createTestContext();
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const result = sent[0] as { type: string; probeId: string; ok: boolean; reason?: string };
+    expect(result.type).toBe('ipc_blob_probe_result');
+    expect(result.probeId).toBe('../../../etc/passwd');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_probe_id');
+  });
+});

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -45,7 +45,9 @@ import type {
   BundleAppRequest,
   SharedAppDeleteRequest,
   UiSurfaceShow,
+  IpcBlobProbe,
 } from './ipc-protocol.js';
+import { createHash } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { existsSync, rmSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -62,6 +64,7 @@ import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { removeSkillsIndexEntry } from '../skills/managed-store.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
+import { resolveBlobPath, deleteBlob, isValidBlobId } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
 import { getAttachmentsForMessageUnscoped } from '../memory/attachments-store.js';
@@ -400,6 +403,7 @@ const handlers: DispatchMap = {
     // satisfy the exhaustive dispatch map; signing is invoked via SigningCallback.
   },
   ping: (_msg, socket, ctx) => { ctx.send(socket, { type: 'pong' }); },
+  ipc_blob_probe: handleIpcBlobProbe,
   ui_surface_action: (msg, _socket, ctx) => {
     const cuSession = ctx.cuSessions.get(msg.sessionId);
     if (cuSession) {
@@ -1734,6 +1738,73 @@ async function handleBundleApp(
     log.error({ err, appId: msg.appId }, 'Failed to bundle app');
     ctx.send(socket, { type: 'error', message: `Failed to bundle app: ${message}` });
   }
+}
+
+// ─── IPC blob probe handler ─────────────────────────────────────────────────
+
+function handleIpcBlobProbe(
+  msg: IpcBlobProbe,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  if (!isValidBlobId(msg.probeId)) {
+    ctx.send(socket, {
+      type: 'ipc_blob_probe_result',
+      probeId: msg.probeId,
+      ok: false,
+      reason: 'invalid_probe_id',
+    });
+    return;
+  }
+
+  let filePath: string;
+  try {
+    filePath = resolveBlobPath(msg.probeId);
+  } catch {
+    ctx.send(socket, {
+      type: 'ipc_blob_probe_result',
+      probeId: msg.probeId,
+      ok: false,
+      reason: 'invalid_probe_id',
+    });
+    return;
+  }
+
+  let content: Buffer;
+  try {
+    content = readFileSync(filePath);
+  } catch {
+    ctx.send(socket, {
+      type: 'ipc_blob_probe_result',
+      probeId: msg.probeId,
+      ok: false,
+      reason: 'missing_probe_file',
+    });
+    return;
+  }
+
+  const observedHash = createHash('sha256').update(content).digest('hex');
+
+  // Best-effort cleanup regardless of match outcome
+  deleteBlob(msg.probeId);
+
+  if (observedHash !== msg.nonceSha256) {
+    ctx.send(socket, {
+      type: 'ipc_blob_probe_result',
+      probeId: msg.probeId,
+      ok: false,
+      observedNonceSha256: observedHash,
+      reason: 'hash_mismatch',
+    });
+    return;
+  }
+
+  ctx.send(socket, {
+    type: 'ipc_blob_probe_result',
+    probeId: msg.probeId,
+    ok: true,
+    observedNonceSha256: observedHash,
+  });
 }
 
 // ─── Computer-use handlers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `handleIpcBlobProbe` handler in `handlers.ts` that reads a client-written probe file, computes SHA-256, compares it to the client's declared hash, and replies with `ipc_blob_probe_result`
- Wire `ipc_blob_probe` into the dispatch map alongside other handlers
- Add tests covering success path, missing probe file, hash mismatch, and invalid probe ID

## Context
PR 4 of the ZERO_COPY plan. Enables clients to verify they share the same blob directory with the daemon before using zero-copy IPC blob transport. The `ipc_blob_probe` / `ipc_blob_probe_result` message types and validation were added in PR 2; the blob store utilities (`resolveBlobPath`, `deleteBlob`) were added in PR 3.

## Test plan
- [x] `bun test src/__tests__/handlers-ipc-blob-probe.test.ts` — 4 tests pass
- [x] Lint passes (no new errors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
