### PR TITLE
refactor(swift): introduce AppServices container

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -7,7 +7,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(ambientAgent: appDelegate.ambientAgent, daemonClient: appDelegate.daemonClient)
+            SettingsView(ambientAgent: appDelegate.services.ambientAgent, daemonClient: appDelegate.services.daemonClient)
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -85,14 +85,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var voiceInput: VoiceInputManager?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     private var thinkingWindow: ThinkingIndicatorWindow?
-    public let ambientAgent = AmbientAgent()
-    public let daemonClient = DaemonClient()
-    let surfaceManager = SurfaceManager()
-    let toolConfirmationManager = ToolConfirmationManager()
-    let secretPromptManager = SecretPromptManager()
+    public let services = AppServices()
     private let daemonLauncher = DaemonLauncher()
     private let updateManager = UpdateManager()
-    let zoomManager = ZoomManager()
+
+    // Forwarding accessors — ownership lives in `services`, these keep
+    // existing internal references working without a mass-rename.
+    private var daemonClient: DaemonClient { services.daemonClient }
+    private var ambientAgent: AmbientAgent { services.ambientAgent }
+    private var surfaceManager: SurfaceManager { services.surfaceManager }
+    private var toolConfirmationManager: ToolConfirmationManager { services.toolConfirmationManager }
+    private var secretPromptManager: SecretPromptManager { services.secretPromptManager }
+    private var zoomManager: ZoomManager { services.zoomManager }
 
     private var onboardingWindow: OnboardingWindow?
     private var mainWindow: MainWindow?
@@ -888,7 +892,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.show()
             return
         }
-        let main = MainWindow(daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, zoomManager: zoomManager)
+        let main = MainWindow(services: services)
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }
@@ -922,7 +926,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let hostingController = NSHostingController(rootView: SettingsView(ambientAgent: ambientAgent, daemonClient: daemonClient))
+        let hostingController = NSHostingController(rootView: SettingsView(ambientAgent: services.ambientAgent, daemonClient: services.daemonClient))
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 450, height: 700),
             styleMask: [.titled, .closable, .miniaturizable],

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -1,0 +1,13 @@
+import VellumAssistantShared
+
+/// Single owner of app-lifetime services. Replaces scattered service properties
+/// that were previously declared directly on `AppDelegate`.
+@MainActor
+public final class AppServices {
+    public let daemonClient = DaemonClient()
+    public let ambientAgent = AmbientAgent()
+    let surfaceManager = SurfaceManager()
+    let toolConfirmationManager = ToolConfirmationManager()
+    let secretPromptManager = SecretPromptManager()
+    let zoomManager = ZoomManager()
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -5,14 +5,18 @@ import SwiftUI
 
 @MainActor
 final class MainWindow {
-    private let daemonClient: DaemonClient
-    private let surfaceManager: SurfaceManager
-    private let ambientAgent: AmbientAgent
-    private let zoomManager: ZoomManager
+    private let services: AppServices
     private var window: NSWindow?
     let threadManager: ThreadManager
     let traceStore = TraceStore()
     var onMicrophoneToggle: (() -> Void)?
+
+    // Forwarding accessors — keeps existing references working while
+    // ownership lives in the `services` container.
+    private var daemonClient: DaemonClient { services.daemonClient }
+    private var surfaceManager: SurfaceManager { services.surfaceManager }
+    private var ambientAgent: AmbientAgent { services.ambientAgent }
+    private var zoomManager: ZoomManager { services.zoomManager }
 
     /// Tracks daemon reconnects so trace state can be reset on stream restart.
     private var connectionCancellable: AnyCancellable?
@@ -30,13 +34,10 @@ final class MainWindow {
         threadManager.activeViewModel
     }
 
-    init(daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, zoomManager: ZoomManager) {
-        self.daemonClient = daemonClient
-        self.surfaceManager = surfaceManager
-        self.ambientAgent = ambientAgent
-        self.zoomManager = zoomManager
-        self.threadManager = ThreadManager(daemonClient: daemonClient)
-        daemonClient.onTraceEvent = { [weak self] msg in
+    init(services: AppServices) {
+        self.services = services
+        self.threadManager = ThreadManager(daemonClient: services.daemonClient)
+        services.daemonClient.onTraceEvent = { [weak self] msg in
             Task { @MainActor in
                 self?.traceStore.ingest(msg)
             }


### PR DESCRIPTION
## Summary

- Create `AppServices` as the single owner of six app-lifetime services (`DaemonClient`, `AmbientAgent`, `SurfaceManager`, `ToolConfirmationManager`, `SecretPromptManager`, `ZoomManager`)
- Replace scattered stored properties in `AppDelegate` with `services` container + private forwarding accessors
- Update `MainWindow` init to take `AppServices` instead of four separate service parameters
- Update `VellumAssistantApp` and settings entrypoints to access services through the container

## Test plan

- [x] `./build.sh lint` passes (no errors)
- [x] `./build.sh test` — all 188 + 28 tests pass
- [ ] Manual smoke: launch app, open main window, open settings, run one chat message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
