### PR TITLE
feat(memory): inject and strip dynamic profile context

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,10 +193,12 @@ graph TB
     SESSION_MGR --> GEMINI
     SESSION_MGR --> OLLAMA
     SESSION_MGR --> CONV_STORE
+    SESSION_MGR --> PROFILE_COMPILER
     CONV_STORE --> DB_CONV
     CONV_STORE --> DB_MSG
     CONV_STORE --> DB_TOOL
     CONV_STORE --> DB_ATTACH
+    PROFILE_COMPILER --> DB_ITEMS
     INDEXER --> DB_SEG
     INDEXER --> DB_FTS
     INDEXER --> DB_ITEMS
@@ -529,6 +531,8 @@ graph TB
     subgraph "Read Path (Memory Recall)"
         QUERY["Recall Query Builder<br/>User request + compacted context summary<br/>+ conversation summary + weekly summary"]
         CONFLICT_GATE["Soft Conflict Gate<br/>resolve pending conflicts from user turn<br/>relevance + cooldown ask-once behavior"]
+        PROFILE_BUILD["Dynamic Profile Compiler<br/>active trusted profile memories<br/>user_confirmed > user_reported > assistant_inferred"]
+        PROFILE_INJECT["Inject profile context block<br/>into runtime user tail<br/>(strict token cap)"]
         BUDGET["Dynamic Recall Budget<br/>computeRecallBudget()<br/>from prompt headroom"]
         LEX["Lexical Search<br/>FTS5 on memory_segment_fts"]
         SEM["Semantic Search<br/>Qdrant cosine similarity"]
@@ -542,6 +546,7 @@ graph TB
         TRIM["Token Trim<br/>maxInjectTokens override<br/>or static fallback"]
         INJECT["Attention-ordered<br/>Injection into prompt"]
         TELEMETRY["Emit memory_recalled<br/>hits + relation counters +<br/>ranking diagnostics"]
+        STRIP_PROFILE["Strip injected dynamic profile block<br/>before persisting conversation history"]
     end
 
     subgraph "Context Window Management"
@@ -577,6 +582,8 @@ graph TB
     EMBED_SEG --> OLL_EMB
 
     QUERY --> CONFLICT_GATE
+    CONFLICT_GATE --> PROFILE_BUILD
+    PROFILE_BUILD --> PROFILE_INJECT
     CONFLICT_GATE --> LEX
     CONFLICT_GATE --> SEM
     CONFLICT_GATE --> ENTITY_SEARCH
@@ -592,7 +599,9 @@ graph TB
     RERANK --> TRIM
     BUDGET --> TRIM
     TRIM --> INJECT
+    PROFILE_INJECT --> INJECT
     INJECT --> TELEMETRY
