### PR TITLE
feat(workspace): polish dynamic workspace with floating overlays

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -141,7 +141,7 @@ function buildDynamicUiSection(): string {
     '',
     '### Tool chaining',
     'After gathering data via tools (web search, browser, `get_weather`, APIs), synthesize results into a `dynamic_page` rather than displaying raw tool outputs.',
-    '- **Weather**: After `get_weather` returns data, call `ui_show` with `surface_type: "dynamic_page"` and the `data` object provided in the tool result (contains pre-built `html` and `preview`). Pass the data exactly as-is.',
+    '- **Weather**: `get_weather` automatically renders a dynamic page with a compact preview card. Do NOT call `ui_show` after `get_weather` — the weather surface is emitted directly. Just respond with a brief natural-language summary.',
     '- **Research → Render**: When using browser/web search to research something visual (flights, hotels, products, comparisons), gather the data first, then compose it into a polished `dynamic_page` with the appropriate component classes.',
   ].join('\n');
 }

--- a/assistant/src/tools/weather/get-weather.ts
+++ b/assistant/src/tools/weather/get-weather.ts
@@ -1,5 +1,5 @@
 import { RiskLevel } from '../../permissions/types.js';
-import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
+import type { Tool, ToolContext, ToolExecutionResult, ProxyToolResolver } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
 import { registerTool } from '../registry.js';
 import { getLogger } from '../../util/logger.js';
@@ -229,6 +229,7 @@ type FetchFn = typeof globalThis.fetch;
 export async function executeGetWeather(
   input: Record<string, unknown>,
   fetchFn: FetchFn = globalThis.fetch,
+  proxyToolResolver?: ProxyToolResolver,
 ): Promise<ToolExecutionResult> {
   const location = input.location;
   if (typeof location !== 'string' || location.trim() === '') {
@@ -424,6 +425,22 @@ export async function executeGetWeather(
     },
   };
 
+  // Auto-emit the weather surface via proxy resolver (same pattern as app_create).
+  // This removes the need for the model to make a second ui_show call.
+  if (proxyToolResolver) {
+    try {
+      await proxyToolResolver('ui_show', {
+        surface_type: 'dynamic_page',
+        data: uiShowData,
+      });
+    } catch (err) {
+      log.warn({ err }, 'Failed to auto-emit weather surface');
+    }
+    // Return concise result — the surface is already displayed
+    return { content: lines.join('\n'), isError: false };
+  }
+
+  // Fallback for non-UI channels: include render instructions for the model
   lines.push('', '--- Render with ui_show ---');
   lines.push('Call ui_show with surface_type "dynamic_page" and the following data (pass exactly as-is):');
   lines.push(JSON.stringify(uiShowData));
@@ -463,8 +480,8 @@ class GetWeatherTool implements Tool {
     };
   }
 
