### PR TITLE
fix(test): align Docker shell resolution test with error message

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox-docker.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox-docker.test.ts
@@ -695,7 +695,7 @@ describe('DockerBackend — preflight: shell resolution', () => {
     const backend = new DockerBackend(sandboxRoot, undefined, 1000, 1000);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(ToolError);
     expect(() => backend.wrap('ls', sandboxRoot)).toThrow(
-      'Neither "bash" nor "sh" is available',
+      'is not available in Docker image',
     );
   });
 


### PR DESCRIPTION
## Summary
- Update expected error substring in `terminal-sandbox-docker.test.ts` to match the actual error message from `docker.ts`
- The default shell is `sh`, so when both shells fail, the `sh`-specific error branch fires instead of the "Neither" branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
