### PR TITLE
fix(macos): rename body property to fix SwiftUI build error

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -309,7 +309,7 @@ struct SkillsSettingsView: View {
         .sheet(item: $inspectingSkill) { skill in
             SkillInspectSheet(
                 skill: skill,
-                body: viewModel.loadedBodies[skill.id],
+                skillBody: viewModel.loadedBodies[skill.id],
                 onDismiss: { inspectingSkill = nil }
             )
         }
@@ -336,7 +336,7 @@ struct SkillsSettingsView: View {
 
 private struct SkillInspectSheet: View {
     let skill: SkillInfo
-    let body: String?
+    let skillBody: String?
     let onDismiss: () -> Void
 
     var body: some View {
@@ -354,7 +354,7 @@ private struct SkillInspectSheet: View {
 
             Divider()
 
-            if let content = self.body {
+            if let content = skillBody {
                 ScrollView {
                     Text(content)
                         .font(.system(.body, design: .monospaced))


### PR DESCRIPTION
## Summary
- Renamed `SkillInspectSheet.body: String?` to `skillBody` to avoid clashing with SwiftUI's required `var body: some View` computed property
- Fixes build failure: `invalid redeclaration of 'body'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
