### PR TITLE
fix(swift): make build.sh test pass on macOS by guarding iOS sources

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import UIKit
 import VellumAssistantShared
 
@@ -20,3 +21,4 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
 }
+#endif

--- a/clients/ios/App/VellumAssistantApp.swift
+++ b/clients/ios/App/VellumAssistantApp.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -17,3 +18,11 @@ struct VellumAssistantApp: App {
         }
     }
 }
+#else
+// Stub entry point so the iOS executable target links on macOS
+// (all real code is UIKit-only and compiled out on this platform).
+@main
+struct VellumAssistantApp {
+    static func main() {}
+}
+#endif

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -93,3 +94,4 @@ struct ChatTabView: View {
         ChatTabView(daemonClient: daemonClient)
     }
 }
+#endif

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -25,3 +26,4 @@ struct ContentView: View {
     ContentView()
         .environmentObject(DaemonClient(config: .default))
 }
+#endif

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -59,3 +60,4 @@ struct InputBarView_Previews: PreviewProvider {
         PreviewWrapper()
     }
 }
+#endif

--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -162,3 +163,4 @@ struct MessageBubbleView: View {
     .padding()
     .background(VColor.background)
 }
+#endif

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -179,3 +180,4 @@ struct ReadyStep: View {
 #Preview {
     OnboardingView(isCompleted: .constant(false))
 }
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import VellumAssistantShared
 
@@ -163,3 +164,4 @@ extension Bundle {
 #Preview {
     SettingsView()
 }
+#endif

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import VellumAssistantLib
-import VellumAssistantShared
+@testable import VellumAssistantShared
 
 @MainActor
 final class ChatViewModelTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Wrap all 8 iOS source files with `#if canImport(UIKit)` guards so they compile as empty on macOS (where UIKit doesn't exist)
- Add macOS stub `@main` entry point in `VellumAssistantApp.swift` so the iOS executable target links
- Fix `ChatViewModelTests.swift`: add `@testable import VellumAssistantShared` so the internal memberwise init of `IPCHistoryResponseMessage` is accessible

Before: `build.sh test` failed with `error: no such module 'UIKit'`
After: `build.sh test` builds and runs all tests successfully (28/28 pass, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
