### PR TITLE
fix(test): correct regex escaping and dynamic budget config in context-memory tests

### DIFF
--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -90,7 +90,7 @@ function insertSegment(id: string, messageId: string, conversationId: string, ro
     INSERT INTO memory_segments (
       id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at
     ) VALUES (
-      '${id}', '${messageId}', '${conversationId}', '${role}', 0, '${text.replace(/'/g, "''")}', ${Math.max(6, Math.ceil(text.split(/\\s+/).length * 1.3))}, 'default', ${createdAt}, ${createdAt}
+      '${id}', '${messageId}', '${conversationId}', '${role}', 0, '${text.replace(/'/g, "''")}', ${Math.max(6, Math.ceil(text.split(/\s+/).length * 1.3))}, 'default', ${createdAt}, ${createdAt}
     )
   `);
 }
@@ -357,6 +357,7 @@ describe('Context + Memory E2E regression', () => {
 
     const recallConfig = {
       ...DEFAULT_CONFIG,
+      contextWindow: { ...DEFAULT_CONFIG.contextWindow, maxInputTokens: 5200 },
       memory: {
         ...DEFAULT_CONFIG.memory,
         embeddings: {

--- a/assistant/src/__tests__/memory-context-benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.test.ts
@@ -180,6 +180,7 @@ describe('Memory context benchmark', () => {
 
     const recallConfig = {
       ...DEFAULT_CONFIG,
+      contextWindow: { ...DEFAULT_CONFIG.contextWindow, maxInputTokens: 6000 },
       memory: {
         ...DEFAULT_CONFIG.memory,
         embeddings: {


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #2401:

- **Fix escaped regex** in `insertSegment` helper: `/\\s+/` was matching literal `\s` instead of whitespace, causing token estimates to always be `6`. Changed to `/\s+/` so word-count-based estimates reflect actual text length.
- **Override `contextWindow.maxInputTokens`** in `recallConfig` for both test files so `computeRecallBudget` uses the test's actual context window size (5200 / 6000) instead of the default 180000. This ensures the dynamic budget path is genuinely exercised rather than always clamping to `maxInjectTokens`.

## Files modified
- `assistant/src/__tests__/context-memory-e2e.test.ts`
- `assistant/src/__tests__/memory-context-benchmark.test.ts`

## Test plan
- [x] `bun test src/__tests__/context-memory-e2e.test.ts` — 1 pass
- [x] `bun test src/__tests__/memory-context-benchmark.test.ts` — 1 pass
- [x] `bunx tsc --noEmit` — pre-existing errors only, no new type issues
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
