### PR TITLE
fix: strip surface context after run and sync activeSurfaceId across threads

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -53,6 +53,23 @@ export function injectActiveSurfaceContext(message: Message, surfaceId: string, 
 }
 
 /**
+ * Strip `<active_dynamic_page>` blocks that were injected by
+ * `injectActiveSurfaceContext`.  Called after the agent run to prevent
+ * the (potentially 100 KB) surface HTML from persisting in session history.
+ */
+export function stripActiveSurfaceContext(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    const nextContent = message.content.filter((block) => {
+      if (block.type !== 'text') return true;
+      return !block.text.startsWith('<active_dynamic_page>');
+    });
+    if (nextContent.length === message.content.length) return message;
+    return { ...message, content: nextContent };
+  });
+}
+
+/**
  * Apply a chain of user-message injections to `runMessages`.
  *
  * Each injection is optional — pass `null`/`undefined` to skip it.

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -57,7 +57,7 @@ import { ConflictGate } from './session-conflict-gate.js';
 import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from './session-dynamic-profile.js';
 import { MessageQueue } from './session-queue-manager.js';
 import type { QueueDrainReason } from './session-queue-manager.js';
-import { applyRuntimeInjections } from './session-runtime-assembly.js';
+import { applyRuntimeInjections, stripActiveSurfaceContext } from './session-runtime-assembly.js';
 import type { UsageActor } from '../usage/actors.js';
 import { loadSkillCatalog } from '../config/skills.js';
 import { resolveSkillStates } from '../config/skill-state.js';
@@ -1027,7 +1027,9 @@ export class Session {
       });
       const restoredHistory = [...preRepairMessages, ...newMessages];
       const recallStripped = stripMemoryRecallMessages(restoredHistory, recall.injectedText, recallInjectionStrategy);
-      this.messages = stripDynamicProfileMessages(recallStripped, dynamicProfile.text);
+      this.messages = stripActiveSurfaceContext(
+        stripDynamicProfileMessages(recallStripped, dynamicProfile.text),
+      );
 
       this.recordUsage(exchangeInputTokens, exchangeOutputTokens, model, onEvent, 'main_agent', reqId);
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -167,9 +167,14 @@ struct MainWindowView: View {
                 threadManager.selectThread(id: newId)
             }
         }
-        .onChange(of: threadManager.activeThreadId) { _, newId in
+        .onChange(of: threadManager.activeThreadId) { oldId, newId in
             // Sync activeThreadId changes back to selectedThreadId to keep sidebar selection in sync
             selectedThreadId = newId
+            // Clear stale activeSurfaceId on the old thread and sync the new one
+            if let oldId {
+                threadManager.clearActiveSurface(threadId: oldId)
+            }
+            threadManager.activeViewModel?.activeSurfaceId = isDynamicExpanded ? activeDynamicSurface?.surfaceId : nil
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -76,6 +76,12 @@ final class ThreadManager: ObservableObject {
         log.info("Closed thread \(id)")
     }
 
+    /// Clear the `activeSurfaceId` on a specific thread's ChatViewModel.
+    /// Used when switching threads to prevent stale surface context injection.
+    func clearActiveSurface(threadId: UUID) {
+        chatViewModels[threadId]?.activeSurfaceId = nil
+    }
+
     func selectThread(id: UUID) {
         guard threads.contains(where: { $0.id == id }) else { return }
         activeThreadId = id


### PR DESCRIPTION
## Summary
- Add `stripActiveSurfaceContext()` to remove injected `<active_dynamic_page>` HTML blocks from session messages after agent runs, preventing runaway token growth
- Sync `activeSurfaceId` across thread switches: clear the old thread's VM and set the new thread's VM based on current workspace state
- Add `clearActiveSurface(threadId:)` helper to ThreadManager

Addresses review feedback from PR #2482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
