### PR TITLE
fix(workspace): reapply insets after HTML reload and include attachment height

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -449,7 +449,9 @@ struct MainWindowView: View {
         let expanded = workspaceComposerExpanded
         let topPad: CGFloat = expanded ? VSpacing.lg : VSpacing.sm
         let buttonRow: CGFloat = expanded ? 28 + VSpacing.xs : 0
-        return VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow
+        let hasAttachments = !(threadManager.activeViewModel?.pendingAttachments.isEmpty ?? true)
+        let attachmentStrip: CGFloat = hasAttachments ? VSpacing.sm + 36 + VSpacing.xs : 0
+        return VSpacing.md + 18 + topPad + VSpacing.sm + contentHeight + buttonRow + attachmentStrip
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -316,6 +316,10 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             context.coordinator.currentHTML = data.html
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
             webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+            // Reset cached insets so the check below re-injects the correct values
+            // after the page reloads (the WKUserScript from makeNSView has stale values).
+            context.coordinator.lastTopInset = 0
+            context.coordinator.lastBottomInset = 0
         }
 
         // Re-apply content insets and fade overlay when they change (e.g. composer expands).


### PR DESCRIPTION
## Summary
- Reset coordinator's cached inset values after `loadHTMLString` in DynamicPageSurfaceView so the inset check re-injects correct CSS padding when HTML content changes
- Include attachment strip height in `workspaceComposerReservedHeight` so the WebView bottom padding accounts for the attachment preview strip

Addresses review feedback from PR #2449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
