### PR TITLE
fix(ipc): derive blob directory from BASE_DATA_DIR

### DIFF
--- a/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/IpcBlobStoreTests.swift
@@ -5,13 +5,13 @@ import CryptoKit
 final class IpcBlobStoreTests: XCTestCase {
 
     private var tempDir: URL!
-    private var blobStore: TestableIpcBlobStore!
+    private var blobStore: IpcBlobStore!
 
     override func setUp() {
         super.setUp()
         tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        blobStore = TestableIpcBlobStore(blobDir: tempDir)
+        blobStore = IpcBlobStore(blobDir: tempDir)
     }
 
     override func tearDown() {
@@ -109,59 +109,34 @@ final class IpcBlobStoreTests: XCTestCase {
         let fileData = try Data(contentsOf: probePath)
         XCTAssertEqual(fileData.count, 32)
     }
-}
 
-// MARK: - Testable Subclass
+    // MARK: - resolveBlobDir
 
-/// A testable wrapper around IpcBlobStore that uses a custom blob directory
-/// instead of the hardcoded ~/.vellum/data/ipc-blobs/.
-private final class TestableIpcBlobStore {
-    private let blobDir: URL
-
-    init(blobDir: URL) {
-        self.blobDir = blobDir
+    func testResolveBlobDirDefaultsToHomeDotVellum() {
+        let resolved = resolveBlobDir(environment: [:])
+        let expected = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        XCTAssertEqual(resolved, expected)
     }
 
-    func writeBlob(data: Data, kind: String, encoding: String) -> IPCIpcBlobRef? {
-        let id = UUID().uuidString.lowercased()
-        let targetURL = blobDir.appendingPathComponent("\(id).blob")
-        let tempURL = blobDir.appendingPathComponent("\(id).tmp")
-
-        do {
-            try data.write(to: tempURL)
-            try FileManager.default.moveItem(at: tempURL, to: targetURL)
-
-            let sha256 = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-
-            return IPCIpcBlobRef(
-                id: id,
-                kind: kind,
-                encoding: encoding,
-                byteLength: data.count,
-                sha256: sha256
-            )
-        } catch {
-            try? FileManager.default.removeItem(at: tempURL)
-            return nil
-        }
+    func testResolveBlobDirHonorsBaseDataDir() {
+        let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "/tmp/custom-root"])
+        let expected = URL(fileURLWithPath: "/tmp/custom-root")
+            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        XCTAssertEqual(resolved, expected)
     }
 
-    func writeProbeFile() -> (probeId: String, nonceSha256: String)? {
-        let probeId = UUID().uuidString.lowercased()
-        let targetURL = blobDir.appendingPathComponent("\(probeId).blob")
+    func testResolveBlobDirIgnoresEmptyBaseDataDir() {
+        let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "  "])
+        let expected = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        XCTAssertEqual(resolved, expected)
+    }
 
-        var nonce = Data(count: 32)
-        let result = nonce.withUnsafeMutableBytes { ptr in
-            SecRandomCopyBytes(kSecRandomDefault, 32, ptr.baseAddress!)
-        }
-        guard result == errSecSuccess else { return nil }
-
-        do {
-            try nonce.write(to: targetURL)
-            let sha256 = SHA256.hash(data: nonce).map { String(format: "%02x", $0) }.joined()
-            return (probeId: probeId, nonceSha256: sha256)
-        } catch {
-            return nil
-        }
+    func testResolveBlobDirExpandsTildeInBaseDataDir() {
+        let resolved = resolveBlobDir(environment: ["BASE_DATA_DIR": "~/custom"])
+        let expected = URL(fileURLWithPath: NSHomeDirectory() + "/custom")
+            .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        XCTAssertEqual(resolved, expected)
     }
 }

--- a/clients/shared/IPC/IpcBlobStore.swift
+++ b/clients/shared/IPC/IpcBlobStore.swift
@@ -4,16 +4,44 @@ import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "IpcBlobStore")
 
+/// Resolve the IPC blob directory, mirroring the daemon's `getIpcBlobDir()`.
+/// The daemon derives its blob dir from `BASE_DATA_DIR` (or `$HOME`), so the
+/// client must use the same root to ensure probe files land in the same directory.
+///
+/// Resolution: `(BASE_DATA_DIR || $HOME) / .vellum / data / ipc-blobs`
+func resolveBlobDir(environment: [String: String]? = nil) -> URL {
+    let env = environment ?? ProcessInfo.processInfo.environment
+    let root: String
+    if let baseDataDir = env["BASE_DATA_DIR"], !baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        let trimmed = baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("~/") {
+            root = NSHomeDirectory() + "/" + String(trimmed.dropFirst(2))
+        } else {
+            root = trimmed
+        }
+    } else {
+        root = NSHomeDirectory()
+    }
+    return URL(fileURLWithPath: root)
+        .appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+}
+
 /// Manages local blob files for zero-copy IPC transport.
-/// Blobs are written atomically (temp file + rename) to ~/.vellum/data/ipc-blobs/.
+/// Blobs are written atomically (temp file + rename) to the directory resolved
+/// by `resolveBlobDir()`, which honors the `BASE_DATA_DIR` environment variable.
 public final class IpcBlobStore: Sendable {
     public static let shared = IpcBlobStore()
 
     private let blobDir: URL
 
+    /// Creates a blob store using the directory resolved from `BASE_DATA_DIR` / `$HOME`.
     private init() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        blobDir = home.appendingPathComponent(".vellum/data/ipc-blobs", isDirectory: true)
+        blobDir = resolveBlobDir()
+    }
+
+    /// Creates a blob store targeting a specific directory (for testing).
+    init(blobDir: URL) {
+        self.blobDir = blobDir
     }
 
     /// Ensure the blob directory exists.


### PR DESCRIPTION
## Summary

- The `IpcBlobStore` was hardcoded to `~/.vellum/data/ipc-blobs`, but the daemon resolves its blob directory via `getIpcBlobDir()` which honors `BASE_DATA_DIR`. In setups with a non-default data root, probe files were written to a different directory than the daemon reads from, leaving `isBlobTransportAvailable` permanently `false`.
- Added `resolveBlobDir()` that mirrors the daemon's resolution logic: `(BASE_DATA_DIR || $HOME) / .vellum / data / ipc-blobs`
- Added internal `init(blobDir:)` for testability, replacing the duplicated `TestableIpcBlobStore` wrapper in tests
- Added unit tests for `resolveBlobDir()` covering default, custom root, empty env, and tilde expansion

Addresses feedback from PR #2389.

## Test plan

- [x] `swift build` passes
- [ ] Existing `IpcBlobStoreTests` pass (use `init(blobDir:)` directly)
- [ ] New `resolveBlobDir` tests verify env variable handling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
