### PR TITLE
feat(swarm): add DAG scheduler, retries, and final synthesis

### DIFF
--- a/assistant/src/__tests__/swarm-orchestrator.test.ts
+++ b/assistant/src/__tests__/swarm-orchestrator.test.ts
@@ -1,0 +1,232 @@
+import { describe, test, expect } from 'bun:test';
+import { executeSwarm } from '../swarm/orchestrator.js';
+import type { OrchestratorEvent } from '../swarm/orchestrator.js';
+import type { SwarmPlan } from '../swarm/types.js';
+import type { SwarmWorkerBackend } from '../swarm/worker-backend.js';
+import { resolveSwarmLimits } from '../swarm/limits.js';
+
+const DEFAULT_LIMITS = resolveSwarmLimits({
+  maxWorkers: 3,
+  maxTasks: 8,
+  maxRetriesPerTask: 1,
+  workerTimeoutSec: 900,
+});
+
+function makeBackend(overrides?: Partial<SwarmWorkerBackend>): SwarmWorkerBackend {
+  return {
+    name: 'test-backend',
+    isAvailable: () => true,
+    runTask: async () => ({
+      success: true,
+      output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+      durationMs: 50,
+    }),
+    ...overrides,
+  };
+}
+
+function makePlan(overrides?: Partial<SwarmPlan>): SwarmPlan {
+  return {
+    objective: 'Test objective',
+    tasks: [
+      { id: 'task-1', role: 'coder', objective: 'Do task 1', dependencies: [] },
+    ],
+    ...overrides,
+  };
+}
+
+describe('executeSwarm', () => {
+  test('executes a single-task plan successfully', async () => {
+    const summary = await executeSwarm({
+      plan: makePlan(),
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.totalTasks).toBe(1);
+    expect(summary.stats.completed).toBe(1);
+    expect(summary.stats.failed).toBe(0);
+    expect(summary.stats.blocked).toBe(0);
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0].status).toBe('completed');
+    expect(summary.finalAnswer).toContain('task-1');
+  });
+
+  test('executes parallel independent tasks', async () => {
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: [] },
+      ],
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.completed).toBe(2);
+    expect(summary.stats.failed).toBe(0);
+  });
+
+  test('executes sequential tasks in dependency order', async () => {
+    const executionOrder: string[] = [];
+    const plan = makePlan({
+      tasks: [
+        { id: 'research', role: 'researcher', objective: 'Research', dependencies: [] },
+        { id: 'code', role: 'coder', objective: 'Code', dependencies: ['research'] },
+        { id: 'review', role: 'reviewer', objective: 'Review', dependencies: ['code'] },
+      ],
+    });
+
+    const backend = makeBackend({
+      runTask: async (input) => {
+        // Extract task id from prompt
+        const match = input.prompt.match(/researcher|coder|reviewer/);
+        if (match) executionOrder.push(match[0]);
+        return {
+          success: true,
+          output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+          durationMs: 10,
+        };
+      },
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend,
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.completed).toBe(3);
+    expect(executionOrder).toEqual(['researcher', 'coder', 'reviewer']);
+  });
+
+  test('blocks dependents when a task fails', async () => {
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: ['a'] },
+        { id: 'c', role: 'coder', objective: 'C', dependencies: ['b'] },
+      ],
+    });
+
+    const backend = makeBackend({
+      runTask: async () => ({
+        success: false,
+        output: 'Failed',
+        failureReason: 'timeout',
+        durationMs: 10,
+      }),
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: resolveSwarmLimits({ ...DEFAULT_LIMITS, maxRetriesPerTask: 0 }),
+      backend,
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.failed).toBe(1);
+    expect(summary.stats.blocked).toBe(2);
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0].taskId).toBe('a');
+  });
+
+  test('retries failed tasks up to maxRetriesPerTask', async () => {
+    let callCount = 0;
+    const plan = makePlan();
+
+    const backend = makeBackend({
+      runTask: async () => {
+        callCount++;
+        if (callCount <= 1) {
+          return { success: false, output: 'fail', failureReason: 'timeout' as const, durationMs: 10 };
+        }
+        return {
+          success: true,
+          output: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+          durationMs: 10,
+        };
+      },
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: resolveSwarmLimits({ ...DEFAULT_LIMITS, maxRetriesPerTask: 2 }),
+      backend,
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.completed).toBe(1);
+    expect(summary.results[0].retryCount).toBe(1);
+  });
+
+  test('emits orchestrator events', async () => {
+    const events: OrchestratorEvent[] = [];
+    const plan = makePlan();
+
+    await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      onStatus: (event) => events.push(event),
+    });
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain('plan_created');
+    expect(kinds).toContain('task_started');
+    expect(kinds).toContain('task_completed');
+    expect(kinds).toContain('synthesis_started');
+    expect(kinds).toContain('done');
+  });
+
+  test('uses fallback markdown when no synthesis provider given', async () => {
+    const summary = await executeSwarm({
+      plan: makePlan(),
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+    });
+
+    expect(summary.finalAnswer).toContain('Swarm Results');
+    expect(summary.finalAnswer).toContain('task-1');
+  });
+
+  test('reports totalDurationMs', async () => {
+    const summary = await executeSwarm({
+      plan: makePlan(),
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.totalDurationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('handles diamond dependency pattern', async () => {
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: ['a'] },
+        { id: 'c', role: 'coder', objective: 'C', dependencies: ['a'] },
+        { id: 'd', role: 'coder', objective: 'D', dependencies: ['b', 'c'] },
+      ],
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend: makeBackend(),
+      workingDir: '/tmp',
+    });
+
+    expect(summary.stats.completed).toBe(4);
+    expect(summary.stats.blocked).toBe(0);
+  });
+});

