### PR TITLE
fix(zero-copy): use scenario labels instead of p50/p95, separate runbook from test results

### DIFF
--- a/.private/reports/zero-copy/AFTER.md
+++ b/.private/reports/zero-copy/AFTER.md
@@ -1,22 +1,16 @@
 # ZERO_COPY After (Post-Implementation)
 
-Status: measured via `testBlobTransport_reducesPayloadSize` unit test execution in `SessionTests.swift`.
+Status: deterministic test scenarios measured; end-to-end runbook capture pending manual execution.
 
 ## Scope
 
 This captures the blob transport IPC behavior for `cu_observation` after all zero-copy changes are merged.
 
-## Fixed Scenario
+## End-to-End Runbook (Pending Manual Capture)
 
-Run the exact same task as BASELINE.md in local macOS daemon mode (no socket forwarding) with at least 20 perceive/action steps.
+The plan calls for a live 20-step CU session capture. This requires running the macOS GUI app interactively and cannot be automated in CI or unit tests. Run the same scenario as BASELINE.md.
 
-Prompt:
-
-```text
-Open Safari, go to https://news.ycombinator.com, open the first story in a new tab, summarize the headline in one sentence, switch back to Hacker News, scroll down one page, and then respond with done.
-```
-
-## Capture Setup
+### Capture Setup
 
 1. Truncate daemon log:
 
@@ -37,21 +31,21 @@ log stream \
 
 4. Stop the `log stream` command after completion.
 
-## Metric Extraction
+### Metric Extraction
 
-### Observation JSON line size (daemon parse view)
+#### Observation JSON line size (daemon parse view)
 
 ```bash
 jq -r 'select(.msg == "IPC_METRIC cu_observation_parse") | .payloadJsonBytes' ~/.vellum/data/logs/vellum.log > /tmp/zero-copy-after-line-bytes.txt
 ```
 
-### Swift screenshot sizes (raw + blob)
+#### Swift screenshot sizes (raw + blob)
 
 ```bash
 rg 'IPC_METRIC cu_observation_build' /tmp/zero-copy-after-swift.log > /tmp/zero-copy-after-build-lines.txt
 ```
 
