### PR TITLE
feat(ipc): screenshot blob producer integration

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -446,8 +446,23 @@ final class ComputerUseSession: ObservableObject {
         previousElements = elements
         previousFlatElements = flatElements
 
-        // Encode screenshot as base64
-        let screenshotBase64 = screenshot?.base64EncodedString()
+        // Transport screenshot via blob or inline base64
+        var screenshotBase64: String?
+        var screenshotBlobRef: IPCIpcBlobRef?
+
+        if let screenshotData = screenshot {
+            if daemonClient.isBlobTransportAvailable {
+                if let ref = IpcBlobStore.shared.writeBlob(data: screenshotData, kind: "screenshot_jpeg", encoding: "binary") {
+                    screenshotBlobRef = ref
+                    log.info("[\(stepNumber)] Screenshot written as blob (\(screenshotData.count) bytes, id=\(ref.id))")
+                } else {
+                    log.warning("[\(stepNumber)] Blob write failed for screenshot, falling back to inline base64")
+                    screenshotBase64 = screenshotData.base64EncodedString()
+                }
+            } else {
+                screenshotBase64 = screenshotData.base64EncodedString()
+            }
+        }
 
         let observation = CuObservationMessage(
             sessionId: id,
@@ -456,18 +471,20 @@ final class ComputerUseSession: ObservableObject {
             secondaryWindows: secondaryWindowsText,
             screenshot: screenshotBase64,
             executionResult: executionResult,
-            executionError: executionError
+            executionError: executionError,
+            screenshotBlob: screenshotBlobRef
         )
 
         let screenshotRawBytes = screenshot?.count ?? 0
         let screenshotBase64Bytes = screenshotBase64?.utf8.count ?? 0
+        let screenshotUsedBlob = screenshotBlobRef != nil
         let axTreeBytes = axTreeText?.utf8.count ?? 0
         let axDiffBytes = axDiffText?.utf8.count ?? 0
         let secondaryWindowsBytes = secondaryWindowsText?.utf8.count ?? 0
         let payloadJSONBytes = (try? JSONEncoder().encode(observation).count) ?? 0
         let buildTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
         log.info(
-            "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) axTreeBytes=\(axTreeBytes) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"
+            "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) screenshotUsedBlob=\(screenshotUsedBlob) axTreeBytes=\(axTreeBytes) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"
         )
 
         return observation

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -11,6 +11,7 @@ import VellumAssistantShared
 @MainActor
 final class MockDaemonClient: DaemonClientProtocol {
     var sentMessages: [Any] = []
+    var isBlobTransportAvailable: Bool = false
     private var testContinuation: AsyncStream<ServerMessage>.Continuation?
     private var _messages: AsyncStream<ServerMessage>
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -27,6 +27,7 @@ func resolveSocketPath(environment: [String: String]? = nil) -> String {
 /// Protocol for daemon client communication, enabling dependency injection and testing.
 @MainActor
 public protocol DaemonClientProtocol {
+    var isBlobTransportAvailable: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
 }


### PR DESCRIPTION
## Summary
- When `isBlobTransportAvailable` is true (probe succeeded), screenshots are written as blob files to `~/.vellum/data/ipc-blobs/` instead of being base64-encoded inline in the CU observation JSON
- Falls back to inline base64 if blob write fails or transport is unavailable
- Adds `isBlobTransportAvailable` to `DaemonClientProtocol` for clean protocol-level access
- Adds `screenshotUsedBlob` flag to IPC metrics logging

## Files changed
- `clients/shared/IPC/DaemonClient.swift` — added `isBlobTransportAvailable` to protocol
- `clients/macos/vellum-assistant/ComputerUse/Session.swift` — blob transport for screenshots in `buildObservation`
- `clients/macos/vellum-assistantTests/SessionTests.swift` — updated mock to satisfy protocol

Part of the zero-copy IPC plan (PR 7 of 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
