### PR TITLE
fix(permissions,handlers): add trust defaults for managed skill tools + reuse shared delete

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -61,7 +61,7 @@ import { queryAppRecords, createAppRecord, updateAppRecord, deleteAppRecord, lis
 import { getRootDir } from '../util/platform.js';
 import { clawhubInstall, clawhubUpdate, clawhubSearch, clawhubCheckUpdates, clawhubInspect } from '../skills/clawhub.js';
 import { parseSlashCandidate } from '../skills/slash-commands.js';
-import { removeSkillsIndexEntry } from '../skills/managed-store.js';
+import { removeSkillsIndexEntry, deleteManagedSkill, validateManagedSkillId } from '../skills/managed-store.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
 import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId } from './ipc-blob-store.js';
@@ -1098,21 +1098,36 @@ async function handleSkillsUninstall(
     });
     return;
   }
-  const skillDir = join(getRootDir(), 'skills', msg.name);
-  if (!existsSync(skillDir)) {
-    ctx.send(socket, {
-      type: 'skills_operation_response',
-      operation: 'uninstall',
-      success: false,
-      error: 'Skill not found',
-    });
-    return;
-  }
-  try {
-    rmSync(skillDir, { recursive: true });
 
-    // Clean SKILLS.md index entry (idempotent, safe for non-managed skills)
-    try { removeSkillsIndexEntry(msg.name); } catch { /* best effort */ }
+  try {
+    // Use shared managed-store logic for simple managed skill IDs
+    const isManagedId = !validateManagedSkillId(msg.name);
+    if (isManagedId) {
+      const result = deleteManagedSkill(msg.name);
+      if (!result.deleted) {
+        ctx.send(socket, {
+          type: 'skills_operation_response',
+          operation: 'uninstall',
+          success: false,
+          error: result.error ?? 'Failed to delete managed skill',
+        });
+        return;
+      }
+    } else {
+      // Namespaced slug (org/name) — direct filesystem removal
+      const skillDir = join(getRootDir(), 'skills', msg.name);
+      if (!existsSync(skillDir)) {
+        ctx.send(socket, {
+          type: 'skills_operation_response',
+          operation: 'uninstall',
+          success: false,
+          error: 'Skill not found',
+        });
+        return;
+      }
+      rmSync(skillDir, { recursive: true });
+      try { removeSkillsIndexEntry(msg.name); } catch { /* best effort */ }
+    }
 
     // Clean config entry
     const raw = loadRawConfig();

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -82,5 +82,17 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 1000,
   }));
 
-  return [...protectedFileRules, ...hostFileRules, hostShellRule, ...computerUseRules];
+  // Managed skill authoring tools — scaffold and delete modify ~/.vellum/skills/
+  // and should require explicit user approval.
+  const MANAGED_SKILL_TOOLS = ['scaffold_managed_skill', 'delete_managed_skill'] as const;
+  const managedSkillRules = MANAGED_SKILL_TOOLS.map((tool) => ({
+    id: `default:ask-${tool}-global`,
+    tool,
+    pattern: `${tool}:*`,
+    scope: 'everywhere',
+    decision: 'ask' as const,
+    priority: 1000,
+  }));
+
+  return [...protectedFileRules, ...hostFileRules, hostShellRule, ...computerUseRules, ...managedSkillRules];
 }


### PR DESCRIPTION
## Summary
- Adds default `ask` trust rule templates for `scaffold_managed_skill` and `delete_managed_skill` so these tools require explicit user approval by default (pattern: `scaffold_managed_skill:*` / `delete_managed_skill:*`, priority 1000)
- Refactors `handleSkillsUninstall` in `handlers.ts` to delegate directory removal to `deleteManagedSkill()` from `managed-store.ts` for simple managed skill IDs, keeping inline logic only for namespaced ClaWHub slugs (org/name)

## Test plan
- [x] All 111 checker tests pass (verify new default rules are backfilled)
- [x] All 25 managed-store + lifecycle tests pass
- [x] All 8 scaffold/delete tool tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