+    INJECT --> STRIP_PROFILE
 
     CTX --> COMPACT
     COMPACT --> GUARDS

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Message, ProviderResponse } from '../providers/types.js';
+import type { AgentEvent } from '../agent/loop.js';
+import type { ServerMessage } from '../daemon/ipc-protocol.js';
+
+let runCalls: Message[][] = [];
+let profileCompilerCalls = 0;
+let profileEnabled = true;
+let profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
+
+const persistedMessages: Array<{ id: string; role: string; content: string; createdAt: number }> = [];
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module('../util/platform.js', () => ({
+  getSocketPath: () => '/tmp/test.sock',
+  getDataDir: () => '/tmp',
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({ name: 'mock-provider' }),
+  initializeProviders: () => {},
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'mock-provider',
+    maxTokens: 4096,
+    thinking: false,
+    contextWindow: {
+      enabled: true,
+      maxInputTokens: 100000,
+      targetInputTokens: 80000,
+      compactThreshold: 0.8,
+      preserveRecentUserTurns: 8,
+      summaryMaxTokens: 512,
+      chunkTokens: 12000,
+    },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    apiKeys: {},
+    memory: {
+      retrieval: {
+        injectionStrategy: 'prepend_user_block',
+        dynamicBudget: {
+          enabled: false,
+          minInjectTokens: 1200,
+          maxInjectTokens: 10000,
+          targetHeadroomTokens: 10000,
+        },
+      },
+      conflicts: {
+        enabled: false,
+        gateMode: 'soft',
+        reaskCooldownTurns: 3,
+        resolverLlmTimeoutMs: 250,
+        relevanceThreshold: 0.2,
+      },
+      profile: {
+        enabled: profileEnabled,
+        maxInjectTokens: 300,
+      },
+    },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module('../config/system-prompt.js', () => ({
+  buildSystemPrompt: () => 'system prompt',
+}));
+
+mock.module('../config/skills.js', () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module('../config/skill-state.js', () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module('../skills/slash-commands.js', () => ({
+  buildInvocableSlashCatalog: () => new Map(),
+  resolveSlashSkillCommand: () => ({ kind: 'not_slash' }),
+  rewriteKnownSlashCommandPrompt: () => '',
+  parseSlashCandidate: () => ({ kind: 'not_slash' }),
+}));
+
+mock.module('../permissions/trust-store.js', () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module('../security/secret-allowlist.js', () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module('../memory/conversation-store.js', () => ({
+  getMessages: () => persistedMessages,
+  getConversation: () => ({
+    id: 'conv-1',
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    contextCompactedAt: null,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  addMessage: (_conversationId: string, role: string, content: string) => {
+    const row = { id: `msg-${persistedMessages.length + 1}`, role, content, createdAt: Date.now() };
+    persistedMessages.push(row);
+    return { id: row.id };
+  },
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteLastExchange: () => 0,
+  isLastUserMessageToolResult: () => false,
+}));
+
+mock.module('../memory/attachments-store.js', () => ({
+  uploadAttachment: () => ({ id: 'att-1' }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module('../memory/retriever.js', () => ({
+  buildMemoryRecall: async () => ({
+    enabled: true,
+    degraded: false,
+    reason: null,
+    provider: 'mock',
+    model: 'mock',
+    injectedText: '',
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    entityHits: 0,
+    relationSeedEntityCount: 0,
+    relationTraversedEdgeCount: 0,
+    relationNeighborEntityCount: 0,
+    relationExpandedItemCount: 0,
+    mergedCount: 0,
+    selectedCount: 0,
+    rerankApplied: false,
+    injectedTokens: 0,
+    latencyMs: 0,
+    topCandidates: [],
+  }),
+  injectMemoryRecallIntoUserMessage: (msg: Message) => msg,
+  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
+  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+}));
+
+mock.module('../context/window-manager.js', () => ({
+  ContextWindowManager: class {
+    constructor() {}
+    async maybeCompact() { return { compacted: false }; }
+  },
+  createContextSummaryMessage: () => ({ role: 'user', content: [{ type: 'text', text: 'summary' }] }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module('../memory/conflict-store.js', () => ({
+  listPendingConflictDetails: () => [],
+  markConflictAsked: () => true,
+  applyConflictResolution: () => true,
+}));
+
+mock.module('../memory/clarification-resolver.js', () => ({
+  resolveConflictClarification: async () => ({
+    resolution: 'still_unclear',
+    strategy: 'heuristic',
+    resolvedStatement: null,
+    explanation: 'Need user clarification.',
+  }),
+}));
+
+mock.module('../memory/profile-compiler.js', () => ({
+  compileDynamicProfile: () => {
+    profileCompilerCalls += 1;
+    return {
+      text: profileText,
+      sourceCount: 2,
+      selectedCount: 1,
+      budgetTokens: 300,
+      tokenEstimate: 28,
+    };
+  },
+}));
+
+mock.module('../memory/llm-usage-store.js', () => ({
+  recordUsageEvent: () => ({ id: 'usage-1', createdAt: Date.now() }),
+}));
+
+mock.module('../agent/loop.js', () => ({
+  AgentLoop: class {
+    constructor() {}
+    async run(messages: Message[], onEvent: (event: AgentEvent) => void): Promise<Message[]> {
+      runCalls.push(messages);
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'normal assistant answer' }],
+      };
+      onEvent({ type: 'usage', inputTokens: 10, outputTokens: 5, model: 'mock', providerDurationMs: 10 });
+      onEvent({ type: 'message_complete', message: assistantMessage });
+      return [...messages, assistantMessage];
+    }
+  },
+}));
+
+import { Session } from '../daemon/session.js';
+
+function makeSession(): Session {
+  const provider = {
+    name: 'mock',
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: 'mock',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      };
+    },
+  };
+  return new Session('conv-1', provider, 'system prompt', 4096, () => {}, '/tmp');
+}
+
+function messageText(message: Message): string {
+  return message.content
+    .filter((block) => block.type === 'text')
+    .map((block) => (block as { type: 'text'; text: string }).text)
+    .join('\n');
+}
+
+describe('Session dynamic profile injection', () => {
+  beforeEach(() => {
+    runCalls = [];
+    persistedMessages.length = 0;
+    profileCompilerCalls = 0;
+    profileEnabled = true;
+    profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles';
+  });
+
+  test('injects profile context for runtime and strips it from persisted history', async () => {
+    const session = makeSession();
+    await session.loadFromDb();
+
+    const events: ServerMessage[] = [];
+    await session.processMessage('What should I do next?', [], (event) => events.push(event));
+
+    expect(runCalls).toHaveLength(1);
+    const runtimeUser = runCalls[0][runCalls[0].length - 1];
+    expect(runtimeUser.role).toBe('user');
+    const runtimeText = messageText(runtimeUser);
+    expect(runtimeText).toContain('[Dynamic profile context start]');
+    expect(runtimeText).toContain('[Dynamic User Profile]');
+    expect(runtimeText).toContain('[Dynamic profile context end]');
+
+    const persistedUser = session.getMessages().find((message) => message.role === 'user');
+    expect(persistedUser).toBeDefined();
+    if (persistedUser) {
+      const persistedText = messageText(persistedUser);
+      expect(persistedText).not.toContain('[Dynamic profile context start]');
+      expect(persistedText).not.toContain('[Dynamic User Profile]');
+      expect(persistedText).not.toContain('[Dynamic profile context end]');
+    }
+    expect(profileCompilerCalls).toBe(1);
+    expect(events.some((event) => event.type === 'message_complete')).toBe(true);
+  });
+
+  test('skips profile compilation/injection when memory.profile.enabled is false', async () => {
+    profileEnabled = false;
+    const session = makeSession();
+    await session.loadFromDb();
+
+    await session.processMessage('Explain rebase strategy', [], () => {});
+
+    expect(runCalls).toHaveLength(1);
+    const runtimeUser = runCalls[0][runCalls[0].length - 1];
+    const runtimeText = messageText(runtimeUser);
+    expect(runtimeText).not.toContain('[Dynamic profile context start]');
+    expect(profileCompilerCalls).toBe(0);
+  });
+});

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -58,6 +58,7 @@ import {
 } from '../memory/conflict-store.js';
 import type { PendingConflictDetail } from '../memory/conflict-store.js';
 import { resolveConflictClarification } from '../memory/clarification-resolver.js';
+import { compileDynamicProfile } from '../memory/profile-compiler.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
@@ -676,6 +677,13 @@ export class Session {
       const softConflictInstruction = conflictGate && !conflictGate.relevant
         ? conflictGate.question
         : null;
+      const profileConfig = runtimeConfig.memory?.profile;
+      const dynamicProfile = profileConfig?.enabled
+        ? compileDynamicProfile({
+            scopeId: 'default',
+            maxInjectTokensOverride: profileConfig.maxInjectTokens,
+          })
+        : { text: '' };
       const recallQuery = buildMemoryQuery(content, this.messages);
       const recallInjectionStrategy = runtimeConfig.memory?.retrieval?.injectionStrategy ?? 'prepend_user_block';
       const dynamicBudgetConfig = runtimeConfig.memory?.retrieval?.dynamicBudget;
@@ -737,6 +745,16 @@ export class Session {
             latencyMs: recall.latencyMs,
             topCandidates: recall.topCandidates,
           });
+        }
+      }
+
+      if (dynamicProfile.text.length > 0) {
+        const userTail = runMessages[runMessages.length - 1];
+        if (userTail && userTail.role === 'user') {
+          runMessages = [
+            ...runMessages.slice(0, -1),
+            injectDynamicProfileIntoUserMessage(userTail, dynamicProfile.text),
+          ];
         }
       }
 
@@ -1027,7 +1045,8 @@ export class Session {
         return { ...msg, content: cleanedContent as ContentBlock[] };
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
-      this.messages = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
+      const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
+      this.messages = stripDynamicProfileMessages(recallStripped, dynamicProfile.text);
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
 
@@ -1978,6 +1997,44 @@ function injectClarificationRequestIntoUserMessage(message: Message, question: s
       { type: 'text', text: `\n\n${instruction}` },
     ],
   };
+}
+
+function injectDynamicProfileIntoUserMessage(message: Message, profileText: string): Message {
+  const trimmedProfile = profileText.trim();
+  if (trimmedProfile.length === 0) return message;
+  const block = [
+    '[Dynamic profile context start]',
+    trimmedProfile,
+    '[Dynamic profile context end]',
+  ].join('\n');
+  return {
+    ...message,
+    content: [
+      ...message.content,
+      { type: 'text', text: `\n\n${block}` },
+    ],
+  };
+}
+
+function stripDynamicProfileMessages(messages: Message[], profileText: string): Message[] {
+  const trimmedProfile = profileText.trim();
+  if (trimmedProfile.length === 0) return messages;
+  const injectedBlock = `\n\n[Dynamic profile context start]\n${trimmedProfile}\n[Dynamic profile context end]`;
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    let changed = false;
+    const nextContent = message.content.map((block) => {
+      if (block.type !== 'text') return block;
+      const nextText = block.text.split(injectedBlock).join('');
+      if (nextText === block.text) return block;
+      changed = true;
+      return {
+        ...block,
+        text: nextText.replace(/\n{3,}/g, '\n\n').trimEnd(),
+      };
+    });
+    return changed ? { ...message, content: nextContent } : message;
+  });
 }
 
 function buildFallbackConflictQuestion(conflict: PendingConflictDetail): string {


### PR DESCRIPTION
## Summary
- integrate dynamic profile compilation into `Session` turn execution behind `memory.profile.enabled`
- inject a temporary profile context block into the runtime user tail before agent execution
- strip the injected profile block from reconstructed conversation history so it never persists to DB/session state
- add focused session regression coverage for runtime injection + strip hygiene
- update architecture flows to include profile compile/inject/strip paths

## Testing
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/session-profile-injection.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/session-conflict-gate.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/session-slash-known.test.ts
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/profile-compiler.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
