### PR TITLE
test: close test fidelity gaps in chain test, registry, and atomic write

### DIFF
--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -6,6 +6,23 @@ import { tmpdir } from 'node:os';
 
 let TEST_DIR = '';
 
+const mockConfig = {
+  provider: 'anthropic',
+  model: 'test',
+  apiKeys: {},
+  maxTokens: 4096,
+  dataDir: '/tmp',
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: { enabled: false },
+  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  secretDetection: { enabled: true, action: 'warn' as const, entropyThreshold: 4.0 },
+  auditLog: { retentionDays: 0 },
+};
+
 mock.module('../util/platform.js', () => ({
   getRootDir: () => TEST_DIR,
   getDataDir: () => TEST_DIR,
@@ -29,9 +46,29 @@ mock.module('../util/logger.js', () => ({
   }),
 }));
 
+mock.module('../config/loader.js', () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module('../tools/terminal/sandbox.js', () => ({
+  wrapCommand: (command: string, _workingDir: string, _config: unknown) => ({
+    command: 'bash',
+    args: ['-c', '--', command],
+    sandboxed: false,
+  }),
+}));
+
 import { ScaffoldManagedSkillTool } from '../tools/skills/scaffold-managed.js';
 import { DeleteManagedSkillTool } from '../tools/skills/delete-managed.js';
-import { loadSkillCatalog } from '../config/skills.js';
+import { EvaluateTypescriptTool } from '../tools/terminal/evaluate-typescript.js';
+import { loadSkillCatalog, loadSkillBySelector } from '../config/skills.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import type { ToolContext } from '../tools/types.js';
 
@@ -160,44 +197,52 @@ describe('managed skill lifecycle: scaffold → catalog → prompt → delete', 
     expect(result.isError).toBe(true);
   });
 
-  test('evaluate → scaffold → skill_load chain: code output feeds skill creation', async () => {
+  test('evaluate → scaffold → skill_load chain: literal tool execution', async () => {
     const ctx = makeContext();
+    const evalTool = new (EvaluateTypescriptTool as any)() as InstanceType<typeof EvaluateTypescriptTool>;
 
-    // Step 1: Scaffold a skill (simulating what an evaluate call might produce)
+    // Step 1: Run evaluate_typescript_code with code that returns skill metadata
+    const code = `export default () => ({
+  name: 'Chain Test',
+  description: 'Created from evaluate output.',
+  body: 'This skill was dynamically created.\\n\\nRun: \\\`echo chain-test-ok\\\`',
+});`;
+
+    const evalResult = await evalTool.execute({ code }, ctx);
+    expect(evalResult.isError).not.toBe(true);
+
+    const evalData = JSON.parse(evalResult.content as string);
+    expect(evalData.ok).toBe(true);
+    expect(evalData.result).toBeDefined();
+    expect(evalData.result.name).toBe('Chain Test');
+
+    // Step 2: Feed evaluate output into scaffold_managed_skill
+    const meta = evalData.result;
     const scaffoldResult = await scaffoldTool.execute({
       skill_id: 'chain-test',
-      name: 'Chain Test',
-      description: 'Created from evaluate output.',
-      body_markdown: 'This skill was dynamically created.\n\nRun: `echo chain-test-ok`',
-      emoji: '🔗',
+      name: meta.name,
+      description: meta.description,
+      body_markdown: meta.body,
     }, ctx);
 
     expect(scaffoldResult.isError).not.toBe(true);
     const scaffoldData = JSON.parse(scaffoldResult.content as string);
     expect(scaffoldData.created).toBe(true);
 
-    // Step 2: Verify skill is loadable via catalog (skill_load reads from this)
-    const catalog = loadSkillCatalog();
-    const found = catalog.find(s => s.id === 'chain-test');
-    expect(found).toBeDefined();
-    expect(found!.name).toBe('Chain Test');
+    // Step 3: Use loadSkillBySelector (the function skill_load calls) to load the skill
+    const loaded = loadSkillBySelector('chain-test');
+    expect(loaded.skill).toBeDefined();
+    expect(loaded.skill!.name).toBe('Chain Test');
+    expect(loaded.skill!.description).toBe('Created from evaluate output.');
+    expect(loaded.skill!.body).toContain('dynamically created');
+    expect(loaded.skill!.body).toContain('echo chain-test-ok');
 
-    // Step 3: Verify SKILL.md contains the expected body
-    const skillPath = join(TEST_DIR, 'skills', 'chain-test', 'SKILL.md');
-    const content = readFileSync(skillPath, 'utf-8');
-    expect(content).toContain('dynamically created');
-    expect(content).toContain('echo chain-test-ok');
-
-    // Step 4: Verify it appears in the system prompt (skill_load injects from catalog)
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain('chain-test');
-
-    // Step 5: Clean up
+    // Step 4: Clean up
     const deleteResult = await deleteTool.execute({ skill_id: 'chain-test' }, ctx);
     expect(deleteResult.isError).not.toBe(true);
 
-    // Step 6: Verify skill no longer in catalog after reload
-    const catalogAfterDelete = loadSkillCatalog();
-    expect(catalogAfterDelete.find(s => s.id === 'chain-test')).toBeUndefined();
+    // Step 5: Verify skill_load no longer finds the deleted skill
+    const loadedAfter = loadSkillBySelector('chain-test');
+    expect(loadedAfter.skill).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -287,6 +287,34 @@ describe('atomic write safety', () => {
     expect(content).toContain('name: "V2"');
     expect(content).toContain('Replaced.');
     expect(content).not.toContain('Original.');
+  });
+});
+
+describe('atomic write failure', () => {
+  test('read-only directory prevents skill creation and leaves no partial files', () => {
+    const skillsDir = join(TEST_DIR, 'skills');
+    const targetDir = join(skillsDir, 'fail-write');
+    mkdirSync(targetDir, { recursive: true });
+    // Make the skill directory read-only so writeFileSync fails
+    chmodSync(targetDir, 0o555);
+
+    try {
+      expect(() => {
+        createManagedSkill({
+          id: 'fail-write',
+          name: 'Should Fail',
+          description: 'This should not be written',
+          bodyMarkdown: 'Unreachable.',
+        });
+      }).toThrow();
+
+      // Verify no SKILL.md or temp files were left behind
+      const files = readdirSync(targetDir);
+      expect(files.filter(f => f.endsWith('.md') || f.startsWith('.tmp-'))).toEqual([]);
+    } finally {
+      // Restore permissions so afterEach cleanup can remove the directory
+      chmodSync(targetDir, 0o755);
+    }
   });
 });
 

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -84,3 +84,49 @@ describe('tool registry host tools', () => {
     }
   });
 });
