### PR TITLE
refactor: standardize assistant/gateway typecheck and stable test entrypoints

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -15,7 +15,9 @@
     "check:ipc-generated": "bun run scripts/ipc/generate-swift.ts --check",
     "ipc:check-swift-drift": "bun run scripts/ipc/check-swift-decoder-drift.ts",
     "lint": "eslint",
+    "typecheck": "bunx tsc --noEmit",
     "test": "bash scripts/test.sh",
+    "test:stable": "EXCLUDE_EXPERIMENTAL=true bash scripts/test.sh",
     "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `typecheck` (`bunx tsc --noEmit`) script to `assistant/package.json`
- Add `test:stable` (`EXCLUDE_EXPERIMENTAL=true bash scripts/test.sh`) script to `assistant/package.json`
- Gateway already has `typecheck` and `test` — no changes needed there

## Before/After
- **Before:** No `typecheck` or `test:stable` script in assistant; validation required manual commands
- **After:** Both packages have clear, consistent entry points for refactor validation

## Test plan
- [x] `bun run typecheck` runs successfully (reports pre-existing type errors, not introduced here)
- [x] Gateway already has matching scripts

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
