### PR TITLE
docs: fix probe description — runs on every macOS connect, not just local

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -797,7 +797,7 @@ CU observations can carry large payloads (screenshots as JPEG, AX trees as UTF-8
 
 ### Probe Mechanism
 
-Blob transport is opt-in per connection. On macOS local socket connect, the client writes a random nonce file to the blob directory and sends an `ipc_blob_probe` message with the SHA-256 of the nonce. The daemon reads the file, computes the hash, and responds with `ipc_blob_probe_result`. If hashes match, the client sets `isBlobTransportAvailable = true` for that connection. The flag resets to `false` on disconnect or reconnect.
+Blob transport is opt-in per connection. On every macOS socket connect, the client writes a random nonce file to the blob directory and sends an `ipc_blob_probe` message with the SHA-256 of the nonce. The daemon reads the file, computes the hash, and responds with `ipc_blob_probe_result`. If hashes match, the client sets `isBlobTransportAvailable = true` for that connection. The flag resets to `false` on disconnect or reconnect.
 
 On iOS (TCP connections), the probe code is compiled out via `#if os(macOS)` — `isBlobTransportAvailable` stays `false` and inline payloads are always used. Over SSH-forwarded Unix sockets on macOS, the probe runs but fails because the client and daemon don't share a filesystem, so blob transport stays disabled and inline payloads are used transparently.
 


### PR DESCRIPTION
## Summary
- Fix ARCHITECTURE.md probe mechanism description: changed "On macOS local socket connect" to "On every macOS socket connect" to match the actual code behavior in `DaemonClient.swift:332-334`, where `runBlobProbe()` is called on every `#if os(macOS)` connect regardless of whether the socket is local or SSH-forwarded
- The probe result (not a pre-check) determines whether blob transport is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
