### PR TITLE
fix(computer-use): reset block streak on coordinate resolution failure

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -688,6 +688,9 @@ final class ComputerUseSession: ObservableObject {
 
     private func sendRecoverableExecutionError(_ message: String, stepNumber: Int) async {
         log.warning("[\(stepNumber)] Coordinate resolution failed: \(message, privacy: .public)")
+        // Resolution failures are non-blocked turns — reset the consecutive block streak
+        // so they don't contribute to the "3 consecutive blocks" shutdown threshold.
+        verifier.resetBlockCount()
         let obs = await buildObservation(executionResult: nil, executionError: message)
         if let obs {
             try? daemonClient.send(obs)

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -859,6 +859,80 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(executor.executedActions[0].toY ?? -1, 165, accuracy: 0.001)
     }
 
+    @MainActor
+    func testStaleElementId_resetsBlockStreak() async {
+        let daemonClient = MockDaemonClient()
+        let continuation = daemonClient.setupTestStream()
+        let executor = MockActionExecutor()
+        let session = makeSession(daemonClient: daemonClient, executor: executor)
+
+        let runTask = Task { @MainActor in
+            await session.run()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Block 1: AppleScript with "do shell script" → blocked
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_run_applescript",
+            input: ["script": AnyCodable("do shell script \"echo hi\"")],
+            reasoning: "bad 1",
+            stepNumber: 1
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Block 2: same blocked pattern
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_run_applescript",
+            input: ["script": AnyCodable("do shell script \"echo hi\"")],
+            reasoning: "bad 2",
+            stepNumber: 2
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Stale element_id resolution failure — should reset block streak
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_click",
+            input: ["element_id": AnyCodable(999)],
+            reasoning: "stale id",
+            stepNumber: 3
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Block 3: would be the 3rd consecutive block without the reset
+        continuation.yield(.cuAction(makeActionMessage(
+            sessionId: session.id,
+            toolName: "cu_run_applescript",
+            input: ["script": AnyCodable("do shell script \"echo hi\"")],
+            reasoning: "bad 3",
+            stepNumber: 4
+        )))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Session should NOT have failed — the stale-id turn broke the streak
+        if case .failed(let reason) = session.state {
+            XCTFail("Session should not have failed; stale element_id should reset block streak. Got: \(reason)")
+        }
+
+        // Complete the session normally
+        continuation.yield(.cuComplete(makeCompleteMessage(
+            sessionId: session.id,
+            summary: "Survived block streak reset",
+            stepCount: 4
+        )))
+
+        await runTask.value
+
+        if case .completed(let summary, _) = session.state {
+            XCTAssertEqual(summary, "Survived block streak reset")
+        } else {
+            XCTFail("Expected completed state, got \(session.state)")
+        }
+    }
+
     // MARK: - Undo
 
     @MainActor


### PR DESCRIPTION
## Summary
- Fixes a bug where coordinate resolution failures (e.g., stale `element_id`) did not reset the consecutive block streak in `ActionVerifier`
- When `resolveCoordinatesIfNeeded` returned `nil`, `handleAction` returned early before reaching `verifier.verify()`, so `blockedCount` was never cleared
- This could cause premature "3 consecutive actions blocked" session shutdown after a recoverable targeting error between two blocked actions
- Adds `verifier.resetBlockCount()` in `sendRecoverableExecutionError` since resolution failures are non-blocked turns
- Adds test `testStaleElementId_resetsBlockStreak` validating that a stale element_id between blocked actions prevents premature shutdown

Addresses feedback from PR #2369.

## Test plan
- [x] Swift build succeeds
- [x] New test `testStaleElementId_resetsBlockStreak` covers the scenario: 2 blocked actions → stale element_id → blocked action → session should NOT fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
