### PR TITLE
fix(system-prompt): restrict dynamic UI guidance to UI-capable sessions

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -90,6 +90,8 @@ function buildDynamicUiSection(): string {
     '### When to use',
     'Use `ui_show` with `surface_type: "dynamic_page"` when the response involves structured data, visual metrics, comparisons, multi-item results, charts, weather, flights, financial data, dashboards, or anything better presented visually than as plain text. Do NOT use for simple text answers, short factual replies, or casual conversation.',
     '',
+    '**Important:** `ui_show` only works in interactive UI sessions (e.g. the macOS desktop app). Non-UI channels such as HTTP API, Telegram, and gateway integrations cannot render dynamic pages or cards. When responding through a non-UI channel, present data as well-formatted text instead of calling `ui_show`.',
+    '',
     '### How it works',
     'Write a self-contained HTML string (no external resources). The CSS design system (`vellum-design-system.css`) and JS widget library (`vellum-widgets.js`) are auto-injected. Call `ui_show` with `surface_type: "dynamic_page"` and `data: { html: "<your html>", preview: { ... } }`.',
     '',


### PR DESCRIPTION
## Summary
- Add caveat that `ui_show` only works in interactive UI sessions (macOS desktop app)
- Non-UI channels (HTTP API, Telegram, gateway) should present data as formatted text instead
- Prevents the LLM from attempting to render dynamic pages in sessions that can't display them
- Addresses review feedback on #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
