### PR TITLE
fix(composer): set refocus flag on send button click

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -277,7 +277,10 @@ struct ComposerView: View {
                 .accessibilityLabel("Stop generation")
             } else {
                 if canSend {
-                    Button(action: onSend) {
+                    Button {
+                        shouldRefocusAfterSend = true
+                        onSend()
+                    } label: {
                         ZStack {
                             Circle()
                                 .fill(VColor.accent)


### PR DESCRIPTION
## Summary
- Set `shouldRefocusAfterSend = true` in the send button action, matching the Return-key handler behavior
- Fixes composer losing focus after clicking the send button (UX regression from #2427)

## Context
PR #2427 introduced a `shouldRefocusAfterSend` guard to prevent focus theft from side-panel inputs. The guard was correctly applied to the Return-key path but missed in the send button click path. Both Codex and Devin flagged this in their reviews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
