### PR TITLE
fix(ui): use skill.id for uninstall + split per-source sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -46,7 +46,7 @@ struct AgentPanel: View {
             Button("Cancel", role: .cancel) { skillToDelete = nil }
             Button("Delete", role: .destructive) {
                 if let skill = skillToDelete {
-                    skillsManager.uninstallSkill(name: skill.name)
+                    skillsManager.uninstallSkill(id: skill.id)
                     skillToDelete = nil
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -22,7 +22,7 @@ final class SkillsManager: ObservableObject {
     }
 
     struct UninstallResult {
-        let name: String
+        let id: String
         let success: Bool
         let error: String?
     }
@@ -189,7 +189,7 @@ final class SkillsManager: ObservableObject {
         }
     }
 
-    func uninstallSkill(name: String) {
+    func uninstallSkill(id: String) {
         guard !isUninstalling else { return }
         isUninstalling = true
         uninstallResult = nil
@@ -198,10 +198,10 @@ final class SkillsManager: ObservableObject {
             let stream = daemonClient.subscribe()
 
             do {
-                try daemonClient.uninstallSkill(name)
+                try daemonClient.uninstallSkill(id)
             } catch {
                 isUninstalling = false
-                uninstallResult = UninstallResult(name: name, success: false, error: "Failed to connect")
+                uninstallResult = UninstallResult(id: id, success: false, error: "Failed to connect")
                 return
             }
 
@@ -209,16 +209,16 @@ final class SkillsManager: ObservableObject {
                 if case .skillsOperationResponse(let response) = message,
                    response.operation == "uninstall" {
                     if response.success {
-                        uninstallResult = UninstallResult(name: name, success: true, error: nil)
+                        uninstallResult = UninstallResult(id: id, success: true, error: nil)
                         fetchSkills()
                     } else {
-                        uninstallResult = UninstallResult(name: name, success: false, error: response.error)
+                        uninstallResult = UninstallResult(id: id, success: false, error: response.error)
                     }
                     isUninstalling = false
                     // Auto-clear after 3 seconds
                     Task { @MainActor in
                         try? await Task.sleep(nanoseconds: 3_000_000_000)
-                        if self.uninstallResult?.name == name {
+                        if self.uninstallResult?.id == id {
                             self.uninstallResult = nil
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillsSettingsView.swift
@@ -49,7 +49,7 @@ final class SkillsSettingsViewModel: ObservableObject {
         processNextOperation()
     }
 
-    func uninstallSkill(name: String) {
+    func uninstallSkill(id: String) {
         guard !isUninstalling else { return }
         isUninstalling = true
         uninstallError = nil
@@ -58,7 +58,7 @@ final class SkillsSettingsViewModel: ObservableObject {
             let stream = daemonClient.subscribe()
 
             do {
-                try daemonClient.uninstallSkill(name)
+                try daemonClient.uninstallSkill(id)
             } catch {
                 isUninstalling = false
                 uninstallError = "Failed to connect"
@@ -69,7 +69,7 @@ final class SkillsSettingsViewModel: ObservableObject {
                 if case .skillsOperationResponse(let response) = message,
                    response.operation == "uninstall" {
                     if response.success {
-                        skills.removeAll { $0.name == name }
+                        skills.removeAll { $0.id == id }
                     } else {
                         uninstallError = response.error ?? "Uninstall failed"
                     }
@@ -227,10 +227,38 @@ struct SkillsSettingsView: View {
                         }
                     }
 
-                    // Other installed skills (workspace, extra, clawhub)
-                    if !otherSkills.isEmpty {
-                        Section("Other Skills") {
-                            ForEach(otherSkills) { skill in
+                    // Workspace skills
+                    if !workspaceSkills.isEmpty {
+                        Section("Workspace Skills") {
+                            ForEach(workspaceSkills) { skill in
+                                SkillRow(
+                                    skill: skill,
+                                    onToggle: { enabled in
+                                        viewModel.toggleSkill(name: skill.name, enable: enabled)
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    // ClaWHub skills
+                    if !clawhubSkills.isEmpty {
+                        Section("ClaWHub Skills") {
+                            ForEach(clawhubSkills) { skill in
+                                SkillRow(
+                                    skill: skill,
+                                    onToggle: { enabled in
+                                        viewModel.toggleSkill(name: skill.name, enable: enabled)
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    // Extra skills
+                    if !extraSkills.isEmpty {
+                        Section("Extra Skills") {
+                            ForEach(extraSkills) { skill in
                                 SkillRow(
                                     skill: skill,
                                     onToggle: { enabled in
@@ -297,7 +325,7 @@ struct SkillsSettingsView: View {
             Button("Cancel", role: .cancel) { skillToDelete = nil }
             Button("Delete", role: .destructive) {
                 if let skill = skillToDelete {
-                    viewModel.uninstallSkill(name: skill.name)
+                    viewModel.uninstallSkill(id: skill.id)
                     skillToDelete = nil
                 }
             }
@@ -327,8 +355,16 @@ struct SkillsSettingsView: View {
         installedSkills.filter { $0.source == "bundled" }
     }
 
-    private var otherSkills: [SkillInfo] {
-        installedSkills.filter { $0.source != "managed" && $0.source != "bundled" }
+    private var workspaceSkills: [SkillInfo] {
+        installedSkills.filter { $0.source == "workspace" }
+    }
+
+    private var clawhubSkills: [SkillInfo] {
+        installedSkills.filter { $0.source == "clawhub" }
+    }
+
+    private var extraSkills: [SkillInfo] {
+        installedSkills.filter { $0.source == "extra" }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes P1 bug: UI was sending `skill.name` (display name) for uninstall, but the daemon resolves by directory key (`skill.id`). Switched to `skill.id` end-to-end in SkillsSettingsView, SkillsManager, and AgentPanel
- Splits the generic "Other Skills" section in Settings into separate Workspace, ClaWHub, and Extra sections for better source transparency

## Test plan
- [x] macOS `swift build --target vellum-assistant` passes cleanly
- [x] Verified `skill.id` is used in all uninstall call sites (SkillsSettingsView, AgentPanel, SkillsManager)
- [x] Verified `removeAll` filter matches by `$0.id` instead of `$0.name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
