### PR TITLE
chore: regenerate IPC Swift bindings

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -315,6 +315,7 @@ public struct IPCFormSurfaceData: Codable, Sendable {
 
 public struct IPCGenerationCancelled: Codable, Sendable {
     public let type: String
+    public let sessionId: String?
 }
 
 public struct IPCGenerationHandoff: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to include the optional `sessionId` field added to `GenerationCancelled` in #2461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
