### PR TITLE
fix(swarm): skip synthesis when signal is aborted

### DIFF
--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -159,20 +159,24 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     }
   }
 
-  // Synthesize final answer
-  onStatus?.({ kind: 'synthesis_started' });
+  // Synthesize final answer (skip if aborted — no point calling the model)
   const allResults = Array.from(results.values());
 
   let finalAnswer: string;
-  if (opts.synthesisProvider) {
-    finalAnswer = await synthesizeResults({
-      objective: plan.objective,
-      results: allResults,
-      provider: opts.synthesisProvider,
-      model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
-    });
+  if (signal?.aborted) {
+    finalAnswer = 'Swarm cancelled before synthesis.';
   } else {
-    finalAnswer = buildMarkdownFallback(plan.objective, allResults);
+    onStatus?.({ kind: 'synthesis_started' });
+    if (opts.synthesisProvider) {
+      finalAnswer = await synthesizeResults({
+        objective: plan.objective,
+        results: allResults,
+        provider: opts.synthesisProvider,
+        model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
+      });
+    } else {
+      finalAnswer = buildMarkdownFallback(plan.objective, allResults);
+    }
   }
 
   const totalDurationMs = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- Guard synthesis behind `signal?.aborted` check in `orchestrator.ts`
- When aborted, return `'Swarm cancelled before synthesis.'` instead of calling the synthesizer model
- Prevents wasted API calls and `synthesis_started`/`done` events after cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
