### PR TITLE
fix(memory): allow directional replies for recently asked conflicts

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -339,6 +339,47 @@ describe('Session conflict soft gate', () => {
     expect(events.some((event) => event.type === 'message_complete')).toBe(true);
   });
 
+  test('recently asked conflicts still resolve directional clarification replies', async () => {
+    pendingConflicts = [{
+      id: 'conflict-followup',
+      scopeId: 'default',
+      existingItemId: 'existing-followup',
+      candidateItemId: 'candidate-followup',
+      relationship: 'ambiguous_contradiction',
+      status: 'pending_clarification',
+      clarificationQuestion: 'Should I assume Postgres or MySQL?',
+      resolutionNote: null,
+      lastAskedAt: null,
+      resolvedAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      existingStatement: 'Use Postgres as the default database.',
+      candidateStatement: 'Use MySQL as the default database.',
+    }];
+
+    const session = makeSession();
+    await session.loadFromDb();
+
+    // First turn asks the clarification and records it as asked.
+    await session.processMessage('Should I assume Postgres or MySQL?', [], () => {});
+    expect(resolverCallCount).toBe(1);
+    expect(markAskedCalls).toEqual(['conflict-followup']);
+
+    resolverResult = {
+      resolution: 'keep_candidate',
+      strategy: 'heuristic',
+      resolvedStatement: null,
+      explanation: 'Directional clarification received.',
+    };
+
+    // Follow-up reply does not overlap statement tokens but should still resolve.
+    await session.processMessage('Keep the new one.', [], () => {});
+
+    expect(resolverCallCount).toBe(2);
+    expect(markAskedCalls).toEqual(['conflict-followup']);
+    expect(runCalls).toHaveLength(1);
+  });
+
   test('cooldown prevents repeated asks on subsequent turns', async () => {
     pendingConflicts = [{
       id: 'conflict-cooldown',

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -1659,13 +1659,14 @@ export class Session {
     const threshold = conflictConfig.relevanceThreshold;
     const cooldownTurns = Math.max(1, conflictConfig.reaskCooldownTurns);
     const pendingBeforeResolve = listPendingConflictDetails('default', 50);
-    const relevantBeforeResolve = pendingBeforeResolve.filter(
-      (conflict) => computeConflictRelevance(userMessage, conflict) >= threshold,
-    );
+    const candidatesBeforeResolve = pendingBeforeResolve.filter((conflict) => {
+      const relevance = computeConflictRelevance(userMessage, conflict);
+      return relevance >= threshold || this.wasConflictRecentlyAsked(conflict.id, cooldownTurns);
+    });
     await this.resolvePendingConflictsFromUserTurn(
       userMessage,
       conflictConfig.resolverLlmTimeoutMs,
-      relevantBeforeResolve,
+      candidatesBeforeResolve,
     );
 
     const pending = listPendingConflictDetails('default', 50);
@@ -1719,6 +1720,12 @@ export class Session {
     const lastAskedTurn = this.conflictLastAskedTurn.get(conflictId);
     if (lastAskedTurn === undefined) return true;
     return this.conflictTurnCounter - lastAskedTurn >= cooldownTurns;
+  }
+
+  private wasConflictRecentlyAsked(conflictId: string, cooldownTurns: number): boolean {
+    const lastAskedTurn = this.conflictLastAskedTurn.get(conflictId);
+    if (lastAskedTurn === undefined) return false;
+    return this.conflictTurnCounter - lastAskedTurn <= cooldownTurns;
   }
 
   private async surfaceProxyResolver(


### PR DESCRIPTION
## Summary
- address follow-up feedback on #2451
- preserve relevance gating for broad pending-conflict resolution, but include conflicts that were recently asked
- this allows directional clarification replies (for example "keep the new one") to resolve even with zero token overlap
- add session conflict-gate regression coverage for the follow-up clarification turn

## Testing
- cd assistant && bun test src/__tests__/session-conflict-gate.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
