### PR TITLE
Automate memory cleanup scheduling with config-driven retention

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -151,6 +151,23 @@ describe('AssistantConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  test('applies memory.cleanup defaults', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.memory.cleanup).toEqual({
+      enabled: true,
+      enqueueIntervalMs: 6 * 60 * 60 * 1000,
+      resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    });
+  });
+
+  test('rejects invalid memory.cleanup.enqueueIntervalMs', () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { cleanup: { enqueueIntervalMs: 0 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
   test('rejects invalid provider', () => {
     const result = AssistantConfigSchema.safeParse({ provider: 'invalid' });
     expect(result.success).toBe(false);

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -61,7 +61,14 @@ import {
   enqueueMemoryJob,
   enqueueResolvePendingConflictsForMessageJob,
 } from '../memory/jobs-store.js';
-import { currentWeekWindow, resetStaleSweepThrottle, runMemoryJobsOnce, sweepStaleItems } from '../memory/jobs-worker.js';
+import {
+  currentWeekWindow,
+  maybeEnqueueScheduledCleanupJobs,
+  resetCleanupScheduleThrottle,
+  resetStaleSweepThrottle,
+  runMemoryJobsOnce,
+  sweepStaleItems,
+} from '../memory/jobs-worker.js';
 import {
   buildMemoryRecall,
   escapeXmlTags,
@@ -107,6 +114,7 @@ describe('Memory regressions', () => {
     db.run('DELETE FROM conversations');
     db.run('DELETE FROM memory_jobs');
     db.run('DELETE FROM memory_checkpoints');
+    resetCleanupScheduleThrottle();
     resetStaleSweepThrottle();
   });
 
@@ -1365,6 +1373,142 @@ describe('Memory regressions', () => {
     const supersededRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, supersededFirst)).get();
     expect(JSON.parse(resolvedRow?.payload ?? '{}')).toMatchObject({ retentionMs: 12_345 });
     expect(JSON.parse(supersededRow?.payload ?? '{}')).toMatchObject({ retentionMs: 67_890 });
+  });
+
+  test('cleanup job enqueue dedupes against running jobs without mutating payload', () => {
+    const db = getDb();
+
+    const resolvedId = enqueueCleanupResolvedConflictsJob(10_000);
+    const supersededId = enqueueCleanupStaleSupersededItemsJob(20_000);
+
+    db.update(memoryJobs)
+      .set({ status: 'running' })
+      .where(eq(memoryJobs.id, resolvedId))
+      .run();
+    db.update(memoryJobs)
+      .set({ status: 'running' })
+      .where(eq(memoryJobs.id, supersededId))
+      .run();
+
+    const resolvedDedupedId = enqueueCleanupResolvedConflictsJob(11_111);
+    const supersededDedupedId = enqueueCleanupStaleSupersededItemsJob(22_222);
+    expect(resolvedDedupedId).toBe(resolvedId);
+    expect(supersededDedupedId).toBe(supersededId);
+
+    const resolvedRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, resolvedId)).get();
+    const supersededRow = db.select().from(memoryJobs).where(eq(memoryJobs.id, supersededId)).get();
+    expect(JSON.parse(resolvedRow?.payload ?? '{}')).toMatchObject({ retentionMs: 10_000 });
+    expect(JSON.parse(supersededRow?.payload ?? '{}')).toMatchObject({ retentionMs: 20_000 });
+  });
+
+  test('scheduled cleanup enqueue respects throttle and config retention values', () => {
+    const db = getDb();
+    const originalCleanup = { ...TEST_CONFIG.memory.cleanup };
+    TEST_CONFIG.memory.cleanup.enabled = true;
+    TEST_CONFIG.memory.cleanup.enqueueIntervalMs = 1_000;
+    TEST_CONFIG.memory.cleanup.resolvedConflictRetentionMs = 12_345;
+    TEST_CONFIG.memory.cleanup.supersededItemRetentionMs = 67_890;
+
+    try {
+      const first = maybeEnqueueScheduledCleanupJobs(TEST_CONFIG, 5_000);
+      expect(first).toBe(true);
+
+      const tooSoon = maybeEnqueueScheduledCleanupJobs(TEST_CONFIG, 5_500);
+      expect(tooSoon).toBe(false);
+
+      const jobsAfterFirst = db.select().from(memoryJobs).all();
+      const resolvedJob = jobsAfterFirst.find((row) => row.type === 'cleanup_resolved_conflicts');
+      const supersededJob = jobsAfterFirst.find((row) => row.type === 'cleanup_stale_superseded_items');
+      expect(resolvedJob).toBeDefined();
+      expect(supersededJob).toBeDefined();
+      expect(JSON.parse(resolvedJob?.payload ?? '{}')).toMatchObject({ retentionMs: 12_345 });
+      expect(JSON.parse(supersededJob?.payload ?? '{}')).toMatchObject({ retentionMs: 67_890 });
+
+      const secondWindow = maybeEnqueueScheduledCleanupJobs(TEST_CONFIG, 6_500);
+      expect(secondWindow).toBe(true);
+      const jobsAfterSecond = db.select().from(memoryJobs).all();
+      expect(jobsAfterSecond.filter((row) => row.type === 'cleanup_resolved_conflicts').length).toBe(1);
+      expect(jobsAfterSecond.filter((row) => row.type === 'cleanup_stale_superseded_items').length).toBe(1);
+    } finally {
+      TEST_CONFIG.memory.cleanup = originalCleanup;
+    }
+  });
+
+  test('cleanup jobs use config retention defaults when payload retention is missing', async () => {
+    const db = getDb();
+    const now = Date.now();
+    const originalCleanup = { ...TEST_CONFIG.memory.cleanup };
+    TEST_CONFIG.memory.cleanup.resolvedConflictRetentionMs = 10_000;
+    TEST_CONFIG.memory.cleanup.supersededItemRetentionMs = 10_000;
+
+    try {
+      db.insert(memoryItems).values([
+        {
+          id: 'cleanup-config-existing',
+          kind: 'fact',
+          subject: 'stack',
+          statement: 'Use Bun',
+          status: 'active',
+          confidence: 0.8,
+          fingerprint: 'fp-cleanup-config-existing',
+          verificationState: 'assistant_inferred',
+          scopeId: 'default',
+          firstSeenAt: now - 20_000,
+          lastSeenAt: now - 20_000,
+        },
+        {
+          id: 'cleanup-config-candidate',
+          kind: 'fact',
+          subject: 'stack',
+          statement: 'Use Node',
+          status: 'pending_clarification',
+          confidence: 0.8,
+          fingerprint: 'fp-cleanup-config-candidate',
+          verificationState: 'assistant_inferred',
+          scopeId: 'default',
+          firstSeenAt: now - 20_000,
+          lastSeenAt: now - 20_000,
+        },
+        {
+          id: 'cleanup-config-stale-item',
+          kind: 'decision',
+          subject: 'deploy strategy',
+          statement: 'Manual deploy Fridays.',
+          status: 'superseded',
+          confidence: 0.7,
+          fingerprint: 'fp-cleanup-config-stale-item',
+          verificationState: 'assistant_inferred',
+          scopeId: 'default',
+          firstSeenAt: now - 200_000,
+          lastSeenAt: now - 200_000,
+          invalidAt: now - 200_000,
+        },
+      ]).run();
+
+      const conflict = createOrUpdatePendingConflict({
+        existingItemId: 'cleanup-config-existing',
+        candidateItemId: 'cleanup-config-candidate',
+        relationship: 'ambiguous_contradiction',
+      });
+      resolveConflict(conflict.id, { status: 'resolved_keep_existing' });
+      db.run(`
+        UPDATE memory_item_conflicts
+        SET resolved_at = ${now - 100_000}, updated_at = ${now - 100_000}
+        WHERE id = '${conflict.id}'
+      `);
+
+      enqueueMemoryJob('cleanup_resolved_conflicts', {});
+      enqueueMemoryJob('cleanup_stale_superseded_items', {});
+      const processed = await runMemoryJobsOnce();
+      expect(processed).toBe(2);
+
+      const conflictRow = db.select().from(memoryItemConflicts).where(eq(memoryItemConflicts.id, conflict.id)).get();
+      const staleItem = db.select().from(memoryItems).where(eq(memoryItems.id, 'cleanup-config-stale-item')).get();
+      expect(conflictRow).toBeUndefined();
+      expect(staleItem).toBeUndefined();
+    } finally {
+      TEST_CONFIG.memory.cleanup = originalCleanup;
+    }
   });
 
   test('cleanup_resolved_conflicts removes stale resolved rows but keeps recent/pending', async () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -71,6 +71,12 @@ export const DEFAULT_CONFIG: AssistantConfig = {
     retention: {
       keepRawForever: true,
     },
+    cleanup: {
+      enabled: true,
+      enqueueIntervalMs: 6 * 60 * 60 * 1000,
+      resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    },
     extraction: {
       useLLM: true,
       model: 'claude-haiku-4-5-20251001',

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -369,6 +369,27 @@ export const MemoryRetentionConfigSchema = z.object({
     .default(true),
 });
 
+export const MemoryCleanupConfigSchema = z.object({
+  enabled: z
+    .boolean({ error: 'memory.cleanup.enabled must be a boolean' })
+    .default(true),
+  enqueueIntervalMs: z
+    .number({ error: 'memory.cleanup.enqueueIntervalMs must be a number' })
+    .int('memory.cleanup.enqueueIntervalMs must be an integer')
+    .positive('memory.cleanup.enqueueIntervalMs must be a positive integer')
+    .default(6 * 60 * 60 * 1000),
+  resolvedConflictRetentionMs: z
+    .number({ error: 'memory.cleanup.resolvedConflictRetentionMs must be a number' })
+    .int('memory.cleanup.resolvedConflictRetentionMs must be an integer')
+    .positive('memory.cleanup.resolvedConflictRetentionMs must be a positive integer')
+    .default(30 * 24 * 60 * 60 * 1000),
+  supersededItemRetentionMs: z
+    .number({ error: 'memory.cleanup.supersededItemRetentionMs must be a number' })
+    .int('memory.cleanup.supersededItemRetentionMs must be an integer')
+    .positive('memory.cleanup.supersededItemRetentionMs must be a positive integer')
+    .default(30 * 24 * 60 * 60 * 1000),
+});
+
 export const MemoryExtractionConfigSchema = z.object({
   useLLM: z
     .boolean({ error: 'memory.extraction.useLLM must be a boolean' })
@@ -531,6 +552,12 @@ export const MemoryConfigSchema = z.object({
   }),
   retention: MemoryRetentionConfigSchema.default({
     keepRawForever: true,
+  }),
+  cleanup: MemoryCleanupConfigSchema.default({
+    enabled: true,
+    enqueueIntervalMs: 6 * 60 * 60 * 1000,
+    resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
   }),
   extraction: MemoryExtractionConfigSchema.default({
     useLLM: true,
@@ -723,6 +750,12 @@ export const AssistantConfigSchema = z.object({
     retention: {
       keepRawForever: true,
     },
+    cleanup: {
+      enabled: true,
+      enqueueIntervalMs: 6 * 60 * 60 * 1000,
+      resolvedConflictRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    },
     extraction: {
       useLLM: true,
       model: 'claude-haiku-4-5-20251001',
@@ -848,6 +881,7 @@ export type MemoryRetrievalConfig = z.infer<typeof MemoryRetrievalConfigSchema>;
 export type MemorySegmentationConfig = z.infer<typeof MemorySegmentationConfigSchema>;
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
+export type MemoryCleanupConfig = z.infer<typeof MemoryCleanupConfigSchema>;
 export type MemoryExtractionConfig = z.infer<typeof MemoryExtractionConfigSchema>;
 export type MemorySummarizationConfig = z.infer<typeof MemorySummarizationConfigSchema>;
 export type MemoryEntityConfig = z.infer<typeof MemoryEntityConfigSchema>;

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -131,11 +131,14 @@ export function enqueueCleanupResolvedConflictsJob(retentionMs?: number): string
   const existing = db
     .select()
     .from(memoryJobs)
-    .where(and(eq(memoryJobs.type, 'cleanup_resolved_conflicts'), eq(memoryJobs.status, 'pending')))
+    .where(and(
+      eq(memoryJobs.type, 'cleanup_resolved_conflicts'),
+      inArray(memoryJobs.status, ['pending', 'running']),
+    ))
     .orderBy(asc(memoryJobs.createdAt))
     .get();
   if (existing) {
-    if (typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
+    if (existing.status === 'pending' && typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
       let payload: Record<string, unknown> = {};
       try {
         payload = JSON.parse(existing.payload) as Record<string, unknown>;
@@ -166,11 +169,14 @@ export function enqueueCleanupStaleSupersededItemsJob(retentionMs?: number): str
   const existing = db
     .select()
     .from(memoryJobs)
-    .where(and(eq(memoryJobs.type, 'cleanup_stale_superseded_items'), eq(memoryJobs.status, 'pending')))
+    .where(and(
+      eq(memoryJobs.type, 'cleanup_stale_superseded_items'),
+      inArray(memoryJobs.status, ['pending', 'running']),
+    ))
     .orderBy(asc(memoryJobs.createdAt))
     .get();
   if (existing) {
-    if (typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
+    if (existing.status === 'pending' && typeof retentionMs === 'number' && Number.isFinite(retentionMs) && retentionMs > 0) {
       let payload: Record<string, unknown> = {};
       try {
         payload = JSON.parse(existing.payload) as Record<string, unknown>;

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -17,6 +17,8 @@ import {
   completeMemoryJob,
   deferMemoryJob,
   enqueueBackfillEntityRelationsJob,
+  enqueueCleanupResolvedConflictsJob,
+  enqueueCleanupStaleSupersededItemsJob,
   enqueueMemoryJob,
   failMemoryJob,
   type MemoryJob,
@@ -63,8 +65,6 @@ const RELATION_BACKFILL_CHECKPOINT_ID_KEY = 'memory:relation_backfill:last_messa
 
 const SUMMARY_LLM_TIMEOUT_MS = 20_000;
 const SUMMARY_MAX_TOKENS = 800;
-const DEFAULT_CONFLICT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
-const DEFAULT_SUPERSEDED_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const CLEANUP_BATCH_LIMIT = 250;
 
 const CONVERSATION_SUMMARY_SYSTEM_PROMPT = [
@@ -109,7 +109,7 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runMemoryJobsOnce();
+      await runMemoryJobsOnce({ enableScheduledCleanup: true });
     } catch (err) {
       log.error({ err }, 'Memory worker tick failed');
     } finally {
@@ -123,7 +123,7 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
 
   return {
     async runOnce(): Promise<number> {
-      return runMemoryJobsOnce();
+      return runMemoryJobsOnce({ enableScheduledCleanup: true });
     },
     stop(): void {
       stopped = true;
@@ -132,16 +132,24 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
   };
 }
 
-export async function runMemoryJobsOnce(): Promise<number> {
+export async function runMemoryJobsOnce(
+  options: { enableScheduledCleanup?: boolean } = {},
+): Promise<number> {
   const config = getConfig();
   if (!config.memory.enabled) return 0;
+  const enableScheduledCleanup = options.enableScheduledCleanup === true;
 
   // Periodic stale item sweep (throttled to at most once per hour)
   sweepStaleItems(config);
 
   const concurrency = Math.max(1, config.memory.jobs.workerConcurrency);
   const jobs = claimMemoryJobs(concurrency);
-  if (jobs.length === 0) return 0;
+  if (jobs.length === 0) {
+    if (enableScheduledCleanup) {
+      maybeEnqueueScheduledCleanupJobs(config);
+    }
+    return 0;
+  }
 
   let processed = 0;
   for (const job of jobs) {
@@ -164,6 +172,9 @@ export async function runMemoryJobsOnce(): Promise<number> {
         log.warn({ err, jobId: job.id, type: job.type }, 'Memory job failed');
       }
     }
+  }
+  if (enableScheduledCleanup) {
+    maybeEnqueueScheduledCleanupJobs(config);
   }
   return processed;
 }
@@ -189,10 +200,10 @@ async function processJob(job: MemoryJob, config: AssistantConfig): Promise<void
       await resolvePendingConflictsForMessageJob(job, config);
       return;
     case 'cleanup_resolved_conflicts':
-      cleanupResolvedConflictsJob(job);
+      cleanupResolvedConflictsJob(job, config);
       return;
     case 'cleanup_stale_superseded_items':
-      cleanupStaleSupersededItemsJob(job);
+      cleanupStaleSupersededItemsJob(job, config);
       return;
     case 'check_contradictions':
       await checkContradictionsJob(job);
@@ -435,9 +446,9 @@ async function resolvePendingConflictsForMessageJob(job: MemoryJob, config: Assi
   }, 'Processed pending conflict resolution job');
 }
 
-function cleanupResolvedConflictsJob(job: MemoryJob): void {
+function cleanupResolvedConflictsJob(job: MemoryJob, config: AssistantConfig): void {
   const db = getDb();
-  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? DEFAULT_CONFLICT_RETENTION_MS;
+  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? config.memory.cleanup.resolvedConflictRetentionMs;
   const cutoff = Date.now() - retentionMs;
   const stale = db
     .select({ id: memoryItemConflicts.id })
@@ -466,9 +477,9 @@ function cleanupResolvedConflictsJob(job: MemoryJob): void {
   }, 'Cleaned up resolved memory conflicts');
 }
 
-function cleanupStaleSupersededItemsJob(job: MemoryJob): void {
+function cleanupStaleSupersededItemsJob(job: MemoryJob, config: AssistantConfig): void {
   const db = getDb();
-  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? DEFAULT_SUPERSEDED_RETENTION_MS;
+  const retentionMs = asPositiveMs(job.payload.retentionMs) ?? config.memory.cleanup.supersededItemRetentionMs;
   const cutoff = Date.now() - retentionMs;
   const stale = db
     .select({ id: memoryItems.id })
@@ -960,6 +971,37 @@ function weekNumber(date: Date): number {
   tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
   const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
   return Math.ceil((((tmp.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+}
+
+// ── Cleanup scheduling ─────────────────────────────────────────────
+
+let lastScheduledCleanupEnqueueMs = 0;
+
+/** Reset the cleanup enqueue throttle so tests can run deterministic checks. */
+export function resetCleanupScheduleThrottle(): void {
+  lastScheduledCleanupEnqueueMs = 0;
+}
+
+/**
+ * Enqueue periodic cleanup jobs using config-driven retention windows.
+ * Enqueue is deduped in jobs-store, so repeated calls remain safe.
+ */
+export function maybeEnqueueScheduledCleanupJobs(config: AssistantConfig, nowMs = Date.now()): boolean {
+  const cleanup = config.memory.cleanup;
+  if (!cleanup.enabled) return false;
+  if (nowMs - lastScheduledCleanupEnqueueMs < cleanup.enqueueIntervalMs) return false;
+
+  const resolvedConflictsJobId = enqueueCleanupResolvedConflictsJob(cleanup.resolvedConflictRetentionMs);
+  const staleSupersededItemsJobId = enqueueCleanupStaleSupersededItemsJob(cleanup.supersededItemRetentionMs);
+  lastScheduledCleanupEnqueueMs = nowMs;
+  log.debug({
+    resolvedConflictsJobId,
+    staleSupersededItemsJobId,
+    enqueueIntervalMs: cleanup.enqueueIntervalMs,
+    resolvedConflictRetentionMs: cleanup.resolvedConflictRetentionMs,
+    supersededItemRetentionMs: cleanup.supersededItemRetentionMs,
+  }, 'Enqueued scheduled memory cleanup jobs');
+  return true;
 }
 
 // ── Stale item sweep ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add  config defaults/schema for periodic cleanup scheduling and retention windows
- make cleanup enqueue dedupe treat  jobs as in-flight and keep payload upgrades for pending jobs
- add background cleanup scheduler hooks in  with throttle + explicit test reset helper
- switch cleanup worker retention fallbacks from hardcoded constants to config values
- add regression tests for scheduler throttle, dedupe behavior, and config-retention cleanup behavior

## Validation
- bun test v1.3.9 (cf6cdbbb)
- bun test v1.3.9 (cf6cdbbb)

## Notes
- broader  contains pre-existing failing experimental tests on ; this PR validates the cleanup-related slices directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
