### PR TITLE
PR16: add memory conflict schema and store

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,7 @@ graph TB
             CONV_STORE["ConversationStore<br/>Drizzle ORM CRUD"]
             INDEXER["Memory Indexer<br/>segment + extract"]
             RECALL["Memory Recall<br/>FTS5 + Qdrant + Entity Graph + RRF<br/>Trust + Freshness + Scope"]
+            CONFLICT_STORE["ConflictStore<br/>pending/resolved clarification state"]
             JOBS_WORKER["MemoryJobsWorker<br/>poll every 1.5s"]
         end
 
@@ -78,6 +79,7 @@ graph TB
             DB_FTS["memory_segment_fts (FTS5)"]
             DB_ITEMS["memory_items"]
             DB_SRC["memory_item_sources"]
+            DB_CONFLICTS["memory_item_conflicts"]
             DB_ENT["memory_entities"]
             DB_REL["memory_entity_relations"]
             DB_ITEM_ENT["memory_item_entities"]
@@ -282,6 +284,7 @@ graph LR
         SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
         FTS["memory_segment_fts<br/>───────────────<br/>FTS5 virtual table<br/>Auto-synced via triggers<br/>Powers lexical search"]
         ITEMS["memory_items<br/>───────────────<br/>Extracted facts/entities<br/>kind, subject, statement<br/>confidence, fingerprint (dedup)<br/>verification_state, scope_id<br/>first/last seen timestamps"]
+        CONFLICTS["memory_item_conflicts<br/>───────────────<br/>Pending/resolved contradiction pairs<br/>existing_item_id + candidate_item_id<br/>clarification question + resolution note<br/>partial unique pending pair index"]
         ENTITIES["memory_entities<br/>───────────────<br/>Canonical entities + aliases<br/>mention_count, first/last seen<br/>Resolved across messages"]
         RELS["memory_entity_relations<br/>───────────────<br/>Directional entity edges<br/>Unique by source/target/relation<br/>first/last seen + evidence"]
         ITEM_ENTS["memory_item_entities<br/>───────────────<br/>Join table linking extracted<br/>memory_items to entities"]
@@ -1349,6 +1352,7 @@ graph LR
 | Conversations & messages | `~/.vellum/data/db/assistant.db` | SQLite + WAL | Drizzle ORM (Bun) | Permanent |
 | Memory segments & FTS | `~/.vellum/data/db/assistant.db` | SQLite FTS5 | Drizzle ORM | Permanent |
 | Extracted facts | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent, deduped |
+| Conflict lifecycle rows | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Pending until clarified, then retained as resolved history |
 | Entity graph (entities/relations/item links) | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Permanent, deduped by unique relation edge |
 | Embeddings | `~/.vellum/data/db/assistant.db` | JSON float arrays | Drizzle ORM | Permanent |
 | Async job queue | `~/.vellum/data/db/assistant.db` | SQLite | Drizzle ORM | Completed jobs persist |

