### PR TITLE
test(memory): avoid upsert dedupe in resolveEntityName fixture

### DIFF
--- a/assistant/src/__tests__/entity-extractor.test.ts
+++ b/assistant/src/__tests__/entity-extractor.test.ts
@@ -132,19 +132,33 @@ describe('entity extractor helpers', () => {
   });
 
   test('resolveEntityName prefers exact canonical name over alias match', () => {
-    // Entity A has "React" as an alias
-    const aliasEntityId = upsertEntity({
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert two distinct entities directly to avoid upsertEntity dedupe.
+    const aliasEntityId = crypto.randomUUID();
+    db.insert(memoryEntities).values({
+      id: aliasEntityId,
       name: 'React Native',
       type: 'tool',
-      aliases: ['React', 'RN'],
-    });
+      aliases: JSON.stringify(['React', 'RN']),
+      description: null,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      mentionCount: 1,
+    }).run();
 
-    // Entity B has "React" as its canonical name
-    const canonicalEntityId = upsertEntity({
+    const canonicalEntityId = crypto.randomUUID();
+    db.insert(memoryEntities).values({
+      id: canonicalEntityId,
       name: 'React',
       type: 'tool',
-      aliases: ['ReactJS'],
-    });
+      aliases: JSON.stringify(['ReactJS']),
+      description: null,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      mentionCount: 1,
+    }).run();
 
     // resolveEntityName("React") should return the entity whose canonical
     // name is "React", not the one that merely lists it as an alias.


### PR DESCRIPTION
## Summary\n- address feedback on #2367 about the canonical-name preference test being trivially true\n- insert two distinct entities directly into  in the test fixture\n- keep the existing assertions so the test now validates exact-name preference over alias matches\n\n## Testing\n- bun test v1.3.9 (cf6cdbbb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
