### PR TITLE
fix(memory): avoid irrelevant auto-resolution in soft conflict gate

### DIFF
--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -251,6 +251,7 @@ describe('conflict-store', () => {
     const updatedConflict = getConflictById(conflict.id);
 
     expect(typeof existing?.invalidAt).toBe('number');
+    expect(existing?.status).toBe('superseded');
     expect(candidate?.status).toBe('active');
     expect(updatedConflict?.status).toBe('resolved_keep_candidate');
   });

--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1238,6 +1238,7 @@ describe('Memory V2 regressions', () => {
       const updatedConflict = getConflictById(conflict.id);
 
       expect(existing?.invalidAt).not.toBeNull();
+      expect(existing?.status).toBe('superseded');
       expect(candidate?.status).toBe('active');
       expect(updatedConflict?.status).toBe('resolved_keep_candidate');
       expect(updatedConflict?.resolutionNote).toContain('Background message resolver');

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -315,6 +315,12 @@ describe('Session conflict soft gate', () => {
       existingStatement: 'Use Postgres as the default database.',
       candidateStatement: 'Use MySQL as the default database.',
     }];
+    resolverResult = {
+      resolution: 'keep_existing',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'Resolved by accident.',
+    };
 
     const session = makeSession();
     await session.loadFromDb();
@@ -328,6 +334,7 @@ describe('Session conflict soft gate', () => {
     const injectedText = extractText(injectedUser);
     expect(injectedText).toContain('Memory clarification request');
     expect(injectedText).toContain('Should I assume Postgres or MySQL?');
+    expect(resolverCallCount).toBe(0);
     expect(markAskedCalls).toEqual(['conflict-irrelevant']);
     expect(events.some((event) => event.type === 'message_complete')).toBe(true);
   });

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1655,13 +1655,21 @@ export class Session {
     if (!conflictConfig?.enabled || conflictConfig.gateMode !== 'soft') return null;
 
     this.conflictTurnCounter += 1;
-    await this.resolvePendingConflictsFromUserTurn(userMessage, conflictConfig.resolverLlmTimeoutMs);
+    const threshold = conflictConfig.relevanceThreshold;
+    const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
+    const pendingBeforeResolve = listPendingConflictDetails('default', 50);
+    const relevantBeforeResolve = pendingBeforeResolve.filter(
+      (conflict) => computeConflictRelevance(userMessage, conflict) >= threshold,
+    );
+    await this.resolvePendingConflictsFromUserTurn(
+      userMessage,
+      conflictConfig.resolverLlmTimeoutMs,
+      relevantBeforeResolve,
+    );
 
     const pending = listPendingConflictDetails('default', 50);
     if (pending.length === 0) return null;
 
-    const threshold = conflictConfig.relevanceThreshold;
-    const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
     const scored = pending.map((conflict) => ({
       conflict,
       relevance: computeConflictRelevance(userMessage, conflict),
@@ -1684,9 +1692,9 @@ export class Session {
   private async resolvePendingConflictsFromUserTurn(
     userMessage: string,
     resolverTimeoutMs: number,
+    pendingConflicts: PendingConflictDetail[],
   ): Promise<void> {
-    const pending = listPendingConflictDetails('default', 25);
-    for (const conflict of pending) {
+    for (const conflict of pendingConflicts) {
       const resolution = await resolveConflictClarification(
         {
           existingStatement: conflict.existingStatement,

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -284,7 +284,7 @@ export function applyConflictResolution(input: ApplyConflictResolutionInput): bo
     }
     case 'keep_candidate': {
       db.update(memoryItems)
-        .set({ invalidAt: now })
+        .set({ status: 'superseded', invalidAt: now })
         .where(eq(memoryItems.id, existingItem.id))
         .run();
       db.update(memoryItems)


### PR DESCRIPTION
## Summary
- address feedback on #2428 for soft conflict handling
- mark the losing existing item as superseded in keep_candidate resolutions
- only run clarification auto-resolution for conflicts above the relevance threshold to avoid unrelated turns resolving memory conflicts
- add regression assertions in conflict-store, session conflict gate, and memory v2 tests

## Testing
- cd assistant && bun test src/__tests__/conflict-store.test.ts src/__tests__/session-conflict-gate.test.ts
- cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts --test-name-pattern "background conflict resolver job applies user clarification to pending conflicts"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
