### PR TITLE
fix(memory): prevent old messages resolving newer pending conflicts

### DIFF
--- a/assistant/src/__tests__/memory-v2-regressions.test.ts
+++ b/assistant/src/__tests__/memory-v2-regressions.test.ts
@@ -1220,6 +1220,10 @@ describe('Memory V2 regressions', () => {
         candidateItemId: 'item-conflict-candidate',
         relationship: 'ambiguous_contradiction',
       });
+      db.update(memoryItemConflicts)
+        .set({ createdAt: now, updatedAt: now })
+        .where(eq(memoryItemConflicts.id, conflict.id))
+        .run();
 
       enqueueResolvePendingConflictsForMessageJob('msg-conflicts-bg', 'scope-conflicts');
       const processed = await runMemoryJobsOnce();
@@ -1242,6 +1246,101 @@ describe('Memory V2 regressions', () => {
       expect(candidate?.status).toBe('active');
       expect(updatedConflict?.status).toBe('resolved_keep_candidate');
       expect(updatedConflict?.resolutionNote).toContain('Background message resolver');
+    } finally {
+      TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
+    }
+  });
+
+  test('background conflict resolver ignores conflicts created after triggering message', async () => {
+    const db = getDb();
+    const now = 1_700_001_300_000;
+    const originalConflictsEnabled = TEST_CONFIG.memory.conflicts.enabled;
+    TEST_CONFIG.memory.conflicts.enabled = true;
+
+    try {
+      db.insert(conversations).values({
+        id: 'conv-conflicts-age',
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+        contextCompactedAt: null,
+      }).run();
+
+      db.insert(messages).values({
+        id: 'msg-conflicts-age',
+        conversationId: 'conv-conflicts-age',
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Keep the new one instead.' }]),
+        createdAt: now + 1,
+      }).run();
+
+      db.insert(memoryItems).values([
+        {
+          id: 'item-conflict-existing-age',
+          kind: 'preference',
+          subject: 'runtime',
+          statement: 'Use Node.js 20 by default.',
+          status: 'active',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-existing-age',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-age',
+          firstSeenAt: now - 10_000,
+          lastSeenAt: now - 5_000,
+          validFrom: now - 10_000,
+          invalidAt: null,
+        },
+        {
+          id: 'item-conflict-candidate-age',
+          kind: 'preference',
+          subject: 'runtime',
+          statement: 'Use Bun by default.',
+          status: 'pending_clarification',
+          confidence: 0.8,
+          fingerprint: 'fp-conflict-candidate-age',
+          verificationState: 'assistant_inferred',
+          scopeId: 'scope-conflicts-age',
+          firstSeenAt: now - 9_000,
+          lastSeenAt: now - 4_000,
+          validFrom: now - 9_000,
+          invalidAt: null,
+        },
+      ]).run();
+
+      const conflict = createOrUpdatePendingConflict({
+        scopeId: 'scope-conflicts-age',
+        existingItemId: 'item-conflict-existing-age',
+        candidateItemId: 'item-conflict-candidate-age',
+        relationship: 'ambiguous_contradiction',
+      });
+      expect(conflict.createdAt).toBeGreaterThan(now + 1);
+
+      enqueueResolvePendingConflictsForMessageJob('msg-conflicts-age', 'scope-conflicts-age');
+      const processed = await runMemoryJobsOnce();
+      expect(processed).toBe(1);
+
+      const existing = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-existing-age'))
+        .get();
+      const candidate = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, 'item-conflict-candidate-age'))
+        .get();
+      const updatedConflict = getConflictById(conflict.id);
+
+      expect(existing?.status).toBe('active');
+      expect(existing?.invalidAt).toBeNull();
+      expect(candidate?.status).toBe('pending_clarification');
+      expect(updatedConflict?.status).toBe('pending_clarification');
+      expect(updatedConflict?.resolutionNote).toBeNull();
     } finally {
       TEST_CONFIG.memory.conflicts.enabled = originalConflictsEnabled;
     }

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -394,6 +394,7 @@ async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: Assi
       id: messages.id,
       role: messages.role,
       content: messages.content,
+      createdAt: messages.createdAt,
     })
     .from(messages)
     .where(eq(messages.id, messageId))
@@ -404,10 +405,11 @@ async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: Assi
   if (userMessage.length === 0) return;
 
   const pending = listPendingConflictDetails(scopeId, 25);
-  if (pending.length === 0) return;
+  const eligible = pending.filter((conflict) => conflict.createdAt <= message.createdAt);
+  if (eligible.length === 0) return;
 
   let resolvedCount = 0;
-  for (const conflict of pending) {
+  for (const conflict of eligible) {
     const resolution = await resolveConflictClarification(
       {
         existingStatement: conflict.existingStatement,
@@ -430,6 +432,7 @@ async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: Assi
     messageId,
     scopeId,
     pendingConflicts: pending.length,
+    eligibleConflicts: eligible.length,
     resolvedConflicts: resolvedCount,
   }, 'Processed pending conflict resolution job');
 }


### PR DESCRIPTION
## Summary
- address feedback on #2429 about stale message jobs resolving newly-created conflicts
- include  in the background resolver job query
- only resolve pending conflicts whose  is at or before the triggering message timestamp
- add regression coverage for the stale-message/new-conflict case and backdate the existing positive-path test fixture explicitly

## Testing
- cd assistant && bun test src/__tests__/memory-v2-regressions.test.ts --test-name-pattern "background conflict resolver"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
