### PR TITLE
fix(swarm): allow silent truncation of dropped dependencies

### DIFF
--- a/assistant/src/__tests__/swarm-plan-validator.test.ts
+++ b/assistant/src/__tests__/swarm-plan-validator.test.ts
@@ -188,6 +188,29 @@ describe('validateAndNormalizePlan', () => {
     expect(result.tasks[4].id).toBe('t4');
   });
 
+  test('strips dependencies that point to tasks removed by truncation', () => {
+    const plan = makePlan({
+      tasks: [
+        { id: 't0', role: 'coder', objective: 'Task 0', dependencies: [] },
+        { id: 't1', role: 'coder', objective: 'Task 1', dependencies: ['t4'] },
+        { id: 't2', role: 'reviewer', objective: 'Task 2', dependencies: ['t0'] },
+        { id: 't3', role: 'coder', objective: 'Task 3', dependencies: [] },
+        { id: 't4', role: 'coder', objective: 'Task 4', dependencies: [] },
+      ],
+    });
+    const limits = resolveSwarmLimits({
+      maxWorkers: 3,
+      maxTasks: 3,
+      maxRetriesPerTask: 1,
+      workerTimeoutSec: 900,
+    });
+
+    const result = validateAndNormalizePlan(plan, limits);
+    expect(result.tasks).toHaveLength(3);
+    const t1 = result.tasks.find((task) => task.id === 't1');
+    expect(t1?.dependencies).toEqual([]);
+  });
+
   test('rejects empty objective', () => {
     const plan = makePlan({ objective: '' });
     try {

--- a/assistant/src/swarm/plan-validator.ts
+++ b/assistant/src/swarm/plan-validator.ts
@@ -36,6 +36,7 @@ export function validateAndNormalizePlan(
     ...t,
     dependencies: Array.isArray(t.dependencies) ? t.dependencies : [],
   }));
+  const originalIds = new Set(tasks.map((task) => task.id));
 
   // --- Task count limit (silent truncation) ---
   if (tasks.length > limits.maxTasks) {
@@ -69,7 +70,9 @@ export function validateAndNormalizePlan(
     const valid: string[] = [];
     for (const dep of task.dependencies) {
       if (!ids.has(dep)) {
-        issues.push(`Task "${task.id}" depends on unknown task "${dep}".`);
+        if (!originalIds.has(dep)) {
+          issues.push(`Task "${task.id}" depends on unknown task "${dep}".`);
+        }
       } else {
         valid.push(dep);
       }


### PR DESCRIPTION
## Summary
- address feedback on #2430 for dependency validation after task truncation
- preserve the original task-id set before truncation
- treat dependencies pointing to truncated-away tasks as removable orphans, not validation errors
- continue raising errors for truly unknown dependency ids
- add a regression test that validates truncation strips dropped dependencies without throwing

## Testing
- cd assistant && bun test src/__tests__/swarm-plan-validator.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
