### PR TITLE
feat: inject active surface context into messages and default to clean launch state

### DIFF
--- a/assistant/src/daemon/handlers.ts
+++ b/assistant/src/daemon/handlers.ts
@@ -461,7 +461,7 @@ async function handleUserMessage(
       attributes: { source: 'user_message' },
     });
 
-    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId);
+    const result = session.enqueueMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId);
     if (result.rejected) {
       rlog.warn('Message rejected — queue is full');
       session.traceEmitter.emit('request_error', 'Message rejected — queue is full', {
@@ -498,7 +498,7 @@ async function handleUserMessage(
     // Fire-and-forget: don't block the IPC handler so the connection can
     // continue receiving messages (e.g. cancel, confirmations, or
     // additional user_message that will be queued by the session).
-    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId).catch((err) => {
+    session.processMessage(msg.content ?? '', msg.attachments ?? [], sendEvent, requestId, msg.activeSurfaceId).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       rlog.error({ err }, 'Error processing user message (session or provider failure)');
       ctx.send(socket, { type: 'error', message: `Failed to process message: ${message}` });

--- a/assistant/src/daemon/ipc-contract.ts
+++ b/assistant/src/daemon/ipc-contract.ts
@@ -21,6 +21,7 @@ export interface UserMessage {
   sessionId: string;
   content?: string;
   attachments?: UserMessageAttachment[];
+  activeSurfaceId?: string;
 }
 
 export interface UserMessageAttachment {

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -72,6 +72,9 @@ const HIGH_RISK_VALIDATORS: Record<string, PropertyValidator> = {
     if (obj.attachments !== undefined && !Array.isArray(obj.attachments)) {
       return 'user_message "attachments" must be an array when present';
     }
+    if (obj.activeSurfaceId !== undefined && typeof obj.activeSurfaceId !== 'string') {
+      return 'user_message "activeSurfaceId" must be a string when present';
+    }
     return null;
   },
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -87,6 +87,7 @@ interface QueuedMessage {
   attachments: UserMessageAttachment[];
   requestId: string;
   onEvent: (msg: ServerMessage) => void;
+  activeSurfaceId?: string;
 }
 
 export const MAX_QUEUE_DEPTH = 10;
@@ -138,6 +139,7 @@ export class Session {
   private conflictLastAskedTurn = new Map<string, number>();
   private hasNoClient = false;
   private messageQueue: QueuedMessage[] = [];
+  private currentActiveSurfaceId?: string;
   private pendingSurfaceActions = new Map<string, {
     surfaceType: SurfaceType;
   }>();
@@ -395,6 +397,7 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId: string,
+    activeSurfaceId?: string,
   ): { queued: boolean; rejected?: boolean; requestId: string } {
     if (!this.processing) {
       return { queued: false, requestId };
@@ -404,7 +407,7 @@ export class Session {
       return { queued: false, rejected: true, requestId };
     }
 
-    this.messageQueue.push({ content, attachments, requestId, onEvent });
+    this.messageQueue.push({ content, attachments, requestId, onEvent, activeSurfaceId });
     return { queued: true, requestId };
   }
 
@@ -767,6 +770,21 @@ export class Session {
             ...runMessages.slice(0, -1),
             injectClarificationRequestIntoUserMessage(userTail, softConflictInstruction),
           ];
+        }
+      }
+
+      // Inject active surface context for workspace refinement
+      if (this.currentActiveSurfaceId) {
+        const stored = this.surfaceState.get(this.currentActiveSurfaceId);
+        if (stored && stored.surfaceType === 'dynamic_page') {
+          const html = (stored.data as DynamicPageSurfaceData).html;
+          const userTail = runMessages[runMessages.length - 1];
+          if (userTail && userTail.role === 'user') {
+            runMessages = [
+              ...runMessages.slice(0, -1),
+              injectActiveSurfaceContext(userTail, this.currentActiveSurfaceId, html),
+            ];
+          }
         }
       }
 
@@ -1182,6 +1200,7 @@ export class Session {
       this.abortController = null;
       this.processing = false;
       this.currentRequestId = undefined;
+      this.currentActiveSurfaceId = undefined;
 
       // Clean up completed/cancelled timers to prevent unbounded map growth
       pruneSessionTimers(this.conversationId);
@@ -1285,6 +1304,9 @@ export class Session {
       return;
     }
 
+    // Set the active surface for the dequeued message so runAgentLoop can inject context
+    this.currentActiveSurfaceId = next.activeSurfaceId;
+
     // Fire-and-forget: persistUserMessage set this.processing = true
     // so subsequent messages will still be enqueued. runAgentLoop's
     // finally block will call drainQueue when this run completes.
@@ -1304,7 +1326,10 @@ export class Session {
     attachments: UserMessageAttachment[],
     onEvent: (msg: ServerMessage) => void,
     requestId?: string,
+    activeSurfaceId?: string,
   ): Promise<string> {
+    this.currentActiveSurfaceId = activeSurfaceId;
+
     // Resolve slash commands before persistence
     const slashResult = this.resolveSlash(content);
 
@@ -2029,6 +2054,30 @@ function injectDynamicProfileIntoUserMessage(message: Message, profileText: stri
     content: [
       ...message.content,
       { type: 'text', text: `\n\n${block}` },
+    ],
+  };
+}
+
+function injectActiveSurfaceContext(message: Message, surfaceId: string, html: string): Message {
+  const MAX_HTML_LENGTH = 100_000;
+  const truncatedHtml = html.length > MAX_HTML_LENGTH
+    ? html.slice(0, MAX_HTML_LENGTH) + `\n<!-- truncated: original is ${html.length} characters -->`
+    : html;
+  const block = [
+    '<active_dynamic_page>',
+    `The user is viewing a dynamic page (surface_id: "${surfaceId}") in workspace mode.`,
+    `To modify this page, call ui_update with surface_id "${surfaceId}" and provide the complete updated HTML in data.html.`,
+    'Preserve all existing content, design tokens, and styling unless the user explicitly asks to change them.',
+    '',
+    'Current HTML:',
+    truncatedHtml,
+    '</active_dynamic_page>',
+  ].join('\n');
+  return {
+    ...message,
+    content: [
+      { type: 'text', text: block },
+      ...message.content,
     ],
   };
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -208,6 +208,14 @@ struct MainWindowView: View {
                 activeDynamicParsedSurface = nil
             }
         }
+        .onChange(of: isDynamicExpanded) { _, expanded in
+            threadManager.activeViewModel?.activeSurfaceId = expanded ? activeDynamicSurface?.surfaceId : nil
+        }
+        .onChange(of: activeDynamicSurface?.surfaceId) { _, surfaceId in
+            if isDynamicExpanded {
+                threadManager.activeViewModel?.activeSurfaceId = surfaceId
+            }
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1,4 +1,5 @@
 import Combine
+import SwiftUI
 import VellumAssistantShared
 import Foundation
 import os
@@ -7,6 +8,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 @MainActor
 final class ThreadManager: ObservableObject {
+    @AppStorage("restoreRecentThreads") private var restoreRecentThreads = false
     @Published var threads: [ThreadModel] = []
     @Published var activeThreadId: UUID? {
         didSet {
@@ -132,6 +134,7 @@ final class ThreadManager: ObservableObject {
     }
 
     private func handleSessionListResponse(_ response: SessionListResponseMessage) {
+        guard restoreRecentThreads else { return }
         guard !response.sessions.isEmpty else { return }
 
         // Load up to 5 most recent sessions (daemon returns them sorted by updatedAt DESC)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -155,6 +155,10 @@ public final class ChatViewModel: ObservableObject {
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
 
+    /// Surface the user is currently viewing in workspace mode.
+    /// Set by MainWindowView when the dynamic workspace is expanded.
+    public var activeSurfaceId: String?
+
     public init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
     }
@@ -496,7 +500,8 @@ public final class ChatViewModel: ObservableObject {
             try daemonClient.send(UserMessageMessage(
                 sessionId: sessionId,
                 content: text,
-                attachments: attachments
+                attachments: attachments,
+                activeSurfaceId: activeSurfaceId
             ))
         } catch {
             log.error("Failed to send user_message: \(error.localizedDescription)")
@@ -617,7 +622,8 @@ public final class ChatViewModel: ObservableObject {
                         try daemonClient.send(UserMessageMessage(
                             sessionId: info.sessionId,
                             content: pending,
-                            attachments: attachments
+                            attachments: attachments,
+                            activeSurfaceId: activeSurfaceId
                         ))
                     } catch {
                         log.error("Failed to send queued user_message: \(error.localizedDescription)")

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1080,6 +1080,7 @@ public struct IPCUserMessage: Codable, Sendable {
     public let sessionId: String
     public let content: String?
     public let attachments: [IPCUserMessageAttachment]?
+    public let activeSurfaceId: String?
 }
 
 public struct IPCUserMessageAttachment: Codable, Sendable {

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -208,8 +208,8 @@ extension IPCSessionCreateRequest {
 public typealias UserMessageMessage = IPCUserMessage
 
 extension IPCUserMessage {
-    public init(sessionId: String, content: String, attachments: [IPCAttachment]?) {
-        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments)
+    public init(sessionId: String, content: String, attachments: [IPCAttachment]?, activeSurfaceId: String? = nil) {
+        self.init(type: "user_message", sessionId: sessionId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId)
     }
 }
 


### PR DESCRIPTION
## Summary
- Pass `activeSurfaceId` through IPC so the daemon injects the current dynamic page HTML into user messages, enabling workspace refinement without manual context
- Default app launch to a single empty "New Thread" instead of restoring the 5 most recent sessions (opt back in via `defaults write com.vellum.vellum-assistant restoreRecentThreads -bool true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
