### PR TITLE
fix(chat): handle Cmd+Enter in composer to prevent cursor loss

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -182,7 +182,7 @@ struct ComposerView: View {
                 }
                 return .handled
             }
-            guard keyPress.modifiers.isEmpty else { return .ignored }
+            guard keyPress.modifiers.isEmpty || keyPress.modifiers == .command else { return .ignored }
             inputText = inputText.replacingOccurrences(
                 of: "\\n$", with: "", options: .regularExpression
             )


### PR DESCRIPTION
## Summary
- Cmd+Enter in the composer was falling through to SwiftUI's default Cmd+Return behavior, which commits the text field editing and resigns first responder — making the cursor disappear
- Now Cmd+Enter is handled the same as plain Enter (sends the message or stays put if empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
