### PR TITLE
feat(system-prompt): add tool chaining guidance and improve weather render hint

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -135,6 +135,11 @@ function buildDynamicUiSection(): string {
     '  </div>',
     '</div>',
     '```',
+    '',
+    '### Tool chaining',
+    'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a `dynamic_page` rather than displaying raw tool outputs.',
+    '- **Weather**: After `get_weather` returns data, call `ui_show` with `surface_type: "card"`, `template: "weather_forecast"`, passing the structured data as `templateData` for native weather widget rendering.',
+    '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished `dynamic_page` with the appropriate component classes.',
   ].join('\n');
 }
 

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -299,7 +299,8 @@ export async function executeGetWeather(
     forecast: forecastItems,
   };
 
-  lines.push('', '--- Structured Data (for ui_show template "weather_forecast") ---');
+  lines.push('', '--- Render with ui_show ---');
+  lines.push('Call ui_show with: surface_type "card", template "weather_forecast", data: { title: "' + locationDisplay + '", body: "", templateData: <data below> }');
   lines.push(JSON.stringify(structured));
 
   return { content: lines.join('\n'), isError: false };


### PR DESCRIPTION
## Summary
- Add tool chaining guidance to Dynamic UI section: weather → `ui_show` card pattern and research → render pattern
- Update `get-weather.ts` structured data hint from vague label to actionable `ui_show` call instruction with surface_type, template, and templateData
- Ensures the LLM renders native weather cards and polished dynamic pages after gathering data from tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
