### PR TITLE
refactor: remove low-risk dead Swift code and assets

### DIFF
--- a/.private/reports/refactor/PR5_NOOP.md
+++ b/.private/reports/refactor/PR5_NOOP.md
@@ -1,0 +1,23 @@
+# PR 5: Remove Low-Risk Swift Dead Code — No-Op Closeout
+
+**Result:** No safe candidates found for deletion.
+
+## Investigation Summary
+
+All files flagged by static analysis turned out to be false positives:
+
+| File | Flagged Reason | Actual Status |
+|------|---------------|---------------|
+| `ComputerUse/ActionVerifier.swift` | `VerifyResult` unreferenced | Used by `Session.swift` |
+| `Inference/ToolDefinitions.swift` | `ToolDefinitions` unreferenced | Has active tests, defines 12 tools |
+| `Ambient/AmbientSyncClient.swift` | `AutomationDecision` unreferenced | Used by `AppDelegate.swift` and `AmbientAgent.swift` |
+| `Onboarding/Interview/ProfileExtractor.swift` | `UserProfile` unreferenced | Used by `InterviewStepView.swift` and `FirstMeetingIntroductionView.swift` |
+
+## Assets
+- `MenuBarIcon` — actively used
+- `AppIcon` — required system icon
+- No unused image assets detected
+
+## Conclusion
+
+The Swift codebase is lean — no high-confidence dead code candidates exist. Revisit in PR 18 final sweep if new files are added during the refactor.


### PR DESCRIPTION
## Summary
- No-op PR: all Swift dead code candidates turned out to be false positives
- Added closeout note at `.private/reports/refactor/PR5_NOOP.md`

## Before/After
- **Before:** 4 files flagged as potentially dead
- **After:** All verified as actively used (ActionVerifier, ToolDefinitions, AmbientSyncClient, ProfileExtractor)

## Test plan
- [x] No code changes — report only

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
