### PR TITLE
fix(swarm): parse last valid contract JSON block instead of last block

### DIFF
--- a/assistant/src/__tests__/swarm-worker-runner.test.ts
+++ b/assistant/src/__tests__/swarm-worker-runner.test.ts
@@ -203,6 +203,37 @@ describe('parseWorkerOutput', () => {
     expect(result.issues).toEqual(['warn']);
     expect(result.nextSteps).toEqual(['ship']);
   });
+
+  test('skips trailing non-contract JSON and picks the last valid block', () => {
+    const raw = [
+      '```json',
+      '{"summary":"real result","artifacts":["out.ts"],"issues":[],"nextSteps":["deploy"]}',
+      '```',
+      '',
+      'Here is an example config:',
+      '```json',
+      '{"port":3000,"debug":true}',
+      '```',
+    ].join('\n');
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe('real result');
+    expect(result.artifacts).toEqual(['out.ts']);
+    expect(result.nextSteps).toEqual(['deploy']);
+  });
+
+  test('skips trailing malformed JSON and picks an earlier valid block', () => {
+    const raw = [
+      '```json',
+      '{"summary":"good","artifacts":[],"issues":[],"nextSteps":[]}',
+      '```',
+      '',
+      '```json',
+      '{this is not valid json}',
+      '```',
+    ].join('\n');
+    const result = parseWorkerOutput(raw);
+    expect(result.summary).toBe('good');
+  });
 });
 
 describe('buildWorkerPrompt', () => {

--- a/assistant/src/swarm/worker-prompts.ts
+++ b/assistant/src/swarm/worker-prompts.ts
@@ -46,22 +46,26 @@ If you cannot produce valid JSON, just write a plain-text summary.`;
 
 /**
  * Parse the worker's raw output into a structured result shape.
- * Prefers a fenced JSON block; falls back to treating the entire output as a summary.
+ * Scans fenced JSON blocks from last to first, picking the last one that
+ * matches the worker-result contract (has a `summary` string field).
+ * Falls back to treating the entire output as a plain-text summary.
  */
 export function parseWorkerOutput(raw: string): Pick<SwarmTaskResult, 'summary' | 'artifacts' | 'issues' | 'nextSteps'> {
   const jsonBlocks = Array.from(raw.matchAll(/```json\s*\n([\s\S]*?)\n```/g));
-  const jsonMatch = jsonBlocks.length > 0 ? jsonBlocks[jsonBlocks.length - 1] : null;
-  if (jsonMatch) {
+
+  // Walk backwards to prefer the final valid contract block.
+  for (let i = jsonBlocks.length - 1; i >= 0; i--) {
     try {
-      const parsed = JSON.parse(jsonMatch[1]);
+      const parsed = JSON.parse(jsonBlocks[i][1]);
+      if (typeof parsed.summary !== 'string') continue;
       return {
-        summary: typeof parsed.summary === 'string' ? parsed.summary : raw.slice(0, 500),
+        summary: parsed.summary,
         artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
         issues: Array.isArray(parsed.issues) ? parsed.issues : [],
         nextSteps: Array.isArray(parsed.nextSteps) ? parsed.nextSteps : [],
       };
     } catch {
-      // JSON parse failed — fall through to raw summary
+      // Malformed JSON — try the next block up.
     }
   }
 


### PR DESCRIPTION
## Summary
- Addresses codex review feedback on PR #2471: `parseWorkerOutput` now walks fenced JSON blocks from last to first, selecting the last block that matches the worker-result contract (has a `summary` string field).
- Prevents trailing auxiliary or malformed JSON fences from overriding an earlier valid structured result.
- Adds two new test cases: one for trailing non-contract JSON, one for trailing malformed JSON.

## Test plan
- [x] `bun test src/__tests__/swarm-worker-runner.test.ts` — 20/20 pass
- [x] `bunx tsc --noEmit` — no new type errors (pre-existing errors in unrelated files)

## Files modified
- `assistant/src/swarm/worker-prompts.ts` — contract-aware block selection
- `assistant/src/__tests__/swarm-worker-runner.test.ts` — two new test cases

Fixes feedback from #2471.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/2520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
