### PR TITLE
feat(memory): add soft clarification gate for pending conflicts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -525,6 +525,7 @@ graph TB
 
     subgraph "Read Path (Memory Recall)"
         QUERY["Recall Query Builder<br/>User request + compacted context summary<br/>+ conversation summary + weekly summary"]
+        CONFLICT_GATE["Soft Conflict Gate<br/>resolve pending conflicts from user turn<br/>relevance + cooldown ask-once behavior"]
         BUDGET["Dynamic Recall Budget<br/>computeRecallBudget()<br/>from prompt headroom"]
         LEX["Lexical Search<br/>FTS5 on memory_segment_fts"]
         SEM["Semantic Search<br/>Qdrant cosine similarity"]
@@ -570,10 +571,11 @@ graph TB
     EMBED_SEG --> GEM_EMB
     EMBED_SEG --> OLL_EMB
 
-    QUERY --> LEX
-    QUERY --> SEM
-    QUERY --> ENTITY_SEARCH
-    QUERY --> DIRECT
+    QUERY --> CONFLICT_GATE
+    CONFLICT_GATE --> LEX
+    CONFLICT_GATE --> SEM
+    CONFLICT_GATE --> ENTITY_SEARCH
+    CONFLICT_GATE --> DIRECT
     LEX --> SCOPE
     SEM --> SCOPE
     ENTITY_SEARCH --> REL_EXPAND
@@ -608,6 +610,10 @@ graph TB
 | `memory.entity.relationRetrieval.maxNeighborEntities` | `20` | Maximum unique neighbor entities expanded from relation edges. |
 | `memory.entity.relationRetrieval.maxEdges` | `40` | Maximum relation edges traversed during expansion. |
 | `memory.entity.relationRetrieval.neighborScoreMultiplier` | `0.7` | Downweight multiplier for relation-expanded candidates vs direct entity hits. |
+| `memory.conflicts.enabled` | `false` | Enable soft conflict gate for unresolved `memory_item_conflicts`. |
+| `memory.conflicts.reaskCooldownTurns` | `3` | Minimum turn distance before re-asking the same conflict clarification. |
+| `memory.conflicts.resolverLlmTimeoutMs` | `12000` | Timeout bound for clarification resolver LLM fallback. |
+| `memory.conflicts.relevanceThreshold` | `0.3` | Similarity threshold for deciding whether a pending conflict is relevant to the current request. |
 
 ### Memory Recall Debugging Playbook
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -118,6 +118,24 @@ describe('AssistantConfigSchema', () => {
     expect(result.secretDetection.action).toBe('block');
   });
 
