### PR TITLE
refactor(tools): convert credentials and timer tools to explicit registration

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -151,14 +151,17 @@ describe('tool manifest', () => {
   });
 
   test('eager module list contains expected count', () => {
-    expect(eagerModules.length).toBe(18);
+    expect(eagerModules.length).toBe(15);
   });
 
-  test('explicit tools list includes memory tools', () => {
+  test('explicit tools list includes memory, credential, and timer tools', () => {
     const names = explicitTools.map((t) => t.name);
     expect(names).toContain('memory_search');
     expect(names).toContain('memory_save');
     expect(names).toContain('memory_update');
+    expect(names).toContain('credential_store');
+    expect(names).toContain('account_manage');
+    expect(names).toContain('pomodoro');
   });
 
   test('registered tool count is at least eager + lazy + host', async () => {

--- a/assistant/src/tools/credentials/account-registry.ts
+++ b/assistant/src/tools/credentials/account-registry.ts
@@ -1,7 +1,6 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
 import {
   createAccount,
   listAccounts,
@@ -125,4 +124,4 @@ class AccountManageTool implements Tool {
   }
 }
 
-registerTool(new AccountManageTool());
+export const accountManageTool = new AccountManageTool();

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,7 +1,6 @@
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
 import {
   getSecureKey,
   setSecureKey,
@@ -172,4 +171,4 @@ class CredentialStoreTool implements Tool {
   }
 }
 
-registerTool(new CredentialStoreTool());
+export const credentialStoreTool = new CredentialStoreTool();

--- a/assistant/src/tools/timer/pomodoro.ts
+++ b/assistant/src/tools/timer/pomodoro.ts
@@ -2,7 +2,6 @@ import crypto from 'node:crypto';
 import { RiskLevel } from '../../permissions/types.js';
 import type { Tool, ToolContext, ToolExecutionResult } from '../types.js';
 import type { ToolDefinition } from '../../providers/types.js';
-import { registerTool } from '../registry.js';
 import { getLogger } from '../../util/logger.js';
 
 const log = getLogger('pomodoro');
@@ -384,4 +383,4 @@ class PomodoroTool implements Tool {
   }
 }
 
-registerTool(new PomodoroTool());
+export const pomodoroTool = new PomodoroTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -10,6 +10,9 @@ import { RiskLevel } from '../permissions/types.js';
 import type { LazyToolDescriptor } from './registry.js';
 import type { Tool } from './types.js';
 import { memorySearchTool, memorySaveTool, memoryUpdateTool } from './memory/register.js';
+import { credentialStoreTool } from './credentials/vault.js';
+import { accountManageTool } from './credentials/account-registry.js';
+import { pomodoroTool } from './timer/pomodoro.js';
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // Importing these modules triggers a top-level `registerTool()` call.
@@ -25,9 +28,6 @@ export const eagerModules: string[] = [
   './skills/delete-managed.js',
   './browser/headless-browser.js',
   './weather/get-weather.js',
-  './credentials/vault.js',
-  './credentials/account-registry.js',
-  './timer/pomodoro.js',
   './system/system-info.js',
   './schedule/create.js',
   './schedule/list.js',
@@ -43,6 +43,9 @@ export const explicitTools: Tool[] = [
   memorySearchTool,
   memorySaveTool,
   memoryUpdateTool,
+  credentialStoreTool,
+  accountManageTool,
+  pomodoroTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Convert `credential_store`, `account_manage`, and `pomodoro` tools from side-effect `registerTool()` calls to exported instances
- Move these 3 modules from `eagerModules` to `explicitTools` in `tool-manifest.ts` (18 → 15 eager, 3 → 6 explicit)
- Update registry tests to verify new explicit tool count and names

Part of the Phase 2 refactor plan (PR 9 of 18).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
