### PR TITLE
feat(memory): add trusted dynamic profile compiler

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,6 +69,7 @@ graph TB
             RECALL["Memory Recall<br/>FTS5 + Qdrant + Entity Graph + RRF<br/>Trust + Freshness + Scope"]
             CONFLICT_STORE["ConflictStore<br/>pending/resolved clarification state"]
             CLARIFICATION_RESOLVER["ClarificationResolver<br/>heuristics + timeout-bounded LLM fallback"]
+            PROFILE_COMPILER["ProfileCompiler<br/>canonical trusted profile<br/>strict token-cap trimming"]
             JOBS_WORKER["MemoryJobsWorker<br/>poll every 1.5s"]
         end
 
@@ -618,6 +619,8 @@ graph TB
 | `memory.conflicts.reaskCooldownTurns` | `3` | Minimum turn distance before re-asking the same conflict clarification. |
 | `memory.conflicts.resolverLlmTimeoutMs` | `12000` | Timeout bound for clarification resolver LLM fallback. |
 | `memory.conflicts.relevanceThreshold` | `0.3` | Similarity threshold for deciding whether a pending conflict is relevant to the current request. |
+| `memory.profile.enabled` | `false` | Enable dynamic profile compilation from active trusted profile/preference/constraint/instruction memories. |
+| `memory.profile.maxInjectTokens` | `800` | Hard token cap enforced by `ProfileCompiler` when generating the runtime profile block. |
 
 ### Memory Recall Debugging Playbook
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -136,6 +136,21 @@ describe('AssistantConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  test('applies memory.profile defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.memory.profile).toEqual({
+      enabled: false,
+      maxInjectTokens: 800,
+    });
+  });
+
+  test('rejects invalid memory.profile.maxInjectTokens', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { profile: { maxInjectTokens: 0 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
   test('rejects invalid provider', () => {
     const result = AssistantConfigSchema.safeParse({ provider: 'invalid' });
     expect(result.success).toBe(false);

--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -1,0 +1,220 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'profile-compiler-test-'));
+
+let profileEnabled = false;
+let profileMaxInjectTokens = 800;
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+import { DEFAULT_CONFIG } from '../config/defaults.js';
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    ...DEFAULT_CONFIG,
+    memory: {
+      ...DEFAULT_CONFIG.memory,
+      profile: {
+        enabled: profileEnabled,
+        maxInjectTokens: profileMaxInjectTokens,
+      },
+    },
+  }),
+}));
+
+import { estimateTextTokens } from '../context/token-estimator.js';
+import { getDb, initializeDb } from '../memory/db.js';
+import { compileDynamicProfile } from '../memory/profile-compiler.js';
+import { memoryItems } from '../memory/schema.js';
+
+initializeDb();
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true }); } catch { /* best effort */ }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run('DELETE FROM memory_item_sources');
+  db.run('DELETE FROM memory_items');
+}
+
+function insertItem(input: {
+  id: string;
+  kind: string;
+  subject: string;
+  statement: string;
+  verificationState: string;
+  status?: string;
+  invalidAt?: number | null;
+  scopeId?: string;
+  importance?: number;
+}) {
+  const now = Date.now();
+  const db = getDb();
+  db.insert(memoryItems).values({
+    id: input.id,
+    kind: input.kind,
+    subject: input.subject,
+    statement: input.statement,
+    status: input.status ?? 'active',
+    confidence: 0.8,
+    importance: input.importance ?? 0.6,
+    fingerprint: `fp-${input.id}`,
+    verificationState: input.verificationState,
+    scopeId: input.scopeId ?? 'default',
+    firstSeenAt: now - 1000,
+    lastSeenAt: now,
+    validFrom: now - 1000,
+    invalidAt: input.invalidAt ?? null,
+  }).run();
+}
+
+describe('profile-compiler', () => {
+  beforeEach(() => {
+    resetTables();
+    profileEnabled = false;
+    profileMaxInjectTokens = 800;
+  });
+
+  test('returns empty profile when feature is disabled', () => {
+    insertItem({
+      id: 'profile-disabled-1',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'User timezone is PST.',
+      verificationState: 'user_confirmed',
+    });
+
+    const compiled = compileDynamicProfile();
+    expect(compiled.text).toBe('');
+    expect(compiled.selectedCount).toBe(0);
+    expect(compiled.tokenEstimate).toBe(0);
+  });
+
+  test('selects active trusted memories and prefers stronger verification states', () => {
+    profileEnabled = true;
+
+    insertItem({
+      id: 'profile-strong',
+      kind: 'preference',
+      subject: 'package manager',
+      statement: 'Use pnpm for workspace installs.',
+      verificationState: 'user_confirmed',
+      importance: 0.9,
+    });
+    insertItem({
+      id: 'profile-weak',
+      kind: 'preference',
+      subject: 'package manager',
+      statement: 'Use npm for workspace installs.',
+      verificationState: 'assistant_inferred',
+      importance: 0.7,
+    });
+    insertItem({
+      id: 'profile-reported',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is America/Los_Angeles.',
+      verificationState: 'user_reported',
+      importance: 0.8,
+    });
+    insertItem({
+      id: 'profile-superseded',
+      kind: 'profile',
+      subject: 'location',
+      statement: 'Location is Seattle.',
+      verificationState: 'user_confirmed',
+      status: 'superseded',
+    });
+    insertItem({
+      id: 'profile-invalid',
+      kind: 'profile',
+      subject: 'editor',
+      statement: 'Primary editor is Neovim.',
+      verificationState: 'user_confirmed',
+      invalidAt: Date.now(),
+    });
+    insertItem({
+      id: 'profile-untrusted',
+      kind: 'profile',
+      subject: 'phone',
+      statement: 'Phone number is 555-0100.',
+      verificationState: 'legacy_import',
+    });
+    insertItem({
+      id: 'profile-project',
+      kind: 'project',
+      subject: 'repo',
+      statement: 'Project uses TypeScript.',
+      verificationState: 'user_confirmed',
+    });
+
+    const compiled = compileDynamicProfile();
+    expect(compiled.selectedCount).toBe(2);
+    expect(compiled.text).toContain('package manager: Use pnpm');
+    expect(compiled.text).toContain('timezone: Timezone is America/Los_Angeles');
+    expect(compiled.text).not.toContain('Use npm');
+    expect(compiled.text).not.toContain('Location is Seattle');
+    expect(compiled.text).not.toContain('Project uses TypeScript');
+  });
+
+  test('enforces strict token cap', () => {
+    profileEnabled = true;
+    profileMaxInjectTokens = 500;
+
+    insertItem({
+      id: 'profile-budget-1',
+      kind: 'profile',
+      subject: 'timezone',
+      statement: 'Timezone is Pacific time with daylight savings observed.',
+      verificationState: 'user_confirmed',
+      importance: 0.9,
+    });
+    insertItem({
+      id: 'profile-budget-2',
+      kind: 'preference',
+      subject: 'coding style',
+      statement: 'Prefers explicit types and no wildcard exports.',
+      verificationState: 'user_confirmed',
+      importance: 0.8,
+    });
+    insertItem({
+      id: 'profile-budget-3',
+      kind: 'constraint',
+      subject: 'deployment',
+      statement: 'Never deploy on Friday afternoons.',
+      verificationState: 'user_confirmed',
+      importance: 0.7,
+    });
+
+    const full = compileDynamicProfile({ maxInjectTokensOverride: 500 });
+    expect(full.selectedCount).toBeGreaterThan(1);
+
+    const tightBudget = Math.max(1, full.tokenEstimate - 5);
+    const limited = compileDynamicProfile({ maxInjectTokensOverride: tightBudget });
+
+    expect(limited.tokenEstimate).toBeLessThanOrEqual(tightBudget);
+    expect(estimateTextTokens(limited.text)).toBeLessThanOrEqual(tightBudget);
+    expect(limited.selectedCount).toBeLessThan(full.selectedCount);
+  });
+});

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -102,6 +102,10 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
     },
