### PR TITLE
fix(memory): prevent profile dedupe from dropping budget-fit fallback

### DIFF
--- a/assistant/src/__tests__/profile-compiler.test.ts
+++ b/assistant/src/__tests__/profile-compiler.test.ts
@@ -217,4 +217,32 @@ describe('profile-compiler', () => {
     expect(estimateTextTokens(limited.text)).toBeLessThanOrEqual(tightBudget);
     expect(limited.selectedCount).toBeLessThan(full.selectedCount);
   });
+
+  test('uses lower-ranked fallback for same subject when top candidate exceeds budget', () => {
+    profileEnabled = true;
+
+    insertItem({
+      id: 'profile-long-primary',
+      kind: 'profile',
+      subject: 'deployment policy',
+      statement: 'Prefer geographically isolated blue-green rollout windows with mandatory canary burn-in and staged health-check gates before each region is promoted.',
+      verificationState: 'user_confirmed',
+      importance: 0.95,
+    });
+    insertItem({
+      id: 'profile-short-fallback',
+      kind: 'profile',
+      subject: 'deployment policy',
+      statement: 'Deploy only on weekdays.',
+      verificationState: 'user_confirmed',
+      importance: 0.7,
+    });
+
+    const budget = estimateTextTokens('[Dynamic User Profile]\n- deployment policy: Deploy only on weekdays.') + 2;
+    const compiled = compileDynamicProfile({ maxInjectTokensOverride: budget });
+
+    expect(compiled.tokenEstimate).toBeLessThanOrEqual(budget);
+    expect(compiled.text).toContain('deployment policy: Deploy only on weekdays.');
+    expect(compiled.text).not.toContain('geographically isolated blue-green rollout');
+  });
 });

--- a/assistant/src/memory/profile-compiler.ts
+++ b/assistant/src/memory/profile-compiler.ts
@@ -79,11 +79,11 @@ export function compileDynamicProfile(options?: CompileProfileOptions): Compiled
     if (!subject || !statement) continue;
     const dedupeKey = `${candidate.kind}|${subject.toLowerCase()}`;
     if (seenKeys.has(dedupeKey)) continue;
-    seenKeys.add(dedupeKey);
 
     const line = `- ${subject}: ${statement}`;
     const tentative = renderProfileText([...selectedLines, line]);
     if (estimateTextTokens(tentative) > budgetTokens) continue;
+    seenKeys.add(dedupeKey);
     selectedLines.push(line);
   }
 


### PR DESCRIPTION
## Summary
- address #2434 follow-up on profile compiler budget handling
- only mark kind/subject dedupe keys as seen after a candidate actually fits within token budget
- this allows lower-ranked same-subject candidates to be selected when a higher-ranked candidate is too large
- add regression coverage for same-subject fallback behavior under tight budgets

## Testing
- cd assistant && bun test src/__tests__/profile-compiler.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