--- a/assistant/src/swarm/index.ts
+++ b/assistant/src/swarm/index.ts
@@ -37,3 +37,8 @@ export type { WorkerStatusKind, WorkerStatusCallback, RunWorkerTaskOptions } fro
 export { runWorkerTask } from './worker-runner.js';
 
 export { generatePlan, parsePlanJSON, makeFallbackPlan } from './router-planner.js';
+
+export type { OrchestratorEventKind, OrchestratorEvent, OrchestratorStatusCallback, ExecuteSwarmOptions } from './orchestrator.js';
+export { executeSwarm } from './orchestrator.js';
+
+export { synthesizeResults } from './synthesizer.js';

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -1,0 +1,235 @@
+import type { SwarmPlan, SwarmTaskNode, SwarmTaskResult, SwarmExecutionSummary } from './types.js';
+import type { SwarmLimits } from './limits.js';
+import type { SwarmWorkerBackend } from './worker-backend.js';
+import { runWorkerTask } from './worker-runner.js';
+import type { Provider } from '../providers/types.js';
+import { synthesizeResults } from './synthesizer.js';
+
+export type OrchestratorEventKind =
+  | 'plan_created'
+  | 'task_started'
+  | 'task_completed'
+  | 'task_failed'
+  | 'task_blocked'
+  | 'synthesis_started'
+  | 'done';
+
+export interface OrchestratorEvent {
+  kind: OrchestratorEventKind;
+  taskId?: string;
+  message?: string;
+}
+
+export type OrchestratorStatusCallback = (event: OrchestratorEvent) => void;
+
+export interface ExecuteSwarmOptions {
+  plan: SwarmPlan;
+  limits: SwarmLimits;
+  backend: SwarmWorkerBackend;
+  workingDir: string;
+  model?: string;
+  /** Provider + model for final synthesis. */
+  synthesisProvider?: Provider;
+  synthesisModel?: string;
+  onStatus?: OrchestratorStatusCallback;
+}
+
+/**
+ * Execute a validated swarm plan with parallel DAG scheduling,
+ * bounded concurrency, and per-task retries.
+ */
+export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExecutionSummary> {
+  const { plan, limits, backend, workingDir, model, onStatus } = opts;
+  const startTime = Date.now();
+
+  onStatus?.({ kind: 'plan_created', message: `Plan with ${plan.tasks.length} tasks` });
+
+  const results = new Map<string, SwarmTaskResult>();
+  const blocked = new Set<string>();
+
+  // Build adjacency for dependency tracking
+  const dependents = new Map<string, string[]>();
+  for (const task of plan.tasks) {
+    dependents.set(task.id, []);
+  }
+  for (const task of plan.tasks) {
+    for (const dep of task.dependencies) {
+      dependents.get(dep)?.push(task.id);
+    }
+  }
+
+  // Determine initial ready tasks (no dependencies)
+  const ready: SwarmTaskNode[] = [];
+  const remaining = new Map<string, SwarmTaskNode>();
+  const pendingDeps = new Map<string, Set<string>>();
+
+  for (const task of plan.tasks) {
+    remaining.set(task.id, task);
+    if (task.dependencies.length === 0) {
+      ready.push(task);
+    } else {
+      pendingDeps.set(task.id, new Set(task.dependencies));
+    }
+  }
+
+  // Process tasks with bounded concurrency
+  while (ready.length > 0 || isAnyRunning()) {
+    // Launch up to maxWorkers tasks
+    const batch = ready.splice(0, limits.maxWorkers);
+
+    const promises = batch.map(async (task) => {
+      onStatus?.({ kind: 'task_started', taskId: task.id });
+
+      const depOutputs = task.dependencies
+        .map((depId) => {
+          const r = results.get(depId);
+          return r ? { taskId: depId, summary: r.summary } : null;
+        })
+        .filter((d): d is { taskId: string; summary: string } => d !== null);
+
+      let result = await runWorkerTask({
+        task,
+        upstreamContext: plan.objective,
+        dependencyOutputs: depOutputs,
+        backend,
+        workingDir,
+        model,
+        timeoutMs: limits.workerTimeoutSec * 1000,
+      });
+
+      // Retry loop
+      let retries = 0;
+      while (result.status === 'failed' && retries < limits.maxRetriesPerTask) {
+        retries++;
+        result = await runWorkerTask({
+          task,
+          upstreamContext: plan.objective,
+          dependencyOutputs: depOutputs,
+          backend,
+          workingDir,
+          model,
+          timeoutMs: limits.workerTimeoutSec * 1000,
+        });
+      }
+      result.retryCount = retries;
+
+      return result;
+    });
+
+    const batchResults = await Promise.all(promises);
+
+    for (const result of batchResults) {
+      results.set(result.taskId, result);
+      remaining.delete(result.taskId);
+
+      if (result.status === 'completed') {
+        onStatus?.({ kind: 'task_completed', taskId: result.taskId });
+        // Unblock dependents
+        for (const depId of dependents.get(result.taskId) ?? []) {
+          const pending = pendingDeps.get(depId);
+          if (pending) {
+            pending.delete(result.taskId);
+            if (pending.size === 0) {
+              pendingDeps.delete(depId);
+              const task = plan.tasks.find((t) => t.id === depId);
+              if (task && !blocked.has(depId)) {
+                ready.push(task);
+              }
+            }
+          }
+        }
+      } else {
+        onStatus?.({ kind: 'task_failed', taskId: result.taskId });
+        // Block all transitive dependents
+        blockDependents(result.taskId, dependents, blocked, onStatus);
+      }
+    }
+  }
+
+  // Mark any remaining tasks that were never reached as blocked
+  for (const [taskId] of remaining) {
+    if (!results.has(taskId) && !blocked.has(taskId)) {
+      blocked.add(taskId);
+      onStatus?.({ kind: 'task_blocked', taskId });
+    }
+  }
+
+  // Synthesize final answer
+  onStatus?.({ kind: 'synthesis_started' });
+  const allResults = Array.from(results.values());
+
+  let finalAnswer: string;
+  if (opts.synthesisProvider) {
+    finalAnswer = await synthesizeResults({
+      objective: plan.objective,
+      results: allResults,
+      provider: opts.synthesisProvider,
+      model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
+    });
+  } else {
+    finalAnswer = buildMarkdownFallback(plan.objective, allResults);
+  }
+
+  const totalDurationMs = Date.now() - startTime;
+  onStatus?.({ kind: 'done', message: `Completed in ${totalDurationMs}ms` });
+
+  return {
+    objective: plan.objective,
+    plan,
+    results: allResults,
+    finalAnswer,
+    stats: {
+      totalTasks: plan.tasks.length,
+      completed: allResults.filter((r) => r.status === 'completed').length,
+      failed: allResults.filter((r) => r.status === 'failed').length,
+      blocked: blocked.size,
+      totalDurationMs,
+    },
+  };
+
+  // Placeholder — there's no true async tracking in this sync loop,
+  // but the structure supports it.
+  function isAnyRunning(): boolean {
+    return false;
+  }
+}
+
+function blockDependents(
+  taskId: string,
+  dependents: Map<string, string[]>,
+  blocked: Set<string>,
+  onStatus?: OrchestratorStatusCallback,
+): void {
+  for (const depId of dependents.get(taskId) ?? []) {
+    if (!blocked.has(depId)) {
+      blocked.add(depId);
+      onStatus?.({ kind: 'task_blocked', taskId: depId });
+      blockDependents(depId, dependents, blocked, onStatus);
+    }
+  }
+}
+
+function buildMarkdownFallback(objective: string, results: SwarmTaskResult[]): string {
+  const lines: string[] = [`## Swarm Results: ${objective}`, ''];
+
+  const completed = results.filter((r) => r.status === 'completed');
+  const failed = results.filter((r) => r.status === 'failed');
+
+  if (completed.length > 0) {
+    lines.push('### Completed Tasks');
+    for (const r of completed) {
+      lines.push(`- **${r.taskId}**: ${r.summary}`);
+    }
+    lines.push('');
+  }
+
+  if (failed.length > 0) {
+    lines.push('### Failed Tasks');
+    for (const r of failed) {
+      lines.push(`- **${r.taskId}**: ${r.summary}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/assistant/src/swarm/synthesizer.ts
+++ b/assistant/src/swarm/synthesizer.ts
@@ -1,0 +1,62 @@
+import type { Provider, Message } from '../providers/types.js';
+import type { SwarmTaskResult } from './types.js';
+
+/**
+ * Synthesize a final answer from all worker results using an LLM.
+ * Falls back to a deterministic markdown summary if the LLM call fails.
+ */
+export async function synthesizeResults(opts: {
+  objective: string;
+  results: SwarmTaskResult[];
+  provider: Provider;
+  model: string;
+}): Promise<string> {
+  const { objective, results, provider, model } = opts;
+
+  const taskSummaries = results.map((r) => {
+    const status = r.status === 'completed' ? 'completed' : 'FAILED';
+    return `[${r.taskId}] (${status}): ${r.summary}`;
+  }).join('\n');
+
+  const systemPrompt = 'You are a synthesis assistant. Combine the outputs from multiple specialist workers into a coherent, concise final answer. Focus on the user\'s original objective.';
+
+  const userMessage = `Original objective: ${objective}
+
+Worker results:
+${taskSummaries}
+
+Synthesize these results into a clear, complete answer for the user.`;
+
+  try {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: userMessage }] },
+    ];
+
+    const response = await provider.sendMessage(
+      messages,
+      undefined,
+      systemPrompt,
+      { config: { max_tokens: 4096, model } },
+    );
+
+    const textBlock = response.content.find((b) => b.type === 'text');
+    if (textBlock && textBlock.type === 'text') {
+      return textBlock.text;
+    }
+
+    return buildFallbackSynthesis(objective, results);
+  } catch {
+    return buildFallbackSynthesis(objective, results);
+  }
+}
+
+function buildFallbackSynthesis(objective: string, results: SwarmTaskResult[]): string {
+  const lines: string[] = [`## Results: ${objective}`, ''];
+
+  for (const r of results) {
+    const icon = r.status === 'completed' ? 'OK' : 'FAIL';
+    lines.push(`- [${icon}] **${r.taskId}**: ${r.summary}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Implement `executeSwarm()` with topological DAG scheduling and bounded concurrency (`maxWorkers`)
- Add per-task retry loop with configurable `maxRetriesPerTask`
- Transitive dependent blocking when a prerequisite task fails
- LLM-based final synthesis via `synthesizeResults()` with deterministic markdown fallback
- Orchestrator event callbacks for live progress tracking (`plan_created`, `task_started`, `task_completed`, etc.)

## Test plan
- [x] `bun test src/__tests__/swarm-orchestrator.test.ts` — 9/9 pass
- [x] `bunx tsc --noEmit` — no new errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
