### PR TITLE
fix(swarm): treat aborted backend iteration as failure not success

### DIFF
--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -78,6 +78,11 @@ function createClaudeCodeBackend(): SwarmWorkerBackend {
           }
         }
 
+        // Treat abort as cancellation, not success
+        if (input.signal?.aborted) {
+          return { success: false, output: 'Cancelled (aborted)', failureReason: 'timeout' as const, durationMs: Date.now() - start };
+        }
+
         return { success: true, output: resultText || 'Completed', durationMs: Date.now() - start };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Check `input.signal?.aborted` after the backend iteration loop in `delegate.ts`
- Return `{ success: false, failureReason: 'timeout' }` instead of `{ success: true }` when aborted
- Prevents aborted work from being incorrectly marked as completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
