### PR TITLE
feat(system-prompt): add design system token and component class reference

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -95,6 +95,16 @@ function buildDynamicUiSection(): string {
     '',
     '### Preview cards',
     'Always include `preview` in `data`: `{ title, subtitle?, description?, icon? (emoji), metrics?: [{ label, value }] }`. This renders a compact inline card in chat with a "View Output" button. Keep the accompanying chat text to 1-2 sentences summarizing the result.',
+    '',
+    '### Design system tokens',
+    'Semantic colors: `--v-bg`, `--v-surface`, `--v-surface-border`, `--v-text`, `--v-text-secondary`, `--v-text-muted`, `--v-accent`, `--v-success`, `--v-danger`, `--v-warning`.',
+    'Palettes: `--v-slate-{950..50}`, `--v-violet-*`, `--v-emerald-*`, `--v-rose-*`, `--v-amber-*`, `--v-indigo-*`.',
+    'Spacing: `--v-spacing-xs` through `--v-spacing-xxxl`. Radius: `--v-radius-sm`/`md`/`lg`/`pill`.',
+    '',
+    '### Component classes',
+    'Layout: `.v-card`, `.v-card-grid`, `.v-metric-card`, `.v-metric-grid`, `.v-data-table`, `.v-stat-row`, `.v-tabs`, `.v-accordion`, `.v-timeline`, `.v-divider`.',
+    'Domain: `.v-flight-card`, `.v-weather-card`, `.v-stock-ticker`, `.v-billing-chart`, `.v-itinerary`, `.v-boarding-pass`, `.v-receipt`, `.v-invoice`.',
+    'UI: `.v-button` (`.secondary`/`.danger`/`.ghost`), `.v-badge`, `.v-status-badge` (`.success`/`.error`/`.warning`), `.v-progress-bar`, `.v-search-bar`, `.v-empty-state`, `.v-action-list`.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Add design system CSS token reference (semantic colors, palettes, spacing, radius) to the Dynamic UI section
- Add component class catalog organized by Layout, Domain, and UI categories
- Enables the LLM to generate HTML using `.v-card`, `.v-flight-card`, `.v-metric-grid`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
