### PR TITLE
feat(swarm): add worker backend contract and role-scoped claude_code profiles

### DIFF
--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock the Agent SDK — prevents real subprocess spawning
+// ---------------------------------------------------------------------------
+const queryMock = mock(() => {
+  // Returns an async iterable that yields a success result
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        type: 'result' as const,
+        session_id: 'test-session',
+        subtype: 'success' as const,
+        result: 'Done.',
+      };
+    },
+  };
+});
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: queryMock,
+}));
+
+// Mock logger
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+// Mock config
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    apiKeys: { anthropic: 'test-key' },
+  }),
+}));
+
+import { claudeCodeTool } from '../tools/claude-code/claude-code.js';
+import type { ToolContext } from '../tools/types.js';
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    sessionId: 'test-session',
+    workingDir: '/tmp/test',
+    onOutput: () => {},
+    ...overrides,
+  } as ToolContext;
+}
+
+describe('claude_code tool profile support', () => {
+  beforeEach(() => {
+    queryMock.mockClear();
+  });
+
+  test('getDefinition includes profile parameter', () => {
+    const def = claudeCodeTool.getDefinition();
+    const props = (def.input_schema as Record<string, unknown>).properties as Record<string, unknown>;
+    expect(props.profile).toBeDefined();
+  });
+
+  test('rejects invalid profile', async () => {
+    const result = await claudeCodeTool.execute(
+      { prompt: 'test', profile: 'hacker' },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid profile');
+  });
+
+  test('accepts valid profiles without error', async () => {
+    for (const profile of ['general', 'researcher', 'coder', 'reviewer']) {
+      queryMock.mockClear();
+      const result = await claudeCodeTool.execute(
+        { prompt: 'test', profile },
+        makeContext(),
+      );
+      expect(result.isError).toBeFalsy();
+    }
+  });
+
+  test('omitted profile defaults to general (backward compat)', async () => {
+    const result = await claudeCodeTool.execute(
+      { prompt: 'test' },
+      makeContext(),
+    );
+    expect(result.isError).toBeFalsy();
+  });
+});

--- a/assistant/src/__tests__/swarm-worker-backend.test.ts
+++ b/assistant/src/__tests__/swarm-worker-backend.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  getProfilePolicy,
+  roleToProfile,
+} from '../swarm/worker-backend.js';
+import type { WorkerProfile } from '../swarm/worker-backend.js';
+
+describe('roleToProfile', () => {
+  test('maps researcher role to researcher profile', () => {
+    expect(roleToProfile('researcher')).toBe('researcher');
+  });
+
+  test('maps coder role to coder profile', () => {
+    expect(roleToProfile('coder')).toBe('coder');
+  });
+
+  test('maps reviewer role to reviewer profile', () => {
+    expect(roleToProfile('reviewer')).toBe('reviewer');
+  });
+
+  test('maps router role to general profile', () => {
+    expect(roleToProfile('router')).toBe('general');
+  });
+});
+
+describe('getProfilePolicy', () => {
+  const READ_ONLY_TOOLS = [
+    'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS',
+    'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
+  ];
+
+  const WRITE_TOOLS = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+
+  describe('general profile', () => {
+    const policy = getProfilePolicy('general');
+
+    test('allows read-only tools', () => {
+      for (const tool of READ_ONLY_TOOLS) {
+        expect(policy.allow.has(tool)).toBe(true);
+      }
+    });
+
+    test('has no hard denies', () => {
+      expect(policy.deny.size).toBe(0);
+    });
+
+    test('requires approval for write tools and Bash', () => {
+      for (const tool of WRITE_TOOLS) {
+        expect(policy.approvalRequired.has(tool)).toBe(true);
+      }
+      expect(policy.approvalRequired.has('Bash')).toBe(true);
+    });
+  });
+
+  describe('researcher profile', () => {
+    const policy = getProfilePolicy('researcher');
+
+    test('allows read-only tools', () => {
+      for (const tool of READ_ONLY_TOOLS) {
+        expect(policy.allow.has(tool)).toBe(true);
+      }
+    });
+
+    test('denies write tools', () => {
+      for (const tool of WRITE_TOOLS) {
+        expect(policy.deny.has(tool)).toBe(true);
+      }
+    });
+  });
+
+  describe('coder profile', () => {
+    const policy = getProfilePolicy('coder');
+
+    test('allows read-only tools', () => {
+      for (const tool of READ_ONLY_TOOLS) {
+        expect(policy.allow.has(tool)).toBe(true);
+      }
+    });
+
+    test('has no hard denies', () => {
+      expect(policy.deny.size).toBe(0);
+    });
+
+    test('requires approval for write tools and Bash', () => {
+      for (const tool of WRITE_TOOLS) {
+        expect(policy.approvalRequired.has(tool)).toBe(true);
+      }
+      expect(policy.approvalRequired.has('Bash')).toBe(true);
+    });
+  });
+
+  describe('reviewer profile', () => {
+    const policy = getProfilePolicy('reviewer');
+
+    test('allows read-only tools', () => {
+      for (const tool of READ_ONLY_TOOLS) {
+        expect(policy.allow.has(tool)).toBe(true);
+      }
+    });
+
+    test('denies write tools and Bash', () => {
+      for (const tool of WRITE_TOOLS) {
+        expect(policy.deny.has(tool)).toBe(true);
+      }
+      expect(policy.deny.has('Bash')).toBe(true);
+    });
+  });
+
+  test('all profiles allow the same read-only tool set', () => {
+    const profiles: WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
+    for (const profile of profiles) {
+      const policy = getProfilePolicy(profile);
+      for (const tool of READ_ONLY_TOOLS) {
+        expect(policy.allow.has(tool)).toBe(true);
+      }
+    }
+  });
+
+  test('denied tools are never also in allow set', () => {
+    const profiles: WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
+    for (const profile of profiles) {
+      const policy = getProfilePolicy(profile);
+      for (const tool of policy.deny) {
+        expect(policy.allow.has(tool)).toBe(false);
+      }
+    }
+  });
+});

