### PR TITLE
Add integrated memory lifecycle E2E regression

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -1,0 +1,445 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+
+import { DEFAULT_CONFIG } from '../config/defaults.js';
+
+const testDir = mkdtempSync(join(tmpdir(), 'memory-lifecycle-e2e-'));
+
+mock.module('../util/platform.js', () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === 'darwin',
+  isLinux: () => process.platform === 'linux',
+  isWindows: () => process.platform === 'win32',
+  getSocketPath: () => join(testDir, 'test.sock'),
+  getPidPath: () => join(testDir, 'test.pid'),
+  getDbPath: () => join(testDir, 'test.db'),
+  getLogPath: () => join(testDir, 'test.log'),
+  ensureDataDir: () => {},
+}));
+
+mock.module('../util/logger.js', () => ({
+  getLogger: () => new Proxy({} as Record<string, unknown>, {
+    get: () => () => {},
+  }),
+}));
+
+mock.module('../memory/qdrant-client.js', () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
+const TEST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    embeddings: {
+      ...DEFAULT_CONFIG.memory.embeddings,
+      provider: 'openai' as const,
+      required: false,
+    },
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+    retrieval: {
+      ...DEFAULT_CONFIG.memory.retrieval,
+      lexicalTopK: 40,
+      semanticTopK: 0,
+      maxInjectTokens: 900,
+      dynamicBudget: {
+        ...DEFAULT_CONFIG.memory.retrieval.dynamicBudget,
+        enabled: true,
+        minInjectTokens: 180,
+        maxInjectTokens: 360,
+        targetHeadroomTokens: 700,
+      },
+      reranking: {
+        ...DEFAULT_CONFIG.memory.retrieval.reranking,
+        enabled: false,
+      },
+    },
+    entity: {
+      ...DEFAULT_CONFIG.memory.entity,
+      relationRetrieval: {
+        ...DEFAULT_CONFIG.memory.entity.relationRetrieval,
+        enabled: true,
+        maxSeedEntities: 4,
+        maxNeighborEntities: 6,
+        maxEdges: 8,
+        neighborScoreMultiplier: 0.65,
+      },
+    },
+    conflicts: {
+      ...DEFAULT_CONFIG.memory.conflicts,
+      enabled: true,
+      gateMode: 'soft',
+      relevanceThreshold: 0.2,
+      reaskCooldownTurns: 3,
+      resolverLlmTimeoutMs: 250,
+    },
+    profile: {
+      ...DEFAULT_CONFIG.memory.profile,
+      enabled: true,
+      maxInjectTokens: 300,
+    },
+  },
+};
+
+mock.module('../config/loader.js', () => ({
+  loadConfig: () => TEST_CONFIG,
+  getConfig: () => TEST_CONFIG,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+import { ConflictGate } from '../daemon/session-conflict-gate.js';
+import { injectDynamicProfileIntoUserMessage, stripDynamicProfileMessages } from '../daemon/session-dynamic-profile.js';
+import { createOrUpdatePendingConflict, getConflictById } from '../memory/conflict-store.js';
+import { getDb, initializeDb, resetDb } from '../memory/db.js';
+import { enqueueResolvePendingConflictsForMessageJob } from '../memory/jobs-store.js';
+import { resetCleanupScheduleThrottle, resetStaleSweepThrottle, runMemoryJobsOnce } from '../memory/jobs-worker.js';
+import { buildMemoryRecall } from '../memory/retriever.js';
+import {
+  conversations,
+  memoryEntities,
+  memoryEntityRelations,
+  memoryItemConflicts,
+  memoryItemEntities,
+  memoryItems,
+  memoryItemSources,
+  messages,
+} from '../memory/schema.js';
+import type { Message } from '../providers/types.js';
+
+function messageText(message: Message): string {
+  return message.content
+    .filter((block) => block.type === 'text')
+    .map((block) => (block as { type: 'text'; text: string }).text)
+    .join('\n');
+}
+
+describe('Memory lifecycle E2E regression', () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run('DELETE FROM memory_item_conflicts');
+    db.run('DELETE FROM memory_item_entities');
+    db.run('DELETE FROM memory_entity_relations');
+    db.run('DELETE FROM memory_entities');
+    db.run('DELETE FROM memory_item_sources');
+    db.run('DELETE FROM memory_embeddings');
+    db.run('DELETE FROM memory_summaries');
+    db.run('DELETE FROM memory_items');
+    db.run('DELETE FROM memory_segment_fts');
+    db.run('DELETE FROM memory_segments');
+    db.run('DELETE FROM messages');
+    db.run('DELETE FROM conversations');
+    db.run('DELETE FROM memory_jobs');
+    db.run('DELETE FROM memory_checkpoints');
+    resetCleanupScheduleThrottle();
+    resetStaleSweepThrottle();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best effort cleanup
+    }
+  });
+
+  test('relation expansion, soft gate, background resolution, and profile hygiene remain consistent', async () => {
+    const db = getDb();
+    const now = 1_701_100_000_000;
+    const conversationId = 'conv-memory-lifecycle';
+
+    db.insert(conversations).values({
+      id: conversationId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    }).run();
+
+    db.insert(messages).values([
+      {
+        id: 'msg-lifecycle-seed',
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Atlas deployment notes mention Kubernetes infrastructure.' }]),
+        createdAt: now + 10,
+      },
+      {
+        id: 'msg-lifecycle-background',
+        conversationId,
+        role: 'user',
+        content: JSON.stringify([{ type: 'text', text: 'Keep the old runtime one.' }]),
+        createdAt: now + 500,
+      },
+    ]).run();
+
+    db.insert(memoryItems).values([
+      {
+        id: 'item-atlas-direct',
+        kind: 'preference',
+        subject: 'atlas rollout',
+        statement: 'Project Atlas prefers blue-green rollouts.',
+        status: 'active',
+        confidence: 0.95,
+        importance: 0.9,
+        fingerprint: 'fp-item-atlas-direct',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 10,
+        lastSeenAt: now + 10,
+        validFrom: now + 10,
+        invalidAt: null,
+      },
+      {
+        id: 'item-k8s-relation',
+        kind: 'fact',
+        subject: 'autoscaling',
+        statement: 'Scale API pods at 70% CPU with Kubernetes HPA.',
+        status: 'active',
+        confidence: 0.82,
+        importance: 0.7,
+        fingerprint: 'fp-item-k8s-relation',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 12,
+        lastSeenAt: now + 12,
+        validFrom: now + 12,
+        invalidAt: null,
+      },
+    ]).run();
+
+    db.insert(memoryItemSources).values([
+      {
+        memoryItemId: 'item-atlas-direct',
+        messageId: 'msg-lifecycle-seed',
+        evidence: 'Atlas rollout policy note',
+        createdAt: now + 10,
+      },
+      {
+        memoryItemId: 'item-k8s-relation',
+        messageId: 'msg-lifecycle-seed',
+        evidence: 'Kubernetes autoscaling note',
+        createdAt: now + 12,
+      },
+    ]).run();
+
+    db.insert(memoryEntities).values([
+      {
+        id: 'entity-atlas-lifecycle',
+        name: 'Project Atlas',
+        type: 'project',
+        aliases: JSON.stringify(['atlas']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now + 500,
+        mentionCount: 4,
+      },
+      {
+        id: 'entity-kubernetes-lifecycle',
+        name: 'Kubernetes',
+        type: 'tool',
+        aliases: JSON.stringify(['k8s']),
+        description: null,
+        firstSeenAt: now,
+        lastSeenAt: now + 500,
+        mentionCount: 3,
+      },
+    ]).run();
+
+    db.insert(memoryEntityRelations).values({
+      id: 'rel-atlas-kubernetes-lifecycle',
+      sourceEntityId: 'entity-atlas-lifecycle',
+      targetEntityId: 'entity-kubernetes-lifecycle',
+      relation: 'uses',
+      evidence: 'Project Atlas runs on Kubernetes',
+      firstSeenAt: now + 20,
+      lastSeenAt: now + 20,
+    }).run();
+
+    db.insert(memoryItemEntities).values([
+      {
+        memoryItemId: 'item-atlas-direct',
+        entityId: 'entity-atlas-lifecycle',
+      },
+      {
+        memoryItemId: 'item-k8s-relation',
+        entityId: 'entity-kubernetes-lifecycle',
+      },
+    ]).run();
+
+    const recall = await buildMemoryRecall('atlas deployment guidance', conversationId, TEST_CONFIG);
+    expect(recall.injectedText).toContain('blue-green rollouts');
+    expect(recall.injectedText).toContain('70% CPU');
+    expect(recall.relationSeedEntityCount).toBeGreaterThan(0);
+    expect(recall.relationTraversedEdgeCount).toBeGreaterThan(0);
+    expect(recall.relationNeighborEntityCount).toBeGreaterThan(0);
+    expect(recall.relationExpandedItemCount).toBeGreaterThan(0);
+
+    db.insert(memoryItems).values([
+      {
+        id: 'item-ui-existing',
+        kind: 'preference',
+        subject: 'ui renderer',
+        statement: 'React renderer is the default for Atlas dashboard.',
+        status: 'active',
+        confidence: 0.88,
+        importance: 0.8,
+        fingerprint: 'fp-item-ui-existing',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 30,
+        lastSeenAt: now + 30,
+        validFrom: now + 30,
+        invalidAt: null,
+      },
+      {
+        id: 'item-ui-candidate',
+        kind: 'preference',
+        subject: 'ui renderer',
+        statement: 'Svelte renderer is the default for Atlas dashboard.',
+        status: 'pending_clarification',
+        confidence: 0.84,
+        importance: 0.8,
+        fingerprint: 'fp-item-ui-candidate',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 31,
+        lastSeenAt: now + 31,
+        validFrom: now + 31,
+        invalidAt: null,
+      },
+    ]).run();
+
+    const gatedConflict = createOrUpdatePendingConflict({
+      existingItemId: 'item-ui-existing',
+      candidateItemId: 'item-ui-candidate',
+      relationship: 'ambiguous_contradiction',
+      clarificationQuestion: 'Should we keep React or move to Svelte?',
+    });
+
+    const conflictGate = new ConflictGate();
+    const firstGateDecision = await conflictGate.evaluate(
+      'Need react roadmap update today',
+      TEST_CONFIG.memory.conflicts,
+    );
+    expect(firstGateDecision).not.toBeNull();
+    expect(firstGateDecision?.relevant).toBe(true);
+    expect(firstGateDecision?.question).toContain('React');
+
+    const pendingAfterFirstGate = getConflictById(gatedConflict.id);
+    expect(pendingAfterFirstGate?.status).toBe('pending_clarification');
+    expect(pendingAfterFirstGate?.lastAskedAt).not.toBeNull();
+
+    const secondGateDecision = await conflictGate.evaluate(
+      'Use the new renderer going forward.',
+      TEST_CONFIG.memory.conflicts,
+    );
+    expect(secondGateDecision).toBeNull();
+
+    const resolvedAfterSecondGate = getConflictById(gatedConflict.id);
+    expect(resolvedAfterSecondGate?.status).toBe('resolved_keep_candidate');
+
+    const uiExisting = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-ui-existing')).get();
+    const uiCandidate = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-ui-candidate')).get();
+    expect(uiExisting?.status).toBe('superseded');
+    expect(uiCandidate?.status).toBe('active');
+
+    db.insert(memoryItems).values([
+      {
+        id: 'item-runtime-existing',
+        kind: 'preference',
+        subject: 'runtime',
+        statement: 'Node.js 20 remains the default runtime.',
+        status: 'active',
+        confidence: 0.83,
+        importance: 0.7,
+        fingerprint: 'fp-item-runtime-existing',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 200,
+        lastSeenAt: now + 200,
+        validFrom: now + 200,
+        invalidAt: null,
+      },
+      {
+        id: 'item-runtime-candidate',
+        kind: 'preference',
+        subject: 'runtime',
+        statement: 'Bun becomes the default runtime.',
+        status: 'pending_clarification',
+        confidence: 0.81,
+        importance: 0.7,
+        fingerprint: 'fp-item-runtime-candidate',
+        verificationState: 'assistant_inferred',
+        scopeId: 'default',
+        firstSeenAt: now + 201,
+        lastSeenAt: now + 201,
+        validFrom: now + 201,
+        invalidAt: null,
+      },
+    ]).run();
+
+    const backgroundConflict = createOrUpdatePendingConflict({
+      existingItemId: 'item-runtime-existing',
+      candidateItemId: 'item-runtime-candidate',
+      relationship: 'ambiguous_contradiction',
+    });
+
+    db.update(memoryItemConflicts)
+      .set({ createdAt: now + 300, updatedAt: now + 300 })
+      .where(eq(memoryItemConflicts.id, backgroundConflict.id))
+      .run();
+
+    enqueueResolvePendingConflictsForMessageJob('msg-lifecycle-background', 'default');
+    const processedJobs = await runMemoryJobsOnce();
+    expect(processedJobs).toBe(1);
+
+    const backgroundResolvedConflict = getConflictById(backgroundConflict.id);
+    expect(backgroundResolvedConflict?.status).toBe('resolved_keep_existing');
+    expect(backgroundResolvedConflict?.resolutionNote).toContain('Background message resolver');
+
+    const runtimeExisting = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-runtime-existing')).get();
+    const runtimeCandidate = db.select().from(memoryItems).where(eq(memoryItems.id, 'item-runtime-candidate')).get();
+    expect(runtimeExisting?.status).toBe('active');
+    expect(runtimeCandidate?.status).toBe('superseded');
+
+    const profileText = '[Dynamic User Profile]\n- timezone: America/Los_Angeles\n- prefers concise answers';
+    const baseUserMessage: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Plan next sprint milestones.' }],
+    };
+
+    const injectedProfileMessage = injectDynamicProfileIntoUserMessage(baseUserMessage, profileText);
+    const runtimeUserText = messageText(injectedProfileMessage);
+    expect(runtimeUserText).toContain('[Dynamic profile context start]');
+    expect(runtimeUserText).toContain('[Dynamic User Profile]');
+    expect(runtimeUserText).toContain('[Dynamic profile context end]');
+
+    const strippedMessages = stripDynamicProfileMessages([injectedProfileMessage], profileText);
+    expect(strippedMessages).toHaveLength(1);
+    expect(messageText(strippedMessages[0] as Message).trim()).toBe('Plan next sprint milestones.');
+    expect(messageText(baseUserMessage)).toBe('Plan next sprint milestones.');
+  });
+});


### PR DESCRIPTION
## Summary
- add a new deterministic integrated regression test at `assistant/src/__tests__/memory-lifecycle-e2e.test.ts`
- validate one chained lifecycle scenario covering:
  - relation-expansion recall from entity graph neighbors
  - ambiguous contradiction flow through the soft conflict gate
  - background conflict resolution via `resolve_pending_conflicts_for_message`
  - dynamic profile inject/strip hygiene
- keep the fixture self-contained (local temp DB + mocked platform/logger/qdrant/config) so it is stable in CI

## Testing
- `cd assistant && bun test src/__tests__/memory-lifecycle-e2e.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
