### PR TITLE
fix(chat): align thinking indicator with message content

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -260,7 +260,7 @@ struct ChatView: View {
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: VSpacing.lg) {
+                LazyVStack(alignment: .leading, spacing: VSpacing.lg) {
                     ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
                         if shouldShowTimestamp(at: index) {
                             TimestampDivider(date: message.timestamp)


### PR DESCRIPTION
## Summary
- The chat message list's `LazyVStack` used default `.center` alignment, causing the "Thinking ●●●" indicator to render at a slightly different horizontal position than tool call chips and message bubbles above it
- Explicitly set `.leading` alignment on the `LazyVStack` to ensure all chat items share the same left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
