### PR TITLE
Fix pre-commit secret scanner false positives

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -36,8 +36,12 @@ Automatically checks for plain text keys and secrets before allowing a commit.
 - ✅ Blocks commits containing potential secrets
 - ✅ Provides detailed feedback on what was detected and where
 - ✅ Allows clean commits to proceed without interruption
+- ✅ Avoids known false positives for architecture/db identifier strings like `assistant_auth_tokens` and migration checkpoint keys
 - ✅ When IPC contract files are staged, verifies the generated Swift models and inventory snapshot are up to date
 - ✅ Catches unstaged generated output files (e.g., regenerated but not `git add`-ed)
+
+**Verification:**
+- Run `.githooks/pre-commit --self-test` to verify safe architecture/db strings are allowed while seeded real secrets are still detected.
 
 **Bypass (not recommended):**
 If you need to bypass this check in exceptional cases:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,11 +9,6 @@ NC='\033[0m' # No Color
 
 echo "🔍 Checking for plain text keys and secrets..."
 
-# Check if there are any staged files
-if ! git diff --cached --name-only --diff-filter=ACM | grep -q .; then
-    exit 0
-fi
-
 # Patterns to check for sensitive information
 # Note: Using [[:space:]] instead of \s for grep -E compatibility
 declare -a PATTERNS=(
@@ -42,14 +37,14 @@ declare -a PATTERNS=(
     # Tokens
     "token['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-\.]{20,}['\"]"
     "bearer['\"]?[[:space:]]*[:=]?[[:space:]]*[a-zA-Z0-9_\-\.]{20,}"
-    "auth[_-]?token"
+    "auth[_-]?token['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-\.]{20,}['\"]"
 
     # Database URLs with credentials
     "://[a-zA-Z0-9]+:[a-zA-Z0-9]+@[a-zA-Z0-9]"
 
     # Generic secret patterns
     "['\"]?[a-z0-9_]*secret[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][^'\"]{8,}['\"]"
-    "['\"]?[a-z0-9_]*key[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
+    "['\"]?[a-z0-9_]*(api|access|private|secret|client)[a-z0-9_]*key[a-z0-9_]*['\"]?[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z0-9_\-]{16,}['\"]"
 
     # Slack tokens
     "xox[baprs]-[0-9a-zA-Z]{10,}"
@@ -60,6 +55,44 @@ declare -a PATTERNS=(
     # Generic high entropy strings (likely keys)
     "['\"][a-zA-Z0-9+/]{40,}={0,2}['\"]"
 )
+
+matches_secret_pattern() {
+    local text="$1"
+    local pattern
+    for pattern in "${PATTERNS[@]}"; do
+        if printf '%s\n' "$text" | grep -niE -- "$pattern" >/dev/null 2>&1; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    SAFE_ARCHITECTURE_LINE='PG_TOKENS["assistant_auth_tokens"]'
+    SAFE_DB_LINE="SELECT 1 FROM memory_checkpoints WHERE key = 'migration_job_deferrals'"
+    REAL_SECRET_LINE='api_key="sk_live_12345678901234567890"'
+
+    if matches_secret_pattern "$SAFE_ARCHITECTURE_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} ARCHITECTURE allowlist case still matches"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_DB_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} db migration key case still matches"
+        exit 1
+    fi
+    if ! matches_secret_pattern "$REAL_SECRET_LINE"; then
+        echo -e "${RED}Self-test failed:${NC} real secret seed did not match"
+        exit 1
+    fi
+
+    echo "✅ Secret scanner self-test passed"
+    exit 0
+fi
+
+# Check if there are any staged files
+if ! git diff --cached --name-only --diff-filter=ACM | grep -q .; then
+    exit 0
+fi
 
 FOUND_SECRETS=0
 CHECKED_FILES=0


### PR DESCRIPTION
## Summary
- narrow token/key secret regexes to require assignment context instead of matching identifier names
- eliminate false positives for lines like `assistant_auth_tokens` and migration checkpoint SQL key literals
- add `.githooks/pre-commit --self-test` mode that verifies:
  - ARCHITECTURE/db safe-string cases do not match
  - seeded real secret still matches
- document self-test usage in `.githooks/README.md`

## Validation
- `.githooks/pre-commit --self-test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
