### PR TITLE
test(swarm): cover researcher Bash denial policy

### DIFF
--- a/assistant/src/__tests__/swarm-worker-backend.test.ts
+++ b/assistant/src/__tests__/swarm-worker-backend.test.ts
@@ -61,10 +61,11 @@ describe('getProfilePolicy', () => {
       }
     });
 
-    test('denies write tools', () => {
+    test('denies write tools and Bash', () => {
       for (const tool of WRITE_TOOLS) {
         expect(policy.deny.has(tool)).toBe(true);
       }
+      expect(policy.deny.has('Bash')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- follow up #2431 feedback path: code fix already landed in #2450, but test coverage did not assert researcher Bash denial
- extend worker backend policy tests to explicitly require Bash in researcher deny set

## Testing
- cd assistant && bun test src/__tests__/swarm-worker-backend.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
