### PR TITLE
feat(swarm): add router planner with LLM plan generation

### DIFF
--- a/assistant/src/__tests__/swarm-router-planner.test.ts
+++ b/assistant/src/__tests__/swarm-router-planner.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect } from 'bun:test';
+import { generatePlan, parsePlanJSON, makeFallbackPlan } from '../swarm/router-planner.js';
+import { resolveSwarmLimits } from '../swarm/limits.js';
+import type { Provider, ProviderResponse, Message, ToolDefinition, SendMessageOptions } from '../providers/types.js';
+
+const DEFAULT_LIMITS = resolveSwarmLimits({
+  maxWorkers: 3,
+  maxTasks: 8,
+  maxRetriesPerTask: 1,
+  workerTimeoutSec: 900,
+});
+
+function makeProvider(responseText: string): Provider {
+  return {
+    name: 'test',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [{ type: 'text', text: responseText }],
+        model: 'test-model',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+}
+
+function makeFailingProvider(): Provider {
+  return {
+    name: 'test',
+    async sendMessage(): Promise<ProviderResponse> {
+      throw new Error('API error');
+    },
+  };
+}
+
+describe('parsePlanJSON', () => {
+  test('parses bare JSON', () => {
+    const result = parsePlanJSON('{"tasks":[{"id":"a","role":"coder","objective":"do stuff","dependencies":[]}]}');
+    expect(result).not.toBeNull();
+    expect(result!.tasks).toHaveLength(1);
+    expect(result!.tasks[0].id).toBe('a');
+  });
+
+  test('parses fenced JSON', () => {
+    const raw = '```json\n{"tasks":[{"id":"a","role":"coder","objective":"do stuff","dependencies":[]}]}\n```';
+    const result = parsePlanJSON(raw);
+    expect(result).not.toBeNull();
+    expect(result!.tasks).toHaveLength(1);
+  });
+
+  test('parses fenced code block without json tag', () => {
+    const raw = '```\n{"tasks":[{"id":"a","role":"coder","objective":"do stuff","dependencies":[]}]}\n```';
+    const result = parsePlanJSON(raw);
+    expect(result).not.toBeNull();
+  });
+
+  test('returns null for invalid JSON', () => {
+    expect(parsePlanJSON('this is not json')).toBeNull();
+  });
+
+  test('returns null for JSON without tasks array', () => {
+    expect(parsePlanJSON('{"plan":"something"}')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parsePlanJSON('')).toBeNull();
+  });
+});
+
+describe('makeFallbackPlan', () => {
+  test('creates single coder task', () => {
+    const plan = makeFallbackPlan('Build a feature');
+    expect(plan.objective).toBe('Build a feature');
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].role).toBe('coder');
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+    expect(plan.tasks[0].dependencies).toEqual([]);
+  });
+});
+
+describe('generatePlan', () => {
+  test('generates a valid plan from LLM response', async () => {
+    const responseText = JSON.stringify({
+      tasks: [
+        { id: 'research', role: 'researcher', objective: 'Find docs', dependencies: [] },
+        { id: 'code', role: 'coder', objective: 'Implement', dependencies: ['research'] },
+      ],
+    });
+    const plan = await generatePlan({
+      objective: 'Build feature X',
+      provider: makeProvider(responseText),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks).toHaveLength(2);
+    expect(plan.tasks[0].id).toBe('research');
+    expect(plan.tasks[1].dependencies).toContain('research');
+  });
+
+  test('falls back on invalid LLM JSON', async () => {
+    const plan = await generatePlan({
+      objective: 'Build feature X',
+      provider: makeProvider('Sorry, I cannot help with that.'),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+  });
+
+  test('falls back when provider throws', async () => {
+    const plan = await generatePlan({
+      objective: 'Build feature X',
+      provider: makeFailingProvider(),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+  });
+
+  test('falls back when LLM plan has invalid roles', async () => {
+    const responseText = JSON.stringify({
+      tasks: [
+        { id: 'hack', role: 'hacker', objective: 'Hack stuff', dependencies: [] },
+      ],
+    });
+    const plan = await generatePlan({
+      objective: 'Build feature X',
+      provider: makeProvider(responseText),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    // Plan validator rejects invalid roles, so generatePlan catches and falls back
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+  });
+
+  test('falls back when LLM plan has cycles', async () => {
+    const responseText = JSON.stringify({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: ['b'] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: ['a'] },
+      ],
+    });
+    const plan = await generatePlan({
+      objective: 'Build feature X',
+      provider: makeProvider(responseText),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+  });
+
+  test('truncates plans exceeding maxTasks', async () => {
+    const tasks = Array.from({ length: 15 }, (_, i) => ({
+      id: `t${i}`,
+      role: 'coder',
+      objective: `Task ${i}`,
+      dependencies: [],
+    }));
+    const plan = await generatePlan({
+      objective: 'Big feature',
+      provider: makeProvider(JSON.stringify({ tasks })),
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks.length).toBeLessThanOrEqual(DEFAULT_LIMITS.maxTasks);
+  });
+
+  test('handles response with no text content', async () => {
+    const provider: Provider = {
+      name: 'test',
+      async sendMessage(): Promise<ProviderResponse> {
+        return {
+          content: [],
+          model: 'test-model',
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: 'end_turn',
+        };
+      },
+    };
+    const plan = await generatePlan({
+      objective: 'Build feature',
+      provider,
+      model: 'test-model',
+      limits: DEFAULT_LIMITS,
+    });
+    expect(plan.tasks).toHaveLength(1);
+    expect(plan.tasks[0].id).toBe('fallback-coder');
+  });
+});

--- a/assistant/src/swarm/index.ts
+++ b/assistant/src/swarm/index.ts
@@ -35,3 +35,5 @@ export { buildWorkerPrompt, parseWorkerOutput } from './worker-prompts.js';
 
 export type { WorkerStatusKind, WorkerStatusCallback, RunWorkerTaskOptions } from './worker-runner.js';
 export { runWorkerTask } from './worker-runner.js';
+
+export { generatePlan, parsePlanJSON, makeFallbackPlan } from './router-planner.js';

--- a/assistant/src/swarm/router-planner.ts
+++ b/assistant/src/swarm/router-planner.ts
@@ -1,0 +1,91 @@
+import type { Provider, Message } from '../providers/types.js';
+import type { SwarmPlan, SwarmTaskNode } from './types.js';
+import type { SwarmLimits } from './limits.js';
+import { validateAndNormalizePlan } from './plan-validator.js';
+import { ROUTER_SYSTEM_PROMPT, buildPlannerUserMessage } from './router-prompts.js';
+
+/**
+ * Generate a validated swarm plan from a user objective using an LLM.
+ * Falls back to a single-coder plan if generation or validation fails.
+ */
+export async function generatePlan(opts: {
+  objective: string;
+  provider: Provider;
+  model: string;
+  limits: SwarmLimits;
+}): Promise<SwarmPlan> {
+  const { objective, provider, model, limits } = opts;
+
+  try {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: buildPlannerUserMessage(objective, limits.maxTasks) }],
+      },
+    ];
+
+    const response = await provider.sendMessage(
+      messages,
+      undefined,
+      ROUTER_SYSTEM_PROMPT,
+      { config: { max_tokens: 2048, model } },
+    );
+
+    // Extract text from response
+    const textBlock = response.content.find((b) => b.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      return makeFallbackPlan(objective);
+    }
+
+    const rawPlan = parsePlanJSON(textBlock.text);
+    if (!rawPlan) {
+      return makeFallbackPlan(objective);
+    }
+
+    const plan: SwarmPlan = {
+      objective,
+      tasks: rawPlan.tasks as SwarmTaskNode[],
+    };
+
+    return validateAndNormalizePlan(plan, limits);
+  } catch {
+    return makeFallbackPlan(objective);
+  }
+}
+
+/**
+ * Parse the LLM output as a plan JSON. Handles bare JSON objects and
+ * fenced code blocks.
+ */
+export function parsePlanJSON(raw: string): { tasks: Array<{ id: string; role: string; objective: string; dependencies: string[] }> } | null {
+  // Try extracting from fenced code block first
+  const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  const jsonStr = fenced ? fenced[1] : raw;
+
+  try {
+    const parsed = JSON.parse(jsonStr.trim());
+    if (parsed && Array.isArray(parsed.tasks)) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deterministic fallback: a single coder task for the full objective.
+ */
+export function makeFallbackPlan(objective: string): SwarmPlan {
+  return {
+    objective,
+    tasks: [
+      {
+        id: 'fallback-coder',
+        role: 'coder',
+        objective,
+        dependencies: [],
+      },
+    ],
+  };
+}

--- a/assistant/src/swarm/router-prompts.ts
+++ b/assistant/src/swarm/router-prompts.ts
@@ -1,0 +1,36 @@
+/**
+ * System prompt for the router planner LLM call.
+ */
+export const ROUTER_SYSTEM_PROMPT = `You are a task decomposition planner. Given a user objective, break it down into a set of parallel and sequential tasks that can be executed by specialist workers.
+
+Available worker roles:
+- researcher: Can search the web, read files, and gather information. Cannot write or edit files.
+- coder: Can read, write, and edit files, run shell commands, and implement code changes.
+- reviewer: Can read and search files to review code. Cannot write or edit files.
+
+Rules:
+1. Output ONLY a valid JSON object. No prose, no markdown, no explanation.
+2. Each task must have a unique "id" (short slug), a "role", an "objective" (clear instruction), and "dependencies" (array of task IDs that must complete first).
+3. Maximize parallelism: only add a dependency if the task truly needs output from another.
+4. Keep the plan minimal — avoid unnecessary tasks. Prefer fewer, well-scoped tasks.
+5. Do not create tasks for the "router" role.
+6. The total number of tasks must not exceed the provided limit.
+
+Output schema:
+{
+  "tasks": [
+    {
+      "id": "string",
+      "role": "researcher" | "coder" | "reviewer",
+      "objective": "string",
+      "dependencies": ["task-id", ...]
+    }
+  ]
+}`;
+
+/**
+ * Build the user message for the router planner.
+ */
+export function buildPlannerUserMessage(objective: string, maxTasks: number): string {
+  return `Objective: ${objective}\n\nMaximum tasks allowed: ${maxTasks}\n\nReturn ONLY the JSON plan.`;
+}


### PR DESCRIPTION
## Summary
- Add `generatePlan()` that calls a configurable LLM provider to decompose objectives into validated DAG plans
- Implement `parsePlanJSON()` handling both bare JSON and fenced code block responses
- Add deterministic `makeFallbackPlan()` — single coder task when generation fails
- Falls back gracefully on invalid LLM JSON, invalid roles, cycles, or provider errors

## Test plan
- [x] `bun test src/__tests__/swarm-router-planner.test.ts src/__tests__/swarm-plan-validator.test.ts` — 34/34 pass
- [x] `bunx tsc --noEmit` — no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
