### PR TITLE
refactor(swift): extract shared SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -7,7 +7,7 @@ struct VellumAssistantApp: App {
 
     var body: some Scene {
         Settings {
-            SettingsView(ambientAgent: appDelegate.services.ambientAgent, daemonClient: appDelegate.services.daemonClient)
+            SettingsView(store: appDelegate.services.settingsStore, ambientAgent: appDelegate.services.ambientAgent, daemonClient: appDelegate.services.daemonClient)
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -926,7 +926,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let hostingController = NSHostingController(rootView: SettingsView(ambientAgent: services.ambientAgent, daemonClient: services.daemonClient))
+        let hostingController = NSHostingController(rootView: SettingsView(store: services.settingsStore, ambientAgent: services.ambientAgent, daemonClient: services.daemonClient))
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 450, height: 700),
             styleMask: [.titled, .closable, .miniaturizable],

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -10,4 +10,11 @@ public final class AppServices {
     let toolConfirmationManager = ToolConfirmationManager()
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
+
+    /// Shared settings state consumed by both SettingsView and SettingsPanel.
+    /// Lazy because it needs `ambientAgent` and `daemonClient` which are set above.
+    public lazy var settingsStore: SettingsStore = SettingsStore(
+        ambientAgent: ambientAgent,
+        daemonClient: daemonClient
+    )
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -78,7 +78,7 @@ final class MainWindow {
             return
         }
 
-        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, onMicrophoneToggle: onMicrophoneToggle ?? {}))
+        let hostingController = NSHostingController(rootView: MainWindowView(threadManager: threadManager, zoomManager: zoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, onMicrophoneToggle: onMicrophoneToggle ?? {}))
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -23,15 +23,17 @@ struct MainWindowView: View {
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
+    let settingsStore: SettingsStore
     let onMicrophoneToggle: () -> Void
 
-    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, onMicrophoneToggle: @escaping () -> Void = {}) {
+    init(threadManager: ThreadManager, zoomManager: ZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, onMicrophoneToggle: @escaping () -> Void = {}) {
         self.threadManager = threadManager
         self.zoomManager = zoomManager
         self.traceStore = traceStore
         self.daemonClient = daemonClient
         self.surfaceManager = surfaceManager
         self.ambientAgent = ambientAgent
+        self.settingsStore = settingsStore
         self.onMicrophoneToggle = onMicrophoneToggle
     }
 
@@ -591,7 +593,7 @@ struct MainWindowView: View {
                     }
                 }, daemonClient: daemonClient)
             case .settings:
-                SettingsPanel(onClose: { activePanel = nil }, ambientAgent: ambientAgent, daemonClient: daemonClient)
+                SettingsPanel(onClose: { activePanel = nil }, store: settingsStore, daemonClient: daemonClient)
             case .directory:
                 DirectoryPanel(onClose: { activePanel = nil })
             case .debug:
@@ -627,7 +629,8 @@ private struct ZoomIndicatorView: View {
 
 #Preview {
     let dc = DaemonClient()
-    return MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent())
+    let agent = AmbientAgent()
+    MainWindowView(threadManager: ThreadManager(daemonClient: dc), zoomManager: ZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: agent, settingsStore: SettingsStore(ambientAgent: agent, daemonClient: dc))
         .frame(width: 900, height: 600)
         .padding(.top, 36)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1,22 +1,14 @@
