### PR TITLE
fix(chat): animate composerReservedHeight inset in sync with composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -52,6 +52,7 @@ struct ChatView: View {
                     messageList
                         .safeAreaInset(edge: .bottom) {
                             Color.clear.frame(height: composerReservedHeight)
+                                .animation(VAnimation.fast, value: editorContentHeight)
                         }
 
                     composerOverlay


### PR DESCRIPTION
## Summary
- Addresses Codex feedback on #2372: the `.animation(VAnimation.fast)` modifier on `ComposerView` didn't propagate to `ChatView`'s `composerReservedHeight` spacer
- The message list bottom inset now animates in sync with the composer, preventing a transient gap/overlap during expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