+    profile: {
+      enabled: false,
+      maxInjectTokens: 800,
+    },
   },
   dataDir: getDataDir(),
   timeouts: {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -458,6 +458,17 @@ export const MemoryConflictsConfigSchema = z.object({
     .default(0.3),
 });
 
+export const MemoryProfileConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.profile.enabled must be a boolean' })
+    .default(false),
+  maxInjectTokens: z
+    .number({ error: 'memory.profile.maxInjectTokens must be a number' })
+    .int('memory.profile.maxInjectTokens must be an integer')
+    .positive('memory.profile.maxInjectTokens must be a positive integer')
+    .default(800),
+});
+
 export const MemorySummarizationConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.summarization.useLLM must be a boolean' })
@@ -551,6 +562,10 @@ export const MemoryConfigSchema = z.object({
     reaskCooldownTurns: 3,
     resolverLlmTimeoutMs: 12000,
     relevanceThreshold: 0.3,
+  }),
+  profile: MemoryProfileConfigSchema.default({
+    enabled: false,
+    maxInjectTokens: 800,
   }),
 });
 
@@ -739,6 +754,10 @@ export const AssistantConfigSchema = z.object({
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
     },
+    profile: {
+      enabled: false,
+      maxInjectTokens: 800,
+    },
   }),
   dataDir: z
     .string({ error: 'dataDir must be a string' })
