### PR TITLE
fix(swarm): enforce worker timeout via Promise.race

### DIFF
--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -72,7 +72,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
   const profile = roleToProfile(task.role);
 
   try {
-    const result = await backend.runTask({
+    const backendPromise = backend.runTask({
       prompt,
       profile,
       workingDir,
@@ -80,6 +80,32 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
       timeoutMs,
       signal,
     });
+
+    // Enforce timeout via Promise.race
+    const timeoutPromise = new Promise<'timeout'>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), timeoutMs);
+      // Don't keep the process alive just for this timer
+      if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+    });
+
+    const raceResult = await Promise.race([backendPromise, timeoutPromise]);
+
+    if (raceResult === 'timeout') {
+      onStatus?.(task.id, 'failed');
+      return {
+        taskId: task.id,
+        status: 'failed',
+        summary: `Worker timed out after ${timeoutMs}ms`,
+        artifacts: [],
+        issues: ['timeout'],
+        nextSteps: [],
+        rawOutput: '',
+        durationMs: timeoutMs,
+        retryCount: 0,
+      };
+    }
+
+    const result = raceResult;
 
     if (result.success) {
       const parsed = parseWorkerOutput(result.output);


### PR DESCRIPTION
## Summary
- `runWorkerTask` now races `backend.runTask()` against a timeout timer using `Promise.race`
- Returns a deterministic `timeout` failure result when `timeoutMs` is exceeded
- Timer uses `unref()` to avoid keeping the process alive unnecessarily

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
