### PR TITLE
feat(memory): add cleanup jobs and conflict status telemetry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,7 +311,7 @@ graph LR
         ITEM_ENTS["memory_item_entities<br/>───────────────<br/>Join table linking extracted<br/>memory_items to entities"]
         SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
-        JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution<br/>Status: pending → running →<br/>completed | failed"]
+        JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill,<br/>conflict resolution, cleanup<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
     end
 
@@ -532,6 +532,8 @@ graph TB
         EXTRACT["extract_items<br/>→ memory_items +<br/>memory_item_sources"]
         CHECK_CONTRA["check_contradictions<br/>→ contradiction/update merge OR<br/>pending_clarification + memory_item_conflicts"]
         RESOLVE_PENDING["resolve_pending_conflicts_for_message<br/>message-scoped clarification resolution<br/>→ resolved conflict + item status updates"]
+        CLEAN_CONFLICTS["cleanup_resolved_conflicts<br/>delete resolved conflict rows<br/>older than retention window"]
+        CLEAN_SUPERSEDED["cleanup_stale_superseded_items<br/>delete stale superseded items<br/>and item embedding rows"]
         EXTRACT_ENTITIES["extract_entities<br/>→ memory_entities +<br/>memory_item_entities +<br/>memory_entity_relations"]
         BACKFILL_REL["backfill_entity_relations<br/>checkpointed message scan<br/>→ enqueue extract_entities"]
         BUILD_SUM["build_conversation_summary<br/>→ memory_summaries"]
@@ -587,6 +589,8 @@ graph TB
     WORKER --> EXTRACT
     WORKER --> CHECK_CONTRA
     WORKER --> RESOLVE_PENDING
+    WORKER --> CLEAN_CONFLICTS
+    WORKER --> CLEAN_SUPERSEDED
     WORKER --> EXTRACT_ENTITIES
     WORKER --> BACKFILL_REL
     WORKER --> BUILD_SUM
@@ -659,12 +663,15 @@ graph TB
    - `previousEstimatedInputTokens` vs `estimatedInputTokens`
    - `summaryCalls`, `compactedMessages`
 4. If dynamic budget is enabled, verify `injectedTokens` stays within the configured min/max clamps for `dynamicBudget`.
-5. Before tuning ranking or relation settings, run:
+5. Run `bun run src/index.ts memory status` and confirm cleanup pressure signals:
+   - `Pending conflicts`, `Resolved conflicts`, `Oldest pending conflict age`
+   - job queue counts for `cleanup_resolved_conflicts` / `cleanup_stale_superseded_items`
+6. Before tuning ranking or relation settings, run:
    - `cd assistant && bun test src/__tests__/context-memory-e2e.test.ts`
    - `cd assistant && bun test src/__tests__/memory-context-benchmark.test.ts`
    - `cd assistant && bun test src/__tests__/memory-recall-quality.test.ts`
    - `cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts -t "relation"`
-6. After tuning, rerun the same suite and compare:
+7. After tuning, rerun the same suite and compare:
    - relation counters (coverage)
    - selected count / injected tokens (budget safety)
    - latency and ordering regressions via top candidate snapshots

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -45,9 +45,9 @@ mock.module('../config/loader.js', () => ({
   invalidateConfigCache: () => {},
 }));
 import { estimateTextTokens } from '../context/token-estimator.js';
-import { requestMemoryBackfill } from '../memory/admin.js';
+import { getMemorySystemStatus, requestMemoryBackfill, requestMemoryCleanup } from '../memory/admin.js';
 import { getMemoryCheckpoint } from '../memory/checkpoints.js';
-import { createOrUpdatePendingConflict, getConflictById } from '../memory/conflict-store.js';
+import { createOrUpdatePendingConflict, getConflictById, resolveConflict } from '../memory/conflict-store.js';
 import { getDb, initializeDb, resetDb } from '../memory/db.js';
 import { selectEmbeddingBackend } from '../memory/embedding-backend.js';
 import { upsertEntity, upsertEntityRelation } from '../memory/entity-extractor.js';
@@ -56,6 +56,8 @@ import { extractAndUpsertMemoryItemsForMessage } from '../memory/items-extractor
 import {
   claimMemoryJobs,
   enqueueBackfillEntityRelationsJob,
+  enqueueCleanupResolvedConflictsJob,
+  enqueueCleanupStaleSupersededItemsJob,
   enqueueMemoryJob,
   enqueueResolvePendingConflictsForMessageJob,
 } from '../memory/jobs-store.js';
