### PR TITLE
fix(swarm): keep markdown fallback when aborting without synthesis provider

### DIFF
--- a/assistant/src/__tests__/swarm-orchestrator.test.ts
+++ b/assistant/src/__tests__/swarm-orchestrator.test.ts
@@ -209,6 +209,44 @@ describe('executeSwarm', () => {
     expect(summary.stats.totalDurationMs).toBeGreaterThanOrEqual(0);
   });
 
+  test('uses markdown fallback when aborted without synthesis provider', async () => {
+    const controller = new AbortController();
+    let taskRun = false;
+    const backend = makeBackend({
+      runTask: async () => {
+        taskRun = true;
+        // Abort after the first task completes
+        controller.abort();
+        return {
+          success: true,
+          output: '```json\n{"summary":"Partial work done","artifacts":[],"issues":[],"nextSteps":[]}\n```',
+          durationMs: 10,
+        };
+      },
+    });
+
+    const plan = makePlan({
+      tasks: [
+        { id: 'a', role: 'coder', objective: 'A', dependencies: [] },
+        { id: 'b', role: 'coder', objective: 'B', dependencies: ['a'] },
+      ],
+    });
+
+    const summary = await executeSwarm({
+      plan,
+      limits: DEFAULT_LIMITS,
+      backend,
+      workingDir: '/tmp',
+      signal: controller.signal,
+    });
+
+    expect(taskRun).toBe(true);
+    // Should use markdown fallback with partial results, not a fixed cancellation string
+    expect(summary.finalAnswer).toContain('Swarm Results');
+    expect(summary.finalAnswer).toContain('a');
+    expect(summary.finalAnswer).not.toContain('cancelled');
+  });
+
   test('handles diamond dependency pattern', async () => {
     const plan = makePlan({
       tasks: [

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -159,24 +159,22 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
     }
   }
 
-  // Synthesize final answer (skip if aborted — no point calling the model)
+  // Synthesize final answer (skip LLM synthesis when aborted, but still
+  // build the markdown fallback so partial results are preserved)
   const allResults = Array.from(results.values());
 
   let finalAnswer: string;
-  if (signal?.aborted) {
-    finalAnswer = 'Swarm cancelled before synthesis.';
-  } else {
+  if (opts.synthesisProvider && !signal?.aborted) {
     onStatus?.({ kind: 'synthesis_started' });
-    if (opts.synthesisProvider) {
-      finalAnswer = await synthesizeResults({
-        objective: plan.objective,
-        results: allResults,
-        provider: opts.synthesisProvider,
-        model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
-      });
-    } else {
-      finalAnswer = buildMarkdownFallback(plan.objective, allResults);
-    }
+    finalAnswer = await synthesizeResults({
+      objective: plan.objective,
+      results: allResults,
+      provider: opts.synthesisProvider,
+      model: opts.synthesisModel ?? 'claude-sonnet-4-5-20250929',
+    });
+  } else {
+    if (!signal?.aborted) onStatus?.({ kind: 'synthesis_started' });
+    finalAnswer = buildMarkdownFallback(plan.objective, allResults);
   }
 
   const totalDurationMs = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- Fixes the abort guard in `executeSwarm` to only skip LLM synthesis (not the markdown fallback) when the signal is aborted
- When no `synthesisProvider` is configured, `buildMarkdownFallback` is now always called — even after cancellation — so partial task results are preserved for the user
- Adds a test verifying that aborted runs without a synthesis provider return markdown results instead of a fixed cancellation string

Addresses feedback from PR #2473.

## Test plan
- [x] All 10 existing swarm orchestrator tests pass
- [x] New test covers abort-without-provider scenario
- [x] Type-check passes (pre-existing errors in unrelated files only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
