### PR TITLE
feat(macos): open main window at full screen size

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -80,17 +80,9 @@ final class MainWindow {
         let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let windowWidth = min(1100.0, screenFrame.width * 0.75)
-        let windowHeight = min(750.0, screenFrame.height * 0.75)
-        let windowRect = NSRect(
-            x: screenFrame.midX - windowWidth / 2,
-            y: screenFrame.midY - windowHeight / 2,
-            width: windowWidth,
-            height: windowHeight
-        )
 
         let window = NSWindow(
-            contentRect: windowRect,
+            contentRect: screenFrame,
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -102,6 +94,7 @@ final class MainWindow {
         window.backgroundColor = NSColor(VColor.background)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
+        window.setFrame(screenFrame, display: false)
 
         configureTrafficLightPadding(window)
 


### PR DESCRIPTION
## Summary
- Opens the main window filling the entire visible screen area on launch, instead of a 75%-capped centered window
- Simplifies window initialization by using `screenFrame` directly and calling `setFrame` after configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
