### PR TITLE
feat(ipc): add Swift blob writer and probe client state

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -48,6 +48,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     @Published public var isConnected: Bool = false
 
+    /// Whether blob transport has been verified for this connection.
+    /// Resets to `false` on disconnect/reconnect. Only set to `true` after
+    /// a successful probe round-trip on macOS local-socket connections.
+    @Published public private(set) var isBlobTransportAvailable: Bool = false
+
     /// The runtime HTTP server port, populated via `daemon_status` on connect.
     /// `nil` means the HTTP server is not running.
     @Published public var httpPort: Int?
@@ -185,6 +190,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Pong timeout task handle.
     private var pongTimeoutTask: Task<Void, Never>?
 
+    /// Blob probe task handle — fire-and-forget after connect on macOS.
+    private var blobProbeTask: Task<Void, Never>?
+
+    /// The probe ID we're currently waiting for a response to.
+    /// Used to match ipc_blob_probe_result to the outstanding probe.
+    private var pendingProbeId: String?
+
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -214,6 +226,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         reconnectTask?.cancel()
         pingTask?.cancel()
         pongTimeoutTask?.cancel()
+        blobProbeTask?.cancel()
         connection?.cancel()
         for continuation in subscribers.values {
             continuation.finish()
@@ -315,6 +328,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                             self.reconnectDelay = 1.0
                             self.startReceiveLoop()
                             self.startPingTimer()
+                            #if os(macOS)
+                            self.runBlobProbe()
+                            #endif
                             checkedContinuation.resume()
                         }
 
@@ -634,6 +650,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         reconnectTask?.cancel()
         reconnectTask = nil
         stopPingTimer()
+        blobProbeTask?.cancel()
+        blobProbeTask = nil
+        pendingProbeId = nil
+        isBlobTransportAvailable = false
 
         if let conn = connection {
             conn.stateUpdateHandler = nil
@@ -732,6 +752,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             httpPort = status.httpPort.flatMap { Int(exactly: $0) }
         }
 
