### PR TITLE
test(memory): mock clarification resolver in lifecycle E2E test

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -35,6 +35,40 @@ mock.module('../memory/qdrant-client.js', () => ({
   initQdrantClient: () => {},
 }));
 
+// Mock clarification resolver to prevent real Anthropic API calls when
+// ANTHROPIC_API_KEY is set. Without this, resolveConflictClarification can
+// resolve conflicts via LLM before the test asserts on pending state.
+mock.module('../memory/clarification-resolver.js', () => ({
+  resolveConflictClarification: async (input: { userMessage: string }) => {
+    const msg = input.userMessage.toLowerCase();
+    // "Use the new renderer going forward" → keep candidate
+    if (msg.includes('new') || msg.includes('replace') || msg.includes('instead')) {
+      return {
+        resolution: 'keep_candidate' as const,
+        strategy: 'heuristic' as const,
+        resolvedStatement: null,
+        explanation: 'User response explicitly points to candidate/new statement.',
+      };
+    }
+    // "Keep the old runtime one" → keep existing
+    if (msg.includes('old') || msg.includes('existing') || msg.includes('still')) {
+      return {
+        resolution: 'keep_existing' as const,
+        strategy: 'heuristic' as const,
+        resolvedStatement: null,
+        explanation: 'User response explicitly points to existing/old statement.',
+      };
+    }
+    // Default: still_unclear (e.g. "Need react roadmap update today")
+    return {
+      resolution: 'still_unclear' as const,
+      strategy: 'heuristic' as const,
+      resolvedStatement: null,
+      explanation: 'No clear directional cue found in user message.',
+    };
+  },
+}));
+
 const TEST_CONFIG = {
   ...DEFAULT_CONFIG,
   memory: {


### PR DESCRIPTION
## Summary

Addresses feedback from PR #2501 — mocks `resolveConflictClarification` in the memory lifecycle E2E test to prevent flaky real network calls when `ANTHROPIC_API_KEY` is set.

- Adds `mock.module()` for `clarification-resolver.js` that uses input-based routing instead of real heuristic+LLM fallback
- Directional cues in user messages determine resolution deterministically (matching real heuristic behavior)
- Ambiguous messages return `still_unclear` so conflict stays pending for assertion

## Test plan

- [x] `bun test src/__tests__/memory-lifecycle-e2e.test.ts` passes
- [x] Pre-existing type errors confirmed unrelated to this change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
