### PR TITLE
fix(chat): render tool call chips in correct chronological position

### DIFF
--- a/clients/ios/Views/MessageBubbleView.swift
+++ b/clients/ios/Views/MessageBubbleView.swift
@@ -30,9 +30,10 @@ struct MessageBubbleView: View {
                         }
                     )
                 } else {
-                    // Tool calls render above text to match chronological order
-                    if !message.toolCalls.isEmpty {
-                        ForEach(message.toolCalls) { toolCall in
+                    // Pre-text tool calls render above the bubble
+                    let preTextCalls = message.toolCalls.filter { $0.arrivedBeforeText }
+                    if !preTextCalls.isEmpty {
+                        ForEach(preTextCalls) { toolCall in
                             ToolCallChip(toolCall: toolCall)
                         }
                     }
@@ -49,6 +50,14 @@ struct MessageBubbleView: View {
                                     : VColor.surface
                             )
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    }
+
+                    // Post-text tool calls render below the bubble
+                    let postTextCalls = message.toolCalls.filter { !$0.arrivedBeforeText }
+                    if !postTextCalls.isEmpty {
+                        ForEach(postTextCalls) { toolCall in
+                            ToolCallChip(toolCall: toolCall)
+                        }
                     }
 
                     // Inline surfaces (cards, tables, interactive widgets)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -603,18 +603,30 @@ private struct ChatBubble: View {
         return hasText || !message.attachments.isEmpty
     }
 
+    /// Tool calls that arrived before any text content in the message.
+    private var toolCallsBeforeText: [ToolCallData] {
+        message.toolCalls.filter { $0.arrivedBeforeText }
+    }
+
+    /// Tool calls that arrived after text content started streaming.
+    private var toolCallsAfterText: [ToolCallData] {
+        message.toolCalls.filter { !$0.arrivedBeforeText }
+    }
+
     var body: some View {
         HStack {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                // Tool calls render above text to match chronological order:
-                // in the agent loop, tools execute before the final text response.
-                toolCallChips
+                // Pre-text tool calls render above the bubble
+                toolCallChips(toolCallsBeforeText)
 
                 if shouldShowBubble {
                     bubbleContent
                 }
+
+                // Post-text tool calls render below the bubble
+                toolCallChips(toolCallsAfterText)
 
                 // Inline surfaces render below the bubble as full-width cards
                 if !message.inlineSurfaces.isEmpty {
@@ -637,10 +649,10 @@ private struct ChatBubble: View {
     /// Tool call chips rendered outside the bubble.
     /// Hidden for user messages, when there are no tool calls, or when inline surfaces are present.
     @ViewBuilder
-    private var toolCallChips: some View {
-        if !isUser && !message.toolCalls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
+    private func toolCallChips(_ calls: [ToolCallData]) -> some View {
+        if !isUser && !calls.isEmpty && message.inlineSurfaces.isEmpty && !hideToolCalls {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                ForEach(message.toolCalls) { toolCall in
+                ForEach(calls) { toolCall in
                     ToolCallChip(toolCall: toolCall)
                 }
             }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -91,6 +91,9 @@ public struct ToolCallData: Identifiable, Equatable {
     public var result: String?
     public var isError: Bool
     public var isComplete: Bool
+    /// Whether this tool call arrived before any text content in the message.
+    /// Used to render pre-text tool calls above and post-text tool calls below the bubble.
+    public var arrivedBeforeText: Bool
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public var imageData: String?
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
@@ -109,16 +112,18 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.result == rhs.result
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
+            && lhs.arrivedBeforeText == rhs.arrivedBeforeText
             && lhs.imageData == rhs.imageData
     }
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, imageData: String? = nil) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
         self.result = result
         self.isError = isError
         self.isComplete = isComplete
+        self.arrivedBeforeText = arrivedBeforeText
         self.imageData = imageData
         self.cachedImage = Self.decodeImage(from: imageData)
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -126,6 +126,9 @@ public final class ChatViewModel: ObservableObject {
     /// tasks so that a cancelled loop's cleanup doesn't clear a newer replacement.
     private var messageLoopGeneration: UInt64 = 0
     private var currentAssistantMessageId: UUID?
+    /// Tracks whether the current assistant message has received any text content.
+    /// Used to determine `arrivedBeforeText` for each tool call in the message.
+    private var currentAssistantHasText: Bool = false
     /// When true, incoming deltas are suppressed until the daemon acknowledges
     /// the cancellation (via `generation_cancelled` or `message_complete`).
     // Public (rather than private) so tests can simulate the
@@ -649,6 +652,7 @@ public final class ChatViewModel: ObservableObject {
             guard !isCancelling else { return }
             guard !isWorkspaceRefinementInFlight else { return }
             isThinking = false
+            currentAssistantHasText = true
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 // Append to existing streaming message
@@ -687,6 +691,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -707,6 +712,7 @@ public final class ChatViewModel: ObservableObject {
                 messages.removeSubrange((lastUserIndex + 1)...)
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
@@ -734,6 +740,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -782,6 +789,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -801,6 +809,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             if !wasCancelling {
                 errorText = err.message
             }
@@ -881,7 +890,8 @@ public final class ChatViewModel: ObservableObject {
             }
             let toolCall = ToolCallData(
                 toolName: toolDisplayName(msg.toolName),
-                inputSummary: summarizeToolInput(msg.input)
+                inputSummary: summarizeToolInput(msg.input),
+                arrivedBeforeText: !currentAssistantHasText
             )
             // Add to existing assistant message or create one
             if let existingId = currentAssistantMessageId,
@@ -996,6 +1006,7 @@ public final class ChatViewModel: ObservableObject {
                 messages[index].isStreaming = false
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             // When the user intentionally cancelled, suppress both the typed
             // session error and the errorText so no toast appears.
             if !wasCancelling {
@@ -1073,6 +1084,7 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1105,6 +1117,7 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
             currentAssistantMessageId = nil
+            currentAssistantHasText = false
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1148,6 +1161,7 @@ public final class ChatViewModel: ObservableObject {
             self.isCancelling = false
             self.isSending = false
             self.currentAssistantMessageId = nil
+            self.currentAssistantHasText = false
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]


### PR DESCRIPTION
## Summary
- Adds `arrivedBeforeText` flag to `ToolCallData` to track whether each tool call arrived before or after text content in the message
- `ChatViewModel` tracks `currentAssistantHasText` state, setting `arrivedBeforeText` based on whether any `assistantTextDelta` has been received for the current message
- Both macOS `ChatView` and iOS `MessageBubbleView` now split tool calls into pre-text (above bubble) and post-text (below bubble) groups, preserving chronological order for mixed sequences like tool_call -> text -> tool_call

## Test plan
- [ ] Verify tool calls that arrive before text still render above the bubble
- [ ] Verify tool calls that arrive after text render below the bubble
- [ ] Verify history-loaded messages default to `arrivedBeforeText: true` (existing behavior)
- [ ] Verify iOS rendering matches macOS behavior

Addresses codex feedback on #2502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
