### PR TITLE
PR18: add clarification resolver with heuristics and fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,6 +68,7 @@ graph TB
             INDEXER["Memory Indexer<br/>segment + extract"]
             RECALL["Memory Recall<br/>FTS5 + Qdrant + Entity Graph + RRF<br/>Trust + Freshness + Scope"]
             CONFLICT_STORE["ConflictStore<br/>pending/resolved clarification state"]
+            CLARIFICATION_RESOLVER["ClarificationResolver<br/>heuristics + timeout-bounded LLM fallback"]
             JOBS_WORKER["MemoryJobsWorker<br/>poll every 1.5s"]
         end
 

--- a/assistant/src/__tests__/clarification-resolver.test.ts
+++ b/assistant/src/__tests__/clarification-resolver.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let llmCallCount = 0;
+let llmDelayMs = 0;
+let llmResolution: 'keep_existing' | 'keep_candidate' | 'merge' | 'still_unclear' = 'still_unclear';
+let llmResolvedStatement = '';
+let llmExplanation = 'Unclear response from user.';
+
+mock.module('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: async () => {
+        llmCallCount += 1;
+        if (llmDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, llmDelayMs));
+        }
+        return {
+          content: [{
+            type: 'tool_use',
+            input: {
+              resolution: llmResolution,
+              resolved_statement: llmResolvedStatement,
+              explanation: llmExplanation,
+            },
+          }],
+        };
+      },
+    };
+  },
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: {
+      anthropic: 'test-key',
+    },
+  }),
+}));
+
+import { resolveConflictClarification } from '../memory/clarification-resolver.js';
+
+beforeEach(() => {
+  llmCallCount = 0;
+  llmDelayMs = 0;
+  llmResolution = 'still_unclear';
+  llmResolvedStatement = '';
+  llmExplanation = 'Unclear response from user.';
+});
+
+describe('resolveConflictClarification', () => {
+  test('returns keep_existing from deterministic heuristic', async () => {
+    const result = await resolveConflictClarification({
+      existingStatement: 'Use React for frontend work.',
+      candidateStatement: 'Use Vue for frontend work.',
+      userMessage: 'Keep the old React preference.',
+    });
+
+    expect(result.resolution).toBe('keep_existing');
+    expect(result.strategy).toBe('heuristic');
+    expect(llmCallCount).toBe(0);
+  });
+
+  test('returns keep_candidate from deterministic heuristic', async () => {
+    const result = await resolveConflictClarification({
+      existingStatement: 'Use React for frontend work.',
+      candidateStatement: 'Use Vue for frontend work.',
+      userMessage: 'Use the new Vue note going forward.',
+    });
+
+    expect(result.resolution).toBe('keep_candidate');
+    expect(result.strategy).toBe('heuristic');
+    expect(llmCallCount).toBe(0);
+  });
+
+  test('returns merge from deterministic heuristic', async () => {
+    const result = await resolveConflictClarification({
+      existingStatement: 'React is preferred for dashboards.',
+      candidateStatement: 'Vue is preferred for marketing pages.',
+      userMessage: 'Both are true: React for dashboards and Vue for marketing pages.',
+    });
+
+    expect(result.resolution).toBe('merge');
+    expect(result.strategy).toBe('heuristic');
+    expect(result.resolvedStatement).toContain('Both are true');
+    expect(llmCallCount).toBe(0);
+  });
+
+  test('uses LLM fallback when heuristics are inconclusive', async () => {
+    llmResolution = 'still_unclear';
+    llmExplanation = 'The user message does not pick a side.';
+
+    const result = await resolveConflictClarification({
+      existingStatement: 'Use React for frontend work.',
+      candidateStatement: 'Use Vue for frontend work.',
+      userMessage: 'Not sure yet.',
+    });
+
+    expect(result.resolution).toBe('still_unclear');
+    expect(result.strategy).toBe('llm');
+    expect(llmCallCount).toBe(1);
+  });
+
+  test('enforces timeout bound on LLM fallback', async () => {
+    llmResolution = 'keep_candidate';
+    llmExplanation = 'Prefer the newer statement.';
+    llmDelayMs = 50;
+
+    const result = await resolveConflictClarification(
+      {
+        existingStatement: 'Use React for frontend work.',
+        candidateStatement: 'Use Vue for frontend work.',
+        userMessage: 'I cannot decide right now.',
+      },
+      { timeoutMs: 5 },
+    );
+
+    expect(result.resolution).toBe('still_unclear');
+    expect(result.strategy).toBe('llm_timeout');
+    expect(llmCallCount).toBe(1);
+  });
+});