@@ -75,6 +77,7 @@ import {
   memoryEntities,
   memoryEntityRelations,
   memoryItemEntities,
+  memoryItemConflicts,
   memoryItems,
   memoryItemSources,
   memoryJobs,
@@ -90,6 +93,7 @@ describe('Memory V2 regressions', () => {
 
   beforeEach(() => {
     const db = getDb();
+    db.run('DELETE FROM memory_item_conflicts');
     db.run('DELETE FROM memory_item_entities');
     db.run('DELETE FROM memory_entity_relations');
     db.run('DELETE FROM memory_entities');
@@ -1240,6 +1244,323 @@ describe('Memory V2 regressions', () => {
     } finally {
       TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
     }
+  });
+
+  test('cleanup job enqueue is deduped and retention overrides upgrade payload', () => {
+    const db = getDb();
+
+    const resolvedFirst = enqueueCleanupResolvedConflictsJob();
+    const resolvedSecond = enqueueCleanupResolvedConflictsJob();
+    expect(resolvedSecond).toBe(resolvedFirst);
+    const resolvedUpgraded = enqueueCleanupResolvedConflictsJob(12_345);
+    expect(resolvedUpgraded).toBe(resolvedFirst);
+
+    const supersededFirst = enqueueCleanupStaleSupersededItemsJob();
+    const supersededSecond = enqueueCleanupStaleSupersededItemsJob();
+    expect(supersededSecond).toBe(supersededFirst);
+    const supersededUpgraded = enqueueCleanupStaleSupersededItemsJob(67_890);
+    expect(supersededUpgraded).toBe(supersededFirst);
+
+    const resolvedRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, resolvedFirst)).get();
+    const supersededRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, supersededFirst)).get();
+    expect(JSON.parse(resolvedRow?.payload ?? '{}')).toMatchObject({ retentionMs: 12_345 });
+    expect(JSON.parse(supersededRow?.payload ?? '{}')).toMatchObject({ retentionMs: 67_890 });
+  });
+
+  test('cleanup_resolved_conflicts removes stale resolved rows but keeps recent/pending', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'cleanup-conflict-existing-a',
+        kind: 'fact',
+        subject: 'db',
+        statement: 'Use Postgres.',
+        status: 'active',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-existing-a',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+      {
+        id: 'cleanup-conflict-candidate-a',
+        kind: 'fact',
+        subject: 'db',
+        statement: 'Use MySQL.',
+        status: 'pending_clarification',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-candidate-a',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+      {
+        id: 'cleanup-conflict-existing-b',
+        kind: 'fact',
+        subject: 'frontend',
+        statement: 'Use React.',
+        status: 'active',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-existing-b',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+      {
+        id: 'cleanup-conflict-candidate-b',
+        kind: 'fact',
+        subject: 'frontend',
+        statement: 'Use Vue.',
+        status: 'pending_clarification',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-candidate-b',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+      {
+        id: 'cleanup-conflict-existing-c',
+        kind: 'fact',
+        subject: 'orm',
+        statement: 'Use Drizzle.',
+        status: 'active',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-existing-c',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+      {
+        id: 'cleanup-conflict-candidate-c',
+        kind: 'fact',
+        subject: 'orm',
+        statement: 'Use Prisma.',
+        status: 'pending_clarification',
+        confidence: 0.8,
+        fingerprint: 'fp-cleanup-conflict-candidate-c',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 20_000,
+        lastSeenAt: now - 20_000,
+      },
+    ]).run();
+
+    const staleResolved = createOrUpdatePendingConflict({
+      existingItemId: 'cleanup-conflict-existing-a',
+      candidateItemId: 'cleanup-conflict-candidate-a',
+      relationship: 'ambiguous_contradiction',
+    });
+    const pendingConflict = createOrUpdatePendingConflict({
+      existingItemId: 'cleanup-conflict-existing-b',
+      candidateItemId: 'cleanup-conflict-candidate-b',
+      relationship: 'ambiguous_contradiction',
+    });
+    const recentResolved = createOrUpdatePendingConflict({
+      existingItemId: 'cleanup-conflict-existing-c',
+      candidateItemId: 'cleanup-conflict-candidate-c',
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Recent resolution row',
+    });
+
+    resolveConflict(staleResolved.id, { status: 'resolved_keep_existing' });
+    resolveConflict(recentResolved.id, { status: 'resolved_keep_candidate' });
+
+    db.run(`
+      UPDATE memory_item_conflicts
+      SET resolved_at = ${now - 100_000}, updated_at = ${now - 100_000}
+      WHERE id = '${staleResolved.id}'
+    `);
+    db.run(`
+      UPDATE memory_item_conflicts
+      SET resolved_at = ${now - 100}, updated_at = ${now - 100}
+      WHERE id = '${recentResolved.id}'
+    `);
+
+    enqueueMemoryJob('cleanup_resolved_conflicts', { retentionMs: 10_000 });
+    const processed = await runMemoryJobsOnce();
+    expect(processed).toBe(1);
+
+    const staleRow = db.select().from(memoryItemConflicts).where(eq(memoryItemConflicts.id, staleResolved.id)).get();
+    const pendingRow = db.select().from(memoryItemConflicts).where(eq(memoryItemConflicts.id, pendingConflict.id)).get();
+    const recentRow = db.select().from(memoryItemConflicts).where(eq(memoryItemConflicts.id, recentResolved.id)).get();
+    expect(staleRow).toBeUndefined();
+    expect(pendingRow?.status).toBe('pending_clarification');
+    expect(recentRow?.status).toBe('resolved_keep_candidate');
+  });
+
+  test('cleanup_stale_superseded_items removes stale superseded rows and embeddings', async () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'cleanup-stale-item',
+        kind: 'decision',
+        subject: 'deploy strategy',
+        statement: 'Deploy manually every Friday.',
+        status: 'superseded',
+        confidence: 0.7,
+        fingerprint: 'fp-cleanup-stale-item',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 200_000,
+        lastSeenAt: now - 200_000,
+        invalidAt: now - 200_000,
+      },
+      {
+        id: 'cleanup-recent-item',
+        kind: 'decision',
+        subject: 'deploy strategy',
+        statement: 'Deploy continuously via CI.',
+        status: 'superseded',
+        confidence: 0.7,
+        fingerprint: 'fp-cleanup-recent-item',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 200_000,
+        lastSeenAt: now - 200_000,
+        invalidAt: now - 100,
+      },
+    ]).run();
+
+    db.insert(memoryEmbeddings).values([
+      {
+        id: 'cleanup-embed-stale',
+        targetType: 'item',
+        targetId: 'cleanup-stale-item',
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+        dimensions: 3,
+        vectorJson: '[0,0,0]',
+        createdAt: now - 1000,
+        updatedAt: now - 1000,
+      },
+      {
+        id: 'cleanup-embed-recent',
+        targetType: 'item',
+        targetId: 'cleanup-recent-item',
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+        dimensions: 3,
+        vectorJson: '[0,0,0]',
+        createdAt: now - 1000,
+        updatedAt: now - 1000,
+      },
+    ]).run();
+
+    enqueueMemoryJob('cleanup_stale_superseded_items', { retentionMs: 10_000 });
+    const processed = await runMemoryJobsOnce();
+    expect(processed).toBe(1);
+
+    const staleItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'cleanup-stale-item')).get();
+    const recentItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'cleanup-recent-item')).get();
+    const staleEmbedding = db.select().from(memoryEmbeddings).where(eq(memoryEmbeddings.id, 'cleanup-embed-stale')).get();
+    const recentEmbedding = db.select().from(memoryEmbeddings).where(eq(memoryEmbeddings.id, 'cleanup-embed-recent')).get();
+
+    expect(staleItem).toBeUndefined();
+    expect(recentItem).toBeDefined();
+    expect(staleEmbedding).toBeUndefined();
+    expect(recentEmbedding).toBeDefined();
+  });
+
+  test('memory admin status reports pending/resolved conflicts and oldest pending age', () => {
+    const db = getDb();
+    const now = Date.now();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'status-conflict-existing',
+        kind: 'fact',
+        subject: 'editor',
+        statement: 'Use Neovim.',
+        status: 'active',
+        confidence: 0.8,
+        fingerprint: 'fp-status-existing',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 10_000,
+        lastSeenAt: now - 10_000,
+      },
+      {
+        id: 'status-conflict-candidate',
+        kind: 'fact',
+        subject: 'editor',
+        statement: 'Use VS Code.',
+        status: 'pending_clarification',
+        confidence: 0.8,
+        fingerprint: 'fp-status-candidate',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 10_000,
+        lastSeenAt: now - 10_000,
+      },
+      {
+        id: 'status-conflict-existing-2',
+        kind: 'fact',
+        subject: 'shell',
+        statement: 'Use zsh.',
+        status: 'active',
+        confidence: 0.8,
+        fingerprint: 'fp-status-existing-2',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 10_000,
+        lastSeenAt: now - 10_000,
+      },
+      {
+        id: 'status-conflict-candidate-2',
+        kind: 'fact',
+        subject: 'shell',
+        statement: 'Use fish.',
+        status: 'pending_clarification',
+        confidence: 0.8,
+        fingerprint: 'fp-status-candidate-2',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now - 10_000,
+        lastSeenAt: now - 10_000,
+      },
+    ]).run();
+
+    const pending = createOrUpdatePendingConflict({
+      existingItemId: 'status-conflict-existing',
+      candidateItemId: 'status-conflict-candidate',
+      relationship: 'ambiguous_contradiction',
+    });
+    const resolved = createOrUpdatePendingConflict({
+      existingItemId: 'status-conflict-existing-2',
+      candidateItemId: 'status-conflict-candidate-2',
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'resolved-row',
+    });
+    resolveConflict(resolved.id, { status: 'resolved_merge' });
+
+    db.run(`UPDATE memory_item_conflicts SET created_at = ${now - 5_000} WHERE id = '${pending.id}'`);
+
+    const status = getMemorySystemStatus();
+    expect(status.conflicts.pending).toBe(1);
+    expect(status.conflicts.resolved).toBe(1);
+    expect(status.conflicts.oldestPendingAgeMs).not.toBeNull();
+    expect((status.conflicts.oldestPendingAgeMs ?? 0) >= 4_000).toBe(true);
+  });
+
+  test('requestMemoryCleanup queues both cleanup job types', () => {
+    const db = getDb();
+    const queued = requestMemoryCleanup(9_999);
+    expect(queued.resolvedConflictsJobId).toBeTruthy();
+    expect(queued.staleSupersededItemsJobId).toBeTruthy();
+
+    const resolvedRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, queued.resolvedConflictsJobId)).get();
+    const supersededRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, queued.staleSupersededItemsJobId)).get();
+    expect(resolvedRow?.type).toBe('cleanup_resolved_conflicts');
+    expect(supersededRow?.type).toBe('cleanup_stale_superseded_items');
   });
 
   test('relation backfill advances checkpoints in deterministic batches', async () => {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -53,6 +53,7 @@ import {
   getMemorySystemStatus,
   queryMemory,
   requestMemoryBackfill,
+  requestMemoryCleanup,
   requestMemoryRebuildIndex,
 } from './memory/admin.js';
 import { registerHooksCommand } from './hooks/cli.js';
@@ -543,6 +544,14 @@ memory
     console.log(`Items: ${status.counts.items.toLocaleString()}`);
     console.log(`Summaries: ${status.counts.summaries.toLocaleString()}`);
     console.log(`Embeddings: ${status.counts.embeddings.toLocaleString()}`);
+    console.log(`Pending conflicts: ${status.conflicts.pending.toLocaleString()}`);
+    console.log(`Resolved conflicts: ${status.conflicts.resolved.toLocaleString()}`);
+    if (status.conflicts.oldestPendingAgeMs !== null) {
+      const oldestMinutes = Math.floor(status.conflicts.oldestPendingAgeMs / 60_000);
+      console.log(`Oldest pending conflict age: ${oldestMinutes} min`);
+    } else {
+      console.log('Oldest pending conflict age: n/a');
+    }
     console.log('Jobs:');
     for (const [key, value] of Object.entries(status.jobs)) {
       console.log(`  ${key}: ${value}`);
@@ -557,6 +566,18 @@ memory
     initializeDb();
     const jobId = requestMemoryBackfill(Boolean(opts?.force));
     console.log(`Queued backfill job: ${jobId}`);
+  });
+
+memory
+  .command('cleanup')
+  .description('Queue cleanup jobs for resolved conflicts and stale superseded items')
+  .option('--retention-ms <ms>', 'Optional retention threshold in milliseconds')
+  .action((opts: { retentionMs?: string }) => {
+    initializeDb();
+    const retentionMs = opts.retentionMs ? Number.parseInt(opts.retentionMs, 10) : undefined;
+    const jobs = requestMemoryCleanup(Number.isFinite(retentionMs) ? retentionMs : undefined);
+    console.log(`Queued cleanup_resolved_conflicts job: ${jobs.resolvedConflictsJobId}`);
+    console.log(`Queued cleanup_stale_superseded_items job: ${jobs.staleSupersededItemsJobId}`);
   });
 
 memory

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -3,7 +3,11 @@ import { getLogger } from '../util/logger.js';
 import { getMemoryBackendStatus } from './embedding-backend.js';
 import { getDb } from './db.js';
 import { enqueueBackfillJob, enqueueRebuildIndexJob } from './indexer.js';
-import { getMemoryJobCounts } from './jobs-store.js';
+import {
+  enqueueCleanupResolvedConflictsJob,
+  enqueueCleanupStaleSupersededItemsJob,
+  getMemoryJobCounts,
+} from './jobs-store.js';
 import { queryMemoryForCli } from './retriever.js';
 
 const log = getLogger('memory-admin');
@@ -20,6 +24,11 @@ export interface MemorySystemStatus {
     summaries: number;
     embeddings: number;
   };
+  conflicts: {
+    pending: number;
+    resolved: number;
+    oldestPendingAgeMs: number | null;
+  };
   jobs: Record<string, number>;
 }
 