-import Combine
 import SwiftUI
 import VellumAssistantShared
 
 @MainActor
 struct SettingsPanel: View {
     var onClose: () -> Void
-    var ambientAgent: AmbientAgent
+    @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
 
     @State private var apiKeyText: String = ""
-    @State private var hasKey: Bool = false
-    @State private var isTrustRulesSheetOpen: Bool = false
-    /// Tracks whether trust rules are open from any surface (synced from DaemonClient).
-    @State private var trustRulesOpenElsewhere: Bool = false
     @State private var braveKeyText: String = ""
-    @State private var hasBraveKey: Bool = false
-    @AppStorage("maxStepsPerSession") private var maxSteps: Double = 50
-    @AppStorage("ambientAgentEnabled") private var ambientEnabled: Bool = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
 
     var body: some View {
@@ -28,15 +20,14 @@ struct SettingsPanel: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    if hasKey {
+                    if store.hasKey {
                         HStack {
                             Text("sk-ant-...configured")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)
                             Spacer()
                             VButton(label: "Clear", style: .danger) {
-                                APIKeyManager.deleteKey()
-                                hasKey = false
+                                store.clearAPIKey()
                                 apiKeyText = ""
                             }
                         }
@@ -67,10 +58,7 @@ struct SettingsPanel: View {
                             .foregroundColor(VColor.textMuted)
 
                         VButton(label: "Save", style: .primary) {
-                            let trimmed = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !trimmed.isEmpty else { return }
-                            APIKeyManager.setKey(trimmed)
-                            hasKey = true
+                            store.saveAPIKey(apiKeyText)
                             apiKeyText = ""
                         }
                     }
@@ -84,15 +72,14 @@ struct SettingsPanel: View {
                         .font(VFont.sectionTitle)
                         .foregroundColor(VColor.textPrimary)
 
-                    if hasBraveKey {
+                    if store.hasBraveKey {
                         HStack {
                             Text("BSA...configured")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)
                             Spacer()
                             VButton(label: "Clear", style: .danger) {
-                                APIKeyManager.deleteKey(for: "brave")
-                                hasBraveKey = false
+                                store.clearBraveKey()
                                 braveKeyText = ""
                             }
                         }
@@ -123,10 +110,7 @@ struct SettingsPanel: View {
                             .foregroundColor(VColor.textMuted)
 
                         VButton(label: "Save", style: .primary) {
-                            let trimmed = braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !trimmed.isEmpty else { return }
-                            APIKeyManager.setKey(trimmed, for: "brave")
-                            hasBraveKey = true
+                            store.saveBraveKey(braveKeyText)
                             braveKeyText = ""
                         }
                     }
@@ -148,12 +132,12 @@ struct SettingsPanel: View {
                             .font(.system(size: 12))
                             .foregroundColor(VColor.textMuted)
                         Spacer()
-                        Text("\(Int(maxSteps))")
+                        Text("\(Int(store.maxSteps))")
                             .font(VFont.mono)
                             .foregroundColor(VColor.textSecondary)
                     }
 
-                    VSlider(value: $maxSteps, range: 1...100, step: 10, showTickMarks: true)
+                    VSlider(value: $store.maxSteps, range: 1...100, step: 10, showTickMarks: true)
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: Slate._900)
@@ -172,10 +156,7 @@ struct SettingsPanel: View {
                             .font(.system(size: 12))
                             .foregroundColor(VColor.textMuted)
                         Spacer()
-                        VToggle(isOn: $ambientEnabled)
-                    }
-                    .onChange(of: ambientEnabled) { _, newValue in
-                        ambientAgent.isEnabled = newValue
+                        VToggle(isOn: $store.ambientEnabled)
                     }
                 }
                 .padding(VSpacing.lg)
@@ -246,9 +227,9 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                isTrustRulesSheetOpen = true
+                                store.isTrustRulesSheetOpen = true
                             }
-                            .disabled(isTrustRulesSheetOpen || trustRulesOpenElsewhere)
+                            .disabled(store.isTrustRulesDisabled)
                         }
                     }
                     .padding(VSpacing.lg)
@@ -276,19 +257,12 @@ struct SettingsPanel: View {
             }
         }
         .onAppear {
-            refreshAPIKeyState()
+            store.refreshAPIKeyState()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
-            refreshAPIKeyState()
-        }
-        .sheet(isPresented: $isTrustRulesSheetOpen) {
+        .sheet(isPresented: $store.isTrustRulesSheetOpen) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
-        }
-        .onReceive(daemonClient?.$isTrustRulesSheetOpen.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { isOpen in
-            // Only track whether trust rules opened from another surface, not this one
-            trustRulesOpenElsewhere = isOpen && !isTrustRulesSheetOpen
         }
     }
 
