### PR TITLE
chore(knip): exclude nested test directories from inventory

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -4,6 +4,6 @@
     "scripts/**/*.ts"
   ],
   "ignore": [
-    "src/__tests__/**"
+    "src/**/__tests__/**"
   ]
 }

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -3,6 +3,6 @@
     "src/**/*.ts"
   ],
   "ignore": [
-    "src/__tests__/**"
+    "src/**/__tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- address #2460 feedback about noisy dead-code inventory from nested test folders
- update knip ignore globs to  in assistant and gateway
- this excludes all nested test directories, not just top-level src/__tests__

## Validation
- parsed both JSON configs after edit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
