### PR TITLE
fix(chat): fix composer vertical resize by preventing layout oscillation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -20,6 +20,7 @@ struct ComposerView: View {
     @Binding var editorContentHeight: CGFloat
 
     @State private var composerScrollOffset: CGFloat = 0
+    @State private var expandedLatch = false
     @FocusState private var isComposerFocused: Bool
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -112,8 +113,12 @@ struct ComposerView: View {
         }
     }
 
+    /// Sticky: once the text wraps past a single line, stay expanded until
+    /// the text is cleared. This prevents a layout oscillation where the
+    /// wider expanded TextField causes text to unwrap, which triggers compact
+    /// mode, which causes text to wrap again, ad infinitum.
     private var isComposerExpanded: Bool {
-        editorContentHeight > 28
+        expandedLatch
     }
 
     private var isScrolledToBottom: Bool {
@@ -182,11 +187,13 @@ struct ComposerView: View {
             if editorContentHeight > 200 {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)
             }
+            if inputText.isEmpty { expandedLatch = false }
         }
         .onChange(of: editorContentHeight) {
             if editorContentHeight > 200 {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)
             }
+            if editorContentHeight > 28 { expandedLatch = true }
         }
         .onKeyPress(.tab, phases: .down) { keyPress in
             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {


### PR DESCRIPTION
## Summary
- Composer wasn't growing vertically when text wrapped — text was clipped to a single-line height
- Root cause: layout oscillation between compact (buttons beside text) and expanded (buttons below) modes — text would wrap in compact, trigger expanded, unwrap with more width, trigger compact again
- Fixed with a sticky `expandedLatch`: once the text grows past a single line the expanded layout locks in, only resetting when text is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
