### PR TITLE
docs(architecture): finalize conflict/profile lifecycle diagrams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -676,6 +676,29 @@ graph TB
    - selected count / injected tokens (budget safety)
    - latency and ordering regressions via top candidate snapshots
 
+### Conflict Lifecycle and Profile Hygiene
+
+```mermaid
+stateDiagram-v2
+    [*] --> ActiveItems : extract_items/check_contradictions
+    ActiveItems --> PendingConflict : ambiguous_contradiction\n(candidate -> pending_clarification)
+    PendingConflict --> PendingConflict : soft gate ask once\n(reask cooldown + relevance)
+    PendingConflict --> ResolvedKeepExisting : clarification resolver\n+ applyConflictResolution
+    PendingConflict --> ResolvedKeepCandidate : clarification resolver\n+ applyConflictResolution
+    PendingConflict --> ResolvedMerge : clarification resolver\n+ applyConflictResolution
+    ResolvedKeepExisting --> CleanupConflicts : cleanup_resolved_conflicts
+    ResolvedKeepCandidate --> CleanupConflicts : cleanup_resolved_conflicts
+    ResolvedMerge --> CleanupConflicts : cleanup_resolved_conflicts
+    ResolvedKeepExisting --> SupersededItems : candidate superseded
+    ResolvedMerge --> SupersededItems : merged-from candidate superseded
+    SupersededItems --> CleanupItems : cleanup_stale_superseded_items
+```
+
+Runtime profile flow (per turn):
+1. `ProfileCompiler` builds a trusted profile block from active `profile` / `preference` / `constraint` / `instruction` items under strict token cap.
+2. Session injects that block only into runtime prompt state.
+3. Session strips the injected profile block before persisting conversation history, so dynamic profile context never pollutes durable message rows.
+
 ---
 
 ## Web Server — Connection Modes


### PR DESCRIPTION
## Summary
- finalize `ARCHITECTURE.md` coverage for the full memory rollout by adding:
  - explicit conflict lifecycle state transitions
  - cleanup job endpoints for resolved conflicts and stale superseded items
  - dynamic profile hygiene path (compile -> runtime inject -> pre-persist strip)
- tighten architecture parity text so the shipped conflict/profile/cleanup behavior is captured in one place

## Testing
- docs-only change (no runtime code path changes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
