### PR TITLE
fix(weather): move template field inside data payload in ui_show hint

### DIFF
--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -300,7 +300,7 @@ export async function executeGetWeather(
   };
 
   lines.push('', '--- Render with ui_show ---');
-  lines.push('Call ui_show with: surface_type "card", template "weather_forecast", data: { title: "' + locationDisplay + '", body: "", templateData: <data below> }');
+  lines.push('Call ui_show with: surface_type "card", data: { title: "' + locationDisplay + '", body: "", template: "weather_forecast", templateData: <data below> }');
   lines.push(JSON.stringify(structured));
 
   return { content: lines.join('\n'), isError: false };


### PR DESCRIPTION
## Summary
- Move `template: "weather_forecast"` from top-level to inside the `data` object in the weather tool's ui_show hint
- Matches the actual ui_show tool definition where template/templateData are properties of `data`
- Addresses review feedback on #2399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
