### PR TITLE
fix(swift): use local sheet state for trust rules in each settings surface

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -9,6 +9,7 @@ struct SettingsPanel: View {
 
     @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
+    @State private var showingTrustRules = false
     @AppStorage("useThreadDrawer") private var useThreadDrawer: Bool = false
 
     var body: some View {
@@ -227,9 +228,9 @@ struct SettingsPanel: View {
                             }
                             Spacer()
                             VButton(label: "Manage...", style: .ghost) {
-                                store.isTrustRulesSheetOpen = true
+                                showingTrustRules = true
                             }
-                            .disabled(store.isTrustRulesDisabled)
+                            .disabled(store.isAnyTrustRulesSheetOpen)
                         }
                     }
                     .padding(VSpacing.lg)
@@ -259,7 +260,7 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
         }
-        .sheet(isPresented: $store.isTrustRulesSheetOpen) {
+        .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -31,11 +31,10 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Trust Rules Coordination
 
-    @Published var isTrustRulesSheetOpen = false
-    @Published var trustRulesOpenElsewhere = false
-
-    /// Whether the trust rules button should be disabled.
-    var isTrustRulesDisabled: Bool { isTrustRulesSheetOpen || trustRulesOpenElsewhere }
+    /// Whether any settings surface currently has a trust rules sheet open.
+    /// Sourced from `DaemonClient.isTrustRulesSheetOpen` so each view can
+    /// disable its button when the other surface is showing trust rules.
+    @Published var isAnyTrustRulesSheetOpen = false
 
     // MARK: - Private
 
@@ -63,14 +62,10 @@ public final class SettingsStore: ObservableObject {
             .sink { [weak self] _ in self?.refreshAPIKeyState() }
             .store(in: &cancellables)
 
-        // Track whether trust rules are open elsewhere
+        // Mirror DaemonClient's trust-rules-open flag so views can disable their buttons
         daemonClient?.$isTrustRulesSheetOpen
             .receive(on: RunLoop.main)
-            .sink { [weak self] isOpen in
-                guard let self else { return }
-                self.trustRulesOpenElsewhere = isOpen && !self.isTrustRulesSheetOpen
-            }
-            .store(in: &cancellables)
+            .assign(to: &$isAnyTrustRulesSheetOpen)
     }
 
     // MARK: - API Key Actions

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsView.swift
@@ -10,6 +10,7 @@ public struct SettingsView: View {
     @State private var screenRecordingGranted = false
     @State private var showingPrivacy = false
     @State private var showingSkills = false
+    @State private var showingTrustRules = false
     @State private var skillsViewModel: SkillsSettingsViewModel?
     @State private var activationKey: ActivationKey = {
         let stored = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
@@ -189,9 +190,9 @@ public struct SettingsView: View {
                         }
                         Spacer()
                         Button("Manage Trust Rules...") {
-                            store.isTrustRulesSheetOpen = true
+                            showingTrustRules = true
                         }
-                        .disabled(store.isTrustRulesDisabled)
+                        .disabled(store.isAnyTrustRulesSheetOpen)
                     }
                 }
             }
@@ -224,7 +225,7 @@ public struct SettingsView: View {
                 SkillsSettingsView(viewModel: vm)
             }
         }
-        .sheet(isPresented: $store.isTrustRulesSheetOpen) {
+        .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }


### PR DESCRIPTION
Addresses feedback from PR #2494 -- moves `isTrustRulesSheetOpen` back to local `@State` in each view (`SettingsView` and `SettingsPanel`) while keeping coordination in `SettingsStore` via `isAnyTrustRulesSheetOpen` (mirrored from `DaemonClient`).

This prevents dual sheet presentation conflicts when both settings surfaces are visible simultaneously.

## Changes
- **SettingsStore**: Replaced `isTrustRulesSheetOpen` + `trustRulesOpenElsewhere` + `isTrustRulesDisabled` with a single `isAnyTrustRulesSheetOpen` property mirrored from `DaemonClient`
- **SettingsView**: Added local `@State private var showingTrustRules` for sheet binding
- **SettingsPanel**: Added local `@State private var showingTrustRules` for sheet binding

Both views disable their "Manage" button when `store.isAnyTrustRulesSheetOpen` is true (i.e. when `TrustRulesView.onAppear` sets `daemonClient.isTrustRulesSheetOpen = true`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
