### PR TITLE
PR17: add ambiguous contradiction pending-clarification flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -508,6 +508,7 @@ graph TB
         EMBED_ITEM["embed_item<br/>→ memory_embeddings"]
         EMBED_SUM["embed_summary<br/>→ memory_embeddings"]
         EXTRACT["extract_items<br/>→ memory_items +<br/>memory_item_sources"]
+        CHECK_CONTRA["check_contradictions<br/>→ contradiction/update merge OR<br/>pending_clarification + memory_item_conflicts"]
         EXTRACT_ENTITIES["extract_entities<br/>→ memory_entities +<br/>memory_item_entities +<br/>memory_entity_relations"]
         BACKFILL_REL["backfill_entity_relations<br/>checkpointed message scan<br/>→ enqueue extract_entities"]
         BUILD_SUM["build_conversation_summary<br/>→ memory_summaries"]
@@ -556,10 +557,12 @@ graph TB
     WORKER --> EMBED_ITEM
     WORKER --> EMBED_SUM
     WORKER --> EXTRACT
+    WORKER --> CHECK_CONTRA
     WORKER --> EXTRACT_ENTITIES
     WORKER --> BACKFILL_REL
     WORKER --> BUILD_SUM
     WORKER --> WEEKLY
+    EXTRACT --> CHECK_CONTRA
     EXTRACT --> EXTRACT_ENTITIES
 
     EMBED_SEG --> OAI_EMB

--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+
+const testDir = mkdtempSync(join(tmpdir(), 'contradiction-checker-test-'));
+
+let nextRelationship = 'ambiguous_contradiction';
+let nextExplanation = 'Statements likely conflict but need confirmation.';
+let classifyCallCount = 0;
+
+const classifyRelationshipMock = mock(async () => {
+  classifyCallCount += 1;
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        input: {
+          relationship: nextRelationship,
+          explanation: nextExplanation,
+        },
+      },
+    ],
+  };
+});
+
+mock.module('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: classifyRelationshipMock,
+    };
+  },
+}));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { anthropic: 'test-key' },
+  }),
+}));
+
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { checkContradictions } from '../memory/contradiction-checker.js';
+import { memoryItemConflicts, memoryItems } from '../memory/schema.js';
+
+beforeAll(() => {
+  initializeDb();
+});
+
+beforeEach(() => {
+  classifyCallCount = 0;
+  const db = getDb();
+  db.run('DELETE FROM memory_item_conflicts');
+  db.run('DELETE FROM memory_item_sources');
+  db.run('DELETE FROM memory_jobs');
+  db.run('DELETE FROM memory_items');
+});
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+});
+
+function insertMemoryItem(params: {
+  id: string;
+  statement: string;
+  scopeId?: string;
+  status?: 'active' | 'pending_clarification';
+}): void {
+  const now = Date.now();
+  const db = getDb();
+  db.insert(memoryItems).values({
+    id: params.id,
+    kind: 'preference',
+    subject: 'framework preference',
+    statement: params.statement,
+    status: params.status ?? 'active',
+    confidence: 0.8,
+    importance: 0.7,
+    fingerprint: `fp-${params.id}`,
+    verificationState: 'assistant_inferred',
+    scopeId: params.scopeId ?? 'default',
+    firstSeenAt: now,
+    lastSeenAt: now,
+  }).run();
+}
+
+describe('checkContradictions', () => {
+  test('marks candidate pending and writes one conflict row for ambiguous contradictions', async () => {
+    nextRelationship = 'ambiguous_contradiction';
+    nextExplanation = 'Seems contradictory; ask user to choose.';
+
+    insertMemoryItem({
+      id: 'item-existing-ambiguous',
+      statement: 'User prefers React for frontend work.',
+      scopeId: 'workspace-a',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-ambiguous',
+      statement: 'User prefers Vue for frontend work.',
+      scopeId: 'workspace-a',
+    });
+
+    await checkContradictions('item-candidate-ambiguous');
+
+    const db = getDb();
+    const candidate = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, 'item-candidate-ambiguous'))
+      .get();
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, 'item-existing-ambiguous'))
+      .get();
+    const conflicts = db.select().from(memoryItemConflicts).all();
+
+    expect(classifyCallCount).toBe(1);
+    expect(candidate?.status).toBe('pending_clarification');
+    expect(existing?.invalidAt).toBeNull();
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].status).toBe('pending_clarification');
+    expect(conflicts[0].existingItemId).toBe('item-existing-ambiguous');
+    expect(conflicts[0].candidateItemId).toBe('item-candidate-ambiguous');
+    expect(conflicts[0].relationship).toBe('ambiguous_contradiction');
+    expect(conflicts[0].clarificationQuestion).toContain('Which one is correct?');
+  });
+
+  test('keeps existing contradiction behavior and does not create conflict row', async () => {
+    nextRelationship = 'contradiction';
+    nextExplanation = 'The statements are directly incompatible.';
+
+    insertMemoryItem({
+      id: 'item-existing-contradiction',
+      statement: 'User prefers dark mode.',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-contradiction',
+      statement: 'User prefers light mode.',
+    });
+
+    await checkContradictions('item-candidate-contradiction');
+
+    const db = getDb();
+    const candidate = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, 'item-candidate-contradiction'))
+      .get();
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, 'item-existing-contradiction'))
+      .get();
+    const conflicts = db.select().from(memoryItemConflicts).all();
+
+    expect(classifyCallCount).toBe(1);
+    expect(candidate?.status).toBe('active');
+    expect(typeof candidate?.validFrom).toBe('number');
+    expect(typeof existing?.invalidAt).toBe('number');
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test('only evaluates contradiction candidates within the same scope', async () => {
+    nextRelationship = 'ambiguous_contradiction';
+    nextExplanation = 'Should not be used for this test.';
+
+    insertMemoryItem({
+      id: 'item-existing-other-scope',
+      statement: 'Use Go for backend services.',
+      scopeId: 'workspace-b',
+    });
+    insertMemoryItem({
+      id: 'item-candidate-default-scope',
+      statement: 'Use Rust for backend services.',
+      scopeId: 'workspace-a',
+    });
+
+    await checkContradictions('item-candidate-default-scope');
+
+    const db = getDb();
+    const candidate = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.id, 'item-candidate-default-scope'))
+      .get();
+    const conflicts = db.select().from(memoryItemConflicts).all();
+
+    expect(classifyCallCount).toBe(0);
+    expect(candidate?.status).toBe('active');
+    expect(conflicts).toHaveLength(0);
+  });
+});

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -2,6 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { eq } from 'drizzle-orm';
 import { getConfig } from '../config/loader.js';
 import { getLogger } from '../util/logger.js';