--- a/assistant/src/swarm/index.ts
+++ b/assistant/src/swarm/index.ts
@@ -16,3 +16,17 @@ export {
   validateAndNormalizePlan,
   SwarmPlanValidationError,
 } from './plan-validator.js';
+
+export type {
+  WorkerProfile,
+  ProfilePolicy,
+  WorkerFailureReason,
+  SwarmWorkerBackendResult,
+  SwarmWorkerBackendInput,
+  SwarmWorkerBackend,
+} from './worker-backend.js';
+
+export {
+  roleToProfile,
+  getProfilePolicy,
+} from './worker-backend.js';

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -1,0 +1,119 @@
+import type { SwarmRole } from './types.js';
+
+/**
+ * Profile names that scope tool access for worker tasks.
+ */
+export type WorkerProfile = 'general' | 'researcher' | 'coder' | 'reviewer';
+
+/**
+ * Maps swarm roles to worker profiles.
+ */
+export function roleToProfile(role: SwarmRole): WorkerProfile {
+  switch (role) {
+    case 'researcher': return 'researcher';
+    case 'coder': return 'coder';
+    case 'reviewer': return 'reviewer';
+    case 'router': return 'general';
+    default: return 'general';
+  }
+}
+
+/**
+ * Per-profile tool access policy. The sets are checked in order:
+ * 1. If tool is in `deny`, block unconditionally.
+ * 2. If tool is in `allow`, auto-approve.
+ * 3. If tool is in `approvalRequired`, prompt user.
+ * 4. Otherwise follow default approval flow.
+ */
+export interface ProfilePolicy {
+  allow: Set<string>;
+  deny: Set<string>;
+  approvalRequired: Set<string>;
+}
+
+const READ_ONLY_TOOLS = new Set([
+  'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'LS',
+  'Bash(grep *)', 'Bash(rg *)', 'Bash(find *)',
+]);
+
+const WRITE_TOOLS = new Set([
+  'Edit', 'Write', 'MultiEdit', 'NotebookEdit',
+]);
+
+/**
+ * Return the tool access policy for a given profile.
+ */
+export function getProfilePolicy(profile: WorkerProfile): ProfilePolicy {
+  switch (profile) {
+    case 'general':
+      return {
+        allow: new Set(READ_ONLY_TOOLS),
+        deny: new Set(),
+        approvalRequired: new Set(['Bash', ...WRITE_TOOLS]),
+      };
+
+    case 'researcher':
+      return {
+        allow: new Set(READ_ONLY_TOOLS),
+        deny: new Set(WRITE_TOOLS),
+        approvalRequired: new Set(),
+      };
+
+    case 'coder':
+      return {
+        allow: new Set(READ_ONLY_TOOLS),
+        deny: new Set(),
+        approvalRequired: new Set(['Bash', ...WRITE_TOOLS]),
+      };
+
+    case 'reviewer':
+      return {
+        allow: new Set(READ_ONLY_TOOLS),
+        deny: new Set([...WRITE_TOOLS, 'Bash']),
+        approvalRequired: new Set(),
+      };
+
+    default:
+      return {
+        allow: new Set(READ_ONLY_TOOLS),
+        deny: new Set(),
+        approvalRequired: new Set(['Bash', ...WRITE_TOOLS]),
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worker Backend
+// ---------------------------------------------------------------------------
+
+export type WorkerFailureReason =
+  | 'backend_unavailable'
+  | 'timeout'
+  | 'malformed_output'
+  | 'tool_denied';
+
+export interface SwarmWorkerBackendResult {
+  success: boolean;
+  output: string;
+  failureReason?: WorkerFailureReason;
+  durationMs: number;
+}
+
+export interface SwarmWorkerBackendInput {
+  prompt: string;
+  profile: WorkerProfile;
+  workingDir: string;
+  model?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Abstraction over execution backends for swarm workers.
+ */
+export interface SwarmWorkerBackend {
+  readonly name: string;
+  /** Check whether the backend is available (e.g. API key present). */
+  isAvailable(): boolean;
+  /** Run a task with the given input. */
+  runTask(input: SwarmWorkerBackendInput): Promise<SwarmWorkerBackendResult>;
+}

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -3,6 +3,8 @@ import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { getConfig } from '../../config/loader.js';
 import { getLogger } from '../../util/logger.js';
+import { getProfilePolicy } from '../../swarm/worker-backend.js';
+import type { WorkerProfile } from '../../swarm/worker-backend.js';
 
 const log = getLogger('claude-code-tool');
 
@@ -15,7 +17,10 @@ const AUTO_APPROVE_TOOLS = new Set([
 // Tools that always require user approval via confirmation IPC
 const APPROVAL_REQUIRED_TOOLS = new Set([
   'Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit',
+
 ]);
+
+const VALID_PROFILES: readonly WorkerProfile[] = ['general', 'researcher', 'coder', 'reviewer'];
 
 export const claudeCodeTool: Tool = {
   name: 'claude_code',
@@ -46,6 +51,11 @@ export const claudeCodeTool: Tool = {
             type: 'string',
             description: 'Model to use (defaults to claude-sonnet-4-5-20250929)',
           },
+          profile: {
+            type: 'string',
+            enum: ['general', 'researcher', 'coder', 'reviewer'],
+            description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
+          },
         },
         required: ['prompt'],
       },
@@ -57,6 +67,17 @@ export const claudeCodeTool: Tool = {
     const workingDir = (input.working_dir as string) || context.workingDir;
     const resumeSessionId = input.resume as string | undefined;
     const model = (input.model as string) || 'claude-sonnet-4-5-20250929';
+    const profileName = (input.profile as WorkerProfile | undefined) ?? 'general';
+
+    // Validate profile
+    if (!VALID_PROFILES.includes(profileName)) {
+      return {
+        content: `Error: Invalid profile "${profileName}". Valid profiles: ${VALID_PROFILES.join(', ')}.`,
+        isError: true,
+      };
+    }
+
+    const profilePolicy = getProfilePolicy(profileName);
 
     // Validate API key
     const config = getConfig();
@@ -85,16 +106,26 @@ export const claudeCodeTool: Tool = {
 
     log.info({ prompt: prompt.slice(0, 100), workingDir, model, resume: !!resumeSessionId }, 'Starting Claude Code session');
 
-    // Build the canUseTool callback
+    // Build the canUseTool callback, enforcing profile-based restrictions
     const canUseTool: import('@anthropic-ai/claude-agent-sdk').CanUseTool = async (toolName, toolInput, _options) => {
-      // Auto-approve safe read-only tools
+      // Profile hard-deny check first
+      if (profilePolicy.deny.has(toolName)) {
+        log.debug({ toolName, profile: profileName }, 'Tool denied by profile policy');
+        return { behavior: 'deny' as const, message: `Tool "${toolName}" is denied by profile "${profileName}"` };
+      }
+
+      // Profile explicit allow (auto-approve)
+      if (profilePolicy.allow.has(toolName)) {
+        return { behavior: 'allow' as const };
+      }
+
+      // Auto-approve safe read-only tools (backward compat for general profile)
       if (AUTO_APPROVE_TOOLS.has(toolName)) {
         return { behavior: 'allow' as const };
       }
 
       // For tools that need approval, bridge to Velly's confirmation flow
       if (!context.requestConfirmation) {
-        // No confirmation callback available -- deny by default for safety
         log.warn({ toolName }, 'Claude Code tool requires approval but no requestConfirmation callback available');
         return { behavior: 'deny' as const, message: 'Tool approval not available in this context' };
       }
@@ -110,7 +141,6 @@ export const claudeCodeTool: Tool = {
         }
         return { behavior: 'deny' as const, message: `User denied ${toolName}` };
       } catch (err) {
-        // Abort/dispose will reject the promise -- treat as deny
         log.debug({ err, toolName }, 'requestConfirmation rejected (likely abort)');
         return { behavior: 'deny' as const, message: 'Approval request cancelled' };
       }

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -246,6 +246,11 @@ export async function initializeTools(): Promise<void> {
             type: 'string',
             description: 'Model to use (defaults to claude-sonnet-4-5-20250929)',
           },
+          profile: {
+            type: 'string',
+            enum: ['general', 'researcher', 'coder', 'reviewer'],
+            description: 'Worker profile that scopes tool access. Defaults to general (backward compatible).',
+          },
         },
         required: ['prompt'],
       },


### PR DESCRIPTION
## Summary
- Introduce `SwarmWorkerBackend` interface decoupling swarm orchestration from direct tool calls
- Add per-profile tool access policies (`general`, `researcher`, `coder`, `reviewer`) with deterministic allow/deny/approval-required sets
- Enforce profile restrictions in `claude_code`'s `canUseTool` callback before existing approval flow
- Add `profile` parameter to `claude_code` tool schema (backward compatible: omitted = `general`)

## Test plan
- [x] `bun test src/__tests__/swarm-worker-backend.test.ts` — 16/16 pass
- [x] `bun test src/__tests__/claude-code-tool-profiles.test.ts` — 4/4 pass
- [x] `bunx tsc --noEmit` — no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