-  async execute(input: Record<string, unknown>, _context: ToolContext): Promise<ToolExecutionResult> {
-    return executeGetWeather(input);
+  async execute(input: Record<string, unknown>, context: ToolContext): Promise<ToolExecutionResult> {
+    return executeGetWeather(input, globalThis.fetch, context.proxyToolResolver);
   }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -427,73 +427,20 @@ struct MainWindowView: View {
 
     // MARK: - Dynamic Workspace
 
+    /// Height reserved at the bottom so HTML content scrolls past the floating composer.
+    private var workspaceComposerReservedHeight: CGFloat {
+        let editorClamped = min(max(workspaceEditorContentHeight, 14), 200)
+        let contentHeight = max(editorClamped, 28)
+        let expanded = workspaceComposerExpanded
+        let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
+        let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
+        return VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow
+    }
+
     @ViewBuilder
     private func dynamicWorkspaceView(surface: Surface, data: DynamicPageSurfaceData) -> some View {
-        VStack(spacing: 0) {
-            // Toolbar
-            HStack {
-                Button(action: { showSharePicker = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 28, height: 28)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Back to gallery")
-
-                Text(surface.title ?? "App")
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.textPrimary)
-
-                Spacer()
-
-                // Share button — only shown when the runtime page server is active
-                if let appId = data.appId, let shareURL = pageURL(for: appId) {
-                    Menu {
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(shareURL.absoluteString, forType: .string)
-                        } label: {
-                            Label("Copy Link", systemImage: "doc.on.doc")
-                        }
-                        Button {
-                            showSharePicker = true
-                        } label: {
-                            Label("Share\u{2026}", systemImage: "square.and.arrow.up")
-                        }
-                    } label: {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textMuted)
-                            .frame(width: 28, height: 28)
-                    }
-                    .menuStyle(.borderlessButton)
-                    .frame(width: 28)
-                    .accessibilityLabel("Share")
-                    .background(
-                        ShareSheetButton(
-                            items: [shareURL],
-                            isPresented: $showSharePicker
-                        )
-                        .frame(width: 1, height: 1)
-                    )
-                }
-
-                Button(action: { showSharePicker = false; activePanel = nil; isDynamicExpanded = false; activeDynamicSurface = nil; activeDynamicParsedSurface = nil }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(VColor.textMuted)
-                        .frame(width: 32, height: 32)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close workspace")
-            }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.vertical, VSpacing.lg)
-
-            Divider().background(VColor.surfaceBorder)
-
-            // Dynamic page WebView fills remaining space
+        ZStack {
+            // Full-bleed WebView with CSS content insets
             DynamicPageSurfaceView(
                 data: data,
                 onAction: { actionId, actionData in
@@ -506,34 +453,110 @@ struct MainWindowView: View {
                 } : nil,
                 onCoordinatorReady: data.appId != nil ? { coordinator in
                     surfaceManager.surfaceCoordinators[surface.id] = coordinator
-                } : nil
+                } : nil,
+                topContentInset: 56,
+                bottomContentInset: workspaceComposerReservedHeight
             )
 
-            // Chatbar pinned at bottom
-            if let viewModel = threadManager.activeViewModel {
-                ComposerView(
-                    inputText: Binding(
-                        get: { viewModel.inputText },
-                        set: { viewModel.inputText = $0 }
-                    ),
-                    hasAPIKey: hasAPIKey,
-                    isSending: viewModel.isSending,
-                    isRecording: viewModel.isRecording,
-                    suggestion: viewModel.suggestion,
-                    pendingAttachments: viewModel.pendingAttachments,
-                    onSend: viewModel.sendMessage,
-                    onStop: viewModel.stopGenerating,
-                    onAcceptSuggestion: viewModel.acceptSuggestion,
-                    onAttach: { Self.openFilePicker(viewModel: viewModel) },
-                    onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
-                    onPaste: { viewModel.addAttachmentFromPasteboard() },
-                    onMicrophoneToggle: onMicrophoneToggle,
-                    editorContentHeight: $workspaceEditorContentHeight,
-                    isComposerExpanded: $workspaceComposerExpanded
-                )
+            // Floating overlays
+            VStack(spacing: 0) {
+                // Top bar: back button + share button
+                HStack {
+                    // "< Chat" pill button — single exit action
+                    Button(action: {
+                        showSharePicker = false
+                        activePanel = nil
+                        isDynamicExpanded = false
+                        activeDynamicSurface = nil
+                        activeDynamicParsedSurface = nil
+                    }) {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text("Chat")
+                                .font(VFont.bodyMedium)
+                        }
+                        .foregroundColor(VColor.textPrimary)
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .background(
+                            Capsule()
+                                .fill(VColor.surface.opacity(0.85))
+                                .overlay(Capsule().stroke(VColor.surfaceBorder, lineWidth: 1))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Back to chat")
+
+                    Spacer()
+
+                    // Share button — floating circle, only when appId + page URL exist
+                    if let appId = data.appId, let shareURL = pageURL(for: appId) {
+                        Menu {
+                            Button {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(shareURL.absoluteString, forType: .string)
+                            } label: {
+                                Label("Copy Link", systemImage: "doc.on.doc")
+                            }
+                            Button {
+                                showSharePicker = true
+                            } label: {
+                                Label("Share\u{2026}", systemImage: "square.and.arrow.up")
+                            }
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(VColor.textPrimary)
+                                .frame(width: 32, height: 32)
+                                .background(
+                                    Circle()
+                                        .fill(VColor.surface.opacity(0.85))
+                                        .overlay(Circle().stroke(VColor.surfaceBorder, lineWidth: 1))
+                                )
+                        }
+                        .menuStyle(.borderlessButton)
+                        .frame(width: 32)
+                        .accessibilityLabel("Share")
+                        .background(
+                            ShareSheetButton(
+                                items: [shareURL],
+                                isPresented: $showSharePicker
+                            )
+                            .frame(width: 1, height: 1)
+                        )
+                    }
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.top, VSpacing.md)
+
+                Spacer()
+
+                // Floating composer — fade is handled inside the WebView via CSS
+                if let viewModel = threadManager.activeViewModel {
+                    ComposerView(
+                        inputText: Binding(
+                            get: { viewModel.inputText },
+                            set: { viewModel.inputText = $0 }
+                        ),
+                        hasAPIKey: hasAPIKey,
+                        isSending: viewModel.isSending,
+                        isRecording: viewModel.isRecording,
+                        suggestion: viewModel.suggestion,
+                        pendingAttachments: viewModel.pendingAttachments,
+                        onSend: viewModel.sendMessage,
+                        onStop: viewModel.stopGenerating,
+                        onAcceptSuggestion: viewModel.acceptSuggestion,
+                        onAttach: { Self.openFilePicker(viewModel: viewModel) },
+                        onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+                        onPaste: { viewModel.addAttachmentFromPasteboard() },
+                        onMicrophoneToggle: onMicrophoneToggle,
+                        editorContentHeight: $workspaceEditorContentHeight,
+                        isComposerExpanded: $workspaceComposerExpanded
+                    )
+                }
             }
         }
-        .background(VColor.backgroundSubtle)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -43,6 +43,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     let onCoordinatorReady: ((Coordinator) -> Void)?
     /// When true, blocks all network requests to external origins and restricts navigation.
     let sandboxMode: Bool
+    let topContentInset: CGFloat
+    let bottomContentInset: CGFloat
 
     init(
         data: DynamicPageSurfaceData,
@@ -50,7 +52,9 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         appId: String? = nil,
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((Coordinator) -> Void)? = nil,
-        sandboxMode: Bool = false
+        sandboxMode: Bool = false,
+        topContentInset: CGFloat = 0,
+        bottomContentInset: CGFloat = 0
     ) {
         self.data = data
         self.onAction = onAction
@@ -58,6 +62,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         self.onDataRequest = onDataRequest
         self.onCoordinatorReady = onCoordinatorReady
         self.sandboxMode = sandboxMode
+        self.topContentInset = topContentInset
+        self.bottomContentInset = bottomContentInset
     }
 
     func makeCoordinator() -> Coordinator {
@@ -253,6 +259,45 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             }
         }
 
+        // Inject CSS padding so HTML content doesn't get hidden behind floating overlays,
+        // plus a fixed-position fade overlay that uses the page's own background color.
+        if topContentInset > 0 || bottomContentInset > 0 {
+            let top = Int(topContentInset)
+            let bottom = Int(bottomContentInset)
+            let fadeHeight = bottom + 32
+            let insetScript = WKUserScript(
+                source: """
+                    (function() {
+                        var style = document.createElement('style');
+                        style.id = 'vellum-content-insets';
+                        style.textContent = 'body { padding-top: \(top)px; padding-bottom: \(bottom)px; }';
+                        (document.head || document.documentElement).appendChild(style);
+                        if (\(bottom) > 0) {
+                            function setupFade() {
+                                var fade = document.getElementById('vellum-bottom-fade');
+                                if (!fade) {
+                                    fade = document.createElement('div');
+                                    fade.id = 'vellum-bottom-fade';
+                                    fade.style.cssText = 'position:fixed;bottom:0;left:0;right:0;pointer-events:none;z-index:99999;';
+                                    document.body.appendChild(fade);
+                                }
+                                fade.style.height = '\(fadeHeight)px';
+                                requestAnimationFrame(function() {
+                                    var bg = getComputedStyle(document.body).backgroundColor || 'rgba(0,0,0,0)';
+                                    fade.style.background = 'linear-gradient(to bottom, transparent 0%, ' + bg + ' 100%)';
+                                });
+                            }
+                            if (document.body) setupFade();
+                            else document.addEventListener('DOMContentLoaded', setupFade);
+                        }
+                    })();
+                    """,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+            contentController.addUserScript(insetScript)
+        }
+
         onCoordinatorReady?(context.coordinator)
         // Use a per-app origin so localStorage/sessionStorage work natively,
         // isolated per app. Non-app surfaces get a shared fallback origin.
@@ -272,6 +317,29 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
             webView.loadHTMLString(data.html, baseURL: URL(string: origin))
         }
+
+        // Re-apply content insets and fade overlay when they change (e.g. composer expands).
+        let newTop = Int(topContentInset)
+        let newBottom = Int(bottomContentInset)
+        if newTop != context.coordinator.lastTopInset || newBottom != context.coordinator.lastBottomInset {
+            context.coordinator.lastTopInset = newTop
+            context.coordinator.lastBottomInset = newBottom
+            let fadeHeight = newBottom + 32
+            let js = """
+                (function() {
+                    var el = document.getElementById('vellum-content-insets');
+                    if (!el) { el = document.createElement('style'); el.id = 'vellum-content-insets'; (document.head || document.documentElement).appendChild(el); }
+                    el.textContent = 'body { padding-top: \(newTop)px; padding-bottom: \(newBottom)px; }';
+                    var fade = document.getElementById('vellum-bottom-fade');
+                    if (fade) {
+                        fade.style.height = '\(fadeHeight)px';
+                        var bg = getComputedStyle(document.body).backgroundColor || 'rgba(0,0,0,0)';
+                        fade.style.background = 'linear-gradient(to bottom, transparent 0%, ' + bg + ' 100%)';
+                    }
+                })();
+                """
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
     }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
@@ -286,6 +354,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var currentHTML: String
         let sandboxMode: Bool
         weak var webView: WKWebView?
+        var lastTopInset: Int = 0
+        var lastBottomInset: Int = 0
 
         init(
             onAction: @escaping (String, Any?) -> Void,


### PR DESCRIPTION
## Summary
- Replace thick toolbar + pinned composer in dynamic workspace with floating ZStack layout: full-bleed WebView, glass-style "< Chat" pill back button, floating share circle, and floating composer
- Add CSS content insets to DynamicPageSurfaceView (padding + fixed-position fade overlay that reads the page's own background color) so HTML content scrolls past floating overlays
- Auto-emit weather surface via proxy resolver instead of requiring a second ui_show call from the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
