### PR TITLE
fix(swarm): use non-retryable cancellation for aborted tasks

### DIFF
--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -75,9 +75,9 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
           }
         }
 
-        // Treat abort as cancellation, not success
+        // Treat abort as non-retryable cancellation, not a retryable timeout
         if (input.signal?.aborted) {
-          return { success: false, output: 'Cancelled (aborted)', failureReason: 'timeout' as const, durationMs: Date.now() - start };
+          return { success: false, output: 'Cancelled (aborted)', failureReason: 'cancelled' as const, durationMs: Date.now() - start };
         }
 
         return { success: true, output: resultText || 'Completed', durationMs: Date.now() - start };

--- a/assistant/src/swarm/orchestrator.ts
+++ b/assistant/src/swarm/orchestrator.ts
@@ -101,9 +101,9 @@ export async function executeSwarm(opts: ExecuteSwarmOptions): Promise<SwarmExec
         signal,
       });
 
-      // Retry loop
+      // Retry loop — skip retries when the swarm is being cancelled
       let retries = 0;
-      while (result.status === 'failed' && retries < limits.maxRetriesPerTask) {
+      while (result.status === 'failed' && retries < limits.maxRetriesPerTask && !signal?.aborted) {
         retries++;
         result = await runWorkerTask({
           task,

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -89,6 +89,7 @@ export function getProfilePolicy(profile: WorkerProfile): ProfilePolicy {
 export type WorkerFailureReason =
   | 'backend_unavailable'
   | 'timeout'
+  | 'cancelled'
   | 'malformed_output'
   | 'tool_denied';
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #2470 (codex-connector).

The backend was mapping aborted signals to `failureReason: 'timeout'`, which made cancelled tasks look retryable. This caused the orchestrator retry loop to re-launch workers without the abort signal, delaying cancellation by up to `workerTimeoutSec * maxRetriesPerTask` (default: 900s with 1 retry).

- Add `'cancelled'` to `WorkerFailureReason` union type in `worker-backend.ts`
- Use `'cancelled'` instead of `'timeout'` in `backend-claude-code.ts` abort path
- Check `signal.aborted` in orchestrator retry loop to skip retries on cancellation

## Test plan

- [x] `bun test src/__tests__/swarm-tool.test.ts` — 5/5 pass
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing errors in unrelated files only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
