### PR TITLE
docs: add dynamic skill authoring to README, ARCHITECTURE, and lifecycle test

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -932,6 +932,76 @@ Key behaviors:
 
 ---
 
+## Dynamic Skill Authoring — Tool Flow
+
+The assistant can author, test, and persist new skills at runtime through a three-tool workflow. All operations target `~/.vellum/skills/` (managed skills directory) and require explicit user confirmation.
+
+```mermaid
+graph TB
+    subgraph "1. Evaluate (Sandbox)"
+        SNIPPET["Model drafts<br/>TypeScript snippet"]
+        EVAL_TOOL["evaluate_typescript_code<br/>───────────────<br/>RiskLevel: High<br/>Always sandboxed"]
+        TEMP["Temp dir:<br/>workingDir/.vellum-eval/&lt;uuid&gt;"]
+        WRAPPER["Wrapper runner<br/>imports snippet, calls<br/>default() or run()"]
+        SANDBOX["wrapCommand()<br/>forced sandbox=true"]
+        RESULT["JSON result:<br/>ok, exitCode, result,<br/>stdout, stderr,<br/>durationMs, timeout"]
+    end
+
+    subgraph "2. Persist (Filesystem)"
+        SCAFFOLD["scaffold_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
+        MANAGED_STORE["managed-store.ts<br/>───────────────<br/>validateManagedSkillId()<br/>buildSkillMarkdown()<br/>createManagedSkill()<br/>upsertSkillsIndexEntry()"]
+        SKILL_DIR["~/.vellum/skills/&lt;id&gt;/<br/>SKILL.md (frontmatter + body)"]
+        INDEX["~/.vellum/skills/<br/>SKILLS.md (index)"]
+    end
+
+    subgraph "3. Load & Use"
+        SKILL_LOAD["skill_load tool<br/>resolves from disk"]
+        SESSION["Agent session<br/>uses skill instructions"]
+    end
+
+    subgraph "4. Delete"
+        DELETE["delete_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
+        RM_DIR["rmSync skill directory"]
+        RM_INDEX["removeSkillsIndexEntry()"]
+    end
+
+    subgraph "File Watcher"
+        WATCHER["Skills directory watcher<br/>detects changes"]
+        EVICT["Session eviction<br/>+ recreation"]
+    end
+
+    SNIPPET --> EVAL_TOOL
+    EVAL_TOOL --> TEMP
+    TEMP --> WRAPPER
+    WRAPPER --> SANDBOX
+    SANDBOX --> RESULT
+    RESULT -->|"ok=true + user consent"| SCAFFOLD
+
+    SCAFFOLD --> MANAGED_STORE
+    MANAGED_STORE --> SKILL_DIR
+    MANAGED_STORE --> INDEX
+
+    SKILL_DIR --> WATCHER
+    INDEX --> WATCHER
+    WATCHER --> EVICT
+
+    SKILL_DIR --> SKILL_LOAD
+    SKILL_LOAD --> SESSION
+
+    DELETE --> RM_DIR
+    DELETE --> RM_INDEX
+    RM_DIR --> WATCHER
+```
+
+**Key design decisions:**
+- `evaluate_typescript_code` always forces `sandbox.enabled = true` regardless of global config.
+- Snippet contract: must export `default` or `run` with signature `(input: unknown) => unknown | Promise<unknown>`.
+- Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` or `SKILLS.md` files.
+- After persist or delete, the file watcher triggers session eviction; the next turn runs in a fresh session. The model's system prompt instructs it to continue normally.
+- macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
+
+---
+
 ## Opportunistic Message Queue — Handoff Flow
 
 When the daemon is busy generating a response, the client can continue sending messages. These are queued (FIFO, max 10) and drained automatically at safe checkpoints in the tool loop, not only at full completion.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,34 @@ Host tools (`host_bash`, `host_file_read`, `host_file_write`, `host_file_edit`) 
 
 Run `vellum doctor` for a full diagnostic check including sandbox backend status.
 
+## Dynamic Skill Authoring
+
+The assistant can create, test, and persist new skills at runtime. This is useful when no existing tool or skill covers a user's need.
+
+### Workflow
+
+1. **Evaluate**: The assistant drafts a TypeScript snippet and tests it in a sandbox via `evaluate_typescript_code`. Iterates until it passes.
+2. **Persist**: After successful evaluation and explicit user consent, the assistant calls `scaffold_managed_skill` to write the skill to `~/.vellum/skills/<id>/`.
+3. **Load**: The assistant calls `skill_load` with the new skill ID to load its instructions.
+4. **Delete**: To remove a managed skill, use `delete_managed_skill`.
+
+### Tools
+
+| Tool | Risk Level | Description |
+|------|-----------|-------------|
+| `evaluate_typescript_code` | High | Run a TypeScript snippet in a sandbox. Returns structured JSON with `ok`, `exitCode`, `result`, `stdout`, `stderr`. |
+| `scaffold_managed_skill` | High | Write a managed skill to `~/.vellum/skills/<id>/`. Creates `SKILL.md` with frontmatter and updates `SKILLS.md` index. |
+| `delete_managed_skill` | High | Remove a managed skill directory and its index entry. |
+
+All three tools require explicit user approval before execution (Risk Level = High).
+
+### Constraints
+
+- Snippets must export a `default` or `run` function with signature `(input: unknown) => unknown | Promise<unknown>`.
+- If evaluation fails after 3 attempts, the assistant asks for user guidance instead of retrying.
+- After a skill is written or deleted, the file watcher triggers session eviction. The next turn runs in a fresh session.
+- Managed skills appear in the macOS Settings UI with Inspect and Delete controls.
+
 ## Assistant Attachments
 
 The assistant can attach files and images to its replies. Attachments flow through three delivery channels:

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+let TEST_DIR = '';
+
+mock.module('../util/platform.js', () => ({
+  getRootDir: () => TEST_DIR,
+  getDataDir: () => TEST_DIR,
+  ensureDataDir: () => {},
+  getSocketPath: () => join(TEST_DIR, 'vellum.sock'),
+  getPidPath: () => join(TEST_DIR, 'vellum.pid'),
+  getDbPath: () => join(TEST_DIR, 'data', 'assistant.db'),
+  getLogPath: () => join(TEST_DIR, 'logs', 'vellum.log'),
+  getHistoryPath: () => join(TEST_DIR, 'history'),
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getPlatformName: () => process.platform,
+  getClipboardCommand: () => null,
+  removeSocketFile: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { ScaffoldManagedSkillTool } from '../tools/skills/scaffold-managed.js';
+import { DeleteManagedSkillTool } from '../tools/skills/delete-managed.js';
+import { loadSkillCatalog } from '../config/skills.js';
+import { buildSystemPrompt } from '../config/system-prompt.js';
+import type { ToolContext } from '../tools/types.js';
+
+const scaffoldTool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
+const deleteTool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: '/tmp',
+    sessionId: 'test-session',
+    conversationId: 'test-conversation',
+  };
+}
+
+beforeEach(() => {
+  TEST_DIR = mkdtempSync(join(tmpdir(), 'lifecycle-test-'));
+  mkdirSync(join(TEST_DIR, 'skills'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('managed skill lifecycle: scaffold → catalog → prompt → delete', () => {
+  test('full lifecycle: create skill, verify in catalog and prompt, then delete', async () => {
+    // Step 1: Scaffold a managed skill
+    const scaffoldResult = await scaffoldTool.execute({
+      skill_id: 'lifecycle-test',
+      name: 'Lifecycle Test',
+      description: 'Integration test skill.',
+      body_markdown: 'Run the lifecycle test procedure.',
+      emoji: '🧪',
+    }, makeContext());
+
+    expect(scaffoldResult.isError).not.toBe(true);
+    const scaffoldData = JSON.parse(scaffoldResult.content as string);
+    expect(scaffoldData.created).toBe(true);
+
+    // Step 2: Verify SKILL.md was written
+    const skillMdPath = join(TEST_DIR, 'skills', 'lifecycle-test', 'SKILL.md');
+    expect(existsSync(skillMdPath)).toBe(true);
+    const skillContent = readFileSync(skillMdPath, 'utf-8');
+    expect(skillContent).toContain('name: "Lifecycle Test"');
+    expect(skillContent).toContain('description: "Integration test skill."');
+    expect(skillContent).toContain('Run the lifecycle test procedure.');
+
+    // Step 3: Verify skill appears in catalog
+    const catalog = loadSkillCatalog();
+    const found = catalog.find(s => s.id === 'lifecycle-test');
+    expect(found).toBeDefined();
+    expect(found!.name).toBe('Lifecycle Test');
+    expect(found!.description).toBe('Integration test skill.');
+
+    // Step 4: Verify skill appears in system prompt
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('lifecycle-test');
+    expect(prompt).toContain('Lifecycle Test');
+    expect(prompt).toContain('## Dynamic Skill Authoring Workflow');
+
+    // Step 5: Delete the skill
+    const deleteResult = await deleteTool.execute({
+      skill_id: 'lifecycle-test',
+    }, makeContext());
+
+    expect(deleteResult.isError).not.toBe(true);
+    const deleteData = JSON.parse(deleteResult.content as string);
+    expect(deleteData.deleted).toBe(true);
+
+    // Step 6: Verify skill is gone from filesystem
+    expect(existsSync(skillMdPath)).toBe(false);
+
+    // Step 7: Verify skill no longer in catalog
+    const catalogAfter = loadSkillCatalog();
+    expect(catalogAfter.find(s => s.id === 'lifecycle-test')).toBeUndefined();
+
+    // Step 8: Verify SKILLS.md index no longer has the entry
+    const indexPath = join(TEST_DIR, 'skills', 'SKILLS.md');
+    if (existsSync(indexPath)) {
+      const indexContent = readFileSync(indexPath, 'utf-8');
+      expect(indexContent).not.toContain('lifecycle-test');
+    }
+  });
+
+  test('scaffold with overwrite replaces existing skill', async () => {
+    const ctx = makeContext();
+
+    // Create initial skill
+    await scaffoldTool.execute({
+      skill_id: 'overwrite-test',
+      name: 'V1',
+      description: 'Version 1.',
+      body_markdown: 'Original body.',
+    }, ctx);
+
+    // Overwrite with updated content
+    const result = await scaffoldTool.execute({
+      skill_id: 'overwrite-test',
+      name: 'V2',
+      description: 'Version 2.',
+      body_markdown: 'Updated body.',
+      overwrite: true,
+    }, ctx);
+
+    expect(result.isError).not.toBe(true);
+
+    const skillContent = readFileSync(
+      join(TEST_DIR, 'skills', 'overwrite-test', 'SKILL.md'), 'utf-8'
+    );
+    expect(skillContent).toContain('name: "V2"');
+    expect(skillContent).toContain('Updated body.');
+    expect(skillContent).not.toContain('Original body.');
+
+    // Index should still have exactly one entry
+    const indexContent = readFileSync(
+      join(TEST_DIR, 'skills', 'SKILLS.md'), 'utf-8'
+    );
+    const matches = indexContent.match(/overwrite-test/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  test('delete non-existent skill returns error', async () => {
+    const result = await deleteTool.execute({
+      skill_id: 'does-not-exist',
+    }, makeContext());
+
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **README.md**: Added "Dynamic Skill Authoring" section documenting the three new tools (`evaluate_typescript_code`, `scaffold_managed_skill`, `delete_managed_skill`), the end-to-end workflow, and key constraints
- **ARCHITECTURE.md**: Added "Dynamic Skill Authoring — Tool Flow" section with a Mermaid diagram showing the evaluate → scaffold → load → delete lifecycle, file watcher eviction, and managed-store internals
- **Integration test**: Added `managed-skill-lifecycle.test.ts` covering the full scaffold → catalog → prompt → delete path and overwrite behavior (3 tests, 23 assertions)

## Test plan
- [x] All 70 related tests pass (managed-store, scaffold, delete, system-prompt, dynamic-skill-workflow)
- [x] 3 new lifecycle integration tests pass
- [x] Swift build verified (pre-existing IPCMessages.swift errors only)

Part 6 (final) of the DYNAMIC_TOOLS.md plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
