### PR TITLE
test(swift): add DaemonClient probe state tests and macOS README blob docs

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -297,7 +297,9 @@ Inference/            AI action selection
   AnthropicClient     Shared HTTP client with retry logic (used by KnowledgeCron)
   ToolDefinitions     Tool schemas for function calling
 IPC/                  Daemon communication
-  DaemonClient        Unix domain socket IPC client (auto-reconnect, ping/pong)
+  DaemonClient        Unix domain socket IPC client (auto-reconnect, ping/pong,
+                      blob probe for zero-copy transport)
+  IpcBlobStore        Local blob file writer for zero-copy IPC payloads
   Generated/
     IPCContractGenerated  Auto-generated Codable DTOs from the TS IPC contract
   IPCMessages         Typealiases to generated types, convenience inits,
@@ -329,6 +331,10 @@ Logging/
 ## Remote Daemon
 
 The app supports connecting to a remote daemon via SSH socket forwarding. Set `VELLUM_DAEMON_SOCKET` to the forwarded socket path. See the [Remote Access](../../README.md#remote-access) section in the root README.
+
+### Zero-Copy Blob Transport
+
+On local macOS connections, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/data/ipc-blobs/` instead of inline base64/text. On every macOS socket connect, the client runs a blob probe: writes a random nonce to the blob directory and sends its SHA-256 to the daemon. If the daemon reads the file and the hashes match, `isBlobTransportAvailable` is set to `true` and subsequent observations use blob references. Over SSH-forwarded sockets, the probe fails automatically (no shared filesystem) and the client falls back to inline payloads. On iOS, the probe is compiled out via `#if os(macOS)`.
 
 ## Safety
 

--- a/clients/macos/vellum-assistantTests/DaemonClientProbeTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientProbeTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class DaemonClientProbeTests: XCTestCase {
+
+    private var client: DaemonClient!
+
+    override func setUp() {
+        super.setUp()
+        client = DaemonClient()
+    }
+
+    override func tearDown() {
+        client.disconnect()
+        client = nil
+        super.tearDown()
+    }
+
+    // MARK: - Probe result state transitions
+
+    func testProbeResultOkSetsAvailableTrue() {
+        client.pendingProbeId = "probe-1"
+
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+
+        XCTAssertTrue(client.isBlobTransportAvailable)
+    }
+
+    func testProbeResultNotOkSetsAvailableFalse() {
+        // First set it to true via a successful probe
+        client.pendingProbeId = "probe-1"
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+        XCTAssertTrue(client.isBlobTransportAvailable)
+
+        // Now a failed probe
+        client.pendingProbeId = "probe-2"
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-2",
+            ok: false,
+            observedNonceSha256: nil,
+            reason: "hash mismatch"
+        ))
+
+        XCTAssertFalse(client.isBlobTransportAvailable)
+    }
+
+    func testStaleProbeResultIsIgnored() {
+        client.pendingProbeId = "probe-2"
+
+        // Send a result for a different probe ID
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+
+        // Should remain false — stale result was ignored
+        XCTAssertFalse(client.isBlobTransportAvailable)
+        // pendingProbeId should NOT be cleared for stale results
+        XCTAssertEqual(client.pendingProbeId, "probe-2")
+    }
+
+    func testProbeResultClearsPendingProbeId() {
+        client.pendingProbeId = "probe-1"
+
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+
+        XCTAssertNil(client.pendingProbeId)
+    }
+
+    func testProbeResultWithNoPendingIdIsIgnored() {
+        // No pendingProbeId set (nil)
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+
+        XCTAssertFalse(client.isBlobTransportAvailable)
+    }
+
+    // MARK: - Disconnect resets probe state
+
+    func testDisconnectResetsAvailableToFalse() {
+        // Set up a successful probe
+        client.pendingProbeId = "probe-1"
+        client.handleBlobProbeResult(IpcBlobProbeResultMessage(
+            type: "ipc_blob_probe_result",
+            probeId: "probe-1",
+            ok: true,
+            observedNonceSha256: "abc123",
+            reason: nil
+        ))
+        XCTAssertTrue(client.isBlobTransportAvailable)
+
+        // Disconnect
+        client.disconnect()
+
+        XCTAssertFalse(client.isBlobTransportAvailable)
+    }
+
+    func testDisconnectClearsPendingProbeId() {
+        client.pendingProbeId = "probe-1"
+
+        client.disconnect()
+
+        XCTAssertNil(client.pendingProbeId)
+    }
+
+    // MARK: - Initial state
+
+    func testInitialStateIsFalse() {
+        let fresh = DaemonClient()
+        XCTAssertFalse(fresh.isBlobTransportAvailable)
+        XCTAssertNil(fresh.pendingProbeId)
+        fresh.disconnect()
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -196,7 +196,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// The probe ID we're currently waiting for a response to.
     /// Used to match ipc_blob_probe_result to the outstanding probe.
-    private var pendingProbeId: String?
+    /// Internal (not private) for testability via @testable import.
+    var pendingProbeId: String?
 
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
@@ -874,7 +875,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     #endif
 
     /// Process a blob probe result from the daemon.
-    private func handleBlobProbeResult(_ result: IpcBlobProbeResultMessage) {
+    /// Internal (not private) for testability via @testable import.
+    func handleBlobProbeResult(_ result: IpcBlobProbeResultMessage) {
         guard result.probeId == pendingProbeId else {
             log.warning("Blob probe: ignoring stale result for \(result.probeId) (expected \(self.pendingProbeId ?? "nil"))")
             return


### PR DESCRIPTION
## Summary
- Add `DaemonClientProbeTests.swift` with 8 tests for `isBlobTransportAvailable` state machine: successful probe, failed probe, stale probe ID ignored, pending ID cleared after match, nil pending ignored, disconnect resets state, initial state
- Widen `pendingProbeId` and `handleBlobProbeResult` from `private` to `internal` for `@testable import` access
- Add zero-copy blob transport section to `clients/macos/README.md` under Remote Daemon, and add `IpcBlobStore` to the architecture tree

Addresses P2 review feedback: Swift probe-state test coverage and macOS README documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