@@ -34,6 +43,22 @@ export function getMemorySystemStatus(): MemorySystemStatus {
     summaries: countTable('memory_summaries'),
     embeddings: countTable('memory_embeddings'),
   };
+  const conflictStats = raw.query(`
+    SELECT
+      SUM(CASE WHEN status = 'pending_clarification' THEN 1 ELSE 0 END) AS pending_count,
+      SUM(CASE WHEN status != 'pending_clarification' THEN 1 ELSE 0 END) AS resolved_count,
+      MIN(CASE WHEN status = 'pending_clarification' THEN created_at END) AS oldest_pending_created_at
+    FROM memory_item_conflicts
+  `).get() as {
+    pending_count: number | null;
+    resolved_count: number | null;
+    oldest_pending_created_at: number | null;
+  } | null;
+  const pending = conflictStats?.pending_count ?? 0;
+  const oldestPendingCreatedAt = conflictStats?.oldest_pending_created_at ?? null;
+  const oldestPendingAgeMs = oldestPendingCreatedAt === null
+    ? null
+    : Math.max(0, Date.now() - oldestPendingCreatedAt);
   return {
     enabled: backend.enabled,
     degraded: backend.degraded,
@@ -41,6 +66,11 @@ export function getMemorySystemStatus(): MemorySystemStatus {
     provider: backend.provider,
     model: backend.model,
     counts,
+    conflicts: {
+      pending,
+      resolved: conflictStats?.resolved_count ?? 0,
+      oldestPendingAgeMs,
+    },
     jobs: getMemoryJobCounts(),
   };
 
@@ -60,6 +90,13 @@ export function requestMemoryRebuildIndex(): string {
   const id = enqueueRebuildIndexJob();
   log.info({ jobId: id }, 'Queued memory index rebuild job');
   return id;
+}
+
+export function requestMemoryCleanup(retentionMs?: number): { resolvedConflictsJobId: string; staleSupersededItemsJobId: string } {
+  const resolvedConflictsJobId = enqueueCleanupResolvedConflictsJob(retentionMs);
+  const staleSupersededItemsJobId = enqueueCleanupStaleSupersededItemsJob(retentionMs);
+  log.info({ resolvedConflictsJobId, staleSupersededItemsJobId, retentionMs }, 'Queued memory cleanup jobs');
+  return { resolvedConflictsJobId, staleSupersededItemsJobId };
 }
 
 export async function queryMemory(

--- a/assistant/src/memory/db.ts
+++ b/assistant/src/memory/db.ts
@@ -407,6 +407,7 @@ export function initializeDb(): void {
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_created ON memory_segments(conversation_id, created_at DESC)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_sources_message_id ON memory_item_sources(message_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_status_created ON memory_item_conflicts(status, created_at)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_status_resolved_at ON memory_item_conflicts(status, resolved_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_scope_status ON memory_item_conflicts(scope_id, status)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_existing_item_id ON memory_item_conflicts(existing_item_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_item_conflicts_candidate_item_id ON memory_item_conflicts(candidate_item_id)`);
@@ -416,6 +417,7 @@ export function initializeDb(): void {
     WHERE status = 'pending_clarification'
   `);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_kind_status ON memory_items(kind, status)`);
+  database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_status_invalid_at ON memory_items(status, invalid_at)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_target ON memory_embeddings(target_type, target_id)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider_model ON memory_embeddings(provider, model)`);
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`);

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -10,6 +10,8 @@ export type MemoryJobType =
   | 'extract_items'
   | 'extract_entities'
   | 'resolve_pending_conflicts_for_message'
+  | 'cleanup_resolved_conflicts'
+  | 'cleanup_stale_superseded_items'
   | 'backfill_entity_relations'
   | 'check_contradictions'
   | 'refresh_weekly_summary'
@@ -121,6 +123,76 @@ export function enqueueResolvePendingConflictsForMessageJob(
     messageId: normalizedMessageId,
     scopeId: normalizedScopeId,
   });
+}
+
+export function enqueueCleanupResolvedConflictsJob(retentionMs?: number): string {
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(eq(memoryJobs.type, 'cleanup_resolved_conflicts'), eq(memoryJobs.status, 'pending')))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) {
+    if (typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.retentionMs !== retentionMs) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, retentionMs }),
+            updatedAt: now,
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+  const payload = typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0
+    ? { retentionMs }
+    : {};
+  return enqueueMemoryJob('cleanup_resolved_conflicts', payload);
+}
+
+export function enqueueCleanupStaleSupersededItemsJob(retentionMs?: number): string {
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(and(eq(memoryJobs.type, 'cleanup_stale_superseded_items'), eq(memoryJobs.status, 'pending')))
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) {
+    if (typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.retentionMs !== retentionMs) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, retentionMs }),
+            updatedAt: now,
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+  const payload = typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0
+    ? { retentionMs }
+    : {};
+  return enqueueMemoryJob('cleanup_stale_superseded_items', payload);
 }
 
 export function claimMemoryJobs(limit: number): MemoryJob[] {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { and, asc, desc, eq, gt, gte, isNull, lt, ne, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, ne, or } from 'drizzle-orm';
 import { v4 as uuid } from 'uuid';
 import type { AssistantConfig } from '../config/types.js';
 import { getConfig } from '../config/loader.js';
@@ -40,6 +40,7 @@ import { extractTextFromStoredMessageContent } from './message-content.js';
 import { getQdrantClient } from './qdrant-client.js';
 import {
   memoryEmbeddings,
+  memoryItemConflicts,
   memoryItems,
   memoryItemSources,
   memorySegments,
@@ -64,6 +65,9 @@ const RELATION_BACKFILL_CHECKPOINT_ID_KEY = 'memory:relation_backfill:last_messa
 
 const SUMMARY_LLM_TIMEOUT_MS = 20_000;
 const SUMMARY_MAX_TOKENS = 800;
+const DEFAULT_CONFLICT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_SUPERSEDED_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const CLEANUP_BATCH_LIMIT = 250;
 
 const CONVERSATION_SUMMARY_SYSTEM_PROMPT = [
   'You are a memory summarization system. Your job is to produce a compact, information-dense summary of a conversation.',
@@ -185,6 +189,12 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
       return;
     case 'resolve_pending_conflicts_for_message':
       await resolvePendingConflictsForMessageJob(job, config);
+      return;
+    case 'cleanup_resolved_conflicts':
+      cleanupResolvedConflictsJob(job);
+      return;
+    case 'cleanup_stale_superseded_items':
+      cleanupStaleSupersededItemsJob(job);
       return;
     case 'check_contradictions':
       await checkContradictionsJob(job);
@@ -422,6 +432,74 @@ async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: Assi
     pendingConflicts: pending.length,
     resolvedConflicts: resolvedCount,
   }, 'Processed pending conflict resolution job');
+}
+
+function cleanupResolvedConflictsJob(job: MemoryJob): void {
+  const db = getDb();
+  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? DEFAULT_CONFLICT_RETENTION_MS;
+  const cutoff = Date.now() - retentionMs;
+  const stale = db
+    .select({ id: memoryItemConflicts.id })
+    .from(memoryItemConflicts)
+    .where(and(
+      ne(memoryItemConflicts.status, 'pending_clarification'),
+      lt(memoryItemConflicts.resolvedAt, cutoff),
+    ))
+    .orderBy(asc(memoryItemConflicts.resolvedAt), asc(memoryItemConflicts.id))
+    .limit(CLEANUP_BATCH_LIMIT)
+    .all();
+  if (stale.length === 0) return;
+
+  const ids = stale.map((row) => row.id);
+  db.delete(memoryItemConflicts)
+    .where(inArray(memoryItemConflicts.id, ids))
+    .run();
+  if (stale.length === CLEANUP_BATCH_LIMIT) {
+    enqueueMemoryJob('cleanup_resolved_conflicts', { retentionMs });
+  }
+
+  log.debug({
+    removedConflicts: stale.length,
+    retentionMs,
+    cutoff,
+  }, 'Cleaned up resolved memory conflicts');
+}
+
+function cleanupStaleSupersededItemsJob(job: MemoryJob): void {
+  const db = getDb();
+  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? DEFAULT_SUPERSEDED_RETENTION_MS;
+  const cutoff = Date.now() - retentionMs;
+  const stale = db
+    .select({ id: memoryItems.id })
+    .from(memoryItems)
+    .where(and(
+      eq(memoryItems.status, 'superseded'),
+      lt(memoryItems.invalidAt, cutoff),
+    ))
+    .orderBy(asc(memoryItems.invalidAt), asc(memoryItems.id))
+    .limit(CLEANUP_BATCH_LIMIT)
+    .all();
+  if (stale.length === 0) return;
+
+  const ids = stale.map((row) => row.id);
+  db.delete(memoryEmbeddings)
+    .where(and(
+      eq(memoryEmbeddings.targetType, 'item'),
+      inArray(memoryEmbeddings.targetId, ids),
+    ))
+    .run();
+  db.delete(memoryItems)
+    .where(inArray(memoryItems.id, ids))
+    .run();
+  if (stale.length === CLEANUP_BATCH_LIMIT) {
+    enqueueMemoryJob('cleanup_stale_superseded_items', { retentionMs });
+  }
+
+  log.debug({
+    removedItems: stale.length,
+    retentionMs,
+    cutoff,
+  }, 'Cleaned up stale superseded memory items');
 }
 
 async function buildConversationSummaryJob(job: MemoryJob, config: AssistantConfig): Promise<void> {
@@ -838,6 +916,12 @@ async function embedAndUpsert(
 
 function asString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asPositiveMs(value: unknown): number | null {
+  if (typeof value !== 'number') return null;
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return Math.floor(value);
 }
 
 function truncate(text: string, max: number): string {


### PR DESCRIPTION
## Summary
- add cleanup job types and handlers:
  - `cleanup_resolved_conflicts`
  - `cleanup_stale_superseded_items`
- add deduped enqueue helpers for both cleanup jobs (with optional retention override payloads)
- extend memory admin status with conflict lifecycle metrics:
  - `pending`
  - `resolved`
  - `oldestPendingAgeMs`
- add a `memory cleanup` CLI command and enrich `memory status` output with conflict counters/age
- harden cleanup query performance with new indexes on conflict `resolved_at` and item `invalid_at`
- add regression coverage for cleanup enqueue dedupe, cleanup execution behavior, and admin status metrics

## Testing
- export PATH="$HOME/.bun/bin:$PATH"; bun test assistant/src/__tests__/memory-v2-regressions.test.ts -t "cleanup job enqueue is deduped and retention overrides upgrade payload|cleanup_resolved_conflicts removes stale resolved rows but keeps recent/pending|cleanup_stale_superseded_items removes stale superseded rows and embeddings|memory admin status reports pending/resolved conflicts and oldest pending age|requestMemoryCleanup queues both cleanup job types|memory backfill request resumes by default and only restarts when forced|relation backfill enqueue is deduped and force upgrades payload"

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
