### PR TITLE
fix: resolve 27 eslint errors

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -36,7 +36,6 @@ import {
   uploadAttachment,
   linkAttachmentToMessage,
   getAttachmentsForMessageUnscoped,
-  deleteOrphanAttachments,
 } from '../memory/attachments-store.js';
 
 // Initialize db once before all tests

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -19,6 +19,7 @@ mock.module('../util/logger.js', () => ({
 import { DeleteManagedSkillTool } from '../tools/skills/delete-managed.js';
 import type { ToolContext } from '../tools/types.js';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
 const tool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
 
 function makeContext(): ToolContext {

--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -238,7 +238,9 @@ describe('handleCuObservation blob hydration', () => {
     // Should send cu_error
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('cu_error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing union-narrowed property
     expect((sent[0] as any).message).toContain('Failed to hydrate axTreeBlob');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((sent[0] as any).message).toContain('no inline fallback');
   });
 
@@ -288,6 +290,7 @@ describe('handleCuObservation blob hydration', () => {
     // Should send cu_error
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('cu_error');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing union-narrowed property
     expect((sent[0] as any).message).toContain('Failed to hydrate screenshotBlob');
   });
 

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -73,7 +73,9 @@ import { loadSkillCatalog } from '../config/skills.js';
 import { buildSystemPrompt } from '../config/system-prompt.js';
 import type { ToolContext } from '../tools/types.js';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
 const scaffoldTool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const deleteTool = new (DeleteManagedSkillTool as any)() as InstanceType<typeof DeleteManagedSkillTool>;
 
 function makeContext(): ToolContext {
@@ -200,7 +202,9 @@ describe('managed skill lifecycle: scaffold → catalog → prompt → delete', 
 
   test('evaluate → scaffold → skill_load chain: literal tool execution', async () => {
     const ctx = makeContext();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
     const evalTool = new (EvaluateTypescriptTool as any)() as InstanceType<typeof EvaluateTypescriptTool>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const skillLoadTool = new (SkillLoadTool as any)() as InstanceType<typeof SkillLoadTool>;
 
     // Step 1: Run evaluate_typescript_code with code that returns skill metadata

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -18,8 +18,6 @@ mock.module('../util/logger.js', () => ({
 
 import {
   validateManagedSkillId,
-  getManagedSkillsDir,
-  getManagedSkillDir,
   buildSkillMarkdown,
   upsertSkillsIndexEntry,
   removeSkillsIndexEntry,

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -20,6 +20,7 @@ import { ScaffoldManagedSkillTool } from '../tools/skills/scaffold-managed.js';
 import type { ToolContext } from '../tools/types.js';
 
 // Use internal class directly to avoid registry side effects
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- bypass private constructor for testing
 const tool = new (ScaffoldManagedSkillTool as any)() as InstanceType<typeof ScaffoldManagedSkillTool>;
 
 function makeContext(): ToolContext {

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1084,6 +1084,7 @@ describe('Surface-action queue-full trace', () => {
     expect(session.getQueueDepth()).toBe(MAX_QUEUE_DEPTH);
 
     // Register a pending surface action so handleSurfaceAction doesn't bail early
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access private property for testing
     (session as any).pendingSurfaceActions.set('surf-1', { surfaceType: 'confirmation' });
 
     // Trigger the surface action — queue is full, should be rejected
@@ -1100,6 +1101,7 @@ describe('Surface-action queue-full trace', () => {
     );
     expect(errorTrace).toBeDefined();
     expect(errorTrace).toHaveProperty('attributes');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access trace attributes
     const attrs = (errorTrace as any).attributes;
     expect(attrs.reason).toBe('queue_full');
     expect(attrs.source).toBe('surface_action');
@@ -1240,6 +1242,7 @@ describe('Session attachment event payloads', () => {
       content: 'ok',
       isError: false,
       contentBlocks: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock content block
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
       ],
     });
@@ -1283,6 +1286,7 @@ describe('Session attachment event payloads', () => {
       content: 'ok',
       isError: false,
       contentBlocks: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock content block
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0K' } } as any,
       ],
     });

--- a/assistant/src/__tests__/swarm-plan-validator.test.ts
+++ b/assistant/src/__tests__/swarm-plan-validator.test.ts
@@ -82,6 +82,7 @@ describe('validateAndNormalizePlan', () => {
   test('rejects invalid role', () => {
     const plan = makePlan({
       tasks: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid role
         { id: 'bad', role: 'hacker' as any, objective: 'Hack', dependencies: [] },
       ],
     });
@@ -228,6 +229,7 @@ describe('validateAndNormalizePlan', () => {
     const plan: SwarmPlan = {
       objective: 'Test',
       tasks: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing missing dependencies
         { id: 'a', role: 'coder', objective: 'A', dependencies: undefined as any },
       ],
     };
@@ -239,6 +241,7 @@ describe('validateAndNormalizePlan', () => {
     const plan = makePlan({
       objective: '',
       tasks: [
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid role
         { id: 'a', role: 'invalid' as any, objective: 'A', dependencies: ['nonexistent'] },
         { id: 'a', role: 'coder', objective: 'B', dependencies: [] },
       ],

--- a/assistant/src/__tests__/swarm-router-planner.test.ts
+++ b/assistant/src/__tests__/swarm-router-planner.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import { generatePlan, parsePlanJSON, makeFallbackPlan } from '../swarm/router-planner.js';
 import { resolveSwarmLimits } from '../swarm/limits.js';
-import type { Provider, ProviderResponse, Message, ToolDefinition, SendMessageOptions } from '../providers/types.js';
+import type { Provider, ProviderResponse } from '../providers/types.js';
 
 const DEFAULT_LIMITS = resolveSwarmLimits({
   maxWorkers: 3,

--- a/assistant/src/__tests__/swarm-worker-runner.test.ts
+++ b/assistant/src/__tests__/swarm-worker-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import { runWorkerTask } from '../swarm/worker-runner.js';
 import { parseWorkerOutput, buildWorkerPrompt } from '../swarm/worker-prompts.js';
 import type { SwarmWorkerBackend, SwarmWorkerBackendInput } from '../swarm/worker-backend.js';

--- a/assistant/src/__tests__/terminal-sandbox.integration.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.integration.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -6,10 +6,8 @@ import { getConfig } from '../config/loader.js';
 import { estimateTextTokens } from '../context/token-estimator.js';
 import { getLogger } from '../util/logger.js';
 import {
-  getMemoryCheckpoint,
   readMessageCursorCheckpoint,
   resetMessageCursorCheckpoint,
-  setMemoryCheckpoint,
   writeMessageCursorCheckpoint,
 } from './checkpoints.js';
 import { embedWithBackend, getMemoryBackendStatus } from './embedding-backend.js';

--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -169,7 +169,7 @@ export class EvaluateTypescriptTool implements Tool {
     timeoutSec: number,
     timeoutMs: number,
     maxOutputChars: number,
-    context: ToolContext,
+    _context: ToolContext,
   ): Promise<EvalResult> {
     return new Promise<EvalResult>((resolve) => {
       const startTime = Date.now();


### PR DESCRIPTION
## Summary
- Remove unused imports across 6 files (test + production code)
- Prefix unused parameter `context` → `_context` in `evaluate-typescript.ts`
- Add `eslint-disable-next-line` for intentional `as any` usage in test files (private constructor bypass, union property access, invalid input testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
