### PR TITLE
fix(ipc): harden blob hydration and symlink safety

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1078,3 +1078,20 @@ exports[`IPC message snapshots ServerMessage types trace_event serializes to exp
   "type": "trace_event",
 }
 `;
+
+exports[`IPC message snapshots ClientMessage types ipc_blob_probe serializes to expected JSON 1`] = `
+{
+  "nonceSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "probeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "type": "ipc_blob_probe",
+}
+`;
+
+exports[`IPC message snapshots ServerMessage types ipc_blob_probe_result serializes to expected JSON 1`] = `
+{
+  "observedNonceSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "ok": true,
+  "probeId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "type": "ipc_blob_probe_result",
+}
+`;

--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -158,32 +158,10 @@ describe('handleCuObservation blob hydration', () => {
     expect(existsSync(join(blobDir, `${blobRef.id}.blob`))).toBe(false);
   });
 
-  test('both blob + inline: blob succeeds, inline ignored', async () => {
+  test('blob-first: blob succeeds, inline value is overwritten', async () => {
     const sessionId = randomUUID();
     const blobAxTree = 'Blob AX tree content';
-    const blobRef = writeBlobFile(Buffer.from(blobAxTree, 'utf8'), 'ax_tree', 'utf8');
-
-    const msg: CuObservation = {
-      type: 'cu_observation',
-      sessionId,
-      axTreeBlob: blobRef,
-      // No inline axTree — blob should be used
-    };
-
-    const { ctx, observations } = createTestContext(sessionId);
-    const fakeSocket = {} as net.Socket;
-
-    handleMessage(msg, fakeSocket, ctx);
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(observations).toHaveLength(1);
-    expect(observations[0].axTree).toBe(blobAxTree);
-  });
-
-  test('inline takes precedence when present (blob skipped)', async () => {
-    const sessionId = randomUUID();
-    const inlineAxTree = 'Inline AX tree';
-    const blobAxTree = 'Blob AX tree';
+    const inlineAxTree = 'Inline AX tree content';
     const blobRef = writeBlobFile(Buffer.from(blobAxTree, 'utf8'), 'ax_tree', 'utf8');
 
     const msg: CuObservation = {
@@ -200,11 +178,40 @@ describe('handleCuObservation blob hydration', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(observations).toHaveLength(1);
-    // Inline value should be preserved because the hydration skips when inline exists
+    // Blob takes precedence when both are present and blob succeeds
+    expect(observations[0].axTree).toBe(blobAxTree);
+  });
+
+  test('blob fails with inline fallback: uses inline value', async () => {
+    const sessionId = randomUUID();
+    const inlineAxTree = 'Inline AX tree';
+    // Create a blob ref that points to a non-existent file
+    const blobRef: IpcBlobRef = {
+      id: randomUUID(),
+      kind: 'ax_tree',
+      encoding: 'utf8',
+      byteLength: 100,
+    };
+
+    const msg: CuObservation = {
+      type: 'cu_observation',
+      sessionId,
+      axTree: inlineAxTree,
+      axTreeBlob: blobRef,
+    };
+
+    const { ctx, observations } = createTestContext(sessionId);
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(observations).toHaveLength(1);
+    // Inline value should be preserved as fallback when blob fails
     expect(observations[0].axTree).toBe(inlineAxTree);
   });
 
-  test('blob failure: continues without value when no inline fallback', async () => {
+  test('blob failure with no inline fallback: emits cu_error', async () => {
     const sessionId = randomUUID();
     // Create a blob ref that points to a non-existent file
     const blobRef: IpcBlobRef = {
@@ -220,6 +227,34 @@ describe('handleCuObservation blob hydration', () => {
       axTreeBlob: blobRef,
     };
 
+    const { ctx, sent, observations } = createTestContext(sessionId);
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should NOT forward to session
+    expect(observations).toHaveLength(0);
+    // Should send cu_error
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe('cu_error');
+    expect((sent[0] as any).message).toContain('Failed to hydrate axTreeBlob');
+    expect((sent[0] as any).message).toContain('no inline fallback');
+  });
+
+  test('wrong blob kind: fails validation and falls back to inline', async () => {
+    const sessionId = randomUUID();
+    const inlineScreenshot = 'base64screenshotdata';
+    // Create a blob with wrong kind for screenshotBlob field
+    const blobRef = writeBlobFile(Buffer.from([0xFF, 0xD8]), 'ax_tree', 'utf8');
+
+    const msg: CuObservation = {
+      type: 'cu_observation',
+      sessionId,
+      screenshot: inlineScreenshot,
+      screenshotBlob: blobRef,
+    };
+
     const { ctx, observations } = createTestContext(sessionId);
     const fakeSocket = {} as net.Socket;
 
@@ -227,8 +262,33 @@ describe('handleCuObservation blob hydration', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(observations).toHaveLength(1);
-    // axTree should remain undefined since blob failed and no inline fallback
-    expect(observations[0].axTree).toBeUndefined();
+    // Should fall back to inline because kind validation failed
+    expect(observations[0].screenshot).toBe(inlineScreenshot);
+  });
+
+  test('wrong blob kind with no inline fallback: emits cu_error', async () => {
+    const sessionId = randomUUID();
+    // Create a blob with wrong kind for screenshotBlob field, no inline fallback
+    const blobRef = writeBlobFile(Buffer.from([0xFF, 0xD8]), 'ax_tree', 'utf8');
+
+    const msg: CuObservation = {
+      type: 'cu_observation',
+      sessionId,
+      screenshotBlob: blobRef,
+    };
+
+    const { ctx, sent, observations } = createTestContext(sessionId);
+    const fakeSocket = {} as net.Socket;
+
+    handleMessage(msg, fakeSocket, ctx);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should NOT forward to session
+    expect(observations).toHaveLength(0);
+    // Should send cu_error
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe('cu_error');
+    expect((sent[0] as any).message).toContain('Failed to hydrate screenshotBlob');
   });
 
   test('inline-only unchanged: no blob refs, observation passes through', async () => {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -237,6 +237,11 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   sessions_clear: {
     type: 'sessions_clear',
   },
+  ipc_blob_probe: {
+    type: 'ipc_blob_probe',
+    probeId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    nonceSha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -680,6 +685,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     status: 'info',
     summary: 'Running bash: ls -la',
     attributes: { toolName: 'bash', command: 'ls -la', riskLevel: 'low', sandboxed: true },
+  },
+  ipc_blob_probe_result: {
+    type: 'ipc_blob_probe_result',
+    probeId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ok: true,
+    observedNonceSha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
   },
 };
 

--- a/assistant/src/__tests__/ipc-validate.test.ts
+++ b/assistant/src/__tests__/ipc-validate.test.ts
@@ -316,6 +316,7 @@ describe('IPC Validate', () => {
       confirmation_response: { requestId: 'r1', decision: 'allow' },
       secret_response: { requestId: 'r1' },
       ui_surface_action: { sessionId: 's1', surfaceId: 'sf1', actionId: 'a1' },
+      ipc_blob_probe: { probeId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', nonceSha256: 'abc123' },
     };
 
     test('KNOWN_CLIENT_TYPES matches live contract wire types', () => {

--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -64,7 +64,7 @@ import { parseSlashCandidate } from '../skills/slash-commands.js';
 import { removeSkillsIndexEntry } from '../skills/managed-store.js';
 import { packageApp } from '../bundler/app-bundler.js';
 import { handleOpenBundle } from './handlers/open-bundle-handler.js';
-import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId } from './ipc-blob-store.js';
+import { resolveBlobPath, readBlob, deleteBlob, isValidBlobId, validateBlobKindEncoding } from './ipc-blob-store.js';
 import { estimateBase64Bytes } from './assistant-attachments.js';
 import { classifySessionError, buildSessionErrorMessage } from './session-error.js';
 import { getAttachmentsForMessageUnscoped } from '../memory/attachments-store.js';
@@ -1904,24 +1904,42 @@ async function handleCuObservation(
   ctx: HandlerContext,
 ): Promise<void> {
   // Hydrate blob refs to inline values before any other processing.
-  // Inline fields take precedence only as a fallback when blob hydration fails.
-  if (msg.axTreeBlob && !msg.axTree) {
+  // Strategy: blob-first, inline-fallback, cu_error if neither available.
+  if (msg.axTreeBlob) {
     try {
+      validateBlobKindEncoding(msg.axTreeBlob, 'axTreeBlob');
       const buf = await readBlob(msg.axTreeBlob);
       msg.axTree = buf.toString('utf8');
       deleteBlob(msg.axTreeBlob.id);
     } catch (err) {
-      log.warn({ err, blobId: msg.axTreeBlob.id }, 'Failed to hydrate axTreeBlob');
+      log.warn({ err, blobId: msg.axTreeBlob.id }, 'Failed to hydrate axTreeBlob, checking inline fallback');
+      if (!msg.axTree) {
+        ctx.send(socket, {
+          type: 'cu_error',
+          sessionId: msg.sessionId,
+          message: `Failed to hydrate axTreeBlob (id=${msg.axTreeBlob.id}) and no inline fallback available`,
+        });
+        return;
+      }
     }
   }
 
-  if (msg.screenshotBlob && !msg.screenshot) {
+  if (msg.screenshotBlob) {
     try {
+      validateBlobKindEncoding(msg.screenshotBlob, 'screenshotBlob');
       const buf = await readBlob(msg.screenshotBlob);
       msg.screenshot = buf.toString('base64');
       deleteBlob(msg.screenshotBlob.id);
     } catch (err) {
-      log.warn({ err, blobId: msg.screenshotBlob.id }, 'Failed to hydrate screenshotBlob');
+      log.warn({ err, blobId: msg.screenshotBlob.id }, 'Failed to hydrate screenshotBlob, checking inline fallback');
+      if (!msg.screenshot) {
+        ctx.send(socket, {
+          type: 'cu_error',
+          sessionId: msg.sessionId,
+          message: `Failed to hydrate screenshotBlob (id=${msg.screenshotBlob.id}) and no inline fallback available`,
+        });
+        return;
+      }
     }
   }
 

--- a/assistant/src/daemon/ipc-blob-store.ts
+++ b/assistant/src/daemon/ipc-blob-store.ts
@@ -5,8 +5,10 @@ import {
   mkdirSync,
   existsSync,
   unlinkSync,
+  lstatSync,
+  realpathSync,
 } from 'node:fs';
-import { readFile, readdir, stat, unlink } from 'node:fs/promises';
+import { readFile, readdir, lstat, realpath, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 
@@ -52,11 +54,76 @@ export function resolveBlobPath(id: string): string {
 }
 
 /**
+ * Verify that a blob file at the given path is a regular file (not a symlink)
+ * and that its realpath stays within the blob directory.
+ * Throws if the file is a symlink or escapes the blob directory.
+ */
+async function assertRegularFileInBlobDir(filePath: string): Promise<void> {
+  const fileLstat = await lstat(filePath);
+  if (fileLstat.isSymbolicLink()) {
+    throw new Error(`Blob file is a symlink: ${filePath}`);
+  }
+  const real = await realpath(filePath);
+  // Realpath both the file and the blob dir so macOS /var → /private/var is handled
+  const realBlobDir = await realpath(getIpcBlobDir());
+  if (!real.startsWith(realBlobDir + '/')) {
+    throw new Error(`Blob realpath escapes blob directory: ${real}`);
+  }
+}
+
+/**
+ * Synchronous variant for use in deleteBlob.
+ */
+function assertRegularFileInBlobDirSync(filePath: string): void {
+  const fileLstat = lstatSync(filePath);
+  if (fileLstat.isSymbolicLink()) {
+    throw new Error(`Blob file is a symlink: ${filePath}`);
+  }
+  const real = realpathSync(filePath);
+  const realBlobDir = realpathSync(getIpcBlobDir());
+  if (!real.startsWith(realBlobDir + '/')) {
+    throw new Error(`Blob realpath escapes blob directory: ${real}`);
+  }
+}
+
+/** Expected kind and encoding for each blob field. */
+export const EXPECTED_BLOB_FIELD_METADATA = {
+  axTreeBlob: { kind: 'ax_tree' as const, encoding: 'utf8' as const },
+  screenshotBlob: { kind: 'screenshot_jpeg' as const, encoding: 'binary' as const },
+};
+
+/**
+ * Validate that a blob ref's kind and encoding match expectations for a given field.
+ * Throws with a descriptive message if they don't match.
+ */
+export function validateBlobKindEncoding(
+  ref: IpcBlobRef,
+  field: keyof typeof EXPECTED_BLOB_FIELD_METADATA,
+): void {
+  const expected = EXPECTED_BLOB_FIELD_METADATA[field];
+  if (ref.kind !== expected.kind) {
+    throw new Error(
+      `Blob kind mismatch for ${field}: expected "${expected.kind}", got "${ref.kind}"`,
+    );
+  }
+  if (ref.encoding !== expected.encoding) {
+    throw new Error(
+      `Blob encoding mismatch for ${field}: expected "${expected.encoding}", got "${ref.encoding}"`,
+    );
+  }
+}
+
+/**
  * Read a blob file and validate it against the ref metadata.
+ * Verifies the file is a regular file (not a symlink) and its realpath
+ * stays within the blob directory before reading.
  * Returns the raw bytes.
  */
 export async function readBlob(ref: IpcBlobRef): Promise<Buffer> {
   const filePath = resolveBlobPath(ref.id);
+
+  // Symlink-safe: verify the file is a regular file with realpath inside blob dir
+  await assertRegularFileInBlobDir(filePath);
 
   const buf = await readFile(filePath);
 
@@ -92,6 +159,8 @@ export async function readBlob(ref: IpcBlobRef): Promise<Buffer> {
 export function deleteBlob(id: string): void {
   try {
     const filePath = resolveBlobPath(id);
+    // Symlink-safe: verify the file is a regular file before deleting
+    assertRegularFileInBlobDirSync(filePath);
     unlinkSync(filePath);
   } catch (err) {
     // ENOENT is expected when the blob was already cleaned up
@@ -124,8 +193,13 @@ export async function sweepStaleBlobs(maxAgeMs: number): Promise<number> {
 
     const filePath = join(blobDir, entry);
     try {
-      const fileStat = await stat(filePath);
-      const ageMs = now - fileStat.mtimeMs;
+      // Use lstat (not stat) to detect symlinks without following them
+      const fileLstat = await lstat(filePath);
+      if (fileLstat.isSymbolicLink()) {
+        log.warn({ filePath }, 'Skipping symlink during blob sweep');
+        continue;
+      }
+      const ageMs = now - fileLstat.mtimeMs;
       if (ageMs > maxAgeMs) {
         await unlink(filePath);
         deleted++;


### PR DESCRIPTION
## Summary

Addresses review feedback on the zero-copy blob transport implementation:

- **[P1] Blob-first hydration**: Changed from "skip blob if inline exists" to "try blob first, fall back to inline". When both are present and blob succeeds, blob value wins. When blob fails and inline exists, inline is used as fallback.
- **[P1] cu_error on total failure**: When blob hydration fails and no inline fallback is available, the handler now emits `cu_error` and returns early instead of silently continuing with missing data.
- **[P1] Kind/encoding validation**: Added `validateBlobKindEncoding()` — verifies `axTreeBlob` is `kind=ax_tree, encoding=utf8` and `screenshotBlob` is `kind=screenshot_jpeg, encoding=binary` before reading.
- **[P1] Symlink-safe blob I/O**: Added `lstat` + `realpath` guards in `readBlob`, `deleteBlob`, and `sweepStaleBlobs` to reject symlinks and verify realpath stays within the blob directory.
- **[P2] Fix ipc-validate test**: Added `ipc_blob_probe` to `HIGH_RISK_FIXTURES` so the contract parity test passes (previously 1 fail → 0 fail).
- **[P2] IPC snapshot parity**: Added `ipc_blob_probe` and `ipc_blob_probe_result` fixtures to snapshot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