+        // Handle blob probe result internally.
+        if case .ipcBlobProbeResult(let result) = message {
+            handleBlobProbeResult(result)
+        }
+
         // Forward surface messages to registered callbacks.
         switch message {
         case .uiSurfaceShow(let msg):
@@ -806,6 +831,61 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // Broadcast to all subscribers.
         for continuation in subscribers.values {
             continuation.yield(message)
+        }
+    }
+
+    // MARK: - Blob Probe (macOS only)
+
+    #if os(macOS)
+    /// Initiate a blob probe after connecting. Writes a nonce file to the shared
+    /// blob directory and sends a probe message to the daemon. The daemon reads
+    /// the file, hashes it, and responds. If the hashes match, blob transport
+    /// is confirmed available for this connection.
+    private func runBlobProbe() {
+        blobProbeTask?.cancel()
+        isBlobTransportAvailable = false
+
+        blobProbeTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let store = IpcBlobStore.shared
+            store.ensureDirectory()
+
+            guard let probe = store.writeProbeFile() else {
+                log.warning("Blob probe: failed to write probe file")
+                return
+            }
+
+            self.pendingProbeId = probe.probeId
+
+            do {
+                try self.send(IpcBlobProbeMessage(
+                    probeId: probe.probeId,
+                    nonceSha256: probe.nonceSha256
+                ))
+                log.info("Blob probe sent: \(probe.probeId)")
+            } catch {
+                log.warning("Blob probe: failed to send probe message: \(error.localizedDescription)")
+                self.pendingProbeId = nil
+            }
+        }
+    }
+    #endif
+
+    /// Process a blob probe result from the daemon.
+    private func handleBlobProbeResult(_ result: IpcBlobProbeResultMessage) {
+        guard result.probeId == pendingProbeId else {
+            log.warning("Blob probe: ignoring stale result for \(result.probeId) (expected \(self.pendingProbeId ?? "nil"))")
+            return
+        }
+        pendingProbeId = nil
+
+        if result.ok {
+            isBlobTransportAvailable = true
+            log.info("Blob transport verified for this connection")
+        } else {
+            isBlobTransportAvailable = false
+            log.warning("Blob probe failed: \(result.reason ?? "unknown")")
         }
     }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -545,10 +545,10 @@ extension IPCMemoryRecalled {
         semanticHits: Double,
         recencyHits: Double,
         entityHits: Double,
-        relationSeedEntityCount: Double? = nil,
-        relationTraversedEdgeCount: Double? = nil,
-        relationNeighborEntityCount: Double? = nil,
-        relationExpandedItemCount: Double? = nil,
+        relationSeedEntityCount: Int? = nil,
+        relationTraversedEdgeCount: Int? = nil,
+        relationNeighborEntityCount: Int? = nil,
+        relationExpandedItemCount: Int? = nil,
         mergedCount: Int,
         selectedCount: Int,
         rerankApplied: Bool,
@@ -884,6 +884,16 @@ public typealias BundleAppResponseMessage = IPCBundleAppResponse
 /// Request from daemon to sign a bundle payload.
 /// Backed by generated `IPCSignBundlePayloadRequest`.
 public typealias SignBundlePayloadMessage = IPCSignBundlePayloadRequest
+
+/// Blob probe request sent after connecting to verify filesystem reachability.
+/// Backed by generated `IPCIpcBlobProbe`.
+public typealias IpcBlobProbeMessage = IPCIpcBlobProbe
+
+extension IPCIpcBlobProbe {
+    public init(probeId: String, nonceSha256: String) {
+        self.init(type: "ipc_blob_probe", probeId: probeId, nonceSha256: nonceSha256)
+    }
+}
 
 /// Result from a blob probe verification.
 /// Backed by generated `IPCIpcBlobProbeResult`.

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import CryptoKit
+import os
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "IpcBlobStore")
+
+/// Manages local blob files for zero-copy IPC transport.
+/// Blobs are written atomically (temp file + rename) to ~/.vellum/data/ipc-blobs/.
+public final class IpcBlobStore: Sendable {
+    public static let shared = IpcBlobStore()
+
+    private let blobDir: URL
+
+    private init() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        blobDir = home.appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+    }
+
+    /// Ensure the blob directory exists.
+    public func ensureDirectory() {
+        try? FileManager.default.createDirectory(at: blobDir, withIntermediateDirectories: true)
+    }
+
+    /// Write data atomically to a blob file and return a ref describing the blob.
+    /// Uses temp file + rename to guarantee readers never see partial writes.
+    public func writeBlob(data: Data, kind: String, encoding: String) -> IPCIpcBlobRef? {
+        let id = UUID().uuidString.lowercased()
+        let targetURL = blobDir.appendingPathComponent("\(id).blob")
+        let tempURL = blobDir.appendingPathComponent("\(id).tmp")
+
+        do {
+            try data.write(to: tempURL)
+            try FileManager.default.moveItem(at: tempURL, to: targetURL)
+
+            let sha256 = Self.computeSHA256(data: data)
+
+            return IPCIpcBlobRef(
+                id: id,
+                kind: kind,
+                encoding: encoding,
+                byteLength: data.count,
+                sha256: sha256
+            )
+        } catch {
+            log.error("Failed to write blob \(id): \(error.localizedDescription)")
+            try? FileManager.default.removeItem(at: tempURL)
+            return nil
+        }
+    }
+
+    /// Write a probe file containing random nonce bytes and return the probe ID
+    /// and SHA-256 of the nonce. The daemon reads the file, hashes it, and replies
+    /// with its observed hash so the client can verify filesystem-level reachability.
+    public func writeProbeFile() -> (probeId: String, nonceSha256: String)? {
+        let probeId = UUID().uuidString.lowercased()
+        let targetURL = blobDir.appendingPathComponent("\(probeId).blob")
+
+        var nonce = Data(count: 32)
+        let result = nonce.withUnsafeMutableBytes { ptr in
+            SecRandomCopyBytes(kSecRandomDefault, 32, ptr.baseAddress!)
+        }
+        guard result == errSecSuccess else {
+            log.error("Failed to generate random nonce for probe")
+            return nil
+        }
+
+        do {
+            try nonce.write(to: targetURL)
+            let sha256 = Self.computeSHA256(data: nonce)
+            return (probeId: probeId, nonceSha256: sha256)
+        } catch {
+            log.error("Failed to write probe file \(probeId): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private static func computeSHA256(data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IpcBlobStore` for atomic blob writes (temp file + rename) and SHA-256 hashing via CryptoKit
- Add connection-scoped blob transport probing to `DaemonClient`: after connecting on macOS, a nonce file is written, a probe message is sent, and `isBlobTransportAvailable` is set to true only when the daemon confirms hash match
- The flag resets to false on disconnect
- Fix pre-existing type mismatch in `IPCMemoryRecalled` convenience init

## Test plan
- [x] Swift builds successfully
- [x] No new lint errors on TS side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