@@ -833,6 +852,7 @@ export type MemoryExtractionConfig = z.infer<typeof MemoryExtractionConfigSchema
 export type MemorySummarizationConfig = z.infer<typeof MemorySummarizationConfigSchema>;
 export type MemoryEntityConfig = z.infer<typeof MemoryEntityConfigSchema>;
 export type MemoryConflictsConfig = z.infer<typeof MemoryConflictsConfigSchema>;
+export type MemoryProfileConfig = z.infer<typeof MemoryProfileConfigSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;
 export type QdrantConfig = z.infer<typeof QdrantConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -18,6 +18,7 @@ export type {
   MemorySummarizationConfig,
   MemoryEntityConfig,
   MemoryConflictsConfig,
+  MemoryProfileConfig,
   MemoryConfig,
   ModelPricingOverride,
   QdrantConfig,

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -1,0 +1,124 @@
+import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { getConfig } from '../config/loader.js';
+import { estimateTextTokens } from '../context/token-estimator.js';
+import { getDb } from './db.js';
+import { memoryItems } from './schema.js';
+
+const PROFILE_KIND_ALLOWLIST = ['profile', 'preference', 'constraint', 'instruction'] as const;
+
+const TRUST_RANK: Record<string, number> = {
+  user_confirmed: 3,
+  user_reported: 2,
+  assistant_inferred: 1,
+};
+
+export interface CompileProfileOptions {
+  scopeId?: string;
+  maxInjectTokensOverride?: number;
+}
+
+export interface CompiledProfile {
+  text: string;
+  sourceCount: number;
+  selectedCount: number;
+  budgetTokens: number;
+  tokenEstimate: number;
+}
+
+interface ProfileCandidate {
+  kind: string;
+  subject: string;
+  statement: string;
+  verificationState: string;
+  confidence: number;
+  importance: number | null;
+  lastSeenAt: number;
+  firstSeenAt: number;
+}
+
+export function compileDynamicProfile(options?: CompileProfileOptions): CompiledProfile {
+  const config = getConfig();
+  const profileConfig = config.memory.profile;
+  const scopeId = options?.scopeId ?? 'default';
+  const budgetTokens = Math.max(0, Math.floor(options?.maxInjectTokensOverride ?? profileConfig.maxInjectTokens));
+  if (!profileConfig.enabled || budgetTokens <= 0) {
+    return { text: '', sourceCount: 0, selectedCount: 0, budgetTokens, tokenEstimate: 0 };
+  }
+
+  const db = getDb();
+  const rows = db
+    .select({
+      kind: memoryItems.kind,
+      subject: memoryItems.subject,
+      statement: memoryItems.statement,
+      verificationState: memoryItems.verificationState,
+      confidence: memoryItems.confidence,
+      importance: memoryItems.importance,
+      lastSeenAt: memoryItems.lastSeenAt,
+      firstSeenAt: memoryItems.firstSeenAt,
+    })
+    .from(memoryItems)
+    .where(and(
+      eq(memoryItems.scopeId, scopeId),
+      eq(memoryItems.status, 'active'),
+      isNull(memoryItems.invalidAt),
+      inArray(memoryItems.kind, [...PROFILE_KIND_ALLOWLIST]),
+    ))
+    .orderBy(desc(memoryItems.lastSeenAt))
+    .all();
+
+  const trusted = rows
+    .filter((row) => TRUST_RANK[row.verificationState] !== undefined)
+    .sort(compareProfileCandidates);
+
+  const selectedLines: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const candidate of trusted) {
+    const subject = normalizeWhitespace(candidate.subject, 80);
+    const statement = normalizeWhitespace(candidate.statement, 220);
+    if (!subject || !statement) continue;
+    const dedupeKey = `${candidate.kind}|${subject.toLowerCase()}`;
+    if (seenKeys.has(dedupeKey)) continue;
+    seenKeys.add(dedupeKey);
+
+    const line = `- ${subject}: ${statement}`;
+    const tentative = renderProfileText([...selectedLines, line]);
+    if (estimateTextTokens(tentative) > budgetTokens) continue;
+    selectedLines.push(line);
+  }
+
+  const text = renderProfileText(selectedLines);
+  const tokenEstimate = text ? estimateTextTokens(text) : 0;
+  return {
+    text,
+    sourceCount: trusted.length,
+    selectedCount: selectedLines.length,
+    budgetTokens,
+    tokenEstimate,
+  };
+}
+
+function compareProfileCandidates(left: ProfileCandidate, right: ProfileCandidate): number {
+  const trustDelta = (TRUST_RANK[right.verificationState] ?? 0) - (TRUST_RANK[left.verificationState] ?? 0);
+  if (trustDelta !== 0) return trustDelta;
+
+  const importanceDelta = (right.importance ?? 0) - (left.importance ?? 0);
+  if (importanceDelta !== 0) return importanceDelta;
+
+  const confidenceDelta = right.confidence - left.confidence;
+  if (confidenceDelta !== 0) return confidenceDelta;
+
+  const lastSeenDelta = right.lastSeenAt - left.lastSeenAt;
+  if (lastSeenDelta !== 0) return lastSeenDelta;
+
+  return right.firstSeenAt - left.firstSeenAt;
+}
+
+function normalizeWhitespace(input: string, maxLength: number): string {
+  return input.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function renderProfileText(lines: string[]): string {
+  if (lines.length === 0) return '';
+  return ['[Dynamic User Profile]', ...lines].join('\n');
+}


### PR DESCRIPTION
## Summary
- add `assistant/src/memory/profile-compiler.ts` to build a canonical dynamic profile from active, trusted memories only (`user_confirmed > user_reported > assistant_inferred`)
- enforce strict profile token budgeting with deterministic trimming and per-kind/subject dedupe
- add `memory.profile` config (`enabled`, `maxInjectTokens`) to schema, defaults, and exported config types
- add focused unit tests for profile compiler behavior and config schema validation
- document profile compiler/config additions in `ARCHITECTURE.md`

## Testing
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/profile-compiler.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/config-schema.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
