### PR TITLE
refactor: targeted @Observable migration for low-risk types

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
-    @ObservedObject var zoomManager: ZoomManager
+    var zoomManager: ZoomManager
     @ObservedObject var traceStore: TraceStore
     @ObservedObject var windowState: MainWindowState
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic

--- a/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 @MainActor
-final class ZoomManager: ObservableObject {
+@Observable
+final class ZoomManager {
     static let zoomSteps: [CGFloat] = [0.75, 0.80, 0.90, 1.00, 1.10, 1.25, 1.50, 1.75, 2.00]
 
-    @Published var zoomLevel: CGFloat {
+    var zoomLevel: CGFloat {
         didSet { UserDefaults.standard.set(zoomLevel, forKey: "windowZoomLevel") }
     }
-    @Published var showZoomIndicator = false
+    var showZoomIndicator = false
 
     private var dismissTask: Task<Void, Never>?
 

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct TextResponseView: View {
     @ObservedObject var session: TextSession
-    @ObservedObject var inputState: ConversationInputState
+    @Bindable var inputState: ConversationInputState
     var onClose: (() -> Void)?
 
     /// Whether the session is actively processing (thinking or streaming).

--- a/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/TextResponseWindow.swift
@@ -4,9 +4,10 @@ import SwiftUI
 
 /// Shared state for routing voice input into an active conversation panel.
 @MainActor
-final class ConversationInputState: ObservableObject {
-    @Published var inputText: String = ""
-    @Published var isRecording: Bool = false
+@Observable
+final class ConversationInputState {
+    var inputText: String = ""
+    var isRecording: Bool = false
 
     nonisolated init() {
         // Properties are initialized with defaults above

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -2,7 +2,7 @@ import VellumAssistantShared
 import SwiftUI
 
 struct BundleConfirmationView: View {
-    @ObservedObject var viewModel: BundleConfirmationViewModel
+    var viewModel: BundleConfirmationViewModel
 
     var body: some View {
         VStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -3,7 +3,8 @@ import SwiftUI
 import VellumAssistantShared
 
 @MainActor
-final class BundleConfirmationViewModel: ObservableObject {
+@Observable
+final class BundleConfirmationViewModel {
     let manifest: OpenBundleResponseMessage.Manifest
     let scanResult: OpenBundleResponseMessage.ScanResult
     let signatureResult: OpenBundleResponseMessage.SignatureResult
@@ -13,8 +14,8 @@ final class BundleConfirmationViewModel: ObservableObject {
     var onConfirm: (() -> Void)?
     var onCancel: (() -> Void)?
 
-    @Published var showTamperedWarning = false
-    @Published var warningsExpanded = false
+    var showTamperedWarning = false
+    var warningsExpanded = false
 
     init(
         response: OpenBundleResponseMessage,


### PR DESCRIPTION
## Summary
- Migrate `ZoomManager`, `ConversationInputState`, and `BundleConfirmationViewModel` from `ObservableObject`/`@Published` to the Swift Observation `@Observable` macro
- Update consumer views: `@ObservedObject` → `var` (read-only) or `@Bindable` (when bindings needed)
- Skip `VoiceTranscriptionViewModel` — uses Combine `$`-prefixed publishers incompatible with `@Observable`

## Test plan
- [x] All 35 Swift tests pass
- [x] `swift build` succeeds
- [x] Verified `@Bindable` used where bindings are needed (TextResponseView)
- [x] Verified plain `var` used where only reads needed (MainWindowView, BundleConfirmationView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
