### PR TITLE
feat(ipc): AX tree blob producer integration

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -464,14 +464,33 @@ final class ComputerUseSession: ObservableObject {
             }
         }
 
+        // Transport AX tree via blob when large (>8KB) and blob transport available
+        var axTreeInline = axTreeText
+        var axTreeBlobRef: IPCIpcBlobRef?
+        let axTreeBlobThreshold = 8 * 1024 // 8KB
+
+        if let tree = axTreeText, daemonClient.isBlobTransportAvailable {
+            let treeData = Data(tree.utf8)
+            if treeData.count > axTreeBlobThreshold {
+                if let ref = IpcBlobStore.shared.writeBlob(data: treeData, kind: "ax_tree", encoding: "utf8") {
+                    axTreeBlobRef = ref
+                    axTreeInline = nil
+                    log.info("[\(stepNumber)] AX tree written as blob (\(treeData.count) bytes, id=\(ref.id))")
+                } else {
+                    log.warning("[\(stepNumber)] Blob write failed for AX tree, keeping inline")
+                }
+            }
+        }
+
         let observation = CuObservationMessage(
             sessionId: id,
-            axTree: axTreeText,
+            axTree: axTreeInline,
             axDiff: axDiffText,
             secondaryWindows: secondaryWindowsText,
             screenshot: screenshotBase64,
             executionResult: executionResult,
             executionError: executionError,
+            axTreeBlob: axTreeBlobRef,
             screenshotBlob: screenshotBlobRef
         )
 
@@ -479,12 +498,13 @@ final class ComputerUseSession: ObservableObject {
         let screenshotBase64Bytes = screenshotBase64?.utf8.count ?? 0
         let screenshotUsedBlob = screenshotBlobRef != nil
         let axTreeBytes = axTreeText?.utf8.count ?? 0
+        let axTreeUsedBlob = axTreeBlobRef != nil
         let axDiffBytes = axDiffText?.utf8.count ?? 0
         let secondaryWindowsBytes = secondaryWindowsText?.utf8.count ?? 0
         let payloadJSONBytes = (try? JSONEncoder().encode(observation).count) ?? 0
         let buildTimestampMs = Int(Date().timeIntervalSince1970 * 1_000)
         log.info(
-            "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) screenshotUsedBlob=\(screenshotUsedBlob) axTreeBytes=\(axTreeBytes) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"
+            "[\(stepNumber)] IPC_METRIC cu_observation_build buildTsMs=\(buildTimestampMs) payloadJsonBytes=\(payloadJSONBytes) screenshotRawBytes=\(screenshotRawBytes) screenshotBase64Bytes=\(screenshotBase64Bytes) screenshotUsedBlob=\(screenshotUsedBlob) axTreeBytes=\(axTreeBytes) axTreeUsedBlob=\(axTreeUsedBlob) axDiffBytes=\(axDiffBytes) secondaryWindowsBytes=\(secondaryWindowsBytes)"
         )
 
         return observation


### PR DESCRIPTION
## Summary
- Large AX trees (>8KB UTF-8) are offloaded to blob files when blob transport is available
- Small AX trees stay inline to avoid blob overhead
- `axDiff` always stays inline (small and latency-sensitive)
- Falls back to inline if blob write fails
- Adds `axTreeUsedBlob` flag to IPC metrics logging

## Files changed
- `clients/macos/vellum-assistant/ComputerUse/Session.swift` — blob transport for large AX trees in `buildObservation`

Part of the zero-copy IPC plan (PR 8 of 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
