### PR TITLE
fix(composer): scope refocus, UTF-16 cursor, sync expansion state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -42,6 +42,7 @@ struct ChatView: View {
 
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
+    @State private var isComposerExpanded = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
 
     var body: some View {
@@ -95,7 +96,7 @@ struct ChatView: View {
     private var composerReservedHeight: CGFloat {
         let editorClamped = min(max(editorContentHeight, 14), 200)
         let contentHeight = max(editorClamped, 28)
-        let expanded = contentHeight > 28
+        let expanded = isComposerExpanded
         let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
         let base: CGFloat = VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow
@@ -127,7 +128,8 @@ struct ChatView: View {
                 onRemoveAttachment: onRemoveAttachment,
                 onPaste: onPaste,
                 onMicrophoneToggle: onMicrophoneToggle,
-                editorContentHeight: $editorContentHeight
+                editorContentHeight: $editorContentHeight,
+                isComposerExpanded: $isComposerExpanded
             )
         }
         .background(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -19,8 +19,12 @@ struct ComposerView: View {
     /// Bound to ChatView's state so it can compute composerReservedHeight for safe area insets.
     @Binding var editorContentHeight: CGFloat
 
+    /// Exposed to ChatView so composerReservedHeight stays in sync with the
+    /// sticky expansion state (set true when text wraps, reset when text clears).
+    @Binding var isComposerExpanded: Bool
+
     @State private var composerScrollOffset: CGFloat = 0
-    @State private var expandedLatch = false
+    @State private var shouldRefocusAfterSend = false
     @FocusState private var isComposerFocused: Bool
 
     /// The portion of the suggestion that extends beyond the current input.
@@ -93,18 +97,18 @@ struct ComposerView: View {
         .animation(VAnimation.fast, value: editorContentHeight)
         .onAppear { isComposerFocused = true }
         .onChange(of: isComposerFocused) { _, focused in
-            // Re-focus the composer when it loses focus while the window is
-            // still key (e.g. Cmd+Return resignsFirstResponder as a side effect).
-            // Text selection in chat bubbles uses .textSelection(.enabled) which
-            // doesn't steal focus, so this won't fight user interactions.
-            if !focused, NSApp.keyWindow?.isKeyWindow == true {
+            // Only re-focus after sending a message (Return key). Without
+            // the guard, every focus loss while the window is key would
+            // steal first responder from side-panel inputs (settings, etc.).
+            if !focused, shouldRefocusAfterSend {
+                shouldRefocusAfterSend = false
                 DispatchQueue.main.async {
                     isComposerFocused = true
                     // After re-focus, NSTextField selects all text by default.
                     // Clear the selection and place the cursor at the end.
                     DispatchQueue.main.async {
                         if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
-                            let end = textView.string.count
+                            let end = (textView.string as NSString).length
                             textView.setSelectedRange(NSRange(location: end, length: 0))
                         }
                     }
@@ -113,13 +117,9 @@ struct ComposerView: View {
         }
     }
 
-    /// Sticky: once the text wraps past a single line, stay expanded until
-    /// the text is cleared. This prevents a layout oscillation where the
-    /// wider expanded TextField causes text to unwrap, which triggers compact
-    /// mode, which causes text to wrap again, ad infinitum.
-    private var isComposerExpanded: Bool {
-        expandedLatch
-    }
+    // isComposerExpanded is a @Binding — sticky latch set true when text
+    // wraps past a single line, reset when text clears. Prevents layout
+    // oscillation and keeps ChatView.composerReservedHeight in sync.
 
     private var isScrolledToBottom: Bool {
         let maxOffset = editorContentHeight - 200
@@ -187,13 +187,13 @@ struct ComposerView: View {
             if editorContentHeight > 200 {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)
             }
-            if inputText.isEmpty { expandedLatch = false }
+            if inputText.isEmpty { isComposerExpanded = false }
         }
         .onChange(of: editorContentHeight) {
             if editorContentHeight > 200 {
                 proxy.scrollTo("composer-bottom", anchor: .bottom)
             }
-            if editorContentHeight > 28 { expandedLatch = true }
+            if editorContentHeight > 28 { isComposerExpanded = true }
         }
         .onKeyPress(.tab, phases: .down) { keyPress in
             if !keyPress.modifiers.contains(.shift), ghostSuffix != nil {
@@ -216,6 +216,7 @@ struct ComposerView: View {
                 of: "\\n$", with: "", options: .regularExpression
             )
             if canSend {
+                shouldRefocusAfterSend = true
                 onSend()
             }
             return .handled

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -16,6 +16,7 @@ struct MainWindowView: View {
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var selectedThreadId: UUID?
     @State private var workspaceEditorContentHeight: CGFloat = 20
+    @State private var workspaceComposerExpanded = false
     @State private var showSharePicker = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = true
     @AppStorage("sidePanelWidth") private var sidePanelWidth: Double = 400
@@ -527,7 +528,8 @@ struct MainWindowView: View {
                     onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
                     onPaste: { viewModel.addAttachmentFromPasteboard() },
                     onMicrophoneToggle: onMicrophoneToggle,
-                    editorContentHeight: $workspaceEditorContentHeight
+                    editorContentHeight: $workspaceEditorContentHeight,
+                    isComposerExpanded: $workspaceComposerExpanded
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Scope auto-refocus to only fire after sending a message (`shouldRefocusAfterSend` flag), preventing focus theft from side panel inputs
- Use `(textView.string as NSString).length` for correct cursor positioning with emoji/non-BMP characters
- Expose `expandedLatch` as a `@Binding` so `ChatView.composerReservedHeight` stays in sync with `ComposerView`'s sticky expansion state
- Addresses review feedback on #2419 and #2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
