### PR TITLE
fix(webview): re-inject content insets via didFinish after HTML reload

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -311,20 +311,21 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         context.coordinator.onAction = onAction
         context.coordinator.onDataRequest = onDataRequest
 
+        // Keep the coordinator's desired insets up-to-date so webView(_:didFinish:)
+        // can re-inject the correct values after a page reload.
+        let newTop = Int(topContentInset)
+        let newBottom = Int(bottomContentInset)
+        context.coordinator.desiredTopInset = newTop
+        context.coordinator.desiredBottomInset = newBottom
+
         // Reload if the HTML content has changed.
         if data.html != context.coordinator.currentHTML {
             context.coordinator.currentHTML = data.html
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
             webView.loadHTMLString(data.html, baseURL: URL(string: origin))
-            // Reset cached insets so the check below re-injects the correct values
-            // after the page reloads (the WKUserScript from makeNSView has stale values).
-            context.coordinator.lastTopInset = 0
-            context.coordinator.lastBottomInset = 0
         }
 
         // Re-apply content insets and fade overlay when they change (e.g. composer expands).
-        let newTop = Int(topContentInset)
-        let newBottom = Int(bottomContentInset)
         if newTop != context.coordinator.lastTopInset || newBottom != context.coordinator.lastBottomInset {
             context.coordinator.lastTopInset = newTop
             context.coordinator.lastBottomInset = newBottom
@@ -360,6 +361,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         weak var webView: WKWebView?
         var lastTopInset: Int = 0
         var lastBottomInset: Int = 0
+        var desiredTopInset: Int = 0
+        var desiredBottomInset: Int = 0
 
         init(
             onAction: @escaping (String, Any?) -> Void,
@@ -511,8 +514,29 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            // No auto-resize — the panel opens at a fixed default size and the user can
-            // resize manually. Content scrolls if it overflows.
+            // Re-inject content insets after page load completes. The WKUserScript from
+            // makeNSView has creation-time values baked in, which may be stale if insets
+            // changed since then (e.g. composer expanded). Apply the current desired values.
+            let top = desiredTopInset
+            let bottom = desiredBottomInset
+            guard top > 0 || bottom > 0 else { return }
+            lastTopInset = top
+            lastBottomInset = bottom
+            let fadeHeight = bottom + 32
+            let js = """
+                (function() {
+                    var el = document.getElementById('vellum-content-insets');
+                    if (!el) { el = document.createElement('style'); el.id = 'vellum-content-insets'; (document.head || document.documentElement).appendChild(el); }
+                    el.textContent = 'body { padding-top: \(top)px; padding-bottom: \(bottom)px; }';
+                    var fade = document.getElementById('vellum-bottom-fade');
+                    if (fade) {
+                        fade.style.height = '\(fadeHeight)px';
+                        var bg = getComputedStyle(document.body).backgroundColor || 'rgba(0,0,0,0)';
+                        fade.style.background = 'linear-gradient(to bottom, transparent 0%, ' + bg + ' 100%)';
+                    }
+                })();
+                """
+            webView.evaluateJavaScript(js, completionHandler: nil)
         }
 
         func webView(


### PR DESCRIPTION
## Summary

- Fix race condition where `evaluateJavaScript` for content inset injection fired before the new page DOM was ready after `loadHTMLString`
- Store desired inset values (`desiredTopInset`/`desiredBottomInset`) on the Coordinator
- Re-inject correct inset CSS in `webView(_:didFinish:)` delegate after the new page actually loads
- Remove the stale cache-reset-to-0 hack that ran JS on the old/transitioning page

Addresses feedback on #2499.

## Test plan

- [ ] Open a dynamic page in workspace mode
- [ ] Verify content insets (top padding for toolbar, bottom padding for composer) are correct
- [ ] Trigger an HTML reload (e.g. ask the agent to update the page)
- [ ] Verify insets are still correct after the reload
- [ ] Expand/collapse the composer and verify insets update dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
