### PR TITLE
fix(swarm): thread AbortSignal through orchestrator and worker stack

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -32,6 +32,7 @@ export interface ExecuteSwarmOptions {
   synthesisProvider?: Provider;
   synthesisModel?: string;
   onStatus?: OrchestratorStatusCallback;
+  signal?: AbortSignal;
 }
 
 /**
@@ -39,7 +40,7 @@ export interface ExecuteSwarmOptions {
  * bounded concurrency, and per-task retries.
  */
 export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExecutionSummary> {
-  const { plan, limits, backend, workingDir, model, onStatus } = opts;
+  const { plan, limits, backend, workingDir, model, onStatus, signal } = opts;
   const startTime = Date.now();
 
   onStatus?.({ kind: 'plan_created', message: `Plan with ${plan.tasks.length} tasks` });
@@ -74,6 +75,8 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
 
   // Process tasks with bounded concurrency
   while (ready.length > 0 || isAnyRunning()) {
+    if (signal?.aborted) break;
+
     // Launch up to maxWorkers tasks
     const batch = ready.splice(0, limits.maxWorkers);
 
@@ -95,6 +98,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         workingDir,
         model,
         timeoutMs: limits.workerTimeoutSec * 1000,
+        signal,
       });
 
       // Retry loop

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -105,6 +105,7 @@ export interface SwarmWorkerBackendInput {
   workingDir: string;
   model?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 /**

--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -18,6 +18,7 @@ export interface RunWorkerTaskOptions {
   model?: string;
   timeoutMs: number;
   onStatus?: WorkerStatusCallback;
+  signal?: AbortSignal;
 }
 
 /**
@@ -25,7 +26,21 @@ export interface RunWorkerTaskOptions {
  * Returns a normalized SwarmTaskResult regardless of success or failure.
  */
 export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTaskResult> {
-  const { task, backend, workingDir, timeoutMs, onStatus } = opts;
+  const { task, backend, workingDir, timeoutMs, onStatus, signal } = opts;
+
+  if (signal?.aborted) {
+    return {
+      taskId: task.id,
+      status: 'failed',
+      summary: 'Cancelled',
+      artifacts: [],
+      issues: ['aborted'],
+      nextSteps: [],
+      rawOutput: '',
+      durationMs: 0,
+      retryCount: 0,
+    };
+  }
 
   onStatus?.(task.id, 'queued');
 
@@ -63,6 +78,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
       workingDir,
       model: opts.model,
       timeoutMs,
+      signal,
     });
 
     if (result.success) {

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -66,6 +66,7 @@ function createClaudeCodeBackend(): SwarmWorkerBackend {
 
         let resultText = '';
         for await (const message of conversation) {
+          if (input.signal?.aborted) break;
           if (message.type === 'assistant' && message.message?.content) {
             for (const block of message.message.content) {
               if (block.type === 'text') resultText += block.text;
@@ -191,6 +192,7 @@ export const swarmDelegateTool: Tool = {
         model: config.swarm.plannerModel,
         synthesisProvider,
         synthesisModel: config.swarm.synthesizerModel,
+        signal: context.signal,
         onStatus: (event) => {
           switch (event.kind) {
             case 'task_started':


### PR DESCRIPTION
## Summary
- Adds `signal?: AbortSignal` to `ExecuteSwarmOptions`, `RunWorkerTaskOptions`, and `SwarmWorkerBackendInput`
- Orchestrator breaks scheduling loop when signal is aborted
- Worker runner short-circuits with a failed result before dispatching to backend
- Backend stops iterating SDK messages on abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
