### PR TITLE
Enable memory rollout defaults by default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -634,22 +634,22 @@ graph TB
 
 | Config key | Default | Purpose |
 |---|---:|---|
-| `memory.retrieval.dynamicBudget.enabled` | `false` | Toggle per-turn recall budget calculation from live prompt headroom. |
+| `memory.retrieval.dynamicBudget.enabled` | `true` | Toggle per-turn recall budget calculation from live prompt headroom. |
 | `memory.retrieval.dynamicBudget.minInjectTokens` | `1200` | Lower clamp for computed recall injection budget. |
 | `memory.retrieval.dynamicBudget.maxInjectTokens` | `10000` | Upper clamp for computed recall injection budget. |
 | `memory.retrieval.dynamicBudget.targetHeadroomTokens` | `10000` | Reserved headroom to keep free for response generation/tool traces. |
-| `memory.entity.extractRelations.enabled` | `false` | Enable relation edge extraction and persistence in `memory_entity_relations`. |
+| `memory.entity.extractRelations.enabled` | `true` | Enable relation edge extraction and persistence in `memory_entity_relations`. |
 | `memory.entity.extractRelations.backfillBatchSize` | `200` | Batch size for checkpointed `backfill_entity_relations` jobs. |
-| `memory.entity.relationRetrieval.enabled` | `false` | Enable one-hop relation expansion from matched seed entities at recall time. |
+| `memory.entity.relationRetrieval.enabled` | `true` | Enable one-hop relation expansion from matched seed entities at recall time. |
 | `memory.entity.relationRetrieval.maxSeedEntities` | `8` | Maximum matched seed entities from the query. |
 | `memory.entity.relationRetrieval.maxNeighborEntities` | `20` | Maximum unique neighbor entities expanded from relation edges. |
 | `memory.entity.relationRetrieval.maxEdges` | `40` | Maximum relation edges traversed during expansion. |
 | `memory.entity.relationRetrieval.neighborScoreMultiplier` | `0.7` | Downweight multiplier for relation-expanded candidates vs direct entity hits. |
-| `memory.conflicts.enabled` | `false` | Enable soft conflict gate for unresolved `memory_item_conflicts`. |
+| `memory.conflicts.enabled` | `true` | Enable soft conflict gate for unresolved `memory_item_conflicts`. |
 | `memory.conflicts.reaskCooldownTurns` | `3` | Minimum turn distance before re-asking the same conflict clarification. |
 | `memory.conflicts.resolverLlmTimeoutMs` | `12000` | Timeout bound for clarification resolver LLM fallback. |
 | `memory.conflicts.relevanceThreshold` | `0.3` | Similarity threshold for deciding whether a pending conflict is relevant to the current request. |
