### PR TITLE
feat(memory): add background pending-conflict resolver job

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -291,7 +291,7 @@ graph LR
         ITEM_ENTS["memory_item_entities<br/>───────────────<br/>Join table linking extracted<br/>memory_items to entities"]
         SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
-        JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill<br/>Status: pending → running →<br/>completed | failed"]
+        JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
     end
 
@@ -500,6 +500,7 @@ graph TB
         INDEX["Memory Indexer"]
         SEGMENT["Split into segments<br/>→ memory_segments"]
         EXTRACT_JOB["Enqueue extract_items job<br/>→ memory_jobs"]
+        CONFLICT_RESOLVE_JOB["Enqueue resolve_pending_conflicts_for_message<br/>(dedupe by type+message+scope)<br/>→ memory_jobs"]
         SUMMARY_JOB["Enqueue build_conversation_summary<br/>→ memory_jobs"]
     end
 
@@ -510,6 +511,7 @@ graph TB
         EMBED_SUM["embed_summary<br/>→ memory_embeddings"]
         EXTRACT["extract_items<br/>→ memory_items +<br/>memory_item_sources"]
         CHECK_CONTRA["check_contradictions<br/>→ contradiction/update merge OR<br/>pending_clarification + memory_item_conflicts"]
+        RESOLVE_PENDING["resolve_pending_conflicts_for_message<br/>message-scoped clarification resolution<br/>→ resolved conflict + item status updates"]
         EXTRACT_ENTITIES["extract_entities<br/>→ memory_entities +<br/>memory_item_entities +<br/>memory_entity_relations"]
         BACKFILL_REL["backfill_entity_relations<br/>checkpointed message scan<br/>→ enqueue extract_entities"]
         BUILD_SUM["build_conversation_summary<br/>→ memory_summaries"]
@@ -553,6 +555,7 @@ graph TB
     STORE --> INDEX
     INDEX --> SEGMENT
     INDEX --> EXTRACT_JOB
+    INDEX --> CONFLICT_RESOLVE_JOB
     INDEX --> SUMMARY_JOB
 
     WORKER --> EMBED_SEG
@@ -560,6 +563,7 @@ graph TB
     WORKER --> EMBED_SUM
     WORKER --> EXTRACT
     WORKER --> CHECK_CONTRA
