### PR TITLE
fix(chat): render tool call chips in chronological order

### DIFF
--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -30,6 +30,13 @@ struct MessageBubbleView: View {
                         }
                     )
                 } else {
+                    // When tool calls arrived before text, show them first
+                    if message.toolCallsBeforeText && !message.toolCalls.isEmpty {
+                        ForEach(message.toolCalls) { toolCall in
+                            ToolCallChip(toolCall: toolCall)
+                        }
+                    }
+
                     // Message text (only shown for non-confirmation messages)
                     if !message.text.isEmpty {
                         Text(message.text)
@@ -44,8 +51,8 @@ struct MessageBubbleView: View {
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                     }
 
-                    // Tool call chips
-                    if !message.toolCalls.isEmpty {
+                    // Tool call chips (when text came first)
+                    if !message.toolCallsBeforeText && !message.toolCalls.isEmpty {
                         ForEach(message.toolCalls) { toolCall in
                             ToolCallChip(toolCall: toolCall)
                         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -608,19 +608,19 @@ private struct ChatBubble: View {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
+                // When tool calls arrived before text (e.g. the agent ran a command
+                // and then responded), render chips first to match chronological order.
+                if message.toolCallsBeforeText {
+                    toolCallChips
+                }
+
                 if shouldShowBubble {
                     bubbleContent
                 }
 
-                // Tool calls render outside the bubble as compact chips.
-                // Hidden when inline surfaces are present (same or adjacent message).
-                if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(message.toolCalls) { toolCall in
-                            ToolCallChip(toolCall: toolCall)
-                        }
-                    }
-                    .frame(maxWidth: 520, alignment: .leading)
+                // Tool calls that arrived after text render below the bubble.
+                if !message.toolCallsBeforeText {
+                    toolCallChips
                 }
 
                 // Inline surfaces render below the bubble as full-width cards
@@ -639,6 +639,20 @@ private struct ChatBubble: View {
             }
 
             if !isUser { Spacer(minLength: 0) }
+        }
+    }
+
+    /// Tool call chips rendered outside the bubble.
+    /// Hidden for user messages, when there are no tool calls, or when inline surfaces are present.
+    @ViewBuilder
+    private var toolCallChips: some View {
+        if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(message.toolCalls) { toolCall in
+                    ToolCallChip(toolCall: toolCall)
+                }
+            }
+            .frame(maxWidth: 520, alignment: .leading)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -236,8 +236,11 @@ public struct ChatMessage: Identifiable {
     public var attachments: [ChatAttachment]
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]
+    /// True when tool calls were received before any text content, so the UI
+    /// renders tool call chips above the text bubble to match chronological order.
+    public var toolCallsBeforeText: Bool
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = []) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], toolCallsBeforeText: Bool = false) {
         self.id = id
         self.role = role
         self.text = text
@@ -249,5 +252,6 @@ public struct ChatMessage: Identifiable {
         self.attachments = attachments
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
+        self.toolCallsBeforeText = toolCallsBeforeText
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -874,8 +874,12 @@ public final class ChatViewModel: ObservableObject {
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].toolCalls.append(toolCall)
+                // If no text has arrived yet, mark tool calls as first
+                if messages[index].text.isEmpty {
+                    messages[index].toolCallsBeforeText = true
+                }
             } else {
-                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [toolCall])
+                let newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [toolCall], toolCallsBeforeText: true)
                 currentAssistantMessageId = newMsg.id
                 messages.append(newMsg)
             }


### PR DESCRIPTION
## Summary
- Tool calls that execute before the assistant's text response were always rendered below the text bubble, even though they happened first
- Added a `toolCallsBeforeText` flag to `ChatMessage` that tracks whether tool calls arrived before any text content
- When true, tool call chips render above the text bubble; when false, they render below (preserving existing behavior for text-first cases)
- Applied fix to both macOS (`ChatView.swift`) and iOS (`MessageBubbleView.swift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
