### PR TITLE
fix(tools): prevent __runner.ts collision and preserve result on truncation

### DIFF
--- a/assistant/src/__tests__/evaluate-typescript-tool.test.ts
+++ b/assistant/src/__tests__/evaluate-typescript-tool.test.ts
@@ -232,6 +232,46 @@ describe('evaluate_typescript_code tool', () => {
     expect(parsed.stdout.length).toBeLessThan(2000);
   }, 10_000);
 
+  test('filename "__runner.ts" is rejected to avoid collision with harness', async () => {
+    const result = await tool.execute({
+      code: 'export default function() { return "safe"; }',
+      filename: '__runner.ts',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toBe('safe');
+  });
+
+  test('filename "__runner" (no extension) is rejected to avoid collision', async () => {
+    const result = await tool.execute({
+      code: 'export default function() { return "safe"; }',
+      filename: '__runner',
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result).toBe('safe');
+  });
+
+  test('result is preserved even when stdout is truncated', async () => {
+    const result = await tool.execute({
+      code: `export default function() {
+        // Fill stdout so it exceeds max_output_chars
+        for (let i = 0; i < 200; i++) console.log('x'.repeat(100));
+        return { preserved: true };
+      }`,
+      max_output_chars: 500,
+    }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.result).toEqual({ preserved: true });
+  }, 10_000);
+
   test('async snippet works', async () => {
     const result = await tool.execute({
       code: 'export default async function(input: any) { return { async: true, got: input }; }',

--- a/assistant/src/tools/terminal/evaluate-typescript.ts
+++ b/assistant/src/tools/terminal/evaluate-typescript.ts
@@ -34,6 +34,7 @@ interface EvalResult {
 function sanitizeFilename(raw: string): string {
   const base = basename(raw).replace(/[^a-zA-Z0-9._-]/g, '_');
   if (!base || base.startsWith('.')) return 'snippet.ts';
+  if (base === '__runner.ts' || base === '__runner') return 'snippet.ts';
   if (!base.endsWith('.ts')) return base + '.ts';
   return base;
 }
@@ -208,14 +209,7 @@ export class EvaluateTypescriptTool implements Tool {
         let stderr = Buffer.concat(stderrChunks).toString();
         let truncated = false;
 
-        if (stdout.length + stderr.length > maxOutputChars) {
-          truncated = true;
-          const halfMax = Math.floor(maxOutputChars / 2);
-          if (stdout.length > halfMax) stdout = stdout.slice(0, halfMax) + '\n[stdout truncated]';
-          if (stderr.length > halfMax) stderr = stderr.slice(0, halfMax) + '\n[stderr truncated]';
-        }
-
-        // Extract structured result from stdout
+        // Extract structured result from raw stdout before truncation
         let result: unknown = undefined;
         if (code === 0) {
           const lines = stdout.split('\n');
@@ -230,6 +224,13 @@ export class EvaluateTypescriptTool implements Tool {
               // not the result line
             }
           }
+        }
+
+        if (stdout.length + stderr.length > maxOutputChars) {
+          truncated = true;
+          const halfMax = Math.floor(maxOutputChars / 2);
+          if (stdout.length > halfMax) stdout = stdout.slice(0, halfMax) + '\n[stdout truncated]';
+          if (stderr.length > halfMax) stderr = stderr.slice(0, halfMax) + '\n[stderr truncated]';
         }
 
         resolve({


### PR DESCRIPTION
## Summary

Addresses review feedback on #2375:

- **`__runner.ts` filename collision** (Devin): If the caller passes `filename: "__runner.ts"`, `sanitizeFilename` now falls back to `snippet.ts` to prevent the harness wrapper from overwriting the user snippet and causing a self-import loop.
- **Result lost on truncation** (Codex): The `__eval_result` marker is now extracted from raw stdout *before* truncation, so verbose snippets don't lose their return value when output exceeds `max_output_chars`.
- Added 3 new tests covering both edge cases.

## Test plan
- [x] All 18 tests pass (`bun test src/__tests__/evaluate-typescript-tool.test.ts`)
- [x] New test: `__runner.ts` filename is sanitized to `snippet.ts`
- [x] New test: `__runner` (no ext) filename is sanitized to `snippet.ts`
- [x] New test: result is preserved when stdout is truncated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
