### PR TITLE
feat(macos): show priority in trust rules list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -149,7 +149,10 @@ private struct TrustRuleRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                Text(rule.scope == "" || rule.scope == "*" ? "Everywhere" : rule.scope)
+                HStack(spacing: 6) {
+                    Text(rule.scope == "" || rule.scope == "*" ? "everywhere" : rule.scope)
+                    Text("priority \(rule.priority)")
+                }
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)


### PR DESCRIPTION
## Summary
- Display each trust rule's priority value alongside the scope text in the settings panel
- Shows as "everywhere priority 100" (or scope path + priority) in the tertiary caption line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
