### PR TITLE
feat(swarm): add worker runner on top of worker backend

### DIFF
--- a/assistant/src/__tests__/swarm-worker-runner.test.ts
+++ b/assistant/src/__tests__/swarm-worker-runner.test.ts
@@ -1,0 +1,210 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { runWorkerTask } from '../swarm/worker-runner.js';
+import { parseWorkerOutput, buildWorkerPrompt } from '../swarm/worker-prompts.js';
+import type { SwarmWorkerBackend, SwarmWorkerBackendInput } from '../swarm/worker-backend.js';
+import type { SwarmTaskNode } from '../swarm/types.js';
+import type { WorkerStatusKind } from '../swarm/worker-runner.js';
+
+function makeTask(overrides?: Partial<SwarmTaskNode>): SwarmTaskNode {
+  return {
+    id: 'test-task',
+    role: 'coder',
+    objective: 'Write a function',
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+function makeBackend(overrides?: Partial<SwarmWorkerBackend>): SwarmWorkerBackend {
+  return {
+    name: 'test-backend',
+    isAvailable: () => true,
+    runTask: async () => ({
+      success: true,
+      output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+      durationMs: 100,
+    }),
+    ...overrides,
+  };
+}
+
+describe('runWorkerTask', () => {
+  test('returns completed result on success', async () => {
+    const result = await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(result.status).toBe('completed');
+    expect(result.taskId).toBe('test-task');
+    expect(result.summary).toBe('Done');
+    expect(result.durationMs).toBe(100);
+  });
+
+  test('returns failed result when backend is unavailable', async () => {
+    const result = await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend({ isAvailable: () => false }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(result.status).toBe('failed');
+    expect(result.issues[0]).toContain('unavailable');
+  });
+
+  test('returns failed result when backend returns failure', async () => {
+    const result = await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend({
+        runTask: async () => ({
+          success: false,
+          output: 'Something went wrong',
+          failureReason: 'timeout',
+          durationMs: 900,
+        }),
+      }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(result.status).toBe('failed');
+    expect(result.issues).toContain('timeout');
+    expect(result.durationMs).toBe(900);
+  });
+
+  test('returns failed result when backend throws', async () => {
+    const result = await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend({
+        runTask: async () => { throw new Error('Boom'); },
+      }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('Boom');
+  });
+
+  test('emits status callbacks in order', async () => {
+    const statuses: WorkerStatusKind[] = [];
+    await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+      onStatus: (_taskId, status) => statuses.push(status),
+    });
+    expect(statuses).toEqual(['queued', 'running', 'completed']);
+  });
+
+  test('emits queued then failed when backend unavailable', async () => {
+    const statuses: WorkerStatusKind[] = [];
+    await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend({ isAvailable: () => false }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+      onStatus: (_taskId, status) => statuses.push(status),
+    });
+    expect(statuses).toEqual(['queued', 'failed']);
+  });
+
+  test('maps role to correct profile in prompt', async () => {
+    let capturedInput: SwarmWorkerBackendInput | null = null;
+    await runWorkerTask({
+      task: makeTask({ role: 'researcher' }),
+      backend: makeBackend({
+        runTask: async (input) => {
+          capturedInput = input;
+          return { success: true, output: 'ok', durationMs: 50 };
+        },
+      }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(capturedInput!.profile).toBe('researcher');
+  });
+
+  test('includes dependency outputs in prompt', async () => {
+    let capturedInput: SwarmWorkerBackendInput | null = null;
+    await runWorkerTask({
+      task: makeTask(),
+      dependencyOutputs: [{ taskId: 'dep-1', summary: 'Research complete' }],
+      backend: makeBackend({
+        runTask: async (input) => {
+          capturedInput = input;
+          return { success: true, output: 'ok', durationMs: 50 };
+        },
+      }),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+    });
+    expect(capturedInput!.prompt).toContain('dep-1');
+    expect(capturedInput!.prompt).toContain('Research complete');
+  });
+});
+
+describe('parseWorkerOutput', () => {
+  test('parses valid fenced JSON', () => {
+    const raw = 'Some preamble\n```json\n{"summary":"Done","artifacts":["file.ts"],"issues":[],"nextSteps":["test"]}\n```\nSome epilogue';
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe('Done');
+    expect(result.artifacts).toEqual(['file.ts']);
+    expect(result.nextSteps).toEqual(['test']);
+  });
+
+  test('falls back to raw summary on invalid JSON', () => {
+    const raw = '```json\n{invalid json}\n```';
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe(raw.slice(0, 500));
+    expect(result.artifacts).toEqual([]);
+  });
+
+  test('falls back to raw summary when no JSON block', () => {
+    const raw = 'Just a plain text output without any JSON.';
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe(raw);
+    expect(result.artifacts).toEqual([]);
+  });
+
+  test('truncates long raw output to 500 chars', () => {
+    const raw = 'x'.repeat(1000);
+    const result = parseWorkerOutput(raw);
+    expect(result.summary.length).toBe(500);
+  });
+});
+
+describe('buildWorkerPrompt', () => {
+  test('includes role and objective', () => {
+    const prompt = buildWorkerPrompt({ role: 'coder', objective: 'Build feature X' });
+    expect(prompt).toContain('coder');
+    expect(prompt).toContain('Build feature X');
+  });
+
+  test('includes upstream context when provided', () => {
+    const prompt = buildWorkerPrompt({
+      role: 'coder',
+      objective: 'Build it',
+      upstreamContext: 'This is a React project',
+    });
+    expect(prompt).toContain('This is a React project');
+  });
+
+  test('includes dependency outputs when provided', () => {
+    const prompt = buildWorkerPrompt({
+      role: 'coder',
+      objective: 'Build it',
+      dependencyOutputs: [
+        { taskId: 'research', summary: 'Found the API docs' },
+      ],
+    });
+    expect(prompt).toContain('research');
+    expect(prompt).toContain('Found the API docs');
+  });
+
+  test('includes output contract instructions', () => {
+    const prompt = buildWorkerPrompt({ role: 'coder', objective: 'Test' });
+    expect(prompt).toContain('```json');
+    expect(prompt).toContain('summary');
+  });
+});

--- a/assistant/src/swarm/index.ts
+++ b/assistant/src/swarm/index.ts
@@ -30,3 +30,8 @@ export {
   roleToProfile,
   getProfilePolicy,
 } from './worker-backend.js';
+
+export { buildWorkerPrompt, parseWorkerOutput } from './worker-prompts.js';
+
+export type { WorkerStatusKind, WorkerStatusCallback, RunWorkerTaskOptions } from './worker-runner.js';
+export { runWorkerTask } from './worker-runner.js';

--- a/assistant/src/swarm/worker-prompts.ts
+++ b/assistant/src/swarm/worker-prompts.ts
@@ -1,0 +1,73 @@
+import type { SwarmRole, SwarmTaskResult } from './types.js';
+
+/**
+ * Build a role-specific worker prompt for a swarm task.
+ */
+export function buildWorkerPrompt(opts: {
+  role: SwarmRole;
+  objective: string;
+  upstreamContext?: string;
+  dependencyOutputs?: Array<{ taskId: string; summary: string }>;
+}): string {
+  const parts: string[] = [];
+
+  parts.push(`You are a ${opts.role} worker in a swarm. Your objective:\n${opts.objective}`);
+
+  if (opts.upstreamContext) {
+    parts.push(`\nContext from the orchestrator:\n${opts.upstreamContext}`);
+  }
+
+  if (opts.dependencyOutputs && opts.dependencyOutputs.length > 0) {
+    parts.push('\nOutputs from prerequisite tasks:');
+    for (const dep of opts.dependencyOutputs) {
+      parts.push(`- [${dep.taskId}]: ${dep.summary}`);
+    }
+  }
+
+  parts.push(WORKER_OUTPUT_CONTRACT);
+
+  return parts.join('\n');
+}
+
+const WORKER_OUTPUT_CONTRACT = `
+
+When you are finished, output your result as a single fenced JSON block:
+
+\`\`\`json
+{
+  "summary": "Brief summary of what you accomplished",
+  "artifacts": ["list of file paths, code snippets, or other outputs"],
+  "issues": ["list of problems encountered, if any"],
+  "nextSteps": ["suggested follow-up actions, if any"]
+}
+\`\`\`
+
+If you cannot produce valid JSON, just write a plain-text summary.`;
+
+/**
+ * Parse the worker's raw output into a structured result shape.
+ * Prefers a fenced JSON block; falls back to treating the entire output as a summary.
+ */
+export function parseWorkerOutput(raw: string): Pick<SwarmTaskResult, 'summary' | 'artifacts' | 'issues' | 'nextSteps'> {
+  const jsonMatch = raw.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[1]);
+      return {
+        summary: typeof parsed.summary === 'string' ? parsed.summary : raw.slice(0, 500),
+        artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
+        issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+        nextSteps: Array.isArray(parsed.nextSteps) ? parsed.nextSteps : [],
+      };
+    } catch {
+      // JSON parse failed — fall through to raw summary
+    }
+  }
+
+  return {
+    summary: raw.slice(0, 500),
+    artifacts: [],
+    issues: [],
+    nextSteps: [],
+  };
+}

--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -1,0 +1,109 @@
+import type { SwarmTaskNode, SwarmTaskResult } from './types.js';
+import type { SwarmWorkerBackend } from './worker-backend.js';
+import { roleToProfile } from './worker-backend.js';
+import { buildWorkerPrompt, parseWorkerOutput } from './worker-prompts.js';
+
+export type WorkerStatusKind = 'queued' | 'running' | 'completed' | 'failed';
+
+export type WorkerStatusCallback = (taskId: string, status: WorkerStatusKind) => void;
+
+export interface RunWorkerTaskOptions {
+  task: SwarmTaskNode;
+  /** Top-level objective context passed from the orchestrator. */
+  upstreamContext?: string;
+  /** Summaries from completed dependency tasks. */
+  dependencyOutputs?: Array<{ taskId: string; summary: string }>;
+  backend: SwarmWorkerBackend;
+  workingDir: string;
+  model?: string;
+  timeoutMs: number;
+  onStatus?: WorkerStatusCallback;
+}
+
+/**
+ * Execute a single swarm worker task through the given backend.
+ * Returns a normalized SwarmTaskResult regardless of success or failure.
+ */
+export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTaskResult> {
+  const { task, backend, workingDir, timeoutMs, onStatus } = opts;
+
+  onStatus?.(task.id, 'queued');
+
+  // Check backend availability
+  if (!backend.isAvailable()) {
+    onStatus?.(task.id, 'failed');
+    return {
+      taskId: task.id,
+      status: 'failed',
+      summary: `Backend "${backend.name}" is not available. Check API key and SDK configuration.`,
+      artifacts: [],
+      issues: [`Backend "${backend.name}" unavailable`],
+      nextSteps: ['Configure the backend or use a different one'],
+      rawOutput: '',
+      durationMs: 0,
+      retryCount: 0,
+    };
+  }
+
+  onStatus?.(task.id, 'running');
+
+  const prompt = buildWorkerPrompt({
+    role: task.role,
+    objective: task.objective,
+    upstreamContext: opts.upstreamContext,
+    dependencyOutputs: opts.dependencyOutputs,
+  });
+
+  const profile = roleToProfile(task.role);
+
+  try {
+    const result = await backend.runTask({
+      prompt,
+      profile,
+      workingDir,
+      model: opts.model,
+      timeoutMs,
+    });
+
+    if (result.success) {
+      const parsed = parseWorkerOutput(result.output);
+      onStatus?.(task.id, 'completed');
+      return {
+        taskId: task.id,
+        status: 'completed',
+        ...parsed,
+        rawOutput: result.output,
+        durationMs: result.durationMs,
+        retryCount: 0,
+      };
+    }
+
+    // Backend returned a failure
+    onStatus?.(task.id, 'failed');
+    return {
+      taskId: task.id,
+      status: 'failed',
+      summary: result.output || `Task failed: ${result.failureReason ?? 'unknown'}`,
+      artifacts: [],
+      issues: [result.failureReason ?? 'unknown_failure'],
+      nextSteps: [],
+      rawOutput: result.output,
+      durationMs: result.durationMs,
+      retryCount: 0,
+    };
+  } catch (err) {
+    onStatus?.(task.id, 'failed');
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      taskId: task.id,
+      status: 'failed',
+      summary: `Unexpected error: ${message}`,
+      artifacts: [],
+      issues: [message],
+      nextSteps: [],
+      rawOutput: '',
+      durationMs: 0,
+      retryCount: 0,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add worker prompt templates with role-specific instructions and structured JSON output contract
- Implement `parseWorkerOutput()` with fenced-JSON preference and plain-text fallback
- Implement `runWorkerTask()` with status callbacks (`queued` -> `running` -> `completed`/`failed`) and graceful error handling for backend unavailability and exceptions

## Test plan
- [x] `bun test src/__tests__/swarm-worker-runner.test.ts` — 16/16 pass
- [x] `bunx tsc --noEmit` — no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