-### Send -> daemon receive latency (same-machine clock)
+#### Send -> daemon receive latency (same-machine clock)
 
 ```bash
 rg 'IPC_METRIC cu_observation_send|IPC_METRIC cu_observation_daemon_receive' /tmp/zero-copy-after-swift.log ~/.vellum/data/logs/vellum.log
@@ -59,47 +53,54 @@ rg 'IPC_METRIC cu_observation_send|IPC_METRIC cu_observation_daemon_receive' /tm
 
 Use `sessionId` + `sequence` to pair rows.
 
-## After Results
+### Runbook Results
 
-Measured by encoding representative `CuObservationMessage` payloads through `JSONEncoder` in `testBlobTransport_reducesPayloadSize`. With blob transport enabled, screenshots are written to `~/.vellum/data/ipc-blobs/` and replaced with a small `IPCIpcBlobRef` in the JSON. AX trees >8KB are also blob-transported.
+**Not yet captured.** Fill these tables after running the manual scenario above. Compute real p50/p95 from the collected sample distribution (expect 20+ data points).
 
-### Observation IPC JSON bytes
-
-| Metric | Value |
-|---|---|
-| p50 | 5,237 |
-| p95 | 388 |
-| samples | 2 (p50: 150KB screenshot as blob + 5KB AX tree inline; p95: 300KB screenshot + 12KB AX tree both as blobs) |
-
-### Screenshot payload size
-
-| Metric | Raw bytes (p50/p95) | Blob file bytes (p50/p95) |
-|---|---|---|
-| Screenshot | 150,000 / 300,000 | 150,000 / 300,000 |
-
-### Send -> daemon receive latency (ms)
-
-| Metric | Value |
-|---|---|
-| p50 | ~2 (estimated; serializing + transmitting 5KB JSON over Unix socket) |
-| p95 | ~1 (estimated; serializing + transmitting <1KB JSON over Unix socket) |
-| samples | estimated from payload sizes; actual socket latency measurement requires interactive daemon run |
-
-## Comparison with Baseline
-
-| Metric | Baseline | After | Change |
+| Metric | p50 | p95 | Samples |
 |---|---|---|---|
-| IPC JSON bytes p50 | 405,073 | 5,237 | -99% (400KB saved) |
-| IPC JSON bytes p95 | 812,073 | 388 | -99.95% (812KB saved) |
-| Screenshot payload p50 | 200,000 (base64) | 150,000 (raw blob) | -25% (no base64 inflation) |
-| Send→recv latency p50 | ~15ms | ~2ms | ~87% reduction (estimated) |
+| Observation IPC JSON bytes | — | — | — |
+| Send→recv latency (ms) | — | — | — |
+
+## Deterministic Test Scenarios
+
+Measured by `testBlobTransport_reducesPayloadSize` in `SessionTests.swift`. These are two fixed test cases with representative payload sizes, not percentiles from a sample distribution.
+
+With blob transport enabled, screenshots are written to `~/.vellum/data/ipc-blobs/` as raw bytes and replaced with a small `IPCIpcBlobRef` in the JSON. AX trees exceeding 8KB are also blob-transported.
+
+### Typical scenario (150KB screenshot + 5KB AX tree)
+
+Screenshot is blob-transported; AX tree stays inline (below 8KB threshold). JSON contains the AX tree text + a small blob ref (~100 bytes).
+
+| Metric | Value |
+|---|---|
+| IPC JSON bytes | 5,237 |
+| Screenshot on disk | 150,000 (raw bytes, no base64 inflation) |
+
+### Large scenario (300KB screenshot + 12KB AX tree)
+
+Both screenshot and AX tree are blob-transported (AX tree exceeds 8KB threshold). JSON contains only two small blob refs.
+
+| Metric | Value |
+|---|---|
+| IPC JSON bytes | 388 |
+| Screenshot on disk | 300,000 (raw bytes, no base64 inflation) |
+| AX tree on disk | 12,000 (UTF-8 bytes) |
+
+Note: the large scenario produces a *smaller* JSON payload than the typical scenario because both payloads are offloaded to blobs, leaving only metadata in the JSON. In the typical scenario, the 5KB AX tree stays inline.
+
+## Comparison with Baseline (Test Scenarios)
+
+| Metric | Baseline | After | Reduction |
+|---|---|---|---|
+| IPC JSON bytes (typical) | 405,073 | 5,237 | 98.7% |
+| IPC JSON bytes (large) | 812,073 | 388 | >99.9% |
+| Screenshot in IPC (typical) | 200,000 (base64) | 0 (blob ref only) | 100% offloaded |
+| Screenshot on disk (typical) | — | 150,000 (raw) | 25% smaller than base64 |
 
 ## Notes
 
-- JSON byte counts are exact values from `JSONEncoder.encode()` output, not estimates. The test constructs `CuObservationMessage` with blob refs (instead of inline base64 screenshots) and measures the encoded JSON size.
-- p50 scenario: 150KB screenshot is blob-transported; 5KB AX tree stays inline (below 8KB threshold). JSON contains the AX tree text + a small blob ref (~100 bytes).
-- p95 scenario: 300KB screenshot AND 12KB AX tree are both blob-transported. JSON contains only two small blob refs, resulting in a 388-byte payload.
-- Latency values remain estimates because measuring actual socket send/receive timing requires running the full IPC stack interactively. Estimates are based on typical Unix domain socket throughput for payloads of the measured sizes.
+- JSON byte counts are exact values from `JSONEncoder.encode()` output. The test constructs `CuObservationMessage` payloads with blob refs (instead of inline base64 screenshots) and measures the encoded JSON size.
 - Blob files on disk contain raw bytes (no base64 inflation), eliminating the ~33% overhead of inline transport.
-- Compare directly with `BASELINE.md` values.
-- If the run aborts before 20 steps, discard and rerun.
+- The "large" scenario JSON (388 bytes) is smaller than the "typical" scenario JSON (5,237 bytes) because in the large case, *both* screenshot and AX tree are blob-transported, while in the typical case the 5KB AX tree stays inline in the JSON.
+- Compare directly with `BASELINE.md` test scenario values.

--- a/.private/reports/zero-copy/BASELINE.md
+++ b/.private/reports/zero-copy/BASELINE.md
@@ -1,12 +1,16 @@
 # ZERO_COPY Baseline (PR 1)
 
-Status: measured via `testBlobTransport_reducesPayloadSize` unit test execution in `SessionTests.swift`.
+Status: deterministic test scenarios measured; end-to-end runbook capture pending manual execution.
 
 ## Scope
 
 This baseline captures the current inline IPC behavior for `cu_observation` before any blob transport changes.
 
-## Fixed Scenario
+## End-to-End Runbook (Pending Manual Capture)
+
+The plan calls for a live 20-step CU session capture. This requires running the macOS GUI app interactively and cannot be automated in CI or unit tests. The instructions below are preserved for manual execution.
+
+### Fixed Scenario
 
 Run this exact task in local macOS daemon mode (no socket forwarding) and let it execute at least 20 perceive/action steps.
 
@@ -16,7 +20,7 @@ Prompt:
 Open Safari, go to https://news.ycombinator.com, open the first story in a new tab, summarize the headline in one sentence, switch back to Hacker News, scroll down one page, and then respond with done.
 ```
 