+  test('applies memory.conflicts defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.memory.conflicts).toEqual({
+      enabled: false,
+      gateMode: 'soft',
+      reaskCooldownTurns: 3,
+      resolverLlmTimeoutMs: 12000,
+      relevanceThreshold: 0.3,
+    });
+  });
+
+  test('rejects invalid memory.conflicts.relevanceThreshold', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { conflicts: { relevanceThreshold: 2 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
   test('rejects invalid provider', () => {
     const result = AssistantConfigSchema.safeParse({ provider: 'invalid' });
     expect(result.success).toBe(false);

--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
 
 const testDir = mkdtempSync(join(tmpdir(), 'conflict-store-test-'));
 
@@ -26,9 +27,11 @@ mock.module('../util/logger.js', () => ({
 import { initializeDb, getDb } from '../memory/db.js';
 import { memoryItems } from '../memory/schema.js';
 import {
+  applyConflictResolution,
   createOrUpdatePendingConflict,
   getConflictById,
   getPendingConflictByPair,
+  listPendingConflictDetails,
   listPendingConflicts,
   markConflictAsked,
   resolveConflict,
@@ -210,6 +213,72 @@ describe('conflict-store', () => {
     const updated = getConflictById(conflict.id);
     expect(updated?.lastAskedAt).toBe(askedAt);
     expect(updated?.updatedAt).toBe(askedAt);
+  });
+
+  test('listPendingConflictDetails joins current statements', () => {
+    const pair = insertItemPair('details', 'workspace-a');
+    createOrUpdatePendingConflict({
+      scopeId: 'workspace-a',
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Which framework should I keep?',
+    });
+
+    const details = listPendingConflictDetails('workspace-a');
+    expect(details).toHaveLength(1);
+    expect(details[0].existingStatement).toBe('Existing statement details');
+    expect(details[0].candidateStatement).toBe('Candidate statement details');
+  });
+
+  test('applyConflictResolution keeps candidate and resolves conflict row', () => {
+    const pair = insertItemPair('apply-candidate');
+    const conflict = createOrUpdatePendingConflict({
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+
+    expect(applyConflictResolution({
+      conflictId: conflict.id,
+      resolution: 'keep_candidate',
+      resolutionNote: 'User confirmed candidate statement.',
+    })).toBe(true);
+
+    const db = getDb();
+    const existing = db.select().from(memoryItems).where(eq(memoryItems.id, pair.existingItemId)).get();
+    const candidate = db.select().from(memoryItems).where(eq(memoryItems.id, pair.candidateItemId)).get();
+    const updatedConflict = getConflictById(conflict.id);
+
+    expect(typeof existing?.invalidAt).toBe('number');
+    expect(candidate?.status).toBe('active');
+    expect(updatedConflict?.status).toBe('resolved_keep_candidate');
+  });
+
+  test('applyConflictResolution merge updates existing item statement', () => {
+    const pair = insertItemPair('apply-merge');
+    const conflict = createOrUpdatePendingConflict({
+      existingItemId: pair.existingItemId,
+      candidateItemId: pair.candidateItemId,
+      relationship: 'ambiguous_contradiction',
+    });
+
+    const merged = 'Use React for dashboard pages and Vue for marketing pages.';
+    expect(applyConflictResolution({
+      conflictId: conflict.id,
+      resolution: 'merge',
+      mergedStatement: merged,
+      resolutionNote: 'User clarified both apply in different contexts.',
+    })).toBe(true);
+
+    const db = getDb();
+    const existing = db.select().from(memoryItems).where(eq(memoryItems.id, pair.existingItemId)).get();
+    const candidate = db.select().from(memoryItems).where(eq(memoryItems.id, pair.candidateItemId)).get();
+    const updatedConflict = getConflictById(conflict.id);
+
+    expect(existing?.statement).toBe(merged);
+    expect(candidate?.status).toBe('superseded');
+    expect(updatedConflict?.status).toBe('resolved_merge');
   });
 
   test('enforces pending-pair uniqueness with a partial index', () => {

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent } from '../agent/loop.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+let runCalls: Message[][] = [];
+let resolverCallCount = 0;
+let markAskedCalls: string[] = [];
+let pendingConflicts: Array<{
+  id: string;
+  scopeId: string;
+  existingItemId: string;
+  candidateItemId: string;
+  relationship: string;
+  status: 'pending_clarification';
+  clarificationQuestion: string | null;
+  resolutionNote: string | null;
+  lastAskedAt: number | null;
+  resolvedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  existingStatement: string;
+  candidateStatement: string;
+}> = [];
+
+let resolverResult: {
+  resolution: 'keep_existing' | 'keep_candidate' | 'merge' | 'still_unclear';
+  strategy: 'heuristic' | 'llm' | 'llm_timeout' | 'llm_error' | 'no_llm_key';
+  resolvedStatement: string | null;
+  explanation: string;
+} = {
+  resolution: 'still_unclear',
+  strategy: 'heuristic',
+  resolvedStatement: null,
+  explanation: 'Need user clarification.',
+};
+
+const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 100000,
+      targetInputTokens: 80000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 512,
+      chunkTokens: 12000,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+    memory: {
+      retrieval: {
+        injectionStrategy: 'prepend_user_block',
+        dynamicBudget: {
+          enabled: false,
+          minInjectTokens: 1200,
+          maxInjectTokens: 10000,
+          targetHeadroomTokens: 10000,
+        },
+      },
+      conflicts: {
+        enabled: true,
+        gateMode: 'soft',
+        reaskCooldownTurns: 3,
+        resolverLlmTimeoutMs: 250,
+        relevanceThreshold: 0.2,
+      },
+    },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module('../skills/slash-commands.js', () => ({
+  buildInvocableSlashCatalog: () => new Map(),
+  resolveSlashSkillCommand: () => ({ kind: 'not_slash' }),
+  rewriteKnownSlashCommandPrompt: () => '',
+  parseSlashCandidate: () => ({ kind: 'not_slash' }),
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => persistedMessages,
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  addMessage: (_conversationId: string, role: string, content: string) => {
+    const row = { id: `msg-${persistedMessages.length + 1}`, role, content, createdAt: Date.now() };
+    persistedMessages.push(row);
+    return { id: row.id };
+  },
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteLastExchange: () => 0,
+  isLastUserMessageToolResult: () => false,
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  uploadAttachment: () => ({ id: 'att-1' }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: true,
+    degraded: false,
+    reason: null,
+    provider: 'mock',
+    model: 'mock',
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    entityHits: 0,
+    relationSeedEntityCount: 0,
+    relationTraversedEdgeCount: 0,
+    relationNeighborEntityCount: 0,
+    relationExpandedItemCount: 0,
+    mergedCount: 0,
+    selectedCount: 0,
+    rerankApplied: false,
+    injectedTokens: 0,
+    latencyMs: 0,
+    topCandidates: [],
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module('../memory/conflict-store.js', () => ({
+  listPendingConflictDetails: () => pendingConflicts,
+  markConflictAsked: (conflictId: string) => {
+    markAskedCalls.push(conflictId);
+    return true;
+  },
+  applyConflictResolution: () => true,
+}));
+
+mock.module('../memory/clarification-resolver.js', () => ({
+  resolveConflictClarification: async () => {
+    resolverCallCount += 1;
+    return resolverResult;
+  },
+}));
+
+mock.module('../memory/llm-usage-store.js', () => ({
+  recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }),
+}));
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(messages: Message[], onEvent: (event: AgentEvent) => void): Promise<Message[]> {
+      runCalls.push(messages);
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'normal assistant answer' }],
+      };
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 10 });
+      onEvent({ type: 'message_complete', message: assistantMessage });
+      return [...messages, assistantMessage];
+    }
+  },
+}));
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: 'mock',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+function extractText(message: Message): string {
+  return message.content
+    .filter((block) => block.type === 'text')
+    .map((block) => (block as { type: 'text'; text: string }).text)
+    .join('\n');
+}
+
+describe('Session conflict soft gate', () => {
+  beforeEach(() => {
+    runCalls = [];
+    resolverCallCount = 0;
+    markAskedCalls = [];
+    pendingConflicts = [];
+    persistedMessages.length = 0;
+    resolverResult = {
+      resolution: 'still_unclear',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'Need user clarification.',
+    };
+  });
+
+  test('relevant unresolved conflict asks clarification and skips agent loop', async () => {
+    pendingConflicts = [{
+      id: 'conflict-relevant',
+      scopeId: 'default',
+      existingItemId: 'existing-a',
+      candidateItemId: 'candidate-a',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Do you want React or Vue for frontend work?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use React for frontend work.',
+      candidateStatement: 'Use Vue for frontend work.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: ServerMessage[] = [];
+    await session.processMessage('Should I use React or Vue here?', [], (event) => events.push(event));
+
+    expect(runCalls).toHaveLength(0);
+    expect(resolverCallCount).toBe(1);
+    expect(markAskedCalls).toEqual(['conflict-relevant']);
+    const clarificationEvent = events.find((event) => event.type === 'assistant_text_delta');
+    expect(clarificationEvent).toBeDefined();
+    if (clarificationEvent && clarificationEvent.type === 'assistant_text_delta') {
+      expect(clarificationEvent.text).toContain('Do you want React or Vue');
+    }
+    expect(events.some((event) => event.type === 'message_complete')).toBe(true);
+  });
+
+  test('irrelevant unresolved conflict asks once and continues with normal answer flow', async () => {
+    pendingConflicts = [{
+      id: 'conflict-irrelevant',
+      scopeId: 'default',
+      existingItemId: 'existing-b',
+      candidateItemId: 'candidate-b',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: ServerMessage[] = [];
+    await session.processMessage('How do I set up pre-commit hooks?', [], (event) => events.push(event));
+
+    expect(runCalls).toHaveLength(1);
+    const injectedUser = runCalls[0][runCalls[0].length - 1];
+    expect(injectedUser.role).toBe('user');
+    const injectedText = extractText(injectedUser);
+    expect(injectedText).toContain('Memory clarification request');
+    expect(injectedText).toContain('Should I assume Postgres or MySQL?');
+    expect(markAskedCalls).toEqual(['conflict-irrelevant']);
+    expect(events.some((event) => event.type === 'message_complete')).toBe(true);
+  });
+
+  test('cooldown prevents repeated asks on subsequent turns', async () => {
+    pendingConflicts = [{
+      id: 'conflict-cooldown',
+      scopeId: 'default',
+      existingItemId: 'existing-c',
+      candidateItemId: 'candidate-c',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I use pnpm or npm?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use pnpm for workspace installs.',
+      candidateStatement: 'Use npm for workspace installs.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('How should I structure my repo?', [], () => {});
+    await session.processMessage('What branch naming should I use?', [], () => {});
+
+    expect(runCalls).toHaveLength(2);
+    const firstUserText = extractText(runCalls[0][runCalls[0].length - 1]);
+    const secondUserText = extractText(runCalls[1][runCalls[1].length - 1]);
+    expect(firstUserText).toContain('Memory clarification request');
+    expect(secondUserText).not.toContain('Memory clarification request');
+    expect(markAskedCalls).toEqual(['conflict-cooldown']);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -95,6 +95,13 @@ export const DEFAULT_CONFIG: AssistantConfig = {
         neighborScoreMultiplier: 0.7,
       },
     },
+    conflicts: {
+      enabled: false,
+      gateMode: 'soft',
+      reaskCooldownTurns: 3,
+      resolverLlmTimeoutMs: 12000,
+      relevanceThreshold: 0.3,
+    },
   },
   dataDir: getDataDir(),
   timeouts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -434,6 +434,30 @@ export const MemoryEntityConfigSchema = z.object({
   }),
 });
 
+export const MemoryConflictsConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.conflicts.enabled must be a boolean' })
+    .default(false),
+  gateMode: z
+    .enum(['soft'], { error: 'memory.conflicts.gateMode must be "soft"' })
+    .default('soft'),
+  reaskCooldownTurns: z
+    .number({ error: 'memory.conflicts.reaskCooldownTurns must be a number' })
+    .int('memory.conflicts.reaskCooldownTurns must be an integer')
+    .positive('memory.conflicts.reaskCooldownTurns must be a positive integer')
+    .default(3),
+  resolverLlmTimeoutMs: z
+    .number({ error: 'memory.conflicts.resolverLlmTimeoutMs must be a number' })
+    .int('memory.conflicts.resolverLlmTimeoutMs must be an integer')
+    .positive('memory.conflicts.resolverLlmTimeoutMs must be a positive integer')
+    .default(12000),
+  relevanceThreshold: z
+    .number({ error: 'memory.conflicts.relevanceThreshold must be a number' })
+    .min(0, 'memory.conflicts.relevanceThreshold must be >= 0')
+    .max(1, 'memory.conflicts.relevanceThreshold must be <= 1')
+    .default(0.3),
+});
+
 export const MemorySummarizationConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.summarization.useLLM must be a boolean' })
@@ -520,6 +544,13 @@ export const MemoryConfigSchema = z.object({
       maxEdges: 40,
       neighborScoreMultiplier: 0.7,
     },
+  }),
+  conflicts: MemoryConflictsConfigSchema.default({
+    enabled: false,
+    gateMode: 'soft',
+    reaskCooldownTurns: 3,
+    resolverLlmTimeoutMs: 12000,
+    relevanceThreshold: 0.3,
   }),
 });
 
@@ -666,6 +697,13 @@ export const AssistantConfigSchema = z.object({
         neighborScoreMultiplier: 0.7,
       },
     },
+    conflicts: {
+      enabled: false,
+      gateMode: 'soft',
+      reaskCooldownTurns: 3,
+      resolverLlmTimeoutMs: 12000,
+      relevanceThreshold: 0.3,
+    },
   }),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
@@ -750,6 +788,7 @@ export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryExtractionConfig = z.infer<typeof MemoryExtractionConfigSchema>;
 export type MemorySummarizationConfig = z.infer<typeof MemorySummarizationConfigSchema>;
 export type MemoryEntityConfig = z.infer<typeof MemoryEntityConfigSchema>;
+export type MemoryConflictsConfig = z.infer<typeof MemoryConflictsConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
 export type QdrantConfig = z.infer<typeof QdrantConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -17,6 +17,7 @@ export type {
   MemoryExtractionConfig,
   MemorySummarizationConfig,
   MemoryEntityConfig,
+  MemoryConflictsConfig,
   MemoryConfig,
   ModelPricingOverride,
   QdrantConfig,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -51,6 +51,13 @@ import {
 import { buildMemoryQuery } from '../memory/query-builder.js';
 import { computeRecallBudget } from '../memory/retrieval-budget.js';
 import { recordUsageEvent } from '../memory/llm-usage-store.js';
+import {
+  applyConflictResolution,
+  listPendingConflictDetails,
+  markConflictAsked,
+} from '../memory/conflict-store.js';
+import type { PendingConflictDetail } from '../memory/conflict-store.js';
+import { resolveConflictClarification } from '../memory/clarification-resolver.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
@@ -98,6 +105,11 @@ export interface QueuePolicy {
   checkpointHandoffEnabled: boolean;
 }
 
+interface ConflictGateDecision {
+  question: string;
+  relevant: boolean;
+}
+
 export class Session {
   public readonly conversationId: string;
   private provider: Provider;
@@ -120,6 +132,8 @@ export class Session {
   private contextCompactedAt: number | null = null;
   private currentRequestId?: string;
   private assistantId: string | null = null;
+  private conflictTurnCounter = 0;
+  private conflictLastAskedTurn = new Map<string, number>();
   private hasNoClient = false;
   private messageQueue: QueuedMessage[] = [];
   private pendingSurfaceActions = new Map<string, {
@@ -632,8 +646,40 @@ export class Session {
       let pendingDirectiveDisplayBuffer = '';
       let lastAssistantMessageId: string | undefined;
       const runtimeConfig = getConfig();
+      const conflictGate = await this.evaluateConflictGate(content, runtimeConfig);
+      if (conflictGate?.relevant) {
+        const clarificationOnlyResponse = [
+          conflictGate.question,
+          '',
+          'I need this clarification before I can give guidance that depends on that preference.',
+        ].join('\n');
+        const assistantMessage = createAssistantMessage(clarificationOnlyResponse);
+        conversationStore.addMessage(
+          this.conversationId,
+          'assistant',
+          JSON.stringify(assistantMessage.content),
+        );
+        this.messages.push(assistantMessage);
+        onEvent({
+          type: 'assistant_text_delta',
+          text: clarificationOnlyResponse,
+          sessionId: this.conversationId,
+        });
+        this.traceEmitter.emit('message_complete', 'Conflict clarification requested (relevant)', {
+          requestId: reqId,
+          status: 'info',
+          attributes: { conflictGate: 'relevant' },
+        });
+        onEvent({ type: 'message_complete', sessionId: this.conversationId });
+        return;
+      }
+      const softConflictInstruction = conflictGate && !conflictGate.relevant
+        ? conflictGate.question
+        : null;
       const recallQuery = buildMemoryQuery(content, this.messages);
-      const recallBudget = runtimeConfig.memory.retrieval.dynamicBudget.enabled
+      const recallInjectionStrategy = runtimeConfig.memory?.retrieval?.injectionStrategy ?? 'prepend_user_block';
+      const dynamicBudgetConfig = runtimeConfig.memory?.retrieval?.dynamicBudget;
+      const recallBudget = dynamicBudgetConfig?.enabled
         ? computeRecallBudget({
             estimatedPromptTokens: estimatePromptTokens(
               this.messages,
@@ -641,9 +687,9 @@ export class Session {
               { providerName: this.provider.name },
             ),
             maxInputTokens: runtimeConfig.contextWindow.maxInputTokens,
-            targetHeadroomTokens: runtimeConfig.memory.retrieval.dynamicBudget.targetHeadroomTokens,
-            minInjectTokens: runtimeConfig.memory.retrieval.dynamicBudget.minInjectTokens,
-            maxInjectTokens: runtimeConfig.memory.retrieval.dynamicBudget.maxInjectTokens,
+            targetHeadroomTokens: dynamicBudgetConfig.targetHeadroomTokens,
+            minInjectTokens: dynamicBudgetConfig.minInjectTokens,
+            maxInjectTokens: dynamicBudgetConfig.maxInjectTokens,
           })
         : undefined;
       const recall = await buildMemoryRecall(recallQuery, this.conversationId, runtimeConfig, {
@@ -664,8 +710,7 @@ export class Session {
       if (recall.injectedText.length > 0) {
         const userTail = this.messages[this.messages.length - 1];
         if (userTail && userTail.role === 'user') {
-          const strategy = runtimeConfig.memory.retrieval.injectionStrategy;
-          if (strategy === 'separate_context_message') {
+          if (recallInjectionStrategy === 'separate_context_message') {
             runMessages = injectMemoryRecallAsSeparateMessage(this.messages, recall.injectedText);
           } else {
             runMessages = [
@@ -692,6 +737,16 @@ export class Session {
             latencyMs: recall.latencyMs,
             topCandidates: recall.topCandidates,
           });
+        }
+      }
+
+      if (softConflictInstruction) {
+        const userTail = runMessages[runMessages.length - 1];
+        if (userTail && userTail.role === 'user') {
+          runMessages = [
+            ...runMessages.slice(0, -1),
+            injectClarificationRequestIntoUserMessage(userTail, softConflictInstruction),
+          ];
         }
       }
 
@@ -972,7 +1027,7 @@ export class Session {
         return { ...msg, content: cleanedContent as ContentBlock[] };
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
-      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, runtimeConfig.memory.retrieval.injectionStrategy);
+      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
 
@@ -1572,6 +1627,71 @@ export class Session {
     }
   }
 
+  private async evaluateConflictGate(
+    userMessage: string,
+    runtimeConfig: ReturnType<typeof getConfig>,
+  ): Promise<ConflictGateDecision | null> {
+    const conflictConfig = runtimeConfig.memory?.conflicts;
+    if (!conflictConfig?.enabled || conflictConfig.gateMode !== 'soft') return null;
+
+    this.conflictTurnCounter += 1;
+    await this.resolvePendingConflictsFromUserTurn(userMessage, conflictConfig.resolverLlmTimeoutMs);
+
+    const pending = listPendingConflictDetails('default', 50);
+    if (pending.length === 0) return null;
+
+    const threshold = conflictConfig.relevanceThreshold;
+    const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
+    const scored = pending.map((conflict) => ({
+      conflict,
+      relevance: computeConflictRelevance(userMessage, conflict),
+    }));
+    const relevant = scored.filter((entry) => entry.relevance >= threshold);
+    const irrelevant = scored.filter((entry) => entry.relevance < threshold);
+    const ordered = [...relevant, ...irrelevant];
+
+    const askable = ordered.find((entry) => this.shouldAskConflict(entry.conflict.id, cooldownTurns));
+    if (!askable) return null;
+
+    this.conflictLastAskedTurn.set(askable.conflict.id, this.conflictTurnCounter);
+    markConflictAsked(askable.conflict.id);
+    return {
+      question: askable.conflict.clarificationQuestion ?? buildFallbackConflictQuestion(askable.conflict),
+      relevant: askable.relevance >= threshold,
+    };
+  }
+
+  private async resolvePendingConflictsFromUserTurn(
+    userMessage: string,
+    resolverTimeoutMs: number,
+  ): Promise<void> {
+    const pending = listPendingConflictDetails('default', 25);
+    for (const conflict of pending) {
+      const resolution = await resolveConflictClarification(
+        {
+          existingStatement: conflict.existingStatement,
+          candidateStatement: conflict.candidateStatement,
+          userMessage,
+        },
+        { timeoutMs: resolverTimeoutMs },
+      );
+      if (resolution.resolution === 'still_unclear') continue;
+
+      applyConflictResolution({
+        conflictId: conflict.id,
+        resolution: resolution.resolution,
+        mergedStatement: resolution.resolution === 'merge' ? resolution.resolvedStatement : null,
+        resolutionNote: resolution.explanation,
+      });
+    }
+  }
+
+  private shouldAskConflict(conflictId: string, cooldownTurns: number): boolean {
+    const lastAskedTurn = this.conflictLastAskedTurn.get(conflictId);
+    if (lastAskedTurn === undefined) return true;
+    return this.conflictTurnCounter - lastAskedTurn >= cooldownTurns;
+  }
+
   private async surfaceProxyResolver(
     toolName: string,
     input: Record<string, unknown>,
@@ -1843,6 +1963,62 @@ export function findLastUndoableUserMessageIndex(messages: Message[]): number {
     }
   }
   return -1;
+}
+
+function injectClarificationRequestIntoUserMessage(message: Message, question: string): Message {
+  const instruction = [
+    '[Memory clarification request]',
+    `Ask this once in your response: ${question}`,
+    'After asking, continue helping with the current request.',
+  ].join('\n');
+  return {
+    ...message,
+    content: [
+      ...message.content,
+      { type: 'text', text: `\n\n${instruction}` },
+    ],
+  };
+}
+
+function buildFallbackConflictQuestion(conflict: PendingConflictDetail): string {
+  return [
+    'I have two conflicting notes and need your confirmation.',
+    `A) ${conflict.existingStatement}`,
+    `B) ${conflict.candidateStatement}`,
+    'Which one should I keep?',
+  ].join('\n');
+}
+
+function computeConflictRelevance(
+  userMessage: string,
+  conflict: Pick<PendingConflictDetail, 'existingStatement' | 'candidateStatement'>,
+): number {
+  const queryTokens = tokenizeForConflictRelevance(userMessage);
+  if (queryTokens.size === 0) return 0;
+  const existingTokens = tokenizeForConflictRelevance(conflict.existingStatement);
+  const candidateTokens = tokenizeForConflictRelevance(conflict.candidateStatement);
+  return Math.max(
+    overlapRatio(queryTokens, existingTokens),
+    overlapRatio(queryTokens, candidateTokens),
+  );
+}
+
+function tokenizeForConflictRelevance(input: string): Set<string> {
+  const tokens = input
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 4);
+  return new Set(tokens);
+}
+
+function overlapRatio(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 || right.size === 0) return 0;
+  let overlap = 0;
+  for (const token of left) {
+    if (right.has(token)) overlap += 1;
+  }
+  return overlap / Math.max(left.size, right.size);
 }
 
 const ORDERING_ERROR_PATTERNS = [

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -1,7 +1,8 @@
 import { and, asc, eq } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import { getDb } from './db.js';
-import { memoryItemConflicts } from './schema.js';
+import { enqueueMemoryJob } from './jobs-store.js';
+import { memoryItemConflicts, memoryItems } from './schema.js';
 
 export type MemoryConflictRelationship =
   | 'contradiction'
@@ -43,6 +44,20 @@ export interface CreatePendingConflictInput {
 
 export interface ResolveConflictInput {
   status: ResolvedMemoryConflictStatus;
+  resolutionNote?: string | null;
+}
+
+export interface PendingConflictDetail extends MemoryItemConflict {
+  existingStatement: string;
+  candidateStatement: string;
+}
+
+export type ConflictResolutionAction = 'keep_existing' | 'keep_candidate' | 'merge';
+
+export interface ApplyConflictResolutionInput {
+  conflictId: string;
+  resolution: ConflictResolutionAction;
+  mergedStatement?: string | null;
   resolutionNote?: string | null;
 }
 
@@ -136,6 +151,68 @@ export function listPendingConflicts(scopeId: string, limit = 100): MemoryItemCo
   return rows.map(toConflict);
 }
 
+export function listPendingConflictDetails(scopeId: string, limit = 100): PendingConflictDetail[] {
+  if (limit <= 0) return [];
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { all: (...params: unknown[]) => unknown[] } } }).$client;
+  const rows = raw.query(`
+    SELECT
+      c.id,
+      c.scope_id,
+      c.existing_item_id,
+      c.candidate_item_id,
+      c.relationship,
+      c.status,
+      c.clarification_question,
+      c.resolution_note,
+      c.last_asked_at,
+      c.resolved_at,
+      c.created_at,
+      c.updated_at,
+      existing_item.statement AS existing_statement,
+      candidate_item.statement AS candidate_statement
+    FROM memory_item_conflicts c
+    INNER JOIN memory_items existing_item ON existing_item.id = c.existing_item_id
+    INNER JOIN memory_items candidate_item ON candidate_item.id = c.candidate_item_id
+    WHERE c.scope_id = ?
+      AND c.status = 'pending_clarification'
+    ORDER BY c.created_at ASC
+    LIMIT ?
+  `).all(scopeId, limit) as Array<{
+    id: string;
+    scope_id: string;
+    existing_item_id: string;
+    candidate_item_id: string;
+    relationship: string;
+    status: MemoryConflictStatus;
+    clarification_question: string | null;
+    resolution_note: string | null;
+    last_asked_at: number | null;
+    resolved_at: number | null;
+    created_at: number;
+    updated_at: number;
+    existing_statement: string;
+    candidate_statement: string;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    scopeId: row.scope_id,
+    existingItemId: row.existing_item_id,
+    candidateItemId: row.candidate_item_id,
+    relationship: row.relationship,
+    status: row.status,
+    clarificationQuestion: row.clarification_question,
+    resolutionNote: row.resolution_note,
+    lastAskedAt: row.last_asked_at,
+    resolvedAt: row.resolved_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    existingStatement: row.existing_statement,
+    candidateStatement: row.candidate_statement,
+  }));
+}
+
 export function markConflictAsked(conflictId: string, askedAt = Date.now()): boolean {
   const db = getDb();
   const result = db.update(memoryItemConflicts)
@@ -166,6 +243,85 @@ export function resolveConflict(conflictId: string, input: ResolveConflictInput)
     .run();
 
   return getConflictById(conflictId);
+}
+
+export function applyConflictResolution(input: ApplyConflictResolutionInput): boolean {
+  const conflict = getConflictById(input.conflictId);
+  if (!conflict || conflict.status !== 'pending_clarification') return false;
+
+  const db = getDb();
+  const now = Date.now();
+  const existingItem = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, conflict.existingItemId))
+    .get();
+  const candidateItem = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, conflict.candidateItemId))
+    .get();
+
+  if (!existingItem || !candidateItem) {
+    resolveConflict(conflict.id, {
+      status: 'dismissed',
+      resolutionNote: input.resolutionNote ?? 'Conflict items missing at resolution time.',
+    });
+    return false;
+  }
+
+  switch (input.resolution) {
+    case 'keep_existing': {
+      db.update(memoryItems)
+        .set({ status: 'superseded', invalidAt: now })
+        .where(eq(memoryItems.id, candidateItem.id))
+        .run();
+      resolveConflict(conflict.id, {
+        status: 'resolved_keep_existing',
+        resolutionNote: input.resolutionNote ?? null,
+      });
+      return true;
+    }
+    case 'keep_candidate': {
+      db.update(memoryItems)
+        .set({ invalidAt: now })
+        .where(eq(memoryItems.id, existingItem.id))
+        .run();
+      db.update(memoryItems)
+        .set({ status: 'active', validFrom: now })
+        .where(eq(memoryItems.id, candidateItem.id))
+        .run();
+      resolveConflict(conflict.id, {
+        status: 'resolved_keep_candidate',
+        resolutionNote: input.resolutionNote ?? null,
+      });
+      return true;
+    }
+    case 'merge': {
+      const mergedStatement = (input.mergedStatement ?? '').trim();
+      const nextStatement = mergedStatement.length > 0 ? mergedStatement : candidateItem.statement;
+      db.update(memoryItems)
+        .set({
+          statement: nextStatement,
+          status: 'active',
+          invalidAt: null,
+          lastSeenAt: Math.max(existingItem.lastSeenAt, candidateItem.lastSeenAt, now),
+          confidence: Math.max(existingItem.confidence, candidateItem.confidence),
+        })
+        .where(eq(memoryItems.id, existingItem.id))
+        .run();
+      db.update(memoryItems)
+        .set({ status: 'superseded', invalidAt: now })
+        .where(eq(memoryItems.id, candidateItem.id))
+        .run();
+      enqueueMemoryJob('embed_item', { itemId: existingItem.id });
+      resolveConflict(conflict.id, {
+        status: 'resolved_merge',
+        resolutionNote: input.resolutionNote ?? null,
+      });
+      return true;
+    }
+  }
 }
 
 function toConflict(row: typeof memoryItemConflicts.$inferSelect): MemoryItemConflict {


### PR DESCRIPTION
## Summary
- add a soft conflict clarification gate in `Session` that attempts conflict resolution from each incoming user turn before running normal recall/agent flow
- ask clarification immediately when unresolved conflicts are relevant, and inject ask-once guidance into the current turn when conflicts are irrelevant
- add conflict resolution application helpers, pending conflict detail joins, config schema/defaults for `memory.conflicts`, and focused tests for gate behavior + config/store coverage

## Testing
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/conflict-store.test.ts assistant/src/__tests__/clarification-resolver.test.ts assistant/src/__tests__/session-conflict-gate.test.ts assistant/src/__tests__/config-schema.test.ts assistant/src/__tests__/session-slash-known.test.ts