### PR TITLE
fix(swarm): isolate status callback failures and parse final JSON block

### DIFF
--- a/assistant/src/__tests__/swarm-worker-runner.test.ts
+++ b/assistant/src/__tests__/swarm-worker-runner.test.ts
@@ -109,6 +109,20 @@ describe('runWorkerTask', () => {
     expect(statuses).toEqual(['queued', 'failed']);
   });
 
+  test('continues execution when onStatus callback throws', async () => {
+    const result = await runWorkerTask({
+      task: makeTask(),
+      backend: makeBackend(),
+      workingDir: '/tmp',
+      timeoutMs: 5000,
+      onStatus: () => {
+        throw new Error('status callback failed');
+      },
+    });
+    expect(result.status).toBe('completed');
+    expect(result.summary).toBe('Done');
+  });
+
   test('maps role to correct profile in prompt', async () => {
     let capturedInput: SwarmWorkerBackendInput | null = null;
     await runWorkerTask({
@@ -171,6 +185,23 @@ describe('parseWorkerOutput', () => {
     const raw = 'x'.repeat(1000);
     const result = parseWorkerOutput(raw);
     expect(result.summary.length).toBe(500);
+  });
+
+  test('uses the final fenced JSON block when multiple are present', () => {
+    const raw = [
+      '```json',
+      '{"summary":"intermediate","artifacts":["a.ts"],"issues":[],"nextSteps":[]}',
+      '```',
+      '',
+      '```json',
+      '{"summary":"final","artifacts":["b.ts"],"issues":["warn"],"nextSteps":["ship"]}',
+      '```',
+    ].join('\n');
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe('final');
+    expect(result.artifacts).toEqual(['b.ts']);
+    expect(result.issues).toEqual(['warn']);
+    expect(result.nextSteps).toEqual(['ship']);
   });
 });
 

--- a/assistant/src/swarm/worker-prompts.ts
+++ b/assistant/src/swarm/worker-prompts.ts
@@ -49,7 +49,8 @@ If you cannot produce valid JSON, just write a plain-text summary.`;
  * Prefers a fenced JSON block; falls back to treating the entire output as a summary.
  */
 export function parseWorkerOutput(raw: string): Pick<SwarmTaskResult, 'summary' | 'artifacts' | 'issues' | 'nextSteps'> {
-  const jsonMatch = raw.match(/```json\s*\n([\s\S]*?)\n```/);
+  const jsonBlocks = Array.from(raw.matchAll(/```json\s*\n([\s\S]*?)\n```/g));
+  const jsonMatch = jsonBlocks.length > 0 ? jsonBlocks[jsonBlocks.length - 1] : null;
   if (jsonMatch) {
     try {
       const parsed = JSON.parse(jsonMatch[1]);

--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -21,6 +21,19 @@ export interface RunWorkerTaskOptions {
   signal?: AbortSignal;
 }
 
+function emitStatus(
+  onStatus: WorkerStatusCallback | undefined,
+  taskId: string,
+  status: WorkerStatusKind,
+): void {
+  if (!onStatus) return;
+  try {
+    onStatus(taskId, status);
+  } catch {
+    // Observer failures must not abort worker execution.
+  }
+}
+
 /**
  * Execute a single swarm worker task through the given backend.
  * Returns a normalized SwarmTaskResult regardless of success or failure.
@@ -42,11 +55,11 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
     };
   }
 
-  onStatus?.(task.id, 'queued');
+  emitStatus(onStatus, task.id, 'queued');
 
   // Check backend availability
   if (!backend.isAvailable()) {
-    onStatus?.(task.id, 'failed');
+    emitStatus(onStatus, task.id, 'failed');
     return {
       taskId: task.id,
       status: 'failed',
@@ -60,7 +73,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
     };
   }
 
-  onStatus?.(task.id, 'running');
+  emitStatus(onStatus, task.id, 'running');
 
   const prompt = buildWorkerPrompt({
     role: task.role,
@@ -91,7 +104,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
     const raceResult = await Promise.race([backendPromise, timeoutPromise]);
 
     if (raceResult === 'timeout') {
-      onStatus?.(task.id, 'failed');
+      emitStatus(onStatus, task.id, 'failed');
       return {
         taskId: task.id,
         status: 'failed',
@@ -109,7 +122,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
 
     if (result.success) {
       const parsed = parseWorkerOutput(result.output);
-      onStatus?.(task.id, 'completed');
+      emitStatus(onStatus, task.id, 'completed');
       return {
         taskId: task.id,
         status: 'completed',
@@ -121,7 +134,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
     }
 
     // Backend returned a failure
-    onStatus?.(task.id, 'failed');
+    emitStatus(onStatus, task.id, 'failed');
     return {
       taskId: task.id,
       status: 'failed',
@@ -134,7 +147,7 @@ export async function runWorkerTask(opts: RunWorkerTaskOptions): Promise<SwarmTa
       retryCount: 0,
     };
   } catch (err) {
-    onStatus?.(task.id, 'failed');
+    emitStatus(onStatus, task.id, 'failed');
     const message = err instanceof Error ? err.message : String(err);
     return {
       taskId: task.id,


### PR DESCRIPTION
## Summary
- address #2432 follow-up feedback
- guard worker status callback invocations so observer exceptions cannot abort task execution
- parse the final fenced JSON block from worker output instead of the first block
- add regression tests for callback-throw isolation and final-block parsing

## Testing
- cd assistant && bun test src/__tests__/swarm-worker-runner.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
