### PR TITLE
style(css): add subtle radial gradient to dark mode page background

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -183,6 +183,14 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+@media (prefers-color-scheme: dark) {
+  body {
+    background:
+      radial-gradient(ellipse at 50% 0%, var(--v-slate-900) 0%, transparent 50%),
+      var(--v-bg);
+  }
+}
+
 h1, h2, h3, h4, h5, h6 {
   line-height: 1.2;
   margin: 0 0 var(--v-spacing-md) 0;


### PR DESCRIPTION
## Summary
- Add a subtle radial gradient to the dark mode body background in `vellum-design-system.css` — soft slate-900 glow at the top center fading to the standard slate-950 by 50% of the viewport
- Adds visual depth to dynamic pages without introducing new colors or clashing with content
- Layered in `@layer vellum-design-system` so any page that explicitly sets its own background overrides it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