@@ -328,17 +302,13 @@ struct SettingsPanel: View {
         .padding(.vertical, VSpacing.md)
     }
 
-    private func refreshAPIKeyState() {
-        hasKey = APIKeyManager.getKey() != nil
-        hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
-    }
-
 }
 
 #Preview("SettingsPanel") {
+    let agent = AmbientAgent()
     ZStack {
         VColor.background.ignoresSafeArea()
-        SettingsPanel(onClose: {}, ambientAgent: AmbientAgent())
+        SettingsPanel(onClose: {}, store: SettingsStore(ambientAgent: agent))
     }
     .frame(width: 600, height: 700)
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,0 +1,106 @@
+import Combine
+import Foundation
+import VellumAssistantShared
+
+/// Single source of truth for settings state shared between `SettingsView`
+/// (standalone window) and `SettingsPanel` (main window side panel).
+@MainActor
+public final class SettingsStore: ObservableObject {
+    // MARK: - API Key State
+
+    @Published var hasKey: Bool
+    @Published var hasBraveKey: Bool
+
+    // MARK: - Settings Values
+
+    @Published var maxSteps: Double {
+        didSet { UserDefaults.standard.set(maxSteps, forKey: "maxStepsPerSession") }
+    }
+    @Published var ambientEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(ambientEnabled, forKey: "ambientAgentEnabled")
+            ambientAgent?.isEnabled = ambientEnabled
+        }
+    }
+    @Published var ambientInterval: Double {
+        didSet {
+            UserDefaults.standard.set(ambientInterval, forKey: "ambientCaptureInterval")
+            ambientAgent?.captureIntervalSeconds = ambientInterval
+        }
+    }
+
+    // MARK: - Trust Rules Coordination
+
+    @Published var isTrustRulesSheetOpen = false
+    @Published var trustRulesOpenElsewhere = false
+
+    /// Whether the trust rules button should be disabled.
+    var isTrustRulesDisabled: Bool { isTrustRulesSheetOpen || trustRulesOpenElsewhere }
+
+    // MARK: - Private
+
+    private weak var ambientAgent: AmbientAgent?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
+        self.ambientAgent = ambientAgent
+
+        // Seed from UserDefaults / Keychain
+        self.hasKey = APIKeyManager.getKey() != nil
+        self.hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
+
+        let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
+        self.maxSteps = storedMaxSteps == 0 ? 50 : storedMaxSteps
+
+        self.ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
+
+        let storedInterval = UserDefaults.standard.double(forKey: "ambientCaptureInterval")
+        self.ambientInterval = storedInterval == 0 ? 30 : storedInterval
+
+        // React to Keychain changes from other surfaces
+        NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refreshAPIKeyState() }
+            .store(in: &cancellables)
+
+        // Track whether trust rules are open elsewhere
+        daemonClient?.$isTrustRulesSheetOpen
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isOpen in
+                guard let self else { return }
+                self.trustRulesOpenElsewhere = isOpen && !self.isTrustRulesSheetOpen
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - API Key Actions
+
+    func saveAPIKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed)
+        hasKey = true
+    }
+
+    func clearAPIKey() {
+        APIKeyManager.deleteKey()
+        hasKey = false
+    }
+
+    func saveBraveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        APIKeyManager.setKey(trimmed, for: "brave")
+        hasBraveKey = true
+    }
+
+    func clearBraveKey() {
+        APIKeyManager.deleteKey(for: "brave")
+        hasBraveKey = false
+    }
+
+    func refreshAPIKeyState() {
+        hasKey = APIKeyManager.getKey() != nil
+        hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -3,24 +3,11 @@ import SwiftUI
 import VellumAssistantShared
 
 public struct SettingsView: View {
+    @ObservedObject var store: SettingsStore
     @State private var apiKeyText = ""
-    @State private var hasKey = APIKeyManager.getKey() != nil
-    @State private var isTrustRulesSheetOpen = false
-    /// Tracks whether trust rules are open from any surface (synced from DaemonClient).
-    @State private var trustRulesOpenElsewhere = false
     @State private var braveKeyText = ""
-    @State private var hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
-    @State private var maxSteps: Double = {
-        let val = UserDefaults.standard.double(forKey: "maxStepsPerSession")
-        return val == 0 ? 50 : val
-    }()
     @State private var accessibilityGranted = false
     @State private var screenRecordingGranted = false
-    @State private var ambientEnabled = UserDefaults.standard.bool(forKey: "ambientAgentEnabled")
-    @State private var ambientInterval: Double = {
-        let val = UserDefaults.standard.double(forKey: "ambientCaptureInterval")
-        return val == 0 ? 30 : val
-    }()
     @State private var showingPrivacy = false
     @State private var showingSkills = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
@@ -31,7 +18,8 @@ public struct SettingsView: View {
     var ambientAgent: AmbientAgent
     var daemonClient: DaemonClient?
 
-    public init(ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
+    public init(store: SettingsStore, ambientAgent: AmbientAgent, daemonClient: DaemonClient? = nil) {
+        self.store = store
         self.ambientAgent = ambientAgent
         self.daemonClient = daemonClient
     }
@@ -42,14 +30,13 @@ public struct SettingsView: View {
     public var body: some View {
         Form {
             Section("Anthropic API Key") {
-                if hasKey {
+                if store.hasKey {
                     HStack {
                         Text("sk-ant-...configured")
                             .foregroundStyle(.secondary)
                         Spacer()
                         Button("Clear") {
-                            APIKeyManager.deleteKey()
-                            hasKey = false
+                            store.clearAPIKey()
                             apiKeyText = ""
                         }
                         .tint(.red)
@@ -63,10 +50,7 @@ public struct SettingsView: View {
                             .foregroundStyle(.secondary)
                         Spacer()
                         Button("Save") {
-                            let trimmed = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !trimmed.isEmpty else { return }
-                            APIKeyManager.setKey(trimmed)
-                            hasKey = true
+                            store.saveAPIKey(apiKeyText)
                             apiKeyText = ""
                         }
                         .disabled(apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -75,14 +59,13 @@ public struct SettingsView: View {
             }
 
             Section("Brave Search API Key") {
-                if hasBraveKey {
+                if store.hasBraveKey {
                     HStack {
                         Text("BSA...configured")
                             .foregroundStyle(.secondary)
                         Spacer()
                         Button("Clear") {
-                            APIKeyManager.deleteKey(for: "brave")
-                            hasBraveKey = false
+                            store.clearBraveKey()
                             braveKeyText = ""
                         }
                         .tint(.red)
@@ -96,10 +79,7 @@ public struct SettingsView: View {
                             .foregroundStyle(.secondary)
                         Spacer()
                         Button("Save") {
-                            let trimmed = braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !trimmed.isEmpty else { return }
-                            APIKeyManager.setKey(trimmed, for: "brave")
-                            hasBraveKey = true
+                            store.saveBraveKey(braveKeyText)
                             braveKeyText = ""
                         }
                         .disabled(braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -111,14 +91,11 @@ public struct SettingsView: View {
                 HStack {
                     Text("Max steps per session")
                     Spacer()
-                    Text("\(Int(maxSteps))")
+                    Text("\(Int(store.maxSteps))")
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
-                Slider(value: $maxSteps, in: 10...100, step: 10)
-                    .onChange(of: maxSteps) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: "maxStepsPerSession")
-                    }
+                Slider(value: $store.maxSteps, in: 10...100, step: 10)
             }
 
             Section("Voice Activation") {
@@ -137,25 +114,17 @@ public struct SettingsView: View {
             }
 
             Section("Ambient Agent") {
-                Toggle("Enable ambient screen watching", isOn: $ambientEnabled)
-                    .onChange(of: ambientEnabled) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: "ambientAgentEnabled")
-                        ambientAgent.isEnabled = newValue
-                    }
+                Toggle("Enable ambient screen watching", isOn: $store.ambientEnabled)
 
-                if ambientEnabled {
+                if store.ambientEnabled {
                     HStack {
                         Text("Capture interval")
                         Spacer()
-                        Text("\(Int(ambientInterval))s")
+                        Text("\(Int(store.ambientInterval))s")
                             .monospacedDigit()
                             .foregroundStyle(.secondary)
                     }
-                    Slider(value: $ambientInterval, in: 10...120, step: 5)
-                        .onChange(of: ambientInterval) { _, newValue in
-                            UserDefaults.standard.set(newValue, forKey: "ambientCaptureInterval")
-                            ambientAgent.captureIntervalSeconds = newValue
-                        }
+                    Slider(value: $store.ambientInterval, in: 10...120, step: 5)
 
                     KnowledgeSection(store: ambientAgent.knowledgeStore)
 
@@ -220,9 +189,9 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            isTrustRulesSheetOpen = true
+                            store.isTrustRulesSheetOpen = true
                         }
-                        .disabled(isTrustRulesSheetOpen || trustRulesOpenElsewhere)
+                        .disabled(store.isTrustRulesDisabled)
                     }
                 }
             }
@@ -242,14 +211,11 @@ public struct SettingsView: View {
         .formStyle(.grouped)
         .frame(width: 450, height: 700)
         .onAppear {
-            refreshAPIKeyState()
+            store.refreshAPIKeyState()
             checkPermissions()
         }
         .onReceive(permissionTimer) { _ in
             checkPermissions()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
-            refreshAPIKeyState()
         }
         .sheet(isPresented: $showingSkills, onDismiss: {
             skillsViewModel = nil
@@ -258,13 +224,10 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .sheet(isPresented: $isTrustRulesSheetOpen) {
+        .sheet(isPresented: $store.isTrustRulesSheetOpen) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
-        }
-        .onReceive(daemonClient?.$isTrustRulesSheetOpen.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { isOpen in
-            trustRulesOpenElsewhere = isOpen && !isTrustRulesSheetOpen
         }
         .sheet(isPresented: $showingPrivacy) {
             PrivacyDetailView()
@@ -277,10 +240,6 @@ public struct SettingsView: View {
         screenRecordingGranted = status == .granted
     }
 
-    private func refreshAPIKeyState() {
-        hasKey = APIKeyManager.getKey() != nil
-        hasBraveKey = APIKeyManager.getKey(for: "brave") != nil
-    }
 }
 
 // MARK: - Knowledge Section
@@ -613,5 +572,6 @@ private struct KnowledgeEntriesView: View {
 }
 
 #Preview {
-    SettingsView(ambientAgent: AmbientAgent())
+    let agent = AmbientAgent()
+    SettingsView(store: SettingsStore(ambientAgent: agent), ambientAgent: agent)
 }


### PR DESCRIPTION
## Summary
- Create `SettingsStore` as a shared `ObservableObject` centralizing settings state (API key status, max steps, ambient toggle, trust rules coordination) that was previously duplicated across `SettingsView` and `SettingsPanel`
- Remove ~60 lines of duplicated `@State`/`@AppStorage` properties, UserDefaults sync logic, and Keychain/trust-rules observers from both views
- Wire `SettingsStore` through `AppServices` → `MainWindow` → `MainWindowView` → `SettingsPanel` and `AppDelegate` → `SettingsView`

## Test plan
- [x] `swift build` passes
- [x] All 28 Swift tests pass
- [x] SettingsView and SettingsPanel share the same state source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