--- a/assistant/src/memory/clarification-resolver.ts
+++ b/assistant/src/memory/clarification-resolver.ts
@@ -1,0 +1,284 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { getConfig } from '../config/loader.js';
+
+const DEFAULT_RESOLVER_MODEL = 'claude-haiku-4-5-20251001';
+const DEFAULT_RESOLVER_TIMEOUT_MS = 12_000;
+
+const DIRECTIONAL_EXISTING_CUES = ['existing', 'old', 'previous', 'first', 'earlier', 'original', 'still'];
+const DIRECTIONAL_CANDIDATE_CUES = ['candidate', 'new', 'latest', 'second', 'updated', 'instead', 'replace'];
+const MERGE_CUES = ['both', 'merge', 'combine', 'together', 'depends', 'either', 'mix'];
+
+const STOP_WORDS = new Set([
+  'about', 'after', 'again', 'also', 'because', 'been', 'before', 'being', 'between',
+  'could', 'doing', 'from', 'have', 'into', 'just', 'more', 'most', 'only', 'over',
+  'same', 'should', 'some', 'than', 'that', 'their', 'there', 'these', 'they', 'this',
+  'those', 'were', 'what', 'when', 'where', 'which', 'while', 'with', 'would', 'your',
+]);
+
+export type ClarificationResolution =
+  | 'keep_existing'
+  | 'keep_candidate'
+  | 'merge'
+  | 'still_unclear';
+
+export type ClarificationStrategy =
+  | 'heuristic'
+  | 'llm'
+  | 'llm_timeout'
+  | 'llm_error'
+  | 'no_llm_key';
+
+export interface ClarificationResolverInput {
+  existingStatement: string;
+  candidateStatement: string;
+  userMessage: string;
+}
+
+export interface ClarificationResolverOptions {
+  apiKey?: string;
+  model?: string;
+  timeoutMs?: number;
+}
+
+export interface ClarificationResolverResult {
+  resolution: ClarificationResolution;
+  strategy: ClarificationStrategy;
+  resolvedStatement: string | null;
+  explanation: string;
+}
+
+export async function resolveConflictClarification(
+  input: ClarificationResolverInput,
+  options?: ClarificationResolverOptions,
+): Promise<ClarificationResolverResult> {
+  const heuristicResult = resolveWithHeuristics(input);
+  if (heuristicResult) return heuristicResult;
+
+  const config = getConfig();
+  const apiKey = options?.apiKey ?? config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return {
+      resolution: 'still_unclear',
+      strategy: 'no_llm_key',
+      resolvedStatement: null,
+      explanation: 'No Anthropic API key available for clarification fallback.',
+    };
+  }
+
+  try {
+    return await resolveWithLlm(input, {
+      apiKey,
+      model: options?.model ?? DEFAULT_RESOLVER_MODEL,
+      timeoutMs: options?.timeoutMs ?? DEFAULT_RESOLVER_TIMEOUT_MS,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'clarification_resolver_timeout') {
+      return {
+        resolution: 'still_unclear',
+        strategy: 'llm_timeout',
+        resolvedStatement: null,
+        explanation: 'Clarification resolver timed out.',
+      };
+    }
+    return {
+      resolution: 'still_unclear',
+      strategy: 'llm_error',
+      resolvedStatement: null,
+      explanation: `Clarification resolver failed: ${message.slice(0, 300)}`,
+    };
+  }
+}
+
+function resolveWithHeuristics(input: ClarificationResolverInput): ClarificationResolverResult | null {
+  const normalizedMessage = normalize(input.userMessage);
+  if (!normalizedMessage) return null;
+
+  const lowerMessage = normalizedMessage.toLowerCase();
+  if (containsAnyCue(lowerMessage, MERGE_CUES)) {
+    return {
+      resolution: 'merge',
+      strategy: 'heuristic',
+      resolvedStatement: buildMergedStatement(input),
+      explanation: 'User response includes merge cues.',
+    };
+  }
+
+  const hasExistingCue = containsAnyCue(lowerMessage, DIRECTIONAL_EXISTING_CUES);
+  const hasCandidateCue = containsAnyCue(lowerMessage, DIRECTIONAL_CANDIDATE_CUES);
+
+  if (hasExistingCue && !hasCandidateCue) {
+    return {
+      resolution: 'keep_existing',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'User response explicitly points to existing/old statement.',
+    };
+  }
+
+  if (hasCandidateCue && !hasExistingCue) {
+    return {
+      resolution: 'keep_candidate',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'User response explicitly points to candidate/new statement.',
+    };
+  }
+
+  const messageTokens = tokenize(normalizedMessage);
+  const existingOverlap = overlapScore(messageTokens, tokenize(input.existingStatement));
+  const candidateOverlap = overlapScore(messageTokens, tokenize(input.candidateStatement));
+
+  if (existingOverlap >= 2 && existingOverlap >= candidateOverlap + 1) {
+    return {
+      resolution: 'keep_existing',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'User response overlaps more with existing statement details.',
+    };
+  }
+
+  if (candidateOverlap >= 2 && candidateOverlap >= existingOverlap + 1) {
+    return {
+      resolution: 'keep_candidate',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'User response overlaps more with candidate statement details.',
+    };
+  }
+
+  if (existingOverlap > 0 && candidateOverlap > 0) {
+    return {
+      resolution: 'merge',
+      strategy: 'heuristic',
+      resolvedStatement: buildMergedStatement(input),
+      explanation: 'User response overlaps with both statements.',
+    };
+  }
+
+  return null;
+}
+
+async function resolveWithLlm(
+  input: ClarificationResolverInput,
+  options: { apiKey: string; model: string; timeoutMs: number },
+): Promise<ClarificationResolverResult> {
+  const client = new Anthropic({ apiKey: options.apiKey });
+  const userPrompt = [
+    'You are resolving a memory clarification response.',
+    '',
+    `Existing statement: ${input.existingStatement}`,
+    `Candidate statement: ${input.candidateStatement}`,
+    `User clarification: ${input.userMessage}`,
+  ].join('\n');
+
+  const response = await Promise.race([
+    client.messages.create({
+      model: options.model,
+      max_tokens: 256,
+      system: [
+        'Classify the user clarification for conflicting memory statements.',
+        'Return exactly one resolution:',
+        '- keep_existing',
+        '- keep_candidate',
+        '- merge',
+        '- still_unclear',
+      ].join('\n'),
+      tools: [{
+        name: 'resolve_conflict_clarification',
+        description: 'Resolve a pending memory contradiction using user clarification.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            resolution: {
+              type: 'string',
+              enum: ['keep_existing', 'keep_candidate', 'merge', 'still_unclear'],
+            },
+            resolved_statement: {
+              type: 'string',
+              description: 'Required only when resolution is merge.',
+            },
+            explanation: {
+              type: 'string',
+              description: 'One short rationale for the classification.',
+            },
+          },
+          required: ['resolution', 'explanation'],
+        },
+      }],
+      tool_choice: { type: 'tool' as const, name: 'resolve_conflict_clarification' },
+      messages: [{ role: 'user' as const, content: userPrompt }],
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('clarification_resolver_timeout')), options.timeoutMs),
+    ),
+  ]);
+
+  const toolBlock = response.content.find((block) => block.type === 'tool_use');
+  if (!toolBlock || toolBlock.type !== 'tool_use') {
+    throw new Error('No tool_use block in clarification resolver response.');
+  }
+
+  const parsed = toolBlock.input as {
+    resolution?: string;
+    resolved_statement?: string;
+    explanation?: string;
+  };
+
+  if (!isResolution(parsed.resolution)) {
+    throw new Error(`Invalid clarification resolution: ${String(parsed.resolution)}`);
+  }
+
+  const resolvedStatement = parsed.resolution === 'merge'
+    ? normalize(parsed.resolved_statement ?? buildMergedStatement(input)) || buildMergedStatement(input)
+    : null;
+
+  return {
+    resolution: parsed.resolution,
+    strategy: 'llm',
+    resolvedStatement,
+    explanation: normalize(parsed.explanation ?? 'Resolved via LLM fallback.').slice(0, 500),
+  };
+}
+
+function isResolution(value: string | undefined): value is ClarificationResolution {
+  return value === 'keep_existing'
+    || value === 'keep_candidate'
+    || value === 'merge'
+    || value === 'still_unclear';
+}
+
+function containsAnyCue(input: string, cues: readonly string[]): boolean {
+  return cues.some((cue) => input.includes(cue));
+}
+
+function overlapScore(left: Set<string>, right: Set<string>): number {
+  let score = 0;
+  for (const token of left) {
+    if (right.has(token)) score += 1;
+  }
+  return score;
+}
+
+function tokenize(input: string): Set<string> {
+  const words = input
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((word) => word.trim())
+    .filter((word) => word.length >= 4 && !STOP_WORDS.has(word));
+  return new Set(words);
+}
+
+function normalize(input: string): string {
+  return input.replace(/\s+/g, ' ').trim();
+}
+
+function buildMergedStatement(input: ClarificationResolverInput): string {
+  const normalizedUserMessage = normalize(input.userMessage);
+  if (normalizedUserMessage.length >= 8 && normalizedUserMessage.length <= 320) {
+    return normalizedUserMessage;
+  }
+  const existing = normalize(input.existingStatement).slice(0, 140);
+  const candidate = normalize(input.candidateStatement).slice(0, 140);
+  return `Merged clarification: ${existing}; ${candidate}`.slice(0, 320);
+}


### PR DESCRIPTION
## Summary
- add `clarification-resolver.ts` with deterministic heuristics first
- add timeout-bounded Anthropic fallback when heuristics are inconclusive
- return structured resolution outcomes: `keep_existing`, `keep_candidate`, `merge`, `still_unclear`
- include explicit timeout/error/no-key fallback handling
- add dedicated resolver tests for keep-existing, keep-candidate, merge, still-unclear, and timeout boundedness
- update architecture overview with the new ClarificationResolver module

## Testing
- export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/clarification-resolver.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/contradiction-checker.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
