### PR TITLE
fix(system-prompt): correct flight example heading from JFK to LGA

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -121,7 +121,7 @@ function buildDynamicUiSection(): string {
     '### Example — Flight results page',
     '```html',
     '<div style="max-width:500px;margin:0 auto;display:flex;flex-direction:column;gap:12px">',
-    '  <h2 style="color:var(--v-text);margin:0">Flights: IAH → JFK</h2>',
+    '  <h2 style="color:var(--v-text);margin:0">Flights: IAH → LGA</h2>',
     '  <div class="v-flight-card">',
     '    <div class="v-flight-header">',
     '      <span class="v-flight-airline">Spirit</span>',


### PR DESCRIPTION
## Summary
- Fix inconsistency in flight card example: heading said IAH → JFK but destination code was LGA
- Addresses review feedback on #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