-| `memory.profile.enabled` | `false` | Enable dynamic profile compilation from active trusted profile/preference/constraint/instruction memories. |
+| `memory.profile.enabled` | `true` | Enable dynamic profile compilation from active trusted profile/preference/constraint/instruction memories. |
 | `memory.profile.maxInjectTokens` | `800` | Hard token cap enforced by `ProfileCompiler` when generating the runtime profile block. |
 
 ### Memory Recall Debugging Playbook

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -121,7 +121,7 @@ describe('AssistantConfigSchema', () => {
   test('applies memory.conflicts defaults', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.conflicts).toEqual({
-      enabled: false,
+      enabled: true,
       gateMode: 'soft',
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
@@ -139,7 +139,7 @@ describe('AssistantConfigSchema', () => {
   test('applies memory.profile defaults', () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.profile).toEqual({
-      enabled: false,
+      enabled: true,
       maxInjectTokens: 800,
     });
   });
@@ -149,6 +149,27 @@ describe('AssistantConfigSchema', () => {
       memory: { profile: { maxInjectTokens: 0 } },
     });
     expect(result.success).toBe(false);
+  });
+
+  test('applies rollout defaults for dynamic budget and entity relation features', () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.memory.retrieval.dynamicBudget).toEqual({
+      enabled: true,
+      minInjectTokens: 1200,
+      maxInjectTokens: 10000,
+      targetHeadroomTokens: 10000,
+    });
+    expect(result.memory.entity.extractRelations).toEqual({
+      enabled: true,
+      backfillBatchSize: 200,
+    });
+    expect(result.memory.entity.relationRetrieval).toEqual({
+      enabled: true,
+      maxSeedEntities: 8,
+      maxNeighborEntities: 20,
+      maxEdges: 40,
+      neighborScoreMultiplier: 0.7,
+    });
   });
 
   test('applies memory.cleanup defaults', () => {

--- a/assistant/src/config/defaults.ts
+++ b/assistant/src/config/defaults.ts
@@ -55,7 +55,7 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       },
       scopePolicy: 'allow_global_fallback' as const,
       dynamicBudget: {
-        enabled: false,
+        enabled: true,
         minInjectTokens: 1200,
         maxInjectTokens: 10000,
         targetHeadroomTokens: 10000,
@@ -90,11 +90,11 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
       extractRelations: {
-        enabled: false,
+        enabled: true,
         backfillBatchSize: 200,
       },
       relationRetrieval: {
-        enabled: false,
+        enabled: true,
         maxSeedEntities: 8,
         maxNeighborEntities: 20,
         maxEdges: 40,
@@ -102,14 +102,14 @@ export const DEFAULT_CONFIG: AssistantConfig = {
       },
     },
     conflicts: {
-      enabled: false,
+      enabled: true,
       gateMode: 'soft',
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
     },
     profile: {
-      enabled: false,
+      enabled: true,
       maxInjectTokens: 800,
     },
   },

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -222,7 +222,7 @@ export const MemoryRerankingConfigSchema = z.object({
 export const MemoryDynamicBudgetConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.retrieval.dynamicBudget.enabled must be a boolean' })
-    .default(false),
+    .default(true),
   minInjectTokens: z
     .number({ error: 'memory.retrieval.dynamicBudget.minInjectTokens must be a number' })
     .int('memory.retrieval.dynamicBudget.minInjectTokens must be an integer')
@@ -335,7 +335,7 @@ export const MemoryRetrievalConfigSchema = z.object({
     })
     .default('allow_global_fallback'),
   dynamicBudget: MemoryDynamicBudgetConfigSchema.default({
-    enabled: false,
+    enabled: true,
     minInjectTokens: 1200,
     maxInjectTokens: 10000,
     targetHeadroomTokens: 10000,
@@ -412,20 +412,20 @@ export const MemoryEntityConfigSchema = z.object({
   extractRelations: z.object({
     enabled: z
       .boolean({ error: 'memory.entity.extractRelations.enabled must be a boolean' })
-      .default(false),
+      .default(true),
     backfillBatchSize: z
       .number({ error: 'memory.entity.extractRelations.backfillBatchSize must be a number' })
       .int('memory.entity.extractRelations.backfillBatchSize must be an integer')
       .positive('memory.entity.extractRelations.backfillBatchSize must be a positive integer')
       .default(200),
   }).default({
-    enabled: false,
+    enabled: true,
     backfillBatchSize: 200,
   }),
   relationRetrieval: z.object({
     enabled: z
       .boolean({ error: 'memory.entity.relationRetrieval.enabled must be a boolean' })
-      .default(false),
+      .default(true),
     maxSeedEntities: z
       .number({ error: 'memory.entity.relationRetrieval.maxSeedEntities must be a number' })
       .int('memory.entity.relationRetrieval.maxSeedEntities must be an integer')
@@ -447,7 +447,7 @@ export const MemoryEntityConfigSchema = z.object({
       .lte(1, 'memory.entity.relationRetrieval.neighborScoreMultiplier must be <= 1')
       .default(0.7),
   }).default({
-    enabled: false,
+    enabled: true,
     maxSeedEntities: 8,
     maxNeighborEntities: 20,
     maxEdges: 40,
@@ -458,7 +458,7 @@ export const MemoryEntityConfigSchema = z.object({
 export const MemoryConflictsConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.conflicts.enabled must be a boolean' })
-    .default(false),
+    .default(true),
   gateMode: z
     .enum(['soft'], { error: 'memory.conflicts.gateMode must be "soft"' })
     .default('soft'),
@@ -482,7 +482,7 @@ export const MemoryConflictsConfigSchema = z.object({
 export const MemoryProfileConfigSchema = z.object({
   enabled: z
     .boolean({ error: 'memory.profile.enabled must be a boolean' })
-    .default(false),
+    .default(true),
   maxInjectTokens: z
     .number({ error: 'memory.profile.maxInjectTokens must be a number' })
     .int('memory.profile.maxInjectTokens must be an integer')
@@ -537,7 +537,7 @@ export const MemoryConfigSchema = z.object({
     },
     scopePolicy: 'allow_global_fallback',
     dynamicBudget: {
-      enabled: false,
+      enabled: true,
       minInjectTokens: 1200,
       maxInjectTokens: 10000,
       targetHeadroomTokens: 10000,
@@ -572,11 +572,11 @@ export const MemoryConfigSchema = z.object({
     enabled: true,
     model: 'claude-haiku-4-5-20251001',
     extractRelations: {
-      enabled: false,
+      enabled: true,
       backfillBatchSize: 200,
     },
     relationRetrieval: {
-      enabled: false,
+      enabled: true,
       maxSeedEntities: 8,
       maxNeighborEntities: 20,
       maxEdges: 40,
@@ -584,14 +584,14 @@ export const MemoryConfigSchema = z.object({
     },
   }),
   conflicts: MemoryConflictsConfigSchema.default({
-    enabled: false,
+    enabled: true,
     gateMode: 'soft',
     reaskCooldownTurns: 3,
     resolverLlmTimeoutMs: 12000,
     relevanceThreshold: 0.3,
   }),
   profile: MemoryProfileConfigSchema.default({
-    enabled: false,
+    enabled: true,
     maxInjectTokens: 800,
   }),
 });
@@ -734,7 +734,7 @@ export const AssistantConfigSchema = z.object({
       },
       scopePolicy: 'allow_global_fallback',
       dynamicBudget: {
-        enabled: false,
+        enabled: true,
         minInjectTokens: 1200,
         maxInjectTokens: 10000,
         targetHeadroomTokens: 10000,
@@ -769,11 +769,11 @@ export const AssistantConfigSchema = z.object({
       enabled: true,
       model: 'claude-haiku-4-5-20251001',
       extractRelations: {
-        enabled: false,
+        enabled: true,
         backfillBatchSize: 200,
       },
       relationRetrieval: {
-        enabled: false,
+        enabled: true,
         maxSeedEntities: 8,
         maxNeighborEntities: 20,
         maxEdges: 40,
@@ -781,14 +781,14 @@ export const AssistantConfigSchema = z.object({
       },
     },
     conflicts: {
-      enabled: false,
+      enabled: true,
       gateMode: 'soft',
       reaskCooldownTurns: 3,
       resolverLlmTimeoutMs: 12000,
       relevanceThreshold: 0.3,
     },
     profile: {
-      enabled: false,
+      enabled: true,
       maxInjectTokens: 800,
     },
   }),


### PR DESCRIPTION
## Summary
- move memory rollout toggles to default-on in shipped config defaults + schema defaults:
  - `memory.retrieval.dynamicBudget.enabled`
  - `memory.entity.extractRelations.enabled`
  - `memory.entity.relationRetrieval.enabled`
  - `memory.conflicts.enabled`
  - `memory.profile.enabled`
- align schema unit coverage with the new rollout defaults in `config-schema.test.ts`
- update architecture default table so docs match shipped behavior

## Testing
- `cd assistant && bun test src/__tests__/config-schema.test.ts`
- `cd assistant && bun test src/__tests__/session-conflict-gate.test.ts`
- `cd assistant && bun test src/__tests__/session-profile-injection.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