+import { createOrUpdatePendingConflict } from './conflict-store.js';
 import { getDb } from './db.js';
 import { enqueueMemoryJob } from './jobs-store.js';
 import { memoryItems } from './schema.js';
@@ -10,7 +11,7 @@ const log = getLogger('memory-contradiction-checker');
 
 const CONTRADICTION_LLM_TIMEOUT_MS = 15_000;
 
-type Relationship = 'contradiction' | 'update' | 'complement';
+type Relationship = 'contradiction' | 'update' | 'complement' | 'ambiguous_contradiction';
 
 interface ClassifyResult {
   relationship: Relationship;
@@ -23,6 +24,7 @@ Classify the relationship as one of:
 - "contradiction": The new statement directly contradicts the old statement. They cannot both be true at the same time. Example: "User prefers dark mode" vs "User prefers light mode".
 - "update": The new statement provides updated or more specific information that supersedes the old statement, but does not contradict it. Example: "User works at Acme" vs "User works at Acme as a senior engineer".
 - "complement": The statements are compatible and provide different, non-overlapping information. Both can coexist. Example: "User likes TypeScript" vs "User prefers functional programming".
+- "ambiguous_contradiction": The statements appear to conflict, but there is not enough confidence to invalidate either statement without user clarification.
 
 Be conservative: only classify as "contradiction" when the statements are genuinely incompatible. Prefer "complement" when in doubt.`;
 
@@ -65,7 +67,9 @@ export async function checkContradictions(newItemId: string): Promise<void> {
       // Only stop when the new item itself is invalidated (update case).
       // For contradiction, the old item is invalidated but the new item remains
       // active and should continue to be checked against remaining candidates.
-      if (result.relationship === 'update') break;
+      // For ambiguous contradiction, we pause retrieval eligibility for the new
+      // item and ask for clarification on a later turn.
+      if (result.relationship === 'update' || result.relationship === 'ambiguous_contradiction') break;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn({ err: message, newItemId, existingId: existing.id }, 'Contradiction classification failed for pair');
@@ -81,6 +85,7 @@ interface MemoryItemRow {
   status: string;
   confidence: number;
   importance: number | null;
+  scopeId: string;
   lastSeenAt: number;
 }
 
@@ -125,19 +130,20 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
   if (likeClauses.length === 0) return [];
 
   const sqlQuery = `
-    SELECT id, kind, subject, statement, status, confidence, importance, last_seen_at
+    SELECT id, kind, subject, statement, status, confidence, importance, scope_id, last_seen_at
     FROM memory_items
     WHERE status = 'active'
       AND invalid_at IS NULL
       AND kind = ?
       AND id <> ?
+      AND scope_id = ?
       AND (${likeClauses.join(' OR ')})
     ORDER BY last_seen_at DESC
     LIMIT 10
   `;
 
   try {
-    const rows = raw.query(sqlQuery).all(item.kind, item.id) as Array<{
+    const rows = raw.query(sqlQuery).all(item.kind, item.id, item.scopeId) as Array<{
       id: string;
       kind: string;
       subject: string;
@@ -145,6 +151,7 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
       status: string;
       confidence: number;
       importance: number | null;
+      scope_id: string;
       last_seen_at: number;
     }>;
 
@@ -156,6 +163,7 @@ function findSimilarItems(item: MemoryItemRow): MemoryItemRow[] {
       status: row.status,
       confidence: row.confidence,
       importance: row.importance,
+      scopeId: row.scope_id,
       lastSeenAt: row.last_seen_at,
     }));
   } catch (err) {
@@ -194,7 +202,7 @@ async function classifyRelationship(
           properties: {
             relationship: {
               type: 'string',
-              enum: ['contradiction', 'update', 'complement'],
+              enum: ['contradiction', 'update', 'complement', 'ambiguous_contradiction'],
               description: 'The relationship between the old and new statements',
             },
             explanation: {
@@ -220,7 +228,7 @@ async function classifyRelationship(
 
   const input = toolBlock.input as { relationship?: string; explanation?: string };
   const relationship = input.relationship as Relationship;
-  if (!['contradiction', 'update', 'complement'].includes(relationship)) {
+  if (!['contradiction', 'update', 'complement', 'ambiguous_contradiction'].includes(relationship)) {
     throw new Error(`Invalid relationship type: ${relationship}`);
   }
 
@@ -289,9 +297,33 @@ async function handleRelationship(
       );
       break;
     }
+    case 'ambiguous_contradiction': {
+      log.info(
+        { existingId: existingItem.id, newId: newItem.id, explanation: result.explanation },
+        'Ambiguous contradiction detected — gating candidate pending clarification',
+      );
+      db.update(memoryItems)
+        .set({ status: 'pending_clarification' })
+        .where(eq(memoryItems.id, newItem.id))
+        .run();
+      createOrUpdatePendingConflict({
+        scopeId: newItem.scopeId,
+        existingItemId: existingItem.id,
+        candidateItemId: newItem.id,
+        relationship: 'ambiguous_contradiction',
+        clarificationQuestion: buildClarificationQuestion(existingItem.statement, newItem.statement),
+      });
+      break;
+    }
   }
 }
 
 function escapeSqlLike(s: string): string {
   return s.replace(/'/g, "''").replace(/%/g, '').replace(/_/g, '');
+}
+
+function buildClarificationQuestion(existingStatement: string, candidateStatement: string): string {
+  const normalize = (input: string): string =>
+    input.replace(/\s+/g, ' ').trim().slice(0, 180);
+  return `I have conflicting notes: "${normalize(existingStatement)}" vs "${normalize(candidateStatement)}". Which one is correct?`;
 }


### PR DESCRIPTION
## Summary
- extend contradiction classification to include `ambiguous_contradiction`
- on ambiguous contradictions, set the candidate memory item to `pending_clarification`
- persist one pending conflict row via `conflict-store`
- scope contradiction candidate matching to the same `scope_id`
- add focused regression tests for ambiguous flow, contradiction fallback, and scope isolation
- update architecture flow docs for `check_contradictions` conflict lifecycle path

## Testing
- export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/contradiction-checker.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/conflict-store.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