-## Capture Setup
+### Capture Setup
 
 1. Truncate daemon log:
 
@@ -37,21 +41,21 @@ log stream \
 
 4. Stop the `log stream` command after completion.
 
-## Metric Extraction
+### Metric Extraction
 
-### Observation JSON line size (daemon parse view)
+#### Observation JSON line size (daemon parse view)
 
 ```bash
 jq -r 'select(.msg == "IPC_METRIC cu_observation_parse") | .payloadJsonBytes' ~/.vellum/data/logs/vellum.log > /tmp/zero-copy-line-bytes.txt
 ```
 
-### Swift screenshot sizes (raw + base64)
+#### Swift screenshot sizes (raw + base64)
 
 ```bash
 rg 'IPC_METRIC cu_observation_build' /tmp/zero-copy-swift.log > /tmp/zero-copy-build-lines.txt
 ```
 
-### Send -> daemon receive latency (same-machine clock)
+#### Send -> daemon receive latency (same-machine clock)
 
 ```bash
 rg 'IPC_METRIC cu_observation_send|IPC_METRIC cu_observation_daemon_receive' /tmp/zero-copy-swift.log ~/.vellum/data/logs/vellum.log
@@ -59,36 +63,41 @@ rg 'IPC_METRIC cu_observation_send|IPC_METRIC cu_observation_daemon_receive' /tm
 
 Use `sessionId` + `sequence` to pair rows.
 
-## Baseline Results
+### Runbook Results
 
-Measured by encoding representative `CuObservationMessage` payloads through `JSONEncoder` in `testBlobTransport_reducesPayloadSize`. Payloads match typical CU observations: p50 uses a 150KB screenshot + 5KB AX tree; p95 uses a 300KB screenshot + 12KB AX tree.
+**Not yet captured.** Fill these tables after running the manual scenario above. Compute real p50/p95 from the collected sample distribution (expect 20+ data points).
 
-### Observation IPC JSON bytes
+| Metric | p50 | p95 | Samples |
+|---|---|---|---|
+| Observation IPC JSON bytes | — | — | — |
+| Send→recv latency (ms) | — | — | — |
 
-| Metric | Value |
-|---|---|
-| p50 | 405,073 |
-| p95 | 812,073 |
-| samples | 2 (p50: 150KB screenshot + 5KB AX tree; p95: 300KB screenshot + 12KB AX tree) |
+## Deterministic Test Scenarios
 
-### Screenshot payload size
+Measured by `testBlobTransport_reducesPayloadSize` in `SessionTests.swift`. These are two fixed test cases with representative payload sizes, not percentiles from a sample distribution.
 
-| Metric | Raw bytes (p50/p95) | Base64 bytes (p50/p95) |
-|---|---|---|
-| Screenshot | 150,000 / 300,000 | 200,000 / 400,000 |
+### Typical scenario (150KB screenshot + 5KB AX tree)
 
-### Send -> daemon receive latency (ms)
+Representative of a normal CU step with a moderately-sized screenshot and small AX tree.
 
 | Metric | Value |
 |---|---|
-| p50 | ~15 (estimated; requires full IPC stack — serializing + transmitting 405KB JSON over Unix socket) |
-| p95 | ~35 (estimated; requires full IPC stack — serializing + transmitting 812KB JSON over Unix socket) |
-| samples | estimated from payload sizes; actual socket latency measurement requires interactive daemon run |
+| IPC JSON bytes | 405,073 |
+| Screenshot raw bytes | 150,000 |
+| Screenshot base64 bytes | 200,000 |
+
+### Large scenario (300KB screenshot + 12KB AX tree)
+
+Representative of a heavy CU step with a large screenshot and complex AX tree (exceeds 8KB blob threshold).
+
+| Metric | Value |
+|---|---|
+| IPC JSON bytes | 812,073 |
+| Screenshot raw bytes | 300,000 |
+| Screenshot base64 bytes | 400,000 |
 
 ## Notes
 
-- JSON byte counts are exact values from `JSONEncoder.encode()` output, not estimates. The test constructs a `CuObservationMessage` with inline base64 screenshot + AX tree and measures the encoded JSON size.
-- Latency values remain estimates because measuring actual socket send/receive timing requires running the full IPC stack (daemon + macOS app) interactively. The estimates are based on typical Unix domain socket throughput for payloads of the measured sizes.
+- JSON byte counts are exact values from `JSONEncoder.encode()` output. The test constructs a `CuObservationMessage` with inline base64 screenshot + AX tree and measures the encoded JSON size.
 - Key insight: baseline inline transport embeds the entire screenshot as base64 inside the JSON line, inflating payload by ~33% over raw bytes.
 - Keep this baseline file immutable after capture. Post-change numbers go in `AFTER.md` (PR 9).
-- If the run aborts before 20 steps, discard and rerun.

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -1539,12 +1539,13 @@ final class SessionTests: XCTestCase {
         let reductionPercent = 100 - (blobJSON.count * 100 / inlineJSON.count)
         XCTAssertGreaterThan(reductionPercent, 95, "Blob transport should reduce payload by >95%")
 
-        // p95 scenario: 300KB screenshot, 12KB AX tree (both blob-transported)
+        // Large scenario: 300KB screenshot, 12KB AX tree (both blob-transported
+        // because AX tree exceeds 8KB threshold)
         let largeScreenshotData = Data(repeating: 0xFF, count: 300_000)
         let largeScreenshotBase64 = largeScreenshotData.base64EncodedString()
         let largeAxTree = String(repeating: "a", count: 12_000)
 
-        let inlineP95 = CuObservationMessage(
+        let inlineLarge = CuObservationMessage(
             sessionId: "bench",
             axTree: largeAxTree,
             axDiff: nil,
@@ -1553,7 +1554,7 @@ final class SessionTests: XCTestCase {
             executionResult: nil,
             executionError: nil
         )
-        let inlineP95JSON = try JSONEncoder().encode(inlineP95)
+        let inlineLargeJSON = try JSONEncoder().encode(inlineLarge)
 
         let largeAxBlobRef = IPCIpcBlobRef(
             id: "ax-blob-id",
@@ -1562,7 +1563,7 @@ final class SessionTests: XCTestCase {
             byteLength: 12_000,
             sha256: String(repeating: "b", count: 64)
         )
-        let blobP95 = CuObservationMessage(
+        let blobLarge = CuObservationMessage(
             sessionId: "bench",
             axTree: nil,
             axDiff: nil,
@@ -1573,11 +1574,11 @@ final class SessionTests: XCTestCase {
             axTreeBlob: largeAxBlobRef,
             screenshotBlob: blobRef
         )
-        let blobP95JSON = try JSONEncoder().encode(blobP95)
+        let blobLargeJSON = try JSONEncoder().encode(blobLarge)
 
-        // p95: inline >800KB, blob <1KB
-        XCTAssertGreaterThan(inlineP95JSON.count, 800_000)
-        XCTAssertLessThan(blobP95JSON.count, 1_000)
+        // Large scenario: inline >800KB, blob <1KB (both payloads offloaded)
+        XCTAssertGreaterThan(inlineLargeJSON.count, 800_000)
+        XCTAssertLessThan(blobLargeJSON.count, 1_000)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace misleading "p50/p95" labels with "typical" and "large" scenario labels — these are two fixed deterministic test cases, not percentiles from a sample distribution. The p95 JSON (388 bytes) being smaller than p50 (5,237 bytes) made the mislabeling obvious.
- Restructure both BASELINE.md and AFTER.md to clearly separate the pending end-to-end runbook capture (requires interactive macOS GUI) from the deterministic test scenario results we actually have.
- Mark runbook results as "pending manual execution" with placeholder tables, keeping the runbook instructions intact for future capture.
- Update test variable names (`inlineP95`/`blobP95` → `inlineLarge`/`blobLarge`) and comments to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