--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -1,0 +1,254 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'conflict-store-test-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { initializeDb, getDb } from '../memory/db.js';
+import { memoryItems } from '../memory/schema.js';
+import {
+  createOrUpdatePendingConflict,
+  getConflictById,
+  getPendingConflictByPair,
+  listPendingConflicts,
+  markConflictAsked,
+  resolveConflict,
+} from '../memory/conflict-store.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM memory_item_conflicts');
+  db.run('DELETE FROM memory_item_sources');
+  db.run('DELETE FROM memory_items');
+}
+
+function insertItemPair(suffix: string, scopeId = 'default'): { existingItemId: string; candidateItemId: string } {
+  const db = getDb();
+  const now = Date.now();
+  const existingItemId = `existing-${suffix}`;
+  const candidateItemId = `candidate-${suffix}`;
+  db.insert(memoryItems).values([
+    {
+      id: existingItemId,
+      kind: 'fact',
+      subject: 'framework preference',
+      statement: `Existing statement ${suffix}`,
+      status: 'active',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: `fp-existing-${suffix}`,
+      verificationState: 'assistant_inferred',
+      scopeId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+    },
+    {
+      id: candidateItemId,
+      kind: 'fact',
+      subject: 'framework preference',
+      statement: `Candidate statement ${suffix}`,
+      status: 'pending_clarification',
+      confidence: 0.8,
+      importance: 0.5,
+      fingerprint: `fp-candidate-${suffix}`,
+      verificationState: 'assistant_inferred',
+      scopeId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+    },
+  ]).run();
+
+  return { existingItemId, candidateItemId };
+}
+
+describe('conflict-store', () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test('creates and fetches a pending conflict', () => {
+    const pair = insertItemPair('create');
+    const conflict = createOrUpdatePendingConflict({
+      scopeId: 'default',
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Do you prefer React or Vue?',
+    });
+
+    expect(conflict.id).toBeDefined();
+    expect(conflict.status).toBe('pending_clarification');
+    expect(conflict.scopeId).toBe('default');
+    expect(conflict.relationship).toBe('ambiguous_contradiction');
+    expect(conflict.clarificationQuestion).toBe('Do you prefer React or Vue?');
+
+    const byPair = getPendingConflictByPair('default', pair.existingItemId, pair.candidateItemId);
+    expect(byPair?.id).toBe(conflict.id);
+  });
+
+  test('deduplicates unresolved pair and updates fields in place', () => {
+    const pair = insertItemPair('dedupe');
+    const first = createOrUpdatePendingConflict({
+      scopeId: 'default',
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'contradiction',
+      clarificationQuestion: 'First question',
+    });
+
+    const second = createOrUpdatePendingConflict({
+      scopeId: 'default',
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Second question',
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.relationship).toBe('ambiguous_contradiction');
+    expect(second.clarificationQuestion).toBe('Second question');
+    expect(listPendingConflicts('default')).toHaveLength(1);
+  });
+
+  test('allows a new pending row for the same pair after resolution', () => {
+    const pair = insertItemPair('reopen');
+    const first = createOrUpdatePendingConflict({
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+
+    const resolved = resolveConflict(first.id, {
+      status: 'resolved_keep_existing',
+      resolutionNote: 'User confirmed existing statement is correct.',
+    });
+    expect(resolved?.status).toBe('resolved_keep_existing');
+    expect(typeof resolved?.resolvedAt).toBe('number');
+
+    const reopened = createOrUpdatePendingConflict({
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Please confirm again',
+    });
+
+    expect(reopened.id).not.toBe(first.id);
+    expect(getConflictById(first.id)?.status).toBe('resolved_keep_existing');
+    expect(listPendingConflicts('default')).toHaveLength(1);
+  });
+
+  test('lists only pending conflicts for a scope', () => {
+    const defaultA = insertItemPair('scope-a');
+    const defaultB = insertItemPair('scope-b');
+    const otherScope = insertItemPair('scope-other', 'workspace-b');
+
+    const conflictA = createOrUpdatePendingConflict({
+      scopeId: 'default',
+      existingItemId: defaultA.existingItemId,
+      candidateItemId: defaultA.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+    const conflictB = createOrUpdatePendingConflict({
+      scopeId: 'default',
+      existingItemId: defaultB.existingItemId,
+      candidateItemId: defaultB.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+    createOrUpdatePendingConflict({
+      scopeId: 'workspace-b',
+      existingItemId: otherScope.existingItemId,
+      candidateItemId: otherScope.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+
+    resolveConflict(conflictB.id, {
+      status: 'dismissed',
+      resolutionNote: 'Irrelevant to active context',
+    });
+
+    const pendingDefault = listPendingConflicts('default');
+    expect(pendingDefault).toHaveLength(1);
+    expect(pendingDefault[0].id).toBe(conflictA.id);
+    expect(pendingDefault[0].status).toBe('pending_clarification');
+  });
+
+  test('markConflictAsked updates lastAskedAt', () => {
+    const pair = insertItemPair('asked');
+    const conflict = createOrUpdatePendingConflict({
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+
+    const askedAt = 1_734_000_000_000;
+    expect(markConflictAsked(conflict.id, askedAt)).toBe(true);
+    const updated = getConflictById(conflict.id);
+    expect(updated?.lastAskedAt).toBe(askedAt);
+    expect(updated?.updatedAt).toBe(askedAt);
+  });
+
+  test('enforces pending-pair uniqueness with a partial index', () => {
+    const pair = insertItemPair('index');
+    const raw = (getDb() as unknown as { $client: import('bun:sqlite').Database }).$client;
+    const now = Date.now();
+
+    raw.run(
+      `INSERT INTO memory_item_conflicts (
+        id, scope_id, existing_item_id, candidate_item_id, relationship, status,
+        clarification_question, resolution_note, last_asked_at, resolved_at, created_at, updated_at
+      ) VALUES (
+        'conflict-index-a', 'default', '${pair.existingItemId}', '${pair.candidateItemId}',
+        'ambiguous_contradiction', 'pending_clarification', NULL, NULL, NULL, NULL, ${now}, ${now}
+      )`,
+    );
+
+    expect(() => {
+      raw.run(
+        `INSERT INTO memory_item_conflicts (
+          id, scope_id, existing_item_id, candidate_item_id, relationship, status,
+          clarification_question, resolution_note, last_asked_at, resolved_at, created_at, updated_at
+        ) VALUES (
+          'conflict-index-b', 'default', '${pair.existingItemId}', '${pair.candidateItemId}',
+          'ambiguous_contradiction', 'pending_clarification', NULL, NULL, NULL, NULL, ${now + 1}, ${now + 1}
+        )`,
+      );
+    }).toThrow();
+
+    expect(() => {
+      raw.run(
+        `INSERT INTO memory_item_conflicts (
+          id, scope_id, existing_item_id, candidate_item_id, relationship, status,
+          clarification_question, resolution_note, last_asked_at, resolved_at, created_at, updated_at
+        ) VALUES (
+          'conflict-index-c', 'default', '${pair.existingItemId}', '${pair.candidateItemId}',
+          'ambiguous_contradiction', 'resolved_keep_candidate', NULL, NULL, NULL, ${now + 2}, ${now + 2}, ${now + 2}
+        )`,
+      );
+    }).not.toThrow();
+  });
+});

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -1,0 +1,186 @@
+import { and, asc, eq } from 'drizzle-orm';
+import { v4 as uuid } from 'uuid';
+import { getDb } from './db.js';
+import { memoryItemConflicts } from './schema.js';
+
+export type MemoryConflictRelationship =
+  | 'contradiction'
+  | 'ambiguous_contradiction'
+  | 'update'
+  | 'complement';
+
+export type MemoryConflictStatus =
+  | 'pending_clarification'
+  | 'resolved_keep_existing'
+  | 'resolved_keep_candidate'
+  | 'resolved_merge'
+  | 'dismissed';
+
+export type ResolvedMemoryConflictStatus = Exclude<MemoryConflictStatus, 'pending_clarification'>;
+
+export interface MemoryItemConflict {
+  id: string;
+  scopeId: string;
+  existingItemId: string;
+  candidateItemId: string;
+  relationship: string;
+  status: MemoryConflictStatus;
+  clarificationQuestion: string | null;
+  resolutionNote: string | null;
+  lastAskedAt: number | null;
+  resolvedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreatePendingConflictInput {
+  scopeId?: string;
+  existingItemId: string;
+  candidateItemId: string;
+  relationship: string;
+  clarificationQuestion?: string | null;
+}
+
+export interface ResolveConflictInput {
+  status: ResolvedMemoryConflictStatus;
+  resolutionNote?: string | null;
+}
+
+export function createOrUpdatePendingConflict(input: CreatePendingConflictInput): MemoryItemConflict {
+  const db = getDb();
+  const now = Date.now();
+  const scopeId = input.scopeId ?? 'default';
+  const existing = getPendingConflictByPair(scopeId, input.existingItemId, input.candidateItemId);
+
+  if (existing) {
+    db.update(memoryItemConflicts)
+      .set({
+        relationship: input.relationship,
+        clarificationQuestion: input.clarificationQuestion ?? existing.clarificationQuestion,
+        updatedAt: now,
+      })
+      .where(eq(memoryItemConflicts.id, existing.id))
+      .run();
+    const updated = getConflictById(existing.id);
+    if (!updated) {
+      throw new Error(`Failed to reload updated conflict: ${existing.id}`);
+    }
+    return updated;
+  }
+
+  const id = uuid();
+  db.insert(memoryItemConflicts).values({
+    id,
+    scopeId,
+    existingItemId: input.existingItemId,
+    candidateItemId: input.candidateItemId,
+    relationship: input.relationship,
+    status: 'pending_clarification',
+    clarificationQuestion: input.clarificationQuestion ?? null,
+    resolutionNote: null,
+    lastAskedAt: null,
+    resolvedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+
+  const created = getConflictById(id);
+  if (!created) {
+    throw new Error(`Failed to load created conflict: ${id}`);
+  }
+  return created;
+}
+
+export function getConflictById(conflictId: string): MemoryItemConflict | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(memoryItemConflicts)
+    .where(eq(memoryItemConflicts.id, conflictId))
+    .get();
+  return row ? toConflict(row) : null;
+}
+
+export function getPendingConflictByPair(
+  scopeId: string,
+  existingItemId: string,
+  candidateItemId: string,
+): MemoryItemConflict | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(memoryItemConflicts)
+    .where(and(
+      eq(memoryItemConflicts.scopeId, scopeId),
+      eq(memoryItemConflicts.existingItemId, existingItemId),
+      eq(memoryItemConflicts.candidateItemId, candidateItemId),
+      eq(memoryItemConflicts.status, 'pending_clarification'),
+    ))
+    .get();
+  return row ? toConflict(row) : null;
+}
+
+export function listPendingConflicts(scopeId: string, limit = 100): MemoryItemConflict[] {
+  if (limit <= 0) return [];
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memoryItemConflicts)
+    .where(and(
+      eq(memoryItemConflicts.scopeId, scopeId),
+      eq(memoryItemConflicts.status, 'pending_clarification'),
+    ))
+    .orderBy(asc(memoryItemConflicts.createdAt))
+    .limit(limit)
+    .all();
+  return rows.map(toConflict);
+}
+
+export function markConflictAsked(conflictId: string, askedAt = Date.now()): boolean {
+  const db = getDb();
+  const result = db.update(memoryItemConflicts)
+    .set({
+      lastAskedAt: askedAt,
+      updatedAt: askedAt,
+    })
+    .where(eq(memoryItemConflicts.id, conflictId))
+    .run() as unknown as { changes?: number };
+
+  return (result.changes ?? 0) > 0;
+}
+
+export function resolveConflict(conflictId: string, input: ResolveConflictInput): MemoryItemConflict | null {
+  const existing = getConflictById(conflictId);
+  if (!existing) return null;
+
+  const db = getDb();
+  const now = Date.now();
+  db.update(memoryItemConflicts)
+    .set({
+      status: input.status,
+      resolutionNote: input.resolutionNote ?? existing.resolutionNote,
+      resolvedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(memoryItemConflicts.id, conflictId))
+    .run();
+
+  return getConflictById(conflictId);
+}
+
+function toConflict(row: typeof memoryItemConflicts.$inferSelect): MemoryItemConflict {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    existingItemId: row.existingItemId,
+    candidateItemId: row.candidateItemId,
+    relationship: row.relationship,
+    status: row.status as MemoryConflictStatus,
+    clarificationQuestion: row.clarificationQuestion,
+    resolutionNote: row.resolutionNote,
+    lastAskedAt: row.lastAskedAt,
+    resolvedAt: row.resolvedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -107,6 +107,23 @@ export function initializeDb(): void {
   `);
 
   database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_item_conflicts (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      existing_item_id TEXT NOT NULL REFERENCES memory_items(id) ON DELETE CASCADE,
+      candidate_item_id TEXT NOT NULL REFERENCES memory_items(id) ON DELETE CASCADE,
+      relationship TEXT NOT NULL,
+      status TEXT NOT NULL,
+      clarification_question TEXT,
+      resolution_note TEXT,
+      last_asked_at INTEGER,
+      resolved_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS memory_summaries (
       id TEXT PRIMARY KEY,
       scope TEXT NOT NULL,
@@ -389,6 +406,15 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_segments_message_segment ON memory_segments(message_id, segment_index)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_created ON memory_segments(conversation_id, created_at DESC)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_sources_message_id ON memory_item_sources(message_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_status_created ON memory_item_conflicts(status, created_at)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_scope_status ON memory_item_conflicts(scope_id, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_existing_item_id ON memory_item_conflicts(existing_item_id)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_candidate_item_id ON memory_item_conflicts(candidate_item_id)`);
+  database.run(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_item_conflicts_pending_pair_unique
+    ON memory_item_conflicts(scope_id, existing_item_id, candidate_item_id)
+    WHERE status = 'pending_clarification'
+  `);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_kind_status ON memory_items(kind, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);

--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -84,6 +84,25 @@ export const memoryItemSources = sqliteTable('memory_item_sources', {
   createdAt: integer('created_at').notNull(),
 });
 
+export const memoryItemConflicts = sqliteTable('memory_item_conflicts', {
+  id: text('id').primaryKey(),
+  scopeId: text('scope_id').notNull().default('default'),
+  existingItemId: text('existing_item_id')
+    .notNull()
+    .references(() => memoryItems.id, { onDelete: 'cascade' }),
+  candidateItemId: text('candidate_item_id')
+    .notNull()
+    .references(() => memoryItems.id, { onDelete: 'cascade' }),
+  relationship: text('relationship').notNull(),
+  status: text('status').notNull(),
+  clarificationQuestion: text('clarification_question'),
+  resolutionNote: text('resolution_note'),
+  lastAskedAt: integer('last_asked_at'),
+  resolvedAt: integer('resolved_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
 export const memorySummaries = sqliteTable('memory_summaries', {
   id: text('id').primaryKey(),
   scope: text('scope').notNull(),


### PR DESCRIPTION
## Summary
- add `memory_item_conflicts` schema and SQLite DDL
- add conflict lifecycle indexes including partial unique unresolved pair index
- add `conflict-store` helpers for create/update pending conflicts, listing, ask tracking, and resolution
- add `conflict-store` test coverage for dedupe, resolution, and partial-index behavior
- update architecture docs for the new conflict lifecycle table/module

## Testing
- export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/conflict-store.test.ts