### PR TITLE
fix(swarm): pass abort signal to worker retry invocations

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -113,6 +113,7 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
           workingDir,
           model,
           timeoutMs: limits.workerTimeoutSec * 1000,
+          signal,
         });
       }
       result.retryCount = retries;


### PR DESCRIPTION
## Summary
- Pass `signal` parameter to `runWorkerTask` in the retry loop of `orchestrator.ts`
- Previously only the initial invocation received the signal; retries could not be aborted
- Addresses P2 finding: cancellation semantics inconsistent under in-flight abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
