### PR TITLE
test(swarm): add concurrent recursion guard tests with true overlap

### DIFF
--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Gate that the SDK mock waits on, letting us hold a swarm active while
+// attempting a second invocation.
+// ---------------------------------------------------------------------------
+
+let gate: { promise: Promise<void>; resolve: () => void } | null = null;
+
+function openGate() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  gate = { promise, resolve };
+}
+
+function closeGate() {
+  gate?.resolve();
+  gate = null;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports
+// ---------------------------------------------------------------------------
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../config/loader.js', () => ({
+  getConfig: () => ({
+    provider: 'anthropic',
+    apiKeys: { anthropic: 'test-key' },
+    swarm: {
+      enabled: true,
+      maxWorkers: 3,
+      maxTasks: 8,
+      maxRetriesPerTask: 1,
+      workerTimeoutSec: 900,
+      plannerModel: 'claude-haiku-4-5-20251001',
+      synthesizerModel: 'claude-sonnet-4-5-20250929',
+    },
+  }),
+}));
+
+mock.module('../providers/registry.js', () => ({
+  getProvider: () => ({
+    name: 'test',
+    async sendMessage() {
+      return {
+        content: [{ type: 'text', text: '{"tasks":[{"id":"t1","role":"coder","objective":"Do it","dependencies":[]}]}' }],
+        model: 'test',
+        usage: { inputTokens: 10, outputTokens: 10 },
+        stopReason: 'end_turn',
+      };
+    },
+  }),
+}));
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () => ({
+    async *[Symbol.asyncIterator]() {
+      // If a gate is open, wait on it — this holds the swarm active
+      if (gate) await gate.promise;
+      yield {
+        type: 'result' as const,
+        session_id: 'test-session',
+        subtype: 'success' as const,
+        result: '```json\n{"summary":"Done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+      };
+    },
+  }),
+}));
+
+import { swarmDelegateTool, _resetSwarmActive } from '../tools/swarm/delegate.js';
+import type { ToolContext } from '../tools/types.js';
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    sessionId: 'test-session',
+    conversationId: 'test-conv',
+    workingDir: '/tmp/test',
+    onOutput: () => {},
+    ...overrides,
+  } as ToolContext;
+}
+
+describe('swarm recursion guard (concurrent)', () => {
+  beforeEach(() => {
+    _resetSwarmActive();
+    closeGate();
+  });
+
+  test('rejects second invocation on same session while first is still active', async () => {
+    openGate();
+
+    // Start first swarm — it will pause at the SDK mock
+    const first = swarmDelegateTool.execute(
+      { objective: 'First task' },
+      makeContext({ sessionId: 'session-A' }),
+    );
+
+    // Yield to let first reach the SDK gate (executeSwarm path)
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Second invocation on the same session should be rejected
+    const second = await swarmDelegateTool.execute(
+      { objective: 'Second task' },
+      makeContext({ sessionId: 'session-A' }),
+    );
+    expect(second.isError).toBe(true);
+    expect(second.content).toContain('already executing');
+
+    // Release the gate so first completes
+    closeGate();
+    const firstResult = await first;
+    expect(firstResult.isError).toBeFalsy();
+  });
+
+  test('allows concurrent swarms on different sessions', async () => {
+    openGate();
+
+    // Start first swarm on session A
+    const first = swarmDelegateTool.execute(
+      { objective: 'Session A task' },
+      makeContext({ sessionId: 'session-A' }),
+    );
+
+    // Yield to let first reach the gate
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Release the gate before starting session B so both can complete
+    closeGate();
+
+    // Second swarm on a different session should succeed
+    const second = await swarmDelegateTool.execute(
+      { objective: 'Session B task' },
+      makeContext({ sessionId: 'session-B' }),
+    );
+    expect(second.isError).toBeFalsy();
+
+    const firstResult = await first;
+    expect(firstResult.isError).toBeFalsy();
+  });
+
+  test('guard is released after first swarm completes', async () => {
+    // Run and complete first swarm (no gate)
+    const first = await swarmDelegateTool.execute(
+      { objective: 'First task' },
+      makeContext({ sessionId: 'session-A' }),
+    );
+    expect(first.isError).toBeFalsy();
+
+    // Same session should now be allowed again
+    const second = await swarmDelegateTool.execute(
+      { objective: 'Second task' },
+      makeContext({ sessionId: 'session-A' }),
+    );
+    expect(second.isError).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `swarm-recursion.test.ts` with deferred promise gate to hold a swarm active during test
- Tests: same-session rejection during overlap, different-session concurrent success, guard release after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
