### PR TITLE
refactor(swift): split ThreadManager responsibilities

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -7,24 +7,22 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
 
 @MainActor
-final class ThreadManager: ObservableObject {
-    @AppStorage("restoreRecentThreads") private var restoreRecentThreads = false
+final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
+    @AppStorage("restoreRecentThreads") private(set) var restoreRecentThreads = false
     @Published var threads: [ThreadModel] = []
     @Published var activeThreadId: UUID? {
         didSet {
             subscribeToActiveViewModel()
-            loadHistoryForActiveThreadIfNeeded()
+            if let activeThreadId {
+                sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
+            }
         }
     }
 
     private var chatViewModels: [UUID: ChatViewModel] = [:]
     private let daemonClient: DaemonClient
     private var viewModelCancellable: AnyCancellable?
-    private var connectionCancellable: AnyCancellable?
-
-    /// Maps session IDs to thread IDs for in-flight history_request messages,
-    /// so rapid tab switches don't cause history from one thread to land in another.
-    private var pendingHistoryBySessionId: [String: UUID] = [:]
+    private let sessionRestorer: ThreadSessionRestorer
 
     /// Called when an inline confirmation response should dismiss the floating panel.
     var confirmationDismissHandler: ((String) -> Void)?
@@ -36,9 +34,11 @@ final class ThreadManager: ObservableObject {
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
+        self.sessionRestorer = ThreadSessionRestorer(daemonClient: daemonClient)
         // Create one default thread so the window is never empty
         createThread()
-        observeDaemonConnection()
+        sessionRestorer.delegate = self
+        sessionRestorer.startObserving()
     }
 
     func createThread() {
@@ -111,107 +111,21 @@ final class ThreadManager: ObservableObject {
         return true
     }
 
-    // MARK: - Session Restoration
+    // MARK: - ThreadRestorerDelegate
 
-    private func observeDaemonConnection() {
-        daemonClient.onSessionListResponse = { [weak self] response in
-            self?.handleSessionListResponse(response)
-        }
-        daemonClient.onHistoryResponse = { [weak self] response in
-            self?.handleHistoryResponse(response)
-        }
-
-        // Fetch session list when daemon connects
-        connectionCancellable = daemonClient.$isConnected
-            .removeDuplicates()
-            .filter { $0 }
-            .first()
-            .sink { [weak self] _ in
-                self?.fetchSessionList()
-            }
+    func chatViewModel(for threadId: UUID) -> ChatViewModel? {
+        chatViewModels[threadId]
     }
 
-    private func fetchSessionList() {
-        do {
-            try daemonClient.sendSessionList()
-        } catch {
-            log.error("Failed to send session_list: \(error.localizedDescription)")
-        }
+    func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
+        chatViewModels[threadId] = vm
     }
 
-    private func handleSessionListResponse(_ response: SessionListResponseMessage) {
-        guard restoreRecentThreads else { return }
-        guard !response.sessions.isEmpty else { return }
-
-        // Load up to 5 most recent sessions (daemon returns them sorted by updatedAt DESC)
-        let recentSessions = Array(response.sessions.prefix(5))
-
-        // Check if the default "New Thread" is still unused
-        let defaultThreadIsEmpty = threads.count == 1
-            && chatViewModels[threads[0].id]?.messages.isEmpty ?? true
-            && chatViewModels[threads[0].id]?.sessionId == nil
-
-        var restoredThreads: [ThreadModel] = []
-        for session in recentSessions {
-            let thread = ThreadModel(
-                title: session.title,
-                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
-                sessionId: session.id
-            )
-            let viewModel = makeViewModel()
-            viewModel.sessionId = session.id
-            chatViewModels[thread.id] = viewModel
-            restoredThreads.append(thread)
-        }
-
-        if defaultThreadIsEmpty {
-            // Replace the empty default thread with restored sessions
-            if let defaultThread = threads.first {
-                chatViewModels.removeValue(forKey: defaultThread.id)
-            }
-            threads = restoredThreads
-        } else {
-            // Keep the user's active thread, prepend restored sessions
-            threads = restoredThreads + threads
-        }
-
-        // Activate the most recent thread and load its history
-        if let firstThread = restoredThreads.first {
-            activeThreadId = firstThread.id
-        }
-
-        log.info("Restored \(restoredThreads.count) threads from daemon")
+    func removeChatViewModel(for threadId: UUID) {
+        chatViewModels.removeValue(forKey: threadId)
     }
 
-    private func loadHistoryForActiveThreadIfNeeded() {
-        guard let activeThreadId else { return }
-        guard let thread = threads.first(where: { $0.id == activeThreadId }) else { return }
-        guard let sessionId = thread.sessionId else { return }
-        guard let viewModel = chatViewModels[activeThreadId] else { return }
-        guard !viewModel.isHistoryLoaded else { return }
-
-        pendingHistoryBySessionId[sessionId] = activeThreadId
-
-        do {
-            try daemonClient.sendHistoryRequest(sessionId: sessionId)
-        } catch {
-            log.error("Failed to send history_request: \(error.localizedDescription)")
-            pendingHistoryBySessionId.removeValue(forKey: sessionId)
-        }
-    }
-
-    private func handleHistoryResponse(_ response: HistoryResponseMessage) {
-        guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
-
-        guard let viewModel = chatViewModels[threadId] else { return }
-        viewModel.populateFromHistory(response.messages)
-        log.info("Loaded \(response.messages.count) history messages for thread \(threadId)")
-    }
-
-    // MARK: - Private
-
-    /// Create a ChatViewModel with standard callback wiring.
-    private func makeViewModel() -> ChatViewModel {
+    func makeViewModel() -> ChatViewModel {
         let viewModel = ChatViewModel(daemonClient: daemonClient)
         viewModel.onInlineConfirmationResponse = { [weak self] requestId in
             self?.confirmationDismissHandler?(requestId)
@@ -222,6 +136,12 @@ final class ThreadManager: ObservableObject {
         }
         return viewModel
     }
+
+    func activateThread(_ id: UUID) {
+        activeThreadId = id
+    }
+
+    // MARK: - Private
 
     /// Subscribe to the active ChatViewModel's objectWillChange so that
     /// SwiftUI re-evaluates views when the nested view model publishes

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -1,0 +1,131 @@
+import Combine
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadSessionRestorer")
+
+/// Delegate protocol so the restorer can read and mutate thread state
+/// owned by `ThreadManager`.
+@MainActor
+protocol ThreadRestorerDelegate: AnyObject {
+    var threads: [ThreadModel] { get set }
+    var restoreRecentThreads: Bool { get }
+    func chatViewModel(for threadId: UUID) -> ChatViewModel?
+    func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID)
+    func removeChatViewModel(for threadId: UUID)
+    func makeViewModel() -> ChatViewModel
+    func activateThread(_ id: UUID)
+}
+
+/// Handles daemon session restoration: fetching the session list on connect,
+/// creating threads for recent sessions, and loading per-thread history on demand.
+@MainActor
+final class ThreadSessionRestorer {
+    /// Maps session IDs to thread IDs for in-flight `history_request` messages,
+    /// so rapid tab switches don't cause history from one thread to land in another.
+    /// Exposed as internal for `@testable` test access.
+    var pendingHistoryBySessionId: [String: UUID] = [:]
+
+    private let daemonClient: DaemonClient
+    private var connectionCancellable: AnyCancellable?
+
+    weak var delegate: ThreadRestorerDelegate?
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func startObserving() {
+        daemonClient.onSessionListResponse = { [weak self] response in
+            self?.handleSessionListResponse(response)
+        }
+        daemonClient.onHistoryResponse = { [weak self] response in
+            self?.handleHistoryResponse(response)
+        }
+
+        connectionCancellable = daemonClient.$isConnected
+            .removeDuplicates()
+            .filter { $0 }
+            .first()
+            .sink { [weak self] _ in
+                self?.fetchSessionList()
+            }
+    }
+
+    func loadHistoryIfNeeded(threadId: UUID) {
+        guard let delegate else { return }
+        guard let thread = delegate.threads.first(where: { $0.id == threadId }) else { return }
+        guard let sessionId = thread.sessionId else { return }
+        guard let viewModel = delegate.chatViewModel(for: threadId) else { return }
+        guard !viewModel.isHistoryLoaded else { return }
+
+        pendingHistoryBySessionId[sessionId] = threadId
+
+        do {
+            try daemonClient.sendHistoryRequest(sessionId: sessionId)
+        } catch {
+            log.error("Failed to send history_request: \(error.localizedDescription)")
+            pendingHistoryBySessionId.removeValue(forKey: sessionId)
+        }
+    }
+
+    // MARK: - Response Handlers (internal for testability)
+
+    func handleSessionListResponse(_ response: SessionListResponseMessage) {
+        guard let delegate else { return }
+        guard delegate.restoreRecentThreads else { return }
+        guard !response.sessions.isEmpty else { return }
+
+        let recentSessions = Array(response.sessions.prefix(5))
+
+        let defaultThreadIsEmpty = delegate.threads.count == 1
+            && delegate.chatViewModel(for: delegate.threads[0].id)?.messages.isEmpty ?? true
+            && delegate.chatViewModel(for: delegate.threads[0].id)?.sessionId == nil
+
+        var restoredThreads: [ThreadModel] = []
+        for session in recentSessions {
+            let thread = ThreadModel(
+                title: session.title,
+                createdAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                sessionId: session.id
+            )
+            let viewModel = delegate.makeViewModel()
+            viewModel.sessionId = session.id
+            delegate.setChatViewModel(viewModel, for: thread.id)
+            restoredThreads.append(thread)
+        }
+
+        if defaultThreadIsEmpty {
+            if let defaultThread = delegate.threads.first {
+                delegate.removeChatViewModel(for: defaultThread.id)
+            }
+            delegate.threads = restoredThreads
+        } else {
+            delegate.threads = restoredThreads + delegate.threads
+        }
+
+        if let firstThread = restoredThreads.first {
+            delegate.activateThread(firstThread.id)
+        }
+
+        log.info("Restored \(restoredThreads.count) threads from daemon")
+    }
+
+    func handleHistoryResponse(_ response: HistoryResponseMessage) {
+        guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
+        guard let viewModel = delegate?.chatViewModel(for: threadId) else { return }
+        viewModel.populateFromHistory(response.messages)
+        log.info("Loaded \(response.messages.count) history messages for thread \(threadId)")
+    }
+
+    // MARK: - Private
+
+    private func fetchSessionList() {
+        do {
+            try daemonClient.sendSessionList()
+        } catch {
+            log.error("Failed to send session_list: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+import VellumAssistantShared
+
+// MARK: - Mock Delegate
+
+@MainActor
+final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
+    var threads: [ThreadModel] = []
+    var restoreRecentThreads: Bool = true
+    var viewModels: [UUID: ChatViewModel] = [:]
+    var activatedThreadId: UUID?
+    private let daemonClient: DaemonClient
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    func chatViewModel(for threadId: UUID) -> ChatViewModel? {
+        viewModels[threadId]
+    }
+
+    func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID) {
+        viewModels[threadId] = vm
+    }
+
+    func removeChatViewModel(for threadId: UUID) {
+        viewModels.removeValue(forKey: threadId)
+    }
+
+    func makeViewModel() -> ChatViewModel {
+        ChatViewModel(daemonClient: daemonClient)
+    }
+
+    func activateThread(_ id: UUID) {
+        activatedThreadId = id
+    }
+}
+
+// MARK: - Helpers
+
+/// Build an IPCSessionListResponse via JSON round-trip.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int)]) -> SessionListResponseMessage {
+    let sessionDicts = sessions.map { session -> [String: Any] in
+        ["id": session.id, "title": session.title, "updatedAt": session.updatedAt]
+    }
+    let dict: [String: Any] = ["type": "session_list_response", "sessions": sessionDicts]
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
+}
+
+/// Build an IPCHistoryResponse via JSON round-trip.
+private func makeHistoryResponse(sessionId: String, messages: [(role: String, text: String)]) -> HistoryResponseMessage {
+    let msgDicts = messages.map { msg -> [String: Any] in
+        ["role": msg.role, "text": msg.text, "timestamp": 1000.0]
+    }
+    let dict: [String: Any] = ["type": "history_response", "sessionId": sessionId, "messages": msgDicts]
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(HistoryResponseMessage.self, from: data)
+}
+
+// MARK: - Tests
+
+@Suite("ThreadSessionRestorer")
+struct ThreadSessionRestorerTests {
+
+    // MARK: - History Response Routing
+
+    @Test @MainActor
+    func historyResponseRoutesToCorrectThread() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+
+        // Set up two threads with session IDs
+        let threadA = ThreadModel(title: "Thread A", sessionId: "session-A")
+        let threadB = ThreadModel(title: "Thread B", sessionId: "session-B")
+        delegate.threads = [threadA, threadB]
+
+        let vmA = delegate.makeViewModel()
+        let vmB = delegate.makeViewModel()
+        delegate.viewModels[threadA.id] = vmA
+        delegate.viewModels[threadB.id] = vmB
+
+        restorer.delegate = delegate
+
+        // Register pending history for both sessions
+        restorer.pendingHistoryBySessionId["session-A"] = threadA.id
+        restorer.pendingHistoryBySessionId["session-B"] = threadB.id
+
+        // Deliver history for session-B
+        let response = makeHistoryResponse(sessionId: "session-B", messages: [
+            (role: "user", text: "Hello"),
+            (role: "assistant", text: "Hi there"),
+        ])
+        restorer.handleHistoryResponse(response)
+
+        // session-B's view model should have history loaded
+        #expect(vmB.isHistoryLoaded)
+        #expect(vmB.messages.count == 2)
+
+        // session-A should NOT have been affected
+        #expect(!vmA.isHistoryLoaded)
+        #expect(vmA.messages.isEmpty)
+
+        // session-B should be removed from pending, session-A should remain
+        #expect(restorer.pendingHistoryBySessionId["session-B"] == nil)
+        #expect(restorer.pendingHistoryBySessionId["session-A"] == threadA.id)
+    }
+
+    @Test @MainActor
+    func staleHistoryResponseIsDropped() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let thread = ThreadModel(title: "Thread", sessionId: "session-X")
+        delegate.threads = [thread]
+        let vm = delegate.makeViewModel()
+        delegate.viewModels[thread.id] = vm
+
+        // No pending entry for "session-stale"
+        let response = makeHistoryResponse(sessionId: "session-stale", messages: [
+            (role: "user", text: "Should not appear"),
+        ])
+        restorer.handleHistoryResponse(response)
+
+        // The view model should be untouched
+        #expect(!vm.isHistoryLoaded)
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test @MainActor
+    func rapidTabSwitchDoesNotCrossContaminate() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let threadA = ThreadModel(title: "A", sessionId: "sa")
+        let threadB = ThreadModel(title: "B", sessionId: "sb")
+        delegate.threads = [threadA, threadB]
+
+        let vmA = delegate.makeViewModel()
+        let vmB = delegate.makeViewModel()
+        delegate.viewModels[threadA.id] = vmA
+        delegate.viewModels[threadB.id] = vmB
+
+        // User views thread A, then quickly switches to B —
+        // both history requests are in-flight with correct mapping.
+        restorer.pendingHistoryBySessionId["sa"] = threadA.id
+        restorer.pendingHistoryBySessionId["sb"] = threadB.id
+
+        // Responses arrive out of order: B first, then A
+        restorer.handleHistoryResponse(makeHistoryResponse(sessionId: "sb", messages: [
+            (role: "assistant", text: "Response B"),
+        ]))
+        restorer.handleHistoryResponse(makeHistoryResponse(sessionId: "sa", messages: [
+            (role: "user", text: "Request A"),
+            (role: "assistant", text: "Response A"),
+        ]))
+
+        // Each VM should have its own history only
+        #expect(vmA.messages.count == 2)
+        #expect(vmB.messages.count == 1)
+        #expect(vmA.isHistoryLoaded)
+        #expect(vmB.isHistoryLoaded)
+    }
+
+    // MARK: - Session List Restoration
+
+    @Test @MainActor
+    func sessionListCreatesRestoredThreads() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        // Start with one empty default thread
+        let defaultThread = ThreadModel()
+        let defaultVm = delegate.makeViewModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = defaultVm
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Chat 1", updatedAt: 3000),
+            (id: "s2", title: "Chat 2", updatedAt: 2000),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Default empty thread should be replaced
+        #expect(delegate.threads.count == 2)
+        #expect(delegate.viewModels[defaultThread.id] == nil)
+
+        // Restored threads have correct session IDs
+        #expect(delegate.threads[0].sessionId == "s1")
+        #expect(delegate.threads[1].sessionId == "s2")
+        #expect(delegate.threads[0].title == "Chat 1")
+
+        // View models were created and assigned session IDs
+        let vm1 = delegate.viewModels[delegate.threads[0].id]
+        let vm2 = delegate.viewModels[delegate.threads[1].id]
+        #expect(vm1?.sessionId == "s1")
+        #expect(vm2?.sessionId == "s2")
+
+        // Most recent thread should be activated
+        #expect(delegate.activatedThreadId == delegate.threads[0].id)
+    }
+
+    @Test @MainActor
+    func sessionListSkipsWhenRestoreDisabled() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        delegate.restoreRecentThreads = false
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Chat 1", updatedAt: 1000),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Should not modify threads
+        #expect(delegate.threads.count == 1)
+        #expect(delegate.threads[0].id == defaultThread.id)
+        #expect(delegate.activatedThreadId == nil)
+    }
+
+    @Test @MainActor
+    func sessionListPreservesNonEmptyDefaultThread() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        // Default thread that has an active session (not empty)
+        let activeThread = ThreadModel(title: "Active")
+        let activeVm = delegate.makeViewModel()
+        activeVm.sessionId = "active-session"
+        delegate.threads = [activeThread]
+        delegate.viewModels[activeThread.id] = activeVm
+
+        let response = makeSessionListResponse(sessions: [
+            (id: "s1", title: "Restored", updatedAt: 1000),
+        ])
+        restorer.handleSessionListResponse(response)
+
+        // Active thread is preserved, restored thread prepended
+        #expect(delegate.threads.count == 2)
+        #expect(delegate.threads[1].id == activeThread.id)
+        #expect(delegate.threads[0].sessionId == "s1")
+    }
+
+    @Test @MainActor
+    func sessionListCapsAtFive() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let sessions = (0..<10).map { i in
+            (id: "s\(i)", title: "Chat \(i)", updatedAt: 10000 - i)
+        }
+        restorer.handleSessionListResponse(makeSessionListResponse(sessions: sessions))
+
+        // Only 5 sessions should be restored
+        #expect(delegate.threads.count == 5)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ThreadSessionRestorer` from `ThreadManager`, isolating daemon session restoration logic (session list, history loading, pending-history tracking) behind a `ThreadRestorerDelegate` protocol
- `ThreadManager` now focuses on thread CRUD, active thread state, and ChatViewModel bridging
- Add 7 new tests: history routing to correct thread, stale response drops, rapid tab switch isolation, session list restoration, restore-disabled skip, non-empty default thread preservation, and 5-session cap

## Test plan
- [x] `swift build` passes
- [x] All 35 tests pass (28 existing + 7 new ThreadSessionRestorer tests)
- [x] No behavioral change for end users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
