### PR TITLE
fix(test): add managed skill tools to trust store default rules

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -607,6 +607,7 @@ describe('Trust Store', () => {
         'cu_scroll',
         'cu_type_text',
         'cu_wait',
+        'delete_managed_skill',
         'file_edit',
         'file_read',
         'file_write',
@@ -615,6 +616,7 @@ describe('Trust Store', () => {
         'host_file_read',
         'host_file_write',
         'request_computer_control',
+        'scaffold_managed_skill',
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Add `delete_managed_skill` and `scaffold_managed_skill` to the expected default tools list in trust-store test
- These tools were added to the default trust rules but the test expectation wasn't updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
