### PR TITLE
feat(runtime): add tool abort signal plumbing and swarm invocation guidance

### DIFF
--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -127,4 +127,15 @@ describe('swarm_delegate tool', () => {
     );
     expect(result.isError).toBeFalsy();
   });
+
+  test('short-circuits when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const result = await swarmDelegateTool.execute(
+      { objective: 'Should not run' },
+      makeContext({ signal: controller.signal }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe('Cancelled');
+  });
 });

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -135,6 +135,12 @@ describe('buildSystemPrompt', () => {
     expect(result.indexOf('Soul content')).toBeLessThan(result.indexOf('## Available Skills'));
   });
 
+  test('includes swarm guidance section', () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain('## Parallel Task Orchestration');
+    expect(result).toContain('swarm_delegate');
+  });
+
   test('omits user skills from catalog when none are configured', () => {
     const result = buildSystemPrompt();
     // No user skill directories exist, so no user skills should appear.

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -60,6 +60,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildConfigSection(baseDir));
   parts.push(buildAttachmentSection());
   parts.push(buildDynamicUiSection());
+  parts.push(buildSwarmGuidanceSection());
 
   return appendSkillsCatalog(parts.join('\n\n'));
 }
@@ -142,6 +143,14 @@ function buildDynamicUiSection(): string {
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a `dynamic_page` rather than displaying raw tool outputs.',
     '- **Weather**: After `get_weather` returns data, call `ui_show` with `surface_type: "card"` and `data: { title, body, template: "weather_forecast", templateData: <structured data> }` for native weather widget rendering.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished `dynamic_page` with the appropriate component classes.',
+  ].join('\n');
+}
+
+export function buildSwarmGuidanceSection(): string {
+  return [
+    '## Parallel Task Orchestration',
+    '',
+    'Use `swarm_delegate` only when a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"). For single-focus tasks, work directly — do not decompose them into a swarm.',
   ].join('\n');
 }
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -199,6 +199,7 @@ export class Session {
         conversationId: this.conversationId,
         requestId: this.currentRequestId,
         onOutput,
+        signal: this.abortController?.signal,
         sandboxOverride: this.sandboxOverride,
         onToolLifecycleEvent: handleToolLifecycleEvent,
         proxyToolResolver: this.surfaceProxyResolver.bind(this),

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -63,6 +63,11 @@ export const claudeCodeTool: Tool = {
   },
 
   async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    // Early abort check
+    if (context.signal?.aborted) {
+      return { content: 'Cancelled', isError: true };
+    }
+
     const prompt = input.prompt as string;
     const workingDir = (input.working_dir as string) || context.workingDir;
     const resumeSessionId = input.resume as string | undefined;

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -117,6 +117,11 @@ export const swarmDelegateTool: Tool = {
       };
     }
 
+    // Early abort check
+    if (context.signal?.aborted) {
+      return { content: 'Cancelled', isError: true };
+    }
+
     // Recursion guard
     if (swarmActive) {
       return {
@@ -149,6 +154,11 @@ export const swarmDelegateTool: Tool = {
         context.onOutput?.(`  - [${task.role}] ${task.id}: ${task.objective.slice(0, 80)}\n`);
       }
       context.onOutput?.('\nExecuting...\n');
+
+      // Check abort before starting execution
+      if (context.signal?.aborted) {
+        return { content: 'Cancelled before execution', isError: true };
+      }
 
       // Execute
       const backend = createClaudeCodeBackend();

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -85,6 +85,8 @@ export interface ToolContext {
   requestId?: string;
   /** Optional callback for streaming incremental output to the client. */
   onOutput?: (chunk: string) => void;
+  /** Abort signal for cooperative cancellation. Tools should check this periodically. */
+  signal?: AbortSignal;
   /** Per-session sandbox override. When set, takes precedence over the global config. */
   sandboxOverride?: boolean;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error/secret_detected). */


### PR DESCRIPTION
## Summary
- Adds `signal?: AbortSignal` to `ToolContext` and plumbs session abort controller into tool execution
- `swarm_delegate` and `claude_code` tools short-circuit immediately when signal is aborted
- Adds concise system prompt guidance for `swarm_delegate` usage (only for multi-part parallel tasks)

## Test plan
- [x] swarm-tool.test.ts — new test for abort signal short-circuit
- [x] system-prompt.test.ts — new test verifying swarm guidance section is present
- [x] TypeScript type-check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
