### PR TITLE
fix(system-prompt): put template inside data in tool chaining guidance

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -140,7 +140,7 @@ function buildDynamicUiSection(): string {
     '',
     '### Tool chaining',
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a `dynamic_page` rather than displaying raw tool outputs.',
-    '- **Weather**: After `get_weather` returns data, call `ui_show` with `surface_type: "card"`, `template: "weather_forecast"`, passing the structured data as `templateData` for native weather widget rendering.',
+    '- **Weather**: After `get_weather` returns data, call `ui_show` with `surface_type: "card"` and `data: { title, body, template: "weather_forecast", templateData: <structured data> }` for native weather widget rendering.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished `dynamic_page` with the appropriate component classes.',
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- Fix the weather tool chaining hint to place `template` and `templateData` inside the `data` object
- Matches the actual `CardSurfaceData` schema and the corrected hint in `get-weather.ts`
- Addresses review feedback on #2404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