+
+describe('tool registry dynamic-tools tools', () => {
+  test('registers evaluate, scaffold, delete, and skill_load tools', async () => {
+    await initializeTools();
+
+    const dynamicToolNames = [
+      'evaluate_typescript_code',
+      'scaffold_managed_skill',
+      'delete_managed_skill',
+      'skill_load',
+    ] as const;
+
+    for (const toolName of dynamicToolNames) {
+      const tool = getTool(toolName);
+      expect(tool).toBeDefined();
+    }
+
+    const definitionNames = getAllToolDefinitions().map((def) => def.name);
+    for (const toolName of dynamicToolNames) {
+      expect(definitionNames).toContain(toolName);
+    }
+  });
+
+  test('evaluate_typescript_code is registered as High risk', async () => {
+    await initializeTools();
+    const tool = getTool('evaluate_typescript_code');
+    expect(tool).toBeDefined();
+    expect(tool?.defaultRiskLevel).toBe(RiskLevel.High);
+  });
+
+  test('scaffold and delete are registered as High risk', async () => {
+    await initializeTools();
+    for (const name of ['scaffold_managed_skill', 'delete_managed_skill']) {
+      const tool = getTool(name);
+      expect(tool).toBeDefined();
+      expect(tool?.defaultRiskLevel).toBe(RiskLevel.High);
+    }
+  });
+
+  test('skill_load is registered as Low risk', async () => {
+    await initializeTools();
+    const tool = getTool('skill_load');
+    expect(tool).toBeDefined();
+    expect(tool?.defaultRiskLevel).toBe(RiskLevel.Low);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace simulated chain test with literal `EvaluateTypescriptTool.execute()` and `loadSkillBySelector()` calls for true evaluate→scaffold→skill_load coverage
- Add registry assertions verifying `evaluate_typescript_code`, `scaffold_managed_skill`, `delete_managed_skill`, and `skill_load` are registered with correct risk levels
- Add atomic write failure test using read-only directory to verify no partial files remain on error

## Test plan
- [x] `bun test managed-skill-lifecycle.test.ts` — 4 pass
- [x] `bun test registry.test.ts` — 6 pass
- [x] `bun test managed-store.test.ts` — 25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
