### PR TITLE
refactor: remove side-effect registration from memory tools

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -6,7 +6,7 @@ import type { ToolDefinition } from '../providers/types.js';
 // We cannot import the private LazyTool class directly, so we test through
 // registerLazyTool + getTool which exercise the same code path.
 import { registerLazyTool, getTool, getAllTools, getAllToolDefinitions, initializeTools } from '../tools/registry.js';
-import { eagerModules, lazyTools } from '../tools/tool-manifest.js';
+import { eagerModules, explicitTools, lazyTools } from '../tools/tool-manifest.js';
 
 function makeFakeTool(name: string): Tool {
   return {
@@ -151,7 +151,14 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(19);
+    expect(eagerModules.length).toBe(18);
+  });
+
+  test('explicit tools list includes memory tools', () => {
+    const names = explicitTools.map((t) => t.name);
+    expect(names).toContain('memory_search');
+    expect(names).toContain('memory_save');
+    expect(names).toContain('memory_update');
   });
 
   test('registered tool count is at least eager + lazy + host', async () => {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -2,7 +2,6 @@ import { RiskLevel } from '../../permissions/types.js';
 import { getConfig } from '../../config/loader.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
 import { memorySearchDefinition, memorySaveDefinition, memoryUpdateDefinition } from './definitions.js';
 import { handleMemorySearch, handleMemorySave, handleMemoryUpdate } from './handlers.js';
 
@@ -60,8 +59,8 @@ class MemoryUpdateTool implements Tool {
   }
 }
 
-// ── Registration ─────────────────────────────────────────────────────
+// ── Exported tool instances ──────────────────────────────────────────
 
-registerTool(new MemorySearchTool());
-registerTool(new MemorySaveTool());
-registerTool(new MemoryUpdateTool());
+export const memorySearchTool = new MemorySearchTool();
+export const memorySaveTool = new MemorySaveTool();
+export const memoryUpdateTool = new MemoryUpdateTool();

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -100,11 +100,16 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  const { eagerModules, lazyTools } = await import('./tool-manifest.js');
+  const { eagerModules, explicitTools, lazyTools } = await import('./tool-manifest.js');
 
   // Import tool modules to trigger registration side effects.
   for (const modulePath of eagerModules) {
     await import(modulePath);
+  }
+
+  // Explicit tool instances — no side-effect import required.
+  for (const tool of explicitTools) {
+    registerTool(tool);
   }
 
   // Host tools are registered explicitly so host access stays opt-in until

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -8,6 +8,8 @@
 
 import { RiskLevel } from '../permissions/types.js';
 import type { LazyToolDescriptor } from './registry.js';
+import type { Tool } from './types.js';
+import { memorySearchTool, memorySaveTool, memoryUpdateTool } from './memory/register.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -23,7 +25,6 @@ export const eagerModules: string[] = [
   './skills/delete-managed.js',
   './browser/headless-browser.js',
   './weather/get-weather.js',
-  './memory/register.js',
   './credentials/vault.js',
   './credentials/account-registry.js',
   './timer/pomodoro.js',
@@ -32,6 +33,16 @@ export const eagerModules: string[] = [
   './schedule/list.js',
   './schedule/update.js',
   './schedule/delete.js',
+];
+
+// ── Explicit tool instances ─────────────────────────────────────────
+// Tools exported as instances — registered by initializeTools() without
+// relying on import side effects.
+
+export const explicitTools: Tool[] = [
+  memorySearchTool,
+  memorySaveTool,
+  memoryUpdateTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Convert memory tools from side-effect `registerTool()` at module level to explicit exports
- Add `explicitTools` array to tool manifest for tools registered without import side effects
- Update `initializeTools()` to iterate `explicitTools` in addition to eager modules
- Add test verifying memory tools are in the explicit tools list

## Before/After
- **Before:** `memory/register.ts` called `registerTool()` at module level; importing the module was required for registration
- **After:** `register.ts` exports tool instances; manifest declares them as explicit tools; no side-effect import needed

## Test plan
- [x] All 11 registry tests pass
- [x] 63 tools still registered in correct order

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