+    WORKER --> RESOLVE_PENDING
     WORKER --> EXTRACT_ENTITIES
     WORKER --> BACKFILL_REL
     WORKER --> BUILD_SUM

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -47,12 +47,18 @@ mock.module('../config/loader.js', () => ({
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { requestMemoryBackfill } from '../memory/admin.js';
 import { getMemoryCheckpoint } from '../memory/checkpoints.js';
+import { createOrUpdatePendingConflict, getConflictById } from '../memory/conflict-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
 import { getRecentSegmentsForConversation, indexMessageNow } from '../memory/indexer.js';
 import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor.js';
-import { claimMemoryJobs, enqueueBackfillEntityRelationsJob, enqueueMemoryJob } from '../memory/jobs-store.js';
+import {
+  claimMemoryJobs,
+  enqueueBackfillEntityRelationsJob,
+  enqueueMemoryJob,
+  enqueueResolvePendingConflictsForMessageJob,
+} from '../memory/jobs-store.js';
 import { currentWeekWindow, resetStaleSweepThrottle, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
@@ -1120,6 +1126,120 @@ describe('Memory V2 regressions', () => {
       .get();
     expect(row).not.toBeUndefined();
     expect(JSON.parse(row?.payload ?? '{}')).toMatchObject({ force: true });
+  });
+
+  test('pending conflict resolver enqueue is deduped by message and scope', () => {
+    const db = getDb();
+
+    const firstId = enqueueResolvePendingConflictsForMessageJob('msg-conflict-1', 'scope-a');
+    const secondId = enqueueResolvePendingConflictsForMessageJob('msg-conflict-1', 'scope-a');
+    const thirdId = enqueueResolvePendingConflictsForMessageJob('msg-conflict-1', 'scope-b');
+
+    expect(secondId).toBe(firstId);
+    expect(thirdId).not.toBe(firstId);
+
+    const queued = db
+      .select()
+      .from(memoryJobs)
+      .where(and(
+        eq(memoryJobs.type, 'resolve_pending_conflicts_for_message'),
+        eq(memoryJobs.status, 'pending'),
+      ))
+      .all();
+    expect(queued).toHaveLength(2);
+  });
+
+  test('background conflict resolver job applies user clarification to pending conflicts', async () => {
+    const db = getDb();
+    const now = 1_700_001_200_000;
+    const originalConflictsEnabled = TEST_CONFIG.memory.conflicts.enabled;
+    TEST_CONFIG.memory.conflicts.enabled = true;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-conflicts-bg',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values({
+        id: 'msg-conflicts-bg',
+        conversationId: 'conv-conflicts-bg',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        createdAt: now + 1,
+      }).run();
+
+      db.insert(memoryItems).values([
+        {
+          id: 'item-conflict-existing',
+          kind: 'preference',
+          subject: 'database',
+          statement: 'Use Postgres by default.',
+          status: 'active',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-existing',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts',
+          firstSeenAt: now - 10_000,
+          lastSeenAt: now - 5_000,
+          validFrom: now - 10_000,
+          invalidAt: null,
+        },
+        {
+          id: 'item-conflict-candidate',
+          kind: 'preference',
+          subject: 'database',
+          statement: 'Use MySQL by default.',
+          status: 'pending_clarification',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-candidate',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts',
+          firstSeenAt: now - 9_000,
+          lastSeenAt: now - 4_000,
+          validFrom: now - 9_000,
+          invalidAt: null,
+        },
+      ]).run();
+
+      const conflict = createOrUpdatePendingConflict({
+        scopeId: 'scope-conflicts',
+        existingItemId: 'item-conflict-existing',
+        candidateItemId: 'item-conflict-candidate',
+        relationship: 'ambiguous_contradiction',
+      });
+
+      enqueueResolvePendingConflictsForMessageJob('msg-conflicts-bg', 'scope-conflicts');
+      const processed = await runMemoryJobsOnce();
+      expect(processed).toBe(1);
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-existing'))
+        .get();
+      const candidate = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-candidate'))
+        .get();
+      const updatedConflict = getConflictById(conflict.id);
+
+      expect(existing?.invalidAt).not.toBeNull();
+      expect(candidate?.status).toBe('active');
+      expect(updatedConflict?.status).toBe('resolved_keep_candidate');
+      expect(updatedConflict?.resolutionNote).toContain('Background message resolver');
+    } finally {
+      TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
+    }
   });
 
   test('relation backfill advances checkpoints in deterministic batches', async () => {

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -419,6 +419,15 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);
+  database.run(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_jobs_conflict_resolve_dedupe
+    ON memory_jobs(
+      type,
+      status,
+      json_extract(payload, '$.messageId'),
+      COALESCE(json_extract(payload, '$.scopeId'), 'default')
+    )
+  `);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time ON memory_summaries(scope, end_at DESC)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_scope_id ON memory_items(scope_id)`);

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -3,7 +3,7 @@ import type { MemoryConfig } from '../config/types.js';
 import { getLogger } from '../util/logger.js';
 import { getMemoryCheckpoint, setMemoryCheckpoint } from './checkpoints.js';
 import { getDb } from './db.js';
-import { enqueueMemoryJob } from './jobs-store.js';
+import { enqueueMemoryJob, enqueueResolvePendingConflictsForMessageJob } from './jobs-store.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { segmentText } from './segmenter.js';
 import { memorySegments } from './schema.js';
@@ -76,10 +76,14 @@ export function indexMessageNow(
   if (shouldExtract) {
     enqueueMemoryJob('extract_items', { messageId: input.messageId });
   }
+  const shouldResolveConflicts = input.role === 'user' && config.conflicts.enabled;
+  if (shouldResolveConflicts) {
+    enqueueResolvePendingConflictsForMessageJob(input.messageId, input.scopeId ?? 'default');
+  }
   enqueueMemoryJob('build_conversation_summary', { conversationId: input.conversationId });
   enqueueSummaryRollupJobsIfDue();
 
-  const enqueuedJobs = segments.length + (shouldExtract ? 2 : 1);
+  const enqueuedJobs = segments.length + (shouldExtract ? 2 : 1) + (shouldResolveConflicts ? 1 : 0);
   return {
     indexedSegments: segments.length,
     enqueuedJobs,

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -9,6 +9,7 @@ export type MemoryJobType =
   | 'embed_summary'
   | 'extract_items'
   | 'extract_entities'
+  | 'resolve_pending_conflicts_for_message'
   | 'backfill_entity_relations'
   | 'check_contradictions'
   | 'refresh_weekly_summary'
@@ -91,6 +92,35 @@ export function enqueueBackfillEntityRelationsJob(force = false): string {
   }
 
   return enqueueMemoryJob('backfill_entity_relations', { force });
+}
+
+export function enqueueResolvePendingConflictsForMessageJob(
+  messageId: string,
+  scopeId = 'default',
+): string {
+  const normalizedMessageId = messageId.trim();
+  if (!normalizedMessageId) {
+    throw new Error('enqueueResolvePendingConflictsForMessageJob requires a non-empty messageId');
+  }
+  const normalizedScopeId = scopeId.trim() || 'default';
+  const db = getDb();
+  const raw = (db as unknown as { $client: { query: (q: string) => { get: (...params: unknown[]) => unknown } } }).$client;
+  const existing = raw.query(`
+    SELECT id
+    FROM memory_jobs
+    WHERE type = 'resolve_pending_conflicts_for_message'
+      AND status IN ('pending', 'running')
+      AND json_extract(payload, '$.messageId') = ?
+      AND COALESCE(json_extract(payload, '$.scopeId'), 'default') = ?
+    ORDER BY created_at ASC
+    LIMIT 1
+  `).get(normalizedMessageId, normalizedScopeId) as { id: string } | null;
+  if (existing?.id) return existing.id;
+
+  return enqueueMemoryJob('resolve_pending_conflicts_for_message', {
+    messageId: normalizedMessageId,
+    scopeId: normalizedScopeId,
+  });
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -33,6 +33,8 @@ import {
 } from './entity-extractor.js';
 import { indexMessageNow } from './indexer.js';
 import { checkContradictions } from './contradiction-checker.js';
+import { resolveConflictClarification } from './clarification-resolver.js';
+import { applyConflictResolution, listPendingConflictDetails } from './conflict-store.js';
 import { extractAndUpsertMemoryItemsForMessage } from './items-extractor.js';
 import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getQdrantClient } from './qdrant-client.js';
@@ -180,6 +182,9 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
       return;
     case 'extract_entities':
       await extractEntitiesJob(job, config);
+      return;
+    case 'resolve_pending_conflicts_for_message':
+      await resolvePendingConflictsForMessageJob(job, config);
       return;
     case 'check_contradictions':
       await checkContradictionsJob(job);
@@ -366,6 +371,57 @@ async function checkContradictionsJob(job: MemoryJob): Promise<void> {
   const itemId = asString(job.payload.itemId);
   if (!itemId) return;
   await checkContradictions(itemId);
+}
+
+async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
+  if (!config.memory.conflicts.enabled) return;
+  const messageId = asString(job.payload.messageId);
+  if (!messageId) return;
+  const scopeId = asString(job.payload.scopeId) ?? 'default';
+  const db = getDb();
+  const message = db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+    })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (!message || message.role !== 'user') return;
+
+  const userMessage = extractTextFromStoredMessageContent(message.content).trim();
+  if (userMessage.length === 0) return;
+
+  const pending = listPendingConflictDetails(scopeId, 25);
+  if (pending.length === 0) return;
+
+  let resolvedCount = 0;
+  for (const conflict of pending) {
+    const resolution = await resolveConflictClarification(
+      {
+        existingStatement: conflict.existingStatement,
+        candidateStatement: conflict.candidateStatement,
+        userMessage,
+      },
+      { timeoutMs: config.memory.conflicts.resolverLlmTimeoutMs },
+    );
+    if (resolution.resolution === 'still_unclear') continue;
+    const resolved = applyConflictResolution({
+      conflictId: conflict.id,
+      resolution: resolution.resolution,
+      mergedStatement: resolution.resolution === 'merge' ? resolution.resolvedStatement : null,
+      resolutionNote: `Background message resolver (${resolution.strategy}): ${resolution.explanation}`,
+    });
+    if (resolved) resolvedCount += 1;
+  }
+
+  log.debug({
+    messageId,
+    scopeId,
+    pendingConflicts: pending.length,
+    resolvedConflicts: resolvedCount,
+  }, 'Processed pending conflict resolution job');
 }
 
 async function buildConversationSummaryJob(job: MemoryJob, config: AssistantConfig): Promise<void> {


### PR DESCRIPTION
## Summary
- add a new async memory job type, `resolve_pending_conflicts_for_message`, with enqueue dedupe keyed by `(job_type, message_id, scope_id)`
- enqueue the conflict-resolver job during user-message indexing when `memory.conflicts.enabled` is on
- process pending conflict rows in `MemoryJobsWorker` by reusing the clarification resolver + conflict store resolution transitions
- add an expression index on `memory_jobs` payload fields used by dedupe lookup
- extend regressions with enqueue dedupe and end-to-end background conflict resolution tests

## Testing
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/conflict-store.test.ts assistant/src/__tests__/session-conflict-gate.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/memory-v2-regressions.test.ts -t "pending conflict resolver enqueue is deduped by message and scope|background conflict resolver job applies user clarification to pending conflicts|relation backfill enqueue is deduped and force upgrades payload"

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
